### PR TITLE
[codex] Mark milestone 15 delivered

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -121,9 +121,9 @@ The milestone breakdown in `docs/milestones.md` is intentionally focused on exit
 
 ### Priority (Now / Next / Later)
 
-- **Now**: finish Milestone 14 (public API, webhooks, and integration templates).
-- **Next**: Milestone 15 (workspaces/MSP governance).
-- **Later**: Milestone 16 (optional AI/MCP automation).
+- **Now**: Milestone 16 (optional AI/MCP automation).
+- **Next**: release hardening and follow-up triage.
+- **Later**: production-driven improvements from deployment feedback.
 
 ### Tentative Release Plan (Subject to Change)
 

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -246,7 +246,7 @@ Exit criteria:
 
 ## Milestone 15: Workspaces / MSP Mode (Multi-Org Governance)
 
-Status: In progress
+Status: Delivered
 
 Goal: support multi-org deployments (e.g., MSPs) with strong isolation, ownership, and operator ergonomics.
 


### PR DESCRIPTION
## Summary
- mark Milestone 15 as delivered after #149, #150, #151, and #152 merged
- update the roadmap so Milestone 16 is the active next milestone

## Validation
- docs-only change; no test suite required

Closes #148
