### PR TITLE
Add DMARCbis policy discovery

### DIFF
--- a/backend/app/services/cloudflare_dns.py
+++ b/backend/app/services/cloudflare_dns.py
@@ -15,7 +15,11 @@ from app.core.credential_encryption import decrypt_secret
 from app.models.dns_cache import DNSRecordChange, DNSRecordSnapshot
 from app.models.domain import Domain
 from app.models.setting import Setting
-from app.services.dns_resolver import CloudflareDNSProvider, extract_dmarc_policy
+from app.services.dns_resolver import (
+    CloudflareDNSProvider,
+    extract_dmarc_policy,
+    parse_dmarc_record_tags,
+)
 from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
 PROVIDER_NAME = "cloudflare"
@@ -350,8 +354,9 @@ def analyze_dns_records(domain: str, records: List[Dict[str, Any]]) -> Dict[str,
     root_txt = _txt_contents(records, domain)
     dmarc_records = _txt_contents(records, f"_dmarc.{domain}")
     spf_records = [record for record in root_txt if record.lower().startswith("v=spf1")]
+    dmarc_candidate_records = [record for record in dmarc_records if "v=dmarc1" in record.lower()]
     dmarc_auth_records = [
-        record for record in dmarc_records if record.lower().startswith("v=dmarc1")
+        record for record in dmarc_candidate_records if parse_dmarc_record_tags(record)
     ]
     dkim_records = [
         record
@@ -362,7 +367,7 @@ def analyze_dns_records(domain: str, records: List[Dict[str, Any]]) -> Dict[str,
     ]
 
     suggestions: List[Dict[str, str]] = []
-    if not dmarc_auth_records:
+    if not dmarc_candidate_records:
         suggestions.append(
             {
                 "type": "missing_dmarc",
@@ -370,7 +375,7 @@ def analyze_dns_records(domain: str, records: List[Dict[str, Any]]) -> Dict[str,
                 "message": "Add a TXT record at _dmarc with a v=DMARC1 policy.",
             }
         )
-    elif len(dmarc_auth_records) > 1:
+    elif len(dmarc_candidate_records) > 1:
         suggestions.append(
             {
                 "type": "duplicate_dmarc",
@@ -378,7 +383,7 @@ def analyze_dns_records(domain: str, records: List[Dict[str, Any]]) -> Dict[str,
                 "message": "Keep exactly one DMARC TXT record at _dmarc.",
             }
         )
-    elif extract_dmarc_policy(dmarc_auth_records[0]) is None:
+    elif not dmarc_auth_records or extract_dmarc_policy(dmarc_auth_records[0]) is None:
         suggestions.append(
             {
                 "type": "malformed_dmarc",

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -41,6 +41,9 @@ def _result_from_json(value: str) -> DomainDNSResult:
         dkim_selectors=list(data.get("dkim_selectors") or []),
         dkim_record=data.get("dkim_record"),
         selectors_checked=list(data.get("selectors_checked") or []),
+        dmarc_policy_domain=data.get("dmarc_policy_domain"),
+        dmarc_discovery_method=data.get("dmarc_discovery_method"),
+        dmarc_tags=dict(data.get("dmarc_tags") or {}),
     )
 
 

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -167,13 +167,9 @@ def _tree_walk_domains(domain: str) -> List[str]:
     if len(labels) <= 1:
         return []
 
-    if len(labels) <= 8:
-        target_labels = labels[1:]
-    else:
-        target_labels = labels[-7:]
-
     domains: List[str] = []
-    while target_labels:
+    target_labels = labels[1:]
+    while len(target_labels) > 1 and len(domains) < 7:
         domains.append(".".join(target_labels))
         target_labels = target_labels[1:]
     return domains
@@ -233,23 +229,12 @@ class BaseDNSProvider(ABC):
         if record:
             return True, record, normalized_domain, "author", tags
 
-        discovered: List[Tuple[str, str, Dict[str, str]]] = []
         for candidate in _tree_walk_domains(normalized_domain):
             record, tags = await self._lookup_valid_dmarc_at(candidate)
-            if not record:
-                continue
-            discovered.append((candidate, record, tags))
-            if tags.get("psd", "").lower() in {"n", "y"}:
+            if record:
                 return True, record, candidate, "treewalk", tags
 
-        if not discovered:
-            return False, None, None, None, {}
-
-        policy_domain, record, tags = sorted(
-            discovered,
-            key=lambda item: len(item[0].split(".")),
-        )[0]
-        return True, record, policy_domain, "treewalk", tags
+        return False, None, None, None, {}
 
     async def check_dmarc(self, domain: str) -> Tuple[bool, Optional[str]]:
         """Return *(found, record_string)* for the applicable DMARC TXT record."""

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -168,7 +168,10 @@ def _tree_walk_domains(domain: str) -> List[str]:
         return []
 
     domains: List[str] = []
-    target_labels = labels[1:]
+    if len(labels) <= 8:
+        target_labels = labels[1:]
+    else:
+        target_labels = labels[-7:]
     while len(target_labels) > 1 and len(domains) < 7:
         domains.append(".".join(target_labels))
         target_labels = target_labels[1:]

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -12,6 +12,7 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +62,21 @@ COMMON_DKIM_SELECTORS: List[str] = [
 # Seconds to wait for a single DNS query before giving up
 DNS_TIMEOUT: float = 5.0
 
+DMARC_POLICY_VALUES = {"none", "quarantine", "reject"}
+DMARCBIS_ACTIVE_TAGS = {
+    "adkim",
+    "aspf",
+    "fo",
+    "np",
+    "p",
+    "psd",
+    "rua",
+    "ruf",
+    "sp",
+    "t",
+    "v",
+}
+
 
 @dataclass
 class DomainDNSResult:
@@ -76,6 +92,105 @@ class DomainDNSResult:
     dkim_record: Optional[str] = None
     # Track which selectors were tried so callers can surface this information
     selectors_checked: List[str] = field(default_factory=list)
+    dmarc_policy_domain: Optional[str] = None
+    dmarc_discovery_method: Optional[str] = None
+    dmarc_tags: Dict[str, str] = field(default_factory=dict)
+
+
+def _normalize_dns_name(domain: str) -> str:
+    return domain.strip().strip(".").lower()
+
+
+def _is_valid_dmarc_uri_list(value: str) -> bool:
+    uris = [part.strip() for part in value.split(",") if part.strip()]
+    if not uris:
+        return False
+    return all(bool(urlparse(uri).scheme) for uri in uris)
+
+
+def parse_dmarc_record_tags(dmarc_record: Optional[str]) -> Dict[str, str]:
+    """Parse active RFC 9989 DMARC policy tags from a TXT record.
+
+    RFC 9989 requires ``v=DMARC1`` to be the first tag and keeps the version
+    value case-sensitive. Unknown tags are ignored. Historic tags such as
+    ``pct``, ``rf``, and ``ri`` are intentionally not returned here.
+    """
+    if not dmarc_record:
+        return {}
+
+    parts = [part.strip() for part in dmarc_record.split(";") if part.strip()]
+    if not parts or "=" not in parts[0]:
+        return {}
+
+    first_name, first_value = (item.strip() for item in parts[0].split("=", 1))
+    if first_name.lower() != "v" or first_value != "DMARC1":
+        return {}
+
+    tags: Dict[str, str] = {"v": first_value}
+    for part in parts[1:]:
+        if "=" not in part:
+            continue
+        name, value = (item.strip() for item in part.split("=", 1))
+        name = name.lower()
+        if name in DMARCBIS_ACTIVE_TAGS and name not in tags:
+            tags[name] = value.strip()
+    return tags
+
+
+def _valid_policy_value(value: Optional[str]) -> Optional[str]:
+    normalized = (value or "").strip().lower()
+    return normalized if normalized in DMARC_POLICY_VALUES else None
+
+
+def _record_has_valid_policy_or_reporting(tags: Dict[str, str]) -> bool:
+    if _valid_policy_value(tags.get("p")):
+        return True
+    rua = tags.get("rua")
+    return bool(rua and _is_valid_dmarc_uri_list(rua))
+
+
+def _select_valid_dmarc_record(records: List[str]) -> Tuple[Optional[str], Dict[str, str]]:
+    """Return a single valid DMARC record, discarding ambiguous targets."""
+    valid_records: List[Tuple[str, Dict[str, str]]] = []
+    for record in records:
+        tags = parse_dmarc_record_tags(record)
+        if tags and _record_has_valid_policy_or_reporting(tags):
+            valid_records.append((record, tags))
+
+    if len(valid_records) != 1:
+        return None, {}
+    return valid_records[0]
+
+
+def _tree_walk_domains(domain: str) -> List[str]:
+    labels = [label for label in _normalize_dns_name(domain).split(".") if label]
+    if len(labels) <= 1:
+        return []
+
+    if len(labels) <= 8:
+        target_labels = labels[1:]
+    else:
+        target_labels = labels[-7:]
+
+    domains: List[str] = []
+    while target_labels:
+        domains.append(".".join(target_labels))
+        target_labels = target_labels[1:]
+    return domains
+
+
+def effective_dmarc_policy(tags: Dict[str, str]) -> Optional[str]:
+    """Return the RFC 9989 effective base policy from parsed tags.
+
+    Records with a valid reporting URI but without a valid ``p`` tag are treated
+    as monitoring mode, matching RFC 9989 policy discovery behavior.
+    """
+    policy = _valid_policy_value(tags.get("p"))
+    if policy:
+        return policy
+    if tags.get("rua") and _is_valid_dmarc_uri_list(tags["rua"]):
+        return "none"
+    return None
 
 
 class BaseDNSProvider(ABC):
@@ -100,15 +215,47 @@ class BaseDNSProvider(ABC):
     # High-level record checks built on top of lookup_txt
     # ------------------------------------------------------------------
 
-    async def check_dmarc(self, domain: str) -> Tuple[bool, Optional[str]]:
-        """Return *(found, record_string)* for the domain's DMARC TXT record."""
+    async def _lookup_valid_dmarc_at(self, domain: str) -> Tuple[Optional[str], Dict[str, str]]:
+        """Return a valid DMARC record and parsed tags for one policy domain."""
         try:
             records = await self.lookup_txt(f"_dmarc.{domain}")
-            for record in records:
-                if record.lower().startswith("v=dmarc1"):
-                    return True, record
+            return _select_valid_dmarc_record(records)
         except LookupError as exc:
             logger.debug("DMARC lookup failed for %s: %s", _sanitize_for_log(domain), exc)
+        return None, {}
+
+    async def discover_dmarc_policy(
+        self, domain: str
+    ) -> Tuple[bool, Optional[str], Optional[str], Optional[str], Dict[str, str]]:
+        """Discover the applicable RFC 9989 DMARC policy record."""
+        normalized_domain = _normalize_dns_name(domain)
+        record, tags = await self._lookup_valid_dmarc_at(normalized_domain)
+        if record:
+            return True, record, normalized_domain, "author", tags
+
+        discovered: List[Tuple[str, str, Dict[str, str]]] = []
+        for candidate in _tree_walk_domains(normalized_domain):
+            record, tags = await self._lookup_valid_dmarc_at(candidate)
+            if not record:
+                continue
+            discovered.append((candidate, record, tags))
+            if tags.get("psd", "").lower() in {"n", "y"}:
+                return True, record, candidate, "treewalk", tags
+
+        if not discovered:
+            return False, None, None, None, {}
+
+        policy_domain, record, tags = sorted(
+            discovered,
+            key=lambda item: len(item[0].split(".")),
+        )[0]
+        return True, record, policy_domain, "treewalk", tags
+
+    async def check_dmarc(self, domain: str) -> Tuple[bool, Optional[str]]:
+        """Return *(found, record_string)* for the applicable DMARC TXT record."""
+        found, record, _, _, _ = await self.discover_dmarc_policy(domain)
+        if found:
+            return True, record
         return False, None
 
     async def check_spf(self, domain: str) -> Tuple[bool, Optional[str]]:
@@ -177,13 +324,20 @@ class BaseDNSProvider(ABC):
             if s not in all_selectors:
                 all_selectors.append(s)
 
-        dmarc_coro = self.check_dmarc(domain)
+        dmarc_coro = self.discover_dmarc_policy(domain)
         spf_coro = self.check_spf(domain)
         dkim_coro = self.check_dkim(domain, all_selectors)
 
-        (dmarc_ok, dmarc_record), (spf_ok, spf_record), (dkim_ok, dkim_sels, dkim_record) = (
-            await asyncio.gather(dmarc_coro, spf_coro, dkim_coro)
-        )
+        (
+            (dmarc_ok, dmarc_record, dmarc_policy_domain, dmarc_discovery_method, dmarc_tags),
+            (spf_ok, spf_record),
+            (dkim_ok, dkim_sels, dkim_record),
+        ) = await asyncio.gather(dmarc_coro, spf_coro, dkim_coro)
+
+        dmarc_tags = dmarc_tags or {}
+        dmarc_policy = effective_dmarc_policy(dmarc_tags)
+        if dmarc_policy:
+            dmarc_tags = {**dmarc_tags, "p": dmarc_policy}
 
         return DomainDNSResult(
             dmarc=dmarc_ok,
@@ -194,6 +348,9 @@ class BaseDNSProvider(ABC):
             dkim_selectors=dkim_sels,
             dkim_record=dkim_record,
             selectors_checked=all_selectors,
+            dmarc_policy_domain=dmarc_policy_domain,
+            dmarc_discovery_method=dmarc_discovery_method,
+            dmarc_tags=dmarc_tags,
         )
 
 
@@ -214,8 +371,11 @@ class SystemDNSProvider(BaseDNSProvider):
             result: List[str] = []
             if answers:
                 for rdata in answers:
-                    for string in rdata.strings:
-                        result.append(string.decode("utf-8", errors="replace"))
+                    result.append(
+                        "".join(
+                            string.decode("utf-8", errors="replace") for string in rdata.strings
+                        )
+                    )
             return result
         except dns.exception.DNSException as exc:
             raise LookupError(f"TXT lookup failed for {name}: {exc}") from exc
@@ -470,15 +630,9 @@ def get_default_provider(db: Any = None) -> BaseDNSProvider:
 
 
 def extract_dmarc_policy(dmarc_record: Optional[str]) -> Optional[str]:
-    """Parse the *p=* tag from a DMARC TXT record string.
+    """Parse the effective RFC 9989 base policy from a DMARC TXT record string.
 
     Returns the policy value (e.g. ``"none"``, ``"quarantine"``,
     ``"reject"``) or ``None`` if the record is absent or unparsable.
     """
-    if not dmarc_record:
-        return None
-    for part in dmarc_record.split(";"):
-        part = part.strip()
-        if part.lower().startswith("p="):
-            return part[2:].strip().lower()
-    return None
+    return effective_dmarc_policy(parse_dmarc_record_tags(dmarc_record))

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -106,6 +106,31 @@ def test_analyze_dns_records_suggests_malformed_dmarc_fix():
     assert "malformed_dmarc" in {item["type"] for item in result["suggestions"]}
 
 
+def test_analyze_dns_records_treats_reporting_only_dmarc_as_monitoring_mode():
+    records = [
+        _record("dmarc", "TXT", f"_dmarc.{DOMAIN}", "v=DMARC1; rua=mailto:dmarc@example.com"),
+        _record("spf", "TXT", DOMAIN, "v=spf1 include:_spf.google.com ~all"),
+        _record("dkim", "TXT", f"google._domainkey.{DOMAIN}", "v=DKIM1; p=abc"),
+    ]
+
+    result = analyze_dns_records(DOMAIN, records)
+
+    assert result["checks"]["dmarc"] is True
+    assert result["checks"]["dmarc_policy"] == "none"
+    assert "malformed_dmarc" not in {item["type"] for item in result["suggestions"]}
+
+
+def test_analyze_dns_records_suggests_missing_spf_with_valid_dmarc():
+    records = [
+        _record("dmarc", "TXT", f"_dmarc.{DOMAIN}", "v=DMARC1; p=reject"),
+        _record("dkim", "TXT", f"google._domainkey.{DOMAIN}", "v=DKIM1; p=abc"),
+    ]
+
+    result = analyze_dns_records(DOMAIN, records)
+
+    assert "missing_spf" in {item["type"] for item in result["suggestions"]}
+
+
 def test_sync_dns_record_changes_tracks_add_modify_and_remove(db_session):
     first_records = [
         _record("spf", "TXT", DOMAIN, "v=spf1 include:_spf.google.com ~all"),

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -97,7 +97,7 @@ def test_analyze_dns_records_suggests_duplicate_dmarc_fix():
 
 def test_analyze_dns_records_suggests_malformed_dmarc_fix():
     records = [
-        _record("dmarc", "TXT", f"_dmarc.{DOMAIN}", "v=DMARC1; rua=mailto:dmarc@example.com"),
+        _record("dmarc", "TXT", f"_dmarc.{DOMAIN}", "p=none; v=DMARC1"),
         _record("spf", "TXT", DOMAIN, "v=spf1 include:_spf.google.com ~all"),
     ]
 

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -74,6 +74,17 @@ def test_extract_dmarc_policy_missing_tag_without_reporting_uri():
     assert extract_dmarc_policy("v=DMARC1; fo=1") is None
 
 
+def test_parse_dmarc_record_tags_rejects_empty_and_malformed_records():
+    assert parse_dmarc_record_tags("") == {}
+    assert parse_dmarc_record_tags("not-a-tag") == {}
+
+
+def test_extract_dmarc_policy_ignores_duplicate_active_tags():
+    record = "v=DMARC1; p=reject; p=none"
+    assert parse_dmarc_record_tags(record)["p"] == "reject"
+    assert extract_dmarc_policy(record) == "reject"
+
+
 def test_parse_dmarc_record_tags_tracks_active_dmarcbis_tags_only():
     record = (
         "v=DMARC1; p=reject; sp=quarantine; np=none; psd=n; t=y; "
@@ -152,6 +163,33 @@ async def test_check_dmarc_finds_organizational_domain_via_tree_walk():
     assert policy_domain == "example.com"
     assert discovery_method == "treewalk"
     assert tags["p"] == "reject"
+
+
+@pytest.mark.asyncio
+async def test_check_dmarc_tree_walk_skips_to_seven_labels_for_deep_domains():
+    provider = FakeDNSProvider(
+        {"_dmarc.d.e.f.g.h.example.com": ["v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com"]}
+    )
+
+    found, record, policy_domain, discovery_method, tags = await provider.discover_dmarc_policy(
+        "a.b.c.d.e.f.g.h.example.com"
+    )
+
+    assert found is True
+    assert record == "v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com"
+    assert policy_domain == "d.e.f.g.h.example.com"
+    assert discovery_method == "treewalk"
+    assert tags["p"] == "quarantine"
+
+
+@pytest.mark.asyncio
+async def test_check_dmarc_ignores_record_without_policy_or_reporting_uri():
+    provider = FakeDNSProvider({"_dmarc.example.com": ["v=DMARC1; fo=1"]})
+
+    found, record = await provider.check_dmarc("example.com")
+
+    assert found is False
+    assert record is None
 
 
 @pytest.mark.asyncio
@@ -313,7 +351,7 @@ async def test_system_provider_joins_split_txt_record_chunks():
     """TXT chunks from one DNS RDATA item should be one logical record."""
 
     class FakeRdata:
-        strings = [b"v=DMARC1; p=reject; ", b"rua=mailto:dmarc@example.com"]
+        strings = (b"v=DMARC1; p=reject; ", b"rua=mailto:dmarc@example.com")
 
     class FakeAnswers:
         def __iter__(self):

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -18,6 +18,7 @@ from app.services.dns_resolver import (
     SystemDNSProvider,
     extract_dmarc_policy,
     get_default_provider,
+    parse_dmarc_record_tags,
 )
 
 # ---------------------------------------------------------------------------
@@ -56,12 +57,45 @@ def test_extract_dmarc_policy_reject():
     assert extract_dmarc_policy("v=DMARC1; p=reject") == "reject"
 
 
-def test_extract_dmarc_policy_missing_tag():
-    assert extract_dmarc_policy("v=DMARC1; rua=mailto:dmarc@example.com") is None
+def test_extract_dmarc_policy_missing_tag_with_reporting_uri_is_monitoring_mode():
+    assert extract_dmarc_policy("v=DMARC1; rua=mailto:dmarc@example.com") == "none"
 
 
 def test_extract_dmarc_policy_none_input():
     assert extract_dmarc_policy(None) is None
+
+
+def test_extract_dmarc_policy_requires_first_version_tag():
+    assert extract_dmarc_policy("p=reject; v=DMARC1") is None
+    assert extract_dmarc_policy("v=dmarc1; p=reject") is None
+
+
+def test_extract_dmarc_policy_missing_tag_without_reporting_uri():
+    assert extract_dmarc_policy("v=DMARC1; fo=1") is None
+
+
+def test_parse_dmarc_record_tags_tracks_active_dmarcbis_tags_only():
+    record = (
+        "v=DMARC1; p=reject; sp=quarantine; np=none; psd=n; t=y; "
+        "rua=mailto:agg@example.com; ruf=mailto:fail@example.com; fo=1:d:s; "
+        "adkim=s; aspf=r; pct=50; rf=afrf; ri=3600; unknown=value"
+    )
+
+    tags = parse_dmarc_record_tags(record)
+
+    assert tags == {
+        "v": "DMARC1",
+        "p": "reject",
+        "sp": "quarantine",
+        "np": "none",
+        "psd": "n",
+        "t": "y",
+        "rua": "mailto:agg@example.com",
+        "ruf": "mailto:fail@example.com",
+        "fo": "1:d:s",
+        "adkim": "s",
+        "aspf": "r",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -86,6 +120,56 @@ async def test_check_dmarc_not_found():
     found, record = await provider.check_dmarc("example.com")
     assert found is False
     assert record is None
+
+
+@pytest.mark.asyncio
+async def test_check_dmarc_discards_multiple_records_at_same_target():
+    provider = FakeDNSProvider(
+        {
+            "_dmarc.example.com": [
+                "v=DMARC1; p=reject",
+                "v=DMARC1; p=quarantine",
+            ]
+        }
+    )
+    found, record = await provider.check_dmarc("example.com")
+    assert found is False
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_check_dmarc_finds_organizational_domain_via_tree_walk():
+    provider = FakeDNSProvider(
+        {"_dmarc.example.com": ["v=DMARC1; p=reject; rua=mailto:dmarc@example.com"]}
+    )
+
+    found, record, policy_domain, discovery_method, tags = await provider.discover_dmarc_policy(
+        "mail.news.example.com"
+    )
+
+    assert found is True
+    assert record == "v=DMARC1; p=reject; rua=mailto:dmarc@example.com"
+    assert policy_domain == "example.com"
+    assert discovery_method == "treewalk"
+    assert tags["p"] == "reject"
+
+
+@pytest.mark.asyncio
+async def test_check_dmarc_stops_tree_walk_on_psd_tag():
+    provider = FakeDNSProvider(
+        {
+            "_dmarc.mail.example.com": ["v=DMARC1; p=quarantine; psd=n"],
+            "_dmarc.example.com": ["v=DMARC1; p=reject"],
+        }
+    )
+
+    result = await provider.check_domain("news.mail.example.com", selectors=[])
+
+    assert result.dmarc is True
+    assert result.dmarc_policy_domain == "mail.example.com"
+    assert result.dmarc_discovery_method == "treewalk"
+    assert result.dmarc_record == "v=DMARC1; p=quarantine; psd=n"
+    assert result.dmarc_tags["psd"] == "n"
 
 
 @pytest.mark.asyncio
@@ -222,6 +306,24 @@ async def test_system_provider_returns_txt_records():
         records = await provider.lookup_txt("_dmarc.example.com")
 
     assert records == ["v=DMARC1; p=none"]
+
+
+@pytest.mark.asyncio
+async def test_system_provider_joins_split_txt_record_chunks():
+    """TXT chunks from one DNS RDATA item should be one logical record."""
+
+    class FakeRdata:
+        strings = [b"v=DMARC1; p=reject; ", b"rua=mailto:dmarc@example.com"]
+
+    class FakeAnswers:
+        def __iter__(self):
+            return iter([FakeRdata()])
+
+    with patch("dns.asyncresolver.resolve", new=AsyncMock(return_value=FakeAnswers())):
+        provider = SystemDNSProvider()
+        records = await provider.lookup_txt("_dmarc.example.com")
+
+    assert records == ["v=DMARC1; p=reject; rua=mailto:dmarc@example.com"]
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -166,9 +166,13 @@ async def test_check_dmarc_finds_organizational_domain_via_tree_walk():
 
 
 @pytest.mark.asyncio
-async def test_check_dmarc_tree_walk_skips_to_seven_labels_for_deep_domains():
+async def test_check_dmarc_tree_walk_starts_with_last_seven_labels_for_deep_domains():
     provider = FakeDNSProvider(
-        {"_dmarc.d.e.f.g.h.example.com": ["v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com"]}
+        {
+            "_dmarc.d.e.f.g.h.example.com": [
+                "v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com"
+            ]
+        }
     )
 
     found, record, policy_domain, discovery_method, tags = await provider.discover_dmarc_policy(
@@ -180,6 +184,36 @@ async def test_check_dmarc_tree_walk_skips_to_seven_labels_for_deep_domains():
     assert policy_domain == "d.e.f.g.h.example.com"
     assert discovery_method == "treewalk"
     assert tags["p"] == "quarantine"
+
+
+@pytest.mark.asyncio
+async def test_check_dmarc_tree_walk_uses_nearest_parent_record():
+    provider = FakeDNSProvider(
+        {
+            "_dmarc.mail.example.com": ["v=DMARC1; p=quarantine"],
+            "_dmarc.example.com": ["v=DMARC1; p=reject"],
+        }
+    )
+
+    found, record, policy_domain, discovery_method, tags = await provider.discover_dmarc_policy(
+        "news.mail.example.com"
+    )
+
+    assert found is True
+    assert record == "v=DMARC1; p=quarantine"
+    assert policy_domain == "mail.example.com"
+    assert discovery_method == "treewalk"
+    assert tags["p"] == "quarantine"
+
+
+@pytest.mark.asyncio
+async def test_check_dmarc_tree_walk_does_not_query_top_level_domain():
+    provider = FakeDNSProvider({"_dmarc.com": ["v=DMARC1; p=reject"]})
+
+    found, record = await provider.check_dmarc("example.com")
+
+    assert found is False
+    assert record is None
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -168,11 +168,7 @@ async def test_check_dmarc_finds_organizational_domain_via_tree_walk():
 @pytest.mark.asyncio
 async def test_check_dmarc_tree_walk_starts_with_last_seven_labels_for_deep_domains():
     provider = FakeDNSProvider(
-        {
-            "_dmarc.d.e.f.g.h.example.com": [
-                "v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com"
-            ]
-        }
+        {"_dmarc.d.e.f.g.h.example.com": ["v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com"]}
     )
 
     found, record, policy_domain, discovery_method, tags = await provider.discover_dmarc_policy(

--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -11,6 +11,17 @@ DMARQ imports DMARC aggregate reports from direct uploads, IMAP attachments, Gma
 - Namespaced aggregate reports using `urn:ietf:params:xml:ns:dmarc-2.0`.
 - RFC 9990-style reports with optional metadata such as `version`, `generator`, `extra_contact_info`, repeated `error` values, `np`, `fo`, `testing`, `discovery_method`, `envelope_to`, policy override reasons, `human_result`, SPF `scope`, and namespaced extension elements.
 
+## Supported Policy Discovery
+
+Live DNS checks parse DMARC policy records according to RFC 9989:
+
+- `v=DMARC1` must be the first tag and keeps its case-sensitive value.
+- Multiple valid DMARC policy records at the same DNS target are treated as ambiguous and ignored.
+- Active DMARCbis tags are parsed for diagnostics: `p`, `sp`, `np`, `psd`, `t`, `rua`, `ruf`, `fo`, `adkim`, and `aspf`.
+- Historic tags such as `pct`, `rf`, and `ri` are not treated as active DMARCbis policy tags.
+- Subdomain checks fall back to the bounded RFC 9989 DNS Tree Walk, including `psd=n` and `psd=y` stop conditions.
+- Records with a valid aggregate reporting URI but no valid `p` tag are treated as monitoring mode for policy extraction.
+
 ## Preserved Metadata
 
 Newer optional fields are parsed without changing the legacy response shape that existing screens use. When a database is configured, DMARQ also persists the optional report metadata, policy metadata, record identifiers, policy override reasons, and extension payloads so exports and future views can use them.


### PR DESCRIPTION
## Summary
- add RFC 9989 DMARC policy-record parsing for active DMARCbis tags
- discover applicable DMARC policy via bounded DNS Tree Walk, including `psd=n` / `psd=y` stop handling and ambiguous-record discard
- preserve DMARC discovery metadata in cached DNS results and document current DMARCbis compatibility

Closes #207.

## Tests
- `.venv/bin/python -m pytest backend/app/tests/test_dns_resolver.py backend/app/tests/test_dmarc_parser.py backend/app/tests/test_dmarc_compatibility_fixtures.py backend/app/tests/test_reports_api.py backend/app/tests/test_dns_endpoints.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved DMARC support when checking domains, including better handling of valid policy records across parent domains.
  * Added support for additional DMARC details in cached results, so repeated checks retain more complete policy information.

* **Bug Fixes**
  * More reliably interprets DMARC records with missing or partial tags.
  * Handles split DNS TXT responses and ambiguous or duplicate DMARC records more safely.

* **Documentation**
  * Added reference material describing supported DMARC policy discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->