### PR TITLE
Harden backend image mount helpers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,12 +2,16 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
-  # Install required system dependencies
+# Install required system dependencies.
+# The backend does not need privileged mount helpers. Debian 13 currently has
+# no fixed util-linux package for the reported Snyk mount(8) CVEs, so remove
+# the SUID entry points from the runtime image.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libpq-dev \
     curl \
     ca-certificates \
+    && chmod u-s /usr/bin/mount /usr/bin/umount \
     && rm -rf /var/lib/apt/lists/*
 
 # Remove Tailwind & DaisyUI build; using CDN links instead


### PR DESCRIPTION
## Summary
- remove SUID bits from `/usr/bin/mount` and `/usr/bin/umount` in the backend runtime image
- document why this is needed for current Snyk util-linux/mount alerts with no Debian 13 package remediation yet

## Rationale
Snyk reported new util-linux/mount vulnerabilities for `backend/Dockerfile`. The backend container does not need privileged mount helpers, so removing these SUID entry points reduces the local privilege-escalation exposure while Debian/Snyk do not yet offer a fixed Debian 13 util-linux package.

## Validation
- Not run locally: Docker is not installed in this Codex environment.
