### PR TITLE
Add RFC 9991 failure report metadata

### DIFF
--- a/backend/app/services/forensic_analysis.py
+++ b/backend/app/services/forensic_analysis.py
@@ -150,6 +150,19 @@ def _signals(
     identity_alignment = _clean_value(feedback_headers.get("identity_alignment"))
     if identity_alignment:
         signals.append(f"Identity alignment: {identity_alignment}")
+    dkim_identity = _clean_value(feedback_headers.get("dkim_identity"))
+    if dkim_identity:
+        signals.append(f"DKIM identity: {dkim_identity}")
+    dkim_selector = _clean_value(feedback_headers.get("dkim_selector"))
+    if dkim_selector:
+        signals.append(f"DKIM selector: {dkim_selector}")
+    spf_dns = _clean_value(feedback_headers.get("spf_dns"))
+    if spf_dns:
+        signals.append(f"SPF DNS: {spf_dns}")
+    if feedback_headers.get("dkim_canonicalized_header_present"):
+        signals.append("DKIM canonicalized header was supplied but not stored")
+    if feedback_headers.get("dkim_canonicalized_body_present"):
+        signals.append("DKIM canonicalized body was supplied but not stored")
     for mechanism, result in sorted(auth_results.items()):
         signals.append(f"{mechanism.upper()} result: {result}")
     return signals

--- a/backend/app/services/forensic_analysis.py
+++ b/backend/app/services/forensic_analysis.py
@@ -147,6 +147,14 @@ def _signals(
         signals.append(f"DKIM header domain: {header_domain}")
     if mailfrom_domain:
         signals.append(f"SPF mail-from domain: {mailfrom_domain}")
+    signals.extend(_rfc9991_feedback_signals(feedback_headers))
+    for mechanism, result in sorted(auth_results.items()):
+        signals.append(f"{mechanism.upper()} result: {result}")
+    return signals
+
+
+def _rfc9991_feedback_signals(feedback_headers: Dict[str, Any]) -> List[str]:
+    signals = []
     identity_alignment = _clean_value(feedback_headers.get("identity_alignment"))
     if identity_alignment:
         signals.append(f"Identity alignment: {identity_alignment}")
@@ -163,8 +171,6 @@ def _signals(
         signals.append("DKIM canonicalized header was supplied but not stored")
     if feedback_headers.get("dkim_canonicalized_body_present"):
         signals.append("DKIM canonicalized body was supplied but not stored")
-    for mechanism, result in sorted(auth_results.items()):
-        signals.append(f"{mechanism.upper()} result: {result}")
     return signals
 
 

--- a/backend/app/services/forensic_parser.py
+++ b/backend/app/services/forensic_parser.py
@@ -109,6 +109,37 @@ def _message_id_hash(value: str) -> str:
     return hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:24]
 
 
+def _feedback_detail_headers(
+    feedback: Message,
+    *,
+    redaction_policy: Optional[ForensicRedactionPolicy] = None,
+) -> Dict[str, Any]:
+    """Return RFC 9991 ARF metadata without retaining message body content."""
+    details = {
+        "identity_alignment": _header(feedback, "Identity-Alignment", redact=False),
+        "dkim_domain": _header(feedback, "DKIM-Domain", redact=False),
+        "dkim_identity": _header(
+            feedback,
+            "DKIM-Identity",
+            redaction_policy=redaction_policy,
+        ),
+        "dkim_selector": _header(feedback, "DKIM-Selector", redact=False),
+        "spf_dns": _header(feedback, "SPF-DNS", redact=False),
+        "reported_uri": _header(
+            feedback,
+            "Reported-URI",
+            redaction_policy=redaction_policy,
+        ),
+    }
+
+    if _header(feedback, "DKIM-Canonicalized-Header", redact=False):
+        details["dkim_canonicalized_header_present"] = True
+    if _header(feedback, "DKIM-Canonicalized-Body", redact=False):
+        details["dkim_canonicalized_body_present"] = True
+
+    return {key: value for key, value in details.items() if value}
+
+
 class ForensicParser:
     """Parse DMARC forensic/failure report emails without retaining message bodies."""
 
@@ -187,17 +218,7 @@ class ForensicParser:
         source_email = _header(msg, "From", redaction_policy=redaction_policy)
         arrival_date = _parse_datetime(_header(feedback, "Arrival-Date", redact=False))
 
-        details = {
-            "identity_alignment": _header(feedback, "Identity-Alignment", redact=False),
-            "dkim_domain": _header(feedback, "DKIM-Domain", redact=False),
-            "spf_dns": _header(feedback, "SPF-DNS", redact=False),
-            "reported_uri": _header(
-                feedback,
-                "Reported-URI",
-                redaction_policy=redaction_policy,
-            ),
-        }
-        details = {key: value for key, value in details.items() if value}
+        details = _feedback_detail_headers(feedback, redaction_policy=redaction_policy)
 
         return {
             "report_id": report_id,

--- a/backend/app/tests/test_forensic_parser.py
+++ b/backend/app/tests/test_forensic_parser.py
@@ -1,4 +1,5 @@
 import email
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -76,6 +77,71 @@ def test_parse_forensic_email_redacts_and_extracts_failure_fields():
     assert "[redacted-token]" in parsed["original_subject"]
     assert parsed["original_message_id"]
     assert "original-message@example.com" not in parsed["original_message_id"]
+
+
+def test_parse_rfc9991_failure_report_metadata_without_storing_bodies():
+    content = b"""\
+From: DMARC Reporter <dmarc-reports@example.net>
+To: postmaster@example.com
+Subject: DMARC Failure Report for example.com
+Message-ID: <rfc9991-report@example.net>
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=feedback-report; boundary="ruf-boundary"
+
+--ruf-boundary
+Content-Type: text/plain; charset=utf-8
+
+This is a DMARC failure report.
+
+--ruf-boundary
+Content-Type: message/feedback-report
+
+Feedback-Type: auth-failure
+User-Agent: RFC9991 Reporter
+Version: 1
+Original-Mail-From: sender@example.com
+Arrival-Date: Fri, 22 May 2026 10:15:00 +0000
+Source-IP: 203.0.113.8
+Reported-Domain: example.com
+Authentication-Results: mx.example.net; dkim=fail header.d=example.com; spf=pass smtp.mailfrom=example.com; dmarc=fail
+Auth-Failure: dmarc
+Identity-Alignment: dkim
+Delivery-Result: reject
+DKIM-Domain: example.com
+DKIM-Identity: alice@example.com
+DKIM-Selector: mail2026
+DKIM-Canonicalized-Header: from:Alice <alice@example.com>
+DKIM-Canonicalized-Body: sensitive message body
+SPF-DNS: v=spf1 include:_spf.example.com -all
+Reported-URI: mailto:ruf@example.com
+
+--ruf-boundary
+Content-Type: text/rfc822-headers
+
+From: Alice Sender <alice@example.com>
+To: Bob Receiver <bob@example.net>
+Subject: Failed signed mail
+Message-ID: <original-message@example.com>
+Date: Fri, 22 May 2026 10:14:55 +0000
+
+--ruf-boundary--
+"""
+
+    parsed = ForensicParser.parse_bytes(content)
+    details = json.loads(parsed["feedback_headers"])
+
+    assert parsed["auth_failure"] == "dmarc"
+    assert parsed["reported_domain"] == "example.com"
+    assert details["identity_alignment"] == "dkim"
+    assert details["dkim_domain"] == "example.com"
+    assert details["dkim_identity"] == "al***@example.com"
+    assert details["dkim_selector"] == "mail2026"
+    assert details["spf_dns"] == "v=spf1 include:_spf.example.com -all"
+    assert details["reported_uri"] == "mailto:ru***@example.com"
+    assert details["dkim_canonicalized_header_present"] is True
+    assert details["dkim_canonicalized_body_present"] is True
+    assert "sensitive message body" not in parsed["feedback_headers"]
+    assert "from:Alice" not in parsed["feedback_headers"]
 
 
 def test_parse_forensic_email_supports_stricter_redaction_policies():

--- a/backend/app/tests/test_forensics_api.py
+++ b/backend/app/tests/test_forensics_api.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
@@ -104,6 +106,15 @@ def test_forensic_analysis_groups_failure_samples(authed_client, db_session):
                 "mx.example.net; dkim=pass header.d=example.com; "
                 "spf=fail smtp.mailfrom=example.com; dmarc=fail"
             ),
+            "feedback_headers": json.dumps(
+                {
+                    "identity_alignment": "spf",
+                    "dkim_identity": "al***@example.com",
+                    "dkim_selector": "mail2026",
+                    "spf_dns": "v=spf1 include:_spf.example.com -all",
+                    "dkim_canonicalized_body_present": True,
+                }
+            ),
         }
     )
     save_forensic_report(db_session, dkim)
@@ -121,6 +132,11 @@ def test_forensic_analysis_groups_failure_samples(authed_client, db_session):
     assert data["groups"][0]["priority"] == "high"
     assert "redacted headers and metadata only" in data["samples"][0]["privacy_note"]
     assert any("SPF" in action for action in data["samples"][0]["recommendations"])
+    signals = [signal for sample in data["samples"] for signal in sample["signals"]]
+    assert "Identity alignment: spf" in signals
+    assert "DKIM selector: mail2026" in signals
+    assert "SPF DNS: v=spf1 include:_spf.example.com -all" in signals
+    assert "DKIM canonicalized body was supplied but not stored" in signals
 
 
 def test_forensic_report_responses_include_sample_analysis(authed_client):

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -190,11 +190,13 @@ Delivered:
 - Add parser compatibility for RFC 9990-style aggregate report namespaces, version detection, policy metadata, identifiers, override reasons, auth-result details, and namespaced extensions.
 - Keep legacy RFC 7489-style reports backward compatible through fixture coverage.
 - Persist and CSV-export newly introduced aggregate metadata with nullable, backward-safe database fields.
+- Preserve RFC 9991 DMARC failure-report metadata in the forensic/RUF parser, including identity alignment, DKIM selector/identity, SPF DNS detail, and canonicalized-content presence flags without storing message bodies.
 - Add a fixture-driven compatibility pack covering parser, upload, IMAP, and Gmail import paths with supported-format documentation.
 - Verify domain report views and CSV exports render fixture-backed DMARCbis-style imports correctly.
 
 Exit criteria:
 - A DMARCbis-style aggregate report can be imported via upload/IMAP/Gmail and renders correctly in dashboards and exports.
+- A DMARCbis-style failure report can be imported via upload/mailbox paths and appears in forensic analysis with redacted RFC 9991 diagnostics.
 
 ## Milestone 12: Enterprise Mail Sources (Microsoft 365) and Connector Framework
 

--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -1,4 +1,4 @@
-# DMARC Aggregate Format Compatibility
+# DMARC Format Compatibility
 
 DMARQ imports DMARC aggregate reports from direct uploads, IMAP attachments, Gmail API attachments, and the Cloudflare Email Worker webhook. Compatibility is locked by the fixture pack in `backend/app/tests/fixtures/dmarc_aggregate`.
 
@@ -10,6 +10,16 @@ DMARQ imports DMARC aggregate reports from direct uploads, IMAP attachments, Gma
 - RFC 7489-compatible aggregate reports without XML namespaces.
 - Namespaced aggregate reports using `urn:ietf:params:xml:ns:dmarc-2.0`.
 - RFC 9990-style reports with optional metadata such as `version`, `generator`, `extra_contact_info`, repeated `error` values, `np`, `fo`, `testing`, `discovery_method`, `envelope_to`, policy override reasons, `human_result`, SPF `scope`, and namespaced extension elements.
+
+## Supported Failure Report Inputs
+
+DMARQ consumes inbound DMARC failure reports through its forensic/RUF pipeline. This is RFC 9991 receiver-side support for operators who receive reports, not outbound generation of failure reports.
+
+- `multipart/report` messages with `report-type=feedback-report`.
+- ARF feedback parts using `message/feedback-report`.
+- Original-message metadata supplied as `text/rfc822-headers` or `message/rfc822`; message bodies are not stored.
+- RFC 9991 DMARC failure metadata including `Auth-Failure: dmarc`, `Identity-Alignment`, `Delivery-Result`, `DKIM-Domain`, `DKIM-Identity`, `DKIM-Selector`, `SPF-DNS`, and `Reported-URI`.
+- Canonicalized DKIM header/body fields are treated as sensitive content. DMARQ records presence flags for diagnostics but does not persist their values.
 
 ## Supported Policy Discovery
 
@@ -24,7 +34,7 @@ Live DNS checks parse DMARC policy records according to RFC 9989:
 
 ## Preserved Metadata
 
-Newer optional fields are parsed without changing the legacy response shape that existing screens use. When a database is configured, DMARQ also persists the optional report metadata, policy metadata, record identifiers, policy override reasons, and extension payloads so exports and future views can use them.
+Newer optional fields are parsed without changing the legacy response shape that existing screens use. When a database is configured, DMARQ also persists the optional aggregate report metadata, policy metadata, record identifiers, policy override reasons, extension payloads, and redacted failure-report diagnostics so exports and future views can use them.
 
 CSV exports include the most useful aggregate metadata for operators:
 
@@ -46,6 +56,7 @@ CSV exports include the most useful aggregate metadata for operators:
 - Reports with no `<record>` elements import with a zero-count summary.
 - Unsupported attachments are skipped by IMAP and Gmail import paths and recorded in import details when stats are available.
 - For duplicate detection, DMARQ uses the domain and `report_id` pair. Fixture report IDs must remain unique within a single test import run.
+- RFC 9991 describes report generation duties such as outbound rate limiting and external `ruf` destination verification for Mail Receivers. DMARQ currently implements report-consumer parsing and analysis, not report generation.
 
 ## Fixture Pack
 


### PR DESCRIPTION
## Summary
- preserve RFC 9991 DMARC failure-report metadata in the forensic/RUF parser
- surface identity alignment, DKIM identity/selector, SPF DNS, and canonicalized-content presence in forensic analysis signals
- document the current RFC 9989/9990/9991 support boundary and add targeted parser/API coverage

Refs #207.

## Validation
- `git diff --check`
- `.venv/bin/python -m py_compile backend/app/services/forensic_parser.py backend/app/services/forensic_analysis.py backend/app/tests/test_forensic_parser.py backend/app/tests/test_forensics_api.py`
- direct parser verification with dependency stubbing

Note: local pytest did not reach collection because the repo Python 3.14 venv repeatedly stalled while reading imports from site-packages. CI should provide the authoritative full test signal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for richer forensic failure-report metadata, including DKIM selector, DKIM identity, SPF DNS details, and flags for canonicalized header/body presence.
  * Expanded forensic analysis signals to surface more privacy-preserving indicators from incoming reports.

* **Bug Fixes**
  * Improved redaction handling so sensitive message content and canonicalized values are not stored, while still preserving useful diagnostic details.

* **Documentation**
  * Updated compatibility and milestone notes to reflect broader DMARC failure-report support and preserved metadata behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->