### PR TITLE
Add DMARC DNS lint findings

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -93,6 +93,8 @@ class DNSRecordResponse(BaseModel):
     dkimSelectors: List[str] = []
     cached: bool = False
     checkedAt: Optional[str] = None
+    dmarcWarnings: List[str] = []
+    dmarcSuggestions: List[str] = []
 
 
 class DNSHealthEvidence(BaseModel):
@@ -1064,6 +1066,8 @@ async def get_domains_summary(db: Session = Depends(get_db)):
                     if getattr(dns, "checked_at", None)
                     else None
                 ),
+                "dmarc_warnings": dns.dmarc_warnings,
+                "dmarc_suggestions": dns.dmarc_suggestions,
             }
         )
 
@@ -1283,6 +1287,8 @@ async def get_domain_dns_records(
         dkimSelectors=result.dkim_selectors,
         cached=cached,
         checkedAt=checked_at.isoformat(),
+        dmarcWarnings=result.dmarc_warnings,
+        dmarcSuggestions=result.dmarc_suggestions,
     )
 
 

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -44,6 +44,8 @@ def _result_from_json(value: str) -> DomainDNSResult:
         dmarc_policy_domain=data.get("dmarc_policy_domain"),
         dmarc_discovery_method=data.get("dmarc_discovery_method"),
         dmarc_tags=dict(data.get("dmarc_tags") or {}),
+        dmarc_warnings=list(data.get("dmarc_warnings") or []),
+        dmarc_suggestions=list(data.get("dmarc_suggestions") or []),
     )
 
 

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -95,6 +95,8 @@ class DomainDNSResult:
     dmarc_policy_domain: Optional[str] = None
     dmarc_discovery_method: Optional[str] = None
     dmarc_tags: Dict[str, str] = field(default_factory=dict)
+    dmarc_warnings: List[str] = field(default_factory=list)
+    dmarc_suggestions: List[str] = field(default_factory=list)
 
 
 def _normalize_dns_name(domain: str) -> str:
@@ -106,6 +108,21 @@ def _is_valid_dmarc_uri_list(value: str) -> bool:
     if not uris:
         return False
     return all(bool(urlparse(uri).scheme) for uri in uris)
+
+
+def _dmarc_uri_domains(value: Optional[str]) -> List[Tuple[str, str]]:
+    destinations: List[Tuple[str, str]] = []
+    for item in (value or "").split(","):
+        uri = item.strip()
+        if not uri:
+            continue
+        parsed = urlparse(uri)
+        mailbox = parsed.path.split("!", 1)[0]
+        if parsed.scheme.lower() != "mailto" or "@" not in mailbox:
+            destinations.append((uri, ""))
+            continue
+        destinations.append((uri, mailbox.rsplit("@", 1)[-1].strip(".").lower()))
+    return destinations
 
 
 def parse_dmarc_record_tags(dmarc_record: Optional[str]) -> Dict[str, str]:
@@ -190,6 +207,82 @@ def effective_dmarc_policy(tags: Dict[str, str]) -> Optional[str]:
     if tags.get("rua") and _is_valid_dmarc_uri_list(tags["rua"]):
         return "none"
     return None
+
+
+def _lint_dmarc_tags(
+    tags: Dict[str, str],
+    *,
+    checked_domain: str,
+    policy_domain: Optional[str],
+    discovery_method: Optional[str],
+) -> Tuple[List[str], List[str]]:
+    warnings: List[str] = []
+    suggestions: List[str] = []
+    if not tags:
+        return ["No valid DMARC policy record was discovered."], [
+            "Publish v=DMARC1 with p=none and a rua address before tightening policy."
+        ]
+
+    if discovery_method == "treewalk" and policy_domain:
+        suggestions.append(
+            f"DMARC policy for {checked_domain} is inherited from {policy_domain} via tree walk."
+        )
+    if not _valid_policy_value(tags.get("p")) and not tags.get("rua"):
+        warnings.append("DMARC record has neither a valid p tag nor a rua reporting URI.")
+    if not tags.get("rua"):
+        suggestions.append("Add rua=mailto:... so aggregate reports can reach DMARQ.")
+
+    for tag in ("p", "sp", "np"):
+        value = tags.get(tag)
+        if value and not _valid_policy_value(value):
+            warnings.append(f"DMARC {tag} tag uses unsupported policy value {value!r}.")
+    for tag in ("adkim", "aspf"):
+        value = (tags.get(tag) or "").lower()
+        if value and value not in {"r", "s"}:
+            warnings.append(f"DMARC {tag} tag should be r or s.")
+    for tag in ("psd", "t"):
+        value = (tags.get(tag) or "").lower()
+        if value and value not in {"y", "n"}:
+            warnings.append(f"DMARC {tag} tag should be y or n.")
+    fo = tags.get("fo")
+    if fo:
+        allowed = {"0", "1", "d", "s"}
+        invalid = [part for part in fo.split(":") if part not in allowed]
+        if invalid:
+            warnings.append("DMARC fo tag contains unsupported failure options.")
+
+    return warnings, suggestions
+
+
+async def _lint_external_reporting_destinations(
+    provider: "BaseDNSProvider",
+    tags: Dict[str, str],
+    *,
+    policy_domain: Optional[str],
+) -> List[str]:
+    if not policy_domain:
+        return []
+
+    warnings: List[str] = []
+    for tag in ("rua", "ruf"):
+        for uri, destination_domain in _dmarc_uri_domains(tags.get(tag)):
+            if not destination_domain:
+                warnings.append(f"DMARC {tag} URI {uri!r} is not a supported mailto URI.")
+                continue
+            if destination_domain == policy_domain:
+                continue
+
+            auth_name = f"{policy_domain}._report._dmarc.{destination_domain}"
+            try:
+                records = await provider.lookup_txt(auth_name)
+            except LookupError:
+                records = []
+            if not any(record.strip().lower().startswith("v=dmarc1") for record in records):
+                warnings.append(
+                    f"External {tag} destination {destination_domain} is missing "
+                    f"authorization TXT at {auth_name}."
+                )
+    return warnings
 
 
 class BaseDNSProvider(ABC):
@@ -323,6 +416,19 @@ class BaseDNSProvider(ABC):
         ) = await asyncio.gather(dmarc_coro, spf_coro, dkim_coro)
 
         dmarc_tags = dmarc_tags or {}
+        warnings, suggestions = _lint_dmarc_tags(
+            dmarc_tags,
+            checked_domain=_normalize_dns_name(domain),
+            policy_domain=dmarc_policy_domain,
+            discovery_method=dmarc_discovery_method,
+        )
+        warnings.extend(
+            await _lint_external_reporting_destinations(
+                self,
+                dmarc_tags,
+                policy_domain=dmarc_policy_domain,
+            )
+        )
         dmarc_policy = effective_dmarc_policy(dmarc_tags)
         if dmarc_policy:
             dmarc_tags = {**dmarc_tags, "p": dmarc_policy}
@@ -339,6 +445,8 @@ class BaseDNSProvider(ABC):
             dmarc_policy_domain=dmarc_policy_domain,
             dmarc_discovery_method=dmarc_discovery_method,
             dmarc_tags=dmarc_tags,
+            dmarc_warnings=warnings,
+            dmarc_suggestions=suggestions,
         )
 
 

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -232,26 +232,48 @@ def _lint_dmarc_tags(
     if not tags.get("rua"):
         suggestions.append("Add rua=mailto:... so aggregate reports can reach DMARQ.")
 
+    warnings.extend(_lint_policy_tags(tags))
+    warnings.extend(_lint_alignment_tags(tags))
+    warnings.extend(_lint_yes_no_tags(tags))
+    warnings.extend(_lint_failure_options(tags))
+    return warnings, suggestions
+
+
+def _lint_policy_tags(tags: Dict[str, str]) -> List[str]:
+    warnings: List[str] = []
     for tag in ("p", "sp", "np"):
         value = tags.get(tag)
         if value and not _valid_policy_value(value):
             warnings.append(f"DMARC {tag} tag uses unsupported policy value {value!r}.")
+    return warnings
+
+
+def _lint_alignment_tags(tags: Dict[str, str]) -> List[str]:
+    warnings: List[str] = []
     for tag in ("adkim", "aspf"):
         value = (tags.get(tag) or "").lower()
         if value and value not in {"r", "s"}:
             warnings.append(f"DMARC {tag} tag should be r or s.")
+    return warnings
+
+
+def _lint_yes_no_tags(tags: Dict[str, str]) -> List[str]:
+    warnings: List[str] = []
     for tag in ("psd", "t"):
         value = (tags.get(tag) or "").lower()
         if value and value not in {"y", "n"}:
             warnings.append(f"DMARC {tag} tag should be y or n.")
+    return warnings
+
+
+def _lint_failure_options(tags: Dict[str, str]) -> List[str]:
     fo = tags.get("fo")
     if fo:
         allowed = {"0", "1", "d", "s"}
         invalid = [part for part in fo.split(":") if part not in allowed]
         if invalid:
-            warnings.append("DMARC fo tag contains unsupported failure options.")
-
-    return warnings, suggestions
+            return ["DMARC fo tag contains unsupported failure options."]
+    return []
 
 
 async def _lint_external_reporting_destinations(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -267,6 +267,26 @@ def test_dns_endpoint_returns_real_data(client: TestClient):
     assert data["checkedAt"] is not None
 
 
+def test_dns_endpoint_returns_dmarc_lint_findings(client: TestClient):
+    result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@reports.example.net",
+        spf=True,
+        spf_record="v=spf1 include:_spf.example.com -all",
+        dkim=False,
+        dmarc_warnings=["External rua destination reports.example.net is missing authorization."],
+        dmarc_suggestions=["Policy is monitoring-only."],
+    )
+
+    with _mock_dns(result):
+        response = client.get(f"/api/v1/domains/{DOMAIN}/dns")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dmarcWarnings"] == result.dmarc_warnings
+    assert data["dmarcSuggestions"] == result.dmarc_suggestions
+
+
 def test_dns_endpoint_uses_cached_result(client: TestClient, db_session):
     """Repeated DNS checks reuse a fresh cached result."""
     mock_provider = AsyncMock(check_domain=AsyncMock(return_value=MOCK_DNS_RESULT))

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -109,6 +109,49 @@ def test_parse_dmarc_record_tags_tracks_active_dmarcbis_tags_only():
     }
 
 
+@pytest.mark.asyncio
+async def test_check_domain_lints_external_report_destination_without_authorization():
+    provider = FakeDNSProvider(
+        {
+            "_dmarc.example.com": [
+                "v=DMARC1; p=none; rua=mailto:dmarc@reports.example.net!50m"
+            ],
+            "example.com": ["v=spf1 include:_spf.example.com -all"],
+        }
+    )
+
+    result = await provider.check_domain("example.com", selectors=[])
+
+    assert any("reports.example.net" in item for item in result.dmarc_warnings)
+    assert any("authorization TXT" in item for item in result.dmarc_warnings)
+
+
+@pytest.mark.asyncio
+async def test_check_domain_accepts_authorized_external_report_destination():
+    provider = FakeDNSProvider(
+        {
+            "_dmarc.example.com": [
+                "v=DMARC1; p=none; rua=mailto:dmarc@reports.example.net"
+            ],
+            "example.com": ["v=spf1 include:_spf.example.com -all"],
+            "example.com._report._dmarc.reports.example.net": ["v=DMARC1"],
+        }
+    )
+
+    result = await provider.check_domain("example.com", selectors=[])
+
+    assert result.dmarc_warnings == []
+
+
+@pytest.mark.asyncio
+async def test_check_domain_lints_missing_aggregate_reporting_uri():
+    provider = FakeDNSProvider({"_dmarc.example.com": ["v=DMARC1; p=reject"]})
+
+    result = await provider.check_domain("example.com", selectors=[])
+
+    assert "Add rua=mailto:..." in result.dmarc_suggestions[0]
+
+
 # ---------------------------------------------------------------------------
 # BaseDNSProvider helpers via FakeDNSProvider
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -122,8 +122,10 @@ async def test_check_domain_lints_external_report_destination_without_authorizat
 
     result = await provider.check_domain("example.com", selectors=[])
 
-    assert any("reports.example.net" in item for item in result.dmarc_warnings)
-    assert any("authorization TXT" in item for item in result.dmarc_warnings)
+    assert result.dmarc_warnings == [
+        "External rua destination reports.example.net is missing authorization TXT at "
+        "example.com._report._dmarc.reports.example.net."
+    ]
 
 
 @pytest.mark.asyncio

--- a/docs/development/dmarc-scope-open-items.md
+++ b/docs/development/dmarc-scope-open-items.md
@@ -1,0 +1,24 @@
+# DMARC Scope Open Items
+
+DMARQ's DMARC scope is report parsing, report analysis, DNS configuration guidance,
+and DNS linting. DMARQ does not act as a Mail Receiver and should not implement
+DMARC message enforcement or outbound aggregate/failure report generation.
+
+## In Scope
+
+- [x] Parse RFC 9989 policy records and discover effective DMARC policy with DNS Tree Walk.
+- [x] Parse RFC 9990 aggregate reports while preserving useful optional metadata.
+- [x] Parse inbound RFC 9991 failure reports without retaining message bodies.
+- [x] Lint external `rua` / `ruf` destinations for required DNS authorization records.
+- [ ] Add a first-class DNS lint endpoint with typed findings and stable machine-readable codes.
+- [ ] Add DNS-setting generation helpers for DMARC, SPF include/all choices, DKIM selector checks, MTA-STS, TLS-RPT, and BIMI readiness.
+- [ ] Add UI sections that show lint findings next to the current DNS records and suggested target records.
+- [ ] Add bulk domain linting and export for managed-domain reviews.
+- [ ] Expand fixture coverage with real-world DMARCbis aggregate/failure samples from more report generators.
+
+## Out of Scope
+
+- Mail Receiver-side DMARC enforcement.
+- Outbound DMARC aggregate report generation.
+- Outbound DMARC failure report generation.
+- Receiver-side failure-report rate limiting.

--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -31,6 +31,7 @@ Live DNS checks parse DMARC policy records according to RFC 9989:
 - Historic tags such as `pct`, `rf`, and `ri` are not treated as active DMARCbis policy tags.
 - Subdomain checks fall back to the bounded RFC 9989 DNS Tree Walk, including `psd=n` and `psd=y` stop conditions.
 - Records with a valid aggregate reporting URI but no valid `p` tag are treated as monitoring mode for policy extraction.
+- External `rua` and `ruf` destinations are linted for the required DNS authorization TXT record at `<policy-domain>._report._dmarc.<destination-domain>`.
 
 ## Preserved Metadata
 
@@ -57,6 +58,7 @@ CSV exports include the most useful aggregate metadata for operators:
 - Unsupported attachments are skipped by IMAP and Gmail import paths and recorded in import details when stats are available.
 - For duplicate detection, DMARQ uses the domain and `report_id` pair. Fixture report IDs must remain unique within a single test import run.
 - RFC 9991 describes report generation duties such as outbound rate limiting and external `ruf` destination verification for Mail Receivers. DMARQ currently implements report-consumer parsing and analysis, not report generation.
+- The product-scope backlog for parser, analyzer, DNS guidance, and DNS linting work is tracked in `docs/development/dmarc-scope-open-items.md`.
 
 ## Fixture Pack
 


### PR DESCRIPTION
## Summary
- add DMARC DNS lint warnings/suggestions to DNS resolver results and the domain DNS API
- lint external rua/ruf destinations for required authorization TXT records
- document DMARQ's scoped parser/analyzer/DNS-lint backlog and explicitly exclude mail-receiver behavior

## Validation
- `git diff --check`
- `.venv/bin/python -m py_compile backend/app/services/dns_resolver.py backend/app/services/dns_cache.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_dns_endpoints.py`
- direct DNS lint verification with Python 3.12

Note: local Black/isort under the repo Python 3.14 venv stalled while importing packages from site-packages, matching the earlier local venv issue. CI should provide the authoritative formatter/lint signal.
