### PR TITLE
Add typed DNS guidance endpoints

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3,6 +3,7 @@ import csv
 import io
 import ipaddress
 import logging
+from dataclasses import asdict
 from datetime import date, datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -25,6 +26,7 @@ from app.services.cloudflare_dns import (
     sync_dns_record_changes,
 )
 from app.services.dns_cache import resolve_domain_dns_cached
+from app.services.dns_guidance import build_dns_guidance
 from app.services.dns_resolver import (
     DomainDNSResult,
     extract_dmarc_policy,
@@ -95,6 +97,57 @@ class DNSRecordResponse(BaseModel):
     checkedAt: Optional[str] = None
     dmarcWarnings: List[str] = []
     dmarcSuggestions: List[str] = []
+
+
+class DNSGuidanceRecordResponse(BaseModel):
+    """Suggested DNS record for setup or repair."""
+
+    code: str
+    record_type: str
+    name: str
+    value: str
+    purpose: str
+    priority: str = "recommended"
+
+
+class DNSLintFindingResponse(BaseModel):
+    """Machine-readable DNS lint finding."""
+
+    code: str
+    severity: str
+    title: str
+    detail: str
+    action: str
+    record_type: str
+    record_name: str
+    target_record: Optional[DNSGuidanceRecordResponse] = None
+    evidence: List[str] = Field(default_factory=list)
+
+
+class DNSGuidanceResponse(BaseModel):
+    """Typed DNS lint and setup guidance for one domain."""
+
+    domain: str
+    status: str
+    findings: List[DNSLintFindingResponse]
+    target_records: List[DNSGuidanceRecordResponse]
+
+
+class DNSBulkGuidanceItem(BaseModel):
+    """Bulk DNS lint summary for one domain."""
+
+    domain: str
+    status: str
+    finding_count: int
+    highest_severity: str
+    findings: List[DNSLintFindingResponse]
+    target_records: List[DNSGuidanceRecordResponse]
+
+
+class DNSBulkGuidanceResponse(BaseModel):
+    """Bulk DNS lint response for monitored domains."""
+
+    domains: List[DNSBulkGuidanceItem]
 
 
 class DNSHealthEvidence(BaseModel):
@@ -803,6 +856,58 @@ async def _build_domain_dns_health(  # pylint: disable=too-many-locals
     )
 
 
+async def _build_domain_dns_guidance(
+    db: Session,
+    store: ReportStore,
+    domain_id: str,
+    *,
+    refresh: bool = False,
+) -> Dict[str, Any]:
+    """Build typed DNS lint findings and target records for a monitored domain."""
+    manual_selectors = _get_domain_selectors_from_db(db, domain_id)
+    report_selectors = _get_selectors_from_reports(store, domain_id)
+    combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
+
+    provider = get_default_provider(db)
+    dns_result, _, _ = await resolve_domain_dns_cached(
+        db,
+        provider,
+        domain_id,
+        selectors=combined_selectors,
+        refresh=refresh,
+    )
+    mta_sts_result, _, _ = await check_mta_sts_cached(
+        db,
+        provider,
+        domain_id,
+        refresh=refresh,
+    )
+    bimi_result, _, _ = await check_bimi_cached(
+        db,
+        provider,
+        domain_id,
+        refresh=refresh,
+    )
+    guidance = await build_dns_guidance(
+        domain_id,
+        provider,
+        dns_result,
+        mta_sts_result,
+        bimi_result,
+    )
+    return asdict(guidance)
+
+
+def _highest_severity(findings: List[Dict[str, Any]]) -> str:
+    order = {"error": 3, "warning": 2, "info": 1}
+    highest = "info"
+    for finding in findings:
+        severity = str(finding.get("severity") or "info")
+        if order.get(severity, 0) > order.get(highest, 0):
+            highest = severity
+    return highest
+
+
 def _coverage_href(check: DNSHealthCheck) -> str:
     if check.evidence:
         return check.evidence[0].href
@@ -1206,6 +1311,89 @@ async def read_domain(domain_name: str, db: Session = Depends(get_db)):
     )
 
 
+@router.get("/dns/lint", response_model=DNSBulkGuidanceResponse)
+async def lint_all_domain_dns(
+    refresh: bool = Query(False, title="Refresh cached DNS results"),
+    limit: int = Query(100, ge=1, le=500, title="Maximum domains to lint"),
+    db: Session = Depends(get_db),
+):
+    """Return typed DNS lint findings and target records for monitored domains."""
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store)
+    workspace = assign_default_workspace_to_unscoped_rows(db)
+    domains = _domain_names_for_summary(db, store, workspace)[:limit]
+
+    items: List[DNSBulkGuidanceItem] = []
+    for domain_name in domains:
+        guidance = await _build_domain_dns_guidance(db, store, domain_name, refresh=refresh)
+        findings = guidance["findings"]
+        items.append(
+            DNSBulkGuidanceItem(
+                domain=domain_name,
+                status=guidance["status"],
+                finding_count=len(findings),
+                highest_severity=_highest_severity(findings),
+                findings=findings,
+                target_records=guidance["target_records"],
+            )
+        )
+    return DNSBulkGuidanceResponse(domains=items)
+
+
+@router.get("/dns/lint/export")
+async def export_all_domain_dns_lint(
+    refresh: bool = Query(False, title="Refresh cached DNS results"),
+    limit: int = Query(500, ge=1, le=1000, title="Maximum domains to export"),
+    db: Session = Depends(get_db),
+):
+    """Export typed DNS lint findings for monitored domains as CSV."""
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store)
+    workspace = assign_default_workspace_to_unscoped_rows(db)
+    domains = _domain_names_for_summary(db, store, workspace)[:limit]
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(
+        [
+            "domain",
+            "status",
+            "severity",
+            "code",
+            "record_type",
+            "record_name",
+            "title",
+            "detail",
+            "action",
+            "target_value",
+        ]
+    )
+    for domain_name in domains:
+        guidance = await _build_domain_dns_guidance(db, store, domain_name, refresh=refresh)
+        for finding in guidance["findings"]:
+            target = finding.get("target_record") or {}
+            writer.writerow(
+                [
+                    domain_name,
+                    guidance["status"],
+                    finding.get("severity", ""),
+                    finding.get("code", ""),
+                    finding.get("record_type", ""),
+                    finding.get("record_name", ""),
+                    finding.get("title", ""),
+                    finding.get("detail", ""),
+                    finding.get("action", ""),
+                    target.get("value", ""),
+                ]
+            )
+
+    return Response(
+        content=output.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="dmarq-dns-lint.csv"'},
+    )
+
+
 # New endpoints for domain details page
 
 
@@ -1290,6 +1478,26 @@ async def get_domain_dns_records(
         dmarcWarnings=result.dmarc_warnings,
         dmarcSuggestions=result.dmarc_suggestions,
     )
+
+
+@router.get("/{domain_id}/dns/lint", response_model=DNSGuidanceResponse)
+async def get_domain_dns_lint(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS result"),
+    db: Session = Depends(get_db),
+):
+    """Return typed DNS lint findings and target records for one monitored domain."""
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store)
+    workspace = assign_default_workspace_to_unscoped_rows(db)
+
+    if not _domain_exists(db, store, domain_id, workspace):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Domain not found",
+        )
+
+    return await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
 
 
 @router.get("/{domain_id}/dns/health", response_model=DNSHealthResponse)

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -1,0 +1,506 @@
+"""Typed DNS lint and configuration guidance for monitored domains."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from app.services.bimi import BIMIResult
+from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult, extract_dmarc_policy
+from app.services.mta_sts import MTAStsResult
+
+
+@dataclass
+class DNSGuidanceRecord:
+    """Suggested DNS record shape for an operator to publish or review."""
+
+    code: str
+    record_type: str
+    name: str
+    value: str
+    purpose: str
+    priority: str = "recommended"
+
+
+@dataclass
+class DNSLintFinding:
+    """Stable machine-readable lint finding."""
+
+    code: str
+    severity: str
+    title: str
+    detail: str
+    action: str
+    record_type: str
+    record_name: str
+    target_record: Optional[DNSGuidanceRecord] = None
+    evidence: List[str] = field(default_factory=list)
+
+
+@dataclass
+class DNSGuidanceResult:
+    """Complete DNS lint and setup guidance payload for one domain."""
+
+    domain: str
+    status: str
+    findings: List[DNSLintFinding]
+    target_records: List[DNSGuidanceRecord]
+
+
+def _today_id() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d")
+
+
+def _target_records(domain: str, result: DomainDNSResult) -> List[DNSGuidanceRecord]:
+    dmarc_value = result.dmarc_record or (
+        f"v=DMARC1; p=none; rua=mailto:dmarc@{domain}; adkim=r; aspf=r"
+    )
+    spf_value = result.spf_record or "v=spf1 -all"
+    dkim_selector = (result.dkim_selectors or result.selectors_checked or ["selector1"])[0]
+    return [
+        DNSGuidanceRecord(
+            code="target_dmarc",
+            record_type="TXT",
+            name=f"_dmarc.{domain}",
+            value=dmarc_value,
+            purpose="DMARC policy discovery and aggregate report delivery.",
+        ),
+        DNSGuidanceRecord(
+            code="target_spf",
+            record_type="TXT",
+            name=domain,
+            value=spf_value,
+            purpose=(
+                "SPF sender authorization. Use -all for domains with no authorized "
+                "senders, or replace with include/ip mechanisms for real senders."
+            ),
+        ),
+        DNSGuidanceRecord(
+            code="target_dkim",
+            record_type="TXT",
+            name=f"{dkim_selector}._domainkey.{domain}",
+            value="v=DKIM1; k=rsa; p=<provider-public-key>",
+            purpose="DKIM selector public key published by the sending provider.",
+        ),
+        DNSGuidanceRecord(
+            code="target_mta_sts",
+            record_type="TXT",
+            name=f"_mta-sts.{domain}",
+            value=f"v=STSv1; id={_today_id()}",
+            purpose=(
+                "MTA-STS policy discovery. Host the matching HTTPS policy at "
+                f"https://mta-sts.{domain}/.well-known/mta-sts.txt."
+            ),
+        ),
+        DNSGuidanceRecord(
+            code="target_tls_rpt",
+            record_type="TXT",
+            name=f"_smtp._tls.{domain}",
+            value=f"v=TLSRPTv1; rua=mailto:tlsrpt@{domain}",
+            purpose="SMTP TLS Reporting aggregate delivery.",
+        ),
+        DNSGuidanceRecord(
+            code="target_bimi",
+            record_type="TXT",
+            name=f"default._bimi.{domain}",
+            value=f"v=BIMI1; l=https://{domain}/.well-known/bimi.svg; a=",
+            purpose="BIMI logo discovery after DMARC enforcement is ready.",
+            priority="optional",
+        ),
+    ]
+
+
+def _target_by_code(records: List[DNSGuidanceRecord], code: str) -> DNSGuidanceRecord:
+    return next(record for record in records if record.code == code)
+
+
+def _finding(
+    code: str,
+    severity: str,
+    title: str,
+    detail: str,
+    action: str,
+    record_type: str,
+    record_name: str,
+    *,
+    target_record: Optional[DNSGuidanceRecord] = None,
+    evidence: Optional[List[str]] = None,
+) -> DNSLintFinding:
+    return DNSLintFinding(
+        code=code,
+        severity=severity,
+        title=title,
+        detail=detail,
+        action=action,
+        record_type=record_type,
+        record_name=record_name,
+        target_record=target_record,
+        evidence=list(evidence or []),
+    )
+
+
+def _classify_dmarc_warning(message: str) -> str:
+    lowered = message.lower()
+    if "external rua destination" in lowered:
+        return "dmarc_external_rua_unauthorized"
+    if "external ruf destination" in lowered:
+        return "dmarc_external_ruf_unauthorized"
+    if "unsupported policy value" in lowered:
+        return "dmarc_policy_value_invalid"
+    if "adkim" in lowered or "aspf" in lowered:
+        return "dmarc_alignment_value_invalid"
+    if "fo tag" in lowered:
+        return "dmarc_failure_option_invalid"
+    if "neither a valid p tag nor a rua" in lowered:
+        return "dmarc_policy_or_reporting_missing"
+    return "dmarc_lint_warning"
+
+
+def _dmarc_findings(
+    domain: str, result: DomainDNSResult, targets: List[DNSGuidanceRecord]
+) -> List[DNSLintFinding]:
+    findings: List[DNSLintFinding] = []
+    target = _target_by_code(targets, "target_dmarc")
+    if not result.dmarc:
+        findings.append(
+            _finding(
+                "dmarc_missing",
+                "error",
+                "DMARC record is missing",
+                "No valid DMARC policy record was discovered for this domain.",
+                "Publish a DMARC TXT record in monitoring mode before tightening policy.",
+                "TXT",
+                target.name,
+                target_record=target,
+            )
+        )
+    for warning in result.dmarc_warnings:
+        findings.append(
+            _finding(
+                _classify_dmarc_warning(warning),
+                "warning",
+                "DMARC record needs review",
+                warning,
+                "Repair the DMARC tag or supporting authorization record, then refresh lint.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=[result.dmarc_record or ""],
+            )
+        )
+    for suggestion in result.dmarc_suggestions:
+        findings.append(
+            _finding(
+                "dmarc_suggestion",
+                "info",
+                "DMARC setup can be improved",
+                suggestion,
+                "Review the suggested DMARC target record.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=[result.dmarc_record or ""],
+            )
+        )
+    if extract_dmarc_policy(result.dmarc_record) == "none":
+        findings.append(
+            _finding(
+                "dmarc_monitoring_policy",
+                "info",
+                "DMARC is in monitoring mode",
+                "The current policy is p=none.",
+                "Use report evidence before planning quarantine or reject.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=[result.dmarc_record or ""],
+            )
+        )
+    return findings
+
+
+def _spf_terms(record: Optional[str]) -> List[str]:
+    if not record:
+        return []
+    return [part.strip() for part in record.split() if part.strip()]
+
+
+async def _spf_findings(
+    domain: str,
+    provider: BaseDNSProvider,
+    result: DomainDNSResult,
+    targets: List[DNSGuidanceRecord],
+) -> List[DNSLintFinding]:
+    findings: List[DNSLintFinding] = []
+    target = _target_by_code(targets, "target_spf")
+    if not result.spf:
+        return [
+            _finding(
+                "spf_missing",
+                "warning",
+                "SPF record is missing",
+                "No SPF TXT record was found at the domain root.",
+                "Publish one SPF TXT record that matches the domain's authorized senders.",
+                "TXT",
+                target.name,
+                target_record=target,
+            )
+        ]
+
+    try:
+        root_records = await provider.lookup_txt(domain)
+    except LookupError:
+        root_records = []
+    spf_records = [record for record in root_records if record.lower().startswith("v=spf1")]
+    if len(spf_records) > 1:
+        findings.append(
+            _finding(
+                "spf_multiple_records",
+                "error",
+                "Multiple SPF records found",
+                "SPF requires exactly one SPF TXT record at the domain root.",
+                "Merge the mechanisms into a single v=spf1 record.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=spf_records,
+            )
+        )
+
+    terms = _spf_terms(result.spf_record)
+    all_terms = [term for term in terms if term.endswith("all")]
+    if not all_terms:
+        findings.append(
+            _finding(
+                "spf_all_missing",
+                "warning",
+                "SPF all mechanism is missing",
+                "The SPF record does not end with an explicit all policy.",
+                "Choose -all after authorizing all senders, or ~all while still validating.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=[result.spf_record or ""],
+            )
+        )
+    elif all_terms[-1].startswith("+") or all_terms[-1] == "all":
+        findings.append(
+            _finding(
+                "spf_all_too_permissive",
+                "error",
+                "SPF all mechanism is too permissive",
+                f"The SPF record uses {all_terms[-1]}, which authorizes every sender.",
+                "Replace +all with ~all during rollout or -all once sender coverage is complete.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=[result.spf_record or ""],
+            )
+        )
+    elif all_terms[-1].startswith("?"):
+        findings.append(
+            _finding(
+                "spf_all_neutral",
+                "warning",
+                "SPF all mechanism is neutral",
+                "The SPF record ends with ?all, which provides weak sender guidance.",
+                "Use ~all while validating or -all after all senders are authorized.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=[result.spf_record or ""],
+            )
+        )
+
+    dns_lookup_terms = [
+        term
+        for term in terms
+        if term.startswith(("include:", "a", "mx", "ptr", "exists:", "redirect="))
+    ]
+    if len(dns_lookup_terms) > 10:
+        findings.append(
+            _finding(
+                "spf_dns_lookup_limit_risk",
+                "warning",
+                "SPF DNS lookup budget may be exceeded",
+                "The SPF record has more than 10 DNS-lookup mechanisms.",
+                "Flatten or remove unused mechanisms before publishing the final SPF record.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=[result.spf_record or ""],
+            )
+        )
+    return findings
+
+
+def _dkim_findings(
+    result: DomainDNSResult, targets: List[DNSGuidanceRecord]
+) -> List[DNSLintFinding]:
+    if result.dkim:
+        return []
+    target = _target_by_code(targets, "target_dkim")
+    checked = ", ".join(result.selectors_checked or [])
+    detail = "No DKIM selector resolved for configured, observed, or common selectors."
+    if checked:
+        detail = f"{detail} Checked selectors: {checked}."
+    return [
+        _finding(
+            "dkim_selector_missing",
+            "warning",
+            "DKIM selector is missing",
+            detail,
+            "Add the sending provider's selector in DMARQ and publish its DKIM TXT record.",
+            "TXT",
+            target.name,
+            target_record=target,
+        )
+    ]
+
+
+def _mta_sts_findings(
+    result: MTAStsResult, targets: List[DNSGuidanceRecord]
+) -> List[DNSLintFinding]:
+    if result.status == "pass" and not result.warnings:
+        return []
+    target = _target_by_code(targets, "target_mta_sts")
+    severity = "warning" if result.status == "pass" else "info"
+    detail = "; ".join(result.warnings or result.errors or ["MTA-STS is not configured."])
+    return [
+        _finding(
+            "mta_sts_review" if result.status == "pass" else "mta_sts_missing",
+            severity,
+            "MTA-STS setup needs review" if result.status == "pass" else "MTA-STS is not ready",
+            detail,
+            "Publish _mta-sts TXT and validate the HTTPS policy before enforcing.",
+            "TXT",
+            target.name,
+            target_record=target,
+            evidence=[result.dns_record or ""],
+        )
+    ]
+
+
+async def _tls_rpt_findings(
+    domain: str, provider: BaseDNSProvider, targets: List[DNSGuidanceRecord]
+) -> List[DNSLintFinding]:
+    target = _target_by_code(targets, "target_tls_rpt")
+    try:
+        records = await provider.lookup_txt(target.name)
+    except LookupError:
+        records = []
+    tls_rpt_records = [record for record in records if record.lower().startswith("v=tlsrptv1")]
+    if not tls_rpt_records:
+        return [
+            _finding(
+                "tls_rpt_missing",
+                "info",
+                "TLS-RPT record is missing",
+                "No SMTP TLS Reporting TXT record was found.",
+                "Publish a TLS-RPT record so DMARQ can ingest aggregate TLS delivery reports.",
+                "TXT",
+                target.name,
+                target_record=target,
+            )
+        ]
+    if len(tls_rpt_records) > 1:
+        return [
+            _finding(
+                "tls_rpt_multiple_records",
+                "warning",
+                "Multiple TLS-RPT records found",
+                "SMTP TLS Reporting expects one TXT record at _smtp._tls.",
+                "Merge TLS-RPT reporting URIs into one record.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=tls_rpt_records,
+            )
+        ]
+    if "rua=" not in tls_rpt_records[0].lower():
+        return [
+            _finding(
+                "tls_rpt_rua_missing",
+                "warning",
+                "TLS-RPT rua is missing",
+                "The TLS-RPT TXT record does not contain a reporting URI.",
+                "Add rua=mailto:... to deliver TLS reports to DMARQ.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=tls_rpt_records,
+            )
+        ]
+    return []
+
+
+def _bimi_findings(
+    result: BIMIResult, dmarc_policy: Optional[str], targets: List[DNSGuidanceRecord]
+) -> List[DNSLintFinding]:
+    target = _target_by_code(targets, "target_bimi")
+    findings: List[DNSLintFinding] = []
+    if dmarc_policy not in {"quarantine", "reject"}:
+        findings.append(
+            _finding(
+                "bimi_dmarc_not_enforced",
+                "info",
+                "BIMI is waiting on DMARC enforcement",
+                "BIMI readiness requires DMARC policy quarantine or reject.",
+                "Treat BIMI as optional until DMARC enforcement is stable.",
+                "TXT",
+                target.name,
+                target_record=target,
+            )
+        )
+    if result.status == "pass" and not result.warnings:
+        return findings
+    detail = "; ".join(result.warnings or result.errors or ["No BIMI record is published."])
+    findings.append(
+        _finding(
+            "bimi_review" if result.status == "pass" else "bimi_missing",
+            "info",
+            "BIMI setup needs review" if result.status == "pass" else "BIMI record is missing",
+            detail,
+            "Publish BIMI only after DMARC enforcement prerequisites are met.",
+            "TXT",
+            target.name,
+            target_record=target,
+            evidence=[result.dns_record or ""],
+        )
+    )
+    return findings
+
+
+def _status(findings: List[DNSLintFinding]) -> str:
+    severities = {finding.severity for finding in findings}
+    if "error" in severities:
+        return "critical"
+    if "warning" in severities:
+        return "attention"
+    return "ready"
+
+
+async def build_dns_guidance(
+    domain: str,
+    provider: BaseDNSProvider,
+    result: DomainDNSResult,
+    mta_sts: MTAStsResult,
+    bimi: BIMIResult,
+) -> DNSGuidanceResult:
+    """Build typed DNS lint findings and target records for a domain."""
+    normalized_domain = domain.strip().strip(".").lower()
+    targets = _target_records(normalized_domain, result)
+    findings: List[DNSLintFinding] = []
+    findings.extend(_dmarc_findings(normalized_domain, result, targets))
+    findings.extend(await _spf_findings(normalized_domain, provider, result, targets))
+    findings.extend(_dkim_findings(result, targets))
+    findings.extend(_mta_sts_findings(mta_sts, targets))
+    findings.extend(await _tls_rpt_findings(normalized_domain, provider, targets))
+    findings.extend(_bimi_findings(bimi, extract_dmarc_policy(result.dmarc_record), targets))
+    return DNSGuidanceResult(
+        domain=normalized_domain,
+        status=_status(findings),
+        findings=findings,
+        target_records=targets,
+    )

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -393,6 +393,76 @@
                         </div>
                         <p x-show="selectorError" x-text="selectorError" class="text-red-500 text-xs mt-1"></p>
                     </div>
+                    <div id="dns-guidance" class="border rounded-lg p-4">
+                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <h3 class="font-semibold">DNS Guidance</h3>
+                            <span class="inline-flex w-fit rounded px-2 py-1 text-xs font-semibold capitalize"
+                                  :class="dnsGuidanceStatusClass"
+                                  x-text="dnsGuidance.status || 'checking'"></span>
+                        </div>
+                        <div class="mt-3 space-y-2">
+                            <template x-if="dnsGuidance.findings.length === 0">
+                                <p class="text-sm text-base-content/70">No DNS lint findings.</p>
+                            </template>
+                            <template x-for="finding in dnsGuidance.findings" :key="finding.code + finding.record_name">
+                                <div class="rounded border border-base-300 p-3">
+                                    <div class="flex items-start gap-2">
+                                        <span class="mt-1 h-2.5 w-2.5 rounded-full"
+                                              :class="recommendationSeverityClass(finding.severity)"></span>
+                                        <div class="min-w-0 flex-1">
+                                            <div class="flex flex-wrap items-center gap-2">
+                                                <p class="font-semibold" x-text="finding.title"></p>
+                                                <code class="rounded bg-base-200 px-1.5 py-0.5 text-xs" x-text="finding.code"></code>
+                                            </div>
+                                            <p class="mt-1 text-sm text-base-content/70" x-text="finding.detail"></p>
+                                            <p class="mt-1 text-sm" x-text="finding.action"></p>
+                                            <template x-if="finding.target_record">
+                                                <div class="mt-2 rounded bg-base-200 p-2">
+                                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                                                        <code class="flex-1 break-all text-xs" x-text="finding.target_record.name + ' ' + finding.target_record.record_type + ' ' + finding.target_record.value"></code>
+                                                        <button
+                                                            @click="navigator.clipboard.writeText(finding.target_record.value)"
+                                                            class="btn btn-xs btn-ghost"
+                                                            title="Copy DNS value"
+                                                        >
+                                                            Copy
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </template>
+                                        </div>
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+                        <div class="mt-4">
+                            <h4 class="text-sm font-semibold">Target Records</h4>
+                            <div class="mt-2 grid gap-2">
+                                <template x-for="record in dnsGuidance.target_records" :key="record.code">
+                                    <div class="rounded border border-base-300 p-3">
+                                        <div class="flex flex-col gap-2 lg:flex-row lg:items-center">
+                                            <div class="min-w-0 flex-1">
+                                                <div class="flex flex-wrap items-center gap-2">
+                                                    <code class="text-xs font-semibold" x-text="record.name"></code>
+                                                    <span class="badge badge-outline" x-text="record.record_type"></span>
+                                                    <span class="badge badge-ghost" x-text="record.priority"></span>
+                                                </div>
+                                                <code class="mt-2 block break-all rounded bg-base-200 p-2 text-xs" x-text="record.value"></code>
+                                                <p class="mt-1 text-xs text-base-content/60" x-text="record.purpose"></p>
+                                            </div>
+                                            <button
+                                                @click="navigator.clipboard.writeText(record.value)"
+                                                class="btn btn-xs btn-ghost"
+                                                title="Copy DNS value"
+                                            >
+                                                Copy
+                                            </button>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             {% endcall %}
         {% endcall %}
@@ -698,6 +768,11 @@ function domainDetailsApp(domainId) {
             checks: [],
             recommendations: []
         },
+        dnsGuidance: {
+            status: '',
+            findings: [],
+            target_records: []
+        },
         posture: {
             status: '',
             score: 0,
@@ -744,6 +819,7 @@ function domainDetailsApp(domainId) {
             this.fetchDomainStats();
             this.fetchDNSRecords();
             this.fetchDNSHealth();
+            this.fetchDNSGuidance();
             this.fetchPosture();
             this.fetchMtaSts();
             this.fetchBimi();
@@ -796,6 +872,13 @@ function domainDetailsApp(domainId) {
             return 'bg-base-200 text-base-content/70';
         },
 
+        get dnsGuidanceStatusClass() {
+            if (this.dnsGuidance.status === 'ready') return 'bg-green-100 text-green-700';
+            if (this.dnsGuidance.status === 'attention') return 'bg-yellow-100 text-yellow-800';
+            if (this.dnsGuidance.status === 'critical') return 'bg-red-100 text-red-700';
+            return 'bg-base-200 text-base-content/70';
+        },
+
         recommendationSeverityClass(severity) {
             if (severity === 'error') return 'bg-red-500';
             if (severity === 'warning') return 'bg-yellow-500';
@@ -834,6 +917,17 @@ function domainDetailsApp(domainId) {
                 }
             } catch (error) {
                 console.error('Error fetching DNS health:', error);
+            }
+        },
+
+        async fetchDNSGuidance() {
+            try {
+                const response = await fetch(`/api/v1/domains/${this.domainId}/dns/lint`);
+                if (response.ok) {
+                    this.dnsGuidance = await response.json();
+                }
+            } catch (error) {
+                console.error('Error fetching DNS guidance:', error);
             }
         },
 
@@ -899,6 +993,7 @@ function domainDetailsApp(domainId) {
                     this.fetchSelectors();
                     this.fetchDNSRecords();
                     this.fetchDNSHealth();
+                    this.fetchDNSGuidance();
                     this.fetchPosture();
                     this.fetchMtaSts();
                 } else {
@@ -922,6 +1017,7 @@ function domainDetailsApp(domainId) {
                     this.fetchSelectors();
                     this.fetchDNSRecords();
                     this.fetchDNSHealth();
+                    this.fetchDNSGuidance();
                     this.fetchPosture();
                     this.fetchMtaSts();
                 } else {

--- a/backend/app/tests/test_dmarc_compatibility_fixtures.py
+++ b/backend/app/tests/test_dmarc_compatibility_fixtures.py
@@ -191,3 +191,27 @@ def test_gmail_fixture_email_shape_matches_api_raw_encoding():
 
     assert msg["Subject"] == "DMARC aggregate report"
     assert any(part.get_filename() == fixture["filename"] + ".zip" for part in msg.walk())
+
+
+def test_aggregate_compatibility_unknown_safe_fields_do_not_break_summary():
+    xml = load_dmarc_fixture("rfc9990-treewalk-extension.xml")
+    xml = xml.replace(
+        "</policy_evaluated>",
+        "<vendor:confidence>low</vendor:confidence></policy_evaluated>",
+        1,
+    ).replace(
+        "</record>",
+        "<vendor:unknown><vendor:nested>kept</vendor:nested></vendor:unknown></record>",
+        1,
+    )
+
+    report = DMARCParser.parse_file(xml.encode("utf-8"), "unknown-safe-fields.xml")
+
+    assert report["domain"] == "example.org"
+    assert report["summary"] == {
+        "total_count": 5,
+        "passed_count": 5,
+        "failed_count": 0,
+        "pass_rate": 100.0,
+    }
+    assert report["records"][0]["extensions"]["unknown"] == {"nested": "kept"}

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -287,6 +287,74 @@ def test_dns_endpoint_returns_dmarc_lint_findings(client: TestClient):
     assert data["dmarcSuggestions"] == result.dmarc_suggestions
 
 
+def test_dns_lint_endpoint_returns_typed_findings_and_targets(client: TestClient):
+    result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 include:_spf.example.com ~all",
+        dkim=False,
+        selectors_checked=["selector1"],
+    )
+    mta_sts = MTAStsResult(errors=["No _mta-sts TXT record was found."])
+    bimi = BIMIResult(errors=["No BIMI TXT record was found at the selector."])
+
+    with (
+        _mock_dns(result),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(mta_sts, False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(bimi, False, None)),
+        ),
+    ):
+        response = client.get(f"/api/v1/domains/{DOMAIN}/dns/lint")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["domain"] == DOMAIN
+    assert data["status"] == "attention"
+    codes = {finding["code"] for finding in data["findings"]}
+    assert {"dkim_selector_missing", "tls_rpt_missing", "bimi_dmarc_not_enforced"}.issubset(
+        codes
+    )
+    assert {record["code"] for record in data["target_records"]} >= {
+        "target_dmarc",
+        "target_spf",
+        "target_dkim",
+        "target_tls_rpt",
+    }
+
+
+def test_dns_lint_bulk_and_export(client: TestClient):
+    mta_sts = MTAStsResult(status="pass")
+    bimi = BIMIResult(status="pass")
+
+    with (
+        _mock_dns(),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(mta_sts, False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(bimi, False, None)),
+        ),
+    ):
+        response = client.get("/api/v1/domains/dns/lint")
+        export = client.get("/api/v1/domains/dns/lint/export")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["domains"][0]["domain"] == DOMAIN
+    assert data["domains"][0]["finding_count"] >= 1
+    assert export.status_code == 200
+    assert "domain,status,severity,code" in export.text
+    assert DOMAIN in export.text
+
+
 def test_dns_endpoint_uses_cached_result(client: TestClient, db_session):
     """Repeated DNS checks reuse a fresh cached result."""
     mock_provider = AsyncMock(check_domain=AsyncMock(return_value=MOCK_DNS_RESULT))

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -78,3 +78,96 @@ async def test_build_dns_guidance_lints_spf_and_tls_rpt_records():
     assert "spf_multiple_records" in codes
     assert "spf_all_too_permissive" in codes
     assert "tls_rpt_rua_missing" in codes
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_classifies_dmarc_warning_codes():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 ?all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=none",
+        spf=True,
+        spf_record="v=spf1 ?all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+        dmarc_warnings=[
+            "External rua destination reports.example.net is missing authorization TXT.",
+            "DMARC adkim tag should be r or s.",
+            "DMARC fo tag contains unsupported failure options.",
+        ],
+        dmarc_suggestions=["Add rua=mailto:... so aggregate reports can reach DMARQ."],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+    )
+
+    codes = {finding.code for finding in guidance.findings}
+    assert "dmarc_external_rua_unauthorized" in codes
+    assert "dmarc_alignment_value_invalid" in codes
+    assert "dmarc_failure_option_invalid" in codes
+    assert "dmarc_suggestion" in codes
+    assert "dmarc_monitoring_policy" in codes
+    assert "spf_all_neutral" in codes
+    assert "bimi_dmarc_not_enforced" in codes
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_lints_more_spf_tls_mta_and_bimi_states():
+    provider = FakeDNSProvider(
+        {
+            "example.com": [
+                (
+                    "v=spf1 include:a.example include:b.example include:c.example "
+                    "include:d.example include:e.example include:f.example "
+                    "include:g.example include:h.example include:i.example "
+                    "include:j.example include:k.example"
+                )
+            ],
+            "_smtp._tls.example.com": [
+                "v=TLSRPTv1; rua=mailto:tls@example.com",
+                "v=TLSRPTv1; rua=mailto:backup@example.com",
+            ],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record=(
+            "v=spf1 include:a.example include:b.example include:c.example "
+            "include:d.example include:e.example include:f.example "
+            "include:g.example include:h.example include:i.example "
+            "include:j.example include:k.example"
+        ),
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+    mta_sts = MTAStsResult(
+        status="pass",
+        dns_record="v=STSv1; id=20260625",
+        warnings=["MTA-STS policy is valid but not enforcing mail delivery (testing)."],
+    )
+    bimi = BIMIResult(
+        status="pass",
+        dns_record="v=BIMI1; l=https://example.com/logo.svg",
+        warnings=["No BIMI certificate URL is published; some mailbox providers require one."],
+    )
+
+    guidance = await build_dns_guidance("example.com", provider, dns, mta_sts, bimi)
+
+    codes = {finding.code for finding in guidance.findings}
+    assert "spf_all_missing" in codes
+    assert "spf_dns_lookup_limit_risk" in codes
+    assert "tls_rpt_multiple_records" in codes
+    assert "mta_sts_review" in codes
+    assert "bimi_review" in codes

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -1,0 +1,80 @@
+import pytest
+
+from app.services.bimi import BIMIResult
+from app.services.dns_guidance import build_dns_guidance
+from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult
+from app.services.mta_sts import MTAStsResult
+
+
+class FakeDNSProvider(BaseDNSProvider):
+    def __init__(self, records: dict[str, list[str]]):
+        self._records = records
+
+    async def lookup_txt(self, name: str) -> list[str]:
+        if name in self._records:
+            return self._records[name]
+        raise LookupError(f"NXDOMAIN: {name}")
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_returns_typed_findings_and_targets():
+    provider = FakeDNSProvider({})
+    dns = DomainDNSResult(
+        dmarc=False,
+        spf=False,
+        dkim=False,
+        selectors_checked=["selector1"],
+    )
+    mta_sts = MTAStsResult(errors=["No _mta-sts TXT record was found."])
+    bimi = BIMIResult(errors=["No BIMI TXT record was found at the selector."])
+
+    guidance = await build_dns_guidance("example.com", provider, dns, mta_sts, bimi)
+
+    codes = {finding.code for finding in guidance.findings}
+    assert guidance.status == "critical"
+    assert {
+        "dmarc_missing",
+        "spf_missing",
+        "dkim_selector_missing",
+        "mta_sts_missing",
+        "tls_rpt_missing",
+        "bimi_missing",
+    }.issubset(codes)
+    assert {record.code for record in guidance.target_records} == {
+        "target_dmarc",
+        "target_spf",
+        "target_dkim",
+        "target_mta_sts",
+        "target_tls_rpt",
+        "target_bimi",
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_lints_spf_and_tls_rpt_records():
+    provider = FakeDNSProvider(
+        {
+            "example.com": [
+                "v=spf1 include:_spf.example.com +all",
+                "v=spf1 include:_spf2.example.com ~all",
+            ],
+            "_smtp._tls.example.com": ["v=TLSRPTv1"],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 include:_spf.example.com +all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+    mta_sts = MTAStsResult(status="pass")
+    bimi = BIMIResult(status="pass")
+
+    guidance = await build_dns_guidance("example.com", provider, dns, mta_sts, bimi)
+
+    codes = {finding.code for finding in guidance.findings}
+    assert "spf_multiple_records" in codes
+    assert "spf_all_too_permissive" in codes
+    assert "tls_rpt_rua_missing" in codes

--- a/docs/development/dmarc-scope-open-items.md
+++ b/docs/development/dmarc-scope-open-items.md
@@ -10,11 +10,18 @@ DMARC message enforcement or outbound aggregate/failure report generation.
 - [x] Parse RFC 9990 aggregate reports while preserving useful optional metadata.
 - [x] Parse inbound RFC 9991 failure reports without retaining message bodies.
 - [x] Lint external `rua` / `ruf` destinations for required DNS authorization records.
-- [ ] Add a first-class DNS lint endpoint with typed findings and stable machine-readable codes.
-- [ ] Add DNS-setting generation helpers for DMARC, SPF include/all choices, DKIM selector checks, MTA-STS, TLS-RPT, and BIMI readiness.
-- [ ] Add UI sections that show lint findings next to the current DNS records and suggested target records.
-- [ ] Add bulk domain linting and export for managed-domain reviews.
-- [ ] Expand fixture coverage with real-world DMARCbis aggregate/failure samples from more report generators.
+- [x] Add a first-class DNS lint endpoint with typed findings and stable machine-readable codes.
+- [x] Add DNS-setting generation helpers for DMARC, SPF include/all choices, DKIM selector checks, MTA-STS, TLS-RPT, and BIMI readiness.
+- [x] Add UI sections that show lint findings next to the current DNS records and suggested target records.
+- [x] Add bulk domain linting and export for managed-domain reviews.
+- [x] Expand aggregate fixture coverage for representative RFC 9990/DMARCbis variants and unknown-but-safe fields.
+- [ ] Expand fixture coverage with additional real-world aggregate/failure samples from more report generators.
+
+## Implemented DNS Guidance Surfaces
+
+- `GET /api/v1/domains/{domain}/dns/lint` returns typed findings and target records for one domain.
+- `GET /api/v1/domains/dns/lint` returns bulk typed findings for monitored domains.
+- `GET /api/v1/domains/dns/lint/export` exports bulk findings as CSV for managed-domain review.
 
 ## Out of Scope
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -363,6 +363,19 @@ GET /domains/{domain_id}/dns/bimi
 Returns the cached BIMI TXT posture for the default selector, including the
 queried DNS name, record text, logo URL, certificate URL, warnings, and errors.
 
+#### Get DNS Lint Guidance
+
+```
+GET /domains/{domain_id}/dns/lint
+GET /domains/dns/lint
+GET /domains/dns/lint/export
+```
+
+Returns typed DNS lint findings with stable `code` values and suggested target
+records for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI readiness. The bulk
+endpoint returns the same payload shape per monitored domain, and the export
+endpoint returns the finding list as CSV for managed-domain reviews.
+
 #### Get Posture Dashboard
 
 ```

--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -32,6 +32,7 @@ Live DNS checks parse DMARC policy records according to RFC 9989:
 - Subdomain checks fall back to the bounded RFC 9989 DNS Tree Walk, including `psd=n` and `psd=y` stop conditions.
 - Records with a valid aggregate reporting URI but no valid `p` tag are treated as monitoring mode for policy extraction.
 - External `rua` and `ruf` destinations are linted for the required DNS authorization TXT record at `<policy-domain>._report._dmarc.<destination-domain>`.
+- Typed DNS guidance endpoints expose stable finding codes and target records for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI readiness without applying DNS changes automatically.
 
 ## Preserved Metadata
 
@@ -69,7 +70,7 @@ The current fixture pack covers:
 - `rfc9990-treewalk-extension.xml`: RFC 9990-style policy metadata, treewalk discovery, `envelope_to`, override reasons, auth-result details, and report/record extensions.
 - `rfc9990-multi-auth-overrides.xml`: multiple records, multiple DKIM auth results, policy override reasons, PSD-style discovery, and nested vendor extensions.
 
-The compatibility tests exercise every fixture through parser extraction, upload import, IMAP attachment import, and Gmail attachment import.
+The compatibility tests exercise every fixture through parser extraction, upload import, IMAP attachment import, Gmail attachment import, dashboard projection, CSV export, and unknown safe extension handling.
 
 ## Adding Fixtures
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -79,6 +79,13 @@ Operator playbooks sit beside the recommendations. They are short remediation
 checklists for common gaps such as missing SPF, missing DKIM, policy enforcement
 readiness, MTA-STS setup, or BIMI prerequisites.
 
+### DNS Guidance
+
+The domain detail page also shows typed DNS lint findings next to suggested
+target records. DMARQ checks DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI
+readiness, then exposes the same guidance through the single-domain lint API,
+bulk lint API, and CSV export for managed-domain reviews.
+
 ### MTA-STS Posture
 
 The domain detail page checks `_mta-sts.<domain>` and fetches the policy from `https://mta-sts.<domain>/.well-known/mta-sts.txt`.


### PR DESCRIPTION
## Summary\n\n- add a typed DNS guidance service with stable lint finding codes and target records for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI readiness\n- expose single-domain and bulk DNS lint endpoints plus CSV export for managed-domain reviews\n- render DNS guidance and suggested target records on the domain detail page\n- add aggregate compatibility regression coverage for unknown safe DMARCbis fields\n- update the DMARC scope/open-items and compatibility docs\n\n## Closes\n\nCloses #203\nCloses #207\n\n## Validation\n\n- git diff --check\n- python -m py_compile for changed backend modules/tests\n- isort --check-only for changed backend modules/tests\n\nLocal pytest and Black are blocked by slow/hanging imports from this checkout's Python 3.14 virtualenv, so GitHub Actions is the authoritative runtime lint/test gate for this PR.