### PR TITLE
Add opt-in demo data mode

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "DMARQ"
     API_V1_STR: str = "/api/v1"
     ENVIRONMENT: str = "development"
+    DEMO_MODE: bool = False
 
     # Database
     # Default to a sub-directory so the SQLite file lives in a location that

--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -1,0 +1,250 @@
+"""Deterministic demo data for public DMARQ demo environments."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+from app.services.report_store import ReportStore
+
+DEMO_DOMAINS = ("dmarq.org", "dmarq.com")
+DEMO_DAYS = 90
+
+_SOURCE_PROFILES = {
+    "dmarq.org": [
+        {
+            "ip": "203.0.113.10",
+            "name": "primary-saas",
+            "base": 950,
+            "spf": "pass",
+            "dkim": "pass",
+            "selector": "selector1",
+        },
+        {
+            "ip": "203.0.113.44",
+            "name": "newsletter",
+            "base": 420,
+            "spf": "pass",
+            "dkim": "fail",
+            "selector": "news",
+        },
+        {
+            "ip": "198.51.100.23",
+            "name": "ticketing",
+            "base": 180,
+            "spf": "fail",
+            "dkim": "pass",
+            "selector": "zendesk",
+        },
+        {
+            "ip": "192.0.2.66",
+            "name": "legacy-crm",
+            "base": 55,
+            "spf": "fail",
+            "dkim": "fail",
+            "selector": "legacy",
+        },
+    ],
+    "dmarq.com": [
+        {
+            "ip": "203.0.113.75",
+            "name": "workspace-mail",
+            "base": 610,
+            "spf": "pass",
+            "dkim": "pass",
+            "selector": "google",
+        },
+        {
+            "ip": "198.51.100.88",
+            "name": "marketing",
+            "base": 260,
+            "spf": "pass",
+            "dkim": "mixed",
+            "selector": "mailchimp",
+        },
+        {
+            "ip": "192.0.2.114",
+            "name": "billing",
+            "base": 130,
+            "spf": "fail",
+            "dkim": "pass",
+            "selector": "stripe",
+        },
+        {
+            "ip": "198.51.100.199",
+            "name": "unknown-forwarder",
+            "base": 35,
+            "spf": "fail",
+            "dkim": "fail",
+            "selector": "unknown",
+        },
+    ],
+}
+
+
+def _utc_timestamp(day: date, boundary: time) -> int:
+    return int(datetime.combine(day, boundary, tzinfo=timezone.utc).timestamp())
+
+
+def _policy_for_domain(domain: str) -> Dict[str, str]:
+    if domain == "dmarq.org":
+        return {
+            "p": "quarantine",
+            "sp": "reject",
+            "pct": "100",
+            "adkim": "s",
+            "aspf": "r",
+            "fo": "1",
+            "discovery_method": "author",
+        }
+    return {
+        "p": "none",
+        "sp": "quarantine",
+        "pct": "100",
+        "adkim": "r",
+        "aspf": "r",
+        "fo": "1:d",
+        "testing": "y",
+        "discovery_method": "treewalk",
+    }
+
+
+def _result_for(profile: Dict[str, Any], day_index: int, domain: str) -> tuple[str, str]:
+    spf = str(profile["spf"])
+    dkim = str(profile["dkim"])
+    if dkim == "mixed":
+        dkim = "pass" if day_index % 3 else "fail"
+    if profile["name"] == "legacy-crm" and day_index % 14 == 0:
+        return "pass", "fail"
+    if profile["name"] == "unknown-forwarder" and day_index % 11 == 0:
+        return "fail", "pass"
+    if domain == "dmarq.com" and profile["name"] == "marketing" and day_index % 10 == 0:
+        return "pass", "fail"
+    return spf, dkim
+
+
+def _count_for(profile: Dict[str, Any], day_index: int) -> int:
+    base = int(profile["base"])
+    weekly_wave = ((day_index % 7) - 3) * max(2, base // 28)
+    incident = 0
+    if profile["name"] in {"legacy-crm", "unknown-forwarder"} and day_index % 13 == 0:
+        incident = base * 2
+    if profile["name"] == "newsletter" and day_index % 7 in {1, 4}:
+        incident = base // 2
+    return max(1, base + weekly_wave + incident)
+
+
+def _record(domain: str, profile: Dict[str, Any], day_index: int) -> Dict[str, Any]:
+    spf_result, dkim_result = _result_for(profile, day_index, domain)
+    count = _count_for(profile, day_index)
+    dmarc_pass = spf_result == "pass" or dkim_result == "pass"
+    policy = _policy_for_domain(domain)
+    disposition = "none"
+    if not dmarc_pass and policy["p"] in {"quarantine", "reject"}:
+        disposition = policy["p"]
+    if not dmarc_pass and domain == "dmarq.com":
+        disposition = "none"
+    return {
+        "source_ip": profile["ip"],
+        "count": count,
+        "disposition": disposition,
+        "dkim_result": dkim_result,
+        "spf_result": spf_result,
+        "header_from": domain,
+        "envelope_from": f"bounce.{domain}",
+        "envelope_to": f"recipient-{day_index % 5}.example.net",
+        "dkim": [
+            {
+                "domain": domain,
+                "selector": profile["selector"],
+                "result": dkim_result,
+                "human_result": (
+                    "signature verified"
+                    if dkim_result == "pass"
+                    else "body hash did not verify"
+                ),
+            }
+        ],
+        "spf": [
+            {
+                "domain": f"bounce.{domain}",
+                "scope": "mfrom",
+                "result": spf_result,
+                "human_result": (
+                    "sender authorized"
+                    if spf_result == "pass"
+                    else "sender not authorized by SPF"
+                ),
+            }
+        ],
+        "extensions": {
+            "demo:source": profile["name"],
+            "demo:scenario": "corner-case" if not dmarc_pass else "normal",
+        },
+    }
+
+
+def _summary(records: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    rows = list(records)
+    total = sum(int(record["count"]) for record in rows)
+    passed = sum(
+        int(record["count"])
+        for record in rows
+        if record["spf_result"] == "pass" or record["dkim_result"] == "pass"
+    )
+    failed = total - passed
+    return {
+        "total_count": total,
+        "passed_count": passed,
+        "failed_count": failed,
+        "pass_rate": round((passed / total) * 100, 1) if total else 0.0,
+    }
+
+
+def build_demo_reports(today: Optional[date] = None, days: int = DEMO_DAYS) -> List[Dict[str, Any]]:
+    """Return rolling synthetic DMARC aggregate reports through *today*."""
+    anchor = today or datetime.now(timezone.utc).date()
+    reports: List[Dict[str, Any]] = []
+    start = anchor - timedelta(days=days - 1)
+    for day_offset in range(days):
+        report_day = start + timedelta(days=day_offset)
+        day_index = (report_day - date(2026, 1, 1)).days
+        for domain in DEMO_DOMAINS:
+            records = [_record(domain, profile, day_index) for profile in _SOURCE_PROFILES[domain]]
+            begin_ts = _utc_timestamp(report_day, time.min)
+            end_ts = _utc_timestamp(report_day, time.max.replace(microsecond=0))
+            reports.append(
+                {
+                    "domain": domain,
+                    "report_id": f"demo-{domain}-{report_day.isoformat()}",
+                    "org_name": "DMARQ Demo Receiver",
+                    "email": "reports@demo.dmarq.org",
+                    "extra_contact_info": "https://demo.dmarq.org",
+                    "generator": "DMARQ demo data generator",
+                    "variant": "rfc9990",
+                    "schema_version": "1.0",
+                    "xml_namespace": "urn:ietf:params:xml:ns:dmarc-2.0",
+                    "begin_date": datetime.fromtimestamp(begin_ts).isoformat(),
+                    "end_date": datetime.fromtimestamp(end_ts).isoformat(),
+                    "begin_timestamp": begin_ts,
+                    "end_timestamp": end_ts,
+                    "policy": _policy_for_domain(domain),
+                    "records": records,
+                    "summary": _summary(records),
+                    "extensions": {
+                        "demo:rolling_window_days": str(days),
+                        "demo:generated_for": anchor.isoformat(),
+                    },
+                }
+            )
+    return reports
+
+
+def seed_demo_report_store(store: Optional[ReportStore] = None) -> int:
+    """Replace the report store contents with rolling demo reports."""
+    target = store or ReportStore.get_instance()
+    target.clear()
+    reports = build_demo_reports()
+    for report in reports:
+        target.add_report(report)
+    return len(reports)

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -708,6 +708,56 @@ class CloudflareDNSProvider(BaseDNSProvider):
         return None
 
 
+class DemoDNSProvider(BaseDNSProvider):
+    """Deterministic DNS provider for the opt-in public demo mode."""
+
+    def __init__(self) -> None:
+        self._records = {
+            "dmarq.org": ["v=spf1 include:_spf.mail.example -all"],
+            "_dmarc.dmarq.org": [
+                (
+                    "v=DMARC1; p=quarantine; sp=reject; adkim=s; aspf=r; "
+                    "rua=mailto:dmarc@dmarq.org,mailto:dmarc@reports.dmarq.net"
+                )
+            ],
+            "dmarq.org._report._dmarc.reports.dmarq.net": ["v=DMARC1"],
+            "selector1._domainkey.dmarq.org": ["v=DKIM1; k=rsa; p=DEMOSELECTOR1"],
+            "news._domainkey.dmarq.org": ["v=DKIM1; k=rsa; p=DEMONEWS"],
+            "zendesk._domainkey.dmarq.org": ["v=DKIM1; k=rsa; p=DEMOZENDESK"],
+            "_mta-sts.dmarq.org": ["v=STSv1; id=20260625"],
+            "_smtp._tls.dmarq.org": ["v=TLSRPTv1; rua=mailto:tlsrpt@dmarq.org"],
+            "default._bimi.dmarq.org": [
+                "v=BIMI1; l=https://demo.dmarq.org/static/demo-bimi.svg; a="
+            ],
+            "dmarq.com": ["v=spf1 include:_spf.mail.example +all"],
+            "_dmarc.dmarq.com": [
+                "v=DMARC1; p=none; rua=mailto:dmarc@reports.dmarq.org!50m; adkim=r; aspf=r"
+            ],
+            "google._domainkey.dmarq.com": ["v=DKIM1; k=rsa; p=DEMOGOOGLE"],
+            "stripe._domainkey.dmarq.com": ["v=DKIM1; k=rsa; p=DEMOSTRIPE"],
+            "_smtp._tls.dmarq.com": ["v=TLSRPTv1"],
+        }
+
+    async def lookup_txt(self, name: str) -> List[str]:
+        normalized = _normalize_dns_name(name)
+        if normalized in self._records:
+            return list(self._records[normalized])
+        raise LookupError(f"Demo DNS record not found for {name}")
+
+    async def lookup_ptr(self, ip: str) -> Optional[str]:
+        ptr_records = {
+            "203.0.113.10": "primary-saas.demo.dmarq.org",
+            "203.0.113.44": "newsletter.demo.dmarq.org",
+            "198.51.100.23": "ticketing.demo.dmarq.org",
+            "192.0.2.66": "legacy-crm.demo.dmarq.org",
+            "203.0.113.75": "workspace-mail.demo.dmarq.com",
+            "198.51.100.88": "marketing.demo.dmarq.com",
+            "192.0.2.114": "billing.demo.dmarq.com",
+            "198.51.100.199": "unknown-forwarder.demo.dmarq.com",
+        }
+        return ptr_records.get(ip)
+
+
 def _decrypt_setting_value(value: Optional[str]) -> Optional[str]:
     if not value:
         return value
@@ -733,11 +783,14 @@ def _setting_value(db: Any, key: str) -> Optional[str]:
 
 def get_default_provider(db: Any = None) -> BaseDNSProvider:
     """Return the configured default DNS provider."""
+    from app.core.config import get_settings
+
+    settings = get_settings()
+    if settings.DEMO_MODE:
+        return DemoDNSProvider()
+
     resolver = (_setting_value(db, "dns.resolver") or "").strip().lower()
     if resolver == "cloudflare":
-        from app.core.config import get_settings
-
-        settings = get_settings()
         api_token = _decrypt_setting_value(_setting_value(db, "cloudflare.api_token"))
         zone_id = _setting_value(db, "cloudflare.zone_id")
         return CloudflareDNSProvider(

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -4,8 +4,10 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session, selectinload
 
+from app.core.config import get_settings
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
+from app.services.demo_data import seed_demo_report_store
 from app.services.report_store import ReportStore
 from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
@@ -250,6 +252,9 @@ def persisted_report_to_dict(report: DMARCReport) -> Dict[str, Any]:
 
 def hydrate_report_store_from_db(db: Session, store: Optional[ReportStore] = None) -> int:
     """Load persisted reports into ReportStore when the database has report rows."""
+    if get_settings().DEMO_MODE:
+        return seed_demo_report_store(store)
+
     report_count = db.query(DMARCReport.id).count()
     if report_count == 0:
         return 0

--- a/backend/app/tests/test_demo_data.py
+++ b/backend/app/tests/test_demo_data.py
@@ -1,0 +1,73 @@
+from datetime import date, datetime, timezone
+
+import pytest
+
+from app.services.demo_data import DEMO_DOMAINS, build_demo_reports, seed_demo_report_store
+from app.services.dns_resolver import DemoDNSProvider
+from app.services.report_store import ReportStore
+
+
+def _date_from_timestamp(value: int) -> date:
+    return datetime.fromtimestamp(value, tz=timezone.utc).date()
+
+
+def test_build_demo_reports_rolls_with_current_date():
+    reports = build_demo_reports(today=date(2026, 6, 25), days=90)
+
+    assert len(reports) == 180
+    assert {report["domain"] for report in reports} == set(DEMO_DOMAINS)
+    assert min(_date_from_timestamp(report["begin_timestamp"]) for report in reports) == date(
+        2026, 3, 28
+    )
+    assert max(_date_from_timestamp(report["begin_timestamp"]) for report in reports) == date(
+        2026, 6, 25
+    )
+    assert any(
+        record["disposition"] == "quarantine"
+        for report in reports
+        if report["domain"] == "dmarq.org"
+        for record in report["records"]
+    )
+    assert any(
+        record["spf_result"] == "fail" and record["dkim_result"] == "pass"
+        for report in reports
+        if report["domain"] == "dmarq.com"
+        for record in report["records"]
+    )
+
+
+def test_seed_demo_report_store_replaces_store_with_demo_domains():
+    store = ReportStore()
+    store.add_report(
+        {
+            "domain": "real.example",
+            "report_id": "real",
+            "records": [],
+            "summary": {"total_count": 0, "passed_count": 0, "failed_count": 0},
+        }
+    )
+
+    count = seed_demo_report_store(store)
+
+    assert count == 180
+    assert set(store.get_domains()) == set(DEMO_DOMAINS)
+    assert store.get_domain_summary("dmarq.org")["reports_processed"] == 90
+    assert store.get_domain_sources("dmarq.com")
+
+
+@pytest.mark.asyncio
+async def test_demo_dns_provider_returns_corner_case_records():
+    provider = DemoDNSProvider()
+
+    dmarq_org = await provider.check_domain("dmarq.org", selectors=["selector1", "news"])
+    dmarq_com = await provider.check_domain("dmarq.com", selectors=["google", "mailchimp"])
+
+    assert dmarq_org.dmarc is True
+    assert dmarq_org.spf_record.endswith("-all")
+    assert "selector1" in dmarq_org.dkim_selectors
+    assert dmarq_org.dmarc_warnings == []
+
+    assert dmarq_com.dmarc is True
+    assert dmarq_com.spf_record.endswith("+all")
+    assert "google" in dmarq_com.dkim_selectors
+    assert any("External rua destination" in warning for warning in dmarq_com.dmarc_warnings)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - SECRET_KEY=your_secret_key_change_in_production
       - DEBUG=True
       - ENVIRONMENT=development
+      - DEMO_MODE=false
       - DELETE_IMPORTED_EMAILS=false
       # Add NODE_ENV for Tailwind
       - NODE_ENV=production

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -75,6 +75,20 @@ For deployment verification, upgrades, rollback, and routine checks, use the [Op
 | `REPORTS_PER_PAGE` | Reports to show per page | `25` | `10`, `50`, `100` |
 | `MAX_UPLOAD_SIZE` | Maximum file upload size (MB) | `10` | `20`, `50` |
 | `SESSION_LIFETIME` | Session lifetime in minutes | `1440` (24h) | `60`, `720` |
+| `DEMO_MODE` | Force generated demo reports and demo DNS records for public demo instances. Do not enable on production customer data. | `false` | `true` |
+
+### Demo Mode
+
+Set `DEMO_MODE=true` only for public demo environments such as `demo.dmarq.org`.
+When enabled, DMARQ replaces the in-memory report store with deterministic
+synthetic DMARC aggregate reports for `dmarq.org` and `dmarq.com`. The data is
+generated inside the application, rolls forward with the current date, and
+always covers the last 90 days so 30, 60, and 90 day views remain populated.
+
+Demo mode also uses a built-in DNS provider for those two domains. It returns a
+mix of clean records, middle-of-the-road records, and intentional lint findings
+so the domain detail, posture, DNS guidance, CSV export, and report views have
+useful content without requiring real inbound reports or public DNS changes.
 
 ### Notification Configuration
 

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -46,6 +46,14 @@ DMARC (Domain-based Message Authentication, Reporting, and Conformance) is an em
 3. **Add your first domain**: Click "Add Domain" on the dashboard and enter your domain details
 4. **Upload a DMARC report**: Use the "Upload Report" button to add your first report
 
+### Public Demo Instances
+
+Some public demo deployments run with demo mode enabled. In that mode, DMARQ
+shows generated history for `dmarq.org` and `dmarq.com` instead of customer
+data. The reports roll forward with the current date and intentionally include
+clean senders, partial alignment, and a few DNS/reporting issues so the main
+dashboard, domain details, DNS guidance, and exports have realistic examples.
+
 ## Dashboard Overview
 
 The DMARQ dashboard provides an at-a-glance view of your email authentication status:


### PR DESCRIPTION
## Summary\n\n- add DEMO_MODE feature flag for public demo deployments\n- generate deterministic rolling 90-day synthetic DMARC aggregate data for dmarq.org and dmarq.com\n- add demo DNS provider records with clean, middle-ground, and intentionally misconfigured examples\n- wire demo mode into report-store hydration without persisting fake rows\n- document demo-mode deployment behavior and add tests for rolling data and demo DNS\n\n## Issue\n\nAddresses #212\n\n## Validation\n\n- git diff --check\n- python -m py_compile for changed backend modules/tests\n\nLocal pytest remains unreliable in this checkout because the Python 3.14 virtualenv intermittently hangs importing dependencies; GitHub Actions is the runtime lint/test gate.