### PR TITLE
Make demo report dates UTC deterministic

### DIFF
--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -87,7 +87,11 @@ def _utc_timestamp(day: date, boundary: time) -> int:
 
 
 def _utc_iso_from_timestamp(value: int) -> str:
-    return datetime.fromtimestamp(value, tz=timezone.utc).replace(tzinfo=None).isoformat()
+    return (
+        datetime.fromtimestamp(value, tz=timezone.utc)
+        .replace(tzinfo=None)
+        .isoformat(timespec="seconds")
+    )
 
 
 def _policy_for_domain(domain: str) -> Dict[str, str]:

--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -86,6 +86,10 @@ def _utc_timestamp(day: date, boundary: time) -> int:
     return int(datetime.combine(day, boundary, tzinfo=timezone.utc).timestamp())
 
 
+def _utc_iso_from_timestamp(value: int) -> str:
+    return datetime.fromtimestamp(value, tz=timezone.utc).replace(tzinfo=None).isoformat()
+
+
 def _policy_for_domain(domain: str) -> Dict[str, str]:
     if domain == "dmarq.org":
         return {
@@ -224,8 +228,8 @@ def build_demo_reports(today: Optional[date] = None, days: int = DEMO_DAYS) -> L
                     "variant": "rfc9990",
                     "schema_version": "1.0",
                     "xml_namespace": "urn:ietf:params:xml:ns:dmarc-2.0",
-                    "begin_date": datetime.fromtimestamp(begin_ts).isoformat(),
-                    "end_date": datetime.fromtimestamp(end_ts).isoformat(),
+                    "begin_date": _utc_iso_from_timestamp(begin_ts),
+                    "end_date": _utc_iso_from_timestamp(end_ts),
                     "begin_timestamp": begin_ts,
                     "end_timestamp": end_ts,
                     "policy": _policy_for_domain(domain),

--- a/backend/app/tests/test_demo_data.py
+++ b/backend/app/tests/test_demo_data.py
@@ -1,3 +1,5 @@
+import os
+import time
 from datetime import date, datetime, timezone
 
 import pytest
@@ -36,14 +38,27 @@ def test_build_demo_reports_rolls_with_current_date():
     )
 
 
-def test_build_demo_reports_uses_utc_iso_dates():
-    reports = build_demo_reports(today=date(2026, 6, 25), days=1)
-    report = next(report for report in reports if report["domain"] == "dmarq.org")
+def test_build_demo_reports_uses_utc_iso_dates(monkeypatch):
+    if not hasattr(time, "tzset"):
+        pytest.skip("tzset is not available on this platform")
 
-    assert report["begin_timestamp"] == 1782345600
-    assert report["end_timestamp"] == 1782431999
-    assert report["begin_date"] == "2026-06-25T00:00:00"
-    assert report["end_date"] == "2026-06-25T23:59:59"
+    previous_tz = os.environ.get("TZ")
+    monkeypatch.setenv("TZ", "America/Los_Angeles")
+    time.tzset()
+    try:
+        reports = build_demo_reports(today=date(2026, 6, 25), days=1)
+        report = next(report for report in reports if report["domain"] == "dmarq.org")
+
+        assert report["begin_timestamp"] == 1782345600
+        assert report["end_timestamp"] == 1782431999
+        assert report["begin_date"] == "2026-06-25T00:00:00"
+        assert report["end_date"] == "2026-06-25T23:59:59"
+    finally:
+        if previous_tz is None:
+            monkeypatch.delenv("TZ", raising=False)
+        else:
+            monkeypatch.setenv("TZ", previous_tz)
+        time.tzset()
 
 
 def test_seed_demo_report_store_replaces_store_with_demo_domains():

--- a/backend/app/tests/test_demo_data.py
+++ b/backend/app/tests/test_demo_data.py
@@ -40,14 +40,17 @@ def test_build_demo_reports_rolls_with_current_date():
 def test_build_demo_reports_uses_utc_iso_dates(monkeypatch):
     monkeypatch.setenv("TZ", "America/Los_Angeles")
     time.tzset()
+    try:
+        reports = build_demo_reports(today=date(2026, 6, 25), days=1)
+        report = next(report for report in reports if report["domain"] == "dmarq.org")
 
-    reports = build_demo_reports(today=date(2026, 6, 25), days=1)
-    report = next(report for report in reports if report["domain"] == "dmarq.org")
-
-    assert report["begin_timestamp"] == 1782345600
-    assert report["end_timestamp"] == 1782431999
-    assert report["begin_date"] == "2026-06-25T00:00:00"
-    assert report["end_date"] == "2026-06-25T23:59:59"
+        assert report["begin_timestamp"] == 1782345600
+        assert report["end_timestamp"] == 1782431999
+        assert report["begin_date"] == "2026-06-25T00:00:00"
+        assert report["end_date"] == "2026-06-25T23:59:59"
+    finally:
+        monkeypatch.undo()
+        time.tzset()
 
 
 def test_seed_demo_report_store_replaces_store_with_demo_domains():

--- a/backend/app/tests/test_demo_data.py
+++ b/backend/app/tests/test_demo_data.py
@@ -1,4 +1,3 @@
-import os
 import time
 from datetime import date, datetime, timezone
 
@@ -39,26 +38,16 @@ def test_build_demo_reports_rolls_with_current_date():
 
 
 def test_build_demo_reports_uses_utc_iso_dates(monkeypatch):
-    if not hasattr(time, "tzset"):
-        pytest.skip("tzset is not available on this platform")
-
-    previous_tz = os.environ.get("TZ")
     monkeypatch.setenv("TZ", "America/Los_Angeles")
     time.tzset()
-    try:
-        reports = build_demo_reports(today=date(2026, 6, 25), days=1)
-        report = next(report for report in reports if report["domain"] == "dmarq.org")
 
-        assert report["begin_timestamp"] == 1782345600
-        assert report["end_timestamp"] == 1782431999
-        assert report["begin_date"] == "2026-06-25T00:00:00"
-        assert report["end_date"] == "2026-06-25T23:59:59"
-    finally:
-        if previous_tz is None:
-            monkeypatch.delenv("TZ", raising=False)
-        else:
-            monkeypatch.setenv("TZ", previous_tz)
-        time.tzset()
+    reports = build_demo_reports(today=date(2026, 6, 25), days=1)
+    report = next(report for report in reports if report["domain"] == "dmarq.org")
+
+    assert report["begin_timestamp"] == 1782345600
+    assert report["end_timestamp"] == 1782431999
+    assert report["begin_date"] == "2026-06-25T00:00:00"
+    assert report["end_date"] == "2026-06-25T23:59:59"
 
 
 def test_seed_demo_report_store_replaces_store_with_demo_domains():

--- a/backend/app/tests/test_demo_data.py
+++ b/backend/app/tests/test_demo_data.py
@@ -36,6 +36,16 @@ def test_build_demo_reports_rolls_with_current_date():
     )
 
 
+def test_build_demo_reports_uses_utc_iso_dates():
+    reports = build_demo_reports(today=date(2026, 6, 25), days=1)
+    report = next(report for report in reports if report["domain"] == "dmarq.org")
+
+    assert report["begin_timestamp"] == 1782345600
+    assert report["end_timestamp"] == 1782431999
+    assert report["begin_date"] == "2026-06-25T00:00:00"
+    assert report["end_date"] == "2026-06-25T23:59:59"
+
+
 def test_seed_demo_report_store_replaces_store_with_demo_domains():
     store = ReportStore()
     store.add_report(


### PR DESCRIPTION
## Summary
- derive demo report ISO date strings from UTC timestamps instead of the server local timezone
- keep the existing naive ISO string format for UI/API compatibility
- add regression coverage for the UTC day boundary

## Test
- cd backend && ../.venv/bin/python -m pytest app/tests/test_demo_data.py

Follow-up for Copilot feedback on #214.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Demo report dates now consistently display in UTC, avoiding timezone-related shifts in the shown start and end dates.
  * Improved reliability of generated report timestamps and date values across different system timezones.

* **Tests**
  * Added coverage to verify demo report dates remain correct when the local timezone is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->