### PR TITLE
[codex] make demo mode read-only

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from app.core.database import Base, SessionLocal, engine
 from app.core.security import add_api_key, generate_api_key, require_admin_auth
 from app.core.startup_checks import run_startup_checks
 from app.middleware.auth import AuthRedirectMiddleware
+from app.middleware.demo import DemoReadOnlyMiddleware
 from app.middleware.security import SecurityHeadersMiddleware
 from app.models.domain import Domain
 from app.models.mail_source import MailSource  # noqa: F401 – ensure table is registered
@@ -429,6 +430,7 @@ def create_app() -> FastAPI:
     # Determine environment from settings or environment variable
     environment = os.getenv("ENVIRONMENT", "development")
     application.add_middleware(SecurityHeadersMiddleware, environment=environment)
+    application.add_middleware(DemoReadOnlyMiddleware)
 
     # Auth redirect middleware – protects HTML pages; must sit outside CORS
     application.add_middleware(AuthRedirectMiddleware)
@@ -478,15 +480,25 @@ def create_app() -> FastAPI:
 
         # Warn loudly when authentication is completely disabled
         if settings.AUTH_DISABLED:
-            logger.warning(
-                "%s\n"
-                "⚠️  AUTH_DISABLED=true — authentication is turned OFF.\n"
-                "All requests have unrestricted admin access.\n"
-                "Do NOT expose this instance directly to the internet.\n"
-                "%s",
-                "=" * 80,
-                "=" * 80,
-            )
+            if settings.DEMO_MODE:
+                logger.warning(
+                    "%s\n"
+                    "AUTH_DISABLED=true with DEMO_MODE=true — browser access is public, "
+                    "and mutating requests are blocked by the demo read-only guard.\n"
+                    "%s",
+                    "=" * 80,
+                    "=" * 80,
+                )
+            else:
+                logger.warning(
+                    "%s\n"
+                    "⚠️  AUTH_DISABLED=true — authentication is turned OFF.\n"
+                    "All requests have unrestricted admin access.\n"
+                    "Do NOT expose this instance directly to the internet.\n"
+                    "%s",
+                    "=" * 80,
+                    "=" * 80,
+                )
 
         # Load or generate the admin API key
         if settings.ADMIN_API_KEY:

--- a/backend/app/middleware/demo.py
+++ b/backend/app/middleware/demo.py
@@ -1,0 +1,39 @@
+"""Demo-mode request guard."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from fastapi import Request, status
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse, Response
+
+from app.core.config import get_settings
+
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+class DemoReadOnlyMiddleware(BaseHTTPMiddleware):
+    """Block mutating requests when the public demo data mode is enabled."""
+
+    def __init__(
+        self,
+        app,
+        settings_provider: Callable[[], Any] = get_settings,
+    ) -> None:
+        super().__init__(app)
+        self._settings_provider = settings_provider
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        settings = self._settings_provider()
+        if settings.DEMO_MODE and request.method.upper() not in SAFE_METHODS:
+            return JSONResponse(
+                status_code=status.HTTP_403_FORBIDDEN,
+                content={
+                    "detail": (
+                        "This public demo is read-only. "
+                        "Deploy DMARQ with DEMO_MODE=false to make changes."
+                    )
+                },
+            )
+        return await call_next(request)

--- a/backend/app/tests/test_demo_read_only.py
+++ b/backend/app/tests/test_demo_read_only.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.middleware.demo import DemoReadOnlyMiddleware
+
+
+def _build_demo_guard_client(demo_mode: bool = True) -> TestClient:
+    app = FastAPI()
+    app.add_middleware(
+        DemoReadOnlyMiddleware,
+        settings_provider=lambda: SimpleNamespace(DEMO_MODE=demo_mode),
+    )
+
+    @app.api_route(
+        "/resource",
+        methods=["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"],
+    )
+    async def resource():
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def test_demo_mode_allows_safe_methods():
+    client = _build_demo_guard_client()
+
+    assert client.get("/resource").status_code == 200
+    assert client.head("/resource").status_code == 200
+    assert client.options("/resource").status_code == 200
+
+
+def test_demo_mode_blocks_mutating_methods():
+    client = _build_demo_guard_client()
+
+    for method in (client.post, client.put, client.patch, client.delete):
+        response = method("/resource")
+        assert response.status_code == 403
+        assert response.json()["detail"].startswith("This public demo is read-only.")
+
+
+def test_normal_mode_allows_mutating_methods():
+    client = _build_demo_guard_client(demo_mode=False)
+
+    assert client.post("/resource").status_code == 200


### PR DESCRIPTION
## Summary
- add a demo-mode middleware that blocks mutating HTTP methods while DEMO_MODE=true
- keep safe methods available so the public demo remains browsable
- adjust the AUTH_DISABLED startup warning when demo mode has the read-only guard

## Validation
- python3 -m py_compile backend/app/middleware/demo.py backend/app/main.py backend/app/tests/test_demo_read_only.py
- git diff --check
- targeted pytest could not run locally because the fresh checkout has no pytest environment; CI should run the suite