### PR TITLE
Fill demo dashboard surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 **DMARQ** is a modern, privacy-conscious DMARC monitoring and analysis platform built for professionals who want deep visibility into their email authentication posture — without giving up control or relying on third-party SaaS providers.
 
-🌐 [Live Demo (soon)](https://app.dmarq.org)  
-🔒 Self-hosted. Secure. Beautifully visual.  
-🛠️ Docker-deployable. DNS posture checks with optional Cloudflare inspection.
-📬 Aggregate report support (failure/forensic reports planned).
+- 🌐 [Live Demo](https://demo.dmarq.org)
+- 🔒 Self-hosted. Secure. Beautifully visual.
+- 🛠️ Docker-deployable. DNS posture checks with optional Cloudflare inspection.
+- 📬 Aggregate, forensic/failure, and SMTP TLS report support.
 
 ---
 
@@ -17,9 +17,12 @@ No more guessing. See which services are passing DMARC, which are failing, and h
 
 ---
 
-## 🚀 Current Status (Milestones 1–8 Complete)
+## 🚀 Current Status
 
-DMARQ currently supports end-to-end aggregate DMARC monitoring with mailbox ingestion, persistence, reporting, DNS checks, and notifications.
+DMARQ currently focuses on parsing reports and helping operators configure and
+lint DMARC-related DNS settings. It supports aggregate DMARC monitoring,
+failure/forensic samples, SMTP TLS reports, mailbox ingestion, persistence,
+reporting, DNS checks, and notifications.
 
 Included:
 
@@ -31,11 +34,9 @@ Included:
 - ✅ Alerts & notifications via Apprise (test send, alert rules, daily/weekly summaries)
 - ✅ DNS checks (DMARC/SPF/DKIM) with DKIM selector discovery from report data
 - ✅ Cloudflare read-only domain discovery, DNS inspection, recommendations, and change tracking
-
-Up next:
-
-- 🔜 Setup and operations polish (Milestone 9)
-- 🧊 Failure/forensic report support (RUF) (Milestone 10)
+- ✅ Forensic/failure report ingestion with redacted metadata and grouped analysis
+- ✅ SMTP TLS report ingestion, trends, and top failure summaries
+- ✅ Public demo mode with rolling synthetic `dmarq.org` and `dmarq.com` data
 
 ---
 
@@ -45,6 +46,8 @@ Up next:
 - **DMARC Compliance Rate**: Track pass/fail rates over time
 - **Volume & Trends**: Identify traffic spikes and anomalies
 - **Top Sending Sources**: Detect unknown or unauthorized senders
+- **Forensic Reports**: Review redacted failure samples and grouped diagnoses
+- **SMTP TLS Reports**: Track TLS-RPT sessions, failures, and affected domains
 - **Actionable Recommendations**: Prioritize what to fix next
 - **Export**: CSV export for selected domains and date ranges
 
@@ -60,7 +63,13 @@ Up next:
 - Suggestions for missing or malformed entries
 - Track configuration changes over time
 
-### ⚙️ Web-Based Setup Wizard (Planned / In Progress)
+### 🧪 Public Demo Mode
+- `DEMO_MODE=true` seeds deterministic, rolling demo data for `dmarq.org` and `dmarq.com`
+- Demo data fills the dashboard, domain details, DNS posture, aggregate reports,
+  forensic reports, TLS reports, exports, and linting views
+- The public demo is read-only so visitors can explore without modifying data
+
+### ⚙️ Web-Based Setup Wizard
 - Guided onboarding experience (no CLI setup required)
 - Store all configuration in a secure internal database
 - Seed config with environment variables for headless deployment
@@ -148,10 +157,10 @@ settings.
 
 ## 🧭 Development Roadmap
 
-- ✅ **Milestones 1–8**: Parsing, ingestion (upload/IMAP/Gmail), persistence, reporting, notifications, production hardening, DNS health, Cloudflare read-only inspection
-- 🔜 **Milestone 9**: Setup and operations polish
-- 🧊 **Milestone 10**: Failure/forensic report support (RUF)
-- 🧠 **Milestones 11–16**: DMARC format compatibility, Microsoft 365 ingestion, broader email posture, APIs/webhooks, workspaces/MSP, AI/MCP (see docs)
+DMARQ's product scope is deliberately narrow: parse standards-based reports,
+explain the results, and help operators configure and lint DMARC-adjacent DNS
+records. Future work should strengthen that loop rather than turn DMARQ into a
+general-purpose mail gateway or delivery platform.
 
 See the full [Roadmap](docs/development/roadmap.md) and [Milestones](docs/milestones.md).
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1717,6 +1717,7 @@ async def get_domain_reports(
     # Generate report entries
     report_entries = []
     for report in reports:
+        summary = report.get("summary") or {}
         policy_val = report.get("policy", "none")
         if isinstance(policy_val, dict):
             policy_val = policy_val.get("p", "none")
@@ -1726,8 +1727,8 @@ async def get_domain_reports(
                 org_name=report.get("org_name", "Unknown Organization"),
                 begin_date=report.get("begin_timestamp", 0),
                 end_date=report.get("end_timestamp", 0),
-                total_emails=report.get("total_count", 0),
-                pass_rate=report.get("pass_rate", 0.0),
+                total_emails=summary.get("total_count", report.get("total_count", 0)),
+                pass_rate=summary.get("pass_rate", report.get("pass_rate", 0.0)),
                 policy=policy_val,
             )
         )

--- a/backend/app/api/api_v1/endpoints/forensics.py
+++ b/backend/app/api/api_v1/endpoints/forensics.py
@@ -5,10 +5,16 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, selectinload
 
+from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.report import ForensicReport
+from app.services.demo_data import (
+    analyze_demo_forensic_reports,
+    get_demo_forensic_report,
+    list_demo_forensic_reports,
+)
 from app.services.forensic_analysis import analyze_forensic_report, summarize_forensic_samples
 from app.services.forensic_parser import ForensicParser, MAX_FORENSIC_REPORT_SIZE
 from app.services.forensic_persistence import (
@@ -208,6 +214,18 @@ async def list_forensic_reports(
     _auth: dict = Depends(require_admin_auth),
 ):
     """List stored forensic reports, newest first."""
+    if get_settings().DEMO_MODE:
+        return ForensicListResponse(
+            **list_demo_forensic_reports(
+                domain=domain,
+                source_ip=source_ip,
+                auth_failure=auth_failure,
+                delivery_result=delivery_result,
+                page=page,
+                page_size=page_size,
+            )
+        )
+
     query = _filtered_forensic_query(
         db,
         domain=domain,
@@ -244,6 +262,17 @@ async def analyze_forensic_reports(
     _auth: dict = Depends(require_admin_auth),
 ):
     """Summarize stored forensic samples into operator investigation groups."""
+    if get_settings().DEMO_MODE:
+        return ForensicAnalysisResponse(
+            **analyze_demo_forensic_reports(
+                domain=domain,
+                source_ip=source_ip,
+                auth_failure=auth_failure,
+                delivery_result=delivery_result,
+                page_size=page_size,
+            )
+        )
+
     query = _filtered_forensic_query(
         db,
         domain=domain,
@@ -266,6 +295,14 @@ async def get_forensic_report(
     _auth: dict = Depends(require_admin_auth),
 ):
     """Return one stored forensic report by numeric ID."""
+    if get_settings().DEMO_MODE:
+        row = get_demo_forensic_report(report_id)
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Forensic report not found"
+            )
+        return ForensicReportResponse(**row)
+
     row = (
         db.query(ForensicReport)
         .options(selectinload(ForensicReport.domain))

--- a/backend/app/api/api_v1/endpoints/stats.py
+++ b/backend/app/api/api_v1/endpoints/stats.py
@@ -3,7 +3,9 @@ from typing import Any, Dict
 from fastapi import APIRouter, Depends, Path, Query
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.database import get_db
+from app.services.demo_data import build_demo_dashboard_statistics
 from app.utils.stats_summarizer import StatsSummarizer
 
 router = APIRouter()
@@ -26,6 +28,12 @@ async def get_dashboard_statistics(
     Returns:
         Dictionary with dashboard statistics
     """
+    if get_settings().DEMO_MODE:
+        stats = build_demo_dashboard_statistics(period_days=period_days)
+        stats["api_version"] = "1.0"
+        stats["period_days"] = period_days
+        return stats
+
     # Initialize statistics summarizer
     stats_summarizer = StatsSummarizer()
 
@@ -61,6 +69,12 @@ async def get_domain_statistics(
     Returns:
         Dictionary with domain statistics
     """
+    if get_settings().DEMO_MODE:
+        stats = build_demo_dashboard_statistics(period_days=period_days, domain=domain_id)
+        stats["api_version"] = "1.0"
+        stats["period_days"] = period_days
+        return stats
+
     # Initialize statistics summarizer
     stats_summarizer = StatsSummarizer()
 

--- a/backend/app/api/api_v1/endpoints/tls_reports.py
+++ b/backend/app/api/api_v1/endpoints/tls_reports.py
@@ -5,10 +5,12 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, selectinload
 
+from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.report import TLSReport
+from app.services.demo_data import list_demo_tls_reports, summarize_demo_tls_reports
 from app.services.tls_report_parser import MAX_TLS_REPORT_SIZE, TLSReportParser
 from app.services.tls_report_persistence import (
     TLS_REPORT_PRIVACY_CONTROLS,
@@ -158,6 +160,11 @@ async def list_tls_reports(
     _auth: dict = Depends(require_admin_auth),
 ):
     """List stored SMTP TLS reports, newest first."""
+    if get_settings().DEMO_MODE:
+        return TLSReportListResponse(
+            **list_demo_tls_reports(domain=domain, page=page, page_size=page_size)
+        )
+
     query = _filtered_tls_query(db, domain=domain)
     total = query.count()
     rows = (
@@ -186,4 +193,9 @@ async def tls_report_summary(
     _auth: dict = Depends(require_admin_auth),
 ):
     """Summarize TLS reports into trends and top failure causes."""
+    if get_settings().DEMO_MODE:
+        return TLSSummaryResponse(
+            **summarize_demo_tls_reports(domain=domain, days=days, limit=limit)
+        )
+
     return TLSSummaryResponse(**summarize_tls_reports(db, domain=domain, days=days, limit=limit))

--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter, defaultdict
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -9,6 +10,32 @@ from app.services.report_store import ReportStore
 
 DEMO_DOMAINS = ("dmarq.org", "dmarq.com")
 DEMO_DAYS = 90
+DEMO_TLS_REPORT_PRIVACY_CONTROLS = {
+    "retention": (
+        "TLS reports store aggregate session counts, reporting organization metadata, "
+        "policy domains, and grouped TLS failure details."
+    ),
+    "stored_fields": [
+        "report id",
+        "reporting organization",
+        "contact info",
+        "policy domain",
+        "policy type",
+        "report date range",
+        "successful and failed session counts",
+        "grouped result type and failed-session count",
+        "receiving MX host/HELO/IP when supplied by the reporter",
+        "failure reason code and additional grouped diagnostic text",
+    ],
+    "not_stored": [
+        "message bodies",
+        "message subjects",
+        "sender or recipient addresses",
+        "recipient local-parts",
+        "raw uploaded attachments",
+        "mailbox credentials or source message identifiers",
+    ],
+}
 
 _SOURCE_PROFILES = {
     "dmarq.org": [
@@ -209,9 +236,23 @@ def _summary(records: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+def _auth_status_from_counts(pass_count: int, fail_count: int) -> str:
+    if pass_count > 0 and fail_count > 0:
+        return "mixed"
+    if pass_count > 0:
+        return "pass"
+    if fail_count > 0:
+        return "fail"
+    return "none"
+
+
+def _demo_today(today: Optional[date] = None) -> date:
+    return today or datetime.now(timezone.utc).date()
+
+
 def build_demo_reports(today: Optional[date] = None, days: int = DEMO_DAYS) -> List[Dict[str, Any]]:
     """Return rolling synthetic DMARC aggregate reports through *today*."""
-    anchor = today or datetime.now(timezone.utc).date()
+    anchor = _demo_today(today)
     reports: List[Dict[str, Any]] = []
     start = anchor - timedelta(days=days - 1)
     for day_offset in range(days):
@@ -246,6 +287,698 @@ def build_demo_reports(today: Optional[date] = None, days: int = DEMO_DAYS) -> L
                 }
             )
     return reports
+
+
+def build_demo_dashboard_statistics(
+    *,
+    period_days: int = 30,
+    domain: Optional[str] = None,
+    today: Optional[date] = None,
+) -> Dict[str, Any]:
+    """Return dashboard statistics from the rolling aggregate demo reports."""
+    period_days = max(1, int(period_days or 30))
+    anchor = _demo_today(today)
+    start = anchor - timedelta(days=period_days - 1)
+    normalized_domain = domain.lower().strip(".") if domain else None
+    reports = [
+        report
+        for report in build_demo_reports(today=anchor, days=max(DEMO_DAYS, period_days))
+        if datetime.fromtimestamp(report["begin_timestamp"], tz=timezone.utc).date() >= start
+        and (normalized_domain is None or report["domain"] == normalized_domain)
+    ]
+
+    total_emails = 0
+    compliant_emails = 0
+    daily: Dict[str, Dict[str, int]] = defaultdict(lambda: {"total": 0, "passed": 0})
+    sources: Dict[str, Dict[str, Any]] = defaultdict(
+        lambda: {
+            "ip": "",
+            "count": 0,
+            "spf_pass_count": 0,
+            "spf_fail_count": 0,
+            "dkim_pass_count": 0,
+            "dkim_fail_count": 0,
+            "dmarc_pass_count": 0,
+            "dmarc_fail_count": 0,
+            "domains": set(),
+        }
+    )
+
+    for report in reports:
+        report_day = datetime.fromtimestamp(report["begin_timestamp"], tz=timezone.utc).date()
+        day_key = report_day.isoformat()
+        for record in report.get("records") or []:
+            count = int(record.get("count") or 0)
+            spf_pass = record.get("spf_result") == "pass"
+            dkim_pass = record.get("dkim_result") == "pass"
+            dmarc_pass = spf_pass or dkim_pass
+            total_emails += count
+            if dmarc_pass:
+                compliant_emails += count
+            daily[day_key]["total"] += count
+            daily[day_key]["passed"] += count if dmarc_pass else 0
+
+            source = sources[record.get("source_ip") or "unknown"]
+            source["ip"] = record.get("source_ip") or "unknown"
+            source["count"] += count
+            source["spf_pass_count"] += count if spf_pass else 0
+            source["spf_fail_count"] += 0 if spf_pass else count
+            source["dkim_pass_count"] += count if dkim_pass else 0
+            source["dkim_fail_count"] += 0 if dkim_pass else count
+            source["dmarc_pass_count"] += count if dmarc_pass else 0
+            source["dmarc_fail_count"] += 0 if dmarc_pass else count
+            source["domains"].add(report["domain"])
+
+    compliance_trend: List[Dict[str, Any]] = []
+    for day_key in sorted(daily):
+        total = daily[day_key]["total"]
+        passed = daily[day_key]["passed"]
+        failed = max(0, total - passed)
+        compliance_rate = round((passed / total) * 100, 1) if total else 0.0
+        compliance_trend.append(
+            {
+                "date": day_key,
+                "total": total,
+                "volume": total,
+                "passed": passed,
+                "failed": failed,
+                "rate": compliance_rate,
+                "compliance_rate": compliance_rate,
+                "failure_rate": round((failed / total) * 100, 1) if total else 0.0,
+            }
+        )
+
+    source_rows = []
+    for source in sources.values():
+        source_rows.append(
+            {
+                "ip": source["ip"],
+                "count": source["count"],
+                "spf_pass_count": source["spf_pass_count"],
+                "spf_fail_count": source["spf_fail_count"],
+                "dkim_pass_count": source["dkim_pass_count"],
+                "dkim_fail_count": source["dkim_fail_count"],
+                "dmarc_pass_count": source["dmarc_pass_count"],
+                "dmarc_fail_count": source["dmarc_fail_count"],
+                "spf": _auth_status_from_counts(
+                    source["spf_pass_count"], source["spf_fail_count"]
+                ),
+                "dkim": _auth_status_from_counts(
+                    source["dkim_pass_count"], source["dkim_fail_count"]
+                ),
+                "dmarc": _auth_status_from_counts(
+                    source["dmarc_pass_count"], source["dmarc_fail_count"]
+                ),
+                "domains": sorted(source["domains"]),
+            }
+        )
+    source_rows.sort(key=lambda item: item["count"], reverse=True)
+
+    compliance_rate = round((compliant_emails / total_emails) * 100, 1) if total_emails else 0.0
+    stats = {
+        "total_emails": total_emails,
+        "compliant_emails": compliant_emails,
+        "compliance_rate": compliance_rate,
+        "reports_processed": len(reports),
+        "compliance_trend": compliance_trend,
+        "change_summary": _demo_change_summary(source_rows, normalized_domain),
+    }
+    if normalized_domain:
+        stats.update({"domain": normalized_domain, "sources": source_rows[:10]})
+    else:
+        stats.update(
+            {
+                "total_domains": len({report["domain"] for report in reports}),
+                "top_sources": source_rows[:10],
+            }
+        )
+    return stats
+
+
+def _demo_change_summary(
+    source_rows: List[Dict[str, Any]], domain: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    by_ip = {row["ip"]: row for row in source_rows}
+    changes = []
+    if domain in {None, "dmarq.org"} and "203.0.113.44" in by_ip:
+        row = by_ip["203.0.113.44"]
+        changes.append(
+            {
+                "type": "auth_failure",
+                "severity": "warning",
+                "title": "Newsletter DKIM drift",
+                "domain": "dmarq.org",
+                "source_ip": row["ip"],
+                "message_count": row["dkim_fail_count"],
+                "detail": (
+                    "The newsletter source passes SPF but has repeat DKIM body-hash failures."
+                ),
+                "action": (
+                    "Rotate or re-publish the newsletter DKIM selector before enforcing reject."
+                ),
+            }
+        )
+    if domain in {None, "dmarq.com"} and "198.51.100.199" in by_ip:
+        row = by_ip["198.51.100.199"]
+        changes.append(
+            {
+                "type": "misaligned_source",
+                "severity": "critical",
+                "title": "Unknown forwarder is unauthenticated",
+                "domain": "dmarq.com",
+                "source_ip": row["ip"],
+                "message_count": row["dmarc_fail_count"],
+                "detail": "A low-volume forwarding path fails both SPF and DKIM alignment.",
+                "action": "Confirm ownership before adding DNS includes or DKIM selectors.",
+            }
+        )
+    if domain in {None, "dmarq.com"}:
+        changes.append(
+            {
+                "type": "policy_gap",
+                "severity": "info",
+                "title": "Policy still in monitoring mode",
+                "domain": "dmarq.com",
+                "source_ip": None,
+                "message_count": 0,
+                "detail": "dmarq.com shows useful failure data while p=none prevents enforcement.",
+                "action": (
+                    "Fix the known senders, then move to quarantine with a staged percentage."
+                ),
+            }
+        )
+    return changes[:5]
+
+
+def build_demo_tls_reports(
+    today: Optional[date] = None, days: int = DEMO_DAYS
+) -> List[Dict[str, Any]]:
+    """Return rolling SMTP TLS Reporting data for the public demo."""
+    anchor = _demo_today(today)
+    reports: List[Dict[str, Any]] = []
+    report_id = 1
+    start = anchor - timedelta(days=max(1, days) - 1)
+    failure_profiles = {
+        "dmarq.org": [
+            ("certificate-host-mismatch", "mx2.demo.dmarq.org", "mx.demo.dmarq.org", 3),
+            ("certificate-expired", "legacy-mx.demo.dmarq.org", "legacy cert", 1),
+        ],
+        "dmarq.com": [
+            ("starttls-not-supported", "mx1.demo.dmarq.com", "STARTTLS missing", 9),
+            ("certificate-expired", "mx-old.demo.dmarq.com", "expired chain", 5),
+            ("validation-failure", "mx3.demo.dmarq.com", "untrusted intermediate", 2),
+        ],
+    }
+
+    for offset in range(max(1, days)):
+        report_day = start + timedelta(days=offset)
+        day_index = (report_day - date(2026, 1, 1)).days
+        for domain in DEMO_DOMAINS:
+            if day_index % 2 and domain == "dmarq.org":
+                continue
+            failures = []
+            failed_sessions = 0
+            for failure_index, (result_type, host, reason, base) in enumerate(
+                failure_profiles[domain]
+            ):
+                if (day_index + failure_index) % (failure_index + 3) != 0:
+                    continue
+                count = base + (day_index % 4)
+                failed_sessions += count
+                failures.append(
+                    {
+                        "result_type": result_type,
+                        "failed_session_count": count,
+                        "sending_mta_ip": None,
+                        "receiving_mx_hostname": host,
+                        "receiving_mx_helo": host.split(".")[0],
+                        "receiving_ip": None,
+                        "failure_reason_code": reason,
+                        "additional_information": (
+                            "Synthetic demo TLS-RPT group; no message content is stored."
+                        ),
+                    }
+                )
+            successful_sessions = (
+                1800 + (day_index % 9) * 45 if domain == "dmarq.org" else 900 + (day_index % 8) * 30
+            )
+            reports.append(
+                {
+                    "id": report_id,
+                    "report_id": f"demo-tls-{domain}-{report_day.isoformat()}",
+                    "domain": domain,
+                    "org_name": "DMARQ Demo TLS Reporter",
+                    "contact_info": "mailto:tls-rpt@demo.dmarq.org",
+                    "policy_domain": domain,
+                    "policy_type": "sts",
+                    "begin_date": datetime.combine(
+                        report_day, time.min, tzinfo=timezone.utc
+                    ).isoformat(),
+                    "end_date": datetime.combine(
+                        report_day, time.max.replace(microsecond=0), tzinfo=timezone.utc
+                    ).isoformat(),
+                    "total_successful_sessions": successful_sessions,
+                    "total_failure_sessions": failed_sessions,
+                    "processed_at": datetime.combine(
+                        report_day + timedelta(days=1), time(hour=1), tzinfo=timezone.utc
+                    ).isoformat(),
+                    "failures": failures,
+                }
+            )
+            report_id += 1
+    reports.sort(key=lambda item: (item["begin_date"], item["id"]), reverse=True)
+    return reports
+
+
+def list_demo_tls_reports(
+    *,
+    domain: Optional[str] = None,
+    page: int = 1,
+    page_size: int = 50,
+    today: Optional[date] = None,
+) -> Dict[str, Any]:
+    normalized_domain = domain.lower().strip(".") if domain else None
+    rows = [
+        row
+        for row in build_demo_tls_reports(today=today)
+        if normalized_domain is None or row["policy_domain"] == normalized_domain
+    ]
+    total = len(rows)
+    start = (page - 1) * page_size
+    end = start + page_size
+    return {
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "total_pages": (total + page_size - 1) // page_size if total else 0,
+        "reports": rows[start:end],
+        "privacy": DEMO_TLS_REPORT_PRIVACY_CONTROLS,
+    }
+
+
+def summarize_demo_tls_reports(
+    *,
+    domain: Optional[str] = None,
+    days: int = 30,
+    limit: int = 10,
+    today: Optional[date] = None,
+) -> Dict[str, Any]:
+    anchor = _demo_today(today)
+    cutoff = anchor - timedelta(days=max(1, days) - 1)
+    normalized_domain = domain.lower().strip(".") if domain else None
+    rows = [
+        row
+        for row in build_demo_tls_reports(today=anchor, days=max(DEMO_DAYS, days))
+        if datetime.fromisoformat(row["begin_date"]).date() >= cutoff
+        and (normalized_domain is None or row["policy_domain"] == normalized_domain)
+    ]
+
+    totals = {
+        "reports": len(rows),
+        "successful_sessions": sum(row["total_successful_sessions"] for row in rows),
+        "failed_sessions": sum(row["total_failure_sessions"] for row in rows),
+    }
+    session_total = totals["successful_sessions"] + totals["failed_sessions"]
+    totals["failure_rate"] = totals["failed_sessions"] / session_total if session_total else 0.0
+
+    trend_map: Dict[str, Dict[str, Any]] = defaultdict(
+        lambda: {"date": "", "reports": 0, "successful_sessions": 0, "failed_sessions": 0}
+    )
+    domain_map: Dict[str, Dict[str, Any]] = defaultdict(
+        lambda: {
+            "domain": "",
+            "reports": 0,
+            "successful_sessions": 0,
+            "failed_sessions": 0,
+            "top_failure": None,
+        }
+    )
+    failure_map: Dict[str, Dict[str, Any]] = defaultdict(
+        lambda: {
+            "result_type": "",
+            "failed_sessions": 0,
+            "reports": set(),
+            "affected_domains": set(),
+            "receiving_mx_hostnames": set(),
+            "reason_codes": set(),
+        }
+    )
+
+    for row in rows:
+        day_key = datetime.fromisoformat(row["begin_date"]).date().isoformat()
+        trend = trend_map[day_key]
+        trend["date"] = day_key
+        trend["reports"] += 1
+        trend["successful_sessions"] += row["total_successful_sessions"]
+        trend["failed_sessions"] += row["total_failure_sessions"]
+
+        domain_summary = domain_map[row["policy_domain"]]
+        domain_summary["domain"] = row["policy_domain"]
+        domain_summary["reports"] += 1
+        domain_summary["successful_sessions"] += row["total_successful_sessions"]
+        domain_summary["failed_sessions"] += row["total_failure_sessions"]
+
+        top_failure = None
+        for failure in row["failures"]:
+            item = failure_map[failure["result_type"]]
+            item["result_type"] = failure["result_type"]
+            item["failed_sessions"] += failure["failed_session_count"]
+            item["reports"].add(row["report_id"])
+            item["affected_domains"].add(row["policy_domain"])
+            if failure.get("receiving_mx_hostname"):
+                item["receiving_mx_hostnames"].add(failure["receiving_mx_hostname"])
+            if failure.get("failure_reason_code"):
+                item["reason_codes"].add(failure["failure_reason_code"])
+            if top_failure is None or failure["failed_session_count"] > top_failure[
+                "failed_session_count"
+            ]:
+                top_failure = failure
+        if top_failure:
+            domain_summary["top_failure"] = top_failure["result_type"]
+
+    affected_domains = []
+    for item in domain_map.values():
+        domain_sessions = item["successful_sessions"] + item["failed_sessions"]
+        item["failure_rate"] = item["failed_sessions"] / domain_sessions if domain_sessions else 0.0
+        affected_domains.append(item)
+    affected_domains.sort(key=lambda item: item["failed_sessions"], reverse=True)
+
+    top_failures = [
+        {
+            "result_type": item["result_type"],
+            "failed_sessions": item["failed_sessions"],
+            "report_count": len(item["reports"]),
+            "affected_domains": sorted(item["affected_domains"]),
+            "receiving_mx_hostnames": sorted(item["receiving_mx_hostnames"])[:5],
+            "reason_codes": sorted(item["reason_codes"])[:5],
+        }
+        for item in failure_map.values()
+    ]
+    top_failures.sort(key=lambda item: item["failed_sessions"], reverse=True)
+
+    return {
+        "domain": normalized_domain,
+        "days": days,
+        "totals": totals,
+        "trends": [trend_map[key] for key in sorted(trend_map)],
+        "top_failures": top_failures[:limit],
+        "affected_domains": affected_domains[:limit],
+        "privacy": DEMO_TLS_REPORT_PRIVACY_CONTROLS,
+    }
+
+
+def _forensic_scenarios() -> List[Dict[str, Any]]:
+    return [
+        {
+            "domain": "dmarq.org",
+            "source_ip": "203.0.113.44",
+            "auth_failure": "dkim",
+            "delivery_result": "quarantine",
+            "selector": "news",
+            "mail_from": "bounce.dmarq.org",
+            "diagnostic": "newsletter body hash did not verify",
+        },
+        {
+            "domain": "dmarq.org",
+            "source_ip": "192.0.2.66",
+            "auth_failure": "dmarc",
+            "delivery_result": "reject",
+            "selector": "legacy",
+            "mail_from": "legacy.dmarq.org",
+            "diagnostic": "legacy CRM failed SPF and DKIM alignment",
+        },
+        {
+            "domain": "dmarq.com",
+            "source_ip": "198.51.100.88",
+            "auth_failure": "dkim",
+            "delivery_result": "none",
+            "selector": "mailchimp",
+            "mail_from": "bounce.dmarq.com",
+            "diagnostic": "marketing sender intermittently signs with the old selector",
+        },
+        {
+            "domain": "dmarq.com",
+            "source_ip": "198.51.100.199",
+            "auth_failure": "spf",
+            "delivery_result": "none",
+            "selector": "unknown",
+            "mail_from": "forwarder.example.net",
+            "diagnostic": "unknown forwarder is not authorized in SPF",
+        },
+    ]
+
+
+def build_demo_forensic_reports(
+    today: Optional[date] = None, days: int = DEMO_DAYS
+) -> List[Dict[str, Any]]:
+    """Return redacted rolling DMARC forensic/failure samples for the demo."""
+    anchor = _demo_today(today)
+    start = anchor - timedelta(days=max(1, days) - 1)
+    reports: List[Dict[str, Any]] = []
+    report_id = 1
+    for offset in range(max(1, days)):
+        report_day = start + timedelta(days=offset)
+        day_index = (report_day - date(2026, 1, 1)).days
+        for scenario_index, scenario in enumerate(_forensic_scenarios()):
+            if (day_index + scenario_index) % (4 + scenario_index) != 0:
+                continue
+            arrival = datetime.combine(
+                report_day, time(hour=8 + scenario_index, minute=15), tzinfo=timezone.utc
+            )
+            dkim_result = "fail" if scenario["auth_failure"] in {"dkim", "dmarc"} else "pass"
+            spf_result = "fail" if scenario["auth_failure"] in {"spf", "dmarc"} else "pass"
+            auth_results = (
+                f"mx.demo.dmarq.org; dkim={dkim_result} "
+                f"header.d={scenario['domain']} header.s={scenario['selector']}; "
+                f"spf={spf_result} "
+                f"smtp.mailfrom={scenario['mail_from']}; dmarc=fail"
+            )
+            item = {
+                "id": report_id,
+                "report_id": (
+                    f"demo-ruf-{scenario['domain']}-{report_day.isoformat()}-{scenario_index}"
+                ),
+                "domain": scenario["domain"],
+                "reported_domain": scenario["domain"],
+                "source_email": "DMARC Reporter <reports@receiver.example>",
+                "feedback_type": "auth-failure",
+                "user_agent": "DMARQ Demo Failure Reporter",
+                "version": "1.0",
+                "source_ip": scenario["source_ip"],
+                "auth_failure": scenario["auth_failure"],
+                "delivery_result": scenario["delivery_result"],
+                "arrival_date": arrival.isoformat(),
+                "authentication_results": auth_results,
+                "original_mail_from": f"bo***@{scenario['mail_from'].split('.', 1)[-1]}",
+                "original_from": f"se***@{scenario['domain']}",
+                "original_to": "re***@recipient.example",
+                "original_subject": "[redacted-subject]",
+                "original_message_id": f"demo-redacted-{report_id}@example.invalid",
+                "original_date": arrival.isoformat(),
+                "feedback_headers": {
+                    "identity_alignment": scenario["auth_failure"],
+                    "dkim_selector": scenario["selector"],
+                    "dkim_identity": f"se***@{scenario['domain']}",
+                    "spf_dns": "v=spf1 include:_spf.example.net -all",
+                    "demo_note": scenario["diagnostic"],
+                },
+                "processed_at": (arrival + timedelta(minutes=3)).isoformat(),
+            }
+            item["analysis"] = _analyze_demo_forensic_item(item)
+            reports.append(item)
+            report_id += 1
+    reports.sort(key=lambda item: (item["arrival_date"], item["id"]), reverse=True)
+    return reports
+
+
+def _priority_for_forensic(item: Dict[str, Any]) -> str:
+    if item.get("delivery_result") in {"reject", "quarantine"}:
+        return "high"
+    if item.get("auth_failure") == "dmarc":
+        return "high"
+    return "medium"
+
+
+def _recommendations_for_forensic(item: Dict[str, Any]) -> List[str]:
+    failure = item.get("auth_failure")
+    if failure == "dkim":
+        return [
+            "Check the signing selector and canonicalization for this sender.",
+            "Confirm the DKIM public key still matches the sending platform.",
+        ]
+    if failure == "spf":
+        return [
+            "Verify whether the source is authorized before extending SPF.",
+            "Prefer DKIM alignment for forwarding paths that cannot pass SPF.",
+        ]
+    return [
+        "Treat this as a full DMARC alignment failure and verify source ownership.",
+        "Keep enforcement in quarantine until the sending path is identified.",
+    ]
+
+
+def _analyze_demo_forensic_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    headers = item.get("feedback_headers") or {}
+    failure = item.get("auth_failure") or "unknown"
+    priority = _priority_for_forensic(item)
+    dkim_domain = item.get("reported_domain")
+    mail_from = (
+        str(item.get("authentication_results") or "")
+        .split("smtp.mailfrom=")[-1]
+        .split(";")[0]
+    )
+    signals = [
+        f"Identity alignment: {headers.get('identity_alignment', failure)}",
+        f"DKIM selector: {headers.get('dkim_selector', 'unknown')}",
+        f"SPF DNS: {headers.get('spf_dns', 'unknown')}",
+    ]
+    if headers.get("demo_note"):
+        signals.append(f"Demo scenario: {headers['demo_note']}")
+    return {
+        "id": item["id"],
+        "report_id": item["report_id"],
+        "domain": item.get("reported_domain"),
+        "source_ip": item.get("source_ip"),
+        "auth_failure": failure,
+        "delivery_result": item.get("delivery_result"),
+        "priority": priority,
+        "diagnosis": (
+            f"{failure.upper()} failure sample from {item.get('source_ip')} "
+            f"for {item.get('reported_domain')}."
+        ),
+        "recommendations": _recommendations_for_forensic(item),
+        "signals": signals,
+        "authentication_results": {
+            "dkim": "fail" if failure in {"dkim", "dmarc"} else "pass",
+            "spf": "fail" if failure in {"spf", "dmarc"} else "pass",
+            "dmarc": "fail",
+        },
+        "dkim_domain": dkim_domain,
+        "mail_from_domain": mail_from,
+        "privacy_note": "DMARQ stores redacted headers and metadata only for forensic samples.",
+    }
+
+
+def _filter_demo_forensics(
+    rows: Iterable[Dict[str, Any]],
+    *,
+    domain: Optional[str] = None,
+    source_ip: Optional[str] = None,
+    auth_failure: Optional[str] = None,
+    delivery_result: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    normalized_domain = domain.lower().strip(".") if domain else None
+    normalized_auth = auth_failure.strip().lower() if auth_failure else None
+    normalized_result = delivery_result.strip().lower() if delivery_result else None
+    normalized_ip = source_ip.strip() if source_ip else None
+    return [
+        row
+        for row in rows
+        if (normalized_domain is None or row["reported_domain"] == normalized_domain)
+        and (normalized_ip is None or row["source_ip"] == normalized_ip)
+        and (normalized_auth is None or row["auth_failure"] == normalized_auth)
+        and (normalized_result is None or row["delivery_result"] == normalized_result)
+    ]
+
+
+def list_demo_forensic_reports(
+    *,
+    domain: Optional[str] = None,
+    source_ip: Optional[str] = None,
+    auth_failure: Optional[str] = None,
+    delivery_result: Optional[str] = None,
+    page: int = 1,
+    page_size: int = 50,
+    today: Optional[date] = None,
+) -> Dict[str, Any]:
+    rows = _filter_demo_forensics(
+        build_demo_forensic_reports(today=today),
+        domain=domain,
+        source_ip=source_ip,
+        auth_failure=auth_failure,
+        delivery_result=delivery_result,
+    )
+    total = len(rows)
+    start = (page - 1) * page_size
+    end = start + page_size
+    return {
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "total_pages": (total + page_size - 1) // page_size if total else 0,
+        "reports": rows[start:end],
+    }
+
+
+def analyze_demo_forensic_reports(
+    *,
+    domain: Optional[str] = None,
+    source_ip: Optional[str] = None,
+    auth_failure: Optional[str] = None,
+    delivery_result: Optional[str] = None,
+    page_size: int = 200,
+    today: Optional[date] = None,
+) -> Dict[str, Any]:
+    rows = _filter_demo_forensics(
+        build_demo_forensic_reports(today=today),
+        domain=domain,
+        source_ip=source_ip,
+        auth_failure=auth_failure,
+        delivery_result=delivery_result,
+    )[:page_size]
+    samples = [row["analysis"] for row in rows]
+    priority_counts = Counter(sample["priority"] for sample in samples)
+    failure_counts = Counter(sample["auth_failure"] for sample in samples)
+    result_counts = Counter(sample.get("delivery_result") or "unknown" for sample in samples)
+
+    grouped: Dict[tuple[str, str, str, str], Dict[str, Any]] = {}
+    for row in rows:
+        key = (
+            row.get("reported_domain") or "",
+            row.get("source_ip") or "",
+            row.get("auth_failure") or "unknown",
+            row.get("delivery_result") or "unknown",
+        )
+        group = grouped.setdefault(
+            key,
+            {
+                "key": "|".join(key),
+                "domain": key[0],
+                "source_ip": key[1],
+                "auth_failure": key[2],
+                "delivery_result": key[3],
+                "count": 0,
+                "priority": row["analysis"]["priority"],
+                "latest_arrival": row.get("arrival_date"),
+                "diagnosis": row["analysis"]["diagnosis"],
+                "recommendations": row["analysis"]["recommendations"],
+            },
+        )
+        group["count"] += 1
+        if row.get("arrival_date") and row["arrival_date"] > (group.get("latest_arrival") or ""):
+            group["latest_arrival"] = row["arrival_date"]
+    groups = sorted(
+        grouped.values(),
+        key=lambda item: (item["count"], item["latest_arrival"]),
+        reverse=True,
+    )
+    return {
+        "total": len(rows),
+        "priority_counts": dict(priority_counts),
+        "failure_counts": dict(failure_counts),
+        "result_counts": dict(result_counts),
+        "groups": groups,
+        "samples": samples[:50],
+    }
+
+
+def get_demo_forensic_report(
+    report_id: int, today: Optional[date] = None
+) -> Optional[Dict[str, Any]]:
+    for row in build_demo_forensic_reports(today=today):
+        if row["id"] == report_id:
+            return row
+    return None
 
 
 def seed_demo_report_store(store: Optional[ReportStore] = None) -> int:

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -9,160 +9,103 @@
 {% block page_title %}Dashboard{% endblock %}
 
 {% block content %}
-<div class="grid gap-4 md:gap-8 py-4" x-data="dashboardApp()">
-    <!-- Overview Stats -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <!-- Total Domains Card -->
-        {% call card() %}
-            {% call card_header() %}
-                <div class="flex items-center justify-between">
-                    {% call card_title() %}Total Domains{% endcall %}
-                    <div class="p-2 bg-primary/10 rounded-full">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-primary"><circle cx="12" cy="12" r="10"></circle><line x1="2" x2="22" y1="12" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>
+<div class="dashboard-page space-y-6" x-data="dashboardApp()">
+    <div class="grid grid-cols-1 gap-6 xl:grid-cols-12" x-show="hasDomainData" x-cloak>
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6">
+            <div class="mb-3 flex items-start justify-between gap-4">
+                <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">
+                    DMARC Compliance Rate
+                </h2>
+                <div id="overall-pass-rate" class="text-4xl font-bold text-[#120d36]">0%</div>
+            </div>
+            <div class="h-44">
+                <canvas id="compliance-trend-chart" aria-label="Daily DMARC compliance trend"></canvas>
+            </div>
+            <div class="mt-4 grid grid-cols-3 gap-3 border-t border-[#dfdfdf] pt-4 text-sm">
+                <div>
+                    <p class="text-[#5f5c78]">Domains</p>
+                    <p id="total-domains" class="text-lg font-semibold text-[#120d36]">0</p>
+                </div>
+                <div>
+                    <p class="text-[#5f5c78]">Emails</p>
+                    <p id="total-emails" class="text-lg font-semibold text-[#120d36]">0</p>
+                </div>
+                <div>
+                    <p class="text-[#5f5c78]">Reports</p>
+                    <p id="reports-processed" class="text-lg font-semibold text-[#120d36]">0</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
+            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Enforcement Rate</h2>
+            <div class="mt-7 flex justify-center">
+                <div id="enforcement-gauge" class="grid h-48 w-48 place-items-center rounded-full"
+                     style="background: conic-gradient(#2f9da5 0deg, #2f9da5 180deg, #e8e8e8 180deg, #e8e8e8 360deg);">
+                    <div class="grid h-32 w-32 place-items-center rounded-full bg-white text-center">
+                        <div>
+                            <p id="enforcement-label" class="text-xl text-[#07071f]">mixed</p>
+                            <p id="enforcement-rate" class="text-4xl font-bold text-[#120d36]">0%</p>
+                        </div>
                     </div>
                 </div>
-            {% endcall %}
-            {% call card_content() %}
-                <div class="stat-card">
-                    <div id="total-domains" class="stat-value">0</div>
-                    <p class="stat-description">Active domains being monitored</p>
+            </div>
+        </section>
+
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
+            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">DNS Record Health</h2>
+            <div class="mt-5 divide-y divide-[#e6e3e1] text-xl">
+                <div class="flex items-center justify-between py-3">
+                    <span>SPF</span><span id="dns-spf-state" class="text-emerald-600">✓</span>
                 </div>
-            {% endcall %}
-        {% endcall %}
-        
-        <!-- Emails Analyzed Card -->
-        {% call card() %}
-            {% call card_header() %}
-                <div class="flex items-center justify-between">
-                    {% call card_title() %}Emails Analyzed{% endcall %}
-                    <div class="p-2 bg-secondary/10 rounded-full">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-secondary"><rect width="20" height="16" x="2" y="4" rx="2"></rect><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path></svg>
-                    </div>
+                <div class="flex items-center justify-between py-3">
+                    <span>DKIM</span><span id="dns-dkim-state" class="text-emerald-600">✓</span>
                 </div>
-            {% endcall %}
-            {% call card_content() %}
-                <div class="stat-card">
-                    <div id="total-emails" class="stat-value">0</div>
-                    <p class="stat-description">Total emails processed</p>
+                <div class="flex items-center justify-between py-3">
+                    <span>DMARC</span><span id="dns-dmarc-state" class="text-emerald-600">✓</span>
                 </div>
-            {% endcall %}
-        {% endcall %}
-        
-        <!-- Pass Rate Card -->
-        {% call card() %}
-            {% call card_header() %}
-                <div class="flex items-center justify-between">
-                    {% call card_title() %}Pass Rate{% endcall %}
-                    <div class="p-2 bg-green-500/10 rounded-full">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-green-500"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
-                    </div>
+                <div class="flex items-center justify-between py-3">
+                    <span>Policy</span><span id="dns-policy-state" class="text-emerald-600">✓</span>
                 </div>
-            {% endcall %}
-            {% call card_content() %}
-                <div class="stat-card">
-                    <div id="overall-pass-rate" class="stat-value text-green-500">0%</div>
-                    <p class="stat-description">Overall DMARC compliance</p>
-                </div>
-            {% endcall %}
-        {% endcall %}
-        
-        <!-- Reports Card -->
-        {% call card() %}
-            {% call card_header() %}
-                <div class="flex items-center justify-between">
-                    {% call card_title() %}Reports Processed{% endcall %}
-                    <div class="p-2 bg-accent/10 rounded-full">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-accent"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"></path><polyline points="14 2 14 8 20 8"></polyline></svg>
-                    </div>
-                </div>
-            {% endcall %}
-            {% call card_content() %}
-                <div class="stat-card">
-                    <div id="reports-processed" class="stat-value">0</div>
-                    <p class="stat-description">DMARC reports received</p>
-                </div>
-            {% endcall %}
-        {% endcall %}
+            </div>
+        </section>
+
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6">
+            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Volume &amp; Trends</h2>
+            <div class="mt-5 h-64">
+                <canvas id="volume-trend-chart" aria-label="Daily compliant and non-compliant volume"></canvas>
+            </div>
+            <div class="mt-4 flex justify-center gap-8 text-lg">
+                <span class="inline-flex items-center gap-2">
+                    <span class="h-4 w-4 rounded-md bg-[#2f9da5]"></span>Compliant
+                </span>
+                <span class="inline-flex items-center gap-2">
+                    <span class="h-4 w-4 rounded-md bg-[#ff6f3c]"></span>Non-compliant
+                </span>
+            </div>
+        </section>
+
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
+            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Top Sending Sources</h2>
+            <div id="top-sources-list" class="mt-5 space-y-4"></div>
+        </section>
+
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
+            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Forensic Reports</h2>
+            <div id="forensic-summary" class="flex min-h-64 items-center justify-center text-center text-2xl text-[#5f5c78]">
+                No failures
+            </div>
+        </section>
     </div>
 
-    <!-- Dashboard Trends -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4" x-show="hasDomainData" x-cloak>
-        {% call card() %}
-            {% call card_header() %}
-                {% call card_title() %}Mail Volume Trend{% endcall %}
-                {% call card_description() %}
-                    Daily DMARC mail volume over the last 30 days
-                {% endcall %}
-            {% endcall %}
-            {% call card_content() %}
-                <div class="h-64">
-                    <canvas id="volume-trend-chart" aria-label="Daily DMARC mail volume trend"></canvas>
-                </div>
-            {% endcall %}
-        {% endcall %}
-
-        {% call card() %}
-            {% call card_header() %}
-                {% call card_title() %}Authentication Trend{% endcall %}
-                {% call card_description() %}
-                    Daily compliance and failure rates over the last 30 days
-                {% endcall %}
-            {% endcall %}
-            {% call card_content() %}
-                <div class="h-64">
-                    <canvas id="compliance-trend-chart" aria-label="Daily DMARC compliance and failure trend"></canvas>
-                </div>
-            {% endcall %}
-        {% endcall %}
-    </div>
-
-    <!-- What Changed -->
-    <div x-show="hasDomainData" x-cloak>
-        {% call card() %}
-            {% call card_header() %}
-                {% call card_title() %}What Changed{% endcall %}
-                {% call card_description() %}
-                    New sending sources and sharp compliance changes from the last 30 days
-                {% endcall %}
-            {% endcall %}
-            {% call card_content() %}
-                <div id="change-summary-list" class="space-y-3">
-                    <!-- Change summaries will be populated here via JavaScript -->
-                </div>
-            {% endcall %}
-        {% endcall %}
-    </div>
-
-    <!-- Top Sending Sources -->
-    <div x-show="hasDomainData" x-cloak>
-        {% call card() %}
-            {% call card_header() %}
-                {% call card_title() %}Top Sending Sources{% endcall %}
-                {% call card_description() %}
-                    Sender IPs with authentication pass and fail breakdowns
-                {% endcall %}
-            {% endcall %}
-            {% call card_content() %}
-                <div class="overflow-x-auto">
-                    {% call table() %}
-                        {% call thead() %}
-                            {% call tr() %}
-                                {% call th() %}Source{% endcall %}
-                                {% call th() %}Messages{% endcall %}
-                                {% call th() %}DMARC{% endcall %}
-                                {% call th() %}SPF{% endcall %}
-                                {% call th() %}DKIM{% endcall %}
-                            {% endcall %}
-                        {% endcall %}
-                        {% call tbody() %}
-                            <tbody id="top-sources-table-body">
-                                <!-- Source data will be populated here via JavaScript -->
-                            </tbody>
-                        {% endcall %}
-                    {% endcall %}
-                </div>
-            {% endcall %}
-        {% endcall %}
+    <div class="rounded-lg bg-white p-6 shadow-sm" x-show="hasDomainData" x-cloak>
+        <div class="mb-4 flex items-center justify-between gap-4">
+            <div>
+                <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">What Changed</h2>
+                <p class="text-sm text-[#5f5c78]">Recent source and compliance changes</p>
+            </div>
+        </div>
+        <div id="change-summary-list" class="grid gap-3 md:grid-cols-3"></div>
     </div>
     
     <!-- Domain Compliance Table -->
@@ -278,6 +221,7 @@ function dashboardApp() {
             
             // Check IMAP status
             this.getImapStatus();
+            this.fetchForensicSummary();
         },
         
         async getImapStatus() {
@@ -321,6 +265,7 @@ function dashboardApp() {
                 if (data && data.domains && data.domains.length > 0) {
                     this.hasDomainData = true;
                     this.updateDashboardStats(data);
+                    this.updateEnforcementAndDns(data.domains || []);
                     this.populateDomainsTable(data.domains);
                     this.$nextTick(() => this.fetchDashboardStats());
                 } else {
@@ -363,10 +308,89 @@ function dashboardApp() {
             const passRate = document.getElementById('overall-pass-rate');
             const reportsProcessed = document.getElementById('reports-processed');
             
-            if (totalDomains) totalDomains.textContent = data.total_domains || 0;
-            if (totalEmails) totalEmails.textContent = data.total_emails || 0;
+            if (totalDomains) totalDomains.textContent = this.formatLargeNumber(data.total_domains || 0);
+            if (totalEmails) totalEmails.textContent = this.formatLargeNumber(data.total_emails || 0);
             if (passRate) passRate.textContent = `${data.overall_pass_rate || 0}%`;
-            if (reportsProcessed) reportsProcessed.textContent = data.reports_processed || 0;
+            if (reportsProcessed) {
+                reportsProcessed.textContent = this.formatLargeNumber(data.reports_processed || 0);
+            }
+        },
+
+        updateEnforcementAndDns(domains) {
+            const activePolicies = new Set(['quarantine', 'reject']);
+            const enforced = domains.filter(domain => {
+                return activePolicies.has(String(domain.dmarc_policy || '').toLowerCase());
+            }).length;
+            const rate = domains.length ? Math.round((enforced / domains.length) * 100) : 0;
+            const label = rate === 100 ? 'enforced' : rate > 0 ? 'mixed' : 'monitoring';
+
+            const gauge = document.getElementById('enforcement-gauge');
+            const labelEl = document.getElementById('enforcement-label');
+            const rateEl = document.getElementById('enforcement-rate');
+            const degrees = Math.round((rate / 100) * 360);
+            if (gauge) {
+                gauge.style.background = `conic-gradient(#2f9da5 0deg, #2f9da5 ${degrees}deg, #e8e8e8 ${degrees}deg, #e8e8e8 360deg)`;
+            }
+            if (labelEl) labelEl.textContent = label;
+            if (rateEl) rateEl.textContent = `${rate}%`;
+
+            this.setDnsState('dns-spf-state', domains.every(domain => domain.spf_status));
+            this.setDnsState('dns-dkim-state', domains.every(domain => domain.dkim_status));
+            this.setDnsState('dns-dmarc-state', domains.every(domain => domain.dmarc_status));
+            this.setDnsState('dns-policy-state', enforced > 0);
+        },
+
+        setDnsState(id, passing) {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.textContent = passing ? '✓' : '!';
+            el.className = passing ? 'text-emerald-600' : 'text-[#ff6f3c]';
+        },
+
+        async fetchForensicSummary() {
+            const target = document.getElementById('forensic-summary');
+            if (!target) return;
+            try {
+                const response = await fetch('/api/v1/forensics/analysis?page_size=200');
+                if (!response.ok) return;
+                const data = await response.json();
+                target.textContent = '';
+                if (!data.total) {
+                    target.textContent = 'No failures';
+                    return;
+                }
+
+                const wrapper = document.createElement('div');
+                wrapper.className = 'w-full space-y-4 text-left';
+
+                const total = document.createElement('p');
+                total.className = 'text-5xl font-bold text-[#120d36]';
+                total.textContent = data.total;
+                wrapper.appendChild(total);
+
+                const label = document.createElement('p');
+                label.className = 'text-lg text-[#5f5c78]';
+                label.textContent = 'failure samples';
+                wrapper.appendChild(label);
+
+                const groups = Object.entries(data.failure_counts || {}).slice(0, 3);
+                groups.forEach(([name, count]) => {
+                    const row = document.createElement('div');
+                    row.className = 'flex items-center justify-between border-t border-[#e6e3e1] pt-3 text-sm';
+                    const key = document.createElement('span');
+                    key.className = 'uppercase tracking-wide text-[#5f5c78]';
+                    key.textContent = name;
+                    const value = document.createElement('span');
+                    value.className = 'font-semibold text-[#120d36]';
+                    value.textContent = count;
+                    row.appendChild(key);
+                    row.appendChild(value);
+                    wrapper.appendChild(row);
+                });
+                target.appendChild(wrapper);
+            } catch (error) {
+                console.error('Error fetching forensic summary:', error);
+            }
         },
 
         renderDashboardCharts(trendData) {
@@ -384,7 +408,8 @@ function dashboardApp() {
             if (!canvas) return;
 
             const labels = trendData.map(item => item.date);
-            const volumes = trendData.map(item => item.volume || item.total || 0);
+            const compliant = trendData.map(item => item.passed || 0);
+            const failed = trendData.map(item => item.failed || 0);
 
             if (this.volumeTrendChart) {
                 this.volumeTrendChart.destroy();
@@ -394,15 +419,28 @@ function dashboardApp() {
                 type: 'bar',
                 data: {
                     labels,
-                    datasets: [{
-                        label: 'Messages',
-                        data: volumes,
-                        backgroundColor: 'rgba(37, 99, 235, 0.72)',
-                        borderColor: 'rgb(37, 99, 235)',
-                        borderWidth: 1,
-                        borderRadius: 4,
-                        maxBarThickness: 28
-                    }]
+                    datasets: [
+                        {
+                            label: 'Non-compliant',
+                            data: failed,
+                            backgroundColor: '#ff6f3c',
+                            borderColor: '#ff6f3c',
+                            borderWidth: 1,
+                            borderRadius: 2,
+                            maxBarThickness: 30,
+                            stack: 'volume'
+                        },
+                        {
+                            label: 'Compliant',
+                            data: compliant,
+                            backgroundColor: '#2f9da5',
+                            borderColor: '#2f9da5',
+                            borderWidth: 1,
+                            borderRadius: 2,
+                            maxBarThickness: 30,
+                            stack: 'volume'
+                        }
+                    ]
                 },
                 options: {
                     responsive: true,
@@ -410,17 +448,21 @@ function dashboardApp() {
                     scales: {
                         y: {
                             beginAtZero: true,
+                            stacked: true,
+                            grid: {
+                                color: '#e1dedc'
+                            },
                             ticks: {
                                 precision: 0,
                                 callback: value => this.formatLargeNumber(value)
-                            },
-                            title: {
-                                display: true,
-                                text: 'Messages'
                             }
                         },
                         x: {
+                            stacked: true,
                             grid: {
+                                display: false
+                            },
+                            ticks: {
                                 display: false
                             }
                         }
@@ -431,7 +473,7 @@ function dashboardApp() {
                         },
                         tooltip: {
                             callbacks: {
-                                label: context => `${this.formatLargeNumber(context.parsed.y)} messages`
+                                label: context => `${context.dataset.label}: ${this.formatLargeNumber(context.parsed.y)}`
                             }
                         }
                     }
@@ -445,7 +487,6 @@ function dashboardApp() {
 
             const labels = trendData.map(item => item.date);
             const complianceRates = trendData.map(item => item.compliance_rate ?? item.rate ?? 0);
-            const failureRates = trendData.map(item => item.failure_rate ?? 0);
 
             if (this.complianceTrendChart) {
                 this.complianceTrendChart.destroy();
@@ -459,24 +500,14 @@ function dashboardApp() {
                         {
                             label: 'Compliance Rate',
                             data: complianceRates,
-                            borderColor: 'rgb(22, 163, 74)',
-                            backgroundColor: 'rgba(22, 163, 74, 0.12)',
-                            pointBackgroundColor: 'rgb(22, 163, 74)',
-                            pointRadius: 3,
+                            borderColor: '#171346',
+                            backgroundColor: 'rgba(23, 19, 70, 0.12)',
+                            pointBackgroundColor: '#171346',
+                            pointRadius: 0,
                             pointHoverRadius: 5,
-                            tension: 0.35,
+                            borderWidth: 4,
+                            tension: 0.42,
                             fill: true
-                        },
-                        {
-                            label: 'Failure Rate',
-                            data: failureRates,
-                            borderColor: 'rgb(220, 38, 38)',
-                            backgroundColor: 'rgba(220, 38, 38, 0.08)',
-                            pointBackgroundColor: 'rgb(220, 38, 38)',
-                            pointRadius: 3,
-                            pointHoverRadius: 5,
-                            tension: 0.35,
-                            fill: false
                         }
                     ]
                 },
@@ -485,23 +516,30 @@ function dashboardApp() {
                     maintainAspectRatio: false,
                     scales: {
                         y: {
-                            beginAtZero: true,
+                            beginAtZero: false,
                             max: 100,
-                            ticks: {
-                                callback: value => `${value}%`
+                            min: 80,
+                            grid: {
+                                color: '#dfdfdf'
                             },
-                            title: {
-                                display: true,
-                                text: 'Rate'
+                            ticks: {
+                                display: false,
+                                callback: value => `${value}%`
                             }
                         },
                         x: {
                             grid: {
                                 display: false
+                            },
+                            ticks: {
+                                display: false
                             }
                         }
                     },
                     plugins: {
+                        legend: {
+                            display: false
+                        },
                         tooltip: {
                             callbacks: {
                                 label: context => `${context.dataset.label}: ${context.parsed.y}%`
@@ -584,6 +622,12 @@ function dashboardApp() {
 
         populateTopSources(sources) {
             const tableBody = document.getElementById('top-sources-table-body');
+            const sourceList = document.getElementById('top-sources-list');
+
+            if (sourceList) {
+                this.populateTopSourcesList(sourceList, sources || []);
+            }
+
             if (!tableBody) return;
 
             tableBody.textContent = '';
@@ -623,6 +667,52 @@ function dashboardApp() {
                 ));
 
                 tableBody.appendChild(row);
+            });
+        },
+
+        populateTopSourcesList(sourceList, sources) {
+            sourceList.textContent = '';
+
+            if (!sources.length) {
+                const empty = document.createElement('p');
+                empty.className = 'text-lg text-[#5f5c78]';
+                empty.textContent = 'No sending source data available';
+                sourceList.appendChild(empty);
+                return;
+            }
+
+            const total = sources.reduce((sum, source) => sum + (source.count || 0), 0) || 1;
+            const colors = ['#2f9da5', '#ff6f3c', '#2f9da5', '#272a5f'];
+
+            sources.slice(0, 4).forEach((source, index) => {
+                const percentage = Math.max(1, Math.round(((source.count || 0) / total) * 100));
+                const item = document.createElement('div');
+                item.className = 'space-y-2';
+
+                const row = document.createElement('div');
+                row.className = 'flex items-center justify-between gap-3 text-lg';
+
+                const label = document.createElement('span');
+                label.className = 'min-w-0 truncate';
+                label.textContent = source.ip || 'Unknown';
+                row.appendChild(label);
+
+                const value = document.createElement('span');
+                value.className = 'font-semibold';
+                value.textContent = `${percentage}%`;
+                row.appendChild(value);
+
+                const track = document.createElement('div');
+                track.className = 'h-3 overflow-hidden rounded bg-[#e6e6e8]';
+                const bar = document.createElement('div');
+                bar.className = 'h-full rounded';
+                bar.style.width = `${percentage}%`;
+                bar.style.backgroundColor = colors[index % colors.length];
+                track.appendChild(bar);
+
+                item.appendChild(row);
+                item.appendChild(track);
+                sourceList.appendChild(item);
             });
         },
 

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -23,36 +23,30 @@
 
     {% block head %}{% endblock %}
 </head>
-<body class="min-h-screen bg-base-100 font-body antialiased">
-    <!-- Updated Menu Bar -->
-    <header class="navbar bg-primary text-primary-content"
+<body class="min-h-screen bg-[#f4f3f2] font-body antialiased text-[#07071f]">
+    <header class="fixed inset-x-0 top-0 z-40 flex h-24 items-center bg-[#272a5f] px-5 text-white shadow-sm md:px-10"
             x-data="userMenu()" x-init="loadUser()">
-        <div class="flex-1">
-            <a href="/" class="btn btn-ghost normal-case text-xl">
-                <img src="/static/img/monogram_light.png" alt="DMARQ Logo" class="w-8 h-8 mr-2">
-                DMARQ
+        <div class="flex flex-1 items-center">
+            <a href="/" class="inline-flex items-center gap-4" aria-label="DMARQ Dashboard">
+                <img src="/static/img/logo_dark.png" alt="" class="h-12 w-12 object-cover">
+                <span class="text-3xl font-bold tracking-normal">DMARQ</span>
             </a>
         </div>
-        <div class="flex-none">
-            <ul class="menu menu-horizontal px-1">
-                <li><a href="/">Dashboard</a></li>
-                <li><a href="/domains">Domains</a></li>
-                <li><a href="/reports">Reports</a></li>
-                <li><a href="/forensics">Forensics</a></li>
-                <li><a href="/tls-reports">TLS Reports</a></li>
-                <li><a href="/upload">Upload</a></li>
-                <li><a href="/mail-sources">Mail Sources</a></li>
-                <li><a href="/operations">Health</a></li>
-                <li><a href="/settings">Settings</a></li>
-            </ul>
-            <!-- User menu -->
-            <div class="ml-2">
+        <div class="flex items-center gap-3">
+            <nav class="hidden items-center gap-1 text-sm font-semibold lg:flex" aria-label="Primary">
+                <a href="/" class="rounded-md px-3 py-2 text-white/90 hover:bg-white/10">Dashboard</a>
+                <a href="/domains" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Domains</a>
+                <a href="/reports" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Reports</a>
+                <a href="/forensics" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Forensics</a>
+                <a href="/tls-reports" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">TLS</a>
+            </nav>
+            <div>
                 <template x-if="user">
                     <div class="dropdown dropdown-end">
-                        <label tabindex="0" class="btn btn-ghost btn-circle avatar placeholder">
-                            <div class="bg-primary-content text-primary rounded-full w-8">
+                        <label tabindex="0" class="btn btn-ghost btn-circle avatar placeholder h-12 w-12 rounded-full border border-white/40 bg-white/90 text-[#272a5f] hover:bg-white">
+                            <div class="rounded-full w-10">
                                 <template x-if="user.picture">
-                                    <img :src="user.picture" :alt="user.full_name || user.email" class="rounded-full w-8 h-8 object-cover">
+                                    <img :src="user.picture" :alt="user.full_name || user.email" class="h-10 w-10 rounded-full object-cover">
                                 </template>
                                 <template x-if="!user.picture">
                                     <span class="text-sm font-semibold" x-text="(user.full_name || user.email || '?')[0].toUpperCase()"></span>
@@ -84,9 +78,28 @@
         </div>
     </header>
 
-    <!-- Updated Main Content Area with page-specific data initialization -->
-    <main class="p-4 md:p-6">
+    <aside class="fixed bottom-0 left-0 top-24 z-30 hidden w-24 flex-col items-center gap-8 bg-[#171b49] py-10 text-white md:flex" aria-label="Section navigation">
+        <a href="/" title="Dashboard" class="rounded-lg p-3 text-white shadow-sm hover:bg-white/10">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M12 3 3 10.7V21h6v-6h6v6h6V10.7L12 3Z"/></svg>
+        </a>
+        <a href="/domains" title="Domains" class="rounded-lg p-3 text-white/70 hover:bg-white/10 hover:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M4 5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V5Zm4 2v2h8V7H8Zm0 4v2h8v-2H8Zm0 4v2h5v-2H8Z"/></svg>
+        </a>
+        <a href="/reports" title="Reports" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M7 3h7l5 5v13H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm6 1.5V9h4.5L13 4.5ZM8 13h8v2H8v-2Zm0 4h6v2H8v-2Z"/></svg>
+        </a>
+        <a href="/forensics" title="Forensics" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M5 4h14v16H5V4Zm3 4v2h8V8H8Zm0 4v2h8v-2H8Zm0 4v2h5v-2H8Z"/></svg>
+        </a>
+        <a href="/settings" title="Settings" class="mt-auto rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M19.4 13.5a7.8 7.8 0 0 0 0-3l2-1.5-2-3.5-2.4 1a7.6 7.6 0 0 0-2.6-1.5L14 2h-4l-.4 3a7.6 7.6 0 0 0-2.6 1.5l-2.4-1-2 3.5 2 1.5a7.8 7.8 0 0 0 0 3l-2 1.5 2 3.5 2.4-1a7.6 7.6 0 0 0 2.6 1.5l.4 3h4l.4-3a7.6 7.6 0 0 0 2.6-1.5l2.4 1 2-3.5-2-1.5ZM12 15.5A3.5 3.5 0 1 1 12 8a3.5 3.5 0 0 1 0 7.5Z"/></svg>
+        </a>
+    </aside>
+
+    <main class="min-h-screen pt-24 md:ml-24">
+        <div class="p-4 md:p-6 lg:p-8">
         {% block content %}{% endblock %}
+        </div>
     </main>
 
     <!-- Scripts -->

--- a/backend/app/tests/test_demo_data.py
+++ b/backend/app/tests/test_demo_data.py
@@ -3,7 +3,17 @@ from datetime import date, datetime, timezone
 
 import pytest
 
-from app.services.demo_data import DEMO_DOMAINS, build_demo_reports, seed_demo_report_store
+from app.services.demo_data import (
+    DEMO_DOMAINS,
+    analyze_demo_forensic_reports,
+    build_demo_dashboard_statistics,
+    build_demo_forensic_reports,
+    build_demo_reports,
+    list_demo_forensic_reports,
+    list_demo_tls_reports,
+    seed_demo_report_store,
+    summarize_demo_tls_reports,
+)
 from app.services.dns_resolver import DemoDNSProvider
 from app.services.report_store import ReportStore
 
@@ -70,6 +80,55 @@ def test_seed_demo_report_store_replaces_store_with_demo_domains():
     assert set(store.get_domains()) == set(DEMO_DOMAINS)
     assert store.get_domain_summary("dmarq.org")["reports_processed"] == 90
     assert store.get_domain_sources("dmarq.com")
+
+
+def test_build_demo_dashboard_statistics_fills_chart_sources_and_changes():
+    stats = build_demo_dashboard_statistics(today=date(2026, 6, 25), period_days=30)
+
+    assert stats["total_domains"] == 2
+    assert stats["total_emails"] > 0
+    assert stats["compliance_trend"]
+    assert stats["top_sources"]
+    assert stats["change_summary"]
+    assert any(source["dmarc"] in {"mixed", "fail"} for source in stats["top_sources"])
+
+
+def test_build_demo_domain_statistics_includes_sources():
+    stats = build_demo_dashboard_statistics(
+        today=date(2026, 6, 25), period_days=30, domain="dmarq.com"
+    )
+
+    assert stats["domain"] == "dmarq.com"
+    assert "sources" in stats
+    assert stats["sources"]
+    assert "top_sources" not in stats
+
+
+def test_demo_tls_reports_fill_summary_and_list_views():
+    listed = list_demo_tls_reports(today=date(2026, 6, 25), page_size=10)
+    summary = summarize_demo_tls_reports(today=date(2026, 6, 25), days=30)
+
+    assert listed["total"] > 10
+    assert listed["reports"][0]["failures"] is not None
+    assert summary["totals"]["reports"] > 0
+    assert summary["totals"]["failed_sessions"] > 0
+    assert summary["trends"]
+    assert summary["top_failures"]
+    assert summary["affected_domains"]
+
+
+def test_demo_forensic_reports_fill_list_and_analysis_views():
+    reports = build_demo_forensic_reports(today=date(2026, 6, 25), days=30)
+    listed = list_demo_forensic_reports(today=date(2026, 6, 25), auth_failure="dkim")
+    analysis = analyze_demo_forensic_reports(today=date(2026, 6, 25), domain="dmarq.org")
+
+    assert reports
+    assert listed["total"] > 0
+    assert all(report["auth_failure"] == "dkim" for report in listed["reports"])
+    assert analysis["total"] > 0
+    assert analysis["groups"]
+    assert analysis["samples"]
+    assert "redacted headers and metadata only" in analysis["samples"][0]["privacy_note"]
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -124,6 +124,14 @@ def test_get_domain_reports_timestamps_are_integers(seeded_client: TestClient):
     assert report["end_date"] == 1597535999
 
 
+def test_get_domain_reports_uses_nested_summary_totals(seeded_client: TestClient):
+    """Report rows should display totals from the parsed report summary."""
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/reports")
+    assert response.status_code == 200
+    report = response.json()["reports"][0]
+    assert report["total_emails"] == 10
+
+
 def test_get_domain_reports_unknown_domain_returns_404(client: TestClient):
     """Returns 404 when the requested domain has no reports."""
     response = client.get("/api/v1/domains/no-such-domain.example.com/reports")

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -90,6 +90,12 @@ mix of clean records, middle-of-the-road records, and intentional lint findings
 so the domain detail, posture, DNS guidance, CSV export, and report views have
 useful content without requiring real inbound reports or public DNS changes.
 
+The generated data also fills the dashboard summary API, top sending source
+rankings, change summaries, redacted forensic/failure samples, and SMTP TLS
+Reporting summaries. Public demo deployments should also keep the demo
+read-only guard enabled by leaving `DEMO_MODE=true`; mutating requests are
+blocked so visitors cannot upload, delete, or reconfigure demo content.
+
 ### Notification Configuration
 
 DMARQ stores notification targets in the web settings table. Configure them under

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -4,60 +4,81 @@ The DMARQ dashboard provides an at-a-glance view of your email authentication st
 
 ## Overview
 
-When you log in to DMARQ, you'll be presented with the main dashboard that displays key metrics about your DMARC compliance and email authentication status. The dashboard is designed to give you immediate insights into your email security posture.
+When you log in to DMARQ, you'll be presented with the main dashboard that displays key metrics about your DMARC compliance and email authentication status. The dashboard is designed to give you immediate insight into the report-and-DNS loop DMARQ focuses on: who sent mail, whether it aligned, which DNS records are healthy, and what should be fixed next.
 
 ## Dashboard Components
 
 ### DMARC Compliance Rate
 
-This section shows the percentage of emails passing DMARC (both SPF and/or DKIM aligned) out of total emails. A higher compliance rate indicates that your email authentication is working correctly.
+This section shows the percentage of emails passing DMARC (SPF or DKIM aligned) out of total emails. A higher compliance rate indicates that your email authentication is working correctly.
 
-- **Compliance Gauge**: Visual representation of your current compliance rate
 - **Trend Line**: Chart showing compliance rate over time
-- **Failure Count**: Number of messages that failed DMARC checks
+- **Domain Count**: Number of monitored domains contributing reports
+- **Email and Report Counts**: Aggregate message and report volume for the visible period
 
 ### Policy Enforcement Trends
 
-This section visualizes how your domain's DMARC policy and enforcement have evolved:
+The enforcement panel summarizes how many monitored domains currently enforce a
+policy of `quarantine` or `reject`. Domains still using `p=none` are treated as
+monitoring-only so you can see whether authentication issues are fixed before
+moving toward enforcement.
 
-- **Timeline Chart**: Shows the proportion of emails that were quarantined/rejected over time
-- **Policy Change Markers**: Indicators of when policy changed from `none → quarantine → reject`
-- **Blocked Email Statistics**: Bar chart showing how many spoofed emails were blocked per month
+- **Enforced**: All monitored domains are enforcing DMARC
+- **Mixed**: Some domains enforce while others remain in monitoring
+- **Monitoring**: No monitored domains are enforcing yet
 
 ### DNS Record Health Check
 
-This panel lists the essential DNS records for email authentication:
+This panel lists the essential DNS signals for email authentication:
 
 - **SPF**: Status of your SPF TXT record
 - **DKIM**: List of DKIM selectors in use from aggregate reports
 - **DMARC**: Your domain's DMARC record and key tags (p= policy, rua, ruf, pct, etc.)
-- **MX**: Status of your mail exchanger records
-- **BIMI**: Status of your Brand Indicators for Message Identification record
+- **Policy**: Whether at least one monitored domain is enforcing DMARC
 
-Each record is displayed with its actual value and a status indicator.
+The domain detail page contains the deeper DNS posture, linting output,
+recommendations, and evidence behind these summary checks.
 
-### Alerts Summary
+### Volume and Sending Sources
 
-This section highlights recent alerts or important notices:
+The volume chart compares compliant and non-compliant messages over the recent
+reporting window. The top sending sources panel ranks the largest source IPs and
+shows which ones account for the most observed volume.
 
-- **Recent Alerts**: List of the last several alerts with severity indicators
-- **Quick Actions**: Options to resolve or dismiss alerts
+Use these two panels together: a traffic spike from a known compliant sender is
+usually routine, while a spike from an unknown or failing sender needs review.
 
 ### Forensic Report Drilldown
 
-For detailed investigation of DMARC failures:
+For detailed investigation of DMARC failures, the dashboard links into redacted
+failure samples:
 
 - **Filtering**: Filter reports by date, source IP, or sending source
-- **Detailed View**: Examine specifics of each forensic report
-- **Header Analysis**: Option to view full email headers for advanced troubleshooting
+- **Detailed View**: Examine metadata and authentication results for each sample
+- **Grouped Analysis**: Review repeated failure patterns without storing message bodies
+
+### What Changed
+
+The change summary highlights new sources, compliance drops, and policy gaps
+detected in the current reporting window. These entries are designed to point to
+the next DNS or sender-configuration action rather than act as a general alert
+feed.
+
+### Demo Mode
+
+When `DEMO_MODE=true`, the dashboard uses generated rolling data for
+`dmarq.org` and `dmarq.com`. The demo data fills the aggregate dashboard,
+forensic report summaries, SMTP TLS report summaries, DNS posture, and exports.
+It intentionally includes healthy senders, partially aligned senders, and a few
+misconfigurations so each dashboard panel has realistic content.
 
 ## Customizing the Dashboard
 
 You can customize various aspects of the dashboard:
 
-1. **Date Range**: Adjust the time period for displayed data
-2. **View Preferences**: Choose which metrics are most important to you
-3. **Refresh Rate**: Set how often data is automatically refreshed
+1. **Date Range**: Adjust the time period for API-backed trend data
+2. **Domain Detail Views**: Drill into one domain for source, DNS, and report evidence
+3. **Settings**: Configure retention, forensic redaction, notifications, and integrations
 
 ## Next Steps
 

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -52,7 +52,9 @@ Some public demo deployments run with demo mode enabled. In that mode, DMARQ
 shows generated history for `dmarq.org` and `dmarq.com` instead of customer
 data. The reports roll forward with the current date and intentionally include
 clean senders, partial alignment, and a few DNS/reporting issues so the main
-dashboard, domain details, DNS guidance, and exports have realistic examples.
+dashboard, domain details, DNS guidance, aggregate reports, forensic reports,
+SMTP TLS reports, and exports have realistic examples. Public demo instances are
+read-only.
 
 ## Dashboard Overview
 
@@ -62,10 +64,12 @@ The DMARQ dashboard provides an at-a-glance view of your email authentication st
 
 ### Key Elements
 
-- **Domain Summary**: Shows all monitored domains with compliance rates
-- **Email Volume**: Displays the total number of emails processed
-- **Compliance Rate**: Shows the overall DMARC pass rate
-- **Recent Reports**: Lists the most recent DMARC reports received
+- **DMARC Compliance Rate**: Shows the overall pass rate and recent trend
+- **Enforcement Rate**: Summarizes how many monitored domains enforce `quarantine` or `reject`
+- **DNS Record Health**: Summarizes SPF, DKIM, DMARC, and policy readiness
+- **Volume & Trends**: Compares compliant and non-compliant mail volume
+- **Top Sending Sources**: Highlights the largest senders and their authentication mix
+- **Forensic Reports**: Shows recent redacted failure sample activity
 
 ## Managing Domains
 


### PR DESCRIPTION
## Summary
- add demo-mode dashboard, TLS-RPT, and forensic/failure data generators so public demo views are populated
- wire demo-mode API branches for dashboard stats, TLS summaries, forensic lists/analysis, and fix domain report totals
- restyle the dashboard shell and first viewport toward the provided mockup
- update GitHub-facing docs for demo mode, report support, and project scope

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_demo_data.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_tls_reports_api.py backend/app/tests/test_forensics_api.py -q
- .venv/bin/python -m py_compile backend/app/services/demo_data.py backend/app/api/api_v1/endpoints/stats.py backend/app/api/api_v1/endpoints/tls_reports.py backend/app/api/api_v1/endpoints/forensics.py backend/app/api/api_v1/endpoints/domains.py
- perl -0ne 'while (/<script>\n(.*?)<\/script>/sg) { print  }' backend/app/templates/index.html | node --check -
- git diff --check
- local demo-mode Playwright screenshot checks at 1536x1024 and 390x844; mobile had no horizontal overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public demo mode with read-only sample data across dashboard, domain, forensic, and TLS report views.
  * Expanded the dashboard with enforcement, DNS health, volume trends, top sources, and forensic failure summaries.
  * Added support for viewing and summarizing forensic and SMTP TLS reports.

* **Bug Fixes**
  * Domain report totals now display more accurate counts from nested report data.

* **Documentation**
  * Updated setup, dashboard, and demo-mode documentation to reflect the latest user-facing capabilities and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->