### PR TITLE
Address demo dashboard review follow-up

### DIFF
--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -373,7 +373,9 @@ function dashboardApp() {
                 label.textContent = 'failure samples';
                 wrapper.appendChild(label);
 
-                const groups = Object.entries(data.failure_counts || {}).slice(0, 3);
+                const groups = Object.entries(data.failure_counts || {})
+                    .sort(([, leftCount], [, rightCount]) => rightCount - leftCount)
+                    .slice(0, 3);
                 groups.forEach(([name, count]) => {
                     const row = document.createElement('div');
                     row.className = 'flex items-center justify-between border-t border-[#e6e3e1] pt-3 text-sm';
@@ -518,7 +520,6 @@ function dashboardApp() {
                         y: {
                             beginAtZero: false,
                             max: 100,
-                            min: 80,
                             grid: {
                                 color: '#dfdfdf'
                             },

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -79,20 +79,20 @@
     </header>
 
     <aside class="fixed bottom-0 left-0 top-24 z-30 hidden w-24 flex-col items-center gap-8 bg-[#171b49] py-10 text-white md:flex" aria-label="Section navigation">
-        <a href="/" title="Dashboard" class="rounded-lg p-3 text-white shadow-sm hover:bg-white/10">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M12 3 3 10.7V21h6v-6h6v6h6V10.7L12 3Z"/></svg>
+        <a href="/" aria-label="Dashboard" title="Dashboard" class="rounded-lg p-3 text-white shadow-sm hover:bg-white/10">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 3 3 10.7V21h6v-6h6v6h6V10.7L12 3Z"/></svg>
         </a>
-        <a href="/domains" title="Domains" class="rounded-lg p-3 text-white/70 hover:bg-white/10 hover:text-white">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M4 5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V5Zm4 2v2h8V7H8Zm0 4v2h8v-2H8Zm0 4v2h5v-2H8Z"/></svg>
+        <a href="/domains" aria-label="Domains" title="Domains" class="rounded-lg p-3 text-white/70 hover:bg-white/10 hover:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4 5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V5Zm4 2v2h8V7H8Zm0 4v2h8v-2H8Zm0 4v2h5v-2H8Z"/></svg>
         </a>
-        <a href="/reports" title="Reports" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M7 3h7l5 5v13H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm6 1.5V9h4.5L13 4.5ZM8 13h8v2H8v-2Zm0 4h6v2H8v-2Z"/></svg>
+        <a href="/reports" aria-label="Reports" title="Reports" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M7 3h7l5 5v13H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm6 1.5V9h4.5L13 4.5ZM8 13h8v2H8v-2Zm0 4h6v2H8v-2Z"/></svg>
         </a>
-        <a href="/forensics" title="Forensics" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M5 4h14v16H5V4Zm3 4v2h8V8H8Zm0 4v2h8v-2H8Zm0 4v2h5v-2H8Z"/></svg>
+        <a href="/forensics" aria-label="Forensics" title="Forensics" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 4h14v16H5V4Zm3 4v2h8V8H8Zm0 4v2h8v-2H8Zm0 4v2h5v-2H8Z"/></svg>
         </a>
-        <a href="/settings" title="Settings" class="mt-auto rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor"><path d="M19.4 13.5a7.8 7.8 0 0 0 0-3l2-1.5-2-3.5-2.4 1a7.6 7.6 0 0 0-2.6-1.5L14 2h-4l-.4 3a7.6 7.6 0 0 0-2.6 1.5l-2.4-1-2 3.5 2 1.5a7.8 7.8 0 0 0 0 3l-2 1.5 2 3.5 2.4-1a7.6 7.6 0 0 0 2.6 1.5l.4 3h4l.4-3a7.6 7.6 0 0 0 2.6-1.5l2.4 1 2-3.5-2-1.5ZM12 15.5A3.5 3.5 0 1 1 12 8a3.5 3.5 0 0 1 0 7.5Z"/></svg>
+        <a href="/settings" aria-label="Settings" title="Settings" class="mt-auto rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.4 13.5a7.8 7.8 0 0 0 0-3l2-1.5-2-3.5-2.4 1a7.6 7.6 0 0 0-2.6-1.5L14 2h-4l-.4 3a7.6 7.6 0 0 0-2.6 1.5l-2.4-1-2 3.5 2 1.5a7.8 7.8 0 0 0 0 3l-2 1.5 2 3.5 2.4-1a7.6 7.6 0 0 0 2.6 1.5l.4 3h4l.4-3a7.6 7.6 0 0 0 2.6-1.5l2.4 1 2-3.5-2-1.5ZM12 15.5A3.5 3.5 0 1 1 12 8a3.5 3.5 0 0 1 0 7.5Z"/></svg>
         </a>
     </aside>
 

--- a/backend/app/tests/test_forensics_api.py
+++ b/backend/app/tests/test_forensics_api.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -90,6 +91,31 @@ def test_list_forensic_reports_filters_failure_fields(authed_client, db_session)
     data = response.json()
     assert data["total"] == 1
     assert data["reports"][0]["report_id"] == "ruf-spf-filter-test"
+
+
+def test_demo_mode_forensic_endpoints_return_synthetic_data(authed_client, monkeypatch):
+    monkeypatch.setattr(
+        forensics_endpoint,
+        "get_settings",
+        lambda: SimpleNamespace(DEMO_MODE=True),
+    )
+
+    list_response = authed_client.get("/api/v1/forensics?domain=dmarq.org&page_size=5")
+    assert list_response.status_code == 200
+    list_data = list_response.json()
+    assert list_data["total"] > 0
+    assert len(list_data["reports"]) <= 5
+
+    report_id = list_data["reports"][0]["id"]
+    detail_response = authed_client.get(f"/api/v1/forensics/{report_id}")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["id"] == report_id
+
+    analysis_response = authed_client.get("/api/v1/forensics/analysis?domain=dmarq.org")
+    assert analysis_response.status_code == 200
+    analysis_data = analysis_response.json()
+    assert analysis_data["total"] > 0
+    assert analysis_data["groups"]
 
 
 def test_forensic_analysis_groups_failure_samples(authed_client, db_session):

--- a/backend/app/tests/test_stats_endpoints.py
+++ b/backend/app/tests/test_stats_endpoints.py
@@ -4,6 +4,7 @@ Tests for the /api/v1/stats endpoints.
 Covers dashboard statistics and per-domain statistics with cache refresh.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
@@ -71,6 +72,23 @@ class TestDashboardStatistics:
             assert response.status_code == 200
             mock_instance.invalidate_cache.assert_not_called()
 
+    def test_dashboard_uses_demo_data_when_demo_mode_enabled(
+        self, client: TestClient, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "app.api.api_v1.endpoints.stats.get_settings",
+            lambda: SimpleNamespace(DEMO_MODE=True),
+        )
+
+        response = client.get("/api/v1/stats/dashboard?period_days=7&force_refresh=true")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["api_version"] == "1.0"
+        assert data["period_days"] == 7
+        assert data["total_domains"] == 2
+        assert data["top_sources"]
+
 
 class TestDomainStatistics:
     """Tests for GET /api/v1/stats/domain/{domain_id}"""
@@ -130,3 +148,20 @@ class TestDomainStatistics:
             response = client.get("/api/v1/stats/domain/example.com")
             assert response.status_code == 200
             mock_instance.invalidate_cache.assert_not_called()
+
+    def test_domain_stats_uses_demo_data_when_demo_mode_enabled(
+        self, client: TestClient, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "app.api.api_v1.endpoints.stats.get_settings",
+            lambda: SimpleNamespace(DEMO_MODE=True),
+        )
+
+        response = client.get("/api/v1/stats/domain/dmarq.com?period_days=14")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["api_version"] == "1.0"
+        assert data["period_days"] == 14
+        assert data["domain"] == "dmarq.com"
+        assert data["sources"]

--- a/backend/app/tests/test_tls_reports_api.py
+++ b/backend/app/tests/test_tls_reports_api.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
@@ -85,6 +87,27 @@ def test_list_tls_reports_filters_by_domain(authed_client, db_session):
     data = response.json()
     assert data["total"] == 1
     assert data["reports"][0]["policy_domain"] == "example.net"
+
+
+def test_demo_mode_tls_endpoints_return_synthetic_data(authed_client, monkeypatch):
+    monkeypatch.setattr(
+        tls_endpoint,
+        "get_settings",
+        lambda: SimpleNamespace(DEMO_MODE=True),
+    )
+
+    list_response = authed_client.get("/api/v1/tls-reports?domain=dmarq.org&page_size=5")
+    assert list_response.status_code == 200
+    list_data = list_response.json()
+    assert list_data["total"] > 0
+    assert len(list_data["reports"]) <= 5
+    assert list_data["privacy"]["not_stored"]
+
+    summary_response = authed_client.get("/api/v1/tls-reports/summary?domain=dmarq.org&days=14")
+    assert summary_response.status_code == 200
+    summary_data = summary_response.json()
+    assert summary_data["totals"]["reports"] > 0
+    assert summary_data["top_failures"]
 
 
 def test_tls_report_summary_empty_response_includes_privacy_controls(authed_client):


### PR DESCRIPTION
## Summary
- fix demo dashboard chart and forensic summary review findings
- add explicit accessible names for icon-only sidebar navigation
- cover demo-mode stats, forensic, and TLS endpoints through API tests

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_stats_endpoints.py backend/app/tests/test_forensics_api.py backend/app/tests/test_tls_reports_api.py -q
- perl -0ne 'while (/<script>\n(.*?)<\/script>/sg) { print  }' backend/app/templates/index.html | node --check -
- .venv/bin/python -m py_compile backend/app/tests/test_stats_endpoints.py backend/app/tests/test_forensics_api.py backend/app/tests/test_tls_reports_api.py
- git diff --check