### PR TITLE
Fix dashboard mobile header overflow

### DIFF
--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -12,11 +12,11 @@
 <div class="dashboard-page space-y-6" x-data="dashboardApp()">
     <div class="grid grid-cols-1 gap-6 xl:grid-cols-12" x-show="hasDomainData" x-cloak>
         <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6">
-            <div class="mb-3 flex items-start justify-between gap-4">
-                <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">
+            <div class="mb-3 grid gap-2 sm:flex sm:items-start sm:justify-between sm:gap-4">
+                <h2 class="min-w-0 text-2xl font-semibold tracking-normal text-[#07071f]">
                     DMARC Compliance Rate
                 </h2>
-                <div id="overall-pass-rate" class="text-4xl font-bold text-[#120d36]">0%</div>
+                <div id="overall-pass-rate" class="text-4xl font-bold leading-none text-[#120d36] sm:text-right">0%</div>
             </div>
             <div class="h-44">
                 <canvas id="compliance-trend-chart" aria-label="Daily DMARC compliance trend"></canvas>


### PR DESCRIPTION
## Summary
- stack the compliance card header on narrow screens so the percentage no longer clips off-canvas
- preserve the mockup-style side-by-side compliance title and percentage on larger screens

## Validation
- perl -0ne 'while (/<script>\n(.*?)<\/script>/sg) { print  }' backend/app/templates/index.html | node --check -
- git diff --check

Note: local app-server verification in a fresh checkout was blocked by a reused virtualenv import hang while loading third-party packages; live verification will be done after CI publishes the image.