### PR TITLE
Unify dashboard navigation color

### DIFF
--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -28,7 +28,7 @@
             x-data="userMenu()" x-init="loadUser()">
         <div class="flex flex-1 items-center">
             <a href="/" class="inline-flex items-center gap-4" aria-label="DMARQ Dashboard">
-                <span class="grid h-12 w-12 place-items-center bg-[#171b49]" aria-hidden="true">
+                <span class="grid h-12 w-12 place-items-center bg-[#272a5f]" aria-hidden="true">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-9 w-9" viewBox="0 0 48 48" fill="none" aria-hidden="true" focusable="false">
                         <path d="M24 4 39 9v12.4c0 9.9-6.1 17.3-15 21.9C15.1 38.7 9 31.3 9 21.4V9l15-5Z" stroke="currentColor" stroke-width="3.5" fill="none"/>
                         <circle cx="24" cy="23" r="9" stroke="currentColor" stroke-width="3.5"/>
@@ -84,7 +84,7 @@
         </div>
     </header>
 
-    <aside class="fixed bottom-0 left-0 top-24 z-30 hidden w-24 flex-col items-center gap-8 bg-[#171b49] py-10 text-white md:flex" aria-label="Section navigation">
+    <aside class="fixed bottom-0 left-0 top-24 z-30 hidden w-24 flex-col items-center gap-8 bg-[#272a5f] py-10 text-white md:flex" aria-label="Section navigation">
         <a href="/" aria-label="Dashboard" title="Dashboard" class="rounded-lg p-3 text-white shadow-sm hover:bg-white/10">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 3 3 10.7V21h6v-6h6v6h6V10.7L12 3Z"/></svg>
         </a>


### PR DESCRIPTION
## Summary
- make the header mark background and vertical rail use the same navy as the top header
- remove the accidental darker navigation block that made the menu colors look inconsistent

## Validation
- git diff --check