### PR TITLE
Polish dashboard drilldowns and detail views

### DIFF
--- a/backend/app/templates/components/ui/card.html
+++ b/backend/app/templates/components/ui/card.html
@@ -1,5 +1,5 @@
 {% macro card() %}
-<div class="card bg-base-100 shadow">
+<div class="card rounded-lg bg-white text-[#07071f] shadow-sm">
     {{ caller() }}
 </div>
 {% endmacro %}
@@ -11,13 +11,13 @@
 {% endmacro %}
 
 {% macro card_title(text='') %}
-<h3 class="card-title text-lg font-bold">
+<h3 class="card-title text-lg font-semibold tracking-normal text-[#07071f]">
     {% if text %}{{ text }}{% else %}{{ caller() }}{% endif %}
 </h3>
 {% endmacro %}
 
 {% macro card_description(text='') %}
-<p class="text-sm opacity-70 mt-1">
+<p class="mt-1 text-sm text-[#5f5c78]">
     {% if text %}{{ text }}{% else %}{{ caller() }}{% endif %}
 </p>
 {% endmacro %}

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -6,33 +6,37 @@
 {% block title %}DMARQ - {{ domain.name }} Details{% endblock %}
 
 {% block content %}
-<div class="container mx-auto py-4" x-data="domainDetailsApp('{{ domain_id }}')">
-    <nav class="mb-4 text-sm">
+<div class="space-y-6" x-data="domainDetailsApp('{{ domain_id }}')">
+    <nav class="text-sm text-[#5f5c78]">
         <ol class="flex items-center space-x-2">
-            <li><a href="/" class="hover:text-primary">Dashboard</a></li>
-            <li><span class="text-muted-foreground px-2">/</span></li>
-            <li><a href="/domains" class="hover:text-primary">Domains</a></li>
-            <li><span class="text-muted-foreground px-2">/</span></li>
-            <li><span class="font-medium">{{ domain.name }}</span></li>
+            <li><a href="/" class="font-semibold hover:text-[#2f9da5]">Dashboard</a></li>
+            <li><span class="px-2 text-[#b8b4bd]">/</span></li>
+            <li><a href="/domains" class="font-semibold hover:text-[#2f9da5]">Domains</a></li>
+            <li><span class="px-2 text-[#b8b4bd]">/</span></li>
+            <li><span class="font-semibold text-[#07071f]">{{ domain.name }}</span></li>
         </ol>
     </nav>
 
     <div class="grid grid-cols-1 gap-6">
         <!-- Domain Overview -->
-        <div class="flex justify-between items-start">
-            <div>
-                <h1 class="text-2xl font-bold mb-1">{{ domain.name }}</h1>
-                <p class="text-muted-foreground">{{ domain.description or "Domain monitored by DMARQ" }}</p>
-            </div>
-            <div class="flex space-x-2">
-                {% call button(variant="outline", size="sm") %}
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"></path><path d="m15 5 4 4"></path></svg>
-                    Edit Domain
-                {% endcall %}
-                {% call button(variant="outline", size="sm") %}
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M12 2v7.5"></path><path d="m4.24 10.37 6.58-3.79"></path><path d="m3.24 16.98 7.5-1.01"></path><path d="m13.24 15.97 7.5 1.01"></path><path d="m13.24 3.79 6.58 3.79"></path><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z"></path><path d="M12 12a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z"></path></svg>
-                    Check DNS
-                {% endcall %}
+        <div class="rounded-lg bg-white p-6 shadow-sm">
+            <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div>
+                    <p class="mb-2 text-sm font-semibold uppercase tracking-wide text-[#2f9da5]">Domain detail</p>
+                    <h1 class="text-3xl font-bold tracking-normal text-[#07071f]">{{ domain.name }}</h1>
+                    <p class="mt-2 max-w-3xl text-[#5f5c78]">{{ domain.description or "Domain monitored by DMARQ" }}</p>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    <a href="/domains" class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M8 6h13"></path><path d="M8 12h13"></path><path d="M8 18h13"></path><path d="M3 6h.01"></path><path d="M3 12h.01"></path><path d="M3 18h.01"></path></svg>
+                        All domains
+                    </a>
+                    <a href="#dns-records" class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M12 2v7.5"></path><path d="m4.24 10.37 6.58-3.79"></path><path d="m3.24 16.98 7.5-1.01"></path><path d="m13.24 15.97 7.5 1.01"></path><path d="m13.24 3.79 6.58 3.79"></path><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z"></path><path d="M12 12a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z"></path></svg>
+                        Check DNS
+                    </a>
+                    <a href="#sending-sources" class="btn btn-sm border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f]">Review sources</a>
+                </div>
             </div>
         </div>
 
@@ -49,9 +53,9 @@
                     </div>
                 {% endcall %}
                 {% call card_content() %}
-                    <div class="stat-card">
-                        <div id="compliance-rate" class="stat-value" x-text="stats.complianceRate + '%'">-</div>
-                        <p class="stat-description">Emails passing DMARC</p>
+                    <div>
+                        <div id="compliance-rate" class="text-3xl font-bold text-[#120d36]" x-text="stats.complianceRate + '%'">-</div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">Emails passing DMARC</p>
                     </div>
                 {% endcall %}
             {% endcall %}
@@ -67,9 +71,9 @@
                     </div>
                 {% endcall %}
                 {% call card_content() %}
-                    <div class="stat-card">
-                        <div id="total-emails" class="stat-value" x-text="stats.totalEmails">-</div>
-                        <p class="stat-description">Total emails processed</p>
+                    <div>
+                        <div id="total-emails" class="text-3xl font-bold text-[#120d36]" x-text="stats.totalEmails">-</div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">Total emails processed</p>
                     </div>
                 {% endcall %}
             {% endcall %}
@@ -85,9 +89,9 @@
                     </div>
                 {% endcall %}
                 {% call card_content() %}
-                    <div class="stat-card">
-                        <div id="failed-emails" class="stat-value" x-text="stats.failedEmails">-</div>
-                        <p class="stat-description">Emails failing DMARC</p>
+                    <div>
+                        <div id="failed-emails" class="text-3xl font-bold text-[#ff6f3c]" x-text="stats.failedEmails">-</div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">Emails failing DMARC</p>
                     </div>
                 {% endcall %}
             {% endcall %}
@@ -103,9 +107,9 @@
                     </div>
                 {% endcall %}
                 {% call card_content() %}
-                    <div class="stat-card">
-                        <div id="report-count" class="stat-value" x-text="stats.reportCount">-</div>
-                        <p class="stat-description">DMARC reports received</p>
+                    <div>
+                        <div id="report-count" class="text-3xl font-bold text-[#120d36]" x-text="stats.reportCount">-</div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">DMARC reports received</p>
                     </div>
                 {% endcall %}
             {% endcall %}
@@ -151,22 +155,22 @@
             {% endcall %}
             {% call card_content() %}
                 <div class="grid gap-4 lg:grid-cols-[220px_minmax(0,1fr)]">
-                    <div class="rounded border border-base-300 p-4">
-                        <div class="text-sm text-base-content/60">Posture score</div>
-                        <div class="mt-2 text-4xl font-bold" x-text="posture.score"></div>
-                        <p class="mt-2 text-sm text-base-content/70" x-text="posture.summary"></p>
+                    <div class="rounded-lg bg-[#f4f3f2] p-4">
+                        <div class="text-sm text-[#5f5c78]">Posture score</div>
+                        <div class="mt-2 text-4xl font-bold text-[#120d36]" x-text="posture.score"></div>
+                        <p class="mt-2 text-sm text-[#5f5c78]" x-text="posture.summary"></p>
                     </div>
                     <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
                         <template x-for="item in posture.coverage" :key="item.key">
-                            <a :href="item.href" class="rounded border border-base-300 p-3 hover:border-primary">
+                            <a :href="item.href" class="rounded-lg border border-[#e6e3e1] p-3 transition hover:border-[#2f9da5] hover:shadow-sm">
                                 <div class="flex items-center justify-between gap-2">
-                                    <h3 class="font-semibold" x-text="item.label"></h3>
+                                    <h3 class="font-semibold text-[#07071f]" x-text="item.label"></h3>
                                     <span class="rounded px-2 py-1 text-xs font-semibold capitalize"
                                           :class="item.status === 'pass' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'"
                                           x-text="item.status"></span>
                                 </div>
-                                <p class="mt-2 text-xs text-base-content/70" x-text="item.message"></p>
-                                <p class="mt-2 text-xs text-base-content/50">
+                                <p class="mt-2 text-xs text-[#5f5c78]" x-text="item.message"></p>
+                                <p class="mt-2 text-xs text-[#5f5c78]">
                                     <span x-text="item.evidence_count"></span>
                                     <span> evidence links</span>
                                 </p>
@@ -179,14 +183,14 @@
                     <div class="space-y-3">
                         <h3 class="font-semibold">Recommendations</h3>
                         <template x-for="recommendation in posture.recommendations" :key="recommendation.type">
-                            <div class="rounded border border-base-300 p-4">
+                            <div class="rounded-lg border border-[#e6e3e1] p-4">
                                 <div class="flex items-start gap-3">
                                     <span class="mt-1 h-2.5 w-2.5 rounded-full"
                                           :class="recommendationSeverityClass(recommendation.severity)"></span>
                                     <div class="min-w-0 flex-1">
                                         <h4 class="font-semibold" x-text="recommendation.title"></h4>
-                                        <p class="mt-1 text-sm text-base-content/70" x-text="recommendation.detail"></p>
-                                        <p class="mt-2 text-sm font-medium" x-text="recommendation.action"></p>
+                                        <p class="mt-1 text-sm text-[#5f5c78]" x-text="recommendation.detail"></p>
+                                        <p class="mt-2 text-sm font-semibold text-[#272a5f]" x-text="recommendation.action"></p>
                                         <div class="mt-3 flex flex-wrap gap-2">
                                             <template x-for="item in recommendation.evidence" :key="item.label + item.value">
                                                 <a :href="item.href" class="badge badge-outline gap-1">
@@ -204,14 +208,14 @@
                     <div class="space-y-3" id="posture-changes">
                         <h3 class="font-semibold">What Changed</h3>
                         <template x-for="change in posture.changes" :key="change.title + change.observed_at">
-                            <div class="rounded border border-base-300 p-4">
+                            <div class="rounded-lg border border-[#e6e3e1] p-4">
                                 <div class="flex items-start gap-3">
                                     <span class="mt-1 h-2.5 w-2.5 rounded-full"
                                           :class="recommendationSeverityClass(change.severity)"></span>
                                     <div class="min-w-0">
                                         <h4 class="font-semibold" x-text="change.title"></h4>
-                                        <p class="mt-1 text-sm text-base-content/70" x-text="change.detail"></p>
-                                        <p class="mt-1 text-xs text-base-content/50" x-show="change.observed_at" x-text="formatIsoDate(change.observed_at)"></p>
+                                        <p class="mt-1 text-sm text-[#5f5c78]" x-text="change.detail"></p>
+                                        <p class="mt-1 text-xs text-[#5f5c78]" x-show="change.observed_at" x-text="formatIsoDate(change.observed_at)"></p>
                                         <div class="mt-3 space-y-1">
                                             <template x-for="item in change.evidence" :key="item.label + item.value">
                                                 <div class="text-xs">
@@ -229,11 +233,11 @@
 
                 <div class="mt-5 grid gap-3 lg:grid-cols-3">
                     <template x-for="playbook in posture.playbooks" :key="playbook.key">
-                        <div class="rounded border border-base-300 p-4">
+                        <div class="rounded-lg border border-[#e6e3e1] p-4">
                             <div class="flex items-start justify-between gap-3">
                                 <div>
                                     <h3 class="font-semibold" x-text="playbook.title"></h3>
-                                    <p class="mt-1 text-sm text-base-content/70" x-text="playbook.summary"></p>
+                                    <p class="mt-1 text-sm text-[#5f5c78]" x-text="playbook.summary"></p>
                                 </div>
                             </div>
                             <ol class="mt-3 list-decimal space-y-1 pl-4 text-sm">

--- a/backend/app/templates/forensic_report_detail.html
+++ b/backend/app/templates/forensic_report_detail.html
@@ -4,14 +4,14 @@
 {% block title %}DMARQ - Forensic Report Detail{% endblock %}
 
 {% block content %}
-<div class="container mx-auto py-4" x-data="forensicReportDetailApp({{ report_id }})" x-init="init()">
-    <nav class="mb-4 text-sm">
+<div class="space-y-6" x-data="forensicReportDetailApp({{ report_id }})" x-init="init()">
+    <nav class="text-sm text-[#5f5c78]">
         <ol class="flex items-center space-x-2">
-            <li><a href="/" class="hover:text-primary">Dashboard</a></li>
-            <li><span class="text-base-content/40 px-2">/</span></li>
-            <li><a href="/forensics" class="hover:text-primary">Forensics</a></li>
-            <li><span class="text-base-content/40 px-2">/</span></li>
-            <li><span class="font-medium" x-text="reportId"></span></li>
+            <li><a href="/" class="font-semibold hover:text-[#2f9da5]">Dashboard</a></li>
+            <li><span class="px-2 text-[#b8b4bd]">/</span></li>
+            <li><a href="/forensics" class="font-semibold hover:text-[#2f9da5]">Forensics</a></li>
+            <li><span class="px-2 text-[#b8b4bd]">/</span></li>
+            <li><span class="font-semibold text-[#07071f]" x-text="reportId"></span></li>
         </ol>
     </nav>
 
@@ -27,37 +27,52 @@
 
     <template x-if="!loading && !error && report">
         <div class="space-y-6">
-            <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                <div>
-                    <h1 class="text-2xl font-bold">Forensic Investigation</h1>
-                    <p class="text-sm text-base-content/70 mt-1">
-                        <span x-text="report.report_id"></span>
-                        <span>&bull;</span>
-                        <span x-text="report.domain || report.reported_domain || 'unknown domain'"></span>
-                    </p>
-                </div>
-                <div class="flex gap-2">
-                    <a href="/forensics" class="btn btn-outline btn-sm">Back to Forensics</a>
-                    <a class="btn btn-outline btn-sm" :href="'/domains/' + encodeURIComponent(report.domain || report.reported_domain)">Domain</a>
+            <div class="rounded-lg bg-white p-6 shadow-sm">
+                <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div>
+                        <p class="mb-2 text-sm font-semibold uppercase tracking-wide text-[#ff6f3c]">Forensic sample</p>
+                        <h1 class="text-3xl font-bold tracking-normal text-[#07071f]">Forensic Investigation</h1>
+                        <p class="mt-2 text-[#5f5c78]">
+                            <span x-text="report.report_id"></span>
+                            <span>&bull;</span>
+                            <span x-text="report.domain || report.reported_domain || 'unknown domain'"></span>
+                        </p>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                        <a href="/forensics" class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]">Back to Forensics</a>
+                        <a class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]" :href="'/domains/' + encodeURIComponent(report.domain || report.reported_domain)">Domain</a>
+                    </div>
                 </div>
             </div>
 
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                 {% call card() %}
                     {% call card_header() %}{% call card_title() %}Failure{% endcall %}{% endcall %}
-                    {% call card_content() %}<div class="text-2xl font-semibold uppercase" x-text="report.auth_failure || 'unknown'"></div>{% endcall %}
+                    {% call card_content() %}
+                        <div class="text-2xl font-bold uppercase text-[#ff6f3c]" x-text="report.auth_failure || 'unknown'"></div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">Authentication failure</p>
+                    {% endcall %}
                 {% endcall %}
                 {% call card() %}
                     {% call card_header() %}{% call card_title() %}Delivery{% endcall %}{% endcall %}
-                    {% call card_content() %}<div class="text-2xl font-semibold uppercase" x-text="report.delivery_result || 'unknown'"></div>{% endcall %}
+                    {% call card_content() %}
+                        <div class="text-2xl font-bold uppercase text-[#120d36]" x-text="report.delivery_result || 'unknown'"></div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">Receiver outcome</p>
+                    {% endcall %}
                 {% endcall %}
                 {% call card() %}
                     {% call card_header() %}{% call card_title() %}Source IP{% endcall %}{% endcall %}
-                    {% call card_content() %}<div class="text-xl font-mono" x-text="report.source_ip || '-'"></div>{% endcall %}
+                    {% call card_content() %}
+                        <div class="text-xl font-bold font-mono text-[#120d36]" x-text="report.source_ip || '-'"></div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">Observed sender</p>
+                    {% endcall %}
                 {% endcall %}
                 {% call card() %}
                     {% call card_header() %}{% call card_title() %}Arrival{% endcall %}{% endcall %}
-                    {% call card_content() %}<div class="text-sm font-medium" x-text="formatDate(report.arrival_date || report.processed_at)"></div>{% endcall %}
+                    {% call card_content() %}
+                        <div class="text-sm font-semibold text-[#120d36]" x-text="formatDate(report.arrival_date || report.processed_at)"></div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">Sample timestamp</p>
+                    {% endcall %}
                 {% endcall %}
             </div>
 

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -16,7 +16,10 @@
                 <h2 class="min-w-0 text-2xl font-semibold tracking-normal text-[#07071f]">
                     DMARC Compliance Rate
                 </h2>
-                <div id="overall-pass-rate" class="text-4xl font-bold leading-none text-[#120d36] sm:text-right">0%</div>
+                <div class="grid gap-2 sm:justify-items-end">
+                    <div id="overall-pass-rate" class="text-4xl font-bold leading-none text-[#120d36] sm:text-right">0%</div>
+                    <a href="/domains" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">View domains</a>
+                </div>
             </div>
             <div class="h-44">
                 <canvas id="compliance-trend-chart" aria-label="Daily DMARC compliance trend"></canvas>
@@ -38,7 +41,10 @@
         </section>
 
         <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
-            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Enforcement Rate</h2>
+            <div class="flex items-start justify-between gap-3">
+                <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Enforcement Rate</h2>
+                <a href="/domains" class="mt-1 text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Review</a>
+            </div>
             <div class="mt-7 flex justify-center">
                 <div id="enforcement-gauge" class="grid h-48 w-48 place-items-center rounded-full"
                      style="background: conic-gradient(#2f9da5 0deg, #2f9da5 180deg, #e8e8e8 180deg, #e8e8e8 360deg);">
@@ -53,7 +59,24 @@
         </section>
 
         <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
-            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">DNS Record Health</h2>
+            <div class="flex flex-col gap-3">
+                <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">DNS Record Health</h2>
+                <div class="flex flex-wrap items-center gap-2">
+                    <label class="sr-only" for="dns-health-domain">DNS health domain</label>
+                    <select id="dns-health-domain"
+                            class="min-w-0 rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm font-semibold text-[#120d36]"
+                            x-model="selectedDnsDomain"
+                            @change="updateDnsHealth()">
+                        <template x-for="domain in domains" :key="domain.domain_name || domain.id">
+                            <option :value="domain.domain_name" x-text="domain.domain_name"></option>
+                        </template>
+                    </select>
+                    <a :href="selectedDomainHref"
+                       class="rounded-md border border-[#dfdfdf] px-3 py-2 text-sm font-semibold text-[#2f9da5] hover:border-[#2f9da5] hover:text-[#272a5f]">
+                        Details
+                    </a>
+                </div>
+            </div>
             <div class="mt-5 divide-y divide-[#e6e3e1] text-xl">
                 <div class="flex items-center justify-between py-3">
                     <span>SPF</span><span id="dns-spf-state" class="text-emerald-600">✓</span>
@@ -68,10 +91,19 @@
                     <span>Policy</span><span id="dns-policy-state" class="text-emerald-600">✓</span>
                 </div>
             </div>
+            <div class="mt-4 rounded-md bg-[#f4f3f2] p-3 text-sm text-[#5f5c78]" x-show="selectedDnsDomainRecord">
+                <span class="font-semibold text-[#120d36]" x-text="selectedDnsDomainRecord?.dmarc_policy ? 'Policy: ' + selectedDnsDomainRecord.dmarc_policy : 'Policy: unknown'"></span>
+                <span x-show="selectedDnsDomainRecord?.dmarc_warnings?.length">
+                    · <span x-text="selectedDnsDomainRecord?.dmarc_warnings?.length || 0"></span> lint warning<span x-show="(selectedDnsDomainRecord?.dmarc_warnings?.length || 0) !== 1">s</span>
+                </span>
+            </div>
         </section>
 
         <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6">
-            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Volume &amp; Trends</h2>
+            <div class="flex items-start justify-between gap-3">
+                <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Volume &amp; Trends</h2>
+                <a href="/reports" class="mt-1 text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open reports</a>
+            </div>
             <div class="mt-5 h-64">
                 <canvas id="volume-trend-chart" aria-label="Daily compliant and non-compliant volume"></canvas>
             </div>
@@ -86,12 +118,18 @@
         </section>
 
         <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
-            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Top Sending Sources</h2>
+            <div class="flex items-start justify-between gap-3">
+                <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Top Sending Sources</h2>
+                <a href="/reports" class="mt-1 text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Investigate</a>
+            </div>
             <div id="top-sources-list" class="mt-5 space-y-4"></div>
         </section>
 
         <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
-            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Forensic Reports</h2>
+            <div class="flex items-start justify-between gap-3">
+                <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Forensic Reports</h2>
+                <a href="/forensics" class="mt-1 text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open</a>
+            </div>
             <div id="forensic-summary" class="flex min-h-64 items-center justify-center text-center text-2xl text-[#5f5c78]">
                 No failures
             </div>
@@ -104,6 +142,7 @@
                 <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">What Changed</h2>
                 <p class="text-sm text-[#5f5c78]">Recent source and compliance changes</p>
             </div>
+            <a href="/reports" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Review evidence</a>
         </div>
         <div id="change-summary-list" class="grid gap-3 md:grid-cols-3"></div>
     </div>
@@ -214,6 +253,17 @@ function dashboardApp() {
         hasDomainData: false,
         volumeTrendChart: null,
         complianceTrendChart: null,
+        domains: [],
+        selectedDnsDomain: '',
+
+        get selectedDnsDomainRecord() {
+            return this.domains.find(domain => domain.domain_name === this.selectedDnsDomain) || this.domains[0] || null;
+        },
+
+        get selectedDomainHref() {
+            const domain = this.selectedDnsDomainRecord;
+            return domain ? this.domainHref(domain) : '/domains';
+        },
         
         init() {
             // Fetch domain summary on page load
@@ -263,12 +313,21 @@ function dashboardApp() {
                 const data = await response.json();
                 
                 if (data && data.domains && data.domains.length > 0) {
+                    this.domains = data.domains || [];
+                    if (!this.domains.some(domain => domain.domain_name === this.selectedDnsDomain)) {
+                        this.selectedDnsDomain = this.domains[0]?.domain_name || '';
+                    }
                     this.hasDomainData = true;
                     this.updateDashboardStats(data);
-                    this.updateEnforcementAndDns(data.domains || []);
+                    this.updateEnforcement(data.domains || []);
                     this.populateDomainsTable(data.domains);
-                    this.$nextTick(() => this.fetchDashboardStats());
+                    this.$nextTick(() => {
+                        this.updateDnsHealth();
+                        this.fetchDashboardStats();
+                    });
                 } else {
+                    this.domains = [];
+                    this.selectedDnsDomain = '';
                     this.hasDomainData = false;
                     this.clearDashboardCharts();
                     this.populateChangeSummary([]);
@@ -276,6 +335,8 @@ function dashboardApp() {
                 }
             } catch (error) {
                 console.error('Error fetching domain summary:', error);
+                this.domains = [];
+                this.selectedDnsDomain = '';
                 this.hasDomainData = false;
                 this.clearDashboardCharts();
                 this.populateChangeSummary([]);
@@ -316,7 +377,7 @@ function dashboardApp() {
             }
         },
 
-        updateEnforcementAndDns(domains) {
+        updateEnforcement(domains) {
             const activePolicies = new Set(['quarantine', 'reject']);
             const enforced = domains.filter(domain => {
                 return activePolicies.has(String(domain.dmarc_policy || '').toLowerCase());
@@ -333,11 +394,26 @@ function dashboardApp() {
             }
             if (labelEl) labelEl.textContent = label;
             if (rateEl) rateEl.textContent = `${rate}%`;
+        },
 
-            this.setDnsState('dns-spf-state', domains.every(domain => domain.spf_status));
-            this.setDnsState('dns-dkim-state', domains.every(domain => domain.dkim_status));
-            this.setDnsState('dns-dmarc-state', domains.every(domain => domain.dmarc_status));
-            this.setDnsState('dns-policy-state', enforced > 0);
+        updateDnsHealth() {
+            const activePolicies = new Set(['quarantine', 'reject']);
+            const selected = this.selectedDnsDomainRecord;
+            if (!selected) {
+                this.setDnsState('dns-spf-state', false);
+                this.setDnsState('dns-dkim-state', false);
+                this.setDnsState('dns-dmarc-state', false);
+                this.setDnsState('dns-policy-state', false);
+                return;
+            }
+
+            this.setDnsState('dns-spf-state', Boolean(selected.spf_status));
+            this.setDnsState('dns-dkim-state', Boolean(selected.dkim_status));
+            this.setDnsState('dns-dmarc-state', Boolean(selected.dmarc_status));
+            this.setDnsState(
+                'dns-policy-state',
+                activePolicies.has(String(selected.dmarc_policy || '').toLowerCase())
+            );
         },
 
         setDnsState(id, passing) {
@@ -566,6 +642,16 @@ function dashboardApp() {
             return new Intl.NumberFormat(undefined, { notation: 'compact' }).format(value);
         },
 
+        domainHref(domain) {
+            const value = domain?.id ?? domain?.domain_name ?? domain;
+            return value ? `/domains/${encodeURIComponent(String(value))}` : '/domains';
+        },
+
+        changeHref(change) {
+            if (change?.domain) return `/domains/${encodeURIComponent(String(change.domain))}`;
+            return '/reports';
+        },
+
         populateChangeSummary(changes) {
             const list = document.getElementById('change-summary-list');
             if (!list) return;
@@ -581,8 +667,9 @@ function dashboardApp() {
             }
 
             changes.forEach(change => {
-                const item = document.createElement('div');
-                item.className = 'rounded-md border border-base-300 bg-base-100 p-3';
+                const item = document.createElement('a');
+                item.href = this.changeHref(change);
+                item.className = 'block rounded-md border border-[#e6e3e1] bg-white p-3 transition hover:border-[#2f9da5] hover:shadow-sm';
 
                 const header = document.createElement('div');
                 header.className = 'flex items-start gap-2';
@@ -595,17 +682,17 @@ function dashboardApp() {
                 content.className = 'min-w-0';
 
                 const title = document.createElement('p');
-                title.className = 'text-sm font-semibold';
+                title.className = 'text-sm font-semibold text-[#07071f]';
                 title.textContent = change.title || 'Change detected';
                 content.appendChild(title);
 
                 const detail = document.createElement('p');
-                detail.className = 'mt-1 text-sm text-muted-foreground';
+                detail.className = 'mt-1 text-sm text-[#5f5c78]';
                 detail.textContent = change.detail || '';
                 content.appendChild(detail);
 
                 const action = document.createElement('p');
-                action.className = 'mt-1 text-sm';
+                action.className = 'mt-2 text-sm font-semibold text-[#2f9da5]';
                 action.textContent = change.action || '';
                 content.appendChild(action);
 
@@ -687,8 +774,9 @@ function dashboardApp() {
 
             sources.slice(0, 4).forEach((source, index) => {
                 const percentage = Math.max(1, Math.round(((source.count || 0) / total) * 100));
-                const item = document.createElement('div');
-                item.className = 'space-y-2';
+                const item = document.createElement('a');
+                item.href = '/reports';
+                item.className = 'block space-y-2 rounded-md border border-transparent p-2 -mx-2 transition hover:border-[#e6e3e1] hover:bg-[#f4f3f2]';
 
                 const row = document.createElement('div');
                 row.className = 'flex items-center justify-between gap-3 text-lg';

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -6,14 +6,14 @@
 {% block title %}DMARQ - Report Detail{% endblock %}
 
 {% block content %}
-<div class="container mx-auto py-4" x-data="reportDetailApp('{{ report_id }}')">
-    <nav class="mb-4 text-sm">
+<div class="space-y-6" x-data="reportDetailApp('{{ report_id }}')">
+    <nav class="text-sm text-[#5f5c78]">
         <ol class="flex items-center space-x-2">
-            <li><a href="/" class="hover:text-primary">Dashboard</a></li>
-            <li><span class="text-muted-foreground px-2">/</span></li>
-            <li><a href="/reports" class="hover:text-primary">Reports</a></li>
-            <li><span class="text-muted-foreground px-2">/</span></li>
-            <li><span class="font-medium" x-text="reportId"></span></li>
+            <li><a href="/" class="font-semibold hover:text-[#2f9da5]">Dashboard</a></li>
+            <li><span class="px-2 text-[#b8b4bd]">/</span></li>
+            <li><a href="/reports" class="font-semibold hover:text-[#2f9da5]">Reports</a></li>
+            <li><span class="px-2 text-[#b8b4bd]">/</span></li>
+            <li><span class="font-semibold text-[#07071f]" x-text="reportId"></span></li>
         </ol>
     </nav>
 
@@ -38,23 +38,29 @@
     <template x-if="!loading && !error && report">
         <div class="grid grid-cols-1 gap-6">
             <!-- Header -->
-            <div class="flex justify-between items-start">
-                <div>
-                    <h1 class="text-2xl font-bold mb-1" x-text="'Report: ' + report.report_id"></h1>
-                    <p class="text-muted-foreground">
-                        Submitted by <span x-text="report.org_name"></span>
-                        &bull;
-                        <a :href="'/domains/' + report.domain" class="hover:text-primary" x-text="report.domain"></a>
-                    </p>
-                </div>
-                <div class="flex space-x-2">
-                    <a :href="'/domains/' + report.domain" class="btn btn-outline btn-sm">
-                        Back to Domain
-                    </a>
-                    <button class="btn btn-error btn-sm"
-                            @click="deleteReport(report.domain, report.report_id)">
-                        Delete Report
-                    </button>
+            <div class="rounded-lg bg-white p-6 shadow-sm">
+                <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div>
+                        <p class="mb-2 text-sm font-semibold uppercase tracking-wide text-[#2f9da5]">Aggregate report</p>
+                        <h1 class="text-3xl font-bold tracking-normal text-[#07071f]" x-text="'Report: ' + report.report_id"></h1>
+                        <p class="mt-2 text-[#5f5c78]">
+                            Submitted by <span x-text="report.org_name"></span>
+                            &bull;
+                            <a :href="'/domains/' + encodeURIComponent(report.domain)" class="font-semibold text-[#2f9da5] hover:text-[#272a5f]" x-text="report.domain"></a>
+                        </p>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                        <a :href="'/domains/' + encodeURIComponent(report.domain)" class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]">
+                            Back to Domain
+                        </a>
+                        <a href="/reports" class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]">
+                            All Reports
+                        </a>
+                        <button class="btn btn-error btn-sm"
+                                @click="deleteReport(report.domain, report.report_id)">
+                            Delete Report
+                        </button>
+                    </div>
                 </div>
             </div>
 
@@ -65,7 +71,8 @@
                         {% call card_title() %}Total Emails{% endcall %}
                     {% endcall %}
                     {% call card_content() %}
-                        <div class="stat-value text-2xl font-bold" x-text="report.summary.total_count">-</div>
+                        <div class="text-3xl font-bold text-[#120d36]" x-text="report.summary.total_count">-</div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">Messages covered</p>
                     {% endcall %}
                 {% endcall %}
                 {% call card() %}
@@ -73,7 +80,8 @@
                         {% call card_title() %}Passed{% endcall %}
                     {% endcall %}
                     {% call card_content() %}
-                        <div class="stat-value text-2xl font-bold text-success" x-text="report.summary.passed_count">-</div>
+                        <div class="text-3xl font-bold text-[#2f9da5]" x-text="report.summary.passed_count">-</div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">DMARC aligned</p>
                     {% endcall %}
                 {% endcall %}
                 {% call card() %}
@@ -81,7 +89,8 @@
                         {% call card_title() %}Failed{% endcall %}
                     {% endcall %}
                     {% call card_content() %}
-                        <div class="stat-value text-2xl font-bold text-error" x-text="report.summary.failed_count">-</div>
+                        <div class="text-3xl font-bold text-[#ff6f3c]" x-text="report.summary.failed_count">-</div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">Needs review</p>
                     {% endcall %}
                 {% endcall %}
                 {% call card() %}
@@ -89,9 +98,10 @@
                         {% call card_title() %}Pass Rate{% endcall %}
                     {% endcall %}
                     {% call card_content() %}
-                        <div class="stat-value text-2xl font-bold"
+                        <div class="text-3xl font-bold"
                              :class="passRateClass(report.summary.pass_rate)"
                              x-text="report.summary.pass_rate.toFixed(1) + '%'">-</div>
+                        <p class="mt-1 text-sm text-[#5f5c78]">Authentication rate</p>
                     {% endcall %}
                 {% endcall %}
             </div>


### PR DESCRIPTION
## Summary
- add actionable dashboard drilldowns for domains, reports, forensics, changes, and DNS health
- add a domain selector and warning summary to DNS Record Health
- carry the dashboard card styling, typography, and action affordances into domain, aggregate report, and forensic detail views

## Validation
- JS template blocks pass `node --check`
- `git diff --check`
- `pytest app/tests/test_demo_data.py app/tests/test_stats_endpoints.py`
- browser QA against local demo mode: dashboard -> dmarq.com DNS selector -> domain details, plus mobile viewport overflow check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed dashboard, domain, report, and forensic pages with improved navigation, breadcrumb links, and clearer action buttons.
  * Added a selectable DNS domain view on the dashboard, with quick access to domain details and DNS health info.
  * Expanded report and investigation pages with more prominent summaries and streamlined top-level actions.

* **Style**
  * Updated card layouts, spacing, colors, and typography across key views for a cleaner, more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->