### PR TITLE
Add mailbox recovery guidance

### DIFF
--- a/backend/app/api/api_v1/endpoints/health.py
+++ b/backend/app/api/api_v1/endpoints/health.py
@@ -8,6 +8,7 @@ from app.core.security import require_admin_auth
 from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
 from app.models.report import DMARCReport
+from app.services.mailbox_recovery import import_row_diagnostic, not_configured_guidance
 from app.services.runtime_status import get_scheduler_status
 
 router = APIRouter()
@@ -73,15 +74,26 @@ async def operations_health(
     scheduler = get_scheduler_status()
     status = "ok"
     checks = []
+    mailbox_recovery = []
     if not database["ok"]:
         status = "degraded"
         checks.append("Database connectivity failed.")
+    if database["ok"] and enabled_sources == 0:
+        mailbox_recovery.append(not_configured_guidance())
     if total_sources and enabled_sources == 0:
         status = "degraded"
         checks.append("All mail sources are disabled.")
     if scheduler.get("last_error"):
         status = "degraded"
         checks.append("The scheduler reported a recent error.")
+    latest_import_diagnostic = import_row_diagnostic(latest_import)
+    if latest_import_diagnostic and latest_import_diagnostic["category"] not in {
+        "ok",
+        "duplicate_only",
+    }:
+        status = "degraded"
+        checks.append(latest_import_diagnostic["summary"])
+        mailbox_recovery.append(latest_import_diagnostic)
 
     return {
         "status": status,
@@ -98,6 +110,7 @@ async def operations_health(
                 "trigger": latest_import.trigger,
                 "reports_found": latest_import.reports_found,
                 "finished_at": _iso(latest_import.finished_at),
+                "diagnostic": latest_import_diagnostic,
             }
             if latest_import
             else None,
@@ -115,4 +128,5 @@ async def operations_health(
             "latest_processed_at": _iso(latest_report),
         },
         "checks": checks,
+        "mailbox_recovery": mailbox_recovery,
     }

--- a/backend/app/api/api_v1/endpoints/imap.py
+++ b/backend/app/api/api_v1/endpoints/imap.py
@@ -9,6 +9,7 @@ from starlette.concurrency import run_in_threadpool
 from app.core.database import SessionLocal
 from app.core.security import require_admin_auth
 from app.services.imap_client import IMAPClient
+from app.services.mailbox_recovery import connection_test_response, import_result_diagnostic
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -65,12 +66,7 @@ async def test_imap_connection(
     success, message, stats = imap_client.test_connection()
 
     return {
-        "success": success,
-        "message": message,
-        "message_count": stats.get("message_count", 0),
-        "unread_count": stats.get("unread_count", 0),
-        "dmarc_count": stats.get("dmarc_count", 0),
-        "available_mailboxes": stats.get("available_mailboxes", []),
+        **connection_test_response(success, message, stats),
         "timestamp": datetime.now().isoformat(),
     }
 
@@ -103,6 +99,7 @@ async def fetch_imap_reports(
     # Otherwise run immediately
     try:
         results = await run_in_threadpool(_fetch_imap_reports_sync, days, delete_emails)
+        diagnostic = import_result_diagnostic(results)
 
         return {
             "success": results["success"],
@@ -112,6 +109,10 @@ async def fetch_imap_reports(
             "duplicate_forensic_reports": int(results.get("duplicate_forensic_reports", 0)),
             "new_domains": results["new_domains"],
             "errors": results["errors"] if "errors" in results and results["errors"] else None,
+            "diagnostic": diagnostic,
+            "diagnostic_category": diagnostic["category"],
+            "diagnostic_summary": diagnostic["summary"],
+            "recovery_steps": diagnostic["recovery_steps"],
             "timestamp": datetime.now().isoformat(),
         }
     except Exception as e:

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -17,13 +17,20 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
-from app.core.redaction import redact_sensitive_text, sanitize_for_log
+from app.core.redaction import sanitize_for_log
 from app.core.security import require_admin_auth
 from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
+from app.services.mailbox_recovery import (
+    connection_diagnostic,
+    connection_test_response,
+    diagnostic_category,
+    import_result_diagnostic,
+    redact_recovery_text,
+)
 from app.services.microsoft_graph_client import MicrosoftGraphClient
 from app.services.workspace_audit import changed_fields, record_workspace_audit_log
 from app.services.workspaces import (
@@ -167,150 +174,19 @@ def _sanitize_for_log(value: object) -> str:
 
 def _redact_sensitive_text(value: object) -> str:
     """Remove log-injection characters and redact secret-like diagnostic text."""
-    return redact_sensitive_text(value)
-
-
-DIAGNOSTIC_COPY: Dict[str, Dict[str, Any]] = {
-    "ok": {
-        "summary": "Connection test completed successfully.",
-        "recovery_steps": [],
-    },
-    "auth_required": {
-        "summary": "The mailbox has not been connected yet.",
-        "recovery_steps": [
-            "Use the Connect Gmail or Connect Microsoft 365 action to complete authorization.",
-            "Confirm the authorized mailbox is the one that receives DMARC aggregate reports.",
-        ],
-    },
-    "auth_expired": {
-        "summary": "The saved authorization is expired, revoked, or no longer accepted.",
-        "recovery_steps": [
-            "Reconnect the mailbox from Mail Sources.",
-            "If your provider shows a consent screen, approve read-only mailbox access again.",
-        ],
-    },
-    "authentication": {
-        "summary": "The server rejected the username, password, app password, or OAuth token.",
-        "recovery_steps": [
-            "Verify the username and use an app-specific password when the provider requires one.",
-            "Reconnect OAuth sources if the provider recently changed account security settings.",
-        ],
-    },
-    "permissions": {
-        "summary": "The account is connected but does not have enough mailbox access.",
-        "recovery_steps": [
-            "Grant read access for the mailbox that receives DMARC reports.",
-            "For OAuth sources, reconnect and approve the requested read-only mail scope.",
-        ],
-    },
-    "connectivity": {
-        "summary": "DMARQ could not reach the mail server reliably.",
-        "recovery_steps": [
-            "Check the server hostname, port, TLS setting, and any firewall allowlists.",
-            "Use port 993 with SSL for most IMAP providers.",
-        ],
-    },
-    "mailbox_not_found": {
-        "summary": "The configured mailbox folder could not be opened.",
-        "recovery_steps": [
-            "Choose one of the available mailbox names returned by the test.",
-            "Check capitalization and nested folder separators such as Archive/DMARC.",
-        ],
-    },
-    "throttling": {
-        "summary": "The mail provider is rate limiting or temporarily refusing requests.",
-        "recovery_steps": [
-            "Wait a few minutes and retry the test.",
-            "Increase the polling interval if repeated imports trigger provider limits.",
-        ],
-    },
-    "missing_config": {
-        "summary": "Required connection settings are missing.",
-        "recovery_steps": [
-            "Fill in the server, username, and password or complete OAuth authorization.",
-            "Save the source before running stored-source tests.",
-        ],
-    },
-    "not_implemented": {
-        "summary": "This connection method cannot be tested from this screen yet.",
-        "recovery_steps": [
-            "Use IMAP or Gmail API for mailbox ingestion.",
-            "Keep unsupported sources disabled until a test path is implemented.",
-        ],
-    },
-    "unknown": {
-        "summary": "The connection failed, but DMARQ could not classify the provider response.",
-        "recovery_steps": [
-            "Retry the test once to rule out a transient provider issue.",
-            "Check the latest import history and server logs for the sanitized provider response.",
-        ],
-    },
-}
+    return redact_recovery_text(value)
 
 
 def _diagnostic_category(message: str, details: Optional[object] = None) -> str:
     """Map provider-specific failures to operator-friendly categories."""
-    text = f"{message} {_redact_sensitive_text(details or '')}".lower()
-    if any(term in text for term in ("not yet authorised", "not yet authorized", "complete oauth")):
-        return "auth_required"
-    if any(
-        term in text
-        for term in (
-            "expired",
-            "revoked",
-            "invalid_grant",
-            "interaction_required",
-            "refresh token",
-            "oauth",
-        )
-    ):
-        return "auth_expired"
-    if any(term in text for term in ("rate", "quota", "throttl", "too many", "429")):
-        return "throttling"
-    if any(
-        term in text
-        for term in ("scope", "permission", "access denied", "insufficient", "forbidden", "403")
-    ):
-        return "permissions"
-    if any(term in text for term in ("mailbox", "folder", "select failed", "does not exist")):
-        return "mailbox_not_found"
-    if any(term in text for term in ("credential", "password", "auth", "login", "invalid token")):
-        return "authentication"
-    if any(
-        term in text
-        for term in (
-            "timeout",
-            "timed out",
-            "dns",
-            "resolve",
-            "refused",
-            "network",
-            "ssl",
-            "certificate",
-        )
-    ):
-        return "connectivity"
-    if "not yet implemented" in text:
-        return "not_implemented"
-    if any(term in text for term in ("not fully configured", "missing", "required")):
-        return "missing_config"
-    return "unknown"
+    return diagnostic_category(message, details)
 
 
 def _connection_diagnostic(
     success: bool, message: str, details: Optional[object] = None
 ) -> Dict[str, Any]:
     """Build sanitized connection diagnostics for API responses and UI recovery copy."""
-    category = "ok" if success else _diagnostic_category(message, details)
-    diagnostic_copy = DIAGNOSTIC_COPY[category]
-    diagnostic: Dict[str, Any] = {
-        "category": category,
-        "summary": diagnostic_copy["summary"],
-        "recovery_steps": diagnostic_copy["recovery_steps"],
-    }
-    if details and not success:
-        diagnostic["details"] = _redact_sensitive_text(details)
-    return diagnostic
+    return connection_diagnostic(success, message, details)
 
 
 def _connection_test_response(
@@ -320,18 +196,8 @@ def _connection_test_response(
     details: Optional[object] = None,
 ) -> Dict[str, Any]:
     """Normalize stored and ad-hoc mailbox test responses."""
-    stats = stats or {}
-    diagnostic = _connection_diagnostic(success, message, details or stats.get("diagnostic_detail"))
     return {
-        "success": success,
-        "message": _redact_sensitive_text(message),
-        "message_count": stats.get("message_count", 0),
-        "unread_count": stats.get("unread_count", 0),
-        "dmarc_count": stats.get("dmarc_count", 0),
-        "available_mailboxes": stats.get("available_mailboxes", []),
-        "diagnostic": diagnostic,
-        "diagnostic_category": diagnostic["category"],
-        "recovery_steps": diagnostic["recovery_steps"],
+        **connection_test_response(success, message, stats, details),
         "timestamp": datetime.now().isoformat(),
     }
 
@@ -465,6 +331,7 @@ def _import_to_response(row: MailSourceImport) -> MailSourceImportResponse:
 
 def _fetch_response(source: MailSource, results: Dict[str, Any]) -> Dict[str, Any]:
     """Build the common response payload for a manual source fetch."""
+    diagnostic = import_result_diagnostic(results)
     return {
         "source_id": source.id,
         "name": source.name,
@@ -479,6 +346,10 @@ def _fetch_response(source: MailSource, results: Dict[str, Any]) -> Dict[str, An
         "target_mailbox": results.get("target_mailbox"),
         "target_folder": results.get("target_folder"),
         "search_window_days": results.get("search_window_days"),
+        "diagnostic": diagnostic,
+        "diagnostic_category": diagnostic["category"],
+        "diagnostic_summary": diagnostic["summary"],
+        "recovery_steps": diagnostic["recovery_steps"],
         "timestamp": datetime.now().isoformat(),
     }
 

--- a/backend/app/api/api_v1/endpoints/setup.py
+++ b/backend/app/api/api_v1/endpoints/setup.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Security, status
 from fastapi.security import HTTPAuthorizationCredentials
@@ -9,7 +9,9 @@ from app.core.database import get_db
 from app.core.security import api_key_header, require_admin_auth, security_bearer
 from app.models.domain import Domain
 from app.models.mail_source import MailSource
+from app.models.mail_source_import import MailSourceImport
 from app.models.setting import Setting
+from app.services.mailbox_recovery import import_row_diagnostic, not_configured_guidance
 
 router = APIRouter()
 
@@ -94,6 +96,7 @@ class SetupStatusResponse(BaseModel):
     total_domains: int = 0
     total_mail_sources: int = 0
     enabled_mail_sources: int = 0
+    mailbox_recovery_hint: Optional[Dict[str, Any]] = None
 
 
 class AdminSetupRequest(BaseModel):
@@ -127,14 +130,30 @@ async def require_setup_write_auth(
 async def get_setup_status(db: Session = Depends(get_db)):
     """Get the current setup status"""
     current_status = _refresh_setup_status_from_db(db)
+    total_mail_sources = db.query(MailSource.id).count()
+    enabled_mail_sources = (
+        db.query(MailSource.id).filter(MailSource.enabled == True).count()  # noqa: E712
+    )
+    latest_import = (
+        db.query(MailSourceImport)
+        .order_by(MailSourceImport.finished_at.desc(), MailSourceImport.id.desc())
+        .first()
+    )
+    mailbox_recovery_hint = None
+    if enabled_mail_sources == 0:
+        mailbox_recovery_hint = not_configured_guidance()
+    elif latest_import:
+        diagnostic = import_row_diagnostic(latest_import)
+        if diagnostic and diagnostic["category"] not in {"ok", "duplicate_only"}:
+            mailbox_recovery_hint = diagnostic
+
     return SetupStatusResponse(
         is_setup_complete=current_status["is_setup_complete"],
         app_name=current_status["app_name"],
         total_domains=db.query(Domain.id).count(),
-        total_mail_sources=db.query(MailSource.id).count(),
-        enabled_mail_sources=db.query(MailSource.id)
-        .filter(MailSource.enabled == True)  # noqa: E712
-        .count(),
+        total_mail_sources=total_mail_sources,
+        enabled_mail_sources=enabled_mail_sources,
+        mailbox_recovery_hint=mailbox_recovery_hint,
     )
 
 

--- a/backend/app/services/mailbox_recovery.py
+++ b/backend/app/services/mailbox_recovery.py
@@ -1,0 +1,294 @@
+"""Operator-facing recovery guidance for mailbox tests and imports."""
+
+import json
+from typing import Any, Dict, Optional
+
+from app.core.redaction import redact_sensitive_text
+
+
+DIAGNOSTIC_COPY: Dict[str, Dict[str, Any]] = {
+    "ok": {
+        "summary": "Connection test completed successfully.",
+        "recovery_steps": [],
+    },
+    "auth_required": {
+        "summary": "The mailbox has not been connected yet.",
+        "recovery_steps": [
+            "Use the Connect Gmail or Connect Microsoft 365 action to complete authorization.",
+            "Confirm the authorized mailbox is the one that receives DMARC aggregate reports.",
+        ],
+    },
+    "auth_expired": {
+        "summary": "The saved authorization is expired, revoked, or no longer accepted.",
+        "recovery_steps": [
+            "Reconnect the mailbox from Mail Sources.",
+            "If your provider shows a consent screen, approve read-only mailbox access again.",
+        ],
+    },
+    "authentication": {
+        "summary": "The server rejected the username, password, app password, or OAuth token.",
+        "recovery_steps": [
+            "Verify the username and use an app-specific password when the provider requires one.",
+            "Reconnect OAuth sources if the provider recently changed account security settings.",
+        ],
+    },
+    "permissions": {
+        "summary": "The account is connected but does not have enough mailbox access.",
+        "recovery_steps": [
+            "Grant read access for the mailbox that receives DMARC reports.",
+            "For OAuth sources, reconnect and approve the requested read-only mail scope.",
+        ],
+    },
+    "connectivity": {
+        "summary": "DMARQ could not reach the mail server reliably.",
+        "recovery_steps": [
+            "Check the server hostname, port, TLS setting, and any firewall allowlists.",
+            "Use port 993 with SSL for most IMAP providers.",
+        ],
+    },
+    "mailbox_not_found": {
+        "summary": "The configured mailbox folder could not be opened.",
+        "recovery_steps": [
+            "Choose one of the available mailbox names returned by the test.",
+            "Check capitalization and nested folder separators such as Archive/DMARC.",
+        ],
+    },
+    "folder_search": {
+        "summary": (
+            "The mailbox was reachable, but the selected folder or search window did not "
+            "contain new DMARC reports."
+        ),
+        "recovery_steps": [
+            "Confirm DMARC aggregate reports are delivered to the configured mailbox and folder.",
+            "Run a wider backfill window if reports may be older than the current search range.",
+        ],
+    },
+    "parsing": {
+        "summary": "DMARQ reached the mailbox but could not parse one or more report attachments.",
+        "recovery_steps": [
+            "Open the latest import details and identify the affected attachment or reporter.",
+            "Upload a known-good XML, ZIP, or GZIP aggregate report to confirm parsing still "
+            "works.",
+        ],
+    },
+    "duplicate_only": {
+        "summary": "The latest run only found reports that were already imported.",
+        "recovery_steps": [
+            "No immediate action is needed if the mailbox is expected to be quiet.",
+            "If fresh reports are expected, confirm they are arriving in the configured folder.",
+        ],
+    },
+    "throttling": {
+        "summary": "The mail provider is rate limiting or temporarily refusing requests.",
+        "recovery_steps": [
+            "Wait a few minutes and retry the test.",
+            "Increase the polling interval if repeated imports trigger provider limits.",
+        ],
+    },
+    "missing_config": {
+        "summary": "Required connection settings are missing.",
+        "recovery_steps": [
+            "Fill in the server, username, and password or complete OAuth authorization.",
+            "Save the source before running stored-source tests.",
+        ],
+    },
+    "not_implemented": {
+        "summary": "This connection method cannot be tested from this screen yet.",
+        "recovery_steps": [
+            "Use IMAP, Gmail API, or Microsoft 365 Graph for mailbox ingestion.",
+            "Keep unsupported sources disabled until a test path is implemented.",
+        ],
+    },
+    "not_configured": {
+        "summary": "No enabled mailbox source is available for scheduled DMARC imports.",
+        "recovery_steps": [
+            "Add or enable a mail source that receives DMARC aggregate reports.",
+            "Run Test Connection before relying on scheduled imports.",
+        ],
+    },
+    "unknown": {
+        "summary": "The connection failed, but DMARQ could not classify the provider response.",
+        "recovery_steps": [
+            "Retry the test once to rule out a transient provider issue.",
+            "Check the latest import history and server logs for the sanitized provider response.",
+        ],
+    },
+}
+
+
+def redact_recovery_text(value: object) -> str:
+    """Return a log-safe, secret-redacted string for operator payloads."""
+    return redact_sensitive_text(value)
+
+
+def diagnostic_category(message: str, details: Optional[object] = None) -> str:
+    """Map provider-specific failures to operator-friendly categories."""
+    text = f"{message} {redact_recovery_text(details or '')}".lower()
+    if any(term in text for term in ("not yet authorised", "not yet authorized", "complete oauth")):
+        return "auth_required"
+    if any(
+        term in text
+        for term in (
+            "expired",
+            "revoked",
+            "invalid_grant",
+            "interaction_required",
+            "refresh token",
+            "oauth",
+        )
+    ):
+        return "auth_expired"
+    if any(term in text for term in ("rate", "quota", "throttl", "too many", "429")):
+        return "throttling"
+    if any(
+        term in text
+        for term in ("scope", "permission", "access denied", "insufficient", "forbidden", "403")
+    ):
+        return "permissions"
+    if any(term in text for term in ("mailbox", "folder", "select failed", "does not exist")):
+        return "mailbox_not_found"
+    if any(term in text for term in ("credential", "password", "auth", "login", "invalid token")):
+        return "authentication"
+    if any(
+        term in text
+        for term in (
+            "timeout",
+            "timed out",
+            "dns",
+            "resolve",
+            "refused",
+            "network",
+            "ssl",
+            "certificate",
+        )
+    ):
+        return "connectivity"
+    if "not yet implemented" in text:
+        return "not_implemented"
+    if any(term in text for term in ("not fully configured", "missing", "required")):
+        return "missing_config"
+    return "unknown"
+
+
+def connection_diagnostic(
+    success: bool, message: str, details: Optional[object] = None
+) -> Dict[str, Any]:
+    """Build sanitized connection diagnostics for API responses and UI recovery copy."""
+    category = "ok" if success else diagnostic_category(message, details)
+    diagnostic_copy = DIAGNOSTIC_COPY[category]
+    diagnostic: Dict[str, Any] = {
+        "category": category,
+        "summary": diagnostic_copy["summary"],
+        "recovery_steps": diagnostic_copy["recovery_steps"],
+    }
+    if details and not success:
+        diagnostic["details"] = redact_recovery_text(details)
+    return diagnostic
+
+
+def connection_test_response(
+    success: bool,
+    message: str,
+    stats: Optional[Dict[str, Any]] = None,
+    details: Optional[object] = None,
+) -> Dict[str, Any]:
+    """Normalize stored and ad-hoc mailbox test responses."""
+    stats = stats or {}
+    diagnostic = connection_diagnostic(success, message, details or stats.get("diagnostic_detail"))
+    return {
+        "success": success,
+        "message": redact_recovery_text(message),
+        "message_count": stats.get("message_count", 0),
+        "unread_count": stats.get("unread_count", 0),
+        "dmarc_count": stats.get("dmarc_count", 0),
+        "available_mailboxes": stats.get("available_mailboxes", []),
+        "diagnostic": diagnostic,
+        "diagnostic_category": diagnostic["category"],
+        "diagnostic_summary": diagnostic["summary"],
+        "recovery_steps": diagnostic["recovery_steps"],
+    }
+
+
+def not_configured_guidance() -> Dict[str, Any]:
+    """Return setup/health guidance when no enabled mailbox source exists."""
+    return _guidance("not_configured")
+
+
+def import_result_diagnostic(results: Dict[str, Any]) -> Dict[str, Any]:
+    """Classify a mailbox import result into recovery guidance."""
+    success = bool(results.get("success", False))
+    errors = [str(error) for error in results.get("errors") or []]
+    detail_text = " ".join(str(detail) for detail in results.get("details") or [])
+    combined = " ".join(errors + [detail_text]).lower()
+
+    if errors:
+        if any(
+            term in combined
+            for term in (
+                "xml",
+                "zip",
+                "gzip",
+                "attachment",
+                "parse",
+                "parsing",
+                "malformed",
+                "decode",
+                "unsupported",
+            )
+        ):
+            return _guidance("parsing")
+        return _guidance(diagnostic_category(" ".join(errors), detail_text))
+
+    reports_found = int(results.get("reports_found", 0) or 0) + int(
+        results.get("forensic_reports_found", 0) or 0
+    )
+    duplicate_reports = int(results.get("duplicate_reports", 0) or 0) + int(
+        results.get("duplicate_forensic_reports", 0) or 0
+    )
+    processed = int(results.get("processed", 0) or 0)
+
+    if success and reports_found == 0 and duplicate_reports > 0:
+        return _guidance("duplicate_only")
+    if success and processed > 0 and reports_found == 0:
+        return _guidance("folder_search")
+    if success:
+        return _guidance("ok")
+    return _guidance("unknown")
+
+
+def import_row_diagnostic(row: Optional[Any]) -> Optional[Dict[str, Any]]:
+    """Classify a persisted import-history row, if one exists."""
+    if row is None:
+        return None
+
+    return import_result_diagnostic(
+        {
+            "success": row.status in {"success", "warning"},
+            "processed": row.processed,
+            "reports_found": row.reports_found,
+            "duplicate_reports": row.duplicate_reports,
+            "errors": _decode_json_list(row.errors),
+            "details": _decode_json_list(row.details),
+        }
+    )
+
+
+def _guidance(category: str) -> Dict[str, Any]:
+    copy = DIAGNOSTIC_COPY[category]
+    return {
+        "category": category,
+        "summary": copy["summary"],
+        "recovery_steps": copy["recovery_steps"],
+    }
+
+
+def _decode_json_list(value: Optional[str]) -> list:
+    if not value:
+        return []
+    try:
+        decoded = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return []
+    if isinstance(decoded, list):
+        return decoded
+    return []

--- a/backend/app/templates/operations.html
+++ b/backend/app/templates/operations.html
@@ -106,6 +106,28 @@
             </ul>
         </div>
     </section>
+
+    <section class="card bg-base-100 shadow" x-show="health.mailbox_recovery?.length">
+        <div class="card-body">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <h2 class="card-title">Mailbox Recovery</h2>
+                <a href="/mail-sources" class="btn btn-outline btn-sm">Open Mail Sources</a>
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+                <template x-for="item in health.mailbox_recovery" :key="item.category + item.summary">
+                    <div class="rounded-lg border border-base-300 bg-base-200/60 p-4">
+                        <div class="text-xs font-semibold uppercase tracking-wide text-base-content/60" x-text="categoryLabel(item.category)"></div>
+                        <p class="mt-1 text-sm font-medium" x-text="item.summary"></p>
+                        <ul class="mt-3 list-disc space-y-1 pl-5 text-sm text-base-content/70" x-show="item.recovery_steps?.length">
+                            <template x-for="step in item.recovery_steps" :key="step">
+                                <li x-text="step"></li>
+                            </template>
+                        </ul>
+                    </div>
+                </template>
+            </div>
+        </div>
+    </section>
 </div>
 {% endblock %}
 
@@ -141,6 +163,11 @@ function operationsHealth() {
         formatImport(value) {
             if (!value) return 'Not recorded';
             return `${value.status} (${value.reports_found} reports) at ${this.formatDate(value.finished_at)}`;
+        },
+
+        categoryLabel(value) {
+            if (!value) return 'Mailbox';
+            return value.replaceAll('_', ' ');
         },
     };
 }

--- a/backend/app/templates/setup.html
+++ b/backend/app/templates/setup.html
@@ -189,6 +189,15 @@
                             </span>
                         </li>
                     </ul>
+                    <div x-show="mailboxRecoveryHint" class="mt-4 rounded-lg border border-warning/30 bg-warning/10 p-4 text-sm">
+                        <div class="font-semibold text-base-content" x-text="mailboxRecoveryHint?.summary"></div>
+                        <ul class="mt-2 list-disc space-y-1 pl-5 text-base-content/70" x-show="mailboxRecoveryHint?.recovery_steps?.length">
+                            <template x-for="step in mailboxRecoveryHint.recovery_steps" :key="step">
+                                <li x-text="step"></li>
+                            </template>
+                        </ul>
+                        <a href="/mail-sources" class="btn btn-outline btn-xs mt-3">Open Mail Sources</a>
+                    </div>
                 </div>
             </div>
         </aside>
@@ -207,6 +216,7 @@
             totalDomains: 0,
             totalMailSources: 0,
             enabledMailSources: 0,
+            mailboxRecoveryHint: null,
             steps: [
                 { id: 1, title: 'Admin', detail: 'Contact details' },
                 { id: 2, title: 'System', detail: 'Name and URL' },
@@ -236,6 +246,7 @@
                     this.totalDomains = status.total_domains || 0;
                     this.totalMailSources = status.total_mail_sources || 0;
                     this.enabledMailSources = status.enabled_mail_sources || 0;
+                    this.mailboxRecoveryHint = status.mailbox_recovery_hint || null;
                 } catch (err) {
                     this.error = err.message || 'Could not load setup status.';
                 } finally {

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -52,6 +52,16 @@ def test_operations_health_endpoint(authed_client: TestClient):
     assert "scheduler" in data
     assert "imports" in data
     assert "reports" in data
+    assert data["mailbox_recovery"][0]["category"] == "not_configured"
+
+
+def test_setup_status_includes_mailbox_recovery_hint(client: TestClient):
+    """Setup status points first-run operators at mailbox configuration."""
+    response = client.get("/api/v1/setup/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mailbox_recovery_hint"]["category"] == "not_configured"
+    assert data["mailbox_recovery_hint"]["recovery_steps"]
 
 
 def test_reports_upload_invalid_extension(client: TestClient):

--- a/backend/app/tests/test_imap_endpoints.py
+++ b/backend/app/tests/test_imap_endpoints.py
@@ -45,10 +45,12 @@ class TestImapTestConnection:
         assert data["message_count"] == 5
         assert data["unread_count"] == 2
         assert "INBOX" in data["available_mailboxes"]
+        assert data["diagnostic_category"] == "ok"
+        assert data["recovery_steps"] == []
 
     def test_failed_connection(self, authed_client: TestClient):
         mock_client = MagicMock()
-        mock_client.test_connection.return_value = (False, "Connection failed", {})
+        mock_client.test_connection.return_value = (False, "Login failed invalid password", {})
 
         with patch("app.api.api_v1.endpoints.imap.IMAPClient", return_value=mock_client):
             response = authed_client.post(
@@ -60,6 +62,8 @@ class TestImapTestConnection:
         data = response.json()
         assert data["success"] is False
         assert data["message_count"] == 0
+        assert data["diagnostic_category"] == "authentication"
+        assert data["recovery_steps"]
 
     def test_requires_auth(self, client: TestClient):
         """Without auth, the endpoint should return 401."""
@@ -94,6 +98,7 @@ class TestImapFetchReports:
         assert data["success"] is True
         assert data["processed_emails"] == 3
         assert data["reports_found"] == 2
+        assert data["diagnostic_category"] == "ok"
 
     def test_fetch_days_too_low(self, authed_client: TestClient):
         response = authed_client.post("/api/v1/imap/fetch-reports?days=0")
@@ -136,6 +141,8 @@ class TestImapFetchReports:
         assert response.status_code == 200
         data = response.json()
         assert data["errors"] is not None
+        assert data["diagnostic_category"] == "parsing"
+        assert data["recovery_steps"]
 
     def test_fetch_exception_returns_500(self, authed_client: TestClient):
         mock_client = MagicMock()

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -1605,6 +1605,8 @@ class TestManualSourceFetchEndpoint:
         assert data["reports_found"] == 3
         assert data["duplicate_reports"] == 1
         assert data["error_count"] == 1
+        assert data["diagnostic_category"] == "parsing"
+        assert data["recovery_steps"]
         assert "bad attachment with newline" in caplog.text
         history_resp = authed_client.get(f"/api/v1/mail-sources/{source_id}/imports")
         assert history_resp.json()[0]["details"] == [{"status": "error", "filename": "bad.xml"}]

--- a/backend/app/tests/test_mailbox_recovery.py
+++ b/backend/app/tests/test_mailbox_recovery.py
@@ -1,0 +1,60 @@
+"""Tests for mailbox recovery guidance."""
+
+from app.services.mailbox_recovery import connection_test_response, import_result_diagnostic
+
+
+def test_connection_response_classifies_auth_failure_without_raw_secret():
+    response = connection_test_response(
+        False,
+        "Login failed invalid password",
+        {"diagnostic_detail": "password=super-secret rejected"},
+    )
+
+    assert response["diagnostic_category"] == "authentication"
+    assert response["diagnostic_summary"]
+    assert response["recovery_steps"]
+    assert "super-secret" not in str(response)
+
+
+def test_import_result_classifies_parsing_failure():
+    diagnostic = import_result_diagnostic(
+        {
+            "success": True,
+            "processed": 1,
+            "reports_found": 0,
+            "errors": ["Could not parse ZIP attachment report.zip"],
+        }
+    )
+
+    assert diagnostic["category"] == "parsing"
+    assert "parse" in diagnostic["summary"].lower()
+
+
+def test_import_result_classifies_duplicate_only_as_no_outage():
+    diagnostic = import_result_diagnostic(
+        {
+            "success": True,
+            "processed": 2,
+            "reports_found": 0,
+            "duplicate_reports": 2,
+            "errors": [],
+        }
+    )
+
+    assert diagnostic["category"] == "duplicate_only"
+    assert diagnostic["recovery_steps"]
+
+
+def test_import_result_success_has_no_recovery_steps():
+    diagnostic = import_result_diagnostic(
+        {
+            "success": True,
+            "processed": 2,
+            "reports_found": 2,
+            "duplicate_reports": 0,
+            "errors": [],
+        }
+    )
+
+    assert diagnostic["category"] == "ok"
+    assert diagnostic["recovery_steps"] == []

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -80,8 +80,12 @@ Open **Mail Sources**, run **Test connection**, and use the diagnostic category 
 | `permissions` | The account is connected but lacks mailbox access. | Grant mailbox read access or reconnect Gmail with the requested read-only scope. |
 | `connectivity` | DMARQ cannot reach the provider. | Check hostname, port, TLS setting, firewall, DNS, and provider availability. |
 | `mailbox_not_found` | The configured folder cannot be opened. | Use one of the returned mailbox names and match capitalization/separators exactly. |
+| `folder_search` | The mailbox is reachable, but the selected folder or search window has no new DMARC reports. | Confirm reports arrive in that folder, then run a wider backfill if needed. |
+| `parsing` | DMARQ reached messages but could not parse one or more report attachments. | Inspect import details, then validate with a known-good XML, ZIP, or GZIP aggregate report. |
+| `duplicate_only` | The latest run found only reports DMARQ already imported. | No action is needed for quiet mailboxes; otherwise confirm fresh reports are arriving in the configured folder. |
 | `throttling` | Provider is rate limiting requests. | Wait, retry, and increase the polling interval if failures repeat. |
 | `missing_config` | Required settings are absent. | Fill in server, username, password, or complete OAuth authorization. |
+| `not_configured` | No enabled mailbox source is available. | Add or enable a source, then run **Test connection** before relying on scheduled imports. |
 
 Never paste mailbox passwords or OAuth tokens into logs or issue comments. If a provider error contains a token-like value, redact it before sharing.
 
@@ -172,4 +176,3 @@ Open a follow-up issue with:
 - Whether a recent upgrade, migration, credential rotation, or DNS change happened.
 
 Do not include raw secrets, mailbox contents, OAuth tokens, API tokens, database passwords, or full report files unless they have been sanitized.
-

--- a/docs/user_guide/imap.md
+++ b/docs/user_guide/imap.md
@@ -69,14 +69,18 @@ Configure how DMARQ handles report attachments:
 
 ### Troubleshooting IMAP Connections
 
-If you're having trouble with IMAP integration:
+If you're having trouble with IMAP integration, run **Test connection** from **Mail Sources** first. DMARQ returns a diagnostic category and recovery steps for the most common cases:
 
-1. **Check Credentials**: Verify username and password are correct
-2. **Verify Server Settings**: Confirm IMAP server address and port
-3. **Check IMAP Access**: Ensure IMAP is enabled for your email account
-4. **App Passwords**: If using 2FA, verify you're using an app-specific password
-5. **Firewall Issues**: Ensure your DMARQ instance can connect to your IMAP server
-6. **View IMAP Logs**: Check the IMAP connection logs in **Settings** > **Logs**
+| Category | What to check |
+|----------|---------------|
+| `authentication` | Verify username and password, and use an app password when MFA is enabled. |
+| `connectivity` | Confirm server address, port, TLS, DNS, and firewall access from the DMARQ host. |
+| `mailbox_not_found` | Match the folder name exactly, including case and nested separators. |
+| `folder_search` | Confirm DMARC reports are delivered to the selected folder, then run a wider backfill. |
+| `parsing` | Check import details for malformed XML, unsupported attachments, or corrupt ZIP/GZIP files. |
+| `duplicate_only` | Treat this as normal when the mailbox is quiet; check folder delivery if fresh reports are expected. |
+
+If the category is not enough to resolve the issue, check **Operations** for mailbox recovery guidance and review the latest import history from **Mail Sources**. Keep passwords, tokens, and provider error secrets redacted in notes and issue comments.
 
 ## Managing IMAP Integration
 


### PR DESCRIPTION
## Summary
- centralize mailbox connection/import recovery guidance in a shared service
- add diagnostic summaries and recovery steps to IMAP tests, manual fetch responses, setup status, and operations health
- surface mailbox recovery hints on setup and operations pages
- document mailbox diagnostic categories, including parsing, folder/search, duplicate-only, and not-configured states

Closes #202

## Validation
- PYTHONPATH=backend .venv/bin/python -m py_compile backend/app/services/mailbox_recovery.py backend/app/api/api_v1/endpoints/mail_sources.py backend/app/api/api_v1/endpoints/imap.py backend/app/api/api_v1/endpoints/health.py backend/app/api/api_v1/endpoints/setup.py backend/app/tests/test_mailbox_recovery.py backend/app/tests/test_imap_endpoints.py backend/app/tests/test_mail_sources.py backend/app/tests/test_api.py
- PYTHONPATH=backend .venv/bin/python - <<'PY'
from app.services.mailbox_recovery import connection_test_response, import_result_diagnostic
cases = [
    connection_test_response(False, 'Login failed invalid password', {'diagnostic_detail': 'password=super-secret rejected'})['diagnostic_category'],
    import_result_diagnostic({'success': True, 'processed': 1, 'reports_found': 0, 'errors': ['Could not parse ZIP attachment report.zip']})['category'],
    import_result_diagnostic({'success': True, 'processed': 2, 'reports_found': 0, 'duplicate_reports': 2, 'errors': []})['category'],
    import_result_diagnostic({'success': True, 'processed': 2, 'reports_found': 2, 'errors': []})['category'],
]
assert cases == ['authentication', 'parsing', 'duplicate_only', 'ok'], cases
print('direct assertions ok')
PY
- git diff --check

Note: full pytest could not be completed locally because this checkout's Python 3.14 virtualenv hangs during endpoint module import/pytest startup. The shared recovery service imports and direct assertions pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mailbox recovery guidance across health, setup, and IMAP screens.
  * Connection tests and import results now show clearer diagnostic categories, summaries, and recovery steps.
  * Setup status can now surface a mailbox recovery hint when mail sources are not ready.

* **Bug Fixes**
  * Improved health checks to flag recent import issues as degraded when needed.
  * Added recovery guidance for missing configuration and import parsing or authentication issues.

* **Documentation**
  * Expanded troubleshooting guidance with updated diagnostic categories and next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->