### PR TITLE
Address mailbox recovery review feedback

### DIFF
--- a/backend/app/services/mailbox_recovery.py
+++ b/backend/app/services/mailbox_recovery.py
@@ -8,7 +8,7 @@ from app.core.redaction import redact_sensitive_text
 
 DIAGNOSTIC_COPY: Dict[str, Dict[str, Any]] = {
     "ok": {
-        "summary": "Connection test completed successfully.",
+        "summary": "Mailbox operation completed successfully.",
         "recovery_steps": [],
     },
     "auth_required": {
@@ -67,8 +67,10 @@ DIAGNOSTIC_COPY: Dict[str, Dict[str, Any]] = {
         "summary": "DMARQ reached the mailbox but could not parse one or more report attachments.",
         "recovery_steps": [
             "Open the latest import details and identify the affected attachment or reporter.",
-            "Upload a known-good XML, ZIP, or GZIP aggregate report to confirm parsing still "
-            "works.",
+            (
+                "Upload a known-good XML, ZIP, or GZIP aggregate report "
+                + "to confirm parsing still works."
+            ),
         ],
     },
     "duplicate_only": {
@@ -145,10 +147,19 @@ def diagnostic_category(message: str, details: Optional[object] = None) -> str:
         for term in ("scope", "permission", "access denied", "insufficient", "forbidden", "403")
     ):
         return "permissions"
-    if any(term in text for term in ("mailbox", "folder", "select failed", "does not exist")):
-        return "mailbox_not_found"
     if any(term in text for term in ("credential", "password", "auth", "login", "invalid token")):
         return "authentication"
+    if any(
+        term in text
+        for term in (
+            "folder",
+            "select failed",
+            "does not exist",
+            "mailbox not found",
+            "no such mailbox",
+        )
+    ):
+        return "mailbox_not_found"
     if any(
         term in text
         for term in (

--- a/backend/app/services/mailbox_recovery.py
+++ b/backend/app/services/mailbox_recovery.py
@@ -67,10 +67,7 @@ DIAGNOSTIC_COPY: Dict[str, Dict[str, Any]] = {
         "summary": "DMARQ reached the mailbox but could not parse one or more report attachments.",
         "recovery_steps": [
             "Open the latest import details and identify the affected attachment or reporter.",
-            (
-                "Upload a known-good XML, ZIP, or GZIP aggregate report "
-                + "to confirm parsing still works."
-            ),
+            "Upload a known-good XML, ZIP, or GZIP aggregate report to confirm parsing works.",
         ],
     },
     "duplicate_only": {

--- a/backend/app/tests/test_mailbox_recovery.py
+++ b/backend/app/tests/test_mailbox_recovery.py
@@ -16,6 +16,15 @@ def test_connection_response_classifies_auth_failure_without_raw_secret():
     assert "super-secret" not in str(response)
 
 
+def test_connection_response_prefers_auth_over_broad_mailbox_text():
+    response = connection_test_response(
+        False,
+        "IMAP authentication failed or the mailbox server rejected the request.",
+    )
+
+    assert response["diagnostic_category"] == "authentication"
+
+
 def test_import_result_classifies_parsing_failure():
     diagnostic = import_result_diagnostic(
         {
@@ -57,4 +66,5 @@ def test_import_result_success_has_no_recovery_steps():
     )
 
     assert diagnostic["category"] == "ok"
+    assert diagnostic["summary"] == "Mailbox operation completed successfully."
     assert diagnostic["recovery_steps"] == []


### PR DESCRIPTION
## Summary
- classify IMAP authentication failures before mailbox folder errors and remove the broad mailbox substring match
- make the shared ok diagnostic summary neutral for both connection checks and import responses
- replace the implicit recovery-step string concatenation and add regression coverage for the review cases

## Validation
- PYTHONPATH=backend python3 -m py_compile backend/app/services/mailbox_recovery.py backend/app/tests/test_mailbox_recovery.py
- git diff --check
- direct assertions for auth classification, import ok summary, and parsing diagnostics

Follow-up to #225.