### PR TITLE
Define Microsoft 365 Graph connector contract

### DIFF
--- a/backend/app/tests/test_microsoft_graph_client.py
+++ b/backend/app/tests/test_microsoft_graph_client.py
@@ -7,7 +7,8 @@ from io import BytesIO
 import httpx
 
 from app.models.report import DMARCReport
-from app.services.microsoft_graph_client import MicrosoftGraphClient
+from app.services.mail_connector import initial_import_stats
+from app.services.microsoft_graph_client import M365_SCOPES, MicrosoftGraphClient
 from app.tests.test_data import SAMPLE_XML
 
 
@@ -33,6 +34,37 @@ def _make_client(db=None, already_ingested=None) -> MicrosoftGraphClient:
 
 
 class TestMicrosoftGraphOAuthHelpers:
+    def test_connector_contract_uses_read_only_scopes_and_safe_context(self):
+        client = MicrosoftGraphClient(
+            tenant_id="organizations",
+            client_id="client-id",
+            client_secret="client-secret",
+            access_token="access-token",
+            refresh_token="refresh-token",
+            mailbox="shared@example.com",
+            folder="DMARC Reports",
+            folder_id="folder-id",
+        )
+
+        context = client.import_context(days=45)
+        stats = initial_import_stats(context)
+
+        assert M365_SCOPES == [
+            "offline_access",
+            "https://graph.microsoft.com/User.Read",
+            "https://graph.microsoft.com/Mail.Read",
+        ]
+        assert callable(client.search_messages)
+        assert callable(client.iter_attachments)
+        assert callable(client.fetch_reports)
+        assert stats["source_type"] == "M365_GRAPH"
+        assert stats["target_mailbox"] == "shared@example.com"
+        assert stats["target_folder"] == "DMARC Reports"
+        assert stats["search_window_days"] == 45
+        assert stats["forensic_reports_found"] == 0
+        assert stats["duplicate_forensic_reports"] == 0
+        assert "client-secret" not in str(stats)
+
     def test_build_authorization_url_includes_required_scopes(self):
         url = MicrosoftGraphClient.build_authorization_url(
             tenant_id="organizations",

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,8 @@ To get started with DMARQ, please see the [Getting Started](user_guide/getting_s
 For installation instructions, check the [Docker Setup](deployment/docker.md) or [Manual Installation](deployment/manual.md) guides. Operators should use the [Operator Runbook](deployment/operations.md) for deployment modes, verification, upgrades, and rollback, and the [Troubleshooting Playbooks](deployment/troubleshooting.md) for ingestion, authentication, DNS, database, and notification failures. For production secrets, use [Secret Handling with 1Password](deployment/secrets.md). For database operations, use [Database Backup and Restore](deployment/backups.md). For upgrades, use the [Release Checklist](deployment/release-checklist.md).
 
 For Microsoft 365 setup, see [Microsoft 365 Mail Sources](user_guide/microsoft365.md).
+For connector implementation boundaries, see the
+[Microsoft 365 Graph Connector Contract](reference/microsoft365-graph-connector.md).
 
 For SMTP TLS reporting imports and privacy controls, see [TLS Reports](user_guide/tls_reports.md).
 

--- a/docs/reference/microsoft365-graph-connector.md
+++ b/docs/reference/microsoft365-graph-connector.md
@@ -1,0 +1,120 @@
+# Microsoft 365 Graph Connector Contract
+
+This contract defines the supported boundary for Microsoft 365 mail sources. The
+connector exists only to import DMARC aggregate report attachments through
+Microsoft Graph and to return sanitized operational metadata that matches the
+shared mail-source import history shape.
+
+## Scope
+
+The connector must remain read-only:
+
+- It may list messages in the configured mailbox and folder.
+- It may list and read `fileAttachment` payloads for messages that look like
+  DMARC aggregate report mail.
+- It must not delete, move, mark read, label, forward, or otherwise mutate
+  Microsoft 365 mailbox content.
+- It must pass supported `.xml`, `.zip`, `.gz`, and `.gzip` attachments through
+  the same aggregate DMARC parser used by upload, IMAP, and Gmail imports.
+
+## OAuth Permissions
+
+DMARQ uses delegated Microsoft Graph permissions:
+
+| Permission | Purpose |
+|------------|---------|
+| `offline_access` | Receive refresh tokens for scheduled polling. |
+| `User.Read` | Identify the authorised account during OAuth setup. |
+| `Mail.Read` | List messages and read report attachments. |
+
+Application-wide Graph permissions are outside this contract. If a deployment
+needs application permissions later, it should be designed as a separate
+connector mode with a separate risk review.
+
+## Mailbox and Folder Selection
+
+The connector supports two mailbox targets:
+
+- Blank mailbox or `me`: read the authorised account through `/me`.
+- User principal name: read a delegated or shared mailbox through `/users/{upn}`.
+
+The authorised account must already have Exchange Online read access to any
+shared mailbox or folder. DMARQ does not grant mailbox permissions.
+
+Folder selection should prefer Microsoft Graph folder ids returned by **Load
+folders**. Folder ids are stable across localized or renamed folders. Manually
+entered folder names are accepted for well-known folders such as `INBOX`, but
+operators should prefer folder ids for dedicated DMARC report folders.
+
+## Backfill and Search Window
+
+All manual imports, scheduled imports, and backfills must use the shared
+connector search-window clamp:
+
+- default: 7 days
+- minimum: 1 day
+- maximum: 365 days
+
+The Graph request must include a `receivedDateTime ge ...` filter for the
+requested window and should order by newest messages first. Connectors must keep
+already-ingested Graph message ids and avoid reprocessing the same message on
+later runs.
+
+## Import Result Shape
+
+Microsoft 365 imports must return the same safe shape as other mailbox
+connectors:
+
+| Field | Meaning |
+|-------|---------|
+| `success` | Whether the provider request and import loop completed. |
+| `processed` | Messages inspected for import. |
+| `reports_found` | New aggregate reports persisted. |
+| `forensic_reports_found` | Reserved for future RUF metadata, separate from aggregate totals. |
+| `duplicate_reports` | Aggregate reports skipped because the report id already exists. |
+| `duplicate_forensic_reports` | Reserved for future forensic/RUF support. |
+| `new_domains` | Domains introduced by newly persisted aggregate reports. |
+| `errors` | Sanitized provider or attachment failures. |
+| `new_ingested_ids` | Graph message ids that can be persisted for dedupe. |
+| `details` | Sanitized per-message or per-attachment outcomes. |
+| `target_mailbox` | Operator-safe mailbox label, never a token or secret. |
+| `target_folder` | Operator-safe folder label or folder id. |
+| `search_window_days` | Effective clamped search window. |
+
+This result shape is what `record_import_attempt` stores in sanitized import
+history. It must remain compatible with IMAP and Gmail import semantics.
+
+## Throttling and Retries
+
+Graph responses with `429`, `503`, or `504` are retryable. The connector should:
+
+- honor `Retry-After` when present,
+- use bounded exponential backoff otherwise,
+- cap waits to a short operational delay,
+- return a sanitized failed import result if Graph remains unavailable.
+
+## Redaction Rules
+
+The connector may store or return:
+
+- mailbox labels,
+- folder labels or ids,
+- Graph message ids,
+- attachment filenames,
+- aggregate report domains and report ids,
+- sanitized provider error categories or messages.
+
+The connector must never store or return:
+
+- access tokens,
+- refresh tokens,
+- client secrets,
+- raw OAuth responses,
+- raw message bodies,
+- raw attachment content,
+- full provider errors containing secrets.
+
+Operators should keep Microsoft 365 secrets in 1Password or the deployment
+secret manager and inject them into the authorized deployment process. DMARQ
+should only receive those secrets through configured runtime settings or
+encrypted database fields, never through logs or issue comments.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - API Reference: reference/api.md
     - SIEM Integrations: reference/siem-integrations.md
     - Ticketing and Chatops: reference/ticketing-chatops-integrations.md
+    - Microsoft 365 Graph Connector: reference/microsoft365-graph-connector.md
     - Workspaces: reference/workspaces.md
     - Architecture: reference/architecture.md
     - Database Schema: reference/database.md


### PR DESCRIPTION
## Summary
- add an explicit Microsoft 365 Graph connector contract covering scopes, shared mailbox/folder selection, backfill windows, throttling, import result shape, and redaction rules
- expose the contract in the documentation nav and index
- add a low-risk contract test for read-only delegated scopes and shared import-history semantics

Closes #204

## Validation
- PYTHONPATH=backend .venv/bin/python -m py_compile backend/app/tests/test_microsoft_graph_client.py

Note: this local Python 3.14 virtualenv hangs when importing the full MicrosoftGraphClient module, so full execution is left to GitHub CI's Python 3.13 runner.