### PR TITLE
Add Microsoft Graph shared mailbox scope

### DIFF
--- a/backend/app/services/microsoft_graph_client.py
+++ b/backend/app/services/microsoft_graph_client.py
@@ -33,6 +33,7 @@ M365_SCOPES = [
     "offline_access",
     "https://graph.microsoft.com/User.Read",
     "https://graph.microsoft.com/Mail.Read",
+    "https://graph.microsoft.com/Mail.Read.Shared",
 ]
 
 _PAGE_SIZE = 100

--- a/backend/app/tests/test_microsoft_graph_client.py
+++ b/backend/app/tests/test_microsoft_graph_client.py
@@ -3,6 +3,7 @@
 import base64
 import zipfile
 from io import BytesIO
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 
@@ -75,13 +76,11 @@ class TestMicrosoftGraphOAuthHelpers:
         )
 
         assert url.startswith("https://login.microsoftonline.com/organizations/")
-        assert "client_id=client-id" in url
-        assert "response_type=code" in url
-        assert "offline_access" in url
-        assert "User.Read" in url
-        assert "Mail.Read" in url
-        assert "Mail.Read.Shared" in url
-        assert "state=42" in url
+        params = parse_qs(urlparse(url).query)
+        assert params["client_id"] == ["client-id"]
+        assert params["response_type"] == ["code"]
+        assert params["scope"] == [" ".join(M365_SCOPES)]
+        assert params["state"] == ["42"]
 
     def test_exchange_code_for_tokens_posts_to_tenant_endpoint(self, monkeypatch):
         def fake_post(url, data=None, timeout=None):

--- a/backend/app/tests/test_microsoft_graph_client.py
+++ b/backend/app/tests/test_microsoft_graph_client.py
@@ -53,6 +53,7 @@ class TestMicrosoftGraphOAuthHelpers:
             "offline_access",
             "https://graph.microsoft.com/User.Read",
             "https://graph.microsoft.com/Mail.Read",
+            "https://graph.microsoft.com/Mail.Read.Shared",
         ]
         assert callable(client.search_messages)
         assert callable(client.iter_attachments)
@@ -79,6 +80,7 @@ class TestMicrosoftGraphOAuthHelpers:
         assert "offline_access" in url
         assert "User.Read" in url
         assert "Mail.Read" in url
+        assert "Mail.Read.Shared" in url
         assert "state=42" in url
 
     def test_exchange_code_for_tokens_posts_to_tenant_endpoint(self, monkeypatch):

--- a/docs/reference/microsoft365-graph-connector.md
+++ b/docs/reference/microsoft365-graph-connector.md
@@ -24,8 +24,9 @@ DMARQ uses delegated Microsoft Graph permissions:
 | Permission | Purpose |
 |------------|---------|
 | `offline_access` | Receive refresh tokens for scheduled polling. |
-| `User.Read` | Identify the authorised account during OAuth setup. |
-| `Mail.Read` | List messages and read report attachments. |
+| `User.Read` | Identify the authorized account during OAuth setup. |
+| `Mail.Read` | List messages and read report attachments from the authorized account. |
+| `Mail.Read.Shared` | Read report messages and attachments in shared or delegated mailboxes. |
 
 Application-wide Graph permissions are outside this contract. If a deployment
 needs application permissions later, it should be designed as a separate
@@ -35,10 +36,10 @@ connector mode with a separate risk review.
 
 The connector supports two mailbox targets:
 
-- Blank mailbox or `me`: read the authorised account through `/me`.
+- Blank mailbox or `me`: read the authorized account through `/me`.
 - User principal name: read a delegated or shared mailbox through `/users/{upn}`.
 
-The authorised account must already have Exchange Online read access to any
+The authorized account must already have Exchange Online read access to any
 shared mailbox or folder. DMARQ does not grant mailbox permissions.
 
 Folder selection should prefer Microsoft Graph folder ids returned by **Load


### PR DESCRIPTION
## Summary
- Add the delegated `Mail.Read.Shared` Microsoft Graph scope for shared/delegated mailbox reads.
- Update the Microsoft 365 connector contract to document the shared-mailbox permission boundary.
- Keep the scope contract test and authorization URL coverage aligned with the connector behavior.

## Validation
- `PYTHONPATH=backend .venv/bin/python -m py_compile backend/app/services/microsoft_graph_client.py backend/app/tests/test_microsoft_graph_client.py`
- `git diff --check`
- changed-file line length check
- `PYTHONPATH=backend .venv/bin/python -m pytest backend/app/tests/test_microsoft_graph_client.py -q`

Follow-up to post-merge review comments on #227.