### PR TITLE
Tighten forensic RUF privacy wording

### DIFF
--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -28,31 +28,35 @@ therefore treats them as a metadata-only signal for receiver-side diagnostics.
 
 DMARQ may persist:
 
-- report identifiers generated from message ids or content hashes,
-- reporter address after the configured redaction policy is applied,
+- report identifiers generated from hashed `Message-ID` values or one-way
+  content hashes.
+- reporter address after the configured redaction policy is applied.
 - reported domain, source IP, authentication failure type, delivery result, and
-  arrival date,
+  arrival date.
 - redacted original envelope/header metadata such as `Original-Mail-From`,
-  `From`, `To`, `Subject`, and hashed `Message-ID`,
+  `From`, `To`, `Subject`, and hashed `Message-ID`.
 - RFC 9991 diagnostic metadata such as alignment, DKIM domain, DKIM selector,
-  SPF DNS text, and `Reported-URI`,
+  SPF DNS text, and `Reported-URI`.
 - boolean flags that canonicalized DKIM header/body fields were present.
 
 DMARQ must not persist:
 
-- raw message bodies,
-- raw attached RFC 822 messages,
-- raw canonicalized DKIM header or body values,
-- raw local-parts when the configured redaction policy would mask them,
+- raw message bodies.
+- raw original-message MIME payloads from `message/rfc822` or
+  `text/rfc822-headers` parts.
+- raw canonicalized DKIM header or body values.
+- raw local-parts when the configured redaction policy would mask them.
 - long opaque tokens found in subjects or headers when token redaction is
-  enabled,
+  enabled.
 - OAuth tokens, mailbox passwords, webhook secrets, or provider error payloads
   containing secrets.
 
 Unsupported or non-forensic messages fail closed: the forensic parser rejects
-empty, oversized, non-ARF, or non-DMARC payloads instead of mixing them into
-aggregate report totals. IMAP and Gmail ingestion paths count accepted
-forensic/RUF reports separately through `forensic_reports_found` and
+empty, oversized, and non-DMARC payloads, while accepting only messages that
+match the supported DMARC failure-report signals above. Those signals include
+ARF feedback parts, `text/rfc822-headers` with DMARC context, or DMARC
+failure/forensic/RUF subject metadata. Accepted forensic/RUF reports are counted
+separately from aggregate report totals through `forensic_reports_found` and
 `duplicate_forensic_reports`.
 
 ## Supported Policy Discovery


### PR DESCRIPTION
## Summary
- Clarify forensic/RUF persisted identifiers as hashed `Message-ID` values or one-way content hashes.
- Use consistent sentence punctuation in the allowed/forbidden persistence lists.
- Align unsupported-message wording with the implemented forensic classifier signals.

## Validation
- `git diff --check`
- changed-file line-length scan only reported pre-existing long lines outside this diff

Follow-up to post-merge review comments on #229.