### PR TITLE
[codex] Harden SIEM template guidance

### DIFF
--- a/backend/app/services/siem_templates.py
+++ b/backend/app/services/siem_templates.py
@@ -96,6 +96,7 @@ SIEM_EVENT_SCHEMA: Dict[str, Any] = {
         "alert": {
             "type": ["object", "null"],
             "additionalProperties": False,
+            "required": ["title", "detail", "status"],
             "properties": {
                 "title": {"type": "string"},
                 "detail": {"type": "string"},
@@ -298,15 +299,19 @@ SIEM_INGESTION_EXAMPLES: Dict[str, Dict[str, Any]] = {
 
 SIEM_CONFIG_TEMPLATES: Dict[str, Dict[str, Any]] = {
     "splunk_hec": {
-        "webhook_url_pattern": "https://splunk.example:8088/services/collector/event",
-        "headers": {
+        "webhook_url_pattern": "https://siem-relay.example/dmarq/splunk-hec",
+        "delivery_model": "relay_required",
+        "relay_target_url_pattern": "https://splunk.example:8088/services/collector/event",
+        "headers_added_by_relay": {
             "Authorization": "Splunk ${SPLUNK_HEC_TOKEN}",
             "Content-Type": "application/json",
         },
         "recommended_index": "email_security",
         "recommended_sourcetype": "_json",
         "notes": [
-            "Store the HEC token in the receiving proxy or SIEM secret store.",
+            "Point DMARQ at a relay or workflow endpoint, not directly at Splunk HEC.",
+            "DMARQ webhook delivery cannot emit the Splunk Authorization header.",
+            "Store the HEC token in the receiving relay, proxy, or SIEM secret store.",
             "Deduplicate with event.event_id or X-DMARQ-Idempotency-Key.",
         ],
     },
@@ -371,6 +376,22 @@ def _append_redaction_errors(event: Dict[str, Any], errors: List[str]) -> None:
     errors.extend(message for passed, message in checks if not passed)
 
 
+def _append_alert_errors(event: Dict[str, Any], errors: List[str]) -> None:
+    alert = event.get("alert")
+    if alert is None:
+        return
+    if not isinstance(alert, dict):
+        errors.append("alert must be an object or null")
+        return
+
+    for field in SIEM_EVENT_SCHEMA["properties"]["alert"]["required"]:
+        if not alert.get(field):
+            errors.append(f"alert.{field} is required when alert is present")
+
+    if alert.get("status") not in {"active", "resolved", "informational"}:
+        errors.append("alert.status is not supported")
+
+
 def get_siem_templates() -> Dict[str, Any]:
     """Return a copy of the versioned SIEM template bundle."""
     return copy.deepcopy(
@@ -402,4 +423,5 @@ def validate_siem_event(event: Dict[str, Any]) -> List[str]:
         errors.append("entity.domain is required")
 
     _append_redaction_errors(event, errors)
+    _append_alert_errors(event, errors)
     return errors

--- a/backend/app/tests/test_siem_templates.py
+++ b/backend/app/tests/test_siem_templates.py
@@ -54,6 +54,45 @@ def test_siem_ingestion_examples_wrap_valid_dmarq_events():
         assert wrapped_event["schema_version"] == SIEM_SCHEMA_VERSION
 
 
+def test_siem_alert_schema_requires_metadata_when_alert_is_present():
+    """Alert metadata is optional, but partial alert objects are not valid."""
+    templates = get_siem_templates()
+    alert_schema = templates["event_schema"]["properties"]["alert"]
+    event = templates["event_examples"]["compliance_drop"].copy()
+
+    assert alert_schema["type"] == ["object", "null"]
+    assert alert_schema["required"] == ["title", "detail", "status"]
+    assert validate_siem_event({**event, "alert": None}) == []
+
+    errors = validate_siem_event({**event, "alert": {}})
+
+    assert "alert.title is required when alert is present" in errors
+    assert "alert.detail is required when alert is present" in errors
+    assert "alert.status is required when alert is present" in errors
+
+    assert "alert must be an object or null" in validate_siem_event({**event, "alert": "active"})
+    assert "alert.status is not supported" in validate_siem_event(
+        {**event, "alert": {"title": "Title", "detail": "Detail", "status": "open"}}
+    )
+
+
+def test_splunk_template_requires_relay_to_add_hec_authorization():
+    """DMARQ cannot send Splunk's Authorization header directly."""
+    templates = get_siem_templates()
+    splunk_template = templates["config_templates"]["splunk_hec"]
+
+    assert splunk_template["delivery_model"] == "relay_required"
+    assert "splunk.example:8088/services/collector/event" not in splunk_template[
+        "webhook_url_pattern"
+    ]
+    assert "Authorization" not in splunk_template.get("headers", {})
+    assert splunk_template["headers_added_by_relay"]["Authorization"].startswith("Splunk ")
+
+    notes = " ".join(splunk_template["notes"]).lower()
+    assert "relay" in notes
+    assert "cannot emit the splunk authorization header" in notes
+
+
 def test_siem_templates_endpoint_returns_common_configs(authed_client: TestClient):
     """Administrators can fetch schemas, examples, and SIEM config hints."""
     response = authed_client.get("/api/v1/integrations/siem/templates")

--- a/docs/reference/siem-integrations.md
+++ b/docs/reference/siem-integrations.md
@@ -84,14 +84,28 @@ Supported normalized event types are:
 
 ## Splunk HEC
 
-Use the webhook URL for a relay or directly for Splunk HEC when your network
-allows it:
+Use the DMARQ webhook URL for a relay, proxy, or workflow endpoint. Do not point
+DMARQ directly at Splunk HEC:
+
+```text
+https://siem-relay.example/dmarq/splunk-hec
+```
+
+The relay forwards to Splunk HEC and adds Splunk's required authorization
+header from its own secret store:
 
 ```text
 https://splunk.example:8088/services/collector/event
+Authorization: Splunk ${SPLUNK_HEC_TOKEN}
 ```
 
-Send the normalized event as the `event` field:
+DMARQ webhook delivery uses a fixed DMARQ header set for signing,
+idempotency, and content type. It cannot emit `Authorization: Splunk <token>`
+on the outbound webhook request. Put the HEC token in the relay, Splunk, or a
+secret manager used by the relay. Do not store Splunk credentials in the DMARQ
+webhook URL.
+
+Forward the normalized event as the HEC `event` field:
 
 ```json
 {
@@ -107,9 +121,6 @@ Send the normalized event as the `event` field:
   }
 }
 ```
-
-Keep the HEC token in Splunk, a receiving proxy, or a secret manager. Do not
-store Splunk credentials in the DMARQ webhook URL.
 
 ## Elastic ECS
 


### PR DESCRIPTION
## Summary
- require SIEM `alert` objects to include `title`, `detail`, and `status` while keeping `alert: null` valid
- clarify that Splunk HEC delivery must go through a relay/proxy because DMARQ cannot emit `Authorization: Splunk <token>` directly
- add regression tests for the tightened alert schema and Splunk relay delivery model

## Validation
- `PYTHONPATH=backend python3.13 -m py_compile backend/app/services/siem_templates.py backend/app/tests/test_siem_templates.py`
- `PYTHONPATH=backend /tmp/dmarq-py313-siem/bin/python -m pytest backend/app/tests/test_siem_templates.py -q`

Closes #194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened SIEM event validation so bundled alerts must include required fields and a valid status.
  * Improved Splunk HEC setup guidance to reflect relay-based delivery, avoiding direct exposure of webhook credentials.

* **Documentation**
  * Updated SIEM integration docs with relay/proxy examples and clearer Splunk header handling instructions.

* **Tests**
  * Added coverage for alert field validation and the relay-based Splunk HEC template behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->