### PR TITLE
Address SIEM template review feedback

### DIFF
--- a/backend/app/services/siem_templates.py
+++ b/backend/app/services/siem_templates.py
@@ -302,6 +302,7 @@ SIEM_CONFIG_TEMPLATES: Dict[str, Dict[str, Any]] = {
         "webhook_url_pattern": "https://siem-relay.example/dmarq/splunk-hec",
         "delivery_model": "relay_required",
         "relay_target_url_pattern": "https://splunk.example:8088/services/collector/event",
+        "headers": {},
         "headers_added_by_relay": {
             "Authorization": "Splunk ${SPLUNK_HEC_TOKEN}",
             "Content-Type": "application/json",
@@ -385,10 +386,11 @@ def _append_alert_errors(event: Dict[str, Any], errors: List[str]) -> None:
         return
 
     for field in SIEM_EVENT_SCHEMA["properties"]["alert"]["required"]:
-        if not alert.get(field):
+        if field not in alert:
             errors.append(f"alert.{field} is required when alert is present")
 
-    if alert.get("status") not in {"active", "resolved", "informational"}:
+    allowed_statuses = SIEM_EVENT_SCHEMA["properties"]["alert"]["properties"]["status"]["enum"]
+    if "status" in alert and alert.get("status") not in allowed_statuses:
         errors.append("alert.status is not supported")
 
 

--- a/backend/app/tests/test_siem_templates.py
+++ b/backend/app/tests/test_siem_templates.py
@@ -69,6 +69,14 @@ def test_siem_alert_schema_requires_metadata_when_alert_is_present():
     assert "alert.title is required when alert is present" in errors
     assert "alert.detail is required when alert is present" in errors
     assert "alert.status is required when alert is present" in errors
+    assert "alert.status is not supported" not in errors
+
+    assert (
+        validate_siem_event(
+            {**event, "alert": {"title": "", "detail": "", "status": "active"}}
+        )
+        == []
+    )
 
     assert "alert must be an object or null" in validate_siem_event({**event, "alert": "active"})
     assert "alert.status is not supported" in validate_siem_event(
@@ -85,6 +93,7 @@ def test_splunk_template_requires_relay_to_add_hec_authorization():
     assert "splunk.example:8088/services/collector/event" not in splunk_template[
         "webhook_url_pattern"
     ]
+    assert splunk_template["headers"] == {}
     assert "Authorization" not in splunk_template.get("headers", {})
     assert splunk_template["headers_added_by_relay"]["Authorization"].startswith("Splunk ")
 


### PR DESCRIPTION
Follow-up to post-merge review feedback on #232.\n\nChanges:\n- Preserve the legacy Splunk template `headers` key as an empty compatibility field while keeping relay-added authorization guidance in `headers_added_by_relay`.\n- Match alert required-field validation to JSON Schema presence semantics.\n- Only validate alert status enum when `status` is present and source allowed statuses from the schema.\n- Add regression coverage for missing-vs-empty alert metadata and Splunk header compatibility.\n\nValidation:\n- `PYTHONPATH=backend python3 -m py_compile backend/app/services/siem_templates.py backend/app/tests/test_siem_templates.py`\n- `git diff --check`\n- `PYTHONPATH=backend .venv/bin/python -m pytest backend/app/tests/test_siem_templates.py -q` (6 passed)\n\nRefs #232