### PR TITLE
Fix SaaS follow-up review findings

### DIFF
--- a/backend/app/api/api_v1/endpoints/operator.py
+++ b/backend/app/api/api_v1/endpoints/operator.py
@@ -80,8 +80,13 @@ async def get_demo_multi_user_deployment(
 ) -> DemoMultiUserDeploymentResponse:
     """Return deterministic demo data for SaaS, managed-service, and ISP views."""
     require_workspace_permission(_auth, PERMISSION_AUDIT_READ)
+    if not get_settings().DEMO_MODE:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Demo multi-user deployment is only available in demo mode",
+        )
     return {
-        "demo_mode": get_settings().DEMO_MODE,
+        "demo_mode": True,
         "deployment": build_demo_multi_user_deployment(),
     }
 

--- a/backend/app/api/api_v1/endpoints/stats.py
+++ b/backend/app/api/api_v1/endpoints/stats.py
@@ -112,6 +112,16 @@ def _days_from_interval(interval: str, fallback_days: Optional[int]) -> int:
     return int(fallback_days or 30)
 
 
+def _summary_cache_key(date_range: Dict[str, Any]) -> str:
+    """Build a stable cache key for resolved dashboard windows."""
+    interval = str(date_range["interval"])
+    if interval == "custom":
+        return f"custom_{date_range['start_date']}_{date_range['end_date']}"
+    if interval in {"week_to_date", "month_to_date"}:
+        return f"{interval}_{date_range['start_date']}"
+    return interval
+
+
 def resolve_dashboard_date_range(
     *,
     interval: Optional[str] = None,
@@ -184,9 +194,6 @@ async def get_dashboard_statistics(
     resolved_days = date_range["period_days"]
     start_ts = int(datetime.fromisoformat(date_range["start_at"]).timestamp())
     end_ts = int(datetime.fromisoformat(date_range["end_at"]).timestamp())
-    if not date_range["is_filtered"]:
-        start_ts = None
-        end_ts = None
 
     if get_settings().DEMO_MODE:
         stats = build_demo_dashboard_statistics(period_days=resolved_days)
@@ -208,6 +215,7 @@ async def get_dashboard_statistics(
         period_days=resolved_days,
         start_ts=start_ts,
         end_ts=end_ts,
+        cache_key=_summary_cache_key(date_range),
     )
 
     # Add version and timestamp
@@ -248,9 +256,6 @@ async def get_domain_statistics(
     resolved_days = date_range["period_days"]
     start_ts = int(datetime.fromisoformat(date_range["start_at"]).timestamp())
     end_ts = int(datetime.fromisoformat(date_range["end_at"]).timestamp())
-    if not date_range["is_filtered"]:
-        start_ts = None
-        end_ts = None
 
     if get_settings().DEMO_MODE:
         stats = build_demo_dashboard_statistics(period_days=resolved_days, domain=domain_id)
@@ -273,6 +278,7 @@ async def get_domain_statistics(
         period_days=resolved_days,
         start_ts=start_ts,
         end_ts=end_ts,
+        cache_key=_summary_cache_key(date_range),
     )
 
     # Add version and timestamp

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time, timezone
+from html import escape
 from typing import Any, Dict, Iterable, List, Optional
 
 from sqlalchemy import func
@@ -50,6 +51,18 @@ PROVIDER_SUBSCRIPTION_STATUSES = {
     "canceled",
     "terminated",
 }
+MAX_PROVIDER_PAYLOAD_SUMMARY_LENGTH = 500
+
+
+def _sanitize_payload_summary(payload_summary: Optional[str]) -> Optional[str]:
+    """Trim provider summaries to safe, displayable text."""
+    if payload_summary is None:
+        return None
+    normalized = " ".join(str(payload_summary).split())
+    if not normalized:
+        return None
+    escaped = escape(normalized, quote=True)
+    return escaped[:MAX_PROVIDER_PAYLOAD_SUMMARY_LENGTH]
 
 
 def get_or_create_default_organization(db: Session, *, commit: bool = True) -> Organization:
@@ -308,9 +321,7 @@ def _plan_to_dict(plan: Plan) -> Dict[str, Any]:
         "included_users": plan.included_users,
         "retention_days": plan.retention_days,
         "features": [
-            feature.strip()
-            for feature in (plan.features or "").split(",")
-            if feature.strip()
+            feature.strip() for feature in (plan.features or "").split(",") if feature.strip()
         ],
     }
 
@@ -368,12 +379,8 @@ def organization_summary(db: Session, organization: Organization) -> Dict[str, A
         "created_at": _iso(organization.created_at),
         "updated_at": _iso(organization.updated_at),
         "workspaces": [_workspace_to_dict(workspace) for workspace in workspaces],
-        "billing_accounts": [
-            _billing_account_to_dict(account) for account in billing_accounts
-        ],
-        "subscriptions": [
-            _subscription_to_dict(subscription) for subscription in subscriptions
-        ],
+        "billing_accounts": [_billing_account_to_dict(account) for account in billing_accounts],
+        "subscriptions": [_subscription_to_dict(subscription) for subscription in subscriptions],
         "entitlements": {
             entitlement.key: {
                 "value": entitlement.value,
@@ -728,7 +735,7 @@ def update_external_subscription_state(
         provider_id=provider_id,
         external_event_id=external_event_id,
         status="applied",
-        payload_summary=payload_summary,
+        payload_summary=_sanitize_payload_summary(payload_summary),
     )
     db.add(event)
     if commit:

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -29,9 +29,11 @@
                         <div class="flex flex-wrap items-center gap-2">
                             <input type="date"
                                    class="rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm text-[#120d36]"
+                                   aria-label="Custom start date"
                                    x-model="customStartDate">
                             <input type="date"
                                    class="rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm text-[#120d36]"
+                                   aria-label="Custom end date"
                                    x-model="customEndDate">
                             <button type="button"
                                     class="rounded-md bg-[#272a5f] px-3 py-2 text-sm font-semibold text-white hover:bg-[#171346]"

--- a/backend/app/tests/test_demo_multi_user_deployment.py
+++ b/backend/app/tests/test_demo_multi_user_deployment.py
@@ -17,10 +17,30 @@ def test_demo_multi_user_deployment_has_saas_and_isp_scenarios():
 
 def test_operator_demo_multi_user_endpoint_returns_showcase(
     authed_client: TestClient,
+    monkeypatch,
 ):
+    monkeypatch.setattr(
+        "app.api.api_v1.endpoints.operator.get_settings",
+        lambda: type("Settings", (), {"DEMO_MODE": True})(),
+    )
+
     response = authed_client.get("/api/v1/operator/demo/multi-user")
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["deployment"]["organizations"][0]["slug"] == "dmarq-foundation"
     assert payload["deployment"]["billing_modes"][0]["mode"] == "direct_stripe"
+
+
+def test_operator_demo_multi_user_endpoint_is_hidden_outside_demo_mode(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "app.api.api_v1.endpoints.operator.get_settings",
+        lambda: type("Settings", (), {"DEMO_MODE": False})(),
+    )
+
+    response = authed_client.get("/api/v1/operator/demo/multi-user")
+
+    assert response.status_code == 404

--- a/backend/app/tests/test_demo_multi_user_deployment.py
+++ b/backend/app/tests/test_demo_multi_user_deployment.py
@@ -3,6 +3,19 @@ from fastapi.testclient import TestClient
 from app.services.demo_data import build_demo_multi_user_deployment
 
 
+class _DemoSettings:
+    def __init__(self, demo_mode: bool):
+        self.DEMO_MODE = demo_mode
+
+
+def _settings_with_demo_enabled():
+    return _DemoSettings(demo_mode=True)
+
+
+def _settings_with_demo_disabled():
+    return _DemoSettings(demo_mode=False)
+
+
 def test_demo_multi_user_deployment_has_saas_and_isp_scenarios():
     deployment = build_demo_multi_user_deployment()
 
@@ -21,7 +34,7 @@ def test_operator_demo_multi_user_endpoint_returns_showcase(
 ):
     monkeypatch.setattr(
         "app.api.api_v1.endpoints.operator.get_settings",
-        lambda: type("Settings", (), {"DEMO_MODE": True})(),
+        _settings_with_demo_enabled,
     )
 
     response = authed_client.get("/api/v1/operator/demo/multi-user")
@@ -38,7 +51,7 @@ def test_operator_demo_multi_user_endpoint_is_hidden_outside_demo_mode(
 ):
     monkeypatch.setattr(
         "app.api.api_v1.endpoints.operator.get_settings",
-        lambda: type("Settings", (), {"DEMO_MODE": False})(),
+        _settings_with_demo_disabled,
     )
 
     response = authed_client.get("/api/v1/operator/demo/multi-user")

--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -8,6 +8,7 @@ from app.models.organization import BillingAccount, BillingEvent, Subscription
 from app.models.report import DMARCReport, ForensicReport, ReportRecord
 from app.models.workspace import Workspace
 from app.services.organizations import (
+    MAX_PROVIDER_PAYLOAD_SUMMARY_LENGTH,
     bootstrap_default_commercial_foundation,
     build_usage_export,
     update_external_subscription_state,
@@ -129,3 +130,45 @@ def test_provider_subscription_state_update_sanitizes_payload_summary(db_session
 
     event = db_session.query(BillingEvent).filter_by(external_event_id="evt-unsafe").one()
     assert event.payload_summary == "&lt;script&gt;alert(1)&lt;/script&gt; provider update"
+
+
+def test_provider_subscription_state_update_drops_blank_payload_summary(db_session: Session):
+    organization = bootstrap_default_commercial_foundation(db_session)
+    subscription = (
+        db_session.query(Subscription).filter(Subscription.organization_id == organization.id).one()
+    )
+    subscription.external_subscription_id = "sub-provider-blank"
+    db_session.commit()
+
+    update_external_subscription_state(
+        db_session,
+        external_subscription_id="sub-provider-blank",
+        status="suspended",
+        provider_id="isp-demo",
+        external_event_id="evt-blank",
+        payload_summary=" \n\t ",
+    )
+
+    event = db_session.query(BillingEvent).filter_by(external_event_id="evt-blank").one()
+    assert event.payload_summary is None
+
+
+def test_provider_subscription_state_update_truncates_payload_summary(db_session: Session):
+    organization = bootstrap_default_commercial_foundation(db_session)
+    subscription = (
+        db_session.query(Subscription).filter(Subscription.organization_id == organization.id).one()
+    )
+    subscription.external_subscription_id = "sub-provider-long"
+    db_session.commit()
+
+    update_external_subscription_state(
+        db_session,
+        external_subscription_id="sub-provider-long",
+        status="suspended",
+        provider_id="isp-demo",
+        external_event_id="evt-long",
+        payload_summary="a" * (MAX_PROVIDER_PAYLOAD_SUMMARY_LENGTH + 10),
+    )
+
+    event = db_session.query(BillingEvent).filter_by(external_event_id="evt-long").one()
+    assert len(event.payload_summary) == MAX_PROVIDER_PAYLOAD_SUMMARY_LENGTH

--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -87,9 +87,7 @@ def test_provider_usage_endpoint_rejects_bad_period(authed_client: TestClient):
 def test_provider_subscription_state_update_records_billing_event(db_session: Session):
     organization = bootstrap_default_commercial_foundation(db_session)
     subscription = (
-        db_session.query(Subscription)
-        .filter(Subscription.organization_id == organization.id)
-        .one()
+        db_session.query(Subscription).filter(Subscription.organization_id == organization.id).one()
     )
     subscription.external_subscription_id = "sub-provider-123"
     db_session.commit()
@@ -110,3 +108,24 @@ def test_provider_subscription_state_update_records_billing_event(db_session: Se
     assert subscription.status == "suspended"
     assert event.event_type == "provider.subscription_state_updated"
     assert event.external_event_id == "evt-1"
+
+
+def test_provider_subscription_state_update_sanitizes_payload_summary(db_session: Session):
+    organization = bootstrap_default_commercial_foundation(db_session)
+    subscription = (
+        db_session.query(Subscription).filter(Subscription.organization_id == organization.id).one()
+    )
+    subscription.external_subscription_id = "sub-provider-unsafe"
+    db_session.commit()
+
+    update_external_subscription_state(
+        db_session,
+        external_subscription_id="sub-provider-unsafe",
+        status="suspended",
+        provider_id="isp-demo",
+        external_event_id="evt-unsafe",
+        payload_summary=" <script>alert(1)</script>\n provider update ",
+    )
+
+    event = db_session.query(BillingEvent).filter_by(external_event_id="evt-unsafe").one()
+    assert event.payload_summary == "&lt;script&gt;alert(1)&lt;/script&gt; provider update"

--- a/backend/app/tests/test_stats_endpoints.py
+++ b/backend/app/tests/test_stats_endpoints.py
@@ -9,6 +9,24 @@ from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
+from app.api.api_v1.endpoints.stats import _summary_cache_key, resolve_dashboard_date_range
+
+
+def test_summary_cache_key_includes_custom_date_bounds():
+    date_range = resolve_dashboard_date_range(
+        interval="custom",
+        start_date="2026-06-01",
+        end_date="2026-06-07",
+    )
+
+    assert _summary_cache_key(date_range) == "custom_2026-06-01_2026-06-07"
+
+
+def test_summary_cache_key_partitions_open_calendar_ranges():
+    date_range = resolve_dashboard_date_range(interval="week_to_date")
+
+    assert _summary_cache_key(date_range).startswith("week_to_date_")
+
 
 class TestDashboardStatistics:
     """Tests for GET /api/v1/stats/dashboard"""

--- a/backend/app/tests/test_stats_endpoints.py
+++ b/backend/app/tests/test_stats_endpoints.py
@@ -42,6 +42,12 @@ class TestDashboardStatistics:
             response = client.get("/api/v1/stats/dashboard?period_days=7")
             assert response.status_code == 200
             assert mock_instance.calculate_summary_statistics.call_args.kwargs["period_days"] == 7
+            assert mock_instance.calculate_summary_statistics.call_args.kwargs["start_ts"]
+            assert mock_instance.calculate_summary_statistics.call_args.kwargs["end_ts"]
+            assert (
+                mock_instance.calculate_summary_statistics.call_args.kwargs["cache_key"]
+                == "last_7_days"
+            )
 
     def test_dashboard_force_refresh(self, client: TestClient):
         """force_refresh=true should trigger cache invalidation without error."""
@@ -72,9 +78,7 @@ class TestDashboardStatistics:
             assert response.status_code == 200
             mock_instance.invalidate_cache.assert_not_called()
 
-    def test_dashboard_uses_demo_data_when_demo_mode_enabled(
-        self, client: TestClient, monkeypatch
-    ):
+    def test_dashboard_uses_demo_data_when_demo_mode_enabled(self, client: TestClient, monkeypatch):
         monkeypatch.setattr(
             "app.api.api_v1.endpoints.stats.get_settings",
             lambda: SimpleNamespace(DEMO_MODE=True),
@@ -123,6 +127,12 @@ class TestDomainStatistics:
             assert response.status_code == 200
             assert mock_instance.calculate_summary_statistics.call_args.args[1] == "example.com"
             assert mock_instance.calculate_summary_statistics.call_args.kwargs["period_days"] == 14
+            assert mock_instance.calculate_summary_statistics.call_args.kwargs["start_ts"]
+            assert mock_instance.calculate_summary_statistics.call_args.kwargs["end_ts"]
+            assert (
+                mock_instance.calculate_summary_statistics.call_args.kwargs["cache_key"]
+                == "last_14_days"
+            )
 
     def test_domain_stats_force_refresh(self, client: TestClient):
         response = client.get("/api/v1/stats/domain/example.com?force_refresh=true")

--- a/backend/app/tests/test_stats_summarizer.py
+++ b/backend/app/tests/test_stats_summarizer.py
@@ -557,6 +557,14 @@ class TestStatsSummarizerCaching:
         assert summarizer.get_cached_summary(period_days=7, cache_key="last_7_days") == stats
         assert summarizer.get_cached_summary(period_days=7, cache_key="custom_june") is None
 
+    def test_cache_key_preserves_period_days_in_filename(self, summarizer):
+        seven_day_cache = summarizer._get_cache_filename(period_days=7, cache_key="shared_window")
+        thirty_day_cache = summarizer._get_cache_filename(period_days=30, cache_key="shared_window")
+
+        assert seven_day_cache != thirty_day_cache
+        assert "7d_shared_window" in seven_day_cache
+        assert "30d_shared_window" in thirty_day_cache
+
     def test_old_cache_without_change_summary_is_refreshed(self, db_session, summarizer):
         _seed_new_source_records(db_session)
         db_session.commit()

--- a/backend/app/tests/test_stats_summarizer.py
+++ b/backend/app/tests/test_stats_summarizer.py
@@ -542,6 +542,21 @@ class TestStatsSummarizerCaching:
         assert len(stats_7_days["compliance_trend"]) == 2
         assert len(stats_1_day["compliance_trend"]) == 1
 
+    def test_windowed_cache_keys_use_separate_cache_files(self, db_session, summarizer):
+        _seed_recent_trend_records(db_session)
+        db_session.commit()
+
+        stats = summarizer.calculate_summary_statistics(
+            db_session,
+            period_days=7,
+            start_ts=0,
+            end_ts=9_999_999_999,
+            cache_key="last_7_days",
+        )
+
+        assert summarizer.get_cached_summary(period_days=7, cache_key="last_7_days") == stats
+        assert summarizer.get_cached_summary(period_days=7, cache_key="custom_june") is None
+
     def test_old_cache_without_change_summary_is_refreshed(self, db_session, summarizer):
         _seed_new_source_records(db_session)
         db_session.commit()

--- a/backend/app/utils/stats_summarizer.py
+++ b/backend/app/utils/stats_summarizer.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
@@ -56,6 +57,7 @@ class StatsSummarizer:
         domain_id: Optional[str] = None,
         max_age_minutes: int = 60,
         period_days: int = 30,
+        cache_key: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Get cached summary statistics if available and not too old
@@ -69,7 +71,7 @@ class StatsSummarizer:
         Returns:
             Cached statistics or None if not available or too old
         """
-        cache_file = self._get_cache_filename(domain_id, period_days)
+        cache_file = self._get_cache_filename(domain_id, period_days, cache_key=cache_key)
 
         try:
             if not os.path.exists(cache_file):
@@ -91,7 +93,11 @@ class StatsSummarizer:
             return None
 
     def save_summary(
-        self, stats: Dict[str, Any], domain_id: Optional[str] = None, period_days: int = 30
+        self,
+        stats: Dict[str, Any],
+        domain_id: Optional[str] = None,
+        period_days: int = 30,
+        cache_key: Optional[str] = None,
     ) -> bool:
         """
         Save summary statistics to cache
@@ -104,7 +110,7 @@ class StatsSummarizer:
         Returns:
             True if save was successful, False otherwise
         """
-        cache_file = self._get_cache_filename(domain_id, period_days)
+        cache_file = self._get_cache_filename(domain_id, period_days, cache_key=cache_key)
 
         try:
             # Add timestamp
@@ -140,7 +146,10 @@ class StatsSummarizer:
                 os.remove(os.path.join(self.cache_dir, filename))
 
     def _get_cache_filename(
-        self, domain_id: Optional[str] = None, period_days: int = 30
+        self,
+        domain_id: Optional[str] = None,
+        period_days: int = 30,
+        cache_key: Optional[str] = None,
     ) -> str:
         """
         Get the filename for a cache file
@@ -153,11 +162,14 @@ class StatsSummarizer:
             Path to the cache file
         """
         period_days = max(1, int(period_days or 30))
+        suffix = f"{period_days}d"
+        if cache_key:
+            suffix = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(cache_key)).strip("_") or suffix
         if domain_id is None:
-            return os.path.join(self.cache_dir, f"global_summary_{period_days}d.json")
+            return os.path.join(self.cache_dir, f"global_summary_{suffix}.json")
         # Sanitize domain_id to use as filename
         safe_domain = domain_id.replace(".", "_").replace("/", "_")
-        return os.path.join(self.cache_dir, f"domain_{safe_domain}_{period_days}d.json")
+        return os.path.join(self.cache_dir, f"domain_{safe_domain}_{suffix}.json")
 
     def calculate_summary_statistics(
         self,
@@ -166,6 +178,7 @@ class StatsSummarizer:
         period_days: int = 30,
         start_ts: Optional[int] = None,
         end_ts: Optional[int] = None,
+        cache_key: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Calculate summary statistics from the database
@@ -180,9 +193,13 @@ class StatsSummarizer:
         """
         period_days = max(1, int(period_days or 30))
 
-        use_cache = start_ts is None and end_ts is None
+        use_cache = bool(cache_key) or (start_ts is None and end_ts is None)
         if use_cache:
-            cached_stats = self.get_cached_summary(domain_id, period_days=period_days)
+            cached_stats = self.get_cached_summary(
+                domain_id,
+                period_days=period_days,
+                cache_key=cache_key,
+            )
             if cached_stats and "change_summary" in cached_stats:
                 return cached_stats
 
@@ -198,7 +215,7 @@ class StatsSummarizer:
             )
 
         if use_cache:
-            self.save_summary(stats, domain_id, period_days)
+            self.save_summary(stats, domain_id, period_days, cache_key=cache_key)
 
         return stats
 
@@ -430,34 +447,31 @@ class StatsSummarizer:
         end_ts: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """Get top sending sources by email volume across all domains."""
-        query = (
-            db.query(
-                ReportRecord.source_ip,
-                func.sum(ReportRecord.count).label("total_count"),
-                func.sum(case((ReportRecord.spf == "pass", ReportRecord.count), else_=0)).label(
-                    "spf_pass_count"
-                ),
-                func.sum(case((ReportRecord.spf == "fail", ReportRecord.count), else_=0)).label(
-                    "spf_fail_count"
-                ),
-                func.sum(case((ReportRecord.dkim == "pass", ReportRecord.count), else_=0)).label(
-                    "dkim_pass_count"
-                ),
-                func.sum(case((ReportRecord.dkim == "fail", ReportRecord.count), else_=0)).label(
-                    "dkim_fail_count"
-                ),
-                func.sum(
-                    case(
-                        (
-                            (ReportRecord.dkim == "pass") | (ReportRecord.spf == "pass"),
-                            ReportRecord.count,
-                        ),
-                        else_=0,
-                    )
-                ).label("dmarc_pass_count"),
-            )
-            .join(DMARCReport, ReportRecord.report_id == DMARCReport.id)
-        )
+        query = db.query(
+            ReportRecord.source_ip,
+            func.sum(ReportRecord.count).label("total_count"),
+            func.sum(case((ReportRecord.spf == "pass", ReportRecord.count), else_=0)).label(
+                "spf_pass_count"
+            ),
+            func.sum(case((ReportRecord.spf == "fail", ReportRecord.count), else_=0)).label(
+                "spf_fail_count"
+            ),
+            func.sum(case((ReportRecord.dkim == "pass", ReportRecord.count), else_=0)).label(
+                "dkim_pass_count"
+            ),
+            func.sum(case((ReportRecord.dkim == "fail", ReportRecord.count), else_=0)).label(
+                "dkim_fail_count"
+            ),
+            func.sum(
+                case(
+                    (
+                        (ReportRecord.dkim == "pass") | (ReportRecord.spf == "pass"),
+                        ReportRecord.count,
+                    ),
+                    else_=0,
+                )
+            ).label("dmarc_pass_count"),
+        ).join(DMARCReport, ReportRecord.report_id == DMARCReport.id)
         results = (
             self._apply_report_window(query, period_days, start_ts, end_ts)
             .group_by(ReportRecord.source_ip)

--- a/backend/app/utils/stats_summarizer.py
+++ b/backend/app/utils/stats_summarizer.py
@@ -164,7 +164,9 @@ class StatsSummarizer:
         period_days = max(1, int(period_days or 30))
         suffix = f"{period_days}d"
         if cache_key:
-            suffix = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(cache_key)).strip("_") or suffix
+            safe_key = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(cache_key)).strip("_")
+            if safe_key:
+                suffix = f"{suffix}_{safe_key}"
         if domain_id is None:
             return os.path.join(self.cache_dir, f"global_summary_{suffix}.json")
         # Sanitize domain_id to use as filename


### PR DESCRIPTION
## Summary

- apply returned dashboard/domain date ranges to the actual stats queries and add cache keys for resolved windows
- hide the demo multi-user showcase endpoint outside DEMO_MODE
- sanitize provider subscription payload summaries before storing billing events
- add accessible labels to custom dashboard date inputs

## Validation

- PYTHONPATH=backend .venv/bin/pytest backend/app/tests/test_stats_endpoints.py backend/app/tests/test_stats_summarizer.py backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_provider_billing_usage.py
- .venv/bin/black --check backend/app/api/api_v1/endpoints/stats.py backend/app/api/api_v1/endpoints/operator.py backend/app/services/organizations.py backend/app/utils/stats_summarizer.py backend/app/tests/test_stats_endpoints.py backend/app/tests/test_stats_summarizer.py backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_provider_billing_usage.py
- .venv/bin/isort --check-only backend/app/api/api_v1/endpoints/stats.py backend/app/api/api_v1/endpoints/operator.py backend/app/services/organizations.py backend/app/utils/stats_summarizer.py backend/app/tests/test_stats_endpoints.py backend/app/tests/test_stats_summarizer.py backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_provider_billing_usage.py
- .venv/bin/flake8 backend/app/api/api_v1/endpoints/stats.py backend/app/api/api_v1/endpoints/operator.py backend/app/services/organizations.py backend/app/utils/stats_summarizer.py backend/app/tests/test_stats_endpoints.py backend/app/tests/test_stats_summarizer.py backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_provider_billing_usage.py

Follow-up to post-merge review feedback on #235.