### PR TITLE
[codex] Enforce workspace RBAC for operator routes

### DIFF
--- a/backend/app/api/api_v1/endpoints/operator.py
+++ b/backend/app/api/api_v1/endpoints/operator.py
@@ -93,8 +93,9 @@ async def get_operator_workspace(
     _auth: dict = Depends(require_admin_auth),
 ) -> Dict[str, Any]:
     """Return one workspace operator summary."""
-    require_workspace_permission(_auth, PERMISSION_AUDIT_READ)
-    return workspace_operator_summary(db, _workspace_or_404(db, workspace_id))
+    workspace = _workspace_or_404(db, workspace_id)
+    require_workspace_permission(_auth, PERMISSION_AUDIT_READ, db, workspace)
+    return workspace_operator_summary(db, workspace)
 
 
 @router.put("/workspaces/{workspace_id}/retention", response_model=WorkspaceRetentionResponse)
@@ -106,8 +107,8 @@ async def update_workspace_retention(
     _auth: dict = Depends(require_admin_auth),
 ) -> WorkspaceRetentionResponse:
     """Update workspace retention controls and audit the change."""
-    require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN)
     workspace = _workspace_or_404(db, workspace_id)
+    require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, workspace)
     old_retention = retention_to_dict(workspace)
     workspace.report_retention_days = payload.aggregate_reports_days
     workspace.forensic_retention_days = payload.forensic_reports_days

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
 
 ROLE_WORKSPACE_OWNER = "workspace_owner"
 ROLE_DOMAIN_ADMIN = "domain_admin"
@@ -77,8 +82,8 @@ def list_workspace_roles() -> List[dict]:
 def role_for_auth_context(auth_context: dict) -> str:
     """Map current admin auth into an initial workspace role.
 
-    Logto users and static admin credentials keep owner-level access until
-    membership assignment and enforcement screens are added.
+    Existing non-workspace-aware endpoints keep owner-level access for any
+    authenticated admin context until they are moved to workspace-aware checks.
     """
     auth_type = (auth_context or {}).get("auth_type")
     if auth_type in {"session", "bearer", "jwt", "api_key", "disabled"}:
@@ -86,9 +91,67 @@ def role_for_auth_context(auth_context: dict) -> str:
     return ROLE_AUDITOR
 
 
-def require_workspace_permission(auth_context: dict, permission: str) -> None:
+def _auth_user_id(auth_context: dict) -> Optional[int]:
+    user_id = (auth_context or {}).get("user_id")
+    if user_id is not None:
+        try:
+            return int(user_id)
+        except (TypeError, ValueError):
+            return None
+
+    payload = (auth_context or {}).get("payload") or {}
+    subject = payload.get("sub")
+    if subject is not None:
+        try:
+            return int(subject)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def role_for_workspace(
+    db: Session,
+    auth_context: dict,
+    workspace: Workspace,
+) -> str:
+    """Resolve the caller's effective role for one workspace."""
+    auth_type = (auth_context or {}).get("auth_type")
+    if auth_type in {"api_key", "disabled"}:
+        return ROLE_WORKSPACE_OWNER
+
+    user_id = _auth_user_id(auth_context)
+    if user_id is None:
+        return ""
+
+    membership = (
+        db.query(WorkspaceMembership)
+        .filter(
+            WorkspaceMembership.workspace_id == workspace.id,
+            WorkspaceMembership.user_id == user_id,
+            WorkspaceMembership.active.is_(True),
+        )
+        .first()
+    )
+    if membership is not None:
+        return membership.role
+
+    user = db.query(User).filter(User.id == user_id, User.is_active.is_(True)).first()
+    if user and user.workspace_id == workspace.id and user.is_superuser:
+        return ROLE_WORKSPACE_OWNER
+    return ""
+
+
+def require_workspace_permission(
+    auth_context: dict,
+    permission: str,
+    db: Optional[Session] = None,
+    workspace: Optional[Workspace] = None,
+) -> None:
     """Raise HTTP 403 when the current role does not grant a permission."""
-    role = role_for_auth_context(auth_context)
+    if db is not None and workspace is not None:
+        role = role_for_workspace(db, auth_context, workspace)
+    else:
+        role = role_for_auth_context(auth_context)
     if role_allows(role, permission):
         return
     raise HTTPException(

--- a/backend/app/tests/test_workspace_audit.py
+++ b/backend/app/tests/test_workspace_audit.py
@@ -3,13 +3,21 @@ import json
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.database import get_db
+from app.core.security import require_admin_auth
+from app.models.user import User
+from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services.workspace_access import (
     PERMISSION_WORKSPACE_ADMIN,
+    ROLE_ANALYST,
+    ROLE_AUDITOR,
     ROLE_DOMAIN_ADMIN,
     ROLE_WORKSPACE_OWNER,
     require_workspace_permission,
     role_for_auth_context,
+    role_for_workspace,
 )
 from app.services.workspace_audit import (
     actor_from_auth,
@@ -19,6 +27,46 @@ from app.services.workspace_audit import (
     sanitize_audit_details,
 )
 from app.services.workspaces import get_or_create_default_workspace
+
+
+def _add_user(db_session: Session, email: str, workspace_id=None, is_superuser=False):
+    user = User(
+        email=email,
+        workspace_id=workspace_id,
+        is_superuser=is_superuser,
+        is_active=True,
+        is_verified=True,
+    )
+    db_session.add(user)
+    db_session.flush()
+    return user
+
+
+def _add_membership(db_session: Session, workspace: Workspace, user: User, role: str):
+    membership = WorkspaceMembership(
+        workspace_id=workspace.id,
+        user_id=user.id,
+        role=role,
+        active=True,
+    )
+    db_session.add(membership)
+    db_session.flush()
+    return membership
+
+
+def _client_as_user(test_app, db_session: Session, user: User):
+    async def mock_admin_auth():
+        return {"auth_type": "session", "user_id": user.id}
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    return TestClient(test_app)
 
 
 def test_workspace_roles_endpoint_lists_permissions(authed_client: TestClient):
@@ -91,6 +139,78 @@ def test_workspace_permission_denial_and_actor_variants(db_session: Session):
         entity_type="workspace",
     )
     assert filtered[0]["action"] == "workspace.test"
+
+
+def test_workspace_role_resolution_uses_membership(db_session: Session):
+    """Workspace-aware RBAC resolves roles from active memberships."""
+    workspace = get_or_create_default_workspace(db_session)
+    auditor = _add_user(db_session, "auditor@example.com")
+    analyst = _add_user(db_session, "analyst@example.com")
+    outsider = _add_user(db_session, "outsider@example.com")
+    _add_membership(db_session, workspace, auditor, ROLE_AUDITOR)
+    _add_membership(db_session, workspace, analyst, ROLE_ANALYST)
+    db_session.commit()
+
+    assert (
+        role_for_workspace(db_session, {"auth_type": "session", "user_id": auditor.id}, workspace)
+        == ROLE_AUDITOR
+    )
+    assert (
+        role_for_workspace(db_session, {"auth_type": "session", "user_id": analyst.id}, workspace)
+        == ROLE_ANALYST
+    )
+    assert (
+        role_for_workspace(db_session, {"auth_type": "session", "user_id": outsider.id}, workspace)
+        == ""
+    )
+
+
+def test_workspace_operator_routes_enforce_membership_roles(test_app, db_session: Session):
+    """Workspace-specific operator endpoints enforce membership permissions."""
+    workspace = get_or_create_default_workspace(db_session)
+    auditor = _add_user(db_session, "operator-auditor@example.com")
+    analyst = _add_user(db_session, "operator-analyst@example.com")
+    owner = _add_user(db_session, "operator-owner@example.com")
+    outsider = _add_user(db_session, "operator-outsider@example.com")
+    _add_membership(db_session, workspace, auditor, ROLE_AUDITOR)
+    _add_membership(db_session, workspace, analyst, ROLE_ANALYST)
+    _add_membership(db_session, workspace, owner, ROLE_WORKSPACE_OWNER)
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, auditor) as client:
+        response = client.get(f"/api/v1/operator/workspaces/{workspace.id}")
+        assert response.status_code == 200
+        response = client.put(
+            f"/api/v1/operator/workspaces/{workspace.id}/retention",
+            json={
+                "aggregate_reports_days": 400,
+                "forensic_reports_days": 90,
+                "tls_reports_days": 400,
+            },
+        )
+        assert response.status_code == 403
+
+    test_app.dependency_overrides.clear()
+    with _client_as_user(test_app, db_session, analyst) as client:
+        response = client.get(f"/api/v1/operator/workspaces/{workspace.id}")
+        assert response.status_code == 403
+
+    test_app.dependency_overrides.clear()
+    with _client_as_user(test_app, db_session, outsider) as client:
+        response = client.get(f"/api/v1/operator/workspaces/{workspace.id}")
+        assert response.status_code == 403
+
+    test_app.dependency_overrides.clear()
+    with _client_as_user(test_app, db_session, owner) as client:
+        response = client.put(
+            f"/api/v1/operator/workspaces/{workspace.id}/retention",
+            json={
+                "aggregate_reports_days": 365,
+                "forensic_reports_days": 120,
+                "tls_reports_days": 365,
+            },
+        )
+        assert response.status_code == 200
 
 
 def test_mail_source_changes_create_workspace_audit_without_secret_values(


### PR DESCRIPTION
## Summary

- resolve effective workspace roles from active workspace memberships for session/JWT users
- keep explicit admin API key and auth-disabled bootstrap behavior for self-hosted/operator recovery
- enforce workspace-aware permissions on operator workspace detail and retention routes
- add regression coverage for auditor, analyst, owner, and no-membership users

## Validation

- python3 -m py_compile backend/app/services/workspace_access.py backend/app/api/api_v1/endpoints/operator.py backend/app/tests/test_workspace_audit.py
- line-length check on changed files

Refs #236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace access is now checked using the specific workspace being viewed or updated, improving permission handling for operator and retention settings.
  * Access results now more consistently return “not found” or “permission denied” based on the workspace’s actual status and your role.
  * Workspace permissions now respect active membership roles, helping ensure only appropriate workspace members can manage operator settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->