### PR TITLE
[codex] Enforce workspace RBAC on audit logs

### DIFF
--- a/backend/app/api/api_v1/endpoints/audit.py
+++ b/backend/app/api/api_v1/endpoints/audit.py
@@ -48,8 +48,8 @@ async def get_workspace_audit_logs(
     _auth: dict = Depends(require_admin_auth),
 ) -> WorkspaceAuditLogResponse:
     """Return recent sanitized audit events for the default workspace."""
-    require_workspace_permission(_auth, PERMISSION_AUDIT_READ)
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    require_workspace_permission(_auth, PERMISSION_AUDIT_READ, db, workspace)
     return {
         "audit": list_workspace_audit_logs(
             db,

--- a/backend/app/tests/test_workspace_audit.py
+++ b/backend/app/tests/test_workspace_audit.py
@@ -213,6 +213,24 @@ def test_workspace_operator_routes_enforce_membership_roles(test_app, db_session
         assert response.status_code == 200
 
 
+def test_workspace_audit_logs_enforce_membership(test_app, db_session: Session):
+    """Audit logs use the default workspace membership before returning data."""
+    workspace = get_or_create_default_workspace(db_session)
+    auditor = _add_user(db_session, "audit-member@example.com")
+    outsider = _add_user(db_session, "audit-outsider@example.com")
+    _add_membership(db_session, workspace, auditor, ROLE_AUDITOR)
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, auditor) as client:
+        response = client.get("/api/v1/audit/logs")
+        assert response.status_code == 200
+
+    test_app.dependency_overrides.clear()
+    with _client_as_user(test_app, db_session, outsider) as client:
+        response = client.get("/api/v1/audit/logs")
+        assert response.status_code == 403
+
+
 def test_mail_source_changes_create_workspace_audit_without_secret_values(
     authed_client: TestClient,
     db_session: Session,


### PR DESCRIPTION
## Summary

- move audit log access to a workspace-aware permission check after resolving the default workspace
- deny audit log access to authenticated users without default-workspace membership
- add regression coverage for auditor access and no-membership denial

## Validation

- python3 -m py_compile backend/app/api/api_v1/endpoints/audit.py backend/app/tests/test_workspace_audit.py
- line-length check on changed files

Refs #236