### PR TITLE
Fix post-merge workspace RBAC findings

### DIFF
--- a/backend/app/api/api_v1/endpoints/audit.py
+++ b/backend/app/api/api_v1/endpoints/audit.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -14,7 +14,7 @@ from app.services.workspace_access import (
     require_workspace_permission,
 )
 from app.services.workspace_audit import list_workspace_audit_logs
-from app.services.workspaces import assign_default_workspace_to_unscoped_rows
+from app.services.workspaces import assign_default_workspace_to_unscoped_rows, get_default_workspace
 
 router = APIRouter()
 
@@ -48,8 +48,16 @@ async def get_workspace_audit_logs(
     _auth: dict = Depends(require_admin_auth),
 ) -> WorkspaceAuditLogResponse:
     """Return recent sanitized audit events for the default workspace."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
+    workspace = get_default_workspace(db)
+    if workspace is None:
+        if (_auth or {}).get("auth_type") not in {"api_key", "disabled"}:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Workspace permission required: {PERMISSION_AUDIT_READ}",
+            )
+        workspace = assign_default_workspace_to_unscoped_rows(db)
     require_workspace_permission(_auth, PERMISSION_AUDIT_READ, db, workspace)
+    workspace = assign_default_workspace_to_unscoped_rows(db)
     return {
         "audit": list_workspace_audit_logs(
             db,

--- a/backend/app/api/api_v1/endpoints/audit.py
+++ b/backend/app/api/api_v1/endpoints/audit.py
@@ -56,6 +56,16 @@ async def get_workspace_audit_logs(
                 detail=f"Workspace permission required: {PERMISSION_AUDIT_READ}",
             )
         workspace = assign_default_workspace_to_unscoped_rows(db)
+        require_workspace_permission(_auth, PERMISSION_AUDIT_READ, db, workspace)
+        return {
+            "audit": list_workspace_audit_logs(
+                db,
+                workspace=workspace,
+                limit=limit,
+                action=action,
+                entity_type=entity_type,
+            )
+        }
     require_workspace_permission(_auth, PERMISSION_AUDIT_READ, db, workspace)
     workspace = assign_default_workspace_to_unscoped_rows(db)
     return {

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set
+from typing import Dict, Iterable, List, Optional, Set
 
 from fastapi import HTTPException, status
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from app.models.user import User
@@ -91,6 +92,17 @@ def role_for_auth_context(auth_context: dict) -> str:
     return ROLE_AUDITOR
 
 
+def _auth_subjects(auth_context: dict) -> Iterable[str]:
+    payload = (auth_context or {}).get("payload") or {}
+    for value in (
+        payload.get("sub"),
+        payload.get("email"),
+        (auth_context or {}).get("email"),
+    ):
+        if value:
+            yield str(value)
+
+
 def _auth_user_id(auth_context: dict) -> Optional[int]:
     user_id = (auth_context or {}).get("user_id")
     if user_id is not None:
@@ -109,6 +121,25 @@ def _auth_user_id(auth_context: dict) -> Optional[int]:
     return None
 
 
+def _auth_user(db: Session, auth_context: dict) -> Optional[User]:
+    user_id = _auth_user_id(auth_context)
+    if user_id is not None:
+        return db.query(User).filter(User.id == user_id, User.is_active.is_(True)).first()
+
+    for subject in _auth_subjects(auth_context):
+        user = (
+            db.query(User)
+            .filter(
+                User.is_active.is_(True),
+                or_(User.email == subject, User.logto_id == subject),
+            )
+            .first()
+        )
+        if user is not None:
+            return user
+    return None
+
+
 def role_for_workspace(
     db: Session,
     auth_context: dict,
@@ -119,15 +150,15 @@ def role_for_workspace(
     if auth_type in {"api_key", "disabled"}:
         return ROLE_WORKSPACE_OWNER
 
-    user_id = _auth_user_id(auth_context)
-    if user_id is None:
+    user = _auth_user(db, auth_context)
+    if user is None:
         return ""
 
     membership = (
         db.query(WorkspaceMembership)
         .filter(
             WorkspaceMembership.workspace_id == workspace.id,
-            WorkspaceMembership.user_id == user_id,
+            WorkspaceMembership.user_id == user.id,
             WorkspaceMembership.active.is_(True),
         )
         .first()
@@ -135,7 +166,6 @@ def role_for_workspace(
     if membership is not None:
         return membership.role
 
-    user = db.query(User).filter(User.id == user_id, User.is_active.is_(True)).first()
     if user and user.workspace_id == workspace.id and user.is_superuser:
         return ROLE_WORKSPACE_OWNER
     return ""

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from fastapi import HTTPException, status
-from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from app.models.user import User
@@ -92,17 +91,6 @@ def role_for_auth_context(auth_context: dict) -> str:
     return ROLE_AUDITOR
 
 
-def _auth_subjects(auth_context: dict) -> Iterable[str]:
-    payload = (auth_context or {}).get("payload") or {}
-    for value in (
-        payload.get("sub"),
-        payload.get("email"),
-        (auth_context or {}).get("email"),
-    ):
-        if value:
-            yield str(value)
-
-
 def _auth_user_id(auth_context: dict) -> Optional[int]:
     user_id = (auth_context or {}).get("user_id")
     if user_id is not None:
@@ -121,22 +109,33 @@ def _auth_user_id(auth_context: dict) -> Optional[int]:
     return None
 
 
+def _active_user_by_email(db: Session, email: str) -> Optional[User]:
+    return db.query(User).filter(User.email == email, User.is_active.is_(True)).first()
+
+
+def _active_user_by_logto_id(db: Session, logto_id: str) -> Optional[User]:
+    return db.query(User).filter(User.logto_id == logto_id, User.is_active.is_(True)).first()
+
+
 def _auth_user(db: Session, auth_context: dict) -> Optional[User]:
     user_id = _auth_user_id(auth_context)
     if user_id is not None:
         return db.query(User).filter(User.id == user_id, User.is_active.is_(True)).first()
 
-    for subject in _auth_subjects(auth_context):
-        user = (
-            db.query(User)
-            .filter(
-                User.is_active.is_(True),
-                or_(User.email == subject, User.logto_id == subject),
-            )
-            .first()
-        )
+    payload = (auth_context or {}).get("payload") or {}
+    subject = payload.get("sub")
+    if subject:
+        subject = str(subject)
+        user = _active_user_by_logto_id(db, subject)
         if user is not None:
             return user
+        user = _active_user_by_email(db, subject)
+        if user is not None:
+            return user
+
+    email = payload.get("email") or (auth_context or {}).get("email")
+    if email:
+        return _active_user_by_email(db, str(email))
     return None
 
 

--- a/backend/app/services/workspaces.py
+++ b/backend/app/services/workspaces.py
@@ -51,6 +51,15 @@ def get_or_create_default_workspace(db: Session, *, commit: bool = True) -> Work
     return workspace
 
 
+def get_default_workspace(db: Session) -> Optional[Workspace]:
+    """Return the default workspace without creating or migrating data."""
+    return (
+        db.query(Workspace)
+        .filter(Workspace.slug == DEFAULT_WORKSPACE_SLUG, Workspace.active.is_(True))
+        .first()
+    )
+
+
 def assign_default_workspace_to_unscoped_rows(
     db: Session,
     *,

--- a/backend/app/tests/test_workspace_audit.py
+++ b/backend/app/tests/test_workspace_audit.py
@@ -289,7 +289,6 @@ def test_workspace_audit_logs_support_jwt_membership_and_defer_migration(
     """Audit reads resolve JWT users and avoid migration side effects before authorization."""
     workspace = get_or_create_default_workspace(db_session)
     auditor = _add_user(db_session, "jwt-auditor@example.com", logto_id="jwt-auditor-sub")
-    outsider = _add_user(db_session, "jwt-outsider@example.com", logto_id="jwt-outsider-sub")
     unscoped_domain = Domain(name="unscoped-audit.example", active=True)
     db_session.add(unscoped_domain)
     _add_membership(db_session, workspace, auditor, ROLE_AUDITOR)

--- a/backend/app/tests/test_workspace_audit.py
+++ b/backend/app/tests/test_workspace_audit.py
@@ -186,8 +186,14 @@ def test_workspace_role_resolution_uses_membership(db_session: Session):
     auditor = _add_user(db_session, "auditor@example.com", logto_id="logto-auditor")
     analyst = _add_user(db_session, "analyst@example.com")
     outsider = _add_user(db_session, "outsider@example.com")
+    conflicting_subject_user = _add_user(
+        db_session,
+        "logto-auditor",
+        logto_id="other-logto-subject",
+    )
     _add_membership(db_session, workspace, auditor, ROLE_AUDITOR)
     _add_membership(db_session, workspace, analyst, ROLE_ANALYST)
+    _add_membership(db_session, workspace, conflicting_subject_user, ROLE_ANALYST)
     db_session.commit()
 
     assert (
@@ -209,6 +215,14 @@ def test_workspace_role_resolution_uses_membership(db_session: Session):
             workspace,
         )
         == ROLE_AUDITOR
+    )
+    assert (
+        role_for_workspace(
+            db_session,
+            {"auth_type": "jwt", "payload": {"email": "logto-auditor"}},
+            workspace,
+        )
+        == ROLE_ANALYST
     )
     assert (
         role_for_workspace(db_session, {"auth_type": "session", "user_id": analyst.id}, workspace)
@@ -309,6 +323,24 @@ def test_workspace_audit_logs_support_jwt_membership_and_defer_migration(
         response = client.get("/api/v1/audit/logs")
         assert response.status_code == 403
 
+    db_session.refresh(unscoped_domain)
+    assert unscoped_domain.workspace_id is None
+
+
+def test_workspace_audit_logs_deny_jwt_without_bootstrapping_default_workspace(
+    test_app,
+    db_session: Session,
+):
+    """JWT callers cannot create or migrate the default workspace before authorization."""
+    unscoped_domain = Domain(name="unscoped-without-workspace.example", active=True)
+    db_session.add(unscoped_domain)
+    db_session.commit()
+
+    with _client_as_jwt(test_app, db_session, "unknown-logto-sub") as client:
+        response = client.get("/api/v1/audit/logs")
+        assert response.status_code == 403
+
+    assert db_session.query(Workspace).count() == 0
     db_session.refresh(unscoped_domain)
     assert unscoped_domain.workspace_id is None
 

--- a/backend/app/tests/test_workspace_audit.py
+++ b/backend/app/tests/test_workspace_audit.py
@@ -1,10 +1,12 @@
 import json
+from contextlib import contextmanager
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.core.security import require_admin_auth
+from app.models.domain import Domain
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
@@ -29,9 +31,16 @@ from app.services.workspace_audit import (
 from app.services.workspaces import get_or_create_default_workspace
 
 
-def _add_user(db_session: Session, email: str, workspace_id=None, is_superuser=False):
+def _add_user(
+    db_session: Session,
+    email: str,
+    workspace_id=None,
+    is_superuser=False,
+    logto_id=None,
+):
     user = User(
         email=email,
+        logto_id=logto_id,
         workspace_id=workspace_id,
         is_superuser=is_superuser,
         is_active=True,
@@ -54,6 +63,7 @@ def _add_membership(db_session: Session, workspace: Workspace, user: User, role:
     return membership
 
 
+@contextmanager
 def _client_as_user(test_app, db_session: Session, user: User):
     async def mock_admin_auth():
         return {"auth_type": "session", "user_id": user.id}
@@ -64,9 +74,38 @@ def _client_as_user(test_app, db_session: Session, user: User):
         finally:
             pass
 
+    original_overrides = dict(test_app.dependency_overrides)
     test_app.dependency_overrides[get_db] = override_get_db
     test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
-    return TestClient(test_app)
+    try:
+        with TestClient(test_app) as client:
+            yield client
+    finally:
+        test_app.dependency_overrides = original_overrides
+
+
+@contextmanager
+def _client_as_jwt(test_app, db_session: Session, subject: str, email: str | None = None):
+    async def mock_admin_auth():
+        payload = {"sub": subject}
+        if email is not None:
+            payload["email"] = email
+        return {"auth_type": "jwt", "payload": payload}
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    original_overrides = dict(test_app.dependency_overrides)
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    try:
+        with TestClient(test_app) as client:
+            yield client
+    finally:
+        test_app.dependency_overrides = original_overrides
 
 
 def test_workspace_roles_endpoint_lists_permissions(authed_client: TestClient):
@@ -144,7 +183,7 @@ def test_workspace_permission_denial_and_actor_variants(db_session: Session):
 def test_workspace_role_resolution_uses_membership(db_session: Session):
     """Workspace-aware RBAC resolves roles from active memberships."""
     workspace = get_or_create_default_workspace(db_session)
-    auditor = _add_user(db_session, "auditor@example.com")
+    auditor = _add_user(db_session, "auditor@example.com", logto_id="logto-auditor")
     analyst = _add_user(db_session, "analyst@example.com")
     outsider = _add_user(db_session, "outsider@example.com")
     _add_membership(db_session, workspace, auditor, ROLE_AUDITOR)
@@ -153,6 +192,22 @@ def test_workspace_role_resolution_uses_membership(db_session: Session):
 
     assert (
         role_for_workspace(db_session, {"auth_type": "session", "user_id": auditor.id}, workspace)
+        == ROLE_AUDITOR
+    )
+    assert (
+        role_for_workspace(
+            db_session,
+            {"auth_type": "jwt", "payload": {"sub": "logto-auditor"}},
+            workspace,
+        )
+        == ROLE_AUDITOR
+    )
+    assert (
+        role_for_workspace(
+            db_session,
+            {"auth_type": "jwt", "payload": {"sub": "auditor@example.com"}},
+            workspace,
+        )
         == ROLE_AUDITOR
     )
     assert (
@@ -190,17 +245,14 @@ def test_workspace_operator_routes_enforce_membership_roles(test_app, db_session
         )
         assert response.status_code == 403
 
-    test_app.dependency_overrides.clear()
     with _client_as_user(test_app, db_session, analyst) as client:
         response = client.get(f"/api/v1/operator/workspaces/{workspace.id}")
         assert response.status_code == 403
 
-    test_app.dependency_overrides.clear()
     with _client_as_user(test_app, db_session, outsider) as client:
         response = client.get(f"/api/v1/operator/workspaces/{workspace.id}")
         assert response.status_code == 403
 
-    test_app.dependency_overrides.clear()
     with _client_as_user(test_app, db_session, owner) as client:
         response = client.put(
             f"/api/v1/operator/workspaces/{workspace.id}/retention",
@@ -225,10 +277,41 @@ def test_workspace_audit_logs_enforce_membership(test_app, db_session: Session):
         response = client.get("/api/v1/audit/logs")
         assert response.status_code == 200
 
-    test_app.dependency_overrides.clear()
     with _client_as_user(test_app, db_session, outsider) as client:
         response = client.get("/api/v1/audit/logs")
         assert response.status_code == 403
+
+
+def test_workspace_audit_logs_support_jwt_membership_and_defer_migration(
+    test_app,
+    db_session: Session,
+):
+    """Audit reads resolve JWT users and avoid migration side effects before authorization."""
+    workspace = get_or_create_default_workspace(db_session)
+    auditor = _add_user(db_session, "jwt-auditor@example.com", logto_id="jwt-auditor-sub")
+    outsider = _add_user(db_session, "jwt-outsider@example.com", logto_id="jwt-outsider-sub")
+    unscoped_domain = Domain(name="unscoped-audit.example", active=True)
+    db_session.add(unscoped_domain)
+    _add_membership(db_session, workspace, auditor, ROLE_AUDITOR)
+    db_session.commit()
+    db_session.refresh(unscoped_domain)
+
+    with _client_as_jwt(test_app, db_session, "jwt-auditor-sub") as client:
+        response = client.get("/api/v1/audit/logs")
+        assert response.status_code == 200
+
+    db_session.refresh(unscoped_domain)
+    assert unscoped_domain.workspace_id == workspace.id
+
+    unscoped_domain.workspace_id = None
+    db_session.commit()
+
+    with _client_as_jwt(test_app, db_session, "jwt-outsider-sub") as client:
+        response = client.get("/api/v1/audit/logs")
+        assert response.status_code == 403
+
+    db_session.refresh(unscoped_domain)
+    assert unscoped_domain.workspace_id is None
 
 
 def test_mail_source_changes_create_workspace_audit_without_secret_values(


### PR DESCRIPTION
## Summary
- resolve JWT workspace memberships by Logto subject or email, not only numeric user IDs
- defer default workspace legacy migration until after audit permission checks
- add focused regression coverage for JWT membership resolution, audit migration deferral, and override cleanup

## Validation
- `PYTHONPATH=backend /tmp/dmarq-py313-venv/bin/python -m py_compile backend/app/services/workspace_access.py backend/app/services/workspaces.py backend/app/api/api_v1/endpoints/audit.py backend/app/tests/test_workspace_audit.py`
- `PYTHONPATH=backend /tmp/dmarq-py313-venv/bin/pytest backend/app/tests/test_workspace_audit.py` hung during test collection/startup with no output; same result with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 --collect-only`, so full local pytest could not complete in this automation run.