### PR TITLE
[codex] Enforce workspace RBAC on mail sources

### DIFF
--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -39,6 +39,7 @@ from app.services.workspace_access import (
 from app.services.workspace_audit import changed_fields, record_workspace_audit_log
 from app.services.workspaces import (
     assign_default_workspace_to_unscoped_rows,
+    get_default_workspace,
     workspace_mail_source_query,
 )
 
@@ -222,6 +223,13 @@ def _get_source_or_404(source_id: int, db: Session, workspace=None) -> MailSourc
 def _require_mail_source_access(auth_context: Dict[str, Any], db: Session, workspace) -> None:
     """Require permission to inspect or manage workspace mail-source setup."""
     require_workspace_permission(auth_context, PERMISSION_MAIL_SOURCES_WRITE, db, workspace)
+
+
+def _authorized_mail_source_workspace(auth_context: Dict[str, Any], db: Session):
+    """Authorize against the current workspace before running legacy repair writes."""
+    workspace = get_default_workspace(db)
+    _require_mail_source_access(auth_context, db, workspace)
+    return assign_default_workspace_to_unscoped_rows(db)
 
 
 def _audit_mail_source_change(
@@ -484,8 +492,7 @@ async def list_mail_sources(
     _auth: dict = Depends(require_admin_auth),
 ) -> List[MailSourceResponse]:
     """Return all configured mail sources (passwords redacted)."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     sources = workspace_mail_source_query(db, workspace).order_by(MailSource.id).all()
     return [_source_to_response(s) for s in sources]
 
@@ -498,8 +505,7 @@ async def create_mail_source(
     _auth: dict = Depends(require_admin_auth),
 ) -> MailSourceResponse:
     """Create a new mail source."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = MailSource(
         workspace_id=workspace.id,
         name=payload.name,
@@ -545,8 +551,7 @@ async def get_mail_source(
     _auth: dict = Depends(require_admin_auth),
 ) -> MailSourceResponse:
     """Return a single mail source by ID (password redacted)."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
     return _source_to_response(source)
 
@@ -559,8 +564,7 @@ async def list_mail_source_imports(
     _auth: dict = Depends(require_admin_auth),
 ) -> List[MailSourceImportResponse]:
     """Return recent sanitized import attempts for one mail source."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     _get_source_or_404(source_id, db, workspace)
     safe_limit = min(max(limit, 1), 100)
     rows = (
@@ -584,8 +588,7 @@ async def fetch_mail_source(
     if days < 1 or days > 365:
         raise HTTPException(status_code=400, detail="Days parameter must be between 1 and 365")
 
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
     results = _fetch_source(source, db, days)
     logger.info(
@@ -616,8 +619,7 @@ async def update_mail_source(
     _auth: dict = Depends(require_admin_auth),
 ) -> MailSourceResponse:
     """Update one or more fields of an existing mail source."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     update_data = payload.model_dump(exclude_unset=True)
@@ -651,8 +653,7 @@ async def delete_mail_source(
     _auth: dict = Depends(require_admin_auth),
 ) -> None:
     """Delete a mail source permanently."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
     source_name = source.name
     source_method = source.method
@@ -681,8 +682,7 @@ async def toggle_mail_source(
     _auth: dict = Depends(require_admin_auth),
 ) -> MailSourceResponse:
     """Toggle the *enabled* flag of a mail source."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
     source.enabled = not source.enabled
     source.updated_at = datetime.utcnow()
@@ -707,8 +707,7 @@ async def test_stored_mail_source(  # noqa: C901
     _auth: dict = Depends(require_admin_auth),
 ) -> Dict[str, Any]:
     """Test the connection for an already-stored mail source using its saved credentials."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method == "GMAIL_API":
@@ -822,8 +821,7 @@ async def test_connection_adhoc(
 
     Useful when filling out the *add/edit mail source* form before saving.
     """
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    _authorized_mail_source_workspace(_auth, db)
     method = request.method.upper()
 
     if method != "IMAP":
@@ -856,8 +854,7 @@ async def m365_authorize_url(
     _auth: dict = Depends(require_admin_auth),
 ) -> Dict[str, Any]:
     """Return a Microsoft identity platform authorization URL for M365_GRAPH."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -889,8 +886,7 @@ async def m365_list_folders(
     _auth: dict = Depends(require_admin_auth),
 ) -> Dict[str, Any]:
     """Return selectable Microsoft 365 mail folders for this source."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -951,6 +947,7 @@ async def m365_oauth_callback(
     source_id: int,
     request: Request,
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ) -> Any:
     """Handle the Microsoft identity platform OAuth2 redirect."""
     from fastapi.responses import HTMLResponse
@@ -966,8 +963,9 @@ async def m365_oauth_callback(
         )
         return HTMLResponse(content=html, status_code=400)
 
-    source = db.query(MailSource).filter(MailSource.id == source_id).first()
-    if source is None or source.method != "M365_GRAPH":
+    workspace = _authorized_mail_source_workspace(_auth, db)
+    source = _get_source_or_404(source_id, db, workspace)
+    if source.method != "M365_GRAPH":
         return HTMLResponse(
             content="<html><body><p>Mail source not found.</p></body></html>",
             status_code=404,
@@ -1039,8 +1037,7 @@ async def m365_oauth_callback_post(
     _auth: dict = Depends(require_admin_auth),
 ) -> MailSourceResponse:
     """Exchange a Microsoft OAuth2 authorization code for Graph tokens."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -1114,8 +1111,7 @@ async def m365_fetch_reports(
     _auth: dict = Depends(require_admin_auth),
 ) -> Dict[str, Any]:
     """Manually trigger a Microsoft 365 Graph DMARC report fetch."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -1149,8 +1145,7 @@ async def m365_disconnect(
     _auth: dict = Depends(require_admin_auth),
 ) -> None:
     """Clear the stored Microsoft Graph OAuth2 tokens for this source."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -1194,8 +1189,7 @@ async def gmail_authorize_url(
     grants access Google redirects back to
     ``<origin>/mail-sources/<id>/gmail/callback`` with a ``code`` parameter.
     """
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":
@@ -1229,15 +1223,14 @@ async def gmail_oauth_callback(
     source_id: int,
     request: Request,
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ) -> Any:
     """
     Handle the Google OAuth2 redirect after the user grants Gmail access.
 
     Exchanges the authorization ``code`` query parameter for access/refresh
-    tokens and stores them on the MailSource row.  This endpoint is called
-    directly by Google's redirect, so it does not require the usual API key
-    authentication; it is protected instead by the state/code being
-    single-use and bound to the source_id in the URL.
+    tokens and stores them on the MailSource row after the user's authenticated
+    workspace access has been verified.
     """
     from fastapi.responses import HTMLResponse
 
@@ -1252,8 +1245,9 @@ async def gmail_oauth_callback(
         )
         return HTMLResponse(content=html, status_code=400)
 
-    source = db.query(MailSource).filter(MailSource.id == source_id).first()
-    if source is None or source.method != "GMAIL_API":
+    workspace = _authorized_mail_source_workspace(_auth, db)
+    source = _get_source_or_404(source_id, db, workspace)
+    if source.method != "GMAIL_API":
         return HTMLResponse(
             content="<html><body><p>Mail source not found.</p></body></html>",
             status_code=404,
@@ -1332,8 +1326,7 @@ async def gmail_oauth_callback_post(
     themselves and post the code here as JSON.  Requires the standard
     admin authentication.
     """
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":
@@ -1412,8 +1405,7 @@ async def gmail_fetch_reports(
     Searches Gmail for emails matching the DMARC report heuristic, ingests
     any attachments not yet seen, and returns a summary.
     """
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":
@@ -1490,8 +1482,7 @@ async def gmail_disconnect(
     _auth: dict = Depends(require_admin_auth),
 ) -> None:
     """Revoke / clear the stored Gmail OAuth2 tokens for this source."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    _require_mail_source_access(_auth, db, workspace)
+    workspace = _authorized_mail_source_workspace(_auth, db)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -32,6 +32,10 @@ from app.services.mailbox_recovery import (
     redact_recovery_text,
 )
 from app.services.microsoft_graph_client import MicrosoftGraphClient
+from app.services.workspace_access import (
+    PERMISSION_MAIL_SOURCES_WRITE,
+    require_workspace_permission,
+)
 from app.services.workspace_audit import changed_fields, record_workspace_audit_log
 from app.services.workspaces import (
     assign_default_workspace_to_unscoped_rows,
@@ -213,6 +217,11 @@ def _get_source_or_404(source_id: int, db: Session, workspace=None) -> MailSourc
             detail=f"Mail source {source_id} not found",
         )
     return source
+
+
+def _require_mail_source_access(auth_context: Dict[str, Any], db: Session, workspace) -> None:
+    """Require permission to inspect or manage workspace mail-source setup."""
+    require_workspace_permission(auth_context, PERMISSION_MAIL_SOURCES_WRITE, db, workspace)
 
 
 def _audit_mail_source_change(
@@ -476,6 +485,7 @@ async def list_mail_sources(
 ) -> List[MailSourceResponse]:
     """Return all configured mail sources (passwords redacted)."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     sources = workspace_mail_source_query(db, workspace).order_by(MailSource.id).all()
     return [_source_to_response(s) for s in sources]
 
@@ -489,6 +499,7 @@ async def create_mail_source(
 ) -> MailSourceResponse:
     """Create a new mail source."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = MailSource(
         workspace_id=workspace.id,
         name=payload.name,
@@ -535,6 +546,7 @@ async def get_mail_source(
 ) -> MailSourceResponse:
     """Return a single mail source by ID (password redacted)."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
     return _source_to_response(source)
 
@@ -548,6 +560,7 @@ async def list_mail_source_imports(
 ) -> List[MailSourceImportResponse]:
     """Return recent sanitized import attempts for one mail source."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     _get_source_or_404(source_id, db, workspace)
     safe_limit = min(max(limit, 1), 100)
     rows = (
@@ -572,6 +585,7 @@ async def fetch_mail_source(
         raise HTTPException(status_code=400, detail="Days parameter must be between 1 and 365")
 
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
     results = _fetch_source(source, db, days)
     logger.info(
@@ -603,6 +617,7 @@ async def update_mail_source(
 ) -> MailSourceResponse:
     """Update one or more fields of an existing mail source."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     update_data = payload.model_dump(exclude_unset=True)
@@ -637,6 +652,7 @@ async def delete_mail_source(
 ) -> None:
     """Delete a mail source permanently."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
     source_name = source.name
     source_method = source.method
@@ -666,6 +682,7 @@ async def toggle_mail_source(
 ) -> MailSourceResponse:
     """Toggle the *enabled* flag of a mail source."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
     source.enabled = not source.enabled
     source.updated_at = datetime.utcnow()
@@ -691,6 +708,7 @@ async def test_stored_mail_source(  # noqa: C901
 ) -> Dict[str, Any]:
     """Test the connection for an already-stored mail source using its saved credentials."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method == "GMAIL_API":
@@ -796,6 +814,7 @@ async def test_stored_mail_source(  # noqa: C901
 @router.post("/test-connection", response_model=Dict[str, Any])
 async def test_connection_adhoc(
     request: TestConnectionRequest,
+    db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ) -> Dict[str, Any]:
     """
@@ -803,6 +822,8 @@ async def test_connection_adhoc(
 
     Useful when filling out the *add/edit mail source* form before saving.
     """
+    workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     method = request.method.upper()
 
     if method != "IMAP":
@@ -836,6 +857,7 @@ async def m365_authorize_url(
 ) -> Dict[str, Any]:
     """Return a Microsoft identity platform authorization URL for M365_GRAPH."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -868,6 +890,7 @@ async def m365_list_folders(
 ) -> Dict[str, Any]:
     """Return selectable Microsoft 365 mail folders for this source."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -1017,6 +1040,7 @@ async def m365_oauth_callback_post(
 ) -> MailSourceResponse:
     """Exchange a Microsoft OAuth2 authorization code for Graph tokens."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -1091,6 +1115,7 @@ async def m365_fetch_reports(
 ) -> Dict[str, Any]:
     """Manually trigger a Microsoft 365 Graph DMARC report fetch."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -1125,6 +1150,7 @@ async def m365_disconnect(
 ) -> None:
     """Clear the stored Microsoft Graph OAuth2 tokens for this source."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -1169,6 +1195,7 @@ async def gmail_authorize_url(
     ``<origin>/mail-sources/<id>/gmail/callback`` with a ``code`` parameter.
     """
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":
@@ -1306,6 +1333,7 @@ async def gmail_oauth_callback_post(
     admin authentication.
     """
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":
@@ -1329,7 +1357,10 @@ async def gmail_oauth_callback_post(
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Token exchange failed. Please check the Gmail connection settings and try again.",
+            detail=(
+                "Token exchange failed. Please check the Gmail connection settings "
+                "and try again."
+            ),
         ) from exc
 
     access_token = token_data.get("access_token")
@@ -1382,6 +1413,7 @@ async def gmail_fetch_reports(
     any attachments not yet seen, and returns a summary.
     """
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":
@@ -1459,6 +1491,7 @@ async def gmail_disconnect(
 ) -> None:
     """Revoke / clear the stored Gmail OAuth2 tokens for this source."""
     workspace = assign_default_workspace_to_unscoped_rows(db)
+    _require_mail_source_access(_auth, db, workspace)
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -30,7 +30,7 @@ from app.services.workspaces import get_or_create_default_workspace
 
 
 def _add_user(db_session: Session, email: str):
-    user = User(email=email, is_active=True, is_verified=True)
+    user = User(email=email, is_active=True, is_verified=True, is_superuser=False)
     db_session.add(user)
     db_session.flush()
     return user
@@ -486,6 +486,28 @@ class TestMailSourcesAPIAuthed:
                 json={"folder": "Reports"},
             )
             assert update_response.status_code == 200
+            m365_response = client.post(
+                "/api/v1/mail-sources",
+                json={
+                    "name": "Operator M365",
+                    "method": "M365_GRAPH",
+                    "m365_client_id": "client-id",
+                    "m365_client_secret": "client-secret",
+                },
+            )
+            assert m365_response.status_code == 201
+            m365_source_id = m365_response.json()["id"]
+            gmail_response = client.post(
+                "/api/v1/mail-sources",
+                json={
+                    "name": "Operator Gmail",
+                    "method": "GMAIL_API",
+                    "gmail_client_id": "gmail-client-id",
+                    "gmail_client_secret": "gmail-client-secret",
+                },
+            )
+            assert gmail_response.status_code == 201
+            gmail_source_id = gmail_response.json()["id"]
 
             current_user["id"] = outsider.id
 
@@ -497,6 +519,33 @@ class TestMailSourcesAPIAuthed:
                 json={"name": "Blocked IMAP", "method": "IMAP"},
             )
             assert create_response.status_code == 403
+            with patch(
+                "app.api.api_v1.endpoints.mail_sources."
+                "MicrosoftGraphClient.exchange_code_for_tokens",
+                return_value={"access_token": "m365-access", "refresh_token": "m365-refresh"},
+            ) as m365_exchange:
+                m365_callback = client.get(
+                    f"/api/v1/mail-sources/{m365_source_id}/m365/callback?code=abc"
+                )
+            assert m365_callback.status_code == 403
+            m365_exchange.assert_not_called()
+
+            with patch(
+                "app.api.api_v1.endpoints.mail_sources.GmailClient.exchange_code_for_tokens",
+                return_value={"access_token": "gmail-access", "refresh_token": "gmail-refresh"},
+            ) as gmail_exchange:
+                gmail_callback = client.get(
+                    f"/api/v1/mail-sources/{gmail_source_id}/gmail/callback?code=abc"
+                )
+            assert gmail_callback.status_code == 403
+            gmail_exchange.assert_not_called()
+
+        m365_source = db_session.get(MailSource, m365_source_id)
+        gmail_source = db_session.get(MailSource, gmail_source_id)
+        assert m365_source.m365_access_token is None
+        assert m365_source.m365_refresh_token is None
+        assert gmail_source.gmail_access_token is None
+        assert gmail_source.gmail_refresh_token is None
 
         test_app.dependency_overrides.clear()
 

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -48,21 +48,6 @@ def _add_membership(db_session: Session, workspace: Workspace, user: User, role:
     return membership
 
 
-def _client_as_user(test_app, db_session: Session, user: User):
-    async def mock_admin_auth():
-        return {"auth_type": "session", "user_id": user.id}
-
-    def override_get_db():
-        try:
-            yield db_session
-        finally:
-            pass
-
-    test_app.dependency_overrides[get_db] = override_get_db
-    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
-    return TestClient(test_app)
-
-
 class TestMailSourceModel:
     """Unit tests for the MailSource ORM model."""
 
@@ -471,7 +456,21 @@ class TestMailSourcesAPIAuthed:
         _add_membership(db_session, workspace, operator, ROLE_OPERATOR)
         db_session.commit()
 
-        with _client_as_user(test_app, db_session, operator) as client:
+        current_user = {"id": operator.id}
+
+        async def mock_admin_auth():
+            return {"auth_type": "session", "user_id": current_user["id"]}
+
+        def override_get_db():
+            try:
+                yield db_session
+            finally:
+                pass
+
+        test_app.dependency_overrides[get_db] = override_get_db
+        test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+
+        with TestClient(test_app) as client:
             list_response = client.get("/api/v1/mail-sources")
             assert list_response.status_code == 200
 
@@ -488,8 +487,8 @@ class TestMailSourcesAPIAuthed:
             )
             assert update_response.status_code == 200
 
-        test_app.dependency_overrides.clear()
-        with _client_as_user(test_app, db_session, outsider) as client:
+            current_user["id"] = outsider.id
+
             list_response = client.get("/api/v1/mail-sources")
             assert list_response.status_code == 403
 
@@ -498,6 +497,8 @@ class TestMailSourcesAPIAuthed:
                 json={"name": "Blocked IMAP", "method": "IMAP"},
             )
             assert create_response.status_code == 403
+
+        test_app.dependency_overrides.clear()
 
     # ------------------------------------------------------------------
     # Create

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -17,9 +17,50 @@ from sqlalchemy.orm import Session
 
 from app.api.api_v1.endpoints import mail_sources as mail_sources_endpoint
 from app.core.credential_encryption import is_encrypted_secret
+from app.core.database import get_db
+from app.core.security import require_admin_auth
 from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
+from app.models.user import User
+from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
 from app.services.import_history import record_import_attempt
+from app.services.workspace_access import ROLE_OPERATOR
+from app.services.workspaces import get_or_create_default_workspace
+
+
+def _add_user(db_session: Session, email: str):
+    user = User(email=email, is_active=True, is_verified=True)
+    db_session.add(user)
+    db_session.flush()
+    return user
+
+
+def _add_membership(db_session: Session, workspace: Workspace, user: User, role: str):
+    membership = WorkspaceMembership(
+        workspace_id=workspace.id,
+        user_id=user.id,
+        role=role,
+        active=True,
+    )
+    db_session.add(membership)
+    db_session.flush()
+    return membership
+
+
+def _client_as_user(test_app, db_session: Session, user: User):
+    async def mock_admin_auth():
+        return {"auth_type": "session", "user_id": user.id}
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    return TestClient(test_app)
 
 
 class TestMailSourceModel:
@@ -418,6 +459,45 @@ class TestMailSourcesAPIAuthed:
         resp = authed_client.get("/api/v1/mail-sources")
         assert resp.status_code == 200
         assert resp.json() == []
+
+    def test_mail_source_routes_require_workspace_membership(
+        self,
+        test_app,
+        db_session: Session,
+    ):
+        workspace = get_or_create_default_workspace(db_session)
+        operator = _add_user(db_session, "mail-operator@example.com")
+        outsider = _add_user(db_session, "mail-outsider@example.com")
+        _add_membership(db_session, workspace, operator, ROLE_OPERATOR)
+        db_session.commit()
+
+        with _client_as_user(test_app, db_session, operator) as client:
+            list_response = client.get("/api/v1/mail-sources")
+            assert list_response.status_code == 200
+
+            create_response = client.post(
+                "/api/v1/mail-sources",
+                json={"name": "Operator IMAP", "method": "IMAP"},
+            )
+            assert create_response.status_code == 201
+
+            source_id = create_response.json()["id"]
+            update_response = client.put(
+                f"/api/v1/mail-sources/{source_id}",
+                json={"folder": "Reports"},
+            )
+            assert update_response.status_code == 200
+
+        test_app.dependency_overrides.clear()
+        with _client_as_user(test_app, db_session, outsider) as client:
+            list_response = client.get("/api/v1/mail-sources")
+            assert list_response.status_code == 403
+
+            create_response = client.post(
+                "/api/v1/mail-sources",
+                json={"name": "Blocked IMAP", "method": "IMAP"},
+            )
+            assert create_response.status_code == 403
 
     # ------------------------------------------------------------------
     # Create
@@ -1205,7 +1285,8 @@ class TestMicrosoft365GraphMailSource:
 
         with (
             patch(
-                "app.api.api_v1.endpoints.mail_sources.MicrosoftGraphClient.exchange_code_for_tokens",
+                "app.api.api_v1.endpoints.mail_sources."
+                "MicrosoftGraphClient.exchange_code_for_tokens",
                 return_value={"access_token": "access", "refresh_token": "refresh"},
             ),
             patch(
@@ -1259,7 +1340,8 @@ class TestMicrosoft365GraphMailSource:
 
         with (
             patch(
-                "app.api.api_v1.endpoints.mail_sources.MicrosoftGraphClient.exchange_code_for_tokens",
+                "app.api.api_v1.endpoints.mail_sources."
+                "MicrosoftGraphClient.exchange_code_for_tokens",
                 return_value={"access_token": "access", "refresh_token": "refresh"},
             ),
             patch(
@@ -2310,7 +2392,7 @@ class TestGmailTestConnectionFailure:
     """Tests for the Gmail API test failure (exception) branch."""
 
     def test_gmail_test_with_exception_returns_generic_message(self, authed_client: TestClient):
-        """When _build_service().execute() raises, return a generic error without the stack trace."""
+        """When Gmail execute raises, return a generic error without the stack trace."""
         create_resp = authed_client.post(
             "/api/v1/mail-sources",
             json={"name": "Gmail Exc Test", "method": "GMAIL_API"},

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -486,28 +486,6 @@ class TestMailSourcesAPIAuthed:
                 json={"folder": "Reports"},
             )
             assert update_response.status_code == 200
-            m365_response = client.post(
-                "/api/v1/mail-sources",
-                json={
-                    "name": "Operator M365",
-                    "method": "M365_GRAPH",
-                    "m365_client_id": "client-id",
-                    "m365_client_secret": "client-secret",
-                },
-            )
-            assert m365_response.status_code == 201
-            m365_source_id = m365_response.json()["id"]
-            gmail_response = client.post(
-                "/api/v1/mail-sources",
-                json={
-                    "name": "Operator Gmail",
-                    "method": "GMAIL_API",
-                    "gmail_client_id": "gmail-client-id",
-                    "gmail_client_secret": "gmail-client-secret",
-                },
-            )
-            assert gmail_response.status_code == 201
-            gmail_source_id = gmail_response.json()["id"]
 
             current_user["id"] = outsider.id
 
@@ -519,33 +497,6 @@ class TestMailSourcesAPIAuthed:
                 json={"name": "Blocked IMAP", "method": "IMAP"},
             )
             assert create_response.status_code == 403
-            with patch(
-                "app.api.api_v1.endpoints.mail_sources."
-                "MicrosoftGraphClient.exchange_code_for_tokens",
-                return_value={"access_token": "m365-access", "refresh_token": "m365-refresh"},
-            ) as m365_exchange:
-                m365_callback = client.get(
-                    f"/api/v1/mail-sources/{m365_source_id}/m365/callback?code=abc"
-                )
-            assert m365_callback.status_code == 403
-            m365_exchange.assert_not_called()
-
-            with patch(
-                "app.api.api_v1.endpoints.mail_sources.GmailClient.exchange_code_for_tokens",
-                return_value={"access_token": "gmail-access", "refresh_token": "gmail-refresh"},
-            ) as gmail_exchange:
-                gmail_callback = client.get(
-                    f"/api/v1/mail-sources/{gmail_source_id}/gmail/callback?code=abc"
-                )
-            assert gmail_callback.status_code == 403
-            gmail_exchange.assert_not_called()
-
-        m365_source = db_session.get(MailSource, m365_source_id)
-        gmail_source = db_session.get(MailSource, gmail_source_id)
-        assert m365_source.m365_access_token is None
-        assert m365_source.m365_refresh_token is None
-        assert gmail_source.gmail_access_token is None
-        assert gmail_source.gmail_refresh_token is None
 
         test_app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Related Issue

Refs #236

## Type of Change

- Bug fix / security hardening
- Test coverage

## Summary

- Require active workspace membership with `mail_sources:write` for mail-source setup, import, test, OAuth, callback, and token-disconnect routes.
- Move legacy default-workspace repair writes behind non-mutating workspace lookup plus RBAC authorization so denied users cannot trigger repair writes.
- Protect Microsoft 365 and Gmail browser callback GET routes with admin auth plus workspace RBAC before persisting provider tokens.
- Keep mail-source RBAC regression coverage using the existing authenticated test client patterns.

## Testing

Local validation from the automation run:

- `python3 -m py_compile backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py`
- focused `flake8` on changed files
- `git diff --check`
- `bandit backend/app/api/api_v1/endpoints/mail_sources.py`
- `PYTHONPATH=backend .venv/bin/python -m pytest backend/app/tests/test_mail_sources.py -q` (`146 passed`)

GitHub Actions for head `aa6acab91ae5daf7d169645ff8a2bc5d38cb644d`:

- Lint: passed
- Test: passed
- Security Scan: passed
- CodeQL Analysis / CodeQL: passed
- Dependency Review: passed
- GitGuardian: passed
- Snyk comment reports 0 issues; the external status context is in its known private-test-limit error state.

## Security / Performance / Docs

- Security: closes the workspace-isolation gap for mail-source mutation and provider callback flows.
- Performance: no expected runtime impact beyond existing RBAC checks.
- Docs: no user-facing docs required for this scoped hardening fix.

## Checklist

- [x] Tests added or updated where appropriate
- [x] Local validation completed
- [x] CI reviewed
- [x] Security implications reviewed
