### PR TITLE
[codex] Enforce workspace RBAC on domain DNS setup

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -38,9 +38,14 @@ from app.services.report_persistence import (
     hydrate_report_store_from_db,
 )
 from app.services.report_store import ReportStore
+from app.services.workspace_access import (
+    PERMISSION_DOMAINS_WRITE,
+    require_workspace_permission,
+)
 from app.services.workspace_audit import record_workspace_audit_log
 from app.services.workspaces import (
     assign_default_workspace_to_unscoped_rows,
+    get_default_workspace,
     workspace_domain_query,
 )
 from app.utils.domain_validator import validate_domain_config
@@ -49,6 +54,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 DOMAIN_SELECTOR_LOOKUP_CHUNK_SIZE = 500
+
+
+def _authorized_domain_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    permission: str = PERMISSION_DOMAINS_WRITE,
+):
+    """Authorize workspace domain/DNS setup before legacy repair writes."""
+    workspace = get_default_workspace(db)
+    require_workspace_permission(auth_context, permission, db, workspace)
+    return assign_default_workspace_to_unscoped_rows(db)
 
 
 class DomainBase(BaseModel):
@@ -1233,7 +1249,7 @@ async def create_domain(
     _auth: dict = Depends(require_admin_auth),
 ):
     """Create a monitored domain before any DMARC reports have arrived."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
+    workspace = _authorized_domain_workspace(_auth, db)
     name = _normalize_domain_name(payload.name)
     validation = validate_domain_config({"name": name, "description": payload.description or ""})
     if not validation["valid"]:
@@ -1615,8 +1631,12 @@ async def get_domain_bimi(
 
 
 @router.get("/cloudflare/discover", response_model=List[CloudflareZoneResponse])
-async def discover_cloudflare_domains(db: Session = Depends(get_db)):
+async def discover_cloudflare_domains(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
     """Discover active Cloudflare zones visible to the configured API token."""
+    _authorized_domain_workspace(_auth, db)
     try:
         return await discover_cloudflare_zones(db)
     except LookupError as exc:
@@ -1630,8 +1650,10 @@ async def discover_cloudflare_domains(db: Session = Depends(get_db)):
 async def import_cloudflare_domain_zones(
     payload: CloudflareImportRequest,
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Import selected, or all, Cloudflare zones as monitored domains."""
+    _authorized_domain_workspace(_auth, db)
     try:
         return await import_cloudflare_domains(db, requested_domains=payload.domains)
     except LookupError as exc:
@@ -1645,8 +1667,10 @@ async def import_cloudflare_domain_zones(
 async def get_cloudflare_domain_dns_analysis(
     domain_id: str = Path(..., title="The domain ID or name"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Analyze Cloudflare-managed DNS records and persist detected changes."""
+    _authorized_domain_workspace(_auth, db)
     try:
         zone_data = await get_zone_for_domain(db, domain_id)
     except LookupError as exc:
@@ -1687,8 +1711,10 @@ async def get_domain_dns_change_history(
     domain_id: str = Path(..., title="The domain ID or name"),
     limit: int = Query(50, title="Maximum number of change events to return"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Return recent provider-backed DNS record changes for a domain."""
+    _authorized_domain_workspace(_auth, db)
     return DNSChangeHistoryResponse(history=list_dns_record_changes(db, domain_id, limit=limit))
 
 
@@ -2159,7 +2185,7 @@ async def add_domain_selector(
     """
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
+    workspace = _authorized_domain_workspace(_auth, db)
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -2208,7 +2234,7 @@ async def delete_domain_selector(
     _auth: dict = Depends(require_admin_auth),
 ):
     """Remove a manually configured DKIM selector from a domain."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
+    workspace = _authorized_domain_workspace(_auth, db)
     domain_db = workspace_domain_query(db, workspace).filter(Domain.name == domain_id).first()
     if not domain_db:
         raise HTTPException(

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -4,14 +4,19 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
 from app.api.api_v1.endpoints.domains import _policy_enforcement_suggestions
 from app.core.credential_encryption import encrypt_secret
+from app.core.database import get_db
+from app.core.security import require_admin_auth
 from app.models.dns_cache import DNSRecordChange, DNSRecordSnapshot
 from app.models.domain import Domain
 from app.models.setting import Setting
+from app.models.user import User
 from app.services import cloudflare_dns
 from app.services.cloudflare_dns import analyze_dns_records, sync_dns_record_changes
+from app.services.workspaces import get_or_create_default_workspace
 
 DOMAIN = "example.com"
 
@@ -372,7 +377,7 @@ def test_policy_enforcement_suggestion_ignores_enforced_policy():
     assert suggestions == []
 
 
-def test_cloudflare_discover_endpoint_returns_zones(client: TestClient):
+def test_cloudflare_discover_endpoint_returns_zones(authed_client: TestClient):
     with patch(
         "app.api.api_v1.endpoints.domains.discover_cloudflare_zones",
         new=AsyncMock(
@@ -387,13 +392,13 @@ def test_cloudflare_discover_endpoint_returns_zones(client: TestClient):
             ]
         ),
     ):
-        response = client.get("/api/v1/domains/cloudflare/discover")
+        response = authed_client.get("/api/v1/domains/cloudflare/discover")
 
     assert response.status_code == 200
     assert response.json()[0]["name"] == DOMAIN
 
 
-def test_cloudflare_import_endpoint_returns_import_summary(client: TestClient):
+def test_cloudflare_import_endpoint_returns_import_summary(authed_client: TestClient):
     with patch(
         "app.api.api_v1.endpoints.domains.import_cloudflare_domains",
         new=AsyncMock(
@@ -405,7 +410,7 @@ def test_cloudflare_import_endpoint_returns_import_summary(client: TestClient):
             }
         ),
     ):
-        response = client.post(
+        response = authed_client.post(
             "/api/v1/domains/cloudflare/import",
             json={"domains": [DOMAIN]},
         )
@@ -414,7 +419,10 @@ def test_cloudflare_import_endpoint_returns_import_summary(client: TestClient):
     assert response.json()["imported"] == [DOMAIN]
 
 
-def test_cloudflare_dns_analysis_endpoint_persists_history(client: TestClient, db_session):
+def test_cloudflare_dns_analysis_endpoint_persists_history(
+    authed_client: TestClient,
+    db_session,
+):
     db_session.add(Domain(name=DOMAIN))
     db_session.commit()
     records = [
@@ -426,7 +434,7 @@ def test_cloudflare_dns_analysis_endpoint_persists_history(client: TestClient, d
         "app.api.api_v1.endpoints.domains.get_zone_for_domain",
         new=AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": records}),
     ):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns/cloudflare")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/cloudflare")
 
     assert response.status_code == 200
     data = response.json()
@@ -435,17 +443,57 @@ def test_cloudflare_dns_analysis_endpoint_persists_history(client: TestClient, d
     assert len(data["changes"]) == 2
     assert len(data["history"]) == 2
 
-    history_response = client.get(f"/api/v1/domains/{DOMAIN}/dns/history")
+    history_response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/history")
     assert history_response.status_code == 200
     assert len(history_response.json()["history"]) == 2
 
 
-def test_cloudflare_dns_analysis_endpoint_returns_configuration_errors(client: TestClient):
+def test_cloudflare_dns_analysis_endpoint_returns_configuration_errors(authed_client: TestClient):
     with patch(
         "app.api.api_v1.endpoints.domains.get_zone_for_domain",
         new=AsyncMock(side_effect=LookupError("Cloudflare API token is not configured")),
     ):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns/cloudflare")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/cloudflare")
 
     assert response.status_code == 400
     assert "Cloudflare API token" in response.json()["detail"]
+
+
+def test_cloudflare_discover_denies_user_without_workspace_membership(
+    test_app,
+    db_session: Session,
+):
+    get_or_create_default_workspace(db_session)
+    user = User(
+        email="domain-outsider@example.com",
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    async def mock_admin_auth():
+        return {"auth_type": "session", "user_id": user.id}
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    discover_mock = AsyncMock(return_value=[])
+    with (
+        TestClient(test_app) as client,
+        patch(
+            "app.api.api_v1.endpoints.domains.discover_cloudflare_zones",
+            new=discover_mock,
+        ),
+    ):
+        response = client.get("/api/v1/domains/cloudflare/discover")
+
+    test_app.dependency_overrides.clear()
+    assert response.status_code == 403
+    discover_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary

- require workspace domain-write permission before monitored-domain creation and DKIM selector mutations
- require workspace domain-write permission before Cloudflare zone discovery, import, DNS analysis, and DNS history reads
- authorize before legacy default-workspace repair writes so no-membership users are not implicitly claimed into the workspace
- add regression coverage proving Cloudflare discovery denies a normal user with no workspace membership

## Validation

- python3 -m py_compile backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py
- line-length check on changed files (only pre-existing long lines remain in domains.py)

Refs #236