### PR TITLE
[codex] Scope persistent API tokens to workspaces

### DIFF
--- a/backend/alembic/versions/6a7b8c9d0e1f_add_api_token_workspace_scope.py
+++ b/backend/alembic/versions/6a7b8c9d0e1f_add_api_token_workspace_scope.py
@@ -1,0 +1,46 @@
+"""add api token workspace scope
+
+Revision ID: 6a7b8c9d0e1f
+Revises: 5f6a7b8c9d0e
+Create Date: 2026-06-26 22:30:00.000000
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6a7b8c9d0e1f"
+down_revision: Union[str, None] = "5f6a7b8c9d0e"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def _default_workspace_id_sql() -> str:
+    return "(SELECT id FROM workspaces WHERE slug = 'default')"
+
+
+def upgrade() -> None:
+    """Attach existing persistent API tokens to the default workspace."""
+    with op.batch_alter_table("api_tokens") as batch_op:
+        batch_op.add_column(sa.Column("workspace_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_api_tokens_workspace_id_workspaces",
+            "workspaces",
+            ["workspace_id"],
+            ["id"],
+        )
+        batch_op.create_index(op.f("ix_api_tokens_workspace_id"), ["workspace_id"])
+        batch_op.create_index("ix_api_tokens_workspace_active", ["workspace_id", "active"])
+
+    op.execute(f"UPDATE api_tokens SET workspace_id = {_default_workspace_id_sql()}")
+
+
+def downgrade() -> None:
+    """Remove API token workspace ownership."""
+    with op.batch_alter_table("api_tokens") as batch_op:
+        batch_op.drop_index("ix_api_tokens_workspace_active")
+        batch_op.drop_index(op.f("ix_api_tokens_workspace_id"))
+        batch_op.drop_constraint("fk_api_tokens_workspace_id_workspaces", type_="foreignkey")
+        batch_op.drop_column("workspace_id")

--- a/backend/app/api/api_v1/endpoints/api_tokens.py
+++ b/backend/app/api/api_v1/endpoints/api_tokens.py
@@ -1,6 +1,6 @@
 """Admin API token management endpoints."""
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
@@ -15,10 +15,25 @@ from app.services.api_tokens import (
     revoke_api_token,
     token_to_dict,
 )
+from app.services.workspace_access import (
+    PERMISSION_WORKSPACE_ADMIN,
+    require_workspace_permission,
+)
 from app.services.workspace_audit import record_workspace_audit_log
-from app.services.workspaces import assign_default_workspace_to_unscoped_rows
+from app.services.workspaces import (
+    assign_default_workspace_to_unscoped_rows,
+    get_default_workspace,
+    get_or_create_default_workspace,
+)
 
 router = APIRouter()
+
+
+def _authorized_api_token_workspace(auth_context: Dict[str, Any], db: Session):
+    """Authorize API-token management for the current workspace."""
+    workspace = get_default_workspace(db) or get_or_create_default_workspace(db)
+    require_workspace_permission(auth_context, PERMISSION_WORKSPACE_ADMIN, db, workspace)
+    return assign_default_workspace_to_unscoped_rows(db)
 
 
 class APITokenCreateRequest(BaseModel):
@@ -32,6 +47,7 @@ class APITokenResponse(BaseModel):
     """API-safe token metadata."""
 
     id: int
+    workspace_id: Optional[int] = None
     name: str
     key_prefix: str
     scopes: List[str]
@@ -63,7 +79,13 @@ async def list_api_tokens(
     _auth: dict = Depends(require_admin_auth),
 ):
     """List API token metadata without exposing raw secrets or hashes."""
-    rows = db.query(APIToken).order_by(APIToken.created_at.desc(), APIToken.id.desc()).all()
+    workspace = _authorized_api_token_workspace(_auth, db)
+    rows = (
+        db.query(APIToken)
+        .filter(APIToken.workspace_id == workspace.id)
+        .order_by(APIToken.created_at.desc(), APIToken.id.desc())
+        .all()
+    )
     return APITokenListResponse(
         tokens=[APITokenResponse(**token_to_dict(row)) for row in rows],
         available_scopes=sorted(PUBLIC_READ_SCOPES),
@@ -78,9 +100,14 @@ async def create_public_api_token(
     _auth: dict = Depends(require_admin_auth),
 ):
     """Create a scoped API token for read-only automation."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
+    workspace = _authorized_api_token_workspace(_auth, db)
     try:
-        created = create_api_token(db, name=payload.name, scopes=payload.scopes)
+        created = create_api_token(
+            db,
+            name=payload.name,
+            scopes=payload.scopes,
+            workspace_id=workspace.id,
+        )
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -115,9 +142,13 @@ async def revoke_public_api_token(
     _auth: dict = Depends(require_admin_auth),
 ):
     """Revoke a scoped API token."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    token = db.query(APIToken).filter(APIToken.id == token_id).first()
-    if not revoke_api_token(db, token_id):
+    workspace = _authorized_api_token_workspace(_auth, db)
+    token = (
+        db.query(APIToken)
+        .filter(APIToken.id == token_id, APIToken.workspace_id == workspace.id)
+        .first()
+    )
+    if not revoke_api_token(db, token_id, workspace_id=workspace.id):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="API token not found",

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -259,6 +259,7 @@ def require_api_token_scope(required_scope: str) -> Callable:
         return {
             "auth_type": "api_token",
             "token_id": token.id,
+            "workspace_id": token.workspace_id,
             "token_name": token.name,
             "scopes": sorted(scopes),
         }

--- a/backend/app/models/api_token.py
+++ b/backend/app/models/api_token.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Index, Integer, String, Text
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.orm import relationship
 
 from app.core.database import Base
 
@@ -11,6 +12,7 @@ class APIToken(Base):
     __tablename__ = "api_tokens"
 
     id = Column(Integer, primary_key=True, index=True)
+    workspace_id = Column(Integer, ForeignKey("workspaces.id"), nullable=True, index=True)
     name = Column(String(120), nullable=False)
     key_hash = Column(String(255), unique=True, nullable=False, index=True)
     key_prefix = Column(String(16), nullable=False, index=True)
@@ -24,9 +26,12 @@ class APIToken(Base):
     usage_count = Column(Integer, default=0, nullable=False)
 
     __table_args__ = (
+        Index("ix_api_tokens_workspace_active", "workspace_id", "active"),
         Index("ix_api_tokens_active_scope", "active", "scopes"),
         Index("ix_api_tokens_last_used", "last_used_at"),
     )
+
+    workspace = relationship("Workspace")
 
     def __repr__(self):
         return f"<APIToken {self.name} active={self.active}>"

--- a/backend/app/services/api_tokens.py
+++ b/backend/app/services/api_tokens.py
@@ -11,6 +11,7 @@ import bcrypt
 from sqlalchemy.orm import Session
 
 from app.models.api_token import APIToken
+from app.services.workspaces import get_or_create_default_workspace
 
 READ_REPORTS_SCOPE = "reports:read"
 READ_POSTURE_SCOPE = "posture:read"
@@ -72,13 +73,22 @@ def verify_api_key_secret(secret: str, hashed_secret: str) -> bool:
         return False
 
 
-def create_api_token(db: Session, *, name: str, scopes: Iterable[str]) -> CreatedAPIToken:
+def create_api_token(
+    db: Session,
+    *,
+    name: str,
+    scopes: Iterable[str],
+    workspace_id: Optional[int] = None,
+) -> CreatedAPIToken:
     """Create a persistent API token and return the raw secret once."""
     clean_name = name.strip()
     if not clean_name:
         raise ValueError("Token name is required")
+    if workspace_id is None:
+        workspace_id = get_or_create_default_workspace(db, commit=False).id
     secret = generate_public_api_key()
     token = APIToken(
+        workspace_id=workspace_id,
         name=clean_name,
         key_hash=hash_api_key(secret),
         key_prefix=secret[:12],
@@ -114,9 +124,17 @@ def record_api_token_use(db: Session, token: APIToken, *, ip_address: Optional[s
     db.commit()
 
 
-def revoke_api_token(db: Session, token_id: int) -> bool:
+def revoke_api_token(
+    db: Session,
+    token_id: int,
+    *,
+    workspace_id: Optional[int] = None,
+) -> bool:
     """Deactivate an API token by id."""
-    token = db.query(APIToken).filter(APIToken.id == token_id).first()
+    query = db.query(APIToken).filter(APIToken.id == token_id)
+    if workspace_id is not None:
+        query = query.filter(APIToken.workspace_id == workspace_id)
+    token = query.first()
     if token is None or not token.active:
         return False
     token.active = False
@@ -129,6 +147,7 @@ def token_to_dict(token: APIToken) -> dict:
     """Return an API-safe token representation without the secret hash."""
     return {
         "id": token.id,
+        "workspace_id": token.workspace_id,
         "name": token.name,
         "key_prefix": token.key_prefix,
         "scopes": sorted(parse_scopes(token.scopes)),

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -152,6 +152,13 @@ def role_for_workspace(
     auth_type = (auth_context or {}).get("auth_type")
     if auth_type in {"api_key", "disabled"}:
         return ROLE_WORKSPACE_OWNER
+    if auth_type == "api_token":
+        try:
+            token_workspace_id = int((auth_context or {}).get("workspace_id") or 0)
+        except (TypeError, ValueError):
+            token_workspace_id = 0
+        if token_workspace_id == workspace.id:
+            return ROLE_ANALYST
 
     user = _auth_user(db, auth_context)
     if user is None:

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -1,8 +1,10 @@
 from fastapi.testclient import TestClient
 
 from app.models.api_token import APIToken
+from app.models.workspace import Workspace
 from app.services.api_tokens import READ_POSTURE_SCOPE, READ_REPORTS_SCOPE, create_api_token
 from app.services.report_store import ReportStore
+from app.services.workspaces import get_or_create_default_workspace
 
 DOMAIN = "example.com"
 
@@ -82,6 +84,7 @@ def test_admin_can_create_list_and_revoke_api_tokens(authed_client: TestClient, 
     body = created.json()
     assert body["token"].startswith("dmarq_")
     assert body["metadata"]["scopes"] == [READ_REPORTS_SCOPE]
+    assert body["metadata"]["workspace_id"] is not None
     assert "key_hash" not in body["metadata"]
 
     listed = authed_client.get("/api/v1/api-tokens")
@@ -103,3 +106,41 @@ def test_admin_can_create_list_and_revoke_api_tokens(authed_client: TestClient, 
         headers={"X-API-Key": body["token"]},
     )
     assert denied.status_code == 401
+
+
+def test_admin_api_token_management_is_workspace_scoped(
+    authed_client: TestClient,
+    db_session,
+):
+    """Token list and revoke operations are limited to the authorized workspace."""
+    default_workspace = get_or_create_default_workspace(db_session)
+    other_workspace = Workspace(
+        slug="other",
+        name="Other Workspace",
+        active=True,
+    )
+    db_session.add(other_workspace)
+    db_session.flush()
+    other_token = create_api_token(
+        db_session,
+        name="other workspace token",
+        scopes=[READ_REPORTS_SCOPE],
+        workspace_id=other_workspace.id,
+    )
+
+    created = authed_client.post(
+        "/api/v1/api-tokens",
+        json={"name": "default workspace token", "scopes": [READ_REPORTS_SCOPE]},
+    )
+    assert created.status_code == 201
+    assert created.json()["metadata"]["workspace_id"] == default_workspace.id
+
+    listed = authed_client.get("/api/v1/api-tokens")
+    assert listed.status_code == 200
+    names = {row["name"] for row in listed.json()["tokens"]}
+    assert names == {"default workspace token"}
+
+    denied_revoke = authed_client.delete(f"/api/v1/api-tokens/{other_token.token.id}")
+    assert denied_revoke.status_code == 404
+    db_session.refresh(other_token.token)
+    assert other_token.token.active is True


### PR DESCRIPTION
## Summary
- add workspace ownership to persistent API tokens and migrate existing tokens to the default workspace
- scope API-token list/create/revoke management to the authorized workspace
- return token workspace context from persistent API-token auth and resolve matching tokens as read-only workspace actors
- add regression coverage for cross-workspace token list/revoke isolation

## Validation
- `PYTHONPATH=backend .venv/bin/python -m pytest -q backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py backend/app/tests/test_workspace_audit.py::test_api_token_create_and_revoke_are_audited_without_raw_token`
- `cd backend && ../.venv/bin/python -m alembic heads`

Refs #236