### PR TITLE
[codex] Scope organization and provider tenant APIs

### DIFF
--- a/backend/app/api/api_v1/endpoints/organizations.py
+++ b/backend/app/api/api_v1/endpoints/organizations.py
@@ -11,12 +11,13 @@ from app.core.security import require_admin_auth
 from app.models.organization import Organization
 from app.services.organizations import (
     bootstrap_default_commercial_foundation,
-    list_organization_summaries,
+    list_scoped_organization_summaries,
     organization_summary,
 )
 from app.services.workspace_access import (
     PERMISSION_AUDIT_READ,
-    require_workspace_permission,
+    organization_ids_for_permission,
+    require_organization_permission,
 )
 
 router = APIRouter()
@@ -40,8 +41,8 @@ async def list_organizations(
     _auth: dict = Depends(require_admin_auth),
 ) -> OrganizationsResponse:
     """Return organization, workspace, subscription, and entitlement summaries."""
-    require_workspace_permission(_auth, PERMISSION_AUDIT_READ)
-    return {"organizations": list_organization_summaries(db)}
+    organization_ids = organization_ids_for_permission(db, _auth, PERMISSION_AUDIT_READ)
+    return {"organizations": list_scoped_organization_summaries(db, organization_ids)}
 
 
 @router.get("/{organization_id}", response_model=OrganizationResponse)
@@ -51,7 +52,6 @@ async def get_organization(
     _auth: dict = Depends(require_admin_auth),
 ) -> OrganizationResponse:
     """Return one organization summary."""
-    require_workspace_permission(_auth, PERMISSION_AUDIT_READ)
     bootstrap_default_commercial_foundation(db)
     organization = (
         db.query(Organization)
@@ -63,4 +63,5 @@ async def get_organization(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Organization {organization_id} not found",
         )
+    require_organization_permission(_auth, PERMISSION_AUDIT_READ, db, organization)
     return {"organization": organization_summary(db, organization)}

--- a/backend/app/api/api_v1/endpoints/provider.py
+++ b/backend/app/api/api_v1/endpoints/provider.py
@@ -1,6 +1,6 @@
 """Provider and ISP integration endpoints."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
@@ -15,7 +15,8 @@ from app.services.organizations import (
 )
 from app.services.workspace_access import (
     PERMISSION_AUDIT_READ,
-    require_workspace_permission,
+    PERMISSION_WORKSPACE_ADMIN,
+    organization_ids_for_permission,
 )
 
 router = APIRouter()
@@ -47,12 +48,14 @@ def _usage_or_400(
     *,
     period: Optional[str],
     external_customer_id: Optional[str] = None,
+    organization_ids: Optional[List[int]] = None,
 ) -> Dict[str, Any]:
     try:
         return build_usage_export(
             db,
             period=period or usage_period_for_current_month(),
             external_customer_id=external_customer_id,
+            organization_ids=organization_ids,
         )
     except ValueError as exc:
         raise HTTPException(
@@ -71,8 +74,8 @@ async def get_provider_billing_usage(
     _auth: dict = Depends(require_admin_auth),
 ) -> ProviderUsageResponse:
     """Return idempotent monthly usage metrics for provider billing systems."""
-    require_workspace_permission(_auth, PERMISSION_AUDIT_READ)
-    return {"usage": _usage_or_400(db, period=period)}
+    organization_ids = organization_ids_for_permission(db, _auth, PERMISSION_AUDIT_READ)
+    return {"usage": _usage_or_400(db, period=period, organization_ids=organization_ids)}
 
 
 @router.get(
@@ -89,12 +92,13 @@ async def get_provider_account_billing_usage(
     _auth: dict = Depends(require_admin_auth),
 ) -> ProviderUsageResponse:
     """Return usage metrics for one provider-billed external customer."""
-    require_workspace_permission(_auth, PERMISSION_AUDIT_READ)
+    organization_ids = organization_ids_for_permission(db, _auth, PERMISSION_AUDIT_READ)
     return {
         "usage": _usage_or_400(
             db,
             period=period,
             external_customer_id=external_customer_id,
+            organization_ids=organization_ids,
         )
     }
 
@@ -110,12 +114,13 @@ async def update_provider_subscription_state(
     _auth: dict = Depends(require_admin_auth),
 ) -> ProviderSubscriptionStateResponse:
     """Apply a provider-reported subscription lifecycle state."""
-    require_workspace_permission(_auth, PERMISSION_AUDIT_READ)
+    organization_ids = organization_ids_for_permission(db, _auth, PERMISSION_WORKSPACE_ADMIN)
     try:
         result = update_external_subscription_state(
             db,
             external_subscription_id=external_subscription_id,
             status=payload.status,
+            organization_ids=organization_ids,
             provider_id=payload.provider_id,
             external_event_id=payload.external_event_id,
             payload_summary=payload.payload_summary,

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -409,6 +409,20 @@ def list_organization_summaries(db: Session) -> List[Dict[str, Any]]:
     return [organization_summary(db, organization) for organization in organizations]
 
 
+def list_scoped_organization_summaries(
+    db: Session,
+    organization_ids: Optional[List[int]] = None,
+) -> List[Dict[str, Any]]:
+    """Return organization summaries constrained to authorized IDs when supplied."""
+    bootstrap_default_commercial_foundation(db)
+    query = db.query(Organization).order_by(Organization.slug.asc())
+    if organization_ids is not None:
+        if not organization_ids:
+            return []
+        query = query.filter(Organization.id.in_(organization_ids))
+    return [organization_summary(db, organization) for organization in query.all()]
+
+
 def parse_usage_period(period: str) -> tuple[datetime, datetime]:
     """Parse a billing period in YYYY-MM form into UTC-naive boundaries."""
     try:
@@ -471,6 +485,7 @@ def build_usage_export(
     *,
     period: Optional[str] = None,
     external_customer_id: Optional[str] = None,
+    organization_ids: Optional[List[int]] = None,
 ) -> Dict[str, Any]:
     """Build idempotent usage metrics suitable for provider monthly billing."""
     period_key = period or usage_period_for_current_month()
@@ -478,11 +493,20 @@ def build_usage_export(
     bootstrap_default_commercial_foundation(db)
 
     organization_query = db.query(Organization).filter(Organization.active.is_(True))
+    if organization_ids is not None:
+        if not organization_ids:
+            organizations = []
+        else:
+            organization_query = organization_query.filter(Organization.id.in_(organization_ids))
+            organizations = None
+    else:
+        organizations = None
     if external_customer_id:
         organization_query = organization_query.join(BillingAccount).filter(
             BillingAccount.external_customer_id == external_customer_id
         )
-    organizations = organization_query.order_by(Organization.slug.asc()).all()
+    if organizations is None:
+        organizations = organization_query.order_by(Organization.slug.asc()).all()
 
     exports = []
     for organization in organizations:
@@ -702,6 +726,7 @@ def update_external_subscription_state(
     *,
     external_subscription_id: str,
     status: str,
+    organization_ids: Optional[List[int]] = None,
     provider_id: Optional[str] = None,
     external_event_id: Optional[str] = None,
     payload_summary: Optional[str] = None,
@@ -719,6 +744,18 @@ def update_external_subscription_state(
         .filter(Subscription.external_subscription_id == external_subscription_id)
         .first()
     )
+    if organization_ids is not None:
+        if not organization_ids:
+            subscription = None
+        else:
+            subscription = (
+                db.query(Subscription)
+                .filter(
+                    Subscription.external_subscription_id == external_subscription_id,
+                    Subscription.organization_id.in_(organization_ids),
+                )
+                .first()
+            )
     if subscription is None:
         raise LookupError("external subscription not found")
 

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Set
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
+from app.models.organization import Organization, OrganizationMembership
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
@@ -61,6 +62,19 @@ ROLE_PERMISSIONS: Dict[str, Set[str]] = {
     },
 }
 
+PLATFORM_ADMIN_AUTH_TYPES = {"api_key", "disabled"}
+
+ORGANIZATION_ROLE_ALIASES = {
+    "organization_owner": ROLE_WORKSPACE_OWNER,
+    "owner": ROLE_WORKSPACE_OWNER,
+    "admin": ROLE_WORKSPACE_OWNER,
+    "organization_admin": ROLE_WORKSPACE_OWNER,
+    "billing_admin": ROLE_WORKSPACE_OWNER,
+    "auditor": ROLE_AUDITOR,
+    "organization_auditor": ROLE_AUDITOR,
+    "analyst": ROLE_ANALYST,
+}
+
 
 def permissions_for_role(role: str) -> Set[str]:
     """Return normalized permissions for a workspace role."""
@@ -90,9 +104,14 @@ def role_for_auth_context(auth_context: dict) -> str:
     authenticated admin context until they are moved to workspace-aware checks.
     """
     auth_type = (auth_context or {}).get("auth_type")
-    if auth_type in {"session", "bearer", "jwt", "api_key", "disabled"}:
+    if auth_type in {"session", "bearer", "jwt", *PLATFORM_ADMIN_AUTH_TYPES}:
         return ROLE_WORKSPACE_OWNER
     return ROLE_AUDITOR
+
+
+def is_platform_admin_auth(auth_context: dict) -> bool:
+    """Return True for deployment-wide admin credentials."""
+    return (auth_context or {}).get("auth_type") in PLATFORM_ADMIN_AUTH_TYPES
 
 
 def _auth_user_id(auth_context: dict) -> Optional[int]:
@@ -141,6 +160,11 @@ def _auth_user(db: Session, auth_context: dict) -> Optional[User]:
     if email:
         return _active_user_by_email(db, str(email))
     return None
+
+
+def _normalize_organization_role(role: str) -> str:
+    normalized = (role or "").strip().lower()
+    return ORGANIZATION_ROLE_ALIASES.get(normalized, normalized)
 
 
 def role_for_workspace(
@@ -197,4 +221,135 @@ def require_workspace_permission(
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
         detail=f"Workspace permission required: {permission}",
+    )
+
+
+def role_for_organization(
+    db: Session,
+    auth_context: dict,
+    organization: Organization,
+    permission: str,
+) -> str:
+    """Resolve an effective organization role for tenant-state endpoints."""
+    if is_platform_admin_auth(auth_context):
+        return ROLE_WORKSPACE_OWNER
+
+    user = _auth_user(db, auth_context)
+    if user is None:
+        return ""
+
+    membership = (
+        db.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.organization_id == organization.id,
+            OrganizationMembership.user_id == user.id,
+            OrganizationMembership.active.is_(True),
+        )
+        .first()
+    )
+    if membership is not None:
+        role = _normalize_organization_role(membership.role)
+        if role_allows(role, permission):
+            return role
+
+    workspace_roles = (
+        db.query(WorkspaceMembership.role)
+        .join(Workspace, WorkspaceMembership.workspace_id == Workspace.id)
+        .filter(
+            Workspace.organization_id == organization.id,
+            Workspace.active.is_(True),
+            WorkspaceMembership.user_id == user.id,
+            WorkspaceMembership.active.is_(True),
+        )
+        .all()
+    )
+    for row in workspace_roles:
+        role = _normalize_organization_role(row[0])
+        if role_allows(role, permission):
+            return role
+
+    if user.workspace_id is not None and user.is_superuser:
+        workspace = (
+            db.query(Workspace)
+            .filter(
+                Workspace.id == user.workspace_id,
+                Workspace.organization_id == organization.id,
+                Workspace.active.is_(True),
+            )
+            .first()
+        )
+        if workspace is not None and role_allows(ROLE_WORKSPACE_OWNER, permission):
+            return ROLE_WORKSPACE_OWNER
+    return ""
+
+
+def organization_ids_for_permission(
+    db: Session,
+    auth_context: dict,
+    permission: str,
+) -> Optional[List[int]]:
+    """Return authorized organization IDs, or None for platform-wide access."""
+    if is_platform_admin_auth(auth_context):
+        return None
+
+    user = _auth_user(db, auth_context)
+    if user is None:
+        return []
+
+    organization_ids: Set[int] = set()
+    organization_roles = (
+        db.query(OrganizationMembership.organization_id, OrganizationMembership.role)
+        .filter(
+            OrganizationMembership.user_id == user.id,
+            OrganizationMembership.active.is_(True),
+        )
+        .all()
+    )
+    for organization_id, role in organization_roles:
+        if role_allows(_normalize_organization_role(role), permission):
+            organization_ids.add(organization_id)
+
+    workspace_roles = (
+        db.query(Workspace.organization_id, WorkspaceMembership.role)
+        .join(Workspace, WorkspaceMembership.workspace_id == Workspace.id)
+        .filter(
+            Workspace.organization_id.isnot(None),
+            Workspace.active.is_(True),
+            WorkspaceMembership.user_id == user.id,
+            WorkspaceMembership.active.is_(True),
+        )
+        .all()
+    )
+    for organization_id, role in workspace_roles:
+        if role_allows(_normalize_organization_role(role), permission):
+            organization_ids.add(organization_id)
+
+    if user.workspace_id is not None and user.is_superuser:
+        workspace = (
+            db.query(Workspace)
+            .filter(
+                Workspace.id == user.workspace_id,
+                Workspace.organization_id.isnot(None),
+                Workspace.active.is_(True),
+            )
+            .first()
+        )
+        if workspace is not None and role_allows(ROLE_WORKSPACE_OWNER, permission):
+            organization_ids.add(workspace.organization_id)
+
+    return sorted(organization_ids)
+
+
+def require_organization_permission(
+    auth_context: dict,
+    permission: str,
+    db: Session,
+    organization: Organization,
+) -> None:
+    """Raise HTTP 403 when the caller cannot access organization tenant state."""
+    if role_for_organization(db, auth_context, organization, permission):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"Organization permission required: {permission}",
     )

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -1,5 +1,10 @@
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.database import get_db
+from app.core.security import require_admin_auth
 from app.models.organization import (
     BillingAccount,
     Entitlement,
@@ -7,7 +12,9 @@ from app.models.organization import (
     Plan,
     Subscription,
 )
+from app.models.user import User
 from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
 from app.services.organizations import (
     BILLING_MODE_SELF_HOSTED,
     DEFAULT_ORGANIZATION_SLUG,
@@ -15,6 +22,28 @@ from app.services.organizations import (
     bootstrap_default_commercial_foundation,
     list_organization_summaries,
 )
+from app.services.workspace_access import ROLE_AUDITOR
+
+
+@contextmanager
+def _client_as_user(test_app, db_session: Session, user: User):
+    async def mock_admin_auth():
+        return {"auth_type": "session", "user_id": user.id}
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    original_overrides = dict(test_app.dependency_overrides)
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    try:
+        with TestClient(test_app) as client:
+            yield client
+    finally:
+        test_app.dependency_overrides = original_overrides
 
 
 def test_bootstrap_default_commercial_foundation_keeps_self_hosted_install_working(
@@ -75,3 +104,47 @@ def test_list_organization_summaries_materializes_account_state(db_session: Sess
     assert summaries[0]["billing_accounts"][0]["billing_mode"] == BILLING_MODE_SELF_HOSTED
     assert summaries[0]["subscriptions"][0]["plan"]["code"] == SELF_HOSTED_PLAN_CODE
     assert summaries[0]["entitlements"]["aggregate_reports"]["value"] == "true"
+
+
+def test_organization_endpoints_are_scoped_to_accessible_tenants(test_app, db_session: Session):
+    allowed_org = Organization(slug="allowed", name="Allowed", active=True)
+    hidden_org = Organization(slug="hidden", name="Hidden", active=True)
+    db_session.add_all([allowed_org, hidden_org])
+    db_session.flush()
+    allowed_workspace = Workspace(
+        slug="allowed-workspace",
+        name="Allowed Workspace",
+        organization_id=allowed_org.id,
+        active=True,
+    )
+    hidden_workspace = Workspace(
+        slug="hidden-workspace",
+        name="Hidden Workspace",
+        organization_id=hidden_org.id,
+        active=True,
+    )
+    user = User(email="auditor-org@example.com", is_active=True, is_verified=True)
+    db_session.add_all([allowed_workspace, hidden_workspace, user])
+    db_session.flush()
+    db_session.add(
+        WorkspaceMembership(
+            workspace_id=allowed_workspace.id,
+            user_id=user.id,
+            role=ROLE_AUDITOR,
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, user) as client:
+        listed = client.get("/api/v1/organizations")
+        assert listed.status_code == 200
+        slugs = {item["slug"] for item in listed.json()["organizations"]}
+        assert slugs == {"allowed"}
+
+        allowed = client.get(f"/api/v1/organizations/{allowed_org.id}")
+        assert allowed.status_code == 200
+        assert allowed.json()["organization"]["slug"] == "allowed"
+
+        hidden = client.get(f"/api/v1/organizations/{hidden_org.id}")
+        assert hidden.status_code == 403

--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -1,18 +1,87 @@
+from contextlib import contextmanager
 from datetime import datetime
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.database import get_db
+from app.core.security import require_admin_auth
 from app.models.domain import Domain
-from app.models.organization import BillingAccount, BillingEvent, Subscription
+from app.models.organization import BillingAccount, BillingEvent, Organization, Plan, Subscription
 from app.models.report import DMARCReport, ForensicReport, ReportRecord
+from app.models.user import User
 from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
 from app.services.organizations import (
+    BILLING_MODE_PROVIDER_RESALE,
     MAX_PROVIDER_PAYLOAD_SUMMARY_LENGTH,
     bootstrap_default_commercial_foundation,
     build_usage_export,
     update_external_subscription_state,
 )
+from app.services.workspace_access import ROLE_AUDITOR, ROLE_WORKSPACE_OWNER
+
+
+@contextmanager
+def _client_as_user(test_app, db_session: Session, user: User):
+    async def mock_admin_auth():
+        return {"auth_type": "session", "user_id": user.id}
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    original_overrides = dict(test_app.dependency_overrides)
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    try:
+        with TestClient(test_app) as client:
+            yield client
+    finally:
+        test_app.dependency_overrides = original_overrides
+
+
+def _add_provider_customer(
+    db_session: Session,
+    *,
+    slug: str,
+    external_customer_id: str,
+    external_subscription_id: str,
+):
+    organization = Organization(slug=slug, name=slug.title(), active=True)
+    plan = Plan(
+        code=f"{slug}-plan",
+        name=f"{slug.title()} Plan",
+        billing_mode=BILLING_MODE_PROVIDER_RESALE,
+        active=True,
+    )
+    db_session.add_all([organization, plan])
+    db_session.flush()
+    workspace = Workspace(
+        slug=f"{slug}-workspace",
+        name=f"{slug.title()} Workspace",
+        organization_id=organization.id,
+        active=True,
+    )
+    account = BillingAccount(
+        organization_id=organization.id,
+        billing_mode=BILLING_MODE_PROVIDER_RESALE,
+        status="active",
+        external_customer_id=external_customer_id,
+    )
+    subscription = Subscription(
+        organization_id=organization.id,
+        plan_id=plan.id,
+        billing_mode=BILLING_MODE_PROVIDER_RESALE,
+        billing_account=account,
+        status="active",
+        external_subscription_id=external_subscription_id,
+    )
+    db_session.add_all([workspace, account, subscription])
+    db_session.flush()
+    return organization, workspace, subscription
 
 
 def test_provider_usage_export_computes_monthly_metrics(db_session: Session):
@@ -85,6 +154,46 @@ def test_provider_usage_endpoint_rejects_bad_period(authed_client: TestClient):
     assert "YYYY-MM" in response.json()["detail"]
 
 
+def test_provider_usage_endpoint_is_scoped_to_accessible_organizations(
+    test_app,
+    db_session: Session,
+):
+    allowed_org, allowed_workspace, _ = _add_provider_customer(
+        db_session,
+        slug="allowed-provider",
+        external_customer_id="cust-allowed",
+        external_subscription_id="sub-allowed",
+    )
+    _add_provider_customer(
+        db_session,
+        slug="hidden-provider",
+        external_customer_id="cust-hidden",
+        external_subscription_id="sub-hidden",
+    )
+    user = User(email="provider-auditor@example.com", is_active=True, is_verified=True)
+    db_session.add(user)
+    db_session.flush()
+    db_session.add(
+        WorkspaceMembership(
+            workspace_id=allowed_workspace.id,
+            user_id=user.id,
+            role=ROLE_AUDITOR,
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, user) as client:
+        response = client.get("/api/v1/provider/billing/usage?period=2026-06")
+        assert response.status_code == 200
+        organizations = response.json()["usage"]["organizations"]
+        assert [item["organization"]["id"] for item in organizations] == [allowed_org.id]
+
+        hidden = client.get("/api/v1/provider/billing/accounts/cust-hidden/usage?period=2026-06")
+        assert hidden.status_code == 200
+        assert hidden.json()["usage"]["organizations"] == []
+
+
 def test_provider_subscription_state_update_records_billing_event(db_session: Session):
     organization = bootstrap_default_commercial_foundation(db_session)
     subscription = (
@@ -109,6 +218,69 @@ def test_provider_subscription_state_update_records_billing_event(db_session: Se
     assert subscription.status == "suspended"
     assert event.event_type == "provider.subscription_state_updated"
     assert event.external_event_id == "evt-1"
+
+
+def test_provider_subscription_state_endpoint_requires_org_admin_access(
+    test_app,
+    db_session: Session,
+):
+    _, allowed_workspace, allowed_subscription = _add_provider_customer(
+        db_session,
+        slug="updatable-provider",
+        external_customer_id="cust-updatable",
+        external_subscription_id="sub-updatable",
+    )
+    _, _, hidden_subscription = _add_provider_customer(
+        db_session,
+        slug="blocked-provider",
+        external_customer_id="cust-blocked",
+        external_subscription_id="sub-blocked",
+    )
+    auditor = User(email="provider-state-auditor@example.com", is_active=True, is_verified=True)
+    owner = User(email="provider-state-owner@example.com", is_active=True, is_verified=True)
+    db_session.add_all([auditor, owner])
+    db_session.flush()
+    db_session.add_all(
+        [
+            WorkspaceMembership(
+                workspace_id=allowed_workspace.id,
+                user_id=auditor.id,
+                role=ROLE_AUDITOR,
+                active=True,
+            ),
+            WorkspaceMembership(
+                workspace_id=allowed_workspace.id,
+                user_id=owner.id,
+                role=ROLE_WORKSPACE_OWNER,
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, auditor) as client:
+        denied = client.post(
+            "/api/v1/provider/subscriptions/sub-updatable/state",
+            json={"status": "suspended"},
+        )
+        assert denied.status_code == 404
+
+    with _client_as_user(test_app, db_session, owner) as client:
+        updated = client.post(
+            "/api/v1/provider/subscriptions/sub-updatable/state",
+            json={"status": "suspended"},
+        )
+        assert updated.status_code == 200
+        blocked = client.post(
+            "/api/v1/provider/subscriptions/sub-blocked/state",
+            json={"status": "suspended"},
+        )
+        assert blocked.status_code == 404
+
+    db_session.refresh(allowed_subscription)
+    db_session.refresh(hidden_subscription)
+    assert allowed_subscription.status == "suspended"
+    assert hidden_subscription.status == "active"
 
 
 def test_provider_subscription_state_update_sanitizes_payload_summary(db_session: Session):


### PR DESCRIPTION
## Summary
- add organization-aware RBAC helpers backed by organization/workspace memberships
- scope organization summaries and provider usage exports to authorized tenant IDs
- restrict provider subscription state updates to organization-admin access and hide unauthorized external subscription IDs
- add regression coverage for cross-organization listing, usage, and subscription update isolation

## Validation
- `.venv/bin/black ...touched files...`
- `.venv/bin/isort ...touched files...`
- `.venv/bin/flake8 ...touched files...`
- `PYTHONPATH=backend .venv/bin/python -m pytest -q backend/app/tests/test_organization_foundations.py backend/app/tests/test_provider_billing_usage.py backend/app/tests/test_workspace_audit.py::test_workspace_role_resolution_uses_membership`

Refs #236