### PR TITLE
[codex] Enforce RBAC on domain read surfaces

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -34,18 +34,19 @@ from app.services.dns_resolver import (
 )
 from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
 from app.services.report_persistence import (
-    delete_persisted_domain,
     hydrate_report_store_from_db,
 )
 from app.services.report_store import ReportStore
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
+    PERMISSION_REPORTS_READ,
     require_workspace_permission,
 )
 from app.services.workspace_audit import record_workspace_audit_log
 from app.services.workspaces import (
     assign_default_workspace_to_unscoped_rows,
     get_default_workspace,
+    get_or_create_default_workspace,
     workspace_domain_query,
 )
 from app.utils.domain_validator import validate_domain_config
@@ -62,9 +63,14 @@ def _authorized_domain_workspace(
     permission: str = PERMISSION_DOMAINS_WRITE,
 ):
     """Authorize workspace domain/DNS setup before legacy repair writes."""
-    workspace = get_default_workspace(db)
+    workspace = get_default_workspace(db) or get_or_create_default_workspace(db)
     require_workspace_permission(auth_context, permission, db, workspace)
     return assign_default_workspace_to_unscoped_rows(db)
+
+
+def _authorized_domain_read_workspace(auth_context: Dict[str, Any], db: Session):
+    """Authorize read-only domain/report/DNS visibility for the default workspace."""
+    return _authorized_domain_workspace(auth_context, db, PERMISSION_REPORTS_READ)
 
 
 class DomainBase(BaseModel):
@@ -1107,7 +1113,10 @@ def _build_posture_dashboard(
 
 
 @router.get("/summary", response_model=DomainSummaryResponse)
-async def get_domains_summary(db: Session = Depends(get_db)):
+async def get_domains_summary(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
     """
     Get summary statistics for all domains, formatted for the dashboard.
 
@@ -1116,9 +1125,10 @@ async def get_domains_summary(db: Session = Depends(get_db)):
     A per-domain timeout of 10 s prevents slow DNS responses from blocking the
     page load.
     """
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    domains = _domain_names_for_summary(db, store)
+    domains = _domain_names_for_summary(db, store, workspace)
     summaries = store.get_all_domain_summaries()
 
     # Perform DNS checks for all domains, reusing fresh cached results.
@@ -1207,13 +1217,16 @@ async def get_domains_summary(db: Session = Depends(get_db)):
 
 
 @router.get("/domains", response_model=List[DomainResponse])
-async def read_domains(db: Session = Depends(get_db)):
+async def read_domains(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
     """
     Retrieve domains with their statistics.
     """
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
     domains = _domain_names_for_summary(db, store, workspace)
     summaries = store.get_all_domain_summaries()
     stored = {
@@ -1295,14 +1308,18 @@ async def create_domain(
 
 
 @router.get("/domains/{domain_name}", response_model=DomainResponse)
-async def read_domain(domain_name: str, db: Session = Depends(get_db)):
+async def read_domain(
+    domain_name: str,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
     """
     Get statistics for a specific domain.
     """
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    domains = store.get_domains()
-    workspace = assign_default_workspace_to_unscoped_rows(db)
+    domains = _domain_names_for_summary(db, store, workspace)
     stored_domain = workspace_domain_query(db, workspace).filter(Domain.name == domain_name).first()
 
     if domain_name not in domains and stored_domain is None:
@@ -1332,11 +1349,12 @@ async def lint_all_domain_dns(
     refresh: bool = Query(False, title="Refresh cached DNS results"),
     limit: int = Query(100, ge=1, le=500, title="Maximum domains to lint"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Return typed DNS lint findings and target records for monitored domains."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
     domains = _domain_names_for_summary(db, store, workspace)[:limit]
 
     items: List[DNSBulkGuidanceItem] = []
@@ -1361,11 +1379,12 @@ async def export_all_domain_dns_lint(
     refresh: bool = Query(False, title="Refresh cached DNS results"),
     limit: int = Query(500, ge=1, le=1000, title="Maximum domains to export"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Export typed DNS lint findings for monitored domains as CSV."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
     domains = _domain_names_for_summary(db, store, workspace)[:limit]
 
     output = io.StringIO()
@@ -1417,13 +1436,15 @@ async def export_all_domain_dns_lint(
 async def get_domain_stats(
     domain_id: str = Path(..., title="The domain ID or name"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """
     Get detailed statistics for a specific domain
     """
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    domains = _domain_names_for_summary(db, store)
+    domains = _domain_names_for_summary(db, store, workspace)
 
     if domain_id not in domains:
         raise HTTPException(
@@ -1451,6 +1472,7 @@ async def get_domain_dns_records(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached DNS result"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """
     Get DNS records for a specific domain using live DNS lookups.
@@ -1459,9 +1481,9 @@ async def get_domain_dns_records(
     selectors observed in stored DMARC reports, with common well-known
     selectors used as a final fallback.
     """
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
 
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
@@ -1501,11 +1523,12 @@ async def get_domain_dns_lint(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached DNS result"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Return typed DNS lint findings and target records for one monitored domain."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
 
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
@@ -1521,11 +1544,12 @@ async def get_domain_dns_health(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached DNS result"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Return evidence-linked DNS health and enforcement readiness guidance."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -1540,11 +1564,12 @@ async def get_domain_posture_dashboard(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached DNS posture"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Return an evidence-first posture dashboard for a monitored domain."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -1561,11 +1586,12 @@ async def get_domain_mta_sts(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached MTA-STS result"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Return cached MTA-STS DNS and HTTPS policy posture for a domain."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -1598,11 +1624,12 @@ async def get_domain_bimi(
     selector: str = Query("default", title="BIMI selector"),
     refresh: bool = Query(False, title="Refresh cached BIMI result"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Return cached BIMI DNS posture for a domain."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -1723,13 +1750,14 @@ async def get_domain_reports(
     domain_id: str = Path(..., title="The domain ID or name"),
     limit: int = Query(10, title="Maximum number of reports to return"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """
     Get recent DMARC reports for a specific domain, along with compliance timeline
     """
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
 
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
@@ -1771,6 +1799,7 @@ async def export_domain_reports(
     start_date: Optional[date] = Query(None, title="Start date for exported reports"),
     end_date: Optional[date] = Query(None, title="End date for exported reports"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """
     Export DMARC report summaries for a specific domain as CSV.
@@ -1781,9 +1810,9 @@ async def export_domain_reports(
             detail="start_date must be on or before end_date",
         )
 
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
 
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
@@ -2091,14 +2120,15 @@ async def get_domain_sources(
     domain_id: str = Path(..., title="The domain ID or name"),
     days: int = Query(30, title="Number of days to look back"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """
     Get sending sources for a specific domain, including reverse-DNS hostnames
     and SPF fix hints for sources that fail authentication.
     """
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
 
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
@@ -2147,6 +2177,7 @@ async def get_domain_sources(
 async def get_domain_selectors(
     domain_id: str = Path(..., title="The domain ID or name"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """Return the manually configured DKIM selectors for a domain.
 
@@ -2154,9 +2185,9 @@ async def get_domain_selectors(
     deleted) and ``report_selectors`` (automatically discovered from received
     DMARC reports, read-only).
     """
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -2272,14 +2303,16 @@ async def delete_domain_selector(
 async def delete_domain(
     domain_id: str = Path(..., title="The domain ID or name"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """
     Delete a domain and all associated data.
     This performs a full cleanup of all reports and records related to this domain.
     """
+    workspace = _authorized_domain_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    domains = store.get_domains()
+    domains = _domain_names_for_summary(db, store, workspace)
 
     if domain_id not in domains:
         raise HTTPException(
@@ -2288,7 +2321,11 @@ async def delete_domain(
         )
 
     # Perform deletion with cleanup
-    deleted_from_db = delete_persisted_domain(db, domain_id)
+    domain_row = workspace_domain_query(db, workspace).filter(Domain.name == domain_id).first()
+    deleted_from_db = False
+    if domain_row is not None:
+        db.delete(domain_row)
+        deleted_from_db = True
     if deleted_from_db:
         db.commit()
     deleted = store.delete_domain_with_cleanup(domain_id) or deleted_from_db
@@ -2310,6 +2347,7 @@ async def search_domains(
     page: int = Query(1, title="Page number", ge=1),
     limit: int = Query(10, title="Number of domains per page", ge=1, le=100),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
 ):
     """
     Search domains with filtering and pagination.
@@ -2321,9 +2359,10 @@ async def search_domains(
         page: Page number (1-based)
         limit: Number of domains per page (max 100)
     """
+    workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
-    domains = store.get_domains()
+    domains = _domain_names_for_summary(db, store, workspace)
     summaries = store.get_all_domain_summaries()
 
     # Apply search filter if provided

--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -19,7 +19,7 @@ async def public_domain_summary(
     _auth: dict = Depends(require_api_token_scope(READ_REPORTS_SCOPE)),
 ):
     """List monitored domains with report and DNS posture summary fields."""
-    return await domains.get_domains_summary(db=db)
+    return await domains.get_domains_summary(db=db, _auth=_auth)
 
 
 @router.get(
@@ -37,6 +37,7 @@ async def public_domain_posture(
         domain_id=domain_id,
         refresh=refresh,
         db=db,
+        _auth=_auth,
     )
 
 
@@ -51,7 +52,12 @@ async def public_domain_reports(
     _auth: dict = Depends(require_api_token_scope(READ_REPORTS_SCOPE)),
 ):
     """Return recent DMARC aggregate report summaries for one domain."""
-    return await domains.get_domain_reports(domain_id=domain_id, limit=limit, db=db)
+    return await domains.get_domain_reports(
+        domain_id=domain_id,
+        limit=limit,
+        db=db,
+        _auth=_auth,
+    )
 
 
 @router.get("/tls-reports/summary", response_model=tls_reports.TLSSummaryResponse)

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -1,18 +1,18 @@
 from fastapi.testclient import TestClient
 
 
-def test_health_check(client: TestClient):
+def test_health_check(authed_client: TestClient):
     """Test the health check endpoint returns status ok."""
-    response = client.get("/api/v1/health")
+    response = authed_client.get("/api/v1/health")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
     assert "version" in data
 
 
-def test_domains_empty(client: TestClient):
+def test_domains_empty(authed_client: TestClient):
     """Test that GET /api/v1/domains/domains returns empty list when no reports uploaded."""
-    response = client.get("/api/v1/domains/domains")
+    response = authed_client.get("/api/v1/domains/domains")
     assert response.status_code == 200
     data = response.json()
     assert data == []
@@ -55,9 +55,9 @@ def test_operations_health_endpoint(authed_client: TestClient):
     assert data["mailbox_recovery"][0]["category"] == "not_configured"
 
 
-def test_setup_status_includes_mailbox_recovery_hint(client: TestClient):
+def test_setup_status_includes_mailbox_recovery_hint(authed_client: TestClient):
     """Setup status points first-run operators at mailbox configuration."""
-    response = client.get("/api/v1/setup/status")
+    response = authed_client.get("/api/v1/setup/status")
     assert response.status_code == 200
     data = response.json()
     assert data["mailbox_recovery_hint"]["category"] == "not_configured"

--- a/backend/app/tests/test_dashboard_timeline.py
+++ b/backend/app/tests/test_dashboard_timeline.py
@@ -33,11 +33,11 @@ def _add_report_to_store(
 class TestComplianceTimeline:
     """Tests that the compliance timeline returns real data instead of mock."""
 
-    def test_timeline_has_entries_after_upload(self, client: TestClient):
+    def test_timeline_has_entries_after_upload(self, authed_client: TestClient):
         """When a domain has reports, the timeline should have entries."""
         _add_report_to_store("example.com", "rpt-001", 1597449600, 1597535999, 10, 8, 2)
 
-        response = client.get("/api/v1/domains/example.com/reports?limit=10")
+        response = authed_client.get("/api/v1/domains/example.com/reports?limit=10")
         assert response.status_code == 200
         data = response.json()
         timeline = data["compliance_timeline"]
@@ -48,11 +48,11 @@ class TestComplianceTimeline:
         assert timeline[0]["failed"] == 2
         assert timeline[0]["failure_rate"] == 20.0
 
-    def test_timeline_uses_real_dates(self, client: TestClient):
+    def test_timeline_uses_real_dates(self, authed_client: TestClient):
         """Timeline dates should come from actual report begin_dates."""
         _add_report_to_store("example.com", "rpt-001", 1597449600, 1597535999, 10, 8, 2)
 
-        response = client.get("/api/v1/domains/example.com/reports?limit=10")
+        response = authed_client.get("/api/v1/domains/example.com/reports?limit=10")
         data = response.json()
         timeline = data["compliance_timeline"]
 
@@ -60,18 +60,18 @@ class TestComplianceTimeline:
         dates = [point["date"] for point in timeline]
         assert "2020-08-15" in dates
 
-    def test_timeline_compliance_rate_is_deterministic(self, client: TestClient):
+    def test_timeline_compliance_rate_is_deterministic(self, authed_client: TestClient):
         """Compliance rate should be deterministic, not random."""
         _add_report_to_store("example.com", "rpt-001", 1597449600, 1597535999, 10, 8, 2)
 
-        resp1 = client.get("/api/v1/domains/example.com/reports?limit=10")
-        resp2 = client.get("/api/v1/domains/example.com/reports?limit=10")
+        resp1 = authed_client.get("/api/v1/domains/example.com/reports?limit=10")
+        resp2 = authed_client.get("/api/v1/domains/example.com/reports?limit=10")
 
         timeline1 = resp1.json()["compliance_timeline"]
         timeline2 = resp2.json()["compliance_timeline"]
         assert timeline1 == timeline2
 
-    def test_timeline_empty_for_domain_with_no_valid_dates(self, client: TestClient):
+    def test_timeline_empty_for_domain_with_no_valid_dates(self, authed_client: TestClient):
         """A domain with begin_date=0 should have an empty timeline."""
         store = ReportStore.get_instance()
         store.add_report(
@@ -87,12 +87,12 @@ class TestComplianceTimeline:
             }
         )
 
-        response = client.get("/api/v1/domains/empty-timeline.com/reports?limit=10")
+        response = authed_client.get("/api/v1/domains/empty-timeline.com/reports?limit=10")
         assert response.status_code == 200
         data = response.json()
         assert data["compliance_timeline"] == []
 
-    def test_timeline_handles_iso_string_dates(self, client: TestClient):
+    def test_timeline_handles_iso_string_dates(self, authed_client: TestClient):
         """Timeline should handle reports with ISO-format string dates."""
         from app.api.api_v1.endpoints.domains import _build_compliance_timeline
 
@@ -123,12 +123,12 @@ class TestComplianceTimeline:
 class TestBuildComplianceTimelineMultipleReports:
     """Test timeline aggregation with multiple reports."""
 
-    def test_multiple_reports_same_day(self, client: TestClient):
+    def test_multiple_reports_same_day(self, authed_client: TestClient):
         """Multiple reports on the same day should be aggregated."""
         _add_report_to_store("multi.com", "rpt-1", 1597449600, 1597535999, 10, 8, 2)
         _add_report_to_store("multi.com", "rpt-2", 1597449600, 1597535999, 10, 6, 4)
 
-        response = client.get("/api/v1/domains/multi.com/reports?limit=10")
+        response = authed_client.get("/api/v1/domains/multi.com/reports?limit=10")
         assert response.status_code == 200
         data = response.json()
         timeline = data["compliance_timeline"]
@@ -142,12 +142,12 @@ class TestBuildComplianceTimelineMultipleReports:
         assert timeline[0]["compliance_rate"] == 70.0
         assert timeline[0]["failure_rate"] == 30.0
 
-    def test_reports_on_different_days(self, client: TestClient):
+    def test_reports_on_different_days(self, authed_client: TestClient):
         """Reports on different days should produce separate timeline points."""
         _add_report_to_store("days.com", "rpt-d1", 1597449600, 1597535999, 10, 10, 0)
         _add_report_to_store("days.com", "rpt-d2", 1597536000, 1597622399, 10, 5, 5)
 
-        response = client.get("/api/v1/domains/days.com/reports?limit=10")
+        response = authed_client.get("/api/v1/domains/days.com/reports?limit=10")
         assert response.status_code == 200
         data = response.json()
         timeline = data["compliance_timeline"]

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -87,18 +87,18 @@ def _mock_dns(result: DomainDNSResult = MOCK_DNS_RESULT):
 # ---------------------------------------------------------------------------
 
 
-def test_get_selectors_empty(client: TestClient):
+def test_get_selectors_empty(authed_client: TestClient):
     """Returns an empty list when no selectors have been configured."""
-    response = client.get(f"/api/v1/domains/{DOMAIN}/selectors")
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/selectors")
     assert response.status_code == 200
     data = response.json()
     assert data["selectors"] == []
     assert "report_selectors" in data
 
 
-def test_get_selectors_unknown_domain(client: TestClient):
+def test_get_selectors_unknown_domain(authed_client: TestClient):
     """Returns 404 for a domain not in the ReportStore."""
-    response = client.get("/api/v1/domains/unknown.example.com/selectors")
+    response = authed_client.get("/api/v1/domains/unknown.example.com/selectors")
     assert response.status_code == 404
 
 
@@ -190,16 +190,16 @@ def test_delete_selector_unknown_domain(authed_client: TestClient):
 # ---------------------------------------------------------------------------
 
 
-def test_get_selectors_includes_report_selectors(client: TestClient):
+def test_get_selectors_includes_report_selectors(authed_client: TestClient):
     """Report selectors (from DMARC report records) are returned in report_selectors."""
-    response = client.get(f"/api/v1/domains/{DOMAIN}/selectors")
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/selectors")
     assert response.status_code == 200
     data = response.json()
     # The MINIMAL_REPORT has a record with selector "google" in its dkim auth results
     assert "google" in data["report_selectors"]
 
 
-def test_get_selectors_ignores_missing_dkim_detail_lists(client: TestClient):
+def test_get_selectors_ignores_missing_dkim_detail_lists(authed_client: TestClient):
     """Missing or malformed DKIM auth-detail arrays should not break selectors."""
     ReportStore.get_instance().add_report(
         {
@@ -219,7 +219,7 @@ def test_get_selectors_ignores_missing_dkim_detail_lists(client: TestClient):
         }
     )
 
-    response = client.get(f"/api/v1/domains/{DOMAIN}/selectors")
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/selectors")
 
     assert response.status_code == 200
     assert "mail" in response.json()["report_selectors"]
@@ -241,10 +241,10 @@ def test_get_selectors_report_selector_moves_to_manual_when_added(authed_client:
     assert "google" not in data["report_selectors"]
 
 
-def test_dns_endpoint_returns_dkim_selectors_as_list(client: TestClient):
+def test_dns_endpoint_returns_dkim_selectors_as_list(authed_client: TestClient):
     """The /dns endpoint should return dkimSelectors as a list."""
     with _mock_dns():
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns")
 
     assert response.status_code == 200
     data = response.json()
@@ -252,10 +252,10 @@ def test_dns_endpoint_returns_dkim_selectors_as_list(client: TestClient):
     assert "google" in data["dkimSelectors"]
 
 
-def test_dns_endpoint_returns_real_data(client: TestClient):
+def test_dns_endpoint_returns_real_data(authed_client: TestClient):
     """The /dns endpoint should return the mocked DNS check result."""
     with _mock_dns():
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns")
 
     assert response.status_code == 200
     data = response.json()
@@ -267,7 +267,7 @@ def test_dns_endpoint_returns_real_data(client: TestClient):
     assert data["checkedAt"] is not None
 
 
-def test_dns_endpoint_returns_dmarc_lint_findings(client: TestClient):
+def test_dns_endpoint_returns_dmarc_lint_findings(authed_client: TestClient):
     result = DomainDNSResult(
         dmarc=True,
         dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@reports.example.net",
@@ -279,7 +279,7 @@ def test_dns_endpoint_returns_dmarc_lint_findings(client: TestClient):
     )
 
     with _mock_dns(result):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns")
 
     assert response.status_code == 200
     data = response.json()
@@ -287,7 +287,7 @@ def test_dns_endpoint_returns_dmarc_lint_findings(client: TestClient):
     assert data["dmarcSuggestions"] == result.dmarc_suggestions
 
 
-def test_dns_lint_endpoint_returns_typed_findings_and_targets(client: TestClient):
+def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: TestClient):
     result = DomainDNSResult(
         dmarc=True,
         dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@example.com",
@@ -310,16 +310,14 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(client: TestClient
             new=AsyncMock(return_value=(bimi, False, None)),
         ),
     ):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns/lint")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/lint")
 
     assert response.status_code == 200
     data = response.json()
     assert data["domain"] == DOMAIN
     assert data["status"] == "attention"
     codes = {finding["code"] for finding in data["findings"]}
-    assert {"dkim_selector_missing", "tls_rpt_missing", "bimi_dmarc_not_enforced"}.issubset(
-        codes
-    )
+    assert {"dkim_selector_missing", "tls_rpt_missing", "bimi_dmarc_not_enforced"}.issubset(codes)
     assert {record["code"] for record in data["target_records"]} >= {
         "target_dmarc",
         "target_spf",
@@ -328,7 +326,7 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(client: TestClient
     }
 
 
-def test_dns_lint_bulk_and_export(client: TestClient):
+def test_dns_lint_bulk_and_export(authed_client: TestClient):
     mta_sts = MTAStsResult(status="pass")
     bimi = BIMIResult(status="pass")
 
@@ -343,8 +341,8 @@ def test_dns_lint_bulk_and_export(client: TestClient):
             new=AsyncMock(return_value=(bimi, False, None)),
         ),
     ):
-        response = client.get("/api/v1/domains/dns/lint")
-        export = client.get("/api/v1/domains/dns/lint/export")
+        response = authed_client.get("/api/v1/domains/dns/lint")
+        export = authed_client.get("/api/v1/domains/dns/lint/export")
 
     assert response.status_code == 200
     data = response.json()
@@ -355,7 +353,7 @@ def test_dns_lint_bulk_and_export(client: TestClient):
     assert DOMAIN in export.text
 
 
-def test_dns_endpoint_uses_cached_result(client: TestClient, db_session):
+def test_dns_endpoint_uses_cached_result(authed_client: TestClient, db_session):
     """Repeated DNS checks reuse a fresh cached result."""
     mock_provider = AsyncMock(check_domain=AsyncMock(return_value=MOCK_DNS_RESULT))
 
@@ -363,8 +361,8 @@ def test_dns_endpoint_uses_cached_result(client: TestClient, db_session):
         "app.api.api_v1.endpoints.domains.get_default_provider",
         return_value=mock_provider,
     ):
-        first = client.get(f"/api/v1/domains/{DOMAIN}/dns")
-        second = client.get(f"/api/v1/domains/{DOMAIN}/dns")
+        first = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns")
+        second = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns")
 
     assert first.status_code == 200
     assert second.status_code == 200
@@ -440,7 +438,7 @@ async def test_dns_cache_reraises_when_conflict_row_missing(db_session, monkeypa
         )
 
 
-def test_dns_endpoint_refresh_bypasses_cache(client: TestClient):
+def test_dns_endpoint_refresh_bypasses_cache(authed_client: TestClient):
     """The refresh query parameter forces a new DNS lookup."""
     mock_provider = AsyncMock(check_domain=AsyncMock(return_value=MOCK_DNS_RESULT))
 
@@ -448,8 +446,8 @@ def test_dns_endpoint_refresh_bypasses_cache(client: TestClient):
         "app.api.api_v1.endpoints.domains.get_default_provider",
         return_value=mock_provider,
     ):
-        client.get(f"/api/v1/domains/{DOMAIN}/dns")
-        refreshed = client.get(f"/api/v1/domains/{DOMAIN}/dns?refresh=true")
+        authed_client.get(f"/api/v1/domains/{DOMAIN}/dns")
+        refreshed = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns?refresh=true")
 
     assert refreshed.status_code == 200
     assert refreshed.json()["cached"] is False
@@ -476,31 +474,31 @@ def test_dns_endpoint_uses_manual_selectors(authed_client: TestClient):
     assert "customsel" in captured_selectors
 
 
-def test_dns_endpoint_404_for_unknown_domain(client: TestClient):
+def test_dns_endpoint_404_for_unknown_domain(authed_client: TestClient):
     with _mock_dns():
-        response = client.get("/api/v1/domains/unknown.example.com/dns")
+        response = authed_client.get("/api/v1/domains/unknown.example.com/dns")
     assert response.status_code == 404
 
 
-def test_dns_endpoint_supports_manually_configured_domain(client: TestClient, db_session):
+def test_dns_endpoint_supports_manually_configured_domain(authed_client: TestClient, db_session):
     """A domain created before reports arrive can still run DNS checks."""
     db_session.add(Domain(name="manual.example", active=True))
     db_session.commit()
 
     with _mock_dns():
-        response = client.get("/api/v1/domains/manual.example/dns")
+        response = authed_client.get("/api/v1/domains/manual.example/dns")
 
     assert response.status_code == 200
     assert response.json()["dmarc"] is True
 
 
-def test_dns_health_404_for_unknown_domain(client: TestClient):
+def test_dns_health_404_for_unknown_domain(authed_client: TestClient):
     with _mock_dns():
-        response = client.get("/api/v1/domains/unknown.example.com/dns/health")
+        response = authed_client.get("/api/v1/domains/unknown.example.com/dns/health")
     assert response.status_code == 404
 
 
-def test_dns_health_links_checks_to_evidence(client: TestClient):
+def test_dns_health_links_checks_to_evidence(authed_client: TestClient):
     """DNS health returns provider-neutral checks, recommendations, and evidence links."""
     missing_dkim = DomainDNSResult(
         dmarc=True,
@@ -536,7 +534,7 @@ def test_dns_health_links_checks_to_evidence(client: TestClient):
             new=AsyncMock(return_value=(bimi, False, None)),
         ),
     ):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns/health")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/health")
 
     assert response.status_code == 200
     data = response.json()
@@ -554,7 +552,7 @@ def test_dns_health_links_checks_to_evidence(client: TestClient):
     assert any(item["type"] == "missing_dkim" for item in data["recommendations"])
 
 
-def test_dns_health_recommends_enforcement_when_evidence_supports_it(client: TestClient):
+def test_dns_health_recommends_enforcement_when_evidence_supports_it(authed_client: TestClient):
     """High-volume p=none domains with strong compliance get plan-only guidance."""
     store = ReportStore.get_instance()
     store.clear()
@@ -574,7 +572,7 @@ def test_dns_health_recommends_enforcement_when_evidence_supports_it(client: Tes
     )
 
     with _mock_dns():
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns/health")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/health")
 
     assert response.status_code == 200
     recommendations = response.json()["recommendations"]
@@ -583,7 +581,7 @@ def test_dns_health_recommends_enforcement_when_evidence_supports_it(client: Tes
     assert any(item["label"] == "Compliance" for item in readiness["evidence"])
 
 
-def test_dns_health_marks_all_missing_records_critical(client: TestClient):
+def test_dns_health_marks_all_missing_records_critical(authed_client: TestClient):
     """Missing DMARC, SPF, and DKIM produce specific repair recommendations."""
     missing_all = DomainDNSResult(
         dmarc=False,
@@ -593,7 +591,7 @@ def test_dns_health_marks_all_missing_records_critical(client: TestClient):
     )
 
     with _mock_dns(result=missing_all):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns/health")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/health")
 
     assert response.status_code == 200
     data = response.json()
@@ -605,7 +603,7 @@ def test_dns_health_marks_all_missing_records_critical(client: TestClient):
     assert any(item["type"] == "policy_needs_more_data" for item in data["recommendations"])
 
 
-def test_mta_sts_endpoint_returns_cached_posture(client: TestClient):
+def test_mta_sts_endpoint_returns_cached_posture(authed_client: TestClient):
     """The domain detail page can fetch MTA-STS posture with cache metadata."""
     checked_at = datetime(2026, 5, 23, 12, 0, 0)
     result = MTAStsResult(
@@ -619,7 +617,7 @@ def test_mta_sts_endpoint_returns_cached_posture(client: TestClient):
         "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
         new=AsyncMock(return_value=(result, True, checked_at)),
     ):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns/mta-sts")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/mta-sts")
 
     assert response.status_code == 200
     data = response.json()
@@ -629,13 +627,13 @@ def test_mta_sts_endpoint_returns_cached_posture(client: TestClient):
     assert data["errors"] == ["No _mta-sts TXT record was found."]
 
 
-def test_mta_sts_endpoint_returns_404_for_unknown_domain(client: TestClient):
-    response = client.get("/api/v1/domains/unknown.example.com/dns/mta-sts")
+def test_mta_sts_endpoint_returns_404_for_unknown_domain(authed_client: TestClient):
+    response = authed_client.get("/api/v1/domains/unknown.example.com/dns/mta-sts")
 
     assert response.status_code == 404
 
 
-def test_bimi_endpoint_returns_cached_posture(client: TestClient):
+def test_bimi_endpoint_returns_cached_posture(authed_client: TestClient):
     """The domain detail page can fetch BIMI posture with cache metadata."""
     checked_at = datetime(2026, 5, 23, 12, 0, 0)
     result = BIMIResult(
@@ -651,7 +649,7 @@ def test_bimi_endpoint_returns_cached_posture(client: TestClient):
         "app.api.api_v1.endpoints.domains.check_bimi_cached",
         new=AsyncMock(return_value=(result, True, checked_at)),
     ):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/dns/bimi")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/bimi")
 
     assert response.status_code == 200
     data = response.json()
@@ -662,14 +660,14 @@ def test_bimi_endpoint_returns_cached_posture(client: TestClient):
     assert data["checked_at"] == checked_at.isoformat()
 
 
-def test_bimi_endpoint_returns_404_for_unknown_domain(client: TestClient):
-    response = client.get("/api/v1/domains/unknown.example.com/dns/bimi")
+def test_bimi_endpoint_returns_404_for_unknown_domain(authed_client: TestClient):
+    response = authed_client.get("/api/v1/domains/unknown.example.com/dns/bimi")
 
     assert response.status_code == 404
 
 
 def test_posture_dashboard_links_recommendations_changes_and_playbooks(
-    client: TestClient, db_session
+    authed_client: TestClient, db_session
 ):
     """The posture dashboard is actionable and links back to underlying evidence."""
     db_session.add(
@@ -722,7 +720,7 @@ def test_posture_dashboard_links_recommendations_changes_and_playbooks(
             new=AsyncMock(return_value=(bimi, False, None)),
         ),
     ):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/posture")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/posture")
 
     assert response.status_code == 200
     data = response.json()
@@ -738,22 +736,22 @@ def test_posture_dashboard_links_recommendations_changes_and_playbooks(
     assert any(playbook["key"] == "missing_spf" for playbook in data["playbooks"])
 
 
-def test_posture_dashboard_returns_404_for_unknown_domain(client: TestClient):
-    response = client.get("/api/v1/domains/unknown.example.com/posture")
+def test_posture_dashboard_returns_404_for_unknown_domain(authed_client: TestClient):
+    response = authed_client.get("/api/v1/domains/unknown.example.com/posture")
 
     assert response.status_code == 404
 
 
 def test_domain_detail_data_endpoints_support_manually_configured_domain(
-    client: TestClient, db_session
+    authed_client: TestClient, db_session
 ):
     """Manually monitored domains should render empty detail data instead of 404s."""
     db_session.add(Domain(name="manual.example", active=True))
     db_session.commit()
 
-    reports = client.get("/api/v1/domains/manual.example/reports")
-    sources = client.get("/api/v1/domains/manual.example/sources")
-    selectors = client.get("/api/v1/domains/manual.example/selectors")
+    reports = authed_client.get("/api/v1/domains/manual.example/reports")
+    sources = authed_client.get("/api/v1/domains/manual.example/sources")
+    selectors = authed_client.get("/api/v1/domains/manual.example/selectors")
 
     assert reports.status_code == 200
     assert reports.json()["reports"] == []
@@ -808,10 +806,10 @@ def test_enforcement_recommendation_common_states(
 # ---------------------------------------------------------------------------
 
 
-def test_summary_includes_dns_fields(client: TestClient):
+def test_summary_includes_dns_fields(authed_client: TestClient):
     """The summary endpoint should include dmarc_status, spf_status, dkim_status."""
     with _mock_dns():
-        response = client.get("/api/v1/domains/summary")
+        response = authed_client.get("/api/v1/domains/summary")
 
     assert response.status_code == 200
     data = response.json()
@@ -826,12 +824,12 @@ def test_summary_includes_dns_fields(client: TestClient):
     assert domain["dmarc_policy"] == "none"
 
 
-def test_summary_dns_failure_defaults_false(client: TestClient):
+def test_summary_dns_failure_defaults_false(authed_client: TestClient):
     """If DNS check fails, status fields default to False rather than crashing."""
     empty_result = DomainDNSResult()
 
     with _mock_dns(result=empty_result):
-        response = client.get("/api/v1/domains/summary")
+        response = authed_client.get("/api/v1/domains/summary")
 
     assert response.status_code == 200
     domain = response.json()["domains"][0]
@@ -920,13 +918,13 @@ def _mock_provider(hostname=None):
     )
 
 
-def test_sources_endpoint_includes_hostname(client: TestClient):
+def test_sources_endpoint_includes_hostname(authed_client: TestClient):
     """The /sources endpoint should return the rDNS hostname when available."""
     store = ReportStore.get_instance()
     store.add_report(FAILING_SOURCE_REPORT)
 
     with _mock_provider(hostname="mail.example.com"):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/sources")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources")
 
     assert response.status_code == 200
     sources = response.json()["sources"]
@@ -936,10 +934,10 @@ def test_sources_endpoint_includes_hostname(client: TestClient):
     assert failing["hostname"] == "mail.example.com"
 
 
-def test_sources_endpoint_hostname_none_when_no_ptr(client: TestClient):
+def test_sources_endpoint_hostname_none_when_no_ptr(authed_client: TestClient):
     """The /sources endpoint should return null hostname when no PTR record exists."""
     with _mock_provider(hostname=None):
-        response = client.get(f"/api/v1/domains/{DOMAIN}/sources")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources")
 
     assert response.status_code == 200
     sources = response.json()["sources"]
@@ -948,13 +946,13 @@ def test_sources_endpoint_hostname_none_when_no_ptr(client: TestClient):
         assert "hostname" in source
 
 
-def test_sources_endpoint_spf_fix_hint_for_failing_ip(client: TestClient):
+def test_sources_endpoint_spf_fix_hint_for_failing_ip(authed_client: TestClient):
     """A source with spf=fail should receive an spf_fix_hint containing its IP."""
     store = ReportStore.get_instance()
     store.add_report(FAILING_SOURCE_REPORT)
 
     with _mock_provider():
-        response = client.get(f"/api/v1/domains/{DOMAIN}/sources")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources")
 
     assert response.status_code == 200
     sources = response.json()["sources"]
@@ -963,10 +961,10 @@ def test_sources_endpoint_spf_fix_hint_for_failing_ip(client: TestClient):
     assert failing["spf_fix_hint"] == "ip4:10.0.0.1"
 
 
-def test_sources_endpoint_no_fix_hint_when_spf_passes(client: TestClient):
+def test_sources_endpoint_no_fix_hint_when_spf_passes(authed_client: TestClient):
     """A source with spf=pass should not receive an spf_fix_hint."""
     with _mock_provider():
-        response = client.get(f"/api/v1/domains/{DOMAIN}/sources")
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources")
 
     assert response.status_code == 200
     sources = response.json()["sources"]

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -74,10 +74,10 @@ REPORT_STR_POLICY = {
 
 
 @pytest.fixture()
-def seeded_client(client: TestClient):
+def seeded_client(authed_client: TestClient):
     """Client with one report (dict-style policy) in the ReportStore."""
     ReportStore.get_instance().add_report(REPORT_DICT_POLICY)
-    return client
+    return authed_client
 
 
 # ---------------------------------------------------------------------------
@@ -103,10 +103,10 @@ def test_get_domain_reports_policy_dict_extracted(seeded_client: TestClient):
     assert reports[0]["policy"] == "reject"
 
 
-def test_get_domain_reports_policy_string_preserved(client: TestClient):
+def test_get_domain_reports_policy_string_preserved(authed_client: TestClient):
     """When the stored policy is already a string it should be kept as-is."""
     ReportStore.get_instance().add_report(REPORT_STR_POLICY)
-    response = client.get(f"/api/v1/domains/{DOMAIN}/reports")
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/reports")
     assert response.status_code == 200
     reports = response.json()["reports"]
     assert len(reports) == 1
@@ -132,9 +132,9 @@ def test_get_domain_reports_uses_nested_summary_totals(seeded_client: TestClient
     assert report["total_emails"] == 10
 
 
-def test_get_domain_reports_unknown_domain_returns_404(client: TestClient):
+def test_get_domain_reports_unknown_domain_returns_404(authed_client: TestClient):
     """Returns 404 when the requested domain has no reports."""
-    response = client.get("/api/v1/domains/no-such-domain.example.com/reports")
+    response = authed_client.get("/api/v1/domains/no-such-domain.example.com/reports")
     assert response.status_code == 404
 
 
@@ -171,7 +171,7 @@ def test_export_domain_reports_returns_csv(seeded_client: TestClient):
     assert rows[0]["generator"] == "ExampleRUA 2.0"
 
 
-def test_export_domain_reports_filters_by_date_range(client: TestClient):
+def test_export_domain_reports_filters_by_date_range(authed_client: TestClient):
     """CSV export only includes reports inside the requested date range."""
     ReportStore.get_instance().add_report(REPORT_DICT_POLICY)
     ReportStore.get_instance().add_report(
@@ -185,7 +185,7 @@ def test_export_domain_reports_filters_by_date_range(client: TestClient):
         }
     )
 
-    response = client.get(
+    response = authed_client.get(
         f"/api/v1/domains/{DOMAIN}/reports/export?start_date=2020-08-16&end_date=2020-08-16"
     )
 
@@ -203,9 +203,9 @@ def test_export_domain_reports_rejects_invalid_date_order(seeded_client: TestCli
     assert response.status_code == 422
 
 
-def test_export_domain_reports_unknown_domain_returns_404(client: TestClient):
+def test_export_domain_reports_unknown_domain_returns_404(authed_client: TestClient):
     """Returns 404 when exporting a domain with no reports."""
-    response = client.get("/api/v1/domains/no-such-domain.example.com/reports/export")
+    response = authed_client.get("/api/v1/domains/no-such-domain.example.com/reports/export")
     assert response.status_code == 404
 
 
@@ -228,7 +228,7 @@ def test_get_domain_sources_returns_200(seeded_client: TestClient):
     assert source["dmarc"] == "pass"
 
 
-def test_get_domain_sources_returns_rollup_counts(client: TestClient):
+def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
     """Endpoint reports pass/fail totals instead of only the latest IP result."""
     report = {
         **REPORT_DICT_POLICY,
@@ -255,7 +255,7 @@ def test_get_domain_sources_returns_rollup_counts(client: TestClient):
     }
     ReportStore.get_instance().add_report(report)
 
-    response = client.get(f"/api/v1/domains/{DOMAIN}/sources")
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources")
 
     assert response.status_code == 200
     source = response.json()["sources"][0]
@@ -274,7 +274,7 @@ def test_get_domain_sources_returns_rollup_counts(client: TestClient):
 
 
 def test_get_domain_sources_returns_recommendations(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    authed_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ):
     """Endpoint includes actionable guidance for common failure patterns."""
 
@@ -299,7 +299,7 @@ def test_get_domain_sources_returns_recommendations(
     }
     ReportStore.get_instance().add_report(report)
 
-    response = client.get(f"/api/v1/domains/{DOMAIN}/sources")
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources")
 
     assert response.status_code == 200
     source = response.json()["sources"][0]
@@ -385,7 +385,7 @@ def test_get_domain_sources_days_param_accepted(seeded_client: TestClient):
     assert response.status_code == 200
 
 
-def test_get_domain_sources_unknown_domain_returns_404(client: TestClient):
+def test_get_domain_sources_unknown_domain_returns_404(authed_client: TestClient):
     """Returns 404 when the requested domain has no reports."""
-    response = client.get("/api/v1/domains/no-such-domain.example.com/sources")
+    response = authed_client.get("/api/v1/domains/no-such-domain.example.com/sources")
     assert response.status_code == 404

--- a/backend/app/tests/test_workspaces.py
+++ b/backend/app/tests/test_workspaces.py
@@ -1,10 +1,16 @@
+from contextlib import contextmanager
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.database import get_db
+from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.user import User
 from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
+from app.services.workspace_access import ROLE_ANALYST
 from app.services.workspaces import (
     DEFAULT_WORKSPACE_SLUG,
     assign_default_workspace_to_unscoped_rows,
@@ -15,6 +21,27 @@ from app.services.workspaces import (
     workspace_mail_source_query,
     workspace_user_query,
 )
+
+
+@contextmanager
+def _client_as_user(test_app, db_session: Session, user: User):
+    async def mock_admin_auth():
+        return {"auth_type": "session", "user_id": user.id}
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    original_overrides = dict(test_app.dependency_overrides)
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    try:
+        with TestClient(test_app) as client:
+            yield client
+    finally:
+        test_app.dependency_overrides = original_overrides
 
 
 def test_default_workspace_claims_legacy_rows(db_session: Session):
@@ -105,3 +132,35 @@ def test_domain_api_defaults_to_default_workspace(
     names = {item["name"] for item in listed.json()}
     assert "default.example" in names
     assert "other.example" not in names
+
+
+def test_domain_read_routes_enforce_workspace_membership(
+    test_app,
+    client: TestClient,
+    db_session: Session,
+):
+    """Read-only domain surfaces allow analysts but reject unauthenticated callers."""
+    workspace = get_or_create_default_workspace(db_session)
+    domain = Domain(name="analyst.example", workspace_id=workspace.id, active=True)
+    analyst = User(email="domain-analyst@example.com", is_active=True, is_verified=True)
+    db_session.add_all([domain, analyst])
+    db_session.flush()
+    db_session.add(
+        WorkspaceMembership(
+            workspace_id=workspace.id,
+            user_id=analyst.id,
+            role=ROLE_ANALYST,
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    assert client.get("/api/v1/domains/domains").status_code == 401
+
+    with _client_as_user(test_app, db_session, analyst) as user_client:
+        listed = user_client.get("/api/v1/domains/domains")
+        assert listed.status_code == 200
+        assert {item["name"] for item in listed.json()} == {"analyst.example"}
+
+        deleted = user_client.delete("/api/v1/domains/analyst.example")
+        assert deleted.status_code == 403


### PR DESCRIPTION
## Summary
- require report-read workspace permission for domain inventory, summary, search, DNS health/lint/posture, sources, selectors, and report export/detail routes
- keep domain deletion behind domain-write workspace permission and delete only inside the authorized workspace
- ensure the default workspace exists before workspace-aware domain checks
- update affected endpoint tests to authenticate and add analyst read/delete-denial coverage

## Validation
- `.venv/bin/black backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_workspaces.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py`
- `.venv/bin/isort backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_workspaces.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py`
- `.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_workspaces.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py`
- `PYTHONPATH=backend .venv/bin/python -m pytest -q backend/app/tests/test_workspaces.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py`

Refs #236