### PR TITLE
test: cover organization provider RBAC edges

### DIFF
--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from datetime import datetime
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -240,28 +241,20 @@ def test_provider_subscription_state_update_rejects_invalid_or_empty_scope(
     subscription.external_subscription_id = "sub-provider-456"
     db_session.commit()
 
-    try:
+    with pytest.raises(ValueError, match="status must be one of"):
         update_external_subscription_state(
             db_session,
             external_subscription_id="sub-provider-456",
             status="paused",
         )
-    except ValueError as exc:
-        assert "status must be one of" in str(exc)
-    else:
-        raise AssertionError("invalid provider status was not rejected")
 
-    try:
+    with pytest.raises(LookupError, match="external subscription not found"):
         update_external_subscription_state(
             db_session,
             external_subscription_id="sub-provider-456",
             status="suspended",
             organization_ids=[],
         )
-    except LookupError as exc:
-        assert "external subscription not found" in str(exc)
-    else:
-        raise AssertionError("empty organization scope was not enforced")
 
 
 def test_provider_subscription_state_endpoint_requires_org_admin_access(

--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -147,6 +147,16 @@ def test_provider_usage_export_computes_monthly_metrics(db_session: Session):
     )
 
 
+def test_provider_usage_export_accepts_empty_authorized_organization_scope(
+    db_session: Session,
+):
+    bootstrap_default_commercial_foundation(db_session)
+
+    usage = build_usage_export(db_session, period="2026-06", organization_ids=[])
+
+    assert usage["organizations"] == []
+
+
 def test_provider_usage_endpoint_rejects_bad_period(authed_client: TestClient):
     response = authed_client.get("/api/v1/provider/billing/usage?period=2026")
 
@@ -218,6 +228,40 @@ def test_provider_subscription_state_update_records_billing_event(db_session: Se
     assert subscription.status == "suspended"
     assert event.event_type == "provider.subscription_state_updated"
     assert event.external_event_id == "evt-1"
+
+
+def test_provider_subscription_state_update_rejects_invalid_or_empty_scope(
+    db_session: Session,
+):
+    organization = bootstrap_default_commercial_foundation(db_session)
+    subscription = (
+        db_session.query(Subscription).filter(Subscription.organization_id == organization.id).one()
+    )
+    subscription.external_subscription_id = "sub-provider-456"
+    db_session.commit()
+
+    try:
+        update_external_subscription_state(
+            db_session,
+            external_subscription_id="sub-provider-456",
+            status="paused",
+        )
+    except ValueError as exc:
+        assert "status must be one of" in str(exc)
+    else:
+        raise AssertionError("invalid provider status was not rejected")
+
+    try:
+        update_external_subscription_state(
+            db_session,
+            external_subscription_id="sub-provider-456",
+            status="suspended",
+            organization_ids=[],
+        )
+    except LookupError as exc:
+        assert "external subscription not found" in str(exc)
+    else:
+        raise AssertionError("empty organization scope was not enforced")
 
 
 def test_provider_subscription_state_endpoint_requires_org_admin_access(

--- a/backend/app/tests/test_workspace_audit.py
+++ b/backend/app/tests/test_workspace_audit.py
@@ -7,18 +7,22 @@ from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
+from app.models.organization import Organization, OrganizationMembership
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services.workspace_access import (
+    PERMISSION_REPORTS_READ,
     PERMISSION_WORKSPACE_ADMIN,
     ROLE_ANALYST,
     ROLE_AUDITOR,
     ROLE_DOMAIN_ADMIN,
     ROLE_WORKSPACE_OWNER,
+    organization_ids_for_permission,
     require_workspace_permission,
     role_for_auth_context,
+    role_for_organization,
     role_for_workspace,
 )
 from app.services.workspace_audit import (
@@ -232,6 +236,141 @@ def test_workspace_role_resolution_uses_membership(db_session: Session):
         role_for_workspace(db_session, {"auth_type": "session", "user_id": outsider.id}, workspace)
         == ""
     )
+
+
+def test_organization_role_resolution_uses_org_workspace_and_superuser_paths(
+    db_session: Session,
+):
+    """Organization RBAC accepts direct org, workspace, and legacy superuser grants."""
+    organization = Organization(slug="rbac-org", name="RBAC Org", active=True)
+    other_organization = Organization(slug="other-rbac-org", name="Other RBAC Org", active=True)
+    db_session.add_all([organization, other_organization])
+    db_session.flush()
+    workspace = Workspace(
+        slug="rbac-workspace",
+        name="RBAC Workspace",
+        organization_id=organization.id,
+        active=True,
+    )
+    superuser_workspace = Workspace(
+        slug="superuser-workspace",
+        name="Superuser Workspace",
+        organization_id=organization.id,
+        active=True,
+    )
+    db_session.add_all([workspace, superuser_workspace])
+    db_session.flush()
+    org_auditor = _add_user(db_session, "org-auditor@example.com")
+    workspace_owner = _add_user(db_session, "workspace-owner@example.com")
+    superuser = _add_user(
+        db_session,
+        "org-superuser@example.com",
+        workspace_id=superuser_workspace.id,
+        is_superuser=True,
+    )
+    _add_membership(db_session, workspace, workspace_owner, ROLE_WORKSPACE_OWNER)
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=org_auditor.id,
+            role="organization_auditor",
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    assert (
+        role_for_organization(
+            db_session,
+            {"auth_type": "api_key"},
+            organization,
+            PERMISSION_WORKSPACE_ADMIN,
+        )
+        == ROLE_WORKSPACE_OWNER
+    )
+    assert (
+        role_for_organization(
+            db_session,
+            {"auth_type": "session", "user_id": org_auditor.id},
+            organization,
+            PERMISSION_REPORTS_READ,
+        )
+        == ROLE_AUDITOR
+    )
+    assert (
+        role_for_organization(
+            db_session,
+            {"auth_type": "session", "user_id": org_auditor.id},
+            organization,
+            PERMISSION_WORKSPACE_ADMIN,
+        )
+        == ""
+    )
+    assert (
+        role_for_organization(
+            db_session,
+            {"auth_type": "session", "user_id": workspace_owner.id},
+            organization,
+            PERMISSION_WORKSPACE_ADMIN,
+        )
+        == ROLE_WORKSPACE_OWNER
+    )
+    assert (
+        role_for_organization(
+            db_session,
+            {"auth_type": "session", "user_id": superuser.id},
+            organization,
+            PERMISSION_WORKSPACE_ADMIN,
+        )
+        == ROLE_WORKSPACE_OWNER
+    )
+    assert (
+        role_for_organization(
+            db_session,
+            {"auth_type": "session", "user_id": superuser.id},
+            other_organization,
+            PERMISSION_WORKSPACE_ADMIN,
+        )
+        == ""
+    )
+    assert (
+        role_for_organization(
+            db_session,
+            {"auth_type": "session", "user_id": 999999},
+            organization,
+            PERMISSION_REPORTS_READ,
+        )
+        == ""
+    )
+
+    assert organization_ids_for_permission(
+        db_session,
+        {"auth_type": "api_key"},
+        PERMISSION_WORKSPACE_ADMIN,
+    ) is None
+    assert (
+        organization_ids_for_permission(
+            db_session,
+            {"auth_type": "session", "user_id": 999999},
+            PERMISSION_WORKSPACE_ADMIN,
+        )
+        == []
+    )
+    assert organization_ids_for_permission(
+        db_session,
+        {"auth_type": "session", "user_id": org_auditor.id},
+        PERMISSION_REPORTS_READ,
+    ) == [organization.id]
+    assert organization_ids_for_permission(
+        db_session,
+        {"auth_type": "session", "user_id": workspace_owner.id},
+        PERMISSION_WORKSPACE_ADMIN,
+    ) == [organization.id]
+    assert organization_ids_for_permission(
+        db_session,
+        {"auth_type": "session", "user_id": superuser.id},
+        PERMISSION_WORKSPACE_ADMIN,
+    ) == [organization.id]
 
 
 def test_workspace_operator_routes_enforce_membership_roles(test_app, db_session: Session):


### PR DESCRIPTION
## Summary
- add organization RBAC coverage for direct membership, workspace membership, platform-admin, missing-user, and legacy superuser paths
- add provider billing coverage for empty organization scopes and invalid subscription statuses

## Tests
- ../dmarq-pr248.HfzhhX/.venv/bin/python -m pytest -q backend/app/tests/test_organization_foundations.py backend/app/tests/test_provider_billing_usage.py backend/app/tests/test_workspace_audit.py::test_workspace_role_resolution_uses_membership backend/app/tests/test_workspace_audit.py::test_organization_role_resolution_uses_org_workspace_and_superuser_paths --cov=app.services.workspace_access --cov=app.services.organizations --cov-report=term-missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing usage export handling for empty organization access, and added clearer validation for invalid subscription updates.
  * Strengthened workspace audit permission checks so role and organization access are resolved more consistently across different access paths.
* **Tests**
  * Added coverage for billing usage edge cases and workspace audit permission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->