### PR TITLE
test: cover domain RBAC follow-up

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1329,15 +1329,14 @@ async def read_domain(
         )
 
     summary = store.get_domain_summary(domain_name)
+    policy = summary.get("policy")
+    if isinstance(policy, dict):
+        policy = policy.get("p")
 
     return DomainResponse(
         name=domain_name,
         description=stored_domain.description if stored_domain else None,
-        policy=(
-            summary.get("policy")
-            or (stored_domain.dmarc_policy if stored_domain else None)
-            or "unknown"
-        ),
+        policy=policy or (stored_domain.dmarc_policy if stored_domain else None) or "unknown",
         reports_count=summary.get("reports_processed", 0),
         emails_count=summary.get("total_count", 0),
         compliance_rate=summary.get("compliance_rate", 0.0),
@@ -2374,8 +2373,12 @@ async def search_domains(
         if q and q.lower() not in domain_name.lower():
             continue
 
+        reported_policy = summary.get("policy", "unknown")
+        if isinstance(reported_policy, dict):
+            reported_policy = reported_policy.get("p") or "unknown"
+
         # Skip domain if it doesn't match the policy filter
-        if policy and summary.get("policy") != policy:
+        if policy and reported_policy != policy:
             continue
 
         # Domain passed all filters
@@ -2383,7 +2386,7 @@ async def search_domains(
             {
                 "name": domain_name,
                 "description": "",  # No description in in-memory store
-                "policy": summary.get("policy", "unknown"),
+                "policy": reported_policy,
                 "reports_count": summary.get("reports_processed", 0),
                 "emails_count": summary.get("total_count", 0),
                 "compliance_rate": summary.get("compliance_rate", 0.0),

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -94,6 +94,37 @@ def test_get_domain_reports_returns_200(seeded_client: TestClient):
     assert "compliance_timeline" in data
 
 
+def test_domain_read_stats_selectors_and_search_use_workspace_auth(
+    seeded_client: TestClient,
+):
+    """Read-only domain surfaces remain available after workspace RBAC checks."""
+    domain = seeded_client.get(f"/api/v1/domains/domains/{DOMAIN}")
+    assert domain.status_code == 200
+    assert domain.json()["name"] == DOMAIN
+
+    stats = seeded_client.get(f"/api/v1/domains/{DOMAIN}/stats")
+    assert stats.status_code == 200
+    assert stats.json()["totalEmails"] == 10
+
+    selectors = seeded_client.get(f"/api/v1/domains/{DOMAIN}/selectors")
+    assert selectors.status_code == 200
+    assert selectors.json() == {"selectors": [], "report_selectors": []}
+
+    search = seeded_client.get("/api/v1/domains/search?q=example")
+    assert search.status_code == 200
+    assert search.json()[0]["name"] == DOMAIN
+
+
+def test_delete_domain_uses_workspace_scoped_domain_cleanup(
+    seeded_client: TestClient,
+):
+    """Domain deletion removes the authorized workspace domain state."""
+    response = seeded_client.delete(f"/api/v1/domains/{DOMAIN}")
+
+    assert response.status_code == 204
+    assert ReportStore.get_instance().get_domains() == []
+
+
 def test_get_domain_reports_policy_dict_extracted(seeded_client: TestClient):
     """When the stored policy is a dict, the 'p' value should be surfaced."""
     response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/reports")

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -64,6 +64,20 @@ def test_public_reports_api_requires_scoped_token(client: TestClient, db_session
     assert token.last_used_ip
 
 
+def test_public_domains_summary_uses_scoped_token_context(client: TestClient, db_session):
+    """Public domain summaries reuse workspace-aware domain authorization."""
+    _seed_report_store()
+    created = create_api_token(db_session, name="summary bot", scopes=[READ_REPORTS_SCOPE])
+
+    response = client.get(
+        "/api/v1/public/domains",
+        headers={"X-API-Key": created.secret},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["domains"][0]["domain_name"] == DOMAIN
+
+
 def test_public_api_rejects_token_without_required_scope(client: TestClient, db_session):
     """Tokens are least-privilege: reports scope cannot read posture payloads."""
     _seed_report_store()


### PR DESCRIPTION
## Summary
- normalize dict-style DMARC policies before returning domain read/search responses
- add regression coverage for workspace-aware domain read surfaces and cleanup
- cover the public domain summary wrapper with scoped token auth

## Tests
- ../dmarq-pr248.HfzhhX/.venv/bin/python -m pytest -q backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_public_api.py
- ../dmarq-pr248.HfzhhX/.venv/bin/python -m pytest -q backend/app/tests/test_workspaces.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_api.py backend/app/tests/test_public_api.py --cov=app.api.api_v1.endpoints.domains --cov=app.api.api_v1.endpoints.public --cov-report=term-missing