### PR TITLE
[codex] Add membership management UI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -697,6 +697,11 @@ async def profile_page(request: Request):
     )
 
 
+@app.get("/members", response_class=HTMLResponse)
+async def members_page(request: Request):
+    return templates.TemplateResponse(request, "members.html")
+
+
 @app.get("/mail-sources", response_class=HTMLResponse)
 async def mail_sources_page(request: Request):
     return templates.TemplateResponse(request, "mail_sources.html")

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -45,6 +45,7 @@
                 <a href="/reports" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Reports</a>
                 <a href="/forensics" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Forensics</a>
                 <a href="/tls-reports" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">TLS</a>
+                <a href="/members" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Members</a>
             </nav>
             <div>
                 <template x-if="user">
@@ -65,6 +66,7 @@
                                 <span class="text-xs text-base-content/50 truncate" x-text="user.email" x-show="user.full_name"></span>
                             </li>
                             <li><a href="/profile">Profile &amp; Security</a></li>
+                            <li><a href="/members">Members</a></li>
                             <li><a href="/settings">Settings</a></li>
                             <li>
                                 <a href="/api/v1/auth/sign-out" class="text-error">
@@ -96,6 +98,9 @@
         </a>
         <a href="/forensics" aria-label="Forensics" title="Forensics" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 4h14v16H5V4Zm3 4v2h8V8H8Zm0 4v2h8v-2H8Zm0 4v2h5v-2H8Z"/></svg>
+        </a>
+        <a href="/members" aria-label="Members" title="Members" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8.5 11a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Zm7 1a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM2 19.5C2 15.9 4.9 13 8.5 13S15 15.9 15 19.5V21H2v-1.5Zm12.8 1.5v-1.5c0-2-.7-3.8-1.9-5.2.8-.2 1.7-.3 2.6-.3 3 0 5.5 2.5 5.5 5.5V21h-6.2Z"/></svg>
         </a>
         <a href="/settings" aria-label="Settings" title="Settings" class="mt-auto rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.4 13.5a7.8 7.8 0 0 0 0-3l2-1.5-2-3.5-2.4 1a7.6 7.6 0 0 0-2.6-1.5L14 2h-4l-.4 3a7.6 7.6 0 0 0-2.6 1.5l-2.4-1-2 3.5 2 1.5a7.8 7.8 0 0 0 0 3l-2 1.5 2 3.5 2.4-1a7.6 7.6 0 0 0 2.6 1.5l.4 3h4l.4-3a7.6 7.6 0 0 0 2.6-1.5l2.4 1 2-3.5-2-1.5ZM12 15.5A3.5 3.5 0 1 1 12 8a3.5 3.5 0 0 1 0 7.5Z"/></svg>

--- a/backend/app/templates/members.html
+++ b/backend/app/templates/members.html
@@ -1,0 +1,518 @@
+{% extends "layouts/base.html" %}
+{% from "components/ui/card.html" import card, card_header, card_title, card_description, card_content %}
+
+{% block title %}Members - DMARQ{% endblock %}
+
+{% block content %}
+<div x-data="membershipApp()" x-init="init()" class="mx-auto max-w-7xl space-y-6 py-4">
+    <section class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+            <p class="text-sm font-semibold uppercase text-[#2c9aa3]">Access control</p>
+            <h1 class="mt-1 text-3xl font-bold text-[#120d36]">Members</h1>
+            <p class="mt-2 max-w-2xl text-sm text-[#5f5c78]">
+                Manage who can administer workspaces, review reports, operate ingestion, and audit tenant activity.
+            </p>
+        </div>
+        <div class="grid grid-cols-3 gap-3 sm:min-w-[32rem]">
+            <div class="rounded-lg border border-[#e6e3df] bg-white p-4 shadow-sm">
+                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Organizations</p>
+                <p class="mt-2 text-2xl font-bold text-[#120d36]" x-text="organizations.length"></p>
+            </div>
+            <div class="rounded-lg border border-[#e6e3df] bg-white p-4 shadow-sm">
+                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Workspaces</p>
+                <p class="mt-2 text-2xl font-bold text-[#120d36]" x-text="workspaceCount()"></p>
+            </div>
+            <div class="rounded-lg border border-[#e6e3df] bg-white p-4 shadow-sm">
+                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Visible Members</p>
+                <p class="mt-2 text-2xl font-bold text-[#120d36]" x-text="memberships.length"></p>
+            </div>
+        </div>
+    </section>
+
+    <template x-if="flash.message">
+        <div class="alert shadow-sm" :class="flash.ok ? 'alert-success' : 'alert-error'">
+            <span x-text="flash.message"></span>
+        </div>
+    </template>
+
+    <div class="grid grid-cols-1 gap-6 xl:grid-cols-[22rem_1fr]">
+        {% call card() %}
+            {% call card_header() %}
+                {% call card_title() %}Tenant Scope{% endcall %}
+                {% call card_description() %}Choose the organization or workspace to manage.{% endcall %}
+            {% endcall %}
+            {% call card_content() %}
+                <div class="space-y-4">
+                    <div class="join w-full">
+                        <button type="button"
+                                class="btn join-item flex-1"
+                                :class="scope === 'workspace' ? 'btn-primary' : 'btn-outline'"
+                                @click="setScope('workspace')">
+                            Workspace
+                        </button>
+                        <button type="button"
+                                class="btn join-item flex-1"
+                                :class="scope === 'organization' ? 'btn-primary' : 'btn-outline'"
+                                @click="setScope('organization')">
+                            Organization
+                        </button>
+                    </div>
+
+                    <label class="form-control">
+                        <span class="label-text mb-2 font-semibold">Organization</span>
+                        <select class="select select-bordered w-full"
+                                x-model="selectedOrgId"
+                                @change="selectOrganization(selectedOrgId)">
+                            <template x-for="organization in organizations" :key="organization.id">
+                                <option :value="organization.id" x-text="organization.name"></option>
+                            </template>
+                        </select>
+                    </label>
+
+                    <template x-if="scope === 'workspace'">
+                        <label class="form-control">
+                            <span class="label-text mb-2 font-semibold">Workspace</span>
+                            <select class="select select-bordered w-full"
+                                    x-model="selectedWorkspaceId"
+                                    @change="loadMemberships()">
+                                <template x-for="workspace in currentWorkspaces()" :key="workspace.id">
+                                    <option :value="workspace.id" x-text="workspace.name"></option>
+                                </template>
+                            </select>
+                        </label>
+                    </template>
+
+                    <div class="rounded-lg border border-[#e6e3df] bg-[#f9f8f6] p-4">
+                        <p class="text-xs font-semibold uppercase text-[#5f5c78]">Current Scope</p>
+                        <p class="mt-2 font-semibold text-[#120d36]" x-text="scopeLabel()"></p>
+                        <p class="mt-1 text-sm text-[#5f5c78]" x-text="scopeDescription()"></p>
+                    </div>
+                </div>
+            {% endcall %}
+        {% endcall %}
+
+        <div class="space-y-6">
+            {% call card() %}
+                {% call card_header() %}
+                    <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div>
+                            {% call card_title() %}Invite or Link Member{% endcall %}
+                            {% call card_description() %}
+                                Add a user to the selected scope and assign the least-privilege role they need.
+                            {% endcall %}
+                        </div>
+                        <span class="badge badge-outline border-[#2c9aa3] text-[#247982]" x-text="scopeLabel()"></span>
+                    </div>
+                {% endcall %}
+                {% call card_content() %}
+                    <form class="grid grid-cols-1 gap-3 lg:grid-cols-[1.2fr_1fr_1fr_auto]"
+                          @submit.prevent="inviteMember()">
+                        <label class="form-control">
+                            <span class="label-text mb-2 font-semibold">Email</span>
+                            <input class="input input-bordered w-full"
+                                   type="email"
+                                   x-model.trim="invite.email"
+                                   placeholder="name@example.com"
+                                   required>
+                        </label>
+                        <label class="form-control">
+                            <span class="label-text mb-2 font-semibold">Display name</span>
+                            <input class="input input-bordered w-full"
+                                   type="text"
+                                   x-model.trim="invite.full_name"
+                                   placeholder="Optional">
+                        </label>
+                        <label class="form-control">
+                            <span class="label-text mb-2 font-semibold">Role</span>
+                            <select class="select select-bordered w-full" x-model="invite.role" required>
+                                <template x-for="role in availableRoles" :key="role">
+                                    <option :value="role" x-text="roleLabel(role)"></option>
+                                </template>
+                            </select>
+                        </label>
+                        <div class="flex items-end">
+                            <button type="submit"
+                                    class="btn btn-primary w-full lg:w-auto"
+                                    :disabled="saving || !canInvite()">
+                                <span x-show="saving" class="loading loading-spinner loading-xs"></span>
+                                Add
+                            </button>
+                        </div>
+                    </form>
+                {% endcall %}
+            {% endcall %}
+
+            {% call card() %}
+                {% call card_header() %}
+                    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                        <div>
+                            {% call card_title() %}Assigned Members{% endcall %}
+                            {% call card_description() %}
+                                Active and inactive assignments for the selected tenant boundary.
+                            {% endcall %}
+                        </div>
+                        <button type="button" class="btn btn-outline btn-sm" @click="loadMemberships()" :disabled="loading">
+                            <span x-show="loading" class="loading loading-spinner loading-xs"></span>
+                            Refresh
+                        </button>
+                    </div>
+                {% endcall %}
+                {% call card_content() %}
+                    <template x-if="loading">
+                        <div class="flex min-h-40 items-center justify-center text-[#5f5c78]">
+                            <span class="loading loading-spinner loading-md"></span>
+                        </div>
+                    </template>
+
+                    <template x-if="!loading && memberships.length === 0">
+                        <div class="rounded-lg border border-dashed border-[#d8d5d0] bg-[#f9f8f6] p-8 text-center">
+                            <p class="font-semibold text-[#120d36]">No members in this scope</p>
+                            <p class="mt-1 text-sm text-[#5f5c78]">Add the first assignment above.</p>
+                        </div>
+                    </template>
+
+                    <template x-if="!loading && memberships.length > 0">
+                        <div class="overflow-x-auto rounded-lg border border-[#e6e3df]">
+                            <table class="table">
+                                <thead class="bg-[#f9f8f6] text-[#5f5c78]">
+                                    <tr>
+                                        <th>Member</th>
+                                        <th>Role</th>
+                                        <th>Status</th>
+                                        <th class="text-right">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <template x-for="membership in memberships" :key="membership.scope + '-' + membership.id">
+                                        <tr>
+                                            <td>
+                                                <div class="flex items-center gap-3">
+                                                    <div class="grid h-10 w-10 place-items-center rounded-full bg-[#272a5f] text-sm font-bold text-white"
+                                                         x-text="memberInitial(membership)"></div>
+                                                    <div class="min-w-0">
+                                                        <p class="truncate font-semibold text-[#120d36]"
+                                                           x-text="membership.user.full_name || membership.user.email"></p>
+                                                        <p class="truncate text-xs text-[#5f5c78]"
+                                                           x-text="membership.user.email"></p>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td class="min-w-56">
+                                                <select class="select select-bordered select-sm w-full"
+                                                        :disabled="saving"
+                                                        x-model="membership.role"
+                                                        @change="updateMembership(membership, true)">
+                                                    <template x-for="role in availableRoles" :key="role">
+                                                        <option :value="role" x-text="roleLabel(role)"></option>
+                                                    </template>
+                                                </select>
+                                            </td>
+                                            <td>
+                                                <span class="badge"
+                                                      :class="membership.active ? 'badge-success' : 'badge-ghost'"
+                                                      x-text="membership.active ? 'Active' : 'Inactive'"></span>
+                                            </td>
+                                            <td class="text-right">
+                                                <button type="button"
+                                                        class="btn btn-outline btn-xs"
+                                                        x-show="membership.active"
+                                                        :disabled="saving"
+                                                        @click="deactivateMembership(membership)">
+                                                    Deactivate
+                                                </button>
+                                                <button type="button"
+                                                        class="btn btn-primary btn-xs"
+                                                        x-show="!membership.active"
+                                                        :disabled="saving"
+                                                        @click="updateMembership(membership, true)">
+                                                    Restore
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    </template>
+                                </tbody>
+                            </table>
+                        </div>
+                    </template>
+                {% endcall %}
+            {% endcall %}
+        </div>
+    </div>
+</div>
+
+<script>
+function membershipApp() {
+    return {
+        organizations: [],
+        memberships: [],
+        availableRoles: [],
+        selectedOrgId: '',
+        selectedWorkspaceId: '',
+        scope: 'workspace',
+        loading: false,
+        saving: false,
+        flash: { message: '', ok: true },
+        invite: { email: '', full_name: '', role: '' },
+
+        async init() {
+            await this.loadOrganizations();
+        },
+
+        apiHeaders() {
+            return { 'Content-Type': 'application/json' };
+        },
+
+        async loadOrganizations() {
+            this.loading = true;
+            try {
+                const response = await fetch('/api/v1/organizations');
+                if (response.status === 401) {
+                    window.location.href = '/login?next=/members';
+                    return;
+                }
+                if (!response.ok) {
+                    throw new Error(await this.errorText(response));
+                }
+                const data = await response.json();
+                this.organizations = data.organizations || [];
+                if (this.organizations.length > 0) {
+                    this.selectedOrgId = this.organizations[0].id;
+                    const workspaces = this.currentWorkspaces();
+                    this.selectedWorkspaceId = workspaces.length > 0 ? workspaces[0].id : '';
+                    if (!this.selectedWorkspaceId) {
+                        this.scope = 'organization';
+                    }
+                }
+                await this.loadMemberships();
+            } catch (error) {
+                this.showFlash(`Could not load tenants: ${error.message}`, false);
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        async loadMemberships() {
+            const endpoint = this.membershipEndpoint();
+            if (!endpoint) {
+                this.memberships = [];
+                this.availableRoles = [];
+                return;
+            }
+            this.loading = true;
+            try {
+                const response = await fetch(`${endpoint}?include_inactive=true`);
+                if (response.status === 401) {
+                    window.location.href = '/login?next=/members';
+                    return;
+                }
+                if (!response.ok) {
+                    throw new Error(await this.errorText(response));
+                }
+                const data = await response.json();
+                this.memberships = data.memberships || [];
+                this.availableRoles = data.available_roles || [];
+                if (!this.invite.role || !this.availableRoles.includes(this.invite.role)) {
+                    this.invite.role = this.defaultRole();
+                }
+            } catch (error) {
+                this.memberships = [];
+                this.availableRoles = [];
+                this.showFlash(`Could not load members: ${error.message}`, false);
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        async inviteMember() {
+            if (!this.canInvite()) {
+                return;
+            }
+            this.saving = true;
+            try {
+                const response = await fetch(`${this.membershipEndpoint()}/invites`, {
+                    method: 'POST',
+                    headers: this.apiHeaders(),
+                    body: JSON.stringify({
+                        email: this.invite.email,
+                        full_name: this.invite.full_name || null,
+                        role: this.invite.role,
+                    }),
+                });
+                if (!response.ok) {
+                    throw new Error(await this.errorText(response));
+                }
+                this.invite.email = '';
+                this.invite.full_name = '';
+                this.showFlash('Member assignment added.', true);
+                await this.loadMemberships();
+            } catch (error) {
+                this.showFlash(`Could not add member: ${error.message}`, false);
+            } finally {
+                this.saving = false;
+            }
+        },
+
+        async updateMembership(membership, active) {
+            this.saving = true;
+            try {
+                const response = await fetch(`${this.membershipEndpoint()}/users/${membership.user.id}`, {
+                    method: 'PUT',
+                    headers: this.apiHeaders(),
+                    body: JSON.stringify({
+                        user_id: membership.user.id,
+                        role: membership.role,
+                        active,
+                    }),
+                });
+                if (!response.ok) {
+                    throw new Error(await this.errorText(response));
+                }
+                this.showFlash('Member assignment updated.', true);
+                await this.loadMemberships();
+            } catch (error) {
+                this.showFlash(`Could not update member: ${error.message}`, false);
+                await this.loadMemberships();
+            } finally {
+                this.saving = false;
+            }
+        },
+
+        async deactivateMembership(membership) {
+            this.saving = true;
+            try {
+                const response = await fetch(`${this.membershipEndpoint()}/users/${membership.user.id}`, {
+                    method: 'DELETE',
+                    headers: this.apiHeaders(),
+                });
+                if (!response.ok) {
+                    throw new Error(await this.errorText(response));
+                }
+                this.showFlash('Member assignment deactivated.', true);
+                await this.loadMemberships();
+            } catch (error) {
+                this.showFlash(`Could not deactivate member: ${error.message}`, false);
+            } finally {
+                this.saving = false;
+            }
+        },
+
+        setScope(scope) {
+            this.scope = scope;
+            if (scope === 'workspace' && !this.selectedWorkspaceId) {
+                const workspaces = this.currentWorkspaces();
+                this.selectedWorkspaceId = workspaces.length > 0 ? workspaces[0].id : '';
+            }
+            this.loadMemberships();
+        },
+
+        selectOrganization(value) {
+            this.selectedOrgId = value;
+            const workspaces = this.currentWorkspaces();
+            this.selectedWorkspaceId = workspaces.length > 0 ? workspaces[0].id : '';
+            if (this.scope === 'workspace' && !this.selectedWorkspaceId) {
+                this.scope = 'organization';
+            }
+            this.loadMemberships();
+        },
+
+        membershipEndpoint() {
+            if (this.scope === 'organization') {
+                return this.selectedOrgId
+                    ? `/api/v1/memberships/organizations/${this.selectedOrgId}`
+                    : '';
+            }
+            return this.selectedWorkspaceId
+                ? `/api/v1/memberships/workspaces/${this.selectedWorkspaceId}`
+                : '';
+        },
+
+        currentOrganization() {
+            return this.organizations.find((organization) => String(organization.id) === String(this.selectedOrgId));
+        },
+
+        currentWorkspaces() {
+            const organization = this.currentOrganization();
+            return organization ? (organization.workspaces || []) : [];
+        },
+
+        workspaceCount() {
+            return this.organizations.reduce((count, organization) => {
+                return count + (organization.workspaces || []).length;
+            }, 0);
+        },
+
+        currentWorkspace() {
+            return this.currentWorkspaces().find((workspace) => String(workspace.id) === String(this.selectedWorkspaceId));
+        },
+
+        scopeLabel() {
+            if (this.scope === 'organization') {
+                const organization = this.currentOrganization();
+                return organization ? organization.name : 'Organization';
+            }
+            const workspace = this.currentWorkspace();
+            return workspace ? workspace.name : 'Workspace';
+        },
+
+        scopeDescription() {
+            if (this.scope === 'organization') {
+                return 'Organization roles apply across tenant-level account and billing surfaces.';
+            }
+            return 'Workspace roles control reports, domains, mail sources, settings, and audit access.';
+        },
+
+        roleLabel(role) {
+            const labels = {
+                workspace_owner: 'Workspace owner',
+                domain_admin: 'Domain admin',
+                operator: 'Operator',
+                analyst: 'Analyst',
+                auditor: 'Auditor',
+                organization_owner: 'Organization owner',
+                organization_admin: 'Organization admin',
+                billing_admin: 'Billing admin',
+                organization_auditor: 'Organization auditor',
+            };
+            return labels[role] || role.replaceAll('_', ' ');
+        },
+
+        defaultRole() {
+            if (this.scope === 'organization' && this.availableRoles.includes('organization_auditor')) {
+                return 'organization_auditor';
+            }
+            if (this.availableRoles.includes('analyst')) {
+                return 'analyst';
+            }
+            return this.availableRoles[0] || '';
+        },
+
+        canInvite() {
+            return Boolean(this.membershipEndpoint() && this.invite.email && this.invite.role);
+        },
+
+        memberInitial(membership) {
+            const value = membership.user.full_name || membership.user.email || '?';
+            return value.trim().charAt(0).toUpperCase();
+        },
+
+        showFlash(message, ok) {
+            this.flash = { message, ok };
+            window.setTimeout(() => {
+                if (this.flash.message === message) {
+                    this.flash.message = '';
+                }
+            }, 4500);
+        },
+
+        async errorText(response) {
+            try {
+                const data = await response.json();
+                return data.detail || response.statusText;
+            } catch (_) {
+                return response.statusText;
+            }
+        },
+    };
+}
+</script>
+{% endblock %}

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -1,5 +1,7 @@
 from fastapi.testclient import TestClient
 
+from app.main import app
+
 
 def test_health_check(authed_client: TestClient):
     """Test the health check endpoint returns status ok."""
@@ -62,6 +64,11 @@ def test_setup_status_includes_mailbox_recovery_hint(authed_client: TestClient):
     data = response.json()
     assert data["mailbox_recovery_hint"]["category"] == "not_configured"
     assert data["mailbox_recovery_hint"]["recovery_steps"]
+
+
+def test_members_page_route_is_registered():
+    """The membership management page is available from the server-rendered UI."""
+    assert any(getattr(route, "path", None) == "/members" for route in app.routes)
 
 
 def test_reports_upload_invalid_extension(authed_client: TestClient):

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -18,3 +18,13 @@ def test_dashboard_domain_details_links_are_encoded():
     template = (Path(__file__).resolve().parents[1] / "templates" / "index.html").read_text()
 
     assert "encodeURIComponent(domainId)" in template
+
+
+def test_members_template_uses_membership_api_without_html_injection():
+    template = (Path(__file__).resolve().parents[1] / "templates" / "members.html").read_text()
+
+    assert "/api/v1/organizations" in template
+    assert "/api/v1/memberships/organizations/" in template
+    assert "/api/v1/memberships/workspaces/" in template
+    assert 'x-text="membership.user.email"' in template
+    assert "x-html" not in template


### PR DESCRIPTION
## Summary
- add a server-rendered Members page for organization and workspace access management
- wire the page into top navigation, user menu, and side navigation
- load organizations/workspaces, list active/inactive memberships, invite/link users, update roles, deactivate, and restore assignments through the membership APIs
- add route/template regression coverage and keep member data rendered through Alpine x-text bindings

## Validation
- python3 -m py_compile backend/app/main.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-membership-venv.mVtg2Q/bin/black --check backend/app/main.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-membership-venv.mVtg2Q/bin/isort --check-only backend/app/main.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-membership-venv.mVtg2Q/bin/flake8 backend/app/main.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py
- PYTHONPATH=backend /tmp/dmarq-membership-venv.mVtg2Q/bin/python -m pytest -q backend/app/tests/test_api.py::test_members_page_route_is_registered backend/app/tests/test_dashboard_template_security.py::test_members_template_uses_membership_api_without_html_injection backend/app/tests/test_memberships_api.py
- PYTHONPATH=backend /tmp/dmarq-membership-venv.mVtg2Q/bin/python - <<'PY'
from jinja2 import Environment, FileSystemLoader, select_autoescape
env = Environment(loader=FileSystemLoader('backend/app/templates'), autoescape=select_autoescape(['html', 'xml']))
env.get_template('members.html')
print('members template parses')
PY

Refs #237