### PR TITLE
test: cover membership management edge cases

### DIFF
--- a/backend/app/api/api_v1/endpoints/memberships.py
+++ b/backend/app/api/api_v1/endpoints/memberships.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.core.database import get_db
 from app.core.security import require_admin_auth
@@ -128,21 +128,16 @@ def _user_or_404(db: Session, user_id: int) -> User:
 def _audit_workspace_for_organization(db: Session, organization: Organization) -> Workspace:
     workspace = (
         db.query(Workspace)
-        .filter(Workspace.organization_id == organization.id, Workspace.active.is_(True))
+        .filter(Workspace.organization_id == organization.id)
         .order_by(Workspace.id.asc())
         .first()
     )
     if workspace is not None:
         return workspace
-    workspace = Workspace(
-        organization_id=organization.id,
-        slug=f"org-{organization.id}",
-        name=f"{organization.name} Workspace",
-        active=True,
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="Organization has no workspace available for audit logging",
     )
-    db.add(workspace)
-    db.flush()
-    return workspace
 
 
 def _normalize_role(role: str, available_roles: set[str]) -> str:
@@ -193,9 +188,16 @@ def _find_or_create_invited_user(
     payload: MembershipInviteRequest,
 ) -> User:
     email = str(payload.email).strip().lower()
-    user = db.query(User).filter(User.email == email).first()
-    if user is None and payload.logto_id:
-        user = db.query(User).filter(User.logto_id == payload.logto_id).first()
+    email_user = db.query(User).filter(User.email == email).first()
+    logto_user = None
+    if payload.logto_id:
+        logto_user = db.query(User).filter(User.logto_id == payload.logto_id).first()
+    if logto_user is not None and email_user is not None and logto_user.id != email_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Invite email and logto_id belong to different users",
+        )
+    user = logto_user or email_user
     if user is None:
         user = User(
             email=email,
@@ -208,6 +210,8 @@ def _find_or_create_invited_user(
         db.add(user)
         db.flush()
         return user
+    if user.email != email:
+        user.email = email
     if payload.logto_id and not user.logto_id:
         user.logto_id = payload.logto_id
     if payload.full_name and not user.full_name:
@@ -227,7 +231,11 @@ async def list_workspace_memberships(
     """List users assigned to one workspace."""
     workspace = _workspace_or_404(db, workspace_id)
     require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, workspace)
-    query = db.query(WorkspaceMembership).filter(WorkspaceMembership.workspace_id == workspace.id)
+    query = (
+        db.query(WorkspaceMembership)
+        .options(selectinload(WorkspaceMembership.user))
+        .filter(WorkspaceMembership.workspace_id == workspace.id)
+    )
     if not include_inactive:
         query = query.filter(WorkspaceMembership.active.is_(True))
     rows = query.order_by(WorkspaceMembership.id.asc()).all()
@@ -375,8 +383,10 @@ async def list_organization_memberships(
     """List users assigned across one organization."""
     organization = _organization_or_404(db, organization_id)
     require_organization_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, organization)
-    query = db.query(OrganizationMembership).filter(
-        OrganizationMembership.organization_id == organization.id
+    query = (
+        db.query(OrganizationMembership)
+        .options(selectinload(OrganizationMembership.user))
+        .filter(OrganizationMembership.organization_id == organization.id)
     )
     if not include_inactive:
         query = query.filter(OrganizationMembership.active.is_(True))

--- a/backend/app/tests/test_memberships_api.py
+++ b/backend/app/tests/test_memberships_api.py
@@ -12,6 +12,7 @@ from app.models.workspace_access import WorkspaceAuditLog, WorkspaceMembership
 from app.services.workspace_access import (
     PERMISSION_AUDIT_READ,
     ROLE_ANALYST,
+    ROLE_AUDITOR,
     ROLE_OPERATOR,
     ROLE_WORKSPACE_OWNER,
     role_for_organization,
@@ -41,8 +42,14 @@ def _client_as_user(test_app, db_session: Session, user: User):
         test_app.dependency_overrides = original_overrides
 
 
-def _add_user(db_session: Session, email: str) -> User:
-    user = User(email=email, is_active=True, is_verified=True, is_superuser=False)
+def _add_user(db_session: Session, email: str, logto_id: str | None = None) -> User:
+    user = User(
+        email=email,
+        logto_id=logto_id,
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
     db_session.add(user)
     db_session.flush()
     return user
@@ -105,6 +112,27 @@ def test_workspace_membership_api_invites_updates_and_deactivates(
         emails = {row["user"]["email"] for row in listed.json()["memberships"]}
         assert {"workspace-owner@example.com", "new.member@example.com"} <= emails
 
+        inactive_before_delete = owner_client.put(
+            f"/api/v1/memberships/workspaces/{workspace.id}/users/{target.id}",
+            json={"user_id": target.id, "role": ROLE_AUDITOR, "active": False},
+        )
+        assert inactive_before_delete.status_code == 200
+        assert inactive_before_delete.json()["active"] is False
+
+        active_only = owner_client.get(f"/api/v1/memberships/workspaces/{workspace.id}")
+        assert active_only.status_code == 200
+        assert "workspace-target@example.com" not in {
+            row["user"]["email"] for row in active_only.json()["memberships"]
+        }
+
+        with_inactive = owner_client.get(
+            f"/api/v1/memberships/workspaces/{workspace.id}?include_inactive=true"
+        )
+        assert with_inactive.status_code == 200
+        assert "workspace-target@example.com" in {
+            row["user"]["email"] for row in with_inactive.json()["memberships"]
+        }
+
         deactivated = owner_client.delete(
             f"/api/v1/memberships/workspaces/{workspace.id}/users/{target.id}"
         )
@@ -122,6 +150,53 @@ def test_workspace_membership_api_invites_updates_and_deactivates(
     audit_actions = {row.action for row in db_session.query(WorkspaceAuditLog).all()}
     assert "workspace.membership_upserted" in audit_actions
     assert "workspace.membership_deactivated" in audit_actions
+
+
+def test_workspace_membership_api_validates_payload_and_invite_identity_conflicts(
+    test_app,
+    db_session: Session,
+):
+    workspace = get_or_create_default_workspace(db_session)
+    owner = _add_user(db_session, "workspace-owner-conflict@example.com")
+    email_user = _add_user(db_session, "conflict-email@example.com")
+    logto_user = _add_user(db_session, "conflict-logto@example.com", logto_id="logto-conflict")
+    _add_workspace_membership(db_session, workspace, owner, ROLE_WORKSPACE_OWNER)
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        mismatched_user = owner_client.put(
+            f"/api/v1/memberships/workspaces/{workspace.id}/users/{email_user.id}",
+            json={"user_id": logto_user.id, "role": ROLE_ANALYST},
+        )
+        assert mismatched_user.status_code == 422
+
+        invalid_role = owner_client.put(
+            f"/api/v1/memberships/workspaces/{workspace.id}/users/{email_user.id}",
+            json={"user_id": email_user.id, "role": "root"},
+        )
+        assert invalid_role.status_code == 422
+
+        conflict = owner_client.post(
+            f"/api/v1/memberships/workspaces/{workspace.id}/invites",
+            json={
+                "email": "conflict-email@example.com",
+                "role": ROLE_ANALYST,
+                "logto_id": "logto-conflict",
+            },
+        )
+        assert conflict.status_code == 409
+
+        linked = owner_client.post(
+            f"/api/v1/memberships/workspaces/{workspace.id}/invites",
+            json={
+                "email": "legacy-logto@example.com",
+                "role": ROLE_ANALYST,
+                "logto_id": "logto-conflict",
+            },
+        )
+        assert linked.status_code == 200
+        assert linked.json()["user"]["id"] == logto_user.id
+        assert linked.json()["user"]["email"] == "legacy-logto@example.com"
 
 
 def test_organization_membership_api_audits_and_deactivates(
@@ -192,3 +267,71 @@ def test_organization_membership_api_audits_and_deactivates(
     audit_actions = {row.action for row in db_session.query(WorkspaceAuditLog).all()}
     assert "organization.membership_upserted" in audit_actions
     assert "organization.membership_deactivated" in audit_actions
+
+
+def test_organization_membership_api_reuses_inactive_audit_workspace(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(slug="inactive-audit-org", name="Inactive Audit Org", active=True)
+    db_session.add(organization)
+    db_session.flush()
+    inactive_workspace = Workspace(
+        slug="inactive-audit-workspace",
+        name="Inactive Audit Workspace",
+        organization_id=organization.id,
+        active=False,
+    )
+    owner = _add_user(db_session, "inactive-audit-owner@example.com")
+    target = _add_user(db_session, "inactive-audit-target@example.com")
+    db_session.add(inactive_workspace)
+    db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=owner.id,
+            role="organization_owner",
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        updated = owner_client.put(
+            f"/api/v1/memberships/organizations/{organization.id}/users/{target.id}",
+            json={"user_id": target.id, "role": "organization_auditor"},
+        )
+        assert updated.status_code == 200
+
+    assert db_session.query(Workspace).filter(Workspace.organization_id == organization.id).count() == 1
+    audit = db_session.query(WorkspaceAuditLog).filter(
+        WorkspaceAuditLog.action == "organization.membership_upserted"
+    ).one()
+    assert audit.workspace_id == inactive_workspace.id
+
+
+def test_organization_membership_api_requires_audit_workspace(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(slug="missing-audit-org", name="Missing Audit Org", active=True)
+    db_session.add(organization)
+    db_session.flush()
+    owner = _add_user(db_session, "missing-audit-owner@example.com")
+    target = _add_user(db_session, "missing-audit-target@example.com")
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=owner.id,
+            role="organization_owner",
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        response = owner_client.put(
+            f"/api/v1/memberships/organizations/{organization.id}/users/{target.id}",
+            json={"user_id": target.id, "role": "organization_auditor"},
+        )
+        assert response.status_code == 409


### PR DESCRIPTION
## Summary
- handle invite identity conflicts between email and Logto IDs
- avoid creating synthetic workspaces for organization audit logs
- eager-load membership users and cover inactive listing behavior

## Verification
- python -m pytest -q backend/app/tests/test_memberships_api.py
- python -m pytest -q backend/app/tests/test_memberships_api.py --cov=app.api.api_v1.endpoints.memberships --cov-report=term-missing
- git diff --check