### PR TITLE
[codex] Add workspace context switcher foundation

### DIFF
--- a/backend/app/api/api_v1/api.py
+++ b/backend/app/api/api_v1/api.py
@@ -25,6 +25,7 @@ from app.api.api_v1.endpoints import (
     tls_reports,
     webhook,
     webhooks,
+    workspaces,
 )
 
 api_router = APIRouter()
@@ -54,3 +55,4 @@ api_router.include_router(settings.router, prefix="/settings", tags=["settings"]
 api_router.include_router(tls_reports.router, prefix="/tls-reports", tags=["tls-reports"])
 api_router.include_router(webhook.router, prefix="/webhook", tags=["webhook"])
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["webhooks"])
+api_router.include_router(workspaces.router, prefix="/workspaces", tags=["workspaces"])

--- a/backend/app/api/api_v1/endpoints/workspaces.py
+++ b/backend/app/api/api_v1/endpoints/workspaces.py
@@ -1,0 +1,69 @@
+"""Current-user workspace context endpoints."""
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import require_admin_auth
+from app.models.workspace import Workspace
+from app.services.workspace_access import (
+    permissions_for_role,
+    role_for_workspace,
+)
+
+router = APIRouter()
+
+
+class WorkspaceContextResponse(BaseModel):
+    """Visible workspace context for client-side scope selection."""
+
+    workspaces: List[Dict[str, Any]]
+    default_workspace_id: Optional[int] = None
+
+
+def _workspace_context_row(
+    db: Session,
+    auth_context: dict,
+    workspace: Workspace,
+) -> Optional[Dict[str, Any]]:
+    role = role_for_workspace(db, auth_context, workspace)
+    if not role:
+        return None
+    organization = workspace.organization
+    return {
+        "id": workspace.id,
+        "slug": workspace.slug,
+        "name": workspace.name,
+        "active": bool(workspace.active),
+        "organization": (
+            {
+                "id": organization.id,
+                "slug": organization.slug,
+                "name": organization.name,
+                "active": bool(organization.active),
+            }
+            if organization is not None
+            else None
+        ),
+        "effective_role": role,
+        "permissions": sorted(permissions_for_role(role)),
+    }
+
+
+@router.get("", response_model=WorkspaceContextResponse)
+async def list_visible_workspaces(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+) -> WorkspaceContextResponse:
+    """Return workspaces visible to the current admin/session context."""
+    workspaces = db.query(Workspace).order_by(Workspace.active.desc(), Workspace.slug.asc()).all()
+    visible = [
+        row
+        for workspace in workspaces
+        if (row := _workspace_context_row(db, _auth, workspace)) is not None
+    ]
+    default_workspace_id = visible[0]["id"] if visible else None
+    return {"workspaces": visible, "default_workspace_id": default_workspace_id}

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -20,6 +20,7 @@
 
     <!-- Alpine.js for interactivity -->
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <style>[x-cloak] { display: none !important; }</style>
 
     {% block head %}{% endblock %}
 </head>
@@ -39,6 +40,19 @@
             </a>
         </div>
         <div class="flex items-center gap-3">
+            <div class="hidden min-w-48 md:block" x-show="workspaces.length > 0" x-cloak>
+                <label class="sr-only" for="workspace-switcher">Workspace</label>
+                <select id="workspace-switcher"
+                        class="select select-sm w-full border-white/30 bg-white/95 text-[#272a5f]"
+                        x-model="selectedWorkspaceId"
+                        @change="selectWorkspace($event.target.value)">
+                    <template x-for="workspace in workspaces" :key="workspace.id">
+                        <option :value="workspace.id"
+                                :disabled="!workspace.active"
+                                x-text="workspaceLabel(workspace)"></option>
+                    </template>
+                </select>
+            </div>
             <nav class="hidden items-center gap-1 text-sm font-semibold lg:flex" aria-label="Primary">
                 <a href="/" class="rounded-md px-3 py-2 text-white/90 hover:bg-white/10">Dashboard</a>
                 <a href="/domains" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Domains</a>
@@ -121,6 +135,8 @@
         function userMenu() {
             return {
                 user: null,
+                workspaces: [],
+                selectedWorkspaceId: localStorage.getItem('dmarq.selectedWorkspaceId') || '',
                 async loadUser() {
                     try {
                         const res = await fetch('/api/v1/auth/me');
@@ -130,9 +146,67 @@
                     } catch (_) {
                         // silently ignore – user is simply not shown
                     }
+                    await this.loadWorkspaces();
+                },
+                async loadWorkspaces() {
+                    try {
+                        const res = await fetch('/api/v1/workspaces');
+                        if (!res.ok) {
+                            return;
+                        }
+                        const data = await res.json();
+                        this.workspaces = data.workspaces || [];
+                        const saved = String(this.selectedWorkspaceId || '');
+                        const selected = this.workspaces.find((workspace) => String(workspace.id) === saved && workspace.active);
+                        const fallback = this.workspaces.find((workspace) => workspace.active) || this.workspaces[0];
+                        if (!selected && fallback) {
+                            this.selectWorkspace(String(fallback.id));
+                        } else if (selected) {
+                            this.selectWorkspace(String(selected.id));
+                        }
+                    } catch (_) {
+                        // workspace selection is optional for single-tenant installs
+                    }
+                },
+                selectWorkspace(workspaceId) {
+                    this.selectedWorkspaceId = workspaceId || '';
+                    if (this.selectedWorkspaceId) {
+                        localStorage.setItem('dmarq.selectedWorkspaceId', this.selectedWorkspaceId);
+                    } else {
+                        localStorage.removeItem('dmarq.selectedWorkspaceId');
+                    }
+                    window.dispatchEvent(new CustomEvent('dmarq:workspace-changed', {
+                        detail: { workspaceId: this.selectedWorkspaceId },
+                    }));
+                },
+                workspaceLabel(workspace) {
+                    const prefix = workspace.organization ? `${workspace.organization.name} / ` : '';
+                    const suffix = workspace.active ? '' : ' (inactive)';
+                    return `${prefix}${workspace.name}${suffix}`;
                 },
             };
         }
+    </script>
+
+    <script>
+        (function attachWorkspaceContextToFetch() {
+            const originalFetch = window.fetch;
+            window.fetch = function(input, init) {
+                const workspaceId = localStorage.getItem('dmarq.selectedWorkspaceId');
+                const url = typeof input === 'string' ? input : (input && input.url) || '';
+                const isApiRequest = url.startsWith('/api/') || url.startsWith(window.location.origin + '/api/');
+                if (!workspaceId || !isApiRequest) {
+                    return originalFetch(input, init);
+                }
+                const nextInit = Object.assign({}, init || {});
+                const headers = new Headers(nextInit.headers || (input && input.headers) || {});
+                if (!headers.has('X-DMARQ-Workspace-ID')) {
+                    headers.set('X-DMARQ-Workspace-ID', workspaceId);
+                }
+                nextInit.headers = headers;
+                return originalFetch(input, nextInit);
+            };
+        })();
     </script>
 
     <!-- Initialize theme from localStorage -->

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -28,3 +28,14 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert "/api/v1/memberships/workspaces/" in template
     assert 'x-text="membership.user.email"' in template
     assert "x-html" not in template
+
+
+def test_base_template_propagates_selected_workspace_context():
+    template = (
+        Path(__file__).resolve().parents[1] / "templates" / "layouts" / "base.html"
+    ).read_text()
+
+    assert "/api/v1/workspaces" in template
+    assert "dmarq.selectedWorkspaceId" in template
+    assert "X-DMARQ-Workspace-ID" in template
+    assert "dmarq:workspace-changed" in template

--- a/backend/app/tests/test_workspace_context_api.py
+++ b/backend/app/tests/test_workspace_context_api.py
@@ -1,0 +1,126 @@
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import require_admin_auth
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
+from app.services.workspace_access import ROLE_ANALYST, ROLE_WORKSPACE_OWNER
+
+
+@contextmanager
+def _client_as_auth(test_app, db_session: Session, auth_context: dict):
+    async def mock_admin_auth():
+        return auth_context
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    original_overrides = dict(test_app.dependency_overrides)
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    try:
+        with TestClient(test_app) as client:
+            yield client
+    finally:
+        test_app.dependency_overrides = original_overrides
+
+
+def _add_workspace(
+    db_session: Session,
+    slug: str,
+    organization: Organization,
+    *,
+    active: bool = True,
+) -> Workspace:
+    workspace = Workspace(
+        slug=slug,
+        name=slug.replace("-", " ").title(),
+        organization_id=organization.id,
+        active=active,
+    )
+    db_session.add(workspace)
+    db_session.flush()
+    return workspace
+
+
+def _add_membership(
+    db_session: Session,
+    workspace: Workspace,
+    user: User,
+    role: str,
+) -> None:
+    db_session.add(
+        WorkspaceMembership(
+            workspace_id=workspace.id,
+            user_id=user.id,
+            role=role,
+            active=True,
+        )
+    )
+    db_session.flush()
+
+
+def test_workspace_context_lists_only_user_visible_workspaces(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(slug="context-org", name="Context Org", active=True)
+    db_session.add(organization)
+    db_session.flush()
+    owned = _add_workspace(db_session, "owned-workspace", organization)
+    audited = _add_workspace(db_session, "audited-workspace", organization)
+    hidden = _add_workspace(db_session, "hidden-workspace", organization)
+    user = User(email="context-user@example.com", is_active=True, is_verified=True)
+    db_session.add(user)
+    db_session.flush()
+    _add_membership(db_session, owned, user, ROLE_WORKSPACE_OWNER)
+    _add_membership(db_session, audited, user, ROLE_ANALYST)
+    db_session.commit()
+
+    with _client_as_auth(
+        test_app,
+        db_session,
+        {"auth_type": "session", "user_id": user.id},
+    ) as client:
+        response = client.get("/api/v1/workspaces")
+
+    assert response.status_code == 200
+    data = response.json()
+    slugs = [workspace["slug"] for workspace in data["workspaces"]]
+    assert slugs == ["audited-workspace", "owned-workspace"]
+    assert hidden.slug not in slugs
+    roles = {workspace["slug"]: workspace["effective_role"] for workspace in data["workspaces"]}
+    assert roles["owned-workspace"] == ROLE_WORKSPACE_OWNER
+    assert roles["audited-workspace"] == ROLE_ANALYST
+    assert data["default_workspace_id"] == audited.id
+
+
+def test_workspace_context_platform_admin_sees_inactive_workspaces(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(slug="platform-context", name="Platform Context", active=True)
+    db_session.add(organization)
+    db_session.flush()
+    active = _add_workspace(db_session, "active-client", organization)
+    _add_workspace(db_session, "inactive-client", organization, active=False)
+    db_session.commit()
+
+    with _client_as_auth(test_app, db_session, {"auth_type": "api_key"}) as client:
+        response = client.get("/api/v1/workspaces")
+
+    assert response.status_code == 200
+    data = response.json()
+    rows = {workspace["slug"]: workspace for workspace in data["workspaces"]}
+    assert rows["active-client"]["active"] is True
+    assert rows["inactive-client"]["active"] is False
+    assert rows["active-client"]["effective_role"] == ROLE_WORKSPACE_OWNER
+    assert data["default_workspace_id"] == active.id


### PR DESCRIPTION
## Summary
- add `/api/v1/workspaces` to list workspaces visible to the current auth context with effective roles and permissions
- add a global workspace switcher to the header that persists the selected workspace in local storage
- attach `X-DMARQ-Workspace-ID` to same-origin API fetches for selected workspace propagation
- add coverage for scoped workspace visibility, platform-admin inactive workspace visibility, and base-template context propagation

## Validation
- python3 -m py_compile backend/app/api/api_v1/api.py backend/app/api/api_v1/endpoints/workspaces.py backend/app/tests/test_workspace_context_api.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-membership-venv.mVtg2Q/bin/black --check backend/app/api/api_v1/api.py backend/app/api/api_v1/endpoints/workspaces.py backend/app/tests/test_workspace_context_api.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-membership-venv.mVtg2Q/bin/isort --check-only backend/app/api/api_v1/api.py backend/app/api/api_v1/endpoints/workspaces.py backend/app/tests/test_workspace_context_api.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-membership-venv.mVtg2Q/bin/flake8 backend/app/api/api_v1/api.py backend/app/api/api_v1/endpoints/workspaces.py backend/app/tests/test_workspace_context_api.py backend/app/tests/test_dashboard_template_security.py
- PYTHONPATH=backend /tmp/dmarq-membership-venv.mVtg2Q/bin/pylint backend/app/api/api_v1/endpoints/workspaces.py backend/app/tests/test_workspace_context_api.py
- PYTHONPATH=backend /tmp/dmarq-membership-venv.mVtg2Q/bin/python -m pytest -q backend/app/tests/test_workspace_context_api.py backend/app/tests/test_dashboard_template_security.py::test_base_template_propagates_selected_workspace_context

Refs #238