### PR TITLE
fix: preserve inactive member state on role change

### DIFF
--- a/backend/app/templates/members.html
+++ b/backend/app/templates/members.html
@@ -201,7 +201,7 @@
                                                 <select class="select select-bordered select-sm w-full"
                                                         :disabled="saving"
                                                         x-model="membership.role"
-                                                        @change="updateMembership(membership, true)">
+                                                        @change="updateMembership(membership, membership.active)">
                                                     <template x-for="role in availableRoles" :key="role">
                                                         <option :value="role" x-text="roleLabel(role)"></option>
                                                     </template>

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -1,5 +1,6 @@
+import asyncio
+
 from fastapi.testclient import TestClient
-import pytest
 from starlette.requests import Request
 
 from app.main import app, members_page
@@ -73,11 +74,10 @@ def test_members_page_route_is_registered():
     assert any(getattr(route, "path", None) == "/members" for route in app.routes)
 
 
-@pytest.mark.asyncio
-async def test_members_page_renders_template():
+def test_members_page_renders_template():
     """The membership management page renders the server-side template."""
     request = Request({"type": "http", "method": "GET", "path": "/members", "headers": []})
-    response = await members_page(request)
+    response = asyncio.run(members_page(request))
 
     assert response.status_code == 200
     assert response.template.name == "members.html"

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -1,6 +1,8 @@
 from fastapi.testclient import TestClient
+import pytest
+from starlette.requests import Request
 
-from app.main import app
+from app.main import app, members_page
 
 
 def test_health_check(authed_client: TestClient):
@@ -69,6 +71,16 @@ def test_setup_status_includes_mailbox_recovery_hint(authed_client: TestClient):
 def test_members_page_route_is_registered():
     """The membership management page is available from the server-rendered UI."""
     assert any(getattr(route, "path", None) == "/members" for route in app.routes)
+
+
+@pytest.mark.asyncio
+async def test_members_page_renders_template():
+    """The membership management page renders the server-side template."""
+    request = Request({"type": "http", "method": "GET", "path": "/members", "headers": []})
+    response = await members_page(request)
+
+    assert response.status_code == 200
+    assert response.template.name == "members.html"
 
 
 def test_reports_upload_invalid_extension(authed_client: TestClient):

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -361,7 +361,7 @@ class TestAuthDisabled:
             mock_settings.AUTH_DISABLED = True
             mock_req = MagicMock()
             mock_req.cookies = {}
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 require_admin_auth(request=mock_req, api_key=None, bearer=None)
             )
         assert result["auth_type"] == "disabled"

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -27,4 +27,6 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert "/api/v1/memberships/organizations/" in template
     assert "/api/v1/memberships/workspaces/" in template
     assert 'x-text="membership.user.email"' in template
+    assert '@change="updateMembership(membership, membership.active)"' in template
+    assert '@change="updateMembership(membership, true)"' not in template
     assert "x-html" not in template


### PR DESCRIPTION
## Summary
- keep inactive memberships inactive when only changing the role dropdown
- add a template regression assertion for the Alpine change handler

## Verification
- python -m pytest -q backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_api.py
- git diff --check origin/main..HEAD