### PR TITLE
fix: normalize domain policies across responses

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -73,6 +73,13 @@ def _authorized_domain_read_workspace(auth_context: Dict[str, Any], db: Session)
     return _authorized_domain_workspace(auth_context, db, PERMISSION_REPORTS_READ)
 
 
+def _normalize_reported_policy(policy_value: Any) -> Optional[str]:
+    """Return the effective DMARC p= policy from stored summary values."""
+    if isinstance(policy_value, dict):
+        return policy_value.get("p")
+    return policy_value
+
+
 class DomainBase(BaseModel):
     """Base Domain schema"""
 
@@ -1171,9 +1178,7 @@ async def get_domains_summary(
 
         # Prefer live DNS policy; fall back to policy seen in reports
         live_policy = extract_dmarc_policy(dns.dmarc_record)
-        reported_policy = summary.get("policy", {})
-        if isinstance(reported_policy, dict):
-            reported_policy = reported_policy.get("p")
+        reported_policy = _normalize_reported_policy(summary.get("policy", {}))
         dmarc_policy = live_policy or reported_policy or "none"
 
         # Format domain data for frontend
@@ -1242,7 +1247,7 @@ async def read_domains(
             name=domain_name,
             description=stored_domain.description if stored_domain else None,
             policy=(
-                summary.get("policy")
+                _normalize_reported_policy(summary.get("policy"))
                 or (stored_domain.dmarc_policy if stored_domain else None)
                 or "unknown"
             ),
@@ -1329,9 +1334,7 @@ async def read_domain(
         )
 
     summary = store.get_domain_summary(domain_name)
-    policy = summary.get("policy")
-    if isinstance(policy, dict):
-        policy = policy.get("p")
+    policy = _normalize_reported_policy(summary.get("policy"))
 
     return DomainResponse(
         name=domain_name,
@@ -2373,9 +2376,7 @@ async def search_domains(
         if q and q.lower() not in domain_name.lower():
             continue
 
-        reported_policy = summary.get("policy", "unknown")
-        if isinstance(reported_policy, dict):
-            reported_policy = reported_policy.get("p") or "unknown"
+        reported_policy = _normalize_reported_policy(summary.get("policy")) or "unknown"
 
         # Skip domain if it doesn't match the policy filter
         if policy and reported_policy != policy:

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -101,6 +101,12 @@ def test_domain_read_stats_selectors_and_search_use_workspace_auth(
     domain = seeded_client.get(f"/api/v1/domains/domains/{DOMAIN}")
     assert domain.status_code == 200
     assert domain.json()["name"] == DOMAIN
+    assert domain.json()["policy"] == "reject"
+
+    domain_list = seeded_client.get("/api/v1/domains/domains")
+    assert domain_list.status_code == 200
+    assert domain_list.json()[0]["name"] == DOMAIN
+    assert domain_list.json()[0]["policy"] == "reject"
 
     stats = seeded_client.get(f"/api/v1/domains/{DOMAIN}/stats")
     assert stats.status_code == 200
@@ -113,6 +119,7 @@ def test_domain_read_stats_selectors_and_search_use_workspace_auth(
     search = seeded_client.get("/api/v1/domains/search?q=example")
     assert search.status_code == 200
     assert search.json()[0]["name"] == DOMAIN
+    assert search.json()[0]["policy"] == "reject"
 
 
 def test_delete_domain_uses_workspace_scoped_domain_cleanup(


### PR DESCRIPTION
## Summary
- centralize reported DMARC policy normalization for domain responses
- apply dict-style policy handling to list, read, summary, and search surfaces
- extend domain regression coverage for list/read/search policy values

## Verification
- python -m pytest -q backend/app/tests/test_domain_detail_endpoints.py --cov=app.api.api_v1.endpoints.domains --cov-report=term-missing
- git diff --check