### PR TITLE
fix: tighten workspace context propagation

### DIFF
--- a/backend/app/api/api_v1/endpoints/workspaces.py
+++ b/backend/app/api/api_v1/endpoints/workspaces.py
@@ -4,14 +4,18 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
 from app.services.workspace_access import (
+    ROLE_ANALYST,
+    ROLE_WORKSPACE_OWNER,
+    _auth_user,
+    is_platform_admin_auth,
     permissions_for_role,
-    role_for_workspace,
 )
 
 router = APIRouter()
@@ -25,11 +29,9 @@ class WorkspaceContextResponse(BaseModel):
 
 
 def _workspace_context_row(
-    db: Session,
-    auth_context: dict,
     workspace: Workspace,
+    role: str,
 ) -> Optional[Dict[str, Any]]:
-    role = role_for_workspace(db, auth_context, workspace)
     if not role:
         return None
     organization = workspace.organization
@@ -53,17 +55,58 @@ def _workspace_context_row(
     }
 
 
+def _visible_workspace_roles(db: Session, auth_context: dict) -> Dict[int, str]:
+    if is_platform_admin_auth(auth_context):
+        return {
+            workspace_id: ROLE_WORKSPACE_OWNER
+            for (workspace_id,) in db.query(Workspace.id).all()
+        }
+
+    if (auth_context or {}).get("auth_type") == "api_token":
+        try:
+            workspace_id = int((auth_context or {}).get("workspace_id") or 0)
+        except (TypeError, ValueError):
+            workspace_id = 0
+        return {workspace_id: ROLE_ANALYST} if workspace_id else {}
+
+    user = _auth_user(db, auth_context)
+    if user is None:
+        return {}
+
+    rows = (
+        db.query(WorkspaceMembership.workspace_id, WorkspaceMembership.role)
+        .filter(
+            WorkspaceMembership.user_id == user.id,
+            WorkspaceMembership.active.is_(True),
+        )
+        .all()
+    )
+    roles = {workspace_id: role for workspace_id, role in rows}
+    if user.is_superuser and user.workspace_id:
+        roles.setdefault(user.workspace_id, ROLE_WORKSPACE_OWNER)
+    return roles
+
+
 @router.get("", response_model=WorkspaceContextResponse)
 async def list_visible_workspaces(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ) -> WorkspaceContextResponse:
     """Return workspaces visible to the current admin/session context."""
-    workspaces = db.query(Workspace).order_by(Workspace.active.desc(), Workspace.slug.asc()).all()
-    visible = [
-        row
-        for workspace in workspaces
-        if (row := _workspace_context_row(db, _auth, workspace)) is not None
-    ]
+    roles_by_workspace = _visible_workspace_roles(db, _auth)
+    if not roles_by_workspace:
+        return {"workspaces": [], "default_workspace_id": None}
+    workspaces = (
+        db.query(Workspace)
+        .options(selectinload(Workspace.organization))
+        .filter(Workspace.id.in_(list(roles_by_workspace)))
+        .order_by(Workspace.active.desc(), Workspace.slug.asc())
+        .all()
+    )
+    visible = []
+    for workspace in workspaces:
+        row = _workspace_context_row(workspace, roles_by_workspace.get(workspace.id, ""))
+        if row is not None:
+            visible.append(row)
     default_workspace_id = visible[0]["id"] if visible else None
     return {"workspaces": visible, "default_workspace_id": default_workspace_id}

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -193,7 +193,9 @@
             const originalFetch = window.fetch;
             window.fetch = function(input, init) {
                 const workspaceId = localStorage.getItem('dmarq.selectedWorkspaceId');
-                const url = typeof input === 'string' ? input : (input && input.url) || '';
+                const url = input instanceof URL
+                    ? input.toString()
+                    : (typeof input === 'string' ? input : (input && input.url) || '');
                 const isApiRequest = url.startsWith('/api/') || url.startsWith(window.location.origin + '/api/');
                 if (!workspaceId || !isApiRequest) {
                     return originalFetch(input, init);

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -39,3 +39,4 @@ def test_base_template_propagates_selected_workspace_context():
     assert "dmarq.selectedWorkspaceId" in template
     assert "X-DMARQ-Workspace-ID" in template
     assert "dmarq:workspace-changed" in template
+    assert "input instanceof URL" in template

--- a/backend/app/tests/test_workspace_context_api.py
+++ b/backend/app/tests/test_workspace_context_api.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.core.security import require_admin_auth
+from app.api.api_v1.endpoints.workspaces import _workspace_context_row
 from app.models.organization import Organization
 from app.models.user import User
 from app.models.workspace import Workspace
@@ -124,3 +125,101 @@ def test_workspace_context_platform_admin_sees_inactive_workspaces(
     assert rows["inactive-client"]["active"] is False
     assert rows["active-client"]["effective_role"] == ROLE_WORKSPACE_OWNER
     assert data["default_workspace_id"] == active.id
+
+
+def test_workspace_context_api_token_limits_context_to_token_workspace(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(slug="token-context", name="Token Context", active=True)
+    db_session.add(organization)
+    db_session.flush()
+    scoped = _add_workspace(db_session, "token-scoped", organization)
+    hidden = _add_workspace(db_session, "token-hidden", organization)
+    db_session.commit()
+
+    with _client_as_auth(
+        test_app,
+        db_session,
+        {"auth_type": "api_token", "workspace_id": str(scoped.id)},
+    ) as client:
+        response = client.get("/api/v1/workspaces")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [workspace["slug"] for workspace in data["workspaces"]] == ["token-scoped"]
+    assert data["workspaces"][0]["effective_role"] == ROLE_ANALYST
+    assert data["default_workspace_id"] == scoped.id
+    assert hidden.slug not in {workspace["slug"] for workspace in data["workspaces"]}
+
+
+def test_workspace_context_invalid_api_token_workspace_returns_empty_context(
+    test_app,
+    db_session: Session,
+):
+    with _client_as_auth(
+        test_app,
+        db_session,
+        {"auth_type": "api_token", "workspace_id": "not-a-workspace-id"},
+    ) as client:
+        response = client.get("/api/v1/workspaces")
+
+    assert response.status_code == 200
+    assert response.json() == {"workspaces": [], "default_workspace_id": None}
+
+
+def test_workspace_context_superuser_uses_primary_workspace_role(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(slug="super-context", name="Super Context", active=True)
+    db_session.add(organization)
+    db_session.flush()
+    workspace = _add_workspace(db_session, "super-primary", organization)
+    user = User(
+        email="super-context@example.com",
+        is_active=True,
+        is_verified=True,
+        is_superuser=True,
+        workspace_id=workspace.id,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    with _client_as_auth(
+        test_app,
+        db_session,
+        {"auth_type": "session", "user_id": user.id},
+    ) as client:
+        response = client.get("/api/v1/workspaces")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [workspace["slug"] for workspace in data["workspaces"]] == ["super-primary"]
+    assert data["workspaces"][0]["effective_role"] == ROLE_WORKSPACE_OWNER
+
+
+def test_workspace_context_missing_session_user_returns_empty_context(
+    test_app,
+    db_session: Session,
+):
+    with _client_as_auth(
+        test_app,
+        db_session,
+        {"auth_type": "session", "user_id": 999_999},
+    ) as client:
+        response = client.get("/api/v1/workspaces")
+
+    assert response.status_code == 200
+    assert response.json() == {"workspaces": [], "default_workspace_id": None}
+
+
+def test_workspace_context_row_omits_workspaces_without_effective_role(
+    db_session: Session,
+):
+    organization = Organization(slug="row-context", name="Row Context", active=True)
+    db_session.add(organization)
+    db_session.flush()
+    workspace = _add_workspace(db_session, "row-context-workspace", organization)
+
+    assert _workspace_context_row(workspace, "") is None


### PR DESCRIPTION
## Summary
- avoid per-workspace role lookup when listing visible workspaces
- eager-load organizations for workspace context rows
- preserve workspace headers for fetch calls that receive URL objects

## Verification
- ../dmarq-pr248.HfzhhX/.venv/bin/python -m pytest -q backend/app/tests/test_workspace_context_api.py backend/app/tests/test_dashboard_template_security.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace context now returns only the workspaces a user can actually see, with the correct role and permissions.
  * API token access is properly limited to the selected workspace, and invalid workspace selections now return an empty context.
  * Superuser and missing-user session cases now handle workspace context more reliably.
  * Workspace headers are now handled correctly for browser requests using URL objects.
* **Tests**
  * Added coverage for workspace visibility, token scoping, superuser behavior, empty results, and template header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->