### PR TITLE
Fix demo billing review follow-ups

### DIFF
--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -333,6 +333,16 @@ def build_demo_multi_user_deployment() -> Dict[str, Any]:
                             "SPF includes exceed the lookup budget",
                         ],
                     },
+                    {
+                        "slug": "retail-example",
+                        "name": "Retail Chain Example",
+                        "domains": ["retail.example", "shop.retail.example"],
+                        "health": "warning",
+                        "primary_findings": [
+                            "legacy sender still aligned through SPF only",
+                            "monitoring grace period expires next week",
+                        ],
+                    },
                 ],
                 "provider_customers": [
                     {

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -235,7 +235,7 @@
                         </div>
                         <div class="rounded-md bg-[#f4f3f2] p-3">
                             <p class="text-[#5f5c78]">Billing</p>
-                            <p class="mt-1 font-semibold text-[#120d36]" x-text="formatMoney(organization.billing.current_period_total_cents, organization.plan.price.currency)"></p>
+                            <p class="mt-1 font-semibold text-[#120d36]" x-text="formatMoney(organization.billing?.current_period_total_cents, organization.plan.price.currency)"></p>
                         </div>
                     </div>
                     <div class="mt-4 rounded-md border border-[#e6e3e1] p-3 text-sm">
@@ -877,8 +877,7 @@ function dashboardApp() {
         formatMoney(cents, currency = 'EUR') {
             return new Intl.NumberFormat(undefined, {
                 style: 'currency',
-                currency,
-                maximumFractionDigits: 0
+                currency
             }).format((Number(cents) || 0) / 100);
         },
 
@@ -922,7 +921,9 @@ function dashboardApp() {
         formatDemoUsage(organization, usage) {
             const entitlement = organization.entitlements?.[usage.metric];
             const used = this.formatLargeNumber(usage.quantity || 0);
-            const limit = entitlement?.included ? ` / ${this.formatLargeNumber(entitlement.included)}` : '';
+            const limit = entitlement?.included !== undefined && entitlement?.included !== null
+                ? ` / ${this.formatLargeNumber(entitlement.included)}`
+                : '';
             return `${this.formatDemoLabel(usage.metric)} ${used}${limit} ${usage.unit || ''}`.trim();
         },
 

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -245,7 +245,7 @@
                                 <p class="mt-1 text-[#5f5c78]" x-text="organization.billing_profile.invoice_reference"></p>
                             </div>
                             <span class="rounded-full bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#5f5c78]"
-                                  x-text="formatDemoLabel(organization.billing.status)"></span>
+                                  x-text="formatDemoLabel(organization.billing?.status || 'not_configured')"></span>
                         </div>
                         <dl class="mt-3 grid grid-cols-2 gap-2 text-xs text-[#5f5c78]">
                             <div>
@@ -254,7 +254,7 @@
                             </div>
                             <div>
                                 <dt>Next invoice</dt>
-                                <dd class="mt-1 font-semibold text-[#120d36]" x-text="organization.billing.next_invoice_date"></dd>
+                                <dd class="mt-1 font-semibold text-[#120d36]" x-text="organization.billing?.next_invoice_date || 'Not scheduled'"></dd>
                             </div>
                             <div>
                                 <dt>Collection</dt>


### PR DESCRIPTION
## Summary
- add the missing retail workspace sample referenced by provider customer demo data
- preserve currency minor units in demo billing displays
- make demo billing rendering resilient to missing billing objects and zero included entitlements

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_dashboard_template_security.py`

Follow-up for review feedback on PR #264.