### PR TITLE
[codex] Block inactive workspace membership mutations

### DIFF
--- a/backend/app/api/api_v1/endpoints/memberships.py
+++ b/backend/app/api/api_v1/endpoints/memberships.py
@@ -101,6 +101,15 @@ def _workspace_or_404(db: Session, workspace_id: int) -> Workspace:
     return workspace
 
 
+def _ensure_workspace_accepts_mutation(workspace: Workspace) -> None:
+    if workspace.active:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="Inactive workspace cannot be modified",
+    )
+
+
 def _organization_or_404(db: Session, organization_id: int) -> Organization:
     organization = (
         db.query(Organization)
@@ -262,6 +271,7 @@ async def upsert_workspace_membership(
         )
     workspace = _workspace_or_404(db, workspace_id)
     require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, workspace)
+    _ensure_workspace_accepts_mutation(workspace)
     user = _user_or_404(db, user_id)
     role = _normalize_role(payload.role, WORKSPACE_ROLES)
     membership = (
@@ -319,6 +329,7 @@ async def invite_workspace_member(
     """Invite or link a user by email and assign a workspace role."""
     workspace = _workspace_or_404(db, workspace_id)
     require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, workspace)
+    _ensure_workspace_accepts_mutation(workspace)
     user = _find_or_create_invited_user(db, payload)
     upsert = MembershipUpsertRequest(user_id=user.id, role=payload.role, active=True)
     return await upsert_workspace_membership(
@@ -342,6 +353,7 @@ async def deactivate_workspace_membership(
     """Deactivate one workspace membership without deleting audit history."""
     workspace = _workspace_or_404(db, workspace_id)
     require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, workspace)
+    _ensure_workspace_accepts_mutation(workspace)
     membership = (
         db.query(WorkspaceMembership)
         .filter(

--- a/backend/app/tests/test_membership_inactive_workspaces.py
+++ b/backend/app/tests/test_membership_inactive_workspaces.py
@@ -1,0 +1,109 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
+from app.services.workspace_access import ROLE_WORKSPACE_OWNER
+
+
+def _inactive_workspace(db_session: Session) -> Workspace:
+    workspace = Workspace(
+        slug="inactive-membership-workspace",
+        name="Inactive Membership Workspace",
+        active=False,
+    )
+    db_session.add(workspace)
+    db_session.flush()
+    return workspace
+
+
+def _user(db_session: Session, email: str) -> User:
+    user = User(email=email, is_active=True, is_verified=True)
+    db_session.add(user)
+    db_session.flush()
+    return user
+
+
+def test_workspace_membership_update_blocks_inactive_workspace_mutation(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    workspace = _inactive_workspace(db_session)
+    user = _user(db_session, "inactive-update@example.com")
+    db_session.commit()
+
+    response = authed_client.put(
+        f"/api/v1/memberships/workspaces/{workspace.id}/users/{user.id}",
+        json={"user_id": user.id, "role": ROLE_WORKSPACE_OWNER, "active": True},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Inactive workspace cannot be modified"
+    assert db_session.query(WorkspaceMembership).count() == 0
+
+
+def test_workspace_membership_invite_blocks_inactive_workspace_mutation(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    workspace = _inactive_workspace(db_session)
+    db_session.commit()
+
+    response = authed_client.post(
+        f"/api/v1/memberships/workspaces/{workspace.id}/invites",
+        json={"email": "inactive-invite@example.com", "role": ROLE_WORKSPACE_OWNER},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Inactive workspace cannot be modified"
+    assert (
+        db_session.query(User).filter(User.email == "inactive-invite@example.com").first() is None
+    )
+
+
+def test_workspace_membership_deactivate_blocks_inactive_workspace_mutation(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    workspace = _inactive_workspace(db_session)
+    user = _user(db_session, "inactive-deactivate@example.com")
+    membership = WorkspaceMembership(
+        workspace_id=workspace.id,
+        user_id=user.id,
+        role=ROLE_WORKSPACE_OWNER,
+        active=True,
+    )
+    db_session.add(membership)
+    db_session.commit()
+
+    response = authed_client.delete(
+        f"/api/v1/memberships/workspaces/{workspace.id}/users/{user.id}",
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Inactive workspace cannot be modified"
+    db_session.refresh(membership)
+    assert membership.active is True
+
+
+def test_workspace_membership_list_allows_inactive_workspace_read(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    workspace = _inactive_workspace(db_session)
+    user = _user(db_session, "inactive-list@example.com")
+    db_session.add(
+        WorkspaceMembership(
+            workspace_id=workspace.id,
+            user_id=user.id,
+            role=ROLE_WORKSPACE_OWNER,
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    response = authed_client.get(f"/api/v1/memberships/workspaces/{workspace.id}")
+
+    assert response.status_code == 200
+    assert response.json()["memberships"][0]["user"]["email"] == user.email


### PR DESCRIPTION
## Summary
- block workspace membership create/update/invite/deactivate operations when the target workspace is inactive
- keep inactive workspace membership reads available for audit/admin review
- add regression coverage for each blocked mutation path

## Validation
- python -m py_compile backend/app/api/api_v1/endpoints/memberships.py backend/app/tests/test_membership_inactive_workspaces.py
- black --check backend/app/api/api_v1/endpoints/memberships.py backend/app/tests/test_membership_inactive_workspaces.py
- isort --check-only backend/app/api/api_v1/endpoints/memberships.py backend/app/tests/test_membership_inactive_workspaces.py

Note: local focused pytest still hangs in global app/conftest import before the test module runs; CI should provide the full fixture-path verdict.

Refs #238


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Membership changes are now blocked for inactive workspaces, returning a clear conflict error instead of allowing updates, invites, or deactivations.
  * Reading membership lists for inactive workspaces still works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->