### PR TITLE
[codex] Scope dashboard stats by selected workspace

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -7,7 +7,7 @@ from dataclasses import asdict
 from datetime import date, datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Request, status
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
@@ -40,13 +40,11 @@ from app.services.report_store import ReportStore
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
     PERMISSION_REPORTS_READ,
-    require_workspace_permission,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
 )
 from app.services.workspace_audit import record_workspace_audit_log
 from app.services.workspaces import (
-    assign_default_workspace_to_unscoped_rows,
-    get_default_workspace,
-    get_or_create_default_workspace,
     workspace_domain_query,
 )
 from app.utils.domain_validator import validate_domain_config
@@ -61,16 +59,29 @@ def _authorized_domain_workspace(
     auth_context: Dict[str, Any],
     db: Session,
     permission: str = PERMISSION_DOMAINS_WRITE,
+    selected_workspace_id: Optional[int] = None,
 ):
     """Authorize workspace domain/DNS setup before legacy repair writes."""
-    workspace = get_default_workspace(db) or get_or_create_default_workspace(db)
-    require_workspace_permission(auth_context, permission, db, workspace)
-    return assign_default_workspace_to_unscoped_rows(db)
+    return resolve_authorized_workspace(
+        db,
+        auth_context,
+        permission,
+        selected_workspace_id=selected_workspace_id,
+    )
 
 
-def _authorized_domain_read_workspace(auth_context: Dict[str, Any], db: Session):
+def _authorized_domain_read_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    selected_workspace_id: Optional[int] = None,
+):
     """Authorize read-only domain/report/DNS visibility for the default workspace."""
-    return _authorized_domain_workspace(auth_context, db, PERMISSION_REPORTS_READ)
+    return _authorized_domain_workspace(
+        auth_context,
+        db,
+        PERMISSION_REPORTS_READ,
+        selected_workspace_id=selected_workspace_id,
+    )
 
 
 def _normalize_reported_policy(policy_value: Any) -> Optional[str]:
@@ -506,7 +517,12 @@ def _normalize_domain_name(name: str) -> str:
     return name.strip().strip(".").lower()
 
 
-def _domain_names_for_summary(db: Session, store: ReportStore, workspace=None) -> List[str]:
+def _domain_names_for_summary(
+    db: Session,
+    store: ReportStore,
+    workspace=None,
+    include_unscoped_report_domains: bool = True,
+) -> List[str]:
     report_domains = store.get_domains()
     stored_query = db.query(Domain.name).filter(Domain.active == True)  # noqa: E712
     if workspace is not None:
@@ -525,7 +541,8 @@ def _domain_names_for_summary(db: Session, store: ReportStore, workspace=None) -
         scoped_report_domains = [
             name
             for name in report_domains
-            if name not in stored_scope or stored_scope[name] == workspace.id
+            if stored_scope.get(name) == workspace.id
+            or (include_unscoped_report_domains and name not in stored_scope)
         ]
     return list(dict.fromkeys(stored_domains + scoped_report_domains))
 
@@ -1123,6 +1140,7 @@ def _build_posture_dashboard(
 async def get_domains_summary(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """
     Get summary statistics for all domains, formatted for the dashboard.
@@ -1132,10 +1150,20 @@ async def get_domains_summary(
     A per-domain timeout of 10 s prevents slow DNS responses from blocking the
     page load.
     """
-    workspace = _authorized_domain_read_workspace(_auth, db)
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
+    workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
     store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
-    domains = _domain_names_for_summary(db, store, workspace)
+    hydrate_report_store_from_db(
+        db,
+        store,
+        workspace_id=workspace.id if selected_workspace_id is not None else None,
+    )
+    domains = _domain_names_for_summary(
+        db,
+        store,
+        workspace,
+        include_unscoped_report_domains=selected_workspace_id is None,
+    )
     summaries = store.get_all_domain_summaries()
 
     # Perform DNS checks for all domains, reusing fresh cached results.

--- a/backend/app/api/api_v1/endpoints/stats.py
+++ b/backend/app/api/api_v1/endpoints/stats.py
@@ -2,12 +2,18 @@ from datetime import date, datetime, time, timedelta, timezone
 from math import ceil
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, status
 from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
 from app.core.database import get_db
+from app.core.security import require_admin_auth
 from app.services.demo_data import build_demo_dashboard_statistics
+from app.services.workspace_access import (
+    PERMISSION_REPORTS_READ,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
+)
 from app.utils.stats_summarizer import StatsSummarizer
 
 router = APIRouter()
@@ -168,6 +174,8 @@ def resolve_dashboard_date_range(
 @router.get("/dashboard")
 async def get_dashboard_statistics(
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
     force_refresh: bool = Query(False, title="Force refresh of statistics"),
     period_days: int = Query(30, ge=1, le=365, title="Period in days for time-based statistics"),
     interval: Optional[str] = Query(None, title="Named date interval"),
@@ -195,6 +203,14 @@ async def get_dashboard_statistics(
     start_ts = int(datetime.fromisoformat(date_range["start_at"]).timestamp())
     end_ts = int(datetime.fromisoformat(date_range["end_at"]).timestamp())
 
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
+    workspace = resolve_authorized_workspace(
+        db,
+        _auth,
+        PERMISSION_REPORTS_READ,
+        selected_workspace_id=selected_workspace_id,
+    )
+
     if get_settings().DEMO_MODE:
         stats = build_demo_dashboard_statistics(period_days=resolved_days)
         stats["api_version"] = "1.0"
@@ -207,7 +223,7 @@ async def get_dashboard_statistics(
 
     # If force refresh, invalidate cache
     if force_refresh:
-        stats_summarizer.invalidate_cache()
+        stats_summarizer.invalidate_cache(workspace_id=workspace.id)
 
     # Get statistics (from cache or calculate if needed)
     stats = stats_summarizer.calculate_summary_statistics(
@@ -216,6 +232,7 @@ async def get_dashboard_statistics(
         start_ts=start_ts,
         end_ts=end_ts,
         cache_key=_summary_cache_key(date_range),
+        workspace_id=workspace.id,
     )
 
     # Add version and timestamp
@@ -230,6 +247,8 @@ async def get_dashboard_statistics(
 async def get_domain_statistics(
     domain_id: str = Path(..., title="The domain ID or name"),
     db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
     force_refresh: bool = Query(False, title="Force refresh of statistics"),
     period_days: int = Query(30, ge=1, le=365, title="Period in days for time-based statistics"),
     interval: Optional[str] = Query(None, title="Named date interval"),
@@ -257,6 +276,14 @@ async def get_domain_statistics(
     start_ts = int(datetime.fromisoformat(date_range["start_at"]).timestamp())
     end_ts = int(datetime.fromisoformat(date_range["end_at"]).timestamp())
 
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
+    workspace = resolve_authorized_workspace(
+        db,
+        _auth,
+        PERMISSION_REPORTS_READ,
+        selected_workspace_id=selected_workspace_id,
+    )
+
     if get_settings().DEMO_MODE:
         stats = build_demo_dashboard_statistics(period_days=resolved_days, domain=domain_id)
         stats["api_version"] = "1.0"
@@ -269,7 +296,7 @@ async def get_domain_statistics(
 
     # If force refresh, invalidate domain cache
     if force_refresh:
-        stats_summarizer.invalidate_cache(domain_id)
+        stats_summarizer.invalidate_cache(domain_id, workspace_id=workspace.id)
 
     # Get domain statistics (from cache or calculate if needed)
     stats = stats_summarizer.calculate_summary_statistics(
@@ -279,6 +306,7 @@ async def get_domain_statistics(
         start_ts=start_ts,
         end_ts=end_ts,
         cache_key=_summary_cache_key(date_range),
+        workspace_id=workspace.id,
     )
 
     # Add version and timestamp

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
@@ -225,8 +225,10 @@ def require_workspace_permission(
     )
 
 
-def parse_selected_workspace_id(value: Optional[str]) -> Optional[int]:
+def parse_selected_workspace_id(value: Optional[Any]) -> Optional[int]:
     """Return a selected workspace id from the UI propagation header."""
+    if value is not None and not isinstance(value, (str, int)):
+        return None
     if value is None or not str(value).strip():
         return None
     try:
@@ -244,6 +246,17 @@ def parse_selected_workspace_id(value: Optional[str]) -> Optional[int]:
     return workspace_id
 
 
+def _workspace_id_from_auth_context(auth_context: dict) -> Optional[int]:
+    """Return the workspace bound to scoped API-token auth, when present."""
+    if (auth_context or {}).get("auth_type") != "api_token":
+        return None
+    try:
+        workspace_id = int((auth_context or {}).get("workspace_id") or 0)
+    except (TypeError, ValueError):
+        return None
+    return workspace_id if workspace_id > 0 else None
+
+
 def resolve_authorized_workspace(
     db: Session,
     auth_context: dict,
@@ -252,6 +265,7 @@ def resolve_authorized_workspace(
     selected_workspace_id: Optional[int] = None,
 ) -> Workspace:
     """Resolve and authorize the selected workspace, defaulting legacy installs safely."""
+    selected_workspace_id = selected_workspace_id or _workspace_id_from_auth_context(auth_context)
     if selected_workspace_id is None:
         workspace = assign_default_workspace_to_unscoped_rows(db)
     else:

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -11,6 +11,7 @@ from app.models.organization import Organization, OrganizationMembership
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
+from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
 ROLE_WORKSPACE_OWNER = "workspace_owner"
 ROLE_DOMAIN_ADMIN = "domain_admin"
@@ -222,6 +223,53 @@ def require_workspace_permission(
         status_code=status.HTTP_403_FORBIDDEN,
         detail=f"Workspace permission required: {permission}",
     )
+
+
+def parse_selected_workspace_id(value: Optional[str]) -> Optional[int]:
+    """Return a selected workspace id from the UI propagation header."""
+    if value is None or not str(value).strip():
+        return None
+    try:
+        workspace_id = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="X-DMARQ-Workspace-ID must be an integer",
+        ) from exc
+    if workspace_id <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="X-DMARQ-Workspace-ID must be a positive integer",
+        )
+    return workspace_id
+
+
+def resolve_authorized_workspace(
+    db: Session,
+    auth_context: dict,
+    permission: str,
+    *,
+    selected_workspace_id: Optional[int] = None,
+) -> Workspace:
+    """Resolve and authorize the selected workspace, defaulting legacy installs safely."""
+    if selected_workspace_id is None:
+        workspace = assign_default_workspace_to_unscoped_rows(db)
+    else:
+        workspace = (
+            db.query(Workspace)
+            .filter(
+                Workspace.id == selected_workspace_id,
+                Workspace.active.is_(True),
+            )
+            .first()
+        )
+        if workspace is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Selected workspace not found",
+            )
+    require_workspace_permission(auth_context, permission, db, workspace)
+    return workspace
 
 
 def role_for_organization(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -16,9 +16,10 @@ from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
-from app.api.api_v1.endpoints.domains import _spf_fix_hint
+from app.api.api_v1.endpoints.domains import _domain_names_for_summary, _spf_fix_hint
 from app.models.dns_cache import DNSCache, DNSRecordChange
 from app.models.domain import Domain
+from app.models.workspace import Workspace
 from app.services.bimi import BIMIResult
 from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
 from app.services.dns_resolver import DomainDNSResult
@@ -856,6 +857,52 @@ def test_summary_endpoint_uses_manual_selectors(authed_client: TestClient):
     assert response.status_code == 200
     assert "manualsel" in captured_selectors
     assert "google" in captured_selectors
+
+
+def test_summary_endpoint_respects_selected_workspace_header(
+    authed_client: TestClient,
+    db_session,
+):
+    """The dashboard domain summary only returns domains in the selected workspace."""
+    alpha = Workspace(slug="summary-alpha", name="Summary Alpha", active=True)
+    beta = Workspace(slug="summary-beta", name="Summary Beta", active=True)
+    db_session.add_all([alpha, beta])
+    db_session.flush()
+    db_session.add_all(
+        [
+            Domain(name="alpha-summary.example", workspace_id=alpha.id, active=True),
+            Domain(name="beta-summary.example", workspace_id=beta.id, active=True),
+        ]
+    )
+    db_session.commit()
+
+    with _mock_dns():
+        response = authed_client.get(
+            "/api/v1/domains/summary",
+            headers={"X-DMARQ-Workspace-ID": str(alpha.id)},
+        )
+
+    assert response.status_code == 200
+    assert [item["domain_name"] for item in response.json()["domains"]] == ["alpha-summary.example"]
+
+
+def test_domain_names_for_selected_workspace_excludes_unscoped_report_cache(db_session):
+    """Selected workspace summaries must not inherit unrelated in-memory report domains."""
+    workspace = Workspace(slug="summary-cache-scope", name="Summary Cache Scope", active=True)
+    db_session.add(workspace)
+    db_session.flush()
+    db_session.add(Domain(name="scoped-cache-summary.example", workspace_id=workspace.id))
+    db_session.commit()
+
+    store = ReportStore()
+    store.add_report({**MINIMAL_REPORT, "domain": "ghost-cache-summary.example"})
+
+    assert _domain_names_for_summary(
+        db_session,
+        store,
+        workspace,
+        include_unscoped_report_domains=False,
+    ) == ["scoped-cache-summary.example"]
 
 
 def test_selector_map_lookup_chunks_domain_names(db_session, monkeypatch):

--- a/backend/app/tests/test_stats_endpoints.py
+++ b/backend/app/tests/test_stats_endpoints.py
@@ -8,8 +8,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
 from app.api.api_v1.endpoints.stats import _summary_cache_key, resolve_dashboard_date_range
+from app.models.workspace import Workspace
 
 
 def test_summary_cache_key_includes_custom_date_bounds():
@@ -31,33 +33,33 @@ def test_summary_cache_key_partitions_open_calendar_ranges():
 class TestDashboardStatistics:
     """Tests for GET /api/v1/stats/dashboard"""
 
-    def test_dashboard_returns_200(self, client: TestClient):
-        response = client.get("/api/v1/stats/dashboard")
+    def test_dashboard_returns_200(self, authed_client: TestClient):
+        response = authed_client.get("/api/v1/stats/dashboard")
         assert response.status_code == 200
 
-    def test_dashboard_response_contains_api_version(self, client: TestClient):
-        response = client.get("/api/v1/stats/dashboard")
+    def test_dashboard_response_contains_api_version(self, authed_client: TestClient):
+        response = authed_client.get("/api/v1/stats/dashboard")
         data = response.json()
         assert data["api_version"] == "1.0"
 
-    def test_dashboard_response_contains_period_days(self, client: TestClient):
-        response = client.get("/api/v1/stats/dashboard")
+    def test_dashboard_response_contains_period_days(self, authed_client: TestClient):
+        response = authed_client.get("/api/v1/stats/dashboard")
         data = response.json()
         assert data["period_days"] == 30
 
-    def test_dashboard_period_days_query_param(self, client: TestClient):
-        response = client.get("/api/v1/stats/dashboard?period_days=7")
+    def test_dashboard_period_days_query_param(self, authed_client: TestClient):
+        response = authed_client.get("/api/v1/stats/dashboard?period_days=7")
         assert response.status_code == 200
         data = response.json()
         assert data["period_days"] == 7
 
-    def test_dashboard_passes_period_days_to_summarizer(self, client: TestClient):
+    def test_dashboard_passes_period_days_to_summarizer(self, authed_client: TestClient):
         with patch("app.api.api_v1.endpoints.stats.StatsSummarizer") as MockSummarizer:
             mock_instance = MagicMock()
             mock_instance.calculate_summary_statistics.return_value = {"total": 0}
             MockSummarizer.return_value = mock_instance
 
-            response = client.get("/api/v1/stats/dashboard?period_days=7")
+            response = authed_client.get("/api/v1/stats/dashboard?period_days=7")
             assert response.status_code == 200
             assert mock_instance.calculate_summary_statistics.call_args.kwargs["period_days"] == 7
             assert mock_instance.calculate_summary_statistics.call_args.kwargs["start_ts"]
@@ -67,42 +69,79 @@ class TestDashboardStatistics:
                 == "last_7_days"
             )
 
-    def test_dashboard_force_refresh(self, client: TestClient):
+    def test_dashboard_force_refresh(self, authed_client: TestClient):
         """force_refresh=true should trigger cache invalidation without error."""
-        response = client.get("/api/v1/stats/dashboard?force_refresh=true")
+        response = authed_client.get("/api/v1/stats/dashboard?force_refresh=true")
         assert response.status_code == 200
         data = response.json()
         assert "api_version" in data
 
-    def test_dashboard_force_refresh_calls_invalidate_cache(self, client: TestClient):
+    def test_dashboard_force_refresh_calls_invalidate_cache(self, authed_client: TestClient):
         """Verify StatsSummarizer.invalidate_cache is called when force_refresh is set."""
         with patch("app.api.api_v1.endpoints.stats.StatsSummarizer") as MockSummarizer:
             mock_instance = MagicMock()
             mock_instance.calculate_summary_statistics.return_value = {"total": 0}
             MockSummarizer.return_value = mock_instance
 
-            response = client.get("/api/v1/stats/dashboard?force_refresh=true")
+            response = authed_client.get("/api/v1/stats/dashboard?force_refresh=true")
             assert response.status_code == 200
             mock_instance.invalidate_cache.assert_called_once()
+            assert "workspace_id" in mock_instance.invalidate_cache.call_args.kwargs
 
-    def test_dashboard_no_force_refresh_skips_invalidate(self, client: TestClient):
+    def test_dashboard_no_force_refresh_skips_invalidate(self, authed_client: TestClient):
         """Without force_refresh, invalidate_cache should NOT be called."""
         with patch("app.api.api_v1.endpoints.stats.StatsSummarizer") as MockSummarizer:
             mock_instance = MagicMock()
             mock_instance.calculate_summary_statistics.return_value = {"total": 0}
             MockSummarizer.return_value = mock_instance
 
-            response = client.get("/api/v1/stats/dashboard")
+            response = authed_client.get("/api/v1/stats/dashboard")
             assert response.status_code == 200
             mock_instance.invalidate_cache.assert_not_called()
 
-    def test_dashboard_uses_demo_data_when_demo_mode_enabled(self, client: TestClient, monkeypatch):
+    def test_dashboard_passes_selected_workspace_to_summarizer(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        workspace = Workspace(slug="selected-stats", name="Selected Stats", active=True)
+        db_session.add(workspace)
+        db_session.commit()
+
+        with patch("app.api.api_v1.endpoints.stats.StatsSummarizer") as MockSummarizer:
+            mock_instance = MagicMock()
+            mock_instance.calculate_summary_statistics.return_value = {"total": 0}
+            MockSummarizer.return_value = mock_instance
+
+            response = authed_client.get(
+                "/api/v1/stats/dashboard",
+                headers={"X-DMARQ-Workspace-ID": str(workspace.id)},
+            )
+
+        assert response.status_code == 200
+        assert (
+            mock_instance.calculate_summary_statistics.call_args.kwargs["workspace_id"]
+            == workspace.id
+        )
+
+    def test_dashboard_rejects_invalid_selected_workspace(self, authed_client: TestClient):
+        response = authed_client.get(
+            "/api/v1/stats/dashboard",
+            headers={"X-DMARQ-Workspace-ID": "not-an-id"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "X-DMARQ-Workspace-ID must be an integer"
+
+    def test_dashboard_uses_demo_data_when_demo_mode_enabled(
+        self, authed_client: TestClient, monkeypatch
+    ):
         monkeypatch.setattr(
             "app.api.api_v1.endpoints.stats.get_settings",
             lambda: SimpleNamespace(DEMO_MODE=True),
         )
 
-        response = client.get("/api/v1/stats/dashboard?period_days=7&force_refresh=true")
+        response = authed_client.get("/api/v1/stats/dashboard?period_days=7&force_refresh=true")
 
         assert response.status_code == 200
         data = response.json()
@@ -115,33 +154,33 @@ class TestDashboardStatistics:
 class TestDomainStatistics:
     """Tests for GET /api/v1/stats/domain/{domain_id}"""
 
-    def test_domain_stats_returns_200(self, client: TestClient):
-        response = client.get("/api/v1/stats/domain/example.com")
+    def test_domain_stats_returns_200(self, authed_client: TestClient):
+        response = authed_client.get("/api/v1/stats/domain/example.com")
         assert response.status_code == 200
 
-    def test_domain_stats_contains_api_version(self, client: TestClient):
-        response = client.get("/api/v1/stats/domain/example.com")
+    def test_domain_stats_contains_api_version(self, authed_client: TestClient):
+        response = authed_client.get("/api/v1/stats/domain/example.com")
         data = response.json()
         assert data["api_version"] == "1.0"
 
-    def test_domain_stats_contains_period_days(self, client: TestClient):
-        response = client.get("/api/v1/stats/domain/example.com")
+    def test_domain_stats_contains_period_days(self, authed_client: TestClient):
+        response = authed_client.get("/api/v1/stats/domain/example.com")
         data = response.json()
         assert data["period_days"] == 30
 
-    def test_domain_stats_custom_period(self, client: TestClient):
-        response = client.get("/api/v1/stats/domain/example.com?period_days=14")
+    def test_domain_stats_custom_period(self, authed_client: TestClient):
+        response = authed_client.get("/api/v1/stats/domain/example.com?period_days=14")
         assert response.status_code == 200
         data = response.json()
         assert data["period_days"] == 14
 
-    def test_domain_stats_passes_period_days_to_summarizer(self, client: TestClient):
+    def test_domain_stats_passes_period_days_to_summarizer(self, authed_client: TestClient):
         with patch("app.api.api_v1.endpoints.stats.StatsSummarizer") as MockSummarizer:
             mock_instance = MagicMock()
             mock_instance.calculate_summary_statistics.return_value = {"total": 0}
             MockSummarizer.return_value = mock_instance
 
-            response = client.get("/api/v1/stats/domain/example.com?period_days=14")
+            response = authed_client.get("/api/v1/stats/domain/example.com?period_days=14")
             assert response.status_code == 200
             assert mock_instance.calculate_summary_statistics.call_args.args[1] == "example.com"
             assert mock_instance.calculate_summary_statistics.call_args.kwargs["period_days"] == 14
@@ -152,40 +191,44 @@ class TestDomainStatistics:
                 == "last_14_days"
             )
 
-    def test_domain_stats_force_refresh(self, client: TestClient):
-        response = client.get("/api/v1/stats/domain/example.com?force_refresh=true")
+    def test_domain_stats_force_refresh(self, authed_client: TestClient):
+        response = authed_client.get("/api/v1/stats/domain/example.com?force_refresh=true")
         assert response.status_code == 200
 
-    def test_domain_stats_force_refresh_calls_invalidate_with_domain(self, client: TestClient):
+    def test_domain_stats_force_refresh_calls_invalidate_with_domain(
+        self, authed_client: TestClient
+    ):
         """Verify invalidate_cache is called with the domain ID."""
         with patch("app.api.api_v1.endpoints.stats.StatsSummarizer") as MockSummarizer:
             mock_instance = MagicMock()
             mock_instance.calculate_summary_statistics.return_value = {"total": 0}
             MockSummarizer.return_value = mock_instance
 
-            response = client.get("/api/v1/stats/domain/example.com?force_refresh=true")
+            response = authed_client.get("/api/v1/stats/domain/example.com?force_refresh=true")
             assert response.status_code == 200
-            mock_instance.invalidate_cache.assert_called_once_with("example.com")
+            mock_instance.invalidate_cache.assert_called_once()
+            assert mock_instance.invalidate_cache.call_args.args == ("example.com",)
+            assert "workspace_id" in mock_instance.invalidate_cache.call_args.kwargs
 
-    def test_domain_stats_no_force_refresh_skips_invalidate(self, client: TestClient):
+    def test_domain_stats_no_force_refresh_skips_invalidate(self, authed_client: TestClient):
         with patch("app.api.api_v1.endpoints.stats.StatsSummarizer") as MockSummarizer:
             mock_instance = MagicMock()
             mock_instance.calculate_summary_statistics.return_value = {"total": 0}
             MockSummarizer.return_value = mock_instance
 
-            response = client.get("/api/v1/stats/domain/example.com")
+            response = authed_client.get("/api/v1/stats/domain/example.com")
             assert response.status_code == 200
             mock_instance.invalidate_cache.assert_not_called()
 
     def test_domain_stats_uses_demo_data_when_demo_mode_enabled(
-        self, client: TestClient, monkeypatch
+        self, authed_client: TestClient, monkeypatch
     ):
         monkeypatch.setattr(
             "app.api.api_v1.endpoints.stats.get_settings",
             lambda: SimpleNamespace(DEMO_MODE=True),
         )
 
-        response = client.get("/api/v1/stats/domain/dmarq.com?period_days=14")
+        response = authed_client.get("/api/v1/stats/domain/dmarq.com?period_days=14")
 
         assert response.status_code == 200
         data = response.json()

--- a/backend/app/tests/test_stats_summarizer.py
+++ b/backend/app/tests/test_stats_summarizer.py
@@ -9,11 +9,16 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 import app.models.domain  # noqa: F401
+import app.models.mail_source  # noqa: F401
+import app.models.organization  # noqa: F401
 import app.models.report  # noqa: F401
 import app.models.user  # noqa: F401
+import app.models.workspace  # noqa: F401
+import app.models.workspace_access  # noqa: F401
 from app.core.database import Base
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
+from app.models.workspace import Workspace
 from app.utils.stats_summarizer import StatsSummarizer, _auth_status_from_counts
 
 
@@ -41,9 +46,16 @@ def summarizer():
     shutil.rmtree(cache_dir, ignore_errors=True)
 
 
-def _seed_domain_and_reports(db, domain_name="example.com"):
+def _workspace(db, slug: str) -> Workspace:
+    workspace = Workspace(slug=slug, name=slug.title(), active=True)
+    db.add(workspace)
+    db.flush()
+    return workspace
+
+
+def _seed_domain_and_reports(db, domain_name="example.com", workspace_id=None):
     """Insert a domain with reports and records into the database."""
-    domain = Domain(name=domain_name)
+    domain = Domain(name=domain_name, workspace_id=workspace_id)
     db.add(domain)
     db.flush()
 
@@ -379,6 +391,23 @@ class TestStatsSummarizerGlobal:
         assert stats["total_emails"] == 16  # 8 * 2
         assert stats["reports_processed"] == 2
 
+    def test_workspace_global_stats_exclude_other_workspaces(self, db_session, summarizer):
+        alpha = _workspace(db_session, "alpha-stats")
+        beta = _workspace(db_session, "beta-stats")
+        _seed_domain_and_reports(db_session, "alpha.example", workspace_id=alpha.id)
+        _seed_domain_and_reports(db_session, "beta.example", workspace_id=beta.id)
+        db_session.commit()
+
+        stats = summarizer.calculate_summary_statistics(db_session, workspace_id=alpha.id)
+
+        assert stats["total_domains"] == 1
+        assert stats["total_emails"] == 8
+        assert stats["reports_processed"] == 1
+        assert {source["ip"] for source in stats["top_sources"]} == {
+            "203.0.113.1",
+            "198.51.100.1",
+        }
+
     def test_global_trend_includes_volume_and_failure_rate(self, db_session, summarizer):
         _seed_recent_trend_records(db_session)
         db_session.commit()
@@ -485,6 +514,39 @@ class TestStatsSummarizerDomain:
 
         stats = summarizer.calculate_summary_statistics(db_session, domain_id="example.com")
         assert stats["total_emails"] == 8  # Only example.com's data
+
+    def test_domain_stats_respect_workspace_scope(self, db_session, summarizer):
+        alpha = _workspace(db_session, "alpha-domain-stats")
+        beta = _workspace(db_session, "beta-domain-stats")
+        _seed_domain_and_reports(db_session, "alpha-only.example", workspace_id=alpha.id)
+        _seed_domain_and_reports(db_session, "beta-only.example", workspace_id=beta.id)
+        db_session.commit()
+
+        stats = summarizer.calculate_summary_statistics(
+            db_session,
+            domain_id="alpha-only.example",
+            workspace_id=alpha.id,
+        )
+
+        assert stats["domain"] == "alpha-only.example"
+        assert stats["total_emails"] == 8
+        assert stats["reports_processed"] == 1
+
+    def test_domain_stats_return_empty_for_domain_outside_workspace(self, db_session, summarizer):
+        alpha = _workspace(db_session, "alpha-empty-domain")
+        beta = _workspace(db_session, "beta-empty-domain")
+        _seed_domain_and_reports(db_session, "beta-only.example", workspace_id=beta.id)
+        db_session.commit()
+
+        stats = summarizer.calculate_summary_statistics(
+            db_session,
+            domain_id="beta-only.example",
+            workspace_id=alpha.id,
+        )
+
+        assert stats["domain"] == "beta-only.example"
+        assert stats["total_emails"] == 0
+        assert stats["reports_processed"] == 0
 
     def test_domain_trend_isolation(self, db_session, summarizer):
         _seed_recent_trend_records(db_session, "example.com")

--- a/backend/app/utils/stats_summarizer.py
+++ b/backend/app/utils/stats_summarizer.py
@@ -58,6 +58,7 @@ class StatsSummarizer:
         max_age_minutes: int = 60,
         period_days: int = 30,
         cache_key: Optional[str] = None,
+        workspace_id: Optional[int] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Get cached summary statistics if available and not too old
@@ -71,7 +72,12 @@ class StatsSummarizer:
         Returns:
             Cached statistics or None if not available or too old
         """
-        cache_file = self._get_cache_filename(domain_id, period_days, cache_key=cache_key)
+        cache_file = self._get_cache_filename(
+            domain_id,
+            period_days,
+            cache_key=cache_key,
+            workspace_id=workspace_id,
+        )
 
         try:
             if not os.path.exists(cache_file):
@@ -98,6 +104,7 @@ class StatsSummarizer:
         domain_id: Optional[str] = None,
         period_days: int = 30,
         cache_key: Optional[str] = None,
+        workspace_id: Optional[int] = None,
     ) -> bool:
         """
         Save summary statistics to cache
@@ -110,7 +117,12 @@ class StatsSummarizer:
         Returns:
             True if save was successful, False otherwise
         """
-        cache_file = self._get_cache_filename(domain_id, period_days, cache_key=cache_key)
+        cache_file = self._get_cache_filename(
+            domain_id,
+            period_days,
+            cache_key=cache_key,
+            workspace_id=workspace_id,
+        )
 
         try:
             # Add timestamp
@@ -125,7 +137,11 @@ class StatsSummarizer:
             logger.error("Error writing cache file %s: %s", cache_file, str(e))
             return False
 
-    def invalidate_cache(self, domain_id: Optional[str] = None) -> None:
+    def invalidate_cache(
+        self,
+        domain_id: Optional[str] = None,
+        workspace_id: Optional[int] = None,
+    ) -> None:
         """
         Invalidate cache for a domain or all domains
 
@@ -133,11 +149,12 @@ class StatsSummarizer:
             domain_id: Optional domain ID to invalidate specific domain cache
                        If None, invalidates global summary cache
         """
+        workspace_prefix = f"workspace_{workspace_id}_" if workspace_id is not None else ""
         if domain_id is None:
-            self._remove_cache_files("global_summary")
+            self._remove_cache_files(f"{workspace_prefix}global_summary")
         else:
             safe_domain = domain_id.replace(".", "_").replace("/", "_")
-            self._remove_cache_files(f"domain_{safe_domain}")
+            self._remove_cache_files(f"{workspace_prefix}domain_{safe_domain}")
 
     def _remove_cache_files(self, prefix: str) -> None:
         """Remove cached summary files that begin with the provided prefix."""
@@ -150,6 +167,7 @@ class StatsSummarizer:
         domain_id: Optional[str] = None,
         period_days: int = 30,
         cache_key: Optional[str] = None,
+        workspace_id: Optional[int] = None,
     ) -> str:
         """
         Get the filename for a cache file
@@ -167,11 +185,12 @@ class StatsSummarizer:
             safe_key = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(cache_key)).strip("_")
             if safe_key:
                 suffix = f"{suffix}_{safe_key}"
+        workspace_prefix = f"workspace_{workspace_id}_" if workspace_id is not None else ""
         if domain_id is None:
-            return os.path.join(self.cache_dir, f"global_summary_{suffix}.json")
+            return os.path.join(self.cache_dir, f"{workspace_prefix}global_summary_{suffix}.json")
         # Sanitize domain_id to use as filename
         safe_domain = domain_id.replace(".", "_").replace("/", "_")
-        return os.path.join(self.cache_dir, f"domain_{safe_domain}_{suffix}.json")
+        return os.path.join(self.cache_dir, f"{workspace_prefix}domain_{safe_domain}_{suffix}.json")
 
     def calculate_summary_statistics(
         self,
@@ -181,6 +200,7 @@ class StatsSummarizer:
         start_ts: Optional[int] = None,
         end_ts: Optional[int] = None,
         cache_key: Optional[str] = None,
+        workspace_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Calculate summary statistics from the database
@@ -201,12 +221,19 @@ class StatsSummarizer:
                 domain_id,
                 period_days=period_days,
                 cache_key=cache_key,
+                workspace_id=workspace_id,
             )
             if cached_stats and "change_summary" in cached_stats:
                 return cached_stats
 
         if domain_id is None:
-            stats = self._calculate_global_statistics(db, period_days, start_ts, end_ts)
+            stats = self._calculate_global_statistics(
+                db,
+                period_days,
+                start_ts,
+                end_ts,
+                workspace_id=workspace_id,
+            )
         else:
             stats = self._calculate_domain_statistics(
                 db,
@@ -214,10 +241,17 @@ class StatsSummarizer:
                 period_days,
                 start_ts,
                 end_ts,
+                workspace_id=workspace_id,
             )
 
         if use_cache:
-            self.save_summary(stats, domain_id, period_days, cache_key=cache_key)
+            self.save_summary(
+                stats,
+                domain_id,
+                period_days,
+                cache_key=cache_key,
+                workspace_id=workspace_id,
+            )
 
         return stats
 
@@ -251,15 +285,23 @@ class StatsSummarizer:
         period_days: int = 30,
         start_ts: Optional[int] = None,
         end_ts: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Calculate global statistics across all domains from the database."""
         # Count total domains
-        total_domains = db.query(func.count(Domain.id)).scalar() or 0
+        domain_query = db.query(Domain)
+        if workspace_id is not None:
+            domain_query = domain_query.filter(Domain.workspace_id == workspace_id)
+        total_domains = domain_query.count()
 
         # Aggregate email counts from report records
         totals_query = db.query(
             func.coalesce(func.sum(ReportRecord.count), 0).label("total_emails")
         ).join(DMARCReport, ReportRecord.report_id == DMARCReport.id)
+        if workspace_id is not None:
+            totals_query = totals_query.join(Domain, DMARCReport.domain_id == Domain.id).filter(
+                Domain.workspace_id == workspace_id
+            )
         totals = self._apply_report_window(
             totals_query,
             period_days,
@@ -274,6 +316,10 @@ class StatsSummarizer:
             .join(DMARCReport, ReportRecord.report_id == DMARCReport.id)
             .filter((ReportRecord.dkim == "pass") | (ReportRecord.spf == "pass"))
         )
+        if workspace_id is not None:
+            compliant_query = compliant_query.join(
+                Domain, DMARCReport.domain_id == Domain.id
+            ).filter(Domain.workspace_id == workspace_id)
         compliant_emails = self._apply_report_window(
             compliant_query,
             period_days,
@@ -283,9 +329,14 @@ class StatsSummarizer:
         compliant_emails = int(compliant_emails) if compliant_emails else 0
 
         # Count reports processed
+        reports_query = db.query(func.count(DMARCReport.id))
+        if workspace_id is not None:
+            reports_query = reports_query.join(Domain, DMARCReport.domain_id == Domain.id).filter(
+                Domain.workspace_id == workspace_id
+            )
         reports_processed = (
             self._apply_report_window(
-                db.query(func.count(DMARCReport.id)),
+                reports_query,
                 period_days,
                 start_ts,
                 end_ts,
@@ -304,6 +355,7 @@ class StatsSummarizer:
             period_days=period_days,
             start_ts=start_ts,
             end_ts=end_ts,
+            workspace_id=workspace_id,
         )
 
         # Compliance trend over recent days
@@ -312,6 +364,7 @@ class StatsSummarizer:
             days=period_days,
             start_ts=start_ts,
             end_ts=end_ts,
+            workspace_id=workspace_id,
         )
 
         # Recently changed source and compliance signals
@@ -321,6 +374,7 @@ class StatsSummarizer:
             trend=compliance_trend,
             start_ts=start_ts,
             end_ts=end_ts,
+            workspace_id=workspace_id,
         )
 
         return {
@@ -341,10 +395,14 @@ class StatsSummarizer:
         period_days: int = 30,
         start_ts: Optional[int] = None,
         end_ts: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Calculate statistics for a specific domain from the database."""
         # Look up the domain by name
-        domain = db.query(Domain).filter(Domain.name == domain_id).first()
+        domain_query = db.query(Domain).filter(Domain.name == domain_id)
+        if workspace_id is not None:
+            domain_query = domain_query.filter(Domain.workspace_id == workspace_id)
+        domain = domain_query.first()
         if not domain:
             return {
                 "domain": domain_id,
@@ -417,6 +475,7 @@ class StatsSummarizer:
             days=period_days,
             start_ts=start_ts,
             end_ts=end_ts,
+            workspace_id=workspace_id,
         )
 
         # Recently changed source and compliance signals
@@ -427,6 +486,7 @@ class StatsSummarizer:
             trend=compliance_trend,
             start_ts=start_ts,
             end_ts=end_ts,
+            workspace_id=workspace_id,
         )
 
         return {
@@ -447,6 +507,7 @@ class StatsSummarizer:
         period_days: int = 30,
         start_ts: Optional[int] = None,
         end_ts: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """Get top sending sources by email volume across all domains."""
         query = db.query(
@@ -474,6 +535,10 @@ class StatsSummarizer:
                 )
             ).label("dmarc_pass_count"),
         ).join(DMARCReport, ReportRecord.report_id == DMARCReport.id)
+        if workspace_id is not None:
+            query = query.join(Domain, DMARCReport.domain_id == Domain.id).filter(
+                Domain.workspace_id == workspace_id
+            )
         results = (
             self._apply_report_window(query, period_days, start_ts, end_ts)
             .group_by(ReportRecord.source_ip)
@@ -584,6 +649,7 @@ class StatsSummarizer:
         days: int = 30,
         start_ts: Optional[int] = None,
         end_ts: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """
         Calculate compliance trend over recent days from report data.
@@ -615,6 +681,10 @@ class StatsSummarizer:
 
         if domain_db_id is not None:
             query = query.filter(DMARCReport.domain_id == domain_db_id)
+        if workspace_id is not None:
+            query = query.join(Domain, DMARCReport.domain_id == Domain.id).filter(
+                Domain.workspace_id == workspace_id
+            )
 
         results = query.group_by(DMARCReport.begin_date).order_by(DMARCReport.begin_date).all()
 
@@ -659,6 +729,7 @@ class StatsSummarizer:
         limit: int = 5,
         start_ts: Optional[int] = None,
         end_ts: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """Return notable source and compliance changes for the reporting window."""
         days = max(1, int(days or 30))
@@ -687,6 +758,9 @@ class StatsSummarizer:
         if domain_db_id is not None:
             current_query = current_query.filter(DMARCReport.domain_id == domain_db_id)
             previous_query = previous_query.filter(DMARCReport.domain_id == domain_db_id)
+        if workspace_id is not None:
+            current_query = current_query.filter(Domain.workspace_id == workspace_id)
+            previous_query = previous_query.filter(Domain.workspace_id == workspace_id)
 
         previous_sources = {(row.domain, row.source_ip) for row in previous_query.distinct().all()}
         current_sources = (


### PR DESCRIPTION
## Summary
- add reusable parsing/resolution for the selected workspace header
- scope dashboard stats, domain stats, and summary cache entries to the authorized workspace
- tighten selected-workspace domain summaries so stale in-memory report domains do not bleed into another workspace
- add coverage for selected-workspace stats and domain summary behavior

Refs #238

## Validation
- python -m py_compile on changed backend files
- black --check on changed backend files
- isort --check-only on changed backend files
- git diff --check on changed backend files
- direct SQLite stats probe confirmed workspace A excludes workspace B reports

## Local test boundary
Focused pytest still stalls during app/conftest import in this worktree before collecting the requested file; CI should be used for the full pytest verdict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard, domain summary, and stats views now respect a selected workspace, letting you switch context with the `X-DMARQ-Workspace-ID` header.
  * Summary results and cache data are separated by workspace, so reports reflect the chosen workspace more accurately.

* **Bug Fixes**
  * Domain summaries now avoid mixing in unrelated report data when a workspace is selected.
  * Stats refreshes and calculations now return the correct totals for the active workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->