### PR TITLE
[codex] Scope aggregate report endpoints by selected workspace

### DIFF
--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Header, HTTPException, UploadFile, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -18,12 +18,8 @@ from app.services.report_store import ReportStore
 from app.services.workspace_access import (
     PERMISSION_REPORTS_READ,
     PERMISSION_REPORTS_WRITE,
-    require_workspace_permission,
-)
-from app.services.workspaces import (
-    assign_default_workspace_to_unscoped_rows,
-    get_default_workspace,
-    get_or_create_default_workspace,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
 )
 from app.utils.domain_validator import DomainValidationError, validate_domain
 
@@ -55,11 +51,29 @@ ALLOWED_MIME_TYPES = {
 ALLOWED_EXTENSIONS = {".xml", ".zip", ".gz", ".gzip"}
 
 
-def _authorized_reports_workspace(auth_context: Dict[str, Any], db: Session, permission: str):
+def _authorized_reports_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    permission: str,
+    selected_workspace_id: Optional[int] = None,
+):
     """Authorize report access before running legacy workspace repair writes."""
-    workspace = get_default_workspace(db) or get_or_create_default_workspace(db)
-    require_workspace_permission(auth_context, permission, db, workspace)
-    return assign_default_workspace_to_unscoped_rows(db)
+    return resolve_authorized_workspace(
+        db,
+        auth_context,
+        permission,
+        selected_workspace_id=selected_workspace_id,
+    )
+
+
+def _selected_workspace_id(selected_workspace: Optional[str]) -> Optional[int]:
+    return parse_selected_workspace_id(selected_workspace)
+
+
+def _hydrated_report_store(db: Session, workspace) -> ReportStore:
+    store = ReportStore()
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    return store
 
 
 def _validate_mime_type(file_content: bytes) -> None:
@@ -187,6 +201,7 @@ async def upload_report(
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """
     Upload and process a DMARC aggregate report file (XML, ZIP, or GZIP)
@@ -197,7 +212,12 @@ async def upload_report(
     - Zip bomb protection
     - Sanitized error messages
     """
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_WRITE)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_WRITE,
+        _selected_workspace_id(selected_workspace),
+    )
     try:
         # Read content first so validators can inspect it
         file_content = await file.read()
@@ -224,7 +244,6 @@ async def upload_report(
             )
 
         # Check for duplicate report before storing
-        store = ReportStore.get_instance()
         report_id = report.get("report_id", "")
         if report_id and report_exists(db, domain, report_id, workspace_id=workspace.id):
             raise HTTPException(
@@ -236,9 +255,8 @@ async def upload_report(
             )
 
         # Store the report
-        save_parsed_report(db, report)
+        save_parsed_report(db, report, workspace_id=workspace.id)
         db.commit()
-        store.add_report(report)
 
         processed_records = report.get("summary", {}).get("total_count", 0)
 
@@ -267,13 +285,18 @@ async def upload_report(
 async def get_all_reports(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """
     Get all DMARC reports across all domains, sorted by end_date descending.
     """
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        _selected_workspace_id(selected_workspace),
+    )
+    store = _hydrated_report_store(db, workspace)
     domains = store.get_domains()
 
     all_reports: List[AllReportsItem] = []
@@ -308,13 +331,18 @@ async def get_all_reports(
 async def get_domains(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """
     Get list of all domains with reports
     """
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        _selected_workspace_id(selected_workspace),
+    )
+    store = _hydrated_report_store(db, workspace)
     return store.get_domains()
 
 
@@ -323,13 +351,18 @@ async def get_domain_summary(
     domain: str,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """
     Get summary statistics for a specific domain
     """
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        _selected_workspace_id(selected_workspace),
+    )
+    store = _hydrated_report_store(db, workspace)
     summary = store.get_domain_summary(domain)
 
     if not summary:
@@ -344,13 +377,18 @@ async def get_domain_summary(
 async def get_all_summaries(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """
     Get summary statistics for all domains
     """
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        _selected_workspace_id(selected_workspace),
+    )
+    store = _hydrated_report_store(db, workspace)
     all_summaries = store.get_all_domain_summaries()
 
     return [DomainSummary(domain=domain, **summary) for domain, summary in all_summaries.items()]
@@ -361,13 +399,18 @@ async def get_domain_reports(
     domain: str,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """
     Get all reports for a specific domain
     """
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        _selected_workspace_id(selected_workspace),
+    )
+    store = _hydrated_report_store(db, workspace)
     reports = store.get_domain_reports(domain)
 
     if not reports:
@@ -398,6 +441,7 @@ async def get_domain_reports_paginated(
     sort_order: str = "desc",
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """
     Get paginated reports for a specific domain with sorting options
@@ -409,9 +453,13 @@ async def get_domain_reports_paginated(
         sort_by: Field to sort by (report_id, org_name, begin_date, end_date, total_count)
         sort_order: Sort order (asc or desc)
     """
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        _selected_workspace_id(selected_workspace),
+    )
+    store = _hydrated_report_store(db, workspace)
     all_reports = store.get_domain_reports(domain)
 
     if not all_reports:
@@ -473,6 +521,7 @@ async def delete_report(
     report_id: str,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """
     Delete a single DMARC report for a domain.
@@ -480,12 +529,17 @@ async def delete_report(
     Removes the report from the store and recomputes all domain statistics so
     that aggregated numbers remain accurate after deletion.
     """
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_WRITE)
-    store = ReportStore.get_instance()
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_WRITE,
+        _selected_workspace_id(selected_workspace),
+    )
     deleted_from_db = delete_persisted_report(db, domain, report_id, workspace_id=workspace.id)
     if deleted_from_db:
         db.commit()
-    deleted = store.delete_report(domain, report_id) or deleted_from_db
+    ReportStore.get_instance().delete_report(domain, report_id)
+    deleted = deleted_from_db
 
     if not deleted:
         raise HTTPException(
@@ -550,13 +604,18 @@ async def get_report_by_id(
     report_id: str,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """
     Get full details for a single DMARC report by its report ID.
     """
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        _selected_workspace_id(selected_workspace),
+    )
+    store = _hydrated_report_store(db, workspace)
     report = store.get_report_by_id(report_id)
 
     if report is None:

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -538,7 +538,6 @@ async def delete_report(
     deleted_from_db = delete_persisted_report(db, domain, report_id, workspace_id=workspace.id)
     if deleted_from_db:
         db.commit()
-    ReportStore.get_instance().delete_report(domain, report_id)
     deleted = deleted_from_db
 
     if not deleted:

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -99,7 +99,12 @@ def report_exists(
     return query.first() is not None
 
 
-def save_parsed_report(db: Session, report: Dict[str, Any]) -> tuple[DMARCReport, bool]:
+def save_parsed_report(
+    db: Session,
+    report: Dict[str, Any],
+    *,
+    workspace_id: Optional[int] = None,
+) -> tuple[DMARCReport, bool]:
     """Persist a parsed DMARC report and its records.
 
     Returns ``(row, created)``. The caller owns the transaction and should
@@ -108,15 +113,17 @@ def save_parsed_report(db: Session, report: Dict[str, Any]) -> tuple[DMARCReport
     domain_name = report.get("domain") or "unknown"
     report_id = report.get("report_id") or ""
     policy = _policy_parts(report)
-    workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+    if workspace_id is None:
+        workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+        workspace_id = workspace.id
 
     domain = (
         db.query(Domain)
-        .filter(Domain.name == domain_name, Domain.workspace_id == workspace.id)
+        .filter(Domain.name == domain_name, Domain.workspace_id == workspace_id)
         .first()
     )
     if domain is None:
-        domain = Domain(name=domain_name, dmarc_policy=policy["p"], workspace_id=workspace.id)
+        domain = Domain(name=domain_name, dmarc_policy=policy["p"], workspace_id=workspace_id)
         db.add(domain)
         db.flush()
     elif policy.get("p"):

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -368,8 +368,32 @@ def test_report_read_and_delete_routes_respect_selected_workspace(
     domains = authed_client.get("/api/v1/reports/domains", headers=selected_header)
     all_reports = authed_client.get("/api/v1/reports", headers=selected_header)
     summaries = authed_client.get("/api/v1/reports/summary", headers=selected_header)
+    domain_summary = authed_client.get(
+        "/api/v1/reports/domain/selected-reports.example/summary",
+        headers=selected_header,
+    )
+    domain_reports = authed_client.get(
+        "/api/v1/reports/domain/selected-reports.example/reports",
+        headers=selected_header,
+    )
+    paginated_reports = authed_client.get(
+        "/api/v1/reports/domain/selected-reports.example/reports/paginated",
+        headers=selected_header,
+    )
     detail = authed_client.get("/api/v1/reports/selected-report", headers=selected_header)
     hidden_detail = authed_client.get("/api/v1/reports/default-report", headers=selected_header)
+    hidden_domain_summary = authed_client.get(
+        "/api/v1/reports/domain/default-reports.example/summary",
+        headers=selected_header,
+    )
+    hidden_domain_reports = authed_client.get(
+        "/api/v1/reports/domain/default-reports.example/reports",
+        headers=selected_header,
+    )
+    hidden_paginated_reports = authed_client.get(
+        "/api/v1/reports/domain/default-reports.example/reports/paginated",
+        headers=selected_header,
+    )
 
     assert domains.status_code == 200
     assert domains.json() == ["selected-reports.example"]
@@ -377,9 +401,20 @@ def test_report_read_and_delete_routes_respect_selected_workspace(
     assert [item["report_id"] for item in all_reports.json()] == ["selected-report"]
     assert summaries.status_code == 200
     assert [item["domain"] for item in summaries.json()] == ["selected-reports.example"]
+    assert domain_summary.status_code == 200
+    assert domain_summary.json()["total_count"] == 9
+    assert domain_reports.status_code == 200
+    assert [item["report_id"] for item in domain_reports.json()] == ["selected-report"]
+    assert paginated_reports.status_code == 200
+    assert [item["report_id"] for item in paginated_reports.json()["reports"]] == [
+        "selected-report"
+    ]
     assert detail.status_code == 200
     assert detail.json()["summary"]["total_count"] == 9
     assert hidden_detail.status_code == 404
+    assert hidden_domain_summary.status_code == 404
+    assert hidden_domain_reports.status_code == 404
+    assert hidden_paginated_reports.status_code == 404
 
     delete_hidden = authed_client.delete(
         "/api/v1/reports/domain/default-reports.example/reports/default-report",

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -9,13 +9,13 @@ from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
 from app.models.user import User
+from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
 from app.services.report_persistence import persisted_report_to_dict, save_parsed_report
 from app.services.report_store import ReportStore
 from app.services.workspace_access import ROLE_ANALYST
 from app.services.workspaces import get_or_create_default_workspace
 from app.tests.test_data import SAMPLE_XML, load_dmarc_fixture
-
 
 SAMPLE_RFC9990_XML = load_dmarc_fixture("rfc9990-treewalk-extension.xml")
 
@@ -28,9 +28,38 @@ def _make_zip(xml_content: str) -> bytes:
     return buf.getvalue()
 
 
-def _persist_parsed_report(db_session, report: dict) -> None:
-    save_parsed_report(db_session, report)
+def _persist_parsed_report(db_session, report: dict, workspace_id: int | None = None) -> None:
+    save_parsed_report(db_session, report, workspace_id=workspace_id)
     db_session.commit()
+
+
+def _parsed_report(
+    *,
+    domain: str,
+    report_id: str,
+    count: int = 5,
+    begin_ts: int = 1704067200,
+    end_ts: int = 1704153599,
+) -> dict:
+    return {
+        "domain": domain,
+        "report_id": report_id,
+        "org_name": "Workspace Test Org",
+        "email": "",
+        "begin_timestamp": begin_ts,
+        "end_timestamp": end_ts,
+        "policy": {"p": "none", "sp": "none", "pct": "100"},
+        "records": [
+            {
+                "source_ip": "192.0.2.55",
+                "count": count,
+                "disposition": "none",
+                "dkim_result": "pass",
+                "spf_result": "pass",
+                "header_from": domain,
+            }
+        ],
+    }
 
 
 def _add_user(db_session, email: str, *, is_superuser: bool = False) -> User:
@@ -141,6 +170,37 @@ def test_upload_persists_report_rows(authed_client: TestClient, db_session):
     assert report.org_name == "google.com"
     assert report.domain.name == "example.com"
     assert db_session.query(ReportRecord).filter_by(report_id=report.id).count() == 1
+
+
+def test_upload_report_respects_selected_workspace_header(
+    authed_client: TestClient,
+    db_session,
+):
+    """Uploaded reports are persisted in the selected workspace."""
+    other_workspace = Workspace(slug="selected-report-upload", name="Selected Report Upload")
+    db_session.add(other_workspace)
+    db_session.commit()
+
+    zip_bytes = _make_zip(SAMPLE_XML)
+    response = authed_client.post(
+        "/api/v1/reports/upload",
+        headers={"X-DMARQ-Workspace-ID": str(other_workspace.id)},
+        files={"file": ("report.zip", zip_bytes, "application/zip")},
+    )
+
+    assert response.status_code == 200
+    domain = db_session.query(Domain).filter(Domain.name == "example.com").one()
+    assert domain.workspace_id == other_workspace.id
+
+    default_listing = authed_client.get("/api/v1/reports/domains")
+    selected_listing = authed_client.get(
+        "/api/v1/reports/domains",
+        headers={"X-DMARQ-Workspace-ID": str(other_workspace.id)},
+    )
+    assert default_listing.status_code == 200
+    assert default_listing.json() == []
+    assert selected_listing.status_code == 200
+    assert selected_listing.json() == ["example.com"]
 
 
 def test_upload_persists_rfc9990_optional_fields(authed_client: TestClient, db_session):
@@ -281,6 +341,59 @@ def test_reports_summary_empty(authed_client: TestClient):
     response = authed_client.get("/api/v1/reports/summary")
     assert response.status_code == 200
     assert response.json() == []
+
+
+def test_report_read_and_delete_routes_respect_selected_workspace(
+    authed_client: TestClient,
+    db_session,
+):
+    """Report read/delete APIs operate inside the selected workspace boundary."""
+    default_workspace = get_or_create_default_workspace(db_session)
+    selected_workspace = Workspace(slug="selected-report-reads", name="Selected Report Reads")
+    db_session.add(selected_workspace)
+    db_session.flush()
+    _persist_parsed_report(
+        db_session,
+        _parsed_report(domain="default-reports.example", report_id="default-report", count=4),
+        workspace_id=default_workspace.id,
+    )
+    _persist_parsed_report(
+        db_session,
+        _parsed_report(domain="selected-reports.example", report_id="selected-report", count=9),
+        workspace_id=selected_workspace.id,
+    )
+
+    selected_header = {"X-DMARQ-Workspace-ID": str(selected_workspace.id)}
+
+    domains = authed_client.get("/api/v1/reports/domains", headers=selected_header)
+    all_reports = authed_client.get("/api/v1/reports", headers=selected_header)
+    summaries = authed_client.get("/api/v1/reports/summary", headers=selected_header)
+    detail = authed_client.get("/api/v1/reports/selected-report", headers=selected_header)
+    hidden_detail = authed_client.get("/api/v1/reports/default-report", headers=selected_header)
+
+    assert domains.status_code == 200
+    assert domains.json() == ["selected-reports.example"]
+    assert all_reports.status_code == 200
+    assert [item["report_id"] for item in all_reports.json()] == ["selected-report"]
+    assert summaries.status_code == 200
+    assert [item["domain"] for item in summaries.json()] == ["selected-reports.example"]
+    assert detail.status_code == 200
+    assert detail.json()["summary"]["total_count"] == 9
+    assert hidden_detail.status_code == 404
+
+    delete_hidden = authed_client.delete(
+        "/api/v1/reports/domain/default-reports.example/reports/default-report",
+        headers=selected_header,
+    )
+    delete_selected = authed_client.delete(
+        "/api/v1/reports/domain/selected-reports.example/reports/selected-report",
+        headers=selected_header,
+    )
+
+    assert delete_hidden.status_code == 404
+    assert delete_selected.status_code == 200
+    assert db_session.query(DMARCReport).filter_by(report_id="default-report").count() == 1
+    assert db_session.query(DMARCReport).filter_by(report_id="selected-report").count() == 0
 
 
 def test_upload_and_get_domain_summary(authed_client: TestClient):


### PR DESCRIPTION
## Summary
- resolve the selected workspace for aggregate report upload, list, summary, detail, pagination, and delete endpoints
- persist uploaded aggregate reports into the authorized workspace instead of always using the default workspace
- use request-local, workspace-hydrated report stores for report read APIs
- add selected-workspace regression coverage for upload/read/delete report flows

Refs #238

## Validation
- `python -m py_compile backend/app/api/api_v1/endpoints/reports.py backend/app/services/report_persistence.py backend/app/tests/test_reports_api.py`
- `black --check backend/app/api/api_v1/endpoints/reports.py backend/app/services/report_persistence.py backend/app/tests/test_reports_api.py`
- `isort --check-only backend/app/api/api_v1/endpoints/reports.py backend/app/services/report_persistence.py backend/app/tests/test_reports_api.py`
- `git diff --check -- backend/app/api/api_v1/endpoints/reports.py backend/app/services/report_persistence.py backend/app/tests/test_reports_api.py`

Local full-test execution is still limited by the known worktree import/file-read stall, so CI is the full verdict for this slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DMARC report endpoints now support selecting a workspace through the `X-DMARQ-Workspace-ID` header.
  * Upload, list, summary, detail, and delete actions now operate within the chosen workspace.

* **Bug Fixes**
  * Report data is now saved and retrieved with the correct workspace context.
  * Delete actions now return the correct result for reports outside the selected workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->