### PR TITLE
Handle cross-workspace report domain conflicts

### DIFF
--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.core.security import require_admin_auth
+from app.models.domain import Domain
 from app.services.dmarc_parser import DMARCParser
 from app.services.report_persistence import (
     delete_persisted_report,
@@ -251,6 +252,16 @@ async def upload_report(
                 detail=(
                     f"Report '{report_id}' for domain '{domain}' has already been uploaded. "
                     "Duplicate reports are not stored to keep statistics accurate."
+                ),
+            )
+
+        existing_domain = db.query(Domain).filter(Domain.name == domain).first()
+        if existing_domain is not None and existing_domain.workspace_id != workspace.id:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Domain '{domain}' already belongs to another workspace. "
+                    "Move or rename the domain before uploading reports for this workspace."
                 ),
             )
 

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -203,6 +203,33 @@ def test_upload_report_respects_selected_workspace_header(
     assert selected_listing.json() == ["example.com"]
 
 
+def test_upload_report_rejects_domain_owned_by_another_workspace(
+    authed_client: TestClient,
+    db_session,
+):
+    """Uploading a cross-workspace duplicate domain returns a controlled conflict."""
+    default_workspace = get_or_create_default_workspace(db_session)
+    other_workspace = Workspace(slug="duplicate-domain-upload", name="Duplicate Domain Upload")
+    db_session.add(other_workspace)
+    db_session.flush()
+    _persist_parsed_report(
+        db_session,
+        _parsed_report(domain="example.com", report_id="default-example"),
+        workspace_id=default_workspace.id,
+    )
+
+    response = authed_client.post(
+        "/api/v1/reports/upload",
+        headers={"X-DMARQ-Workspace-ID": str(other_workspace.id)},
+        files={"file": ("report.zip", _make_zip(SAMPLE_XML), "application/zip")},
+    )
+
+    assert response.status_code == 409
+    assert "already belongs to another workspace" in response.json()["detail"]
+    assert db_session.query(Domain).filter(Domain.name == "example.com").count() == 1
+    assert db_session.query(DMARCReport).filter_by(report_id="123456789").count() == 0
+
+
 def test_upload_persists_rfc9990_optional_fields(authed_client: TestClient, db_session):
     """RFC 9990 / DMARCbis metadata is kept for exports and future UI use."""
     zip_bytes = _make_zip(SAMPLE_RFC9990_XML)


### PR DESCRIPTION
## Summary\n- return a controlled 409 when a report upload targets a domain already owned by another workspace\n- add regression coverage for the cross-workspace duplicate-domain upload path\n\n## Test\n- .venv/bin/python -m pytest backend/app/tests/test_reports_api.py -q\n\nFollow-up from PR #269 review: the main scoped delete/read-route concerns were already merged in #269; this keeps the remaining global Domain.name uniqueness edge from surfacing as an internal upload error.