### PR TITLE
Handle raced report domain conflicts

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -47,7 +47,7 @@ from app.services.workspace_audit import record_workspace_audit_log
 from app.services.workspaces import (
     workspace_domain_query,
 )
-from app.utils.domain_validator import validate_domain_config
+from app.utils.domain_validator import normalize_domain_name, validate_domain_config
 
 logger = logging.getLogger(__name__)
 
@@ -511,10 +511,6 @@ def _policy_enforcement_suggestions(
             }
         ]
     return []
-
-
-def _normalize_domain_name(name: str) -> str:
-    return name.strip().strip(".").lower()
 
 
 def _domain_names_for_summary(
@@ -1303,7 +1299,7 @@ async def create_domain(
 ):
     """Create a monitored domain before any DMARC reports have arrived."""
     workspace = _authorized_domain_workspace(_auth, db)
-    name = _normalize_domain_name(payload.name)
+    name = normalize_domain_name(payload.name)
     validation = validate_domain_config({"name": name, "description": payload.description or ""})
     if not validation["valid"]:
         raise HTTPException(

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, File, Header, HTTPException, UploadFile, status
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
@@ -69,6 +70,10 @@ def _authorized_reports_workspace(
 
 def _selected_workspace_id(selected_workspace: Optional[str]) -> Optional[int]:
     return parse_selected_workspace_id(selected_workspace)
+
+
+def _normalize_domain_name(name: str) -> str:
+    return name.strip().strip(".").lower()
 
 
 def _hydrated_report_store(db: Session, workspace) -> ReportStore:
@@ -235,6 +240,8 @@ async def upload_report(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Report does not contain a valid domain",
             )
+        domain = _normalize_domain_name(domain)
+        report["domain"] = domain
 
         # Validate domain format (not DNS resolution to avoid external calls)
         is_valid, error_msg, error_code = validate_domain(domain, check_dns=False)
@@ -266,8 +273,21 @@ async def upload_report(
             )
 
         # Store the report
-        save_parsed_report(db, report, workspace_id=workspace.id)
-        db.commit()
+        try:
+            save_parsed_report(db, report, workspace_id=workspace.id)
+            db.commit()
+        except IntegrityError as exc:
+            db.rollback()
+            existing_domain = db.query(Domain).filter(Domain.name == domain).first()
+            if existing_domain is not None and existing_domain.workspace_id != workspace.id:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        f"Domain '{domain}' already belongs to another workspace. "
+                        "Move or rename the domain before uploading reports for this workspace."
+                    ),
+                ) from exc
+            raise
 
         processed_records = report.get("summary", {}).get("total_count", 0)
 

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -76,6 +76,37 @@ def _normalize_domain_name(name: str) -> str:
     return name.strip().strip(".").lower()
 
 
+def _domain_workspace_conflict(domain: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=(
+            f"Domain '{domain}' already belongs to another workspace. "
+            "Move or rename the domain before uploading reports for this workspace."
+        ),
+    )
+
+
+def _raise_if_domain_owned_by_other_workspace(db: Session, domain: str, workspace_id: int) -> None:
+    existing_domain = db.query(Domain).filter(Domain.name == domain).first()
+    if existing_domain is not None and existing_domain.workspace_id != workspace_id:
+        raise _domain_workspace_conflict(domain)
+
+
+def _save_uploaded_report(
+    db: Session, report: Dict[str, Any], domain: str, workspace_id: int
+) -> None:
+    try:
+        save_parsed_report(db, report, workspace_id=workspace_id)
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        try:
+            _raise_if_domain_owned_by_other_workspace(db, domain, workspace_id)
+        except HTTPException as conflict:
+            raise conflict from exc
+        raise
+
+
 def _hydrated_report_store(db: Session, workspace) -> ReportStore:
     store = ReportStore()
     hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
@@ -262,32 +293,10 @@ async def upload_report(
                 ),
             )
 
-        existing_domain = db.query(Domain).filter(Domain.name == domain).first()
-        if existing_domain is not None and existing_domain.workspace_id != workspace.id:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=(
-                    f"Domain '{domain}' already belongs to another workspace. "
-                    "Move or rename the domain before uploading reports for this workspace."
-                ),
-            )
+        _raise_if_domain_owned_by_other_workspace(db, domain, workspace.id)
 
         # Store the report
-        try:
-            save_parsed_report(db, report, workspace_id=workspace.id)
-            db.commit()
-        except IntegrityError as exc:
-            db.rollback()
-            existing_domain = db.query(Domain).filter(Domain.name == domain).first()
-            if existing_domain is not None and existing_domain.workspace_id != workspace.id:
-                raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail=(
-                        f"Domain '{domain}' already belongs to another workspace. "
-                        "Move or rename the domain before uploading reports for this workspace."
-                    ),
-                ) from exc
-            raise
+        _save_uploaded_report(db, report, domain, workspace.id)
 
         processed_records = report.get("summary", {}).get("total_count", 0)
 

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -23,7 +23,7 @@ from app.services.workspace_access import (
     parse_selected_workspace_id,
     resolve_authorized_workspace,
 )
-from app.utils.domain_validator import DomainValidationError, validate_domain
+from app.utils.domain_validator import DomainValidationError, normalize_domain_name, validate_domain
 
 logger = logging.getLogger(__name__)
 
@@ -72,10 +72,6 @@ def _selected_workspace_id(selected_workspace: Optional[str]) -> Optional[int]:
     return parse_selected_workspace_id(selected_workspace)
 
 
-def _normalize_domain_name(name: str) -> str:
-    return name.strip().strip(".").lower()
-
-
 def _domain_workspace_conflict(domain: str) -> HTTPException:
     return HTTPException(
         status_code=status.HTTP_409_CONFLICT,
@@ -104,7 +100,8 @@ def _save_uploaded_report(
             _raise_if_domain_owned_by_other_workspace(db, domain, workspace_id)
         except HTTPException as conflict:
             raise conflict from exc
-        raise
+        save_parsed_report(db, report, workspace_id=workspace_id)
+        db.commit()
 
 
 def _hydrated_report_store(db: Session, workspace) -> ReportStore:
@@ -271,7 +268,7 @@ async def upload_report(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Report does not contain a valid domain",
             )
-        domain = _normalize_domain_name(domain)
+        domain = normalize_domain_name(domain)
         report["domain"] = domain
 
         # Validate domain format (not DNS resolution to avoid external calls)

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -3,7 +3,10 @@ import zipfile
 from contextlib import contextmanager
 
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
 
+from app.api.api_v1.endpoints import reports as reports_endpoint
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
@@ -227,6 +230,73 @@ def test_upload_report_rejects_domain_owned_by_another_workspace(
     assert response.status_code == 409
     assert "already belongs to another workspace" in response.json()["detail"]
     assert db_session.query(Domain).filter(Domain.name == "example.com").count() == 1
+    assert db_session.query(DMARCReport).filter_by(report_id="123456789").count() == 0
+
+
+def test_upload_report_normalizes_domain_before_conflict_check(
+    authed_client: TestClient,
+    db_session,
+):
+    """Cross-workspace domain checks use the same normalized domain as persistence."""
+    default_workspace = get_or_create_default_workspace(db_session)
+    other_workspace = Workspace(slug="case-domain-upload", name="Case Domain Upload")
+    db_session.add(other_workspace)
+    db_session.flush()
+    _persist_parsed_report(
+        db_session,
+        _parsed_report(domain="example.com", report_id="default-example"),
+        workspace_id=default_workspace.id,
+    )
+    uppercase_xml = SAMPLE_XML.replace(
+        "<domain>example.com</domain>",
+        "<domain>Example.COM.</domain>",
+        1,
+    )
+
+    response = authed_client.post(
+        "/api/v1/reports/upload",
+        headers={"X-DMARQ-Workspace-ID": str(other_workspace.id)},
+        files={"file": ("report.zip", _make_zip(uppercase_xml), "application/zip")},
+    )
+
+    assert response.status_code == 409
+    assert "Domain 'example.com' already belongs to another workspace" in response.json()["detail"]
+    assert db_session.query(Domain).filter(Domain.name == "example.com").count() == 1
+    assert db_session.query(DMARCReport).filter_by(report_id="123456789").count() == 0
+
+
+def test_upload_report_translates_raced_domain_integrity_error(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """A concurrent cross-workspace domain insert is returned as a controlled 409."""
+    get_or_create_default_workspace(db_session)
+    other_workspace = Workspace(slug="raced-domain-upload", name="Raced Domain Upload")
+    db_session.add(other_workspace)
+    db_session.commit()
+    TestingSessionLocal = sessionmaker(bind=db_session.get_bind())
+
+    def raced_save(db, report, *, workspace_id=None):  # pylint: disable=unused-argument
+        concurrent_db = TestingSessionLocal()
+        try:
+            default_workspace = get_or_create_default_workspace(concurrent_db)
+            concurrent_db.add(Domain(name="example.com", workspace_id=default_workspace.id))
+            concurrent_db.commit()
+        finally:
+            concurrent_db.close()
+        raise IntegrityError("insert", {}, Exception("UNIQUE constraint failed: domains.name"))
+
+    monkeypatch.setattr(reports_endpoint, "save_parsed_report", raced_save)
+
+    response = authed_client.post(
+        "/api/v1/reports/upload",
+        headers={"X-DMARQ-Workspace-ID": str(other_workspace.id)},
+        files={"file": ("report.zip", _make_zip(SAMPLE_XML), "application/zip")},
+    )
+
+    assert response.status_code == 409
+    assert "Domain 'example.com' already belongs to another workspace" in response.json()["detail"]
     assert db_session.query(DMARCReport).filter_by(report_id="123456789").count() == 0
 
 

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -300,6 +300,44 @@ def test_upload_report_translates_raced_domain_integrity_error(
     assert db_session.query(DMARCReport).filter_by(report_id="123456789").count() == 0
 
 
+def test_upload_report_recovers_from_same_workspace_domain_race(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """A same-workspace raced domain insert retries instead of leaking a 500."""
+    default_workspace = get_or_create_default_workspace(db_session)
+    db_session.commit()
+    TestingSessionLocal = sessionmaker(bind=db_session.get_bind())
+    real_save_parsed_report = reports_endpoint.save_parsed_report
+    call_count = 0
+
+    def raced_save(db, report, *, workspace_id=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            concurrent_db = TestingSessionLocal()
+            try:
+                concurrent_db.add(Domain(name="example.com", workspace_id=default_workspace.id))
+                concurrent_db.commit()
+            finally:
+                concurrent_db.close()
+            raise IntegrityError("insert", {}, Exception("UNIQUE constraint failed: domains.name"))
+        return real_save_parsed_report(db, report, workspace_id=workspace_id)
+
+    monkeypatch.setattr(reports_endpoint, "save_parsed_report", raced_save)
+
+    response = authed_client.post(
+        "/api/v1/reports/upload",
+        files={"file": ("report.zip", _make_zip(SAMPLE_XML), "application/zip")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["domain"] == "example.com"
+    assert db_session.query(Domain).filter(Domain.name == "example.com").count() == 1
+    assert db_session.query(DMARCReport).filter_by(report_id="123456789").count() == 1
+
+
 def test_upload_persists_rfc9990_optional_fields(authed_client: TestClient, db_session):
     """RFC 9990 / DMARCbis metadata is kept for exports and future UI use."""
     zip_bytes = _make_zip(SAMPLE_RFC9990_XML)

--- a/backend/app/utils/domain_validator.py
+++ b/backend/app/utils/domain_validator.py
@@ -17,6 +17,11 @@ class DomainValidationError:
     DNS_RESOLUTION_FAILED = "dns_resolution_failed"
 
 
+def normalize_domain_name(name: str) -> str:
+    """Return the canonical stored form for domain names."""
+    return name.strip().strip(".").lower()
+
+
 def _validate_domain_characters(
     domain_name: str,
 ) -> Tuple[bool, Optional[str], Optional[str]]:


### PR DESCRIPTION
## Summary\n- normalize report upload domains before duplicate and cross-workspace conflict checks\n- translate raced cross-workspace Domain.name integrity failures into a controlled 409\n- add regression coverage for normalization and raced conflict handling\n\n## Test\n- .venv/bin/python -m pytest backend/app/tests/test_reports_api.py -q\n- git diff --check\n\nFollow-up from Copilot review on PR #270.