### PR TITLE
[codex] Scope mail source endpoints by selected workspace

### DIFF
--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -12,7 +12,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -34,12 +34,11 @@ from app.services.mailbox_recovery import (
 from app.services.microsoft_graph_client import MicrosoftGraphClient
 from app.services.workspace_access import (
     PERMISSION_MAIL_SOURCES_WRITE,
-    require_workspace_permission,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
 )
 from app.services.workspace_audit import changed_fields, record_workspace_audit_log
 from app.services.workspaces import (
-    assign_default_workspace_to_unscoped_rows,
-    get_default_workspace,
     workspace_mail_source_query,
 )
 
@@ -220,16 +219,44 @@ def _get_source_or_404(source_id: int, db: Session, workspace=None) -> MailSourc
     return source
 
 
-def _require_mail_source_access(auth_context: Dict[str, Any], db: Session, workspace) -> None:
-    """Require permission to inspect or manage workspace mail-source setup."""
-    require_workspace_permission(auth_context, PERMISSION_MAIL_SOURCES_WRITE, db, workspace)
+def _selected_workspace_id(selected_workspace: Optional[str]) -> Optional[int]:
+    return parse_selected_workspace_id(selected_workspace)
 
 
-def _authorized_mail_source_workspace(auth_context: Dict[str, Any], db: Session):
-    """Authorize against the current workspace before running legacy repair writes."""
-    workspace = get_default_workspace(db)
-    _require_mail_source_access(auth_context, db, workspace)
-    return assign_default_workspace_to_unscoped_rows(db)
+def _selected_workspace_or_oauth_state(
+    selected_workspace: Optional[str],
+    state_value: Optional[str],
+) -> Optional[int]:
+    return _workspace_id_from_oauth_state(state_value) or _selected_workspace_id(selected_workspace)
+
+
+def _authorized_mail_source_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    selected_workspace_id: Optional[int] = None,
+):
+    """Resolve and authorize the selected workspace for mail-source operations."""
+    return resolve_authorized_workspace(
+        db,
+        auth_context,
+        PERMISSION_MAIL_SOURCES_WRITE,
+        selected_workspace_id=selected_workspace_id,
+    )
+
+
+def _oauth_state(workspace_id: int, source_id: int) -> str:
+    """Encode selected workspace context for OAuth provider redirects."""
+    return f"workspace:{workspace_id}:source:{source_id}"
+
+
+def _workspace_id_from_oauth_state(state_value: Optional[str]) -> Optional[int]:
+    """Return a selected workspace id from OAuth state, tolerating old state values."""
+    if not state_value:
+        return None
+    parts = state_value.split(":")
+    if len(parts) == 4 and parts[0] == "workspace" and parts[2] == "source":
+        return _selected_workspace_id(parts[1])
+    return None
 
 
 def _audit_mail_source_change(
@@ -490,9 +517,14 @@ def _fetch_source(source: MailSource, db: Session, days: int) -> Dict[str, Any]:
 async def list_mail_sources(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> List[MailSourceResponse]:
     """Return all configured mail sources (passwords redacted)."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_id(selected_workspace),
+    )
     sources = workspace_mail_source_query(db, workspace).order_by(MailSource.id).all()
     return [_source_to_response(s) for s in sources]
 
@@ -503,9 +535,14 @@ async def create_mail_source(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> MailSourceResponse:
     """Create a new mail source."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_id(selected_workspace),
+    )
     source = MailSource(
         workspace_id=workspace.id,
         name=payload.name,
@@ -549,9 +586,14 @@ async def get_mail_source(
     source_id: int,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> MailSourceResponse:
     """Return a single mail source by ID (password redacted)."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_id(selected_workspace),
+    )
     source = _get_source_or_404(source_id, db, workspace)
     return _source_to_response(source)
 
@@ -562,9 +604,14 @@ async def list_mail_source_imports(
     limit: int = 20,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> List[MailSourceImportResponse]:
     """Return recent sanitized import attempts for one mail source."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_id(selected_workspace),
+    )
     _get_source_or_404(source_id, db, workspace)
     safe_limit = min(max(limit, 1), 100)
     rows = (
@@ -583,12 +630,15 @@ async def fetch_mail_source(
     days: int = 7,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Manually fetch DMARC reports for one configured mail source."""
     if days < 1 or days > 365:
         raise HTTPException(status_code=400, detail="Days parameter must be between 1 and 365")
 
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
     results = _fetch_source(source, db, days)
     logger.info(
@@ -617,9 +667,12 @@ async def update_mail_source(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> MailSourceResponse:
     """Update one or more fields of an existing mail source."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     update_data = payload.model_dump(exclude_unset=True)
@@ -651,9 +704,12 @@ async def delete_mail_source(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> None:
     """Delete a mail source permanently."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
     source_name = source.name
     source_method = source.method
@@ -680,9 +736,12 @@ async def toggle_mail_source(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> MailSourceResponse:
     """Toggle the *enabled* flag of a mail source."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
     source.enabled = not source.enabled
     source.updated_at = datetime.utcnow()
@@ -705,9 +764,12 @@ async def test_stored_mail_source(  # noqa: C901
     source_id: int,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Test the connection for an already-stored mail source using its saved credentials."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method == "GMAIL_API":
@@ -815,13 +877,14 @@ async def test_connection_adhoc(
     request: TestConnectionRequest,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """
     Test a connection using ad-hoc credentials (not stored in the database).
 
     Useful when filling out the *add/edit mail source* form before saving.
     """
-    _authorized_mail_source_workspace(_auth, db)
+    _authorized_mail_source_workspace(_auth, db, _selected_workspace_id(selected_workspace))
     method = request.method.upper()
 
     if method != "IMAP":
@@ -852,9 +915,12 @@ async def m365_authorize_url(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Return a Microsoft identity platform authorization URL for M365_GRAPH."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -874,7 +940,7 @@ async def m365_authorize_url(
         tenant_id=source.m365_tenant_id or "common",
         client_id=source.m365_client_id,
         redirect_uri=redirect_uri,
-        state=str(source_id),
+        state=_oauth_state(workspace.id, source_id),
     )
     return {"authorization_url": auth_url, "redirect_uri": redirect_uri}
 
@@ -884,9 +950,12 @@ async def m365_list_folders(
     source_id: int,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Return selectable Microsoft 365 mail folders for this source."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -948,6 +1017,7 @@ async def m365_oauth_callback(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Any:
     """Handle the Microsoft identity platform OAuth2 redirect."""
     from fastapi.responses import HTMLResponse
@@ -963,7 +1033,14 @@ async def m365_oauth_callback(
         )
         return HTMLResponse(content=html, status_code=400)
 
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_or_oauth_state(
+            selected_workspace,
+            request.query_params.get("state"),
+        ),
+    )
     source = _get_source_or_404(source_id, db, workspace)
     if source.method != "M365_GRAPH":
         return HTMLResponse(
@@ -1035,9 +1112,12 @@ async def m365_oauth_callback_post(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> MailSourceResponse:
     """Exchange a Microsoft OAuth2 authorization code for Graph tokens."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -1109,9 +1189,12 @@ async def m365_fetch_reports(
     days: int = Query(7, ge=1, le=365, title="Number of days to fetch"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Manually trigger a Microsoft 365 Graph DMARC report fetch."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -1143,9 +1226,12 @@ async def m365_disconnect(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> None:
     """Clear the stored Microsoft Graph OAuth2 tokens for this source."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "M365_GRAPH":
@@ -1181,6 +1267,7 @@ async def gmail_authorize_url(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """
     Return a Google OAuth2 authorization URL for the given GMAIL_API source.
@@ -1189,7 +1276,9 @@ async def gmail_authorize_url(
     grants access Google redirects back to
     ``<origin>/mail-sources/<id>/gmail/callback`` with a ``code`` parameter.
     """
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":
@@ -1210,7 +1299,7 @@ async def gmail_authorize_url(
     auth_url = GmailClient.build_authorization_url(
         client_id=source.gmail_client_id,
         redirect_uri=redirect_uri,
-        state=str(source_id),
+        state=_oauth_state(workspace.id, source_id),
     )
     return {
         "authorization_url": auth_url,
@@ -1224,6 +1313,7 @@ async def gmail_oauth_callback(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Any:
     """
     Handle the Google OAuth2 redirect after the user grants Gmail access.
@@ -1245,7 +1335,14 @@ async def gmail_oauth_callback(
         )
         return HTMLResponse(content=html, status_code=400)
 
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_or_oauth_state(
+            selected_workspace,
+            request.query_params.get("state"),
+        ),
+    )
     source = _get_source_or_404(source_id, db, workspace)
     if source.method != "GMAIL_API":
         return HTMLResponse(
@@ -1318,6 +1415,7 @@ async def gmail_oauth_callback_post(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> MailSourceResponse:
     """
     Exchange an OAuth2 authorization code for tokens (JSON / programmatic flow).
@@ -1326,7 +1424,9 @@ async def gmail_oauth_callback_post(
     themselves and post the code here as JSON.  Requires the standard
     admin authentication.
     """
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":
@@ -1398,6 +1498,7 @@ async def gmail_fetch_reports(
     source_id: int,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """
     Manually trigger a Gmail DMARC report fetch for the given source.
@@ -1405,7 +1506,9 @@ async def gmail_fetch_reports(
     Searches Gmail for emails matching the DMARC report heuristic, ingests
     any attachments not yet seen, and returns a summary.
     """
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":
@@ -1480,9 +1583,12 @@ async def gmail_disconnect(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> None:
     """Revoke / clear the stored Gmail OAuth2 tokens for this source."""
-    workspace = _authorized_mail_source_workspace(_auth, db)
+    workspace = _authorized_mail_source_workspace(
+        _auth, db, _selected_workspace_id(selected_workspace)
+    )
     source = _get_source_or_404(source_id, db, workspace)
 
     if source.method != "GMAIL_API":

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -500,6 +500,70 @@ class TestMailSourcesAPIAuthed:
 
         test_app.dependency_overrides.clear()
 
+    def test_mail_source_routes_respect_selected_workspace_header(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        """Mail-source CRUD actions stay inside the selected workspace."""
+        get_or_create_default_workspace(db_session)
+        selected_workspace = Workspace(
+            slug="selected-mail-sources",
+            name="Selected Mail Sources",
+        )
+        db_session.add(selected_workspace)
+        db_session.commit()
+        selected_header = {"X-DMARQ-Workspace-ID": str(selected_workspace.id)}
+
+        create_response = authed_client.post(
+            "/api/v1/mail-sources",
+            headers=selected_header,
+            json={"name": "Selected IMAP", "method": "IMAP", "enabled": True},
+        )
+
+        assert create_response.status_code == 201
+        source_id = create_response.json()["id"]
+        source = db_session.get(MailSource, source_id)
+        assert source.workspace_id == selected_workspace.id
+
+        default_list = authed_client.get("/api/v1/mail-sources")
+        selected_list = authed_client.get("/api/v1/mail-sources", headers=selected_header)
+        default_get = authed_client.get(f"/api/v1/mail-sources/{source_id}")
+        selected_get = authed_client.get(
+            f"/api/v1/mail-sources/{source_id}",
+            headers=selected_header,
+        )
+
+        assert default_list.status_code == 200
+        assert default_list.json() == []
+        assert selected_list.status_code == 200
+        assert [item["id"] for item in selected_list.json()] == [source_id]
+        assert default_get.status_code == 404
+        assert selected_get.status_code == 200
+        assert selected_get.json()["name"] == "Selected IMAP"
+
+        update_response = authed_client.put(
+            f"/api/v1/mail-sources/{source_id}",
+            headers=selected_header,
+            json={"name": "Selected IMAP Updated"},
+        )
+        toggle_response = authed_client.post(
+            f"/api/v1/mail-sources/{source_id}/toggle",
+            headers=selected_header,
+        )
+        default_delete = authed_client.delete(f"/api/v1/mail-sources/{source_id}")
+        selected_delete = authed_client.delete(
+            f"/api/v1/mail-sources/{source_id}",
+            headers=selected_header,
+        )
+
+        assert update_response.status_code == 200
+        assert update_response.json()["name"] == "Selected IMAP Updated"
+        assert toggle_response.status_code == 200
+        assert toggle_response.json()["enabled"] is False
+        assert default_delete.status_code == 404
+        assert selected_delete.status_code == 204
+
     # ------------------------------------------------------------------
     # Create
     # ------------------------------------------------------------------
@@ -1461,9 +1525,7 @@ class TestMicrosoft365GraphMailSource:
             "/api/v1/mail-sources",
             json={"name": "No Token Folder List", "method": "M365_GRAPH"},
         )
-        no_token = authed_client.get(
-            f"/api/v1/mail-sources/{m365_resp.json()['id']}/m365/folders"
-        )
+        no_token = authed_client.get(f"/api/v1/mail-sources/{m365_resp.json()['id']}/m365/folders")
         assert no_token.status_code == 400
 
     def test_m365_callback_post_failure_modes(self, authed_client: TestClient):
@@ -2108,6 +2170,64 @@ class TestGmailCallbackGet:
         get_resp = authed_client.get(f"/api/v1/mail-sources/{source_id}")
         assert get_resp.json()["gmail_connected"] is True
         assert get_resp.json()["gmail_email"] == "user@gmail.com"
+
+    def test_callback_uses_oauth_state_for_selected_workspace(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        """Provider redirects can complete selected-workspace OAuth without custom headers."""
+        get_or_create_default_workspace(db_session)
+        selected_workspace = Workspace(slug="gmail-oauth-selected", name="Gmail OAuth Selected")
+        db_session.add(selected_workspace)
+        db_session.commit()
+        selected_header = {"X-DMARQ-Workspace-ID": str(selected_workspace.id)}
+
+        create_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            headers=selected_header,
+            json={
+                "name": "Selected Gmail",
+                "method": "GMAIL_API",
+                "gmail_client_id": "cid",
+                "gmail_client_secret": "secret",
+            },
+        )
+        source_id = create_resp.json()["id"]
+        auth_resp = authed_client.get(
+            f"/api/v1/mail-sources/{source_id}/gmail/authorize-url",
+            headers=selected_header,
+        )
+        auth_url = auth_resp.json()["authorization_url"]
+        state = parse_qs(urlparse(auth_url).query)["state"][0]
+
+        with (
+            patch(
+                "app.api.api_v1.endpoints.mail_sources.GmailClient.exchange_code_for_tokens",
+                return_value={"access_token": "acc", "refresh_token": "ref"},
+            ),
+            patch(
+                "app.api.api_v1.endpoints.mail_sources.GmailClient.get_gmail_email",
+                return_value="selected@gmail.com",
+            ),
+        ):
+            callback_resp = authed_client.get(
+                f"/api/v1/mail-sources/{source_id}/gmail/callback?code=abc&state={state}"
+            )
+
+        assert auth_resp.status_code == 200
+        assert state == f"workspace:{selected_workspace.id}:source:{source_id}"
+        assert callback_resp.status_code == 200
+
+        default_get = authed_client.get(f"/api/v1/mail-sources/{source_id}")
+        selected_get = authed_client.get(
+            f"/api/v1/mail-sources/{source_id}",
+            headers=selected_header,
+        )
+        assert default_get.status_code == 404
+        assert selected_get.status_code == 200
+        assert selected_get.json()["gmail_connected"] is True
+        assert selected_get.json()["gmail_email"] == "selected@gmail.com"
 
     def test_callback_success_without_email(self, authed_client: TestClient):
         """Successful callback where get_gmail_email returns None still saves token."""


### PR DESCRIPTION
## Summary
- route mail-source API operations through the selected workspace header instead of the default workspace
- encode workspace context in Gmail and Microsoft OAuth state so provider redirects complete in the selected workspace
- add regression coverage for selected-workspace mail-source CRUD and Gmail OAuth callback completion

## Validation
- python -m black backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- python -m isort backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- python -m py_compile backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- python -m black --check backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- python -m isort --check-only backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- git diff --check -- backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- python -m pytest backend/app/tests/test_mail_sources.py -q

Refs #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mail source actions now support workspace-specific requests using the selected workspace header.
  * OAuth connections for Microsoft 365 and Gmail now carry workspace context through the authorization flow.

* **Bug Fixes**
  * Mail source list, create, update, delete, toggle, fetch, and test actions now stay scoped to the chosen workspace.
  * OAuth callbacks now complete correctly even when workspace context comes from the returned authorization state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->