### PR TITLE
Harden mail source OAuth state handling

### DIFF
--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -7,6 +7,9 @@ persisting anything.  Gmail API and Microsoft 365 sources additionally have
 OAuth2 helper endpoints (authorize-url, callback, fetch).
 """
 
+import base64
+import hashlib
+import hmac
 import json
 import logging
 from datetime import datetime
@@ -16,6 +19,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, s
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.redaction import sanitize_for_log
 from app.core.security import require_admin_auth
@@ -226,8 +230,11 @@ def _selected_workspace_id(selected_workspace: Optional[str]) -> Optional[int]:
 def _selected_workspace_or_oauth_state(
     selected_workspace: Optional[str],
     state_value: Optional[str],
+    source_id: int,
 ) -> Optional[int]:
-    return _workspace_id_from_oauth_state(state_value) or _selected_workspace_id(selected_workspace)
+    return _workspace_id_from_oauth_state(state_value, source_id) or _selected_workspace_id(
+        selected_workspace
+    )
 
 
 def _authorized_mail_source_workspace(
@@ -245,18 +252,101 @@ def _authorized_mail_source_workspace(
 
 
 def _oauth_state(workspace_id: int, source_id: int) -> str:
-    """Encode selected workspace context for OAuth provider redirects."""
-    return f"workspace:{workspace_id}:source:{source_id}"
+    """Return a signed OAuth state value bound to one workspace and source."""
+    payload = json.dumps(
+        {"source_id": int(source_id), "workspace_id": int(workspace_id)},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    encoded_payload = _base64url_encode(payload)
+    signature = hmac.new(
+        get_settings().SECRET_KEY.encode("utf-8"),
+        encoded_payload.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return f"v1.{encoded_payload}.{_base64url_encode(signature)}"
 
 
-def _workspace_id_from_oauth_state(state_value: Optional[str]) -> Optional[int]:
-    """Return a selected workspace id from OAuth state, tolerating old state values."""
-    if not state_value:
-        return None
+def _base64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _base64url_decode(value: str) -> bytes:
+    padded = value + ("=" * (-len(value) % 4))
+    return base64.urlsafe_b64decode(padded.encode("ascii"))
+
+
+def _invalid_oauth_state() -> HTTPException:
+    return HTTPException(status_code=400, detail="Invalid OAuth state.")
+
+
+def _oauth_state_source_mismatch() -> HTTPException:
+    return HTTPException(
+        status_code=400,
+        detail="OAuth state does not match the requested mail source.",
+    )
+
+
+def _signed_oauth_state_workspace_id(state_value: str, source_id: int) -> int:
+    parts = state_value.split(".")
+    if len(parts) != 3:
+        raise _invalid_oauth_state()
+
+    encoded_payload, encoded_signature = parts[1], parts[2]
+    expected_signature = hmac.new(
+        get_settings().SECRET_KEY.encode("utf-8"),
+        encoded_payload.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    try:
+        actual_signature = _base64url_decode(encoded_signature)
+        payload = json.loads(_base64url_decode(encoded_payload))
+        workspace_id = int(payload["workspace_id"])
+        state_source_id = int(payload["source_id"])
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+        raise _invalid_oauth_state() from None
+
+    if not hmac.compare_digest(actual_signature, expected_signature):
+        raise _invalid_oauth_state()
+    if state_source_id != int(source_id):
+        raise _oauth_state_source_mismatch()
+    return workspace_id
+
+
+def _legacy_oauth_state_workspace_id(state_value: str, source_id: int) -> Optional[int]:
+    # Legacy states from older authorization URLs are accepted only when they
+    # bind to the callback source id; they are not treated as trusted workspace
+    # selectors.
     parts = state_value.split(":")
     if len(parts) == 4 and parts[0] == "workspace" and parts[2] == "source":
-        return _selected_workspace_id(parts[1])
-    return None
+        try:
+            workspace_id = int(parts[1])
+            state_source_id = int(parts[3])
+        except ValueError:
+            raise _invalid_oauth_state() from None
+        if state_source_id != int(source_id):
+            raise _oauth_state_source_mismatch()
+        return workspace_id
+
+    if state_value.isdigit():
+        if int(state_value) != int(source_id):
+            raise _oauth_state_source_mismatch()
+        return None
+
+    raise _invalid_oauth_state()
+
+
+def _workspace_id_from_oauth_state(
+    state_value: Optional[str],
+    source_id: int,
+) -> Optional[int]:
+    """Return a workspace id from OAuth state after validating source binding."""
+    if not state_value:
+        return None
+
+    if state_value.startswith("v1."):
+        return _signed_oauth_state_workspace_id(state_value, source_id)
+    return _legacy_oauth_state_workspace_id(state_value, source_id)
 
 
 def _audit_mail_source_change(
@@ -1039,6 +1129,7 @@ async def m365_oauth_callback(
         _selected_workspace_or_oauth_state(
             selected_workspace,
             request.query_params.get("state"),
+            source_id,
         ),
     )
     source = _get_source_or_404(source_id, db, workspace)
@@ -1341,6 +1432,7 @@ async def gmail_oauth_callback(
         _selected_workspace_or_oauth_state(
             selected_workspace,
             request.query_params.get("state"),
+            source_id,
         ),
     )
     source = _get_source_or_404(source_id, db, workspace)

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -8,7 +8,6 @@ OAuth2 helper endpoints (authorize-url, callback, fetch).
 """
 
 import base64
-import hashlib
 import hmac
 import json
 import logging
@@ -259,11 +258,7 @@ def _oauth_state(workspace_id: int, source_id: int) -> str:
         sort_keys=True,
     ).encode("utf-8")
     encoded_payload = _base64url_encode(payload)
-    signature = hmac.new(
-        get_settings().SECRET_KEY.encode("utf-8"),
-        encoded_payload.encode("ascii"),
-        hashlib.sha256,
-    ).digest()
+    signature = _oauth_state_signature(encoded_payload)
     return f"v1.{encoded_payload}.{_base64url_encode(signature)}"
 
 
@@ -274,6 +269,14 @@ def _base64url_encode(value: bytes) -> str:
 def _base64url_decode(value: str) -> bytes:
     padded = value + ("=" * (-len(value) % 4))
     return base64.urlsafe_b64decode(padded.encode("ascii"))
+
+
+def _oauth_state_signature(encoded_payload: str) -> bytes:
+    return hmac.digest(
+        get_settings().SECRET_KEY.encode("utf-8"),
+        encoded_payload.encode("ascii"),
+        "sha256",
+    )
 
 
 def _invalid_oauth_state() -> HTTPException:
@@ -293,11 +296,7 @@ def _signed_oauth_state_workspace_id(state_value: str, source_id: int) -> int:
         raise _invalid_oauth_state()
 
     encoded_payload, encoded_signature = parts[1], parts[2]
-    expected_signature = hmac.new(
-        get_settings().SECRET_KEY.encode("utf-8"),
-        encoded_payload.encode("ascii"),
-        hashlib.sha256,
-    ).digest()
+    expected_signature = _oauth_state_signature(encoded_payload)
     try:
         actual_signature = _base64url_decode(encoded_signature)
         payload = json.loads(_base64url_decode(encoded_payload))

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -272,6 +272,7 @@ def _base64url_decode(value: str) -> bytes:
 
 
 def _oauth_state_signature(encoded_payload: str) -> bytes:
+    # lgtm[py/weak-sensitive-data-hashing] This HMAC signs an OAuth state payload; it is not password hashing.
     return hmac.digest(
         get_settings().SECRET_KEY.encode("utf-8"),
         encoded_payload.encode("ascii"),

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -7,14 +7,13 @@ persisting anything.  Gmail API and Microsoft 365 sources additionally have
 OAuth2 helper endpoints (authorize-url, callback, fetch).
 """
 
-import base64
-import hmac
 import json
 import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+from jose import JWTError, jwt
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -252,32 +251,12 @@ def _authorized_mail_source_workspace(
 
 def _oauth_state(workspace_id: int, source_id: int) -> str:
     """Return a signed OAuth state value bound to one workspace and source."""
-    payload = json.dumps(
+    token = jwt.encode(
         {"source_id": int(source_id), "workspace_id": int(workspace_id)},
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
-    encoded_payload = _base64url_encode(payload)
-    signature = _oauth_state_signature(encoded_payload)
-    return f"v1.{encoded_payload}.{_base64url_encode(signature)}"
-
-
-def _base64url_encode(value: bytes) -> str:
-    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
-
-
-def _base64url_decode(value: str) -> bytes:
-    padded = value + ("=" * (-len(value) % 4))
-    return base64.urlsafe_b64decode(padded.encode("ascii"))
-
-
-def _oauth_state_signature(encoded_payload: str) -> bytes:
-    # lgtm[py/weak-sensitive-data-hashing] This HMAC signs an OAuth state payload; it is not password hashing.
-    return hmac.digest(
-        get_settings().SECRET_KEY.encode("utf-8"),
-        encoded_payload.encode("ascii"),
-        "sha256",
+        get_settings().SECRET_KEY,
+        algorithm="HS256",
     )
+    return f"v1.{token}"
 
 
 def _invalid_oauth_state() -> HTTPException:
@@ -292,22 +271,22 @@ def _oauth_state_source_mismatch() -> HTTPException:
 
 
 def _signed_oauth_state_workspace_id(state_value: str, source_id: int) -> int:
-    parts = state_value.split(".")
-    if len(parts) != 3:
+    token = state_value.removeprefix("v1.")
+    if not token:
         raise _invalid_oauth_state()
 
-    encoded_payload, encoded_signature = parts[1], parts[2]
-    expected_signature = _oauth_state_signature(encoded_payload)
     try:
-        actual_signature = _base64url_decode(encoded_signature)
-        payload = json.loads(_base64url_decode(encoded_payload))
+        payload = jwt.decode(
+            token,
+            get_settings().SECRET_KEY,
+            algorithms=["HS256"],
+            options={"verify_aud": False},
+        )
         workspace_id = int(payload["workspace_id"])
         state_source_id = int(payload["source_id"])
-    except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+    except (JWTError, ValueError, KeyError, TypeError):
         raise _invalid_oauth_state() from None
 
-    if not hmac.compare_digest(actual_signature, expected_signature):
-        raise _invalid_oauth_state()
     if state_source_id != int(source_id):
         raise _oauth_state_source_mismatch()
     return workspace_id

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -2358,8 +2358,9 @@ class TestGmailCallbackGet:
             headers=selected_header,
         )
         state = parse_qs(urlparse(auth_resp.json()["authorization_url"]).query)["state"][0]
-        replacement = "x" if not state.endswith("x") else "y"
-        tampered_state = f"{state[:-1]}{replacement}"
+        prefix, payload, signature = state.split(".")
+        replacement = "A" if not signature.startswith("A") else "B"
+        tampered_state = f"{prefix}.{payload}.{replacement}{signature[1:]}"
 
         with patch(
             "app.api.api_v1.endpoints.mail_sources.GmailClient.exchange_code_for_tokens"

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -58,14 +58,14 @@ class TestOAuthStateHelpers:
 
     def test_signed_oauth_state_rejects_tampered_payload(self):
         state = mail_sources_endpoint._oauth_state(workspace_id=42, source_id=7)
-        _, _payload, signature = state.split(".")
-        tampered_payload = mail_sources_endpoint._base64url_encode(
-            b'{"source_id":7,"workspace_id":43}'
-        )
+        prefix, token = state.split(".", 1)
+        header, payload, signature = token.split(".")
+        replacement = "A" if not payload.startswith("A") else "B"
+        tampered_payload = f"{replacement}{payload[1:]}"
 
         with pytest.raises(HTTPException) as exc:
             mail_sources_endpoint._workspace_id_from_oauth_state(
-                f"v1.{tampered_payload}.{signature}",
+                f"{prefix}.{header}.{tampered_payload}.{signature}",
                 source_id=7,
             )
 
@@ -2358,9 +2358,10 @@ class TestGmailCallbackGet:
             headers=selected_header,
         )
         state = parse_qs(urlparse(auth_resp.json()["authorization_url"]).query)["state"][0]
-        prefix, payload, signature = state.split(".")
+        prefix, token = state.split(".", 1)
+        header, payload, signature = token.split(".")
         replacement = "A" if not signature.startswith("A") else "B"
-        tampered_state = f"{prefix}.{payload}.{replacement}{signature[1:]}"
+        tampered_state = f"{prefix}.{header}.{payload}.{replacement}{signature[1:]}"
 
         with patch(
             "app.api.api_v1.endpoints.mail_sources.GmailClient.exchange_code_for_tokens"

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -7,10 +7,12 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -27,6 +29,104 @@ from app.models.workspace_access import WorkspaceMembership
 from app.services.import_history import record_import_attempt
 from app.services.workspace_access import ROLE_OPERATOR
 from app.services.workspaces import get_or_create_default_workspace
+
+
+class TestOAuthStateHelpers:
+    """Unit coverage for the signed OAuth state helpers."""
+
+    def test_signed_oauth_state_round_trip(self):
+        state = mail_sources_endpoint._oauth_state(workspace_id=42, source_id=7)
+
+        assert state.startswith("v1.")
+        assert (
+            mail_sources_endpoint._workspace_id_from_oauth_state(
+                state,
+                source_id=7,
+            )
+            == 42
+        )
+
+    def test_signed_oauth_state_rejects_bad_shape(self):
+        with pytest.raises(HTTPException) as exc:
+            mail_sources_endpoint._workspace_id_from_oauth_state(
+                "v1.only-two-parts",
+                source_id=7,
+            )
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Invalid OAuth state."
+
+    def test_signed_oauth_state_rejects_tampered_payload(self):
+        state = mail_sources_endpoint._oauth_state(workspace_id=42, source_id=7)
+        _, _payload, signature = state.split(".")
+        tampered_payload = mail_sources_endpoint._base64url_encode(
+            b'{"source_id":7,"workspace_id":43}'
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            mail_sources_endpoint._workspace_id_from_oauth_state(
+                f"v1.{tampered_payload}.{signature}",
+                source_id=7,
+            )
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Invalid OAuth state."
+
+    def test_signed_oauth_state_rejects_source_mismatch(self):
+        state = mail_sources_endpoint._oauth_state(workspace_id=42, source_id=7)
+
+        with pytest.raises(HTTPException) as exc:
+            mail_sources_endpoint._workspace_id_from_oauth_state(
+                state,
+                source_id=8,
+            )
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "OAuth state does not match the requested mail source."
+
+    @pytest.mark.parametrize(
+        ("state", "source_id", "expected_workspace_id"),
+        [
+            ("workspace:42:source:7", 7, 42),
+            ("7", 7, None),
+        ],
+    )
+    def test_legacy_oauth_state_accepts_matching_source(
+        self,
+        state: str,
+        source_id: int,
+        expected_workspace_id: Optional[int],
+    ):
+        assert (
+            mail_sources_endpoint._workspace_id_from_oauth_state(
+                state,
+                source_id=source_id,
+            )
+            == expected_workspace_id
+        )
+
+    @pytest.mark.parametrize(
+        ("state", "expected_detail"),
+        [
+            ("workspace:42:source:not-an-int", "Invalid OAuth state."),
+            (
+                "workspace:42:source:8",
+                "OAuth state does not match the requested mail source.",
+            ),
+            ("8", "OAuth state does not match the requested mail source."),
+            ("workspace:42", "Invalid OAuth state."),
+        ],
+    )
+    def test_legacy_oauth_state_rejects_invalid_or_mismatched_source(
+        self,
+        state: str,
+        expected_detail: str,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            mail_sources_endpoint._workspace_id_from_oauth_state(state, source_id=7)
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail == expected_detail
 
 
 def _add_user(db_session: Session, email: str):

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -2216,7 +2216,8 @@ class TestGmailCallbackGet:
             )
 
         assert auth_resp.status_code == 200
-        assert state == f"workspace:{selected_workspace.id}:source:{source_id}"
+        assert state.startswith("v1.")
+        assert state != f"workspace:{selected_workspace.id}:source:{source_id}"
         assert callback_resp.status_code == 200
 
         default_get = authed_client.get(f"/api/v1/mail-sources/{source_id}")
@@ -2228,6 +2229,115 @@ class TestGmailCallbackGet:
         assert selected_get.status_code == 200
         assert selected_get.json()["gmail_connected"] is True
         assert selected_get.json()["gmail_email"] == "selected@gmail.com"
+
+    def test_callback_rejects_tampered_oauth_state_before_token_exchange(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        """Tampered OAuth state is rejected before persisting provider tokens."""
+        get_or_create_default_workspace(db_session)
+        selected_workspace = Workspace(slug="tampered-oauth", name="Tampered OAuth")
+        db_session.add(selected_workspace)
+        db_session.commit()
+        selected_header = {"X-DMARQ-Workspace-ID": str(selected_workspace.id)}
+
+        create_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            headers=selected_header,
+            json={
+                "name": "Tampered Gmail",
+                "method": "GMAIL_API",
+                "gmail_client_id": "cid",
+                "gmail_client_secret": "secret",
+            },
+        )
+        source_id = create_resp.json()["id"]
+        auth_resp = authed_client.get(
+            f"/api/v1/mail-sources/{source_id}/gmail/authorize-url",
+            headers=selected_header,
+        )
+        state = parse_qs(urlparse(auth_resp.json()["authorization_url"]).query)["state"][0]
+        replacement = "x" if not state.endswith("x") else "y"
+        tampered_state = f"{state[:-1]}{replacement}"
+
+        with patch(
+            "app.api.api_v1.endpoints.mail_sources.GmailClient.exchange_code_for_tokens"
+        ) as exchange_mock:
+            callback_resp = authed_client.get(
+                f"/api/v1/mail-sources/{source_id}/gmail/callback"
+                f"?code=abc&state={tampered_state}"
+            )
+
+        assert callback_resp.status_code == 400
+        assert callback_resp.json()["detail"] == "Invalid OAuth state."
+        exchange_mock.assert_not_called()
+
+        selected_get = authed_client.get(
+            f"/api/v1/mail-sources/{source_id}",
+            headers=selected_header,
+        )
+        assert selected_get.json()["gmail_connected"] is False
+
+    def test_callback_rejects_oauth_state_for_another_source(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        """OAuth state must be bound to the same source as the callback path."""
+        get_or_create_default_workspace(db_session)
+        selected_workspace = Workspace(slug="source-bound-oauth", name="Source Bound OAuth")
+        db_session.add(selected_workspace)
+        db_session.commit()
+        selected_header = {"X-DMARQ-Workspace-ID": str(selected_workspace.id)}
+
+        first_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            headers=selected_header,
+            json={
+                "name": "First Gmail",
+                "method": "GMAIL_API",
+                "gmail_client_id": "cid-1",
+                "gmail_client_secret": "secret",
+            },
+        )
+        second_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            headers=selected_header,
+            json={
+                "name": "Second Gmail",
+                "method": "GMAIL_API",
+                "gmail_client_id": "cid-2",
+                "gmail_client_secret": "secret",
+            },
+        )
+        first_id = first_resp.json()["id"]
+        second_id = second_resp.json()["id"]
+        auth_resp = authed_client.get(
+            f"/api/v1/mail-sources/{first_id}/gmail/authorize-url",
+            headers=selected_header,
+        )
+        state = parse_qs(urlparse(auth_resp.json()["authorization_url"]).query)["state"][0]
+
+        with patch(
+            "app.api.api_v1.endpoints.mail_sources.GmailClient.exchange_code_for_tokens"
+        ) as exchange_mock:
+            callback_resp = authed_client.get(
+                f"/api/v1/mail-sources/{second_id}/gmail/callback?code=abc&state={state}"
+            )
+
+        assert callback_resp.status_code == 400
+        assert (
+            callback_resp.json()["detail"]
+            == "OAuth state does not match the requested mail source."
+        )
+        exchange_mock.assert_not_called()
+
+        selected_get = authed_client.get(
+            f"/api/v1/mail-sources/{second_id}",
+            headers=selected_header,
+        )
+        assert selected_get.json()["gmail_connected"] is False
 
     def test_callback_success_without_email(self, authed_client: TestClient):
         """Successful callback where get_gmail_email returns None still saves token."""


### PR DESCRIPTION
## Summary
- sign mail-source OAuth state values with the application SECRET_KEY
- bind callback state to both workspace_id and source_id before token persistence
- keep legacy state handling explicit and add tamper/mismatch regression tests

## Validation
- python -m black backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- python -m isort backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- python -m flake8 backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- git diff --check -- backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- python -m pytest backend/app/tests/test_mail_sources.py -q (150 passed)

Follow-up to #272 CodeRabbit/Copilot OAuth state review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth sign-in callback security and reliability by validating callback state more strictly.
  * Added better handling for invalid, tampered, or mismatched sign-in responses, reducing failed or misrouted connections.
  * Preserved compatibility with older sign-in states where possible, while rejecting unsafe cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->