### PR TITLE
[codex] Finish workspace scoping for issue 238

### DIFF
--- a/backend/alembic/versions/7b8c9d0e1f2a_scope_report_uniqueness_by_workspace.py
+++ b/backend/alembic/versions/7b8c9d0e1f2a_scope_report_uniqueness_by_workspace.py
@@ -1,0 +1,51 @@
+"""scope forensic and TLS report uniqueness by workspace
+
+Revision ID: 7b8c9d0e1f2a
+Revises: 6a7b8c9d0e1f
+Create Date: 2026-06-28 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7b8c9d0e1f2a"
+down_revision: Union[str, Sequence[str], None] = "6a7b8c9d0e1f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Allow different workspaces to ingest matching external report ids."""
+    with op.batch_alter_table("forensic_reports") as batch_op:
+        batch_op.drop_constraint("uq_forensic_reports_report_id", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_forensic_reports_domain_report",
+            ["domain_id", "report_id"],
+        )
+
+    with op.batch_alter_table("tls_reports") as batch_op:
+        batch_op.drop_constraint("uq_tls_reports_report_domain", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_tls_reports_domain_report_policy",
+            ["domain_id", "report_id", "policy_domain"],
+        )
+
+
+def downgrade() -> None:
+    """Restore global report-id uniqueness constraints."""
+    with op.batch_alter_table("tls_reports") as batch_op:
+        batch_op.drop_constraint("uq_tls_reports_domain_report_policy", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_tls_reports_report_domain",
+            ["report_id", "policy_domain"],
+        )
+
+    with op.batch_alter_table("forensic_reports") as batch_op:
+        batch_op.drop_constraint("uq_forensic_reports_domain_report", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_forensic_reports_report_id",
+            ["report_id"],
+        )

--- a/backend/alembic/versions/8c9d0e1f2a3b_add_webhook_workspace_scope.py
+++ b/backend/alembic/versions/8c9d0e1f2a3b_add_webhook_workspace_scope.py
@@ -1,0 +1,51 @@
+"""add workspace scope to webhook endpoints
+
+Revision ID: 8c9d0e1f2a3b
+Revises: 7b8c9d0e1f2a
+Create Date: 2026-06-28 00:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "8c9d0e1f2a3b"
+down_revision: Union[str, Sequence[str], None] = "7b8c9d0e1f2a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _default_workspace_id_sql() -> str:
+    return "(SELECT id FROM workspaces WHERE slug = 'default' LIMIT 1)"
+
+
+def upgrade() -> None:
+    """Attach existing webhook endpoints to the default workspace."""
+    with op.batch_alter_table("webhook_endpoints") as batch_op:
+        batch_op.add_column(sa.Column("workspace_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_webhook_endpoints_workspace_id_workspaces",
+            "workspaces",
+            ["workspace_id"],
+            ["id"],
+        )
+        batch_op.create_index(op.f("ix_webhook_endpoints_workspace_id"), ["workspace_id"])
+        batch_op.create_index(
+            "ix_webhook_endpoints_workspace_enabled",
+            ["workspace_id", "enabled"],
+        )
+    op.execute(f"UPDATE webhook_endpoints SET workspace_id = {_default_workspace_id_sql()}")
+
+
+def downgrade() -> None:
+    """Remove webhook endpoint workspace scoping."""
+    with op.batch_alter_table("webhook_endpoints") as batch_op:
+        batch_op.drop_index("ix_webhook_endpoints_workspace_enabled")
+        batch_op.drop_index(op.f("ix_webhook_endpoints_workspace_id"))
+        batch_op.drop_constraint(
+            "fk_webhook_endpoints_workspace_id_workspaces",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("workspace_id")

--- a/backend/app/api/api_v1/endpoints/ai.py
+++ b/backend/app/api/api_v1/endpoints/ai.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -16,8 +16,12 @@ from app.services.ai_assistance import (
     build_safe_context,
     get_assistance_config,
 )
+from app.services.workspace_access import (
+    PERMISSION_REPORTS_READ,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
+)
 from app.services.workspace_audit import record_workspace_audit_log
-from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
 router = APIRouter()
 
@@ -48,6 +52,20 @@ class ProposalConfirmation(BaseModel):
     proposal_id: str
     confirmation_text: str
     note: Optional[str] = None
+
+
+def _authorized_ai_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    selected_workspace_id: Optional[int] = None,
+):
+    """Resolve and authorize the selected workspace for AI assistance audit events."""
+    return resolve_authorized_workspace(
+        db,
+        auth_context,
+        PERMISSION_REPORTS_READ,
+        selected_workspace_id=selected_workspace_id,
+    )
 
 
 def _require_ai_enabled(db: Session) -> None:
@@ -87,6 +105,7 @@ async def get_domain_evidence_summary(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> EvidenceSummaryResponse:
     """Return deterministic evidence-first assistance for one domain."""
     _require_ai_enabled(db)
@@ -94,7 +113,11 @@ async def get_domain_evidence_summary(
         summary = build_evidence_summary(db, domain)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-    workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+    workspace = _authorized_ai_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
     record_workspace_audit_log(
         db,
         workspace=workspace,
@@ -119,6 +142,7 @@ async def get_domain_action_proposals(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> ActionProposalResponse:
     """Return reviewable proposals; this endpoint never applies changes."""
     _require_ai_enabled(db)
@@ -126,7 +150,11 @@ async def get_domain_action_proposals(
         payload = build_action_proposals(db, domain)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-    workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+    workspace = _authorized_ai_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
     record_workspace_audit_log(
         db,
         workspace=workspace,
@@ -149,6 +177,7 @@ async def confirm_action_proposal(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Audit human confirmation for a proposal without applying external changes."""
     _require_ai_enabled(db)
@@ -157,8 +186,7 @@ async def confirm_action_proposal(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=(
-                "Action tools are disabled. Enable ai.action_tools_enabled to confirm "
-                "proposals."
+                "Action tools are disabled. Enable ai.action_tools_enabled to confirm " "proposals."
             ),
         )
     proposals = build_action_proposals(db, domain)["proposals"]
@@ -173,7 +201,11 @@ async def confirm_action_proposal(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="confirmation_text must match proposal_id",
         )
-    workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+    workspace = _authorized_ai_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
     record_workspace_audit_log(
         db,
         workspace=workspace,

--- a/backend/app/api/api_v1/endpoints/api_tokens.py
+++ b/backend/app/api/api_v1/endpoints/api_tokens.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -17,23 +17,26 @@ from app.services.api_tokens import (
 )
 from app.services.workspace_access import (
     PERMISSION_WORKSPACE_ADMIN,
-    require_workspace_permission,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
 )
 from app.services.workspace_audit import record_workspace_audit_log
-from app.services.workspaces import (
-    assign_default_workspace_to_unscoped_rows,
-    get_default_workspace,
-    get_or_create_default_workspace,
-)
 
 router = APIRouter()
 
 
-def _authorized_api_token_workspace(auth_context: Dict[str, Any], db: Session):
+def _authorized_api_token_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    selected_workspace_id: Optional[int] = None,
+):
     """Authorize API-token management for the current workspace."""
-    workspace = get_default_workspace(db) or get_or_create_default_workspace(db)
-    require_workspace_permission(auth_context, PERMISSION_WORKSPACE_ADMIN, db, workspace)
-    return assign_default_workspace_to_unscoped_rows(db)
+    return resolve_authorized_workspace(
+        db,
+        auth_context,
+        PERMISSION_WORKSPACE_ADMIN,
+        selected_workspace_id=selected_workspace_id,
+    )
 
 
 class APITokenCreateRequest(BaseModel):
@@ -77,9 +80,14 @@ class APITokenListResponse(BaseModel):
 async def list_api_tokens(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """List API token metadata without exposing raw secrets or hashes."""
-    workspace = _authorized_api_token_workspace(_auth, db)
+    workspace = _authorized_api_token_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
     rows = (
         db.query(APIToken)
         .filter(APIToken.workspace_id == workspace.id)
@@ -98,9 +106,14 @@ async def create_public_api_token(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Create a scoped API token for read-only automation."""
-    workspace = _authorized_api_token_workspace(_auth, db)
+    workspace = _authorized_api_token_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
     try:
         created = create_api_token(
             db,
@@ -140,9 +153,14 @@ async def revoke_public_api_token(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Revoke a scoped API token."""
-    workspace = _authorized_api_token_workspace(_auth, db)
+    workspace = _authorized_api_token_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
     token = (
         db.query(APIToken)
         .filter(APIToken.id == token_id, APIToken.workspace_id == workspace.id)

--- a/backend/app/api/api_v1/endpoints/audit.py
+++ b/backend/app/api/api_v1/endpoints/audit.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -11,7 +11,9 @@ from app.core.security import require_admin_auth
 from app.services.workspace_access import (
     PERMISSION_AUDIT_READ,
     list_workspace_roles,
+    parse_selected_workspace_id,
     require_workspace_permission,
+    resolve_authorized_workspace,
 )
 from app.services.workspace_audit import list_workspace_audit_logs
 from app.services.workspaces import assign_default_workspace_to_unscoped_rows, get_default_workspace
@@ -31,6 +33,32 @@ class WorkspaceAuditLogResponse(BaseModel):
     audit: List[Dict[str, Any]]
 
 
+def _authorized_audit_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    selected_workspace_id: Optional[int] = None,
+):
+    """Resolve the selected audit workspace without unsafe legacy bootstrapping."""
+    if selected_workspace_id is not None:
+        return resolve_authorized_workspace(
+            db,
+            auth_context,
+            PERMISSION_AUDIT_READ,
+            selected_workspace_id=selected_workspace_id,
+        )
+
+    workspace = get_default_workspace(db)
+    if workspace is None:
+        if (auth_context or {}).get("auth_type") not in {"api_key", "disabled"}:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Workspace permission required: {PERMISSION_AUDIT_READ}",
+            )
+        workspace = assign_default_workspace_to_unscoped_rows(db)
+    require_workspace_permission(auth_context, PERMISSION_AUDIT_READ, db, workspace)
+    return assign_default_workspace_to_unscoped_rows(db)
+
+
 @router.get("/roles", response_model=WorkspaceRoleResponse)
 async def get_workspace_roles(
     _auth: dict = Depends(require_admin_auth),
@@ -46,28 +74,14 @@ async def get_workspace_audit_logs(
     entity_type: Optional[str] = None,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> WorkspaceAuditLogResponse:
-    """Return recent sanitized audit events for the default workspace."""
-    workspace = get_default_workspace(db)
-    if workspace is None:
-        if (_auth or {}).get("auth_type") not in {"api_key", "disabled"}:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Workspace permission required: {PERMISSION_AUDIT_READ}",
-            )
-        workspace = assign_default_workspace_to_unscoped_rows(db)
-        require_workspace_permission(_auth, PERMISSION_AUDIT_READ, db, workspace)
-        return {
-            "audit": list_workspace_audit_logs(
-                db,
-                workspace=workspace,
-                limit=limit,
-                action=action,
-                entity_type=entity_type,
-            )
-        }
-    require_workspace_permission(_auth, PERMISSION_AUDIT_READ, db, workspace)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
+    """Return recent sanitized audit events for the selected workspace."""
+    workspace = _authorized_audit_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
     return {
         "audit": list_workspace_audit_logs(
             db,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1694,11 +1694,16 @@ async def get_domain_bimi(
 async def discover_cloudflare_domains(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Discover active Cloudflare zones visible to the configured API token."""
-    _authorized_domain_workspace(_auth, db)
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
     try:
-        return await discover_cloudflare_zones(db)
+        return await discover_cloudflare_zones(db, workspace_id=workspace.id)
     except LookupError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1711,11 +1716,20 @@ async def import_cloudflare_domain_zones(
     payload: CloudflareImportRequest,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Import selected, or all, Cloudflare zones as monitored domains."""
-    _authorized_domain_workspace(_auth, db)
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
     try:
-        return await import_cloudflare_domains(db, requested_domains=payload.domains)
+        return await import_cloudflare_domains(
+            db,
+            requested_domains=payload.domains,
+            workspace_id=workspace.id,
+        )
     except LookupError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/api/api_v1/endpoints/forensics.py
+++ b/backend/app/api/api_v1/endpoints/forensics.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Header, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, selectinload
 
@@ -16,7 +16,7 @@ from app.services.demo_data import (
     list_demo_forensic_reports,
 )
 from app.services.forensic_analysis import analyze_forensic_report, summarize_forensic_samples
-from app.services.forensic_parser import ForensicParser, MAX_FORENSIC_REPORT_SIZE
+from app.services.forensic_parser import MAX_FORENSIC_REPORT_SIZE, ForensicParser
 from app.services.forensic_persistence import (
     forensic_report_exists,
     forensic_report_to_dict,
@@ -26,12 +26,8 @@ from app.services.forensic_redaction import get_forensic_redaction_policy
 from app.services.workspace_access import (
     PERMISSION_REPORTS_READ,
     PERMISSION_REPORTS_WRITE,
-    require_workspace_permission,
-)
-from app.services.workspaces import (
-    assign_default_workspace_to_unscoped_rows,
-    get_default_workspace,
-    get_or_create_default_workspace,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
 )
 
 logger = logging.getLogger(__name__)
@@ -136,11 +132,19 @@ def _validate_upload(file: UploadFile, content: bytes) -> None:
         )
 
 
-def _authorized_reports_workspace(auth_context: Dict[str, Any], db: Session, permission: str):
-    """Authorize report access before running legacy workspace repair writes."""
-    workspace = get_default_workspace(db) or get_or_create_default_workspace(db)
-    require_workspace_permission(auth_context, permission, db, workspace)
-    return assign_default_workspace_to_unscoped_rows(db)
+def _authorized_reports_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    permission: str,
+    selected_workspace_id: Optional[int] = None,
+):
+    """Resolve and authorize the selected workspace for forensic report operations."""
+    return resolve_authorized_workspace(
+        db,
+        auth_context,
+        permission,
+        selected_workspace_id=selected_workspace_id,
+    )
 
 
 def _filtered_forensic_query(
@@ -182,21 +186,27 @@ async def upload_forensic_report(
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Upload and store a DMARC forensic/failure report email."""
-    _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_WRITE)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_WRITE,
+        parse_selected_workspace_id(selected_workspace),
+    )
     try:
         content = await file.read()
         _validate_upload(file, content)
         redaction_policy = get_forensic_redaction_policy(db)
         parsed = ForensicParser.parse_bytes(content, redaction_policy=redaction_policy)
-        if forensic_report_exists(db, parsed["report_id"]):
+        if forensic_report_exists(db, parsed["report_id"], workspace_id=workspace.id):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Forensic report has already been uploaded.",
             )
 
-        row, created = save_forensic_report(db, parsed)
+        row, created = save_forensic_report(db, parsed, workspace_id=workspace.id)
         if not created:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -235,9 +245,15 @@ async def list_forensic_reports(
     page_size: int = Query(default=50, ge=1, le=200),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """List stored forensic reports, newest first."""
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        parse_selected_workspace_id(selected_workspace),
+    )
     if get_settings().DEMO_MODE:
         return ForensicListResponse(
             **list_demo_forensic_reports(
@@ -285,9 +301,15 @@ async def analyze_forensic_reports(
     page_size: int = Query(default=200, ge=1, le=500),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Summarize stored forensic samples into operator investigation groups."""
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        parse_selected_workspace_id(selected_workspace),
+    )
     if get_settings().DEMO_MODE:
         return ForensicAnalysisResponse(
             **analyze_demo_forensic_reports(
@@ -320,9 +342,15 @@ async def get_forensic_report(
     report_id: int,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Return one stored forensic report by numeric ID."""
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        parse_selected_workspace_id(selected_workspace),
+    )
     if get_settings().DEMO_MODE:
         row = get_demo_forensic_report(report_id)
         if row is None:

--- a/backend/app/api/api_v1/endpoints/mcp.py
+++ b/backend/app/api/api_v1/endpoints/mcp.py
@@ -18,8 +18,8 @@ from app.services.ai_assistance import (
 from app.services.api_tokens import MCP_READ_SCOPE
 from app.services.report_persistence import hydrate_report_store_from_db
 from app.services.report_store import ReportStore
+from app.services.workspace_access import PERMISSION_REPORTS_READ, resolve_authorized_workspace
 from app.services.workspace_audit import record_workspace_audit_log
-from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
 router = APIRouter()
 
@@ -80,9 +80,9 @@ def _require_mcp_enabled(db: Session) -> None:
         )
 
 
-def _list_domains(db: Session) -> Dict[str, Any]:
+def _list_domains(db: Session, *, workspace_id: Optional[int] = None) -> Dict[str, Any]:
     store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
+    hydrate_report_store_from_db(db, store, workspace_id=workspace_id)
     summaries = store.get_all_domain_summaries()
     return {
         "domains": [
@@ -126,9 +126,14 @@ async def mcp_jsonrpc(
 
     name = payload.params.get("name")
     arguments = payload.params.get("arguments") or {}
+    workspace = resolve_authorized_workspace(
+        db,
+        _auth,
+        PERMISSION_REPORTS_READ,
+    )
     try:
         if name == "list_domains":
-            result = _list_domains(db)
+            result = _list_domains(db, workspace_id=workspace.id)
         elif name == "domain_summary":
             result = build_evidence_summary(db, str(arguments.get("domain", "")))
         elif name == "action_proposals":
@@ -141,7 +146,6 @@ async def mcp_jsonrpc(
     except ValueError as exc:
         return _jsonrpc_response(payload.id, error={"code": -32004, "message": str(exc)})
 
-    workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
     record_workspace_audit_log(
         db,
         workspace=workspace,

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -15,7 +15,7 @@ in the ``settings`` database table.  Settings are organised into categories:
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -36,6 +36,11 @@ from app.services.alert_rules import (
 )
 from app.services.notifications import send_notification
 from app.services.summary_notifications import build_summary, send_summary_notification
+from app.services.workspace_access import (
+    PERMISSION_NOTIFICATIONS_WRITE,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
+)
 from app.services.workspace_audit import record_workspace_audit_log
 from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
@@ -395,6 +400,7 @@ def _audit_setting_change(
     new_plain: Optional[str],
     auth_context: Optional[Dict[str, Any]],
     request: Optional[Request] = None,
+    selected_workspace_id: Optional[int] = None,
 ) -> None:
     if not _should_audit_setting(key) or old_plain == new_plain:
         return
@@ -405,7 +411,15 @@ def _audit_setting_change(
         new_value=_audit_value_for_setting(key, new_plain),
         auth_context=auth_context,
     )
-    workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+    if selected_workspace_id is None:
+        workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+    else:
+        workspace = resolve_authorized_workspace(
+            db,
+            auth_context or {},
+            PERMISSION_NOTIFICATIONS_WRITE,
+            selected_workspace_id=selected_workspace_id,
+        )
     record_workspace_audit_log(
         db,
         workspace=workspace,
@@ -677,8 +691,10 @@ async def update_setting(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> SettingResponse:
     """Update or create a single setting."""
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
     row = _get_setting(key, db)
     new_value = payload.value
     if row is None:
@@ -700,6 +716,7 @@ async def update_setting(
             new_plain=new_plain,
             auth_context=_auth,
             request=request,
+            selected_workspace_id=selected_workspace_id,
         )
     else:
         # For secret keys, only update if not the redacted placeholder
@@ -716,6 +733,7 @@ async def update_setting(
             new_plain=new_plain,
             auth_context=_auth,
             request=request,
+            selected_workspace_id=selected_workspace_id,
         )
     db.commit()
     db.refresh(row)
@@ -728,6 +746,7 @@ async def bulk_update_settings(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> List[SettingResponse]:
     """
     Update multiple settings in a single request.
@@ -735,6 +754,7 @@ async def bulk_update_settings(
     Accepts ``{"settings": {"key1": "value1", "key2": "value2", ...}}``.
     """
     results = []
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
     for key, value in payload.settings.items():
         row = _get_setting(key, db)
         if row is None:
@@ -755,6 +775,7 @@ async def bulk_update_settings(
                 new_plain=new_plain,
                 auth_context=_auth,
                 request=request,
+                selected_workspace_id=selected_workspace_id,
             )
         else:
             # Skip secret placeholder updates
@@ -771,6 +792,7 @@ async def bulk_update_settings(
                 new_plain=new_plain,
                 auth_context=_auth,
                 request=request,
+                selected_workspace_id=selected_workspace_id,
             )
         results.append(_row_to_dict(row))
     db.commit()

--- a/backend/app/api/api_v1/endpoints/tls_reports.py
+++ b/backend/app/api/api_v1/endpoints/tls_reports.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Header, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, selectinload
 
@@ -21,12 +21,8 @@ from app.services.tls_report_persistence import (
 from app.services.workspace_access import (
     PERMISSION_REPORTS_READ,
     PERMISSION_REPORTS_WRITE,
-    require_workspace_permission,
-)
-from app.services.workspaces import (
-    assign_default_workspace_to_unscoped_rows,
-    get_default_workspace,
-    get_or_create_default_workspace,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
 )
 
 logger = logging.getLogger(__name__)
@@ -108,11 +104,19 @@ def _validate_upload(file: UploadFile, content: bytes) -> None:
         )
 
 
-def _authorized_reports_workspace(auth_context: Dict[str, Any], db: Session, permission: str):
-    """Authorize report access before running legacy workspace repair writes."""
-    workspace = get_default_workspace(db) or get_or_create_default_workspace(db)
-    require_workspace_permission(auth_context, permission, db, workspace)
-    return assign_default_workspace_to_unscoped_rows(db)
+def _authorized_reports_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    permission: str,
+    selected_workspace_id: Optional[int] = None,
+):
+    """Resolve and authorize the selected workspace for TLS report operations."""
+    return resolve_authorized_workspace(
+        db,
+        auth_context,
+        permission,
+        selected_workspace_id=selected_workspace_id,
+    )
 
 
 def _filtered_tls_query(
@@ -130,9 +134,7 @@ def _filtered_tls_query(
         query = query.filter(Domain.workspace_id == workspace_id)
     if domain:
         normalized = domain.lower().strip(".")
-        query = query.filter(
-            (Domain.name == normalized) | (TLSReport.policy_domain == normalized)
-        )
+        query = query.filter((Domain.name == normalized) | (TLSReport.policy_domain == normalized))
     return query
 
 
@@ -141,14 +143,20 @@ async def upload_tls_report(
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Upload and store an SMTP TLS Reporting aggregate."""
-    _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_WRITE)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_WRITE,
+        parse_selected_workspace_id(selected_workspace),
+    )
     try:
         content = await file.read()
         _validate_upload(file, content)
         parsed = TLSReportParser.parse_file(content, file.filename or "")
-        result = save_tls_report(db, parsed)
+        result = save_tls_report(db, parsed, workspace_id=workspace.id)
         db.commit()
         return TLSReportUploadResponse(
             success=True,
@@ -185,9 +193,15 @@ async def list_tls_reports(
     page_size: int = Query(default=50, ge=1, le=200),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """List stored SMTP TLS reports, newest first."""
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        parse_selected_workspace_id(selected_workspace),
+    )
     if get_settings().DEMO_MODE:
         return TLSReportListResponse(
             **list_demo_tls_reports(domain=domain, page=page, page_size=page_size)
@@ -219,9 +233,15 @@ async def tls_report_summary(
     limit: int = Query(default=10, ge=1, le=50),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Summarize TLS reports into trends and top failure causes."""
-    workspace = _authorized_reports_workspace(_auth, db, PERMISSION_REPORTS_READ)
+    workspace = _authorized_reports_workspace(
+        _auth,
+        db,
+        PERMISSION_REPORTS_READ,
+        parse_selected_workspace_id(selected_workspace),
+    )
     if get_settings().DEMO_MODE:
         return TLSSummaryResponse(
             **summarize_demo_tls_reports(domain=domain, days=days, limit=limit)

--- a/backend/app/api/api_v1/endpoints/webhooks.py
+++ b/backend/app/api/api_v1/endpoints/webhooks.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -18,8 +18,12 @@ from app.services.webhook_events import (
     queue_test_webhook,
     update_webhook_endpoint,
 )
+from app.services.workspace_access import (
+    PERMISSION_NOTIFICATIONS_WRITE,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
+)
 from app.services.workspace_audit import changed_fields, record_workspace_audit_log
-from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
 router = APIRouter()
 
@@ -52,6 +56,7 @@ class WebhookEndpointResponse(BaseModel):
     """API-safe webhook endpoint metadata."""
 
     id: int
+    workspace_id: Optional[int] = None
     name: str
     url: str
     event_types: List[str]
@@ -107,13 +112,38 @@ class WebhookTestResponse(BaseModel):
     delivery: WebhookDeliveryResponse
 
 
+def _authorized_webhook_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    selected_workspace_id: Optional[int] = None,
+):
+    """Resolve and authorize the selected workspace for webhook configuration."""
+    return resolve_authorized_workspace(
+        db,
+        auth_context,
+        PERMISSION_NOTIFICATIONS_WRITE,
+        selected_workspace_id=selected_workspace_id,
+    )
+
+
 @router.get("", response_model=WebhookEndpointListResponse)
 async def list_webhook_endpoints(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Return configured outbound webhook endpoints."""
-    endpoints = db.query(WebhookEndpoint).order_by(WebhookEndpoint.created_at.desc()).all()
+    workspace = _authorized_webhook_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    endpoints = (
+        db.query(WebhookEndpoint)
+        .filter(WebhookEndpoint.workspace_id == workspace.id)
+        .order_by(WebhookEndpoint.created_at.desc())
+        .all()
+    )
     return {
         "endpoints": [endpoint_to_dict(endpoint) for endpoint in endpoints],
         "supported_event_types": SUPPORTED_EVENT_TYPES,
@@ -126,11 +156,20 @@ async def create_webhook(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Create an outbound webhook endpoint."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
+    workspace = _authorized_webhook_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
     try:
-        endpoint, raw_secret = create_webhook_endpoint(db, **payload.model_dump())
+        endpoint, raw_secret = create_webhook_endpoint(
+            db,
+            workspace_id=workspace.id,
+            **payload.model_dump(),
+        )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     record_workspace_audit_log(
@@ -157,10 +196,19 @@ async def update_webhook(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Update an outbound webhook endpoint."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    endpoint = db.query(WebhookEndpoint).filter(WebhookEndpoint.id == endpoint_id).first()
+    workspace = _authorized_webhook_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    endpoint = (
+        db.query(WebhookEndpoint)
+        .filter(WebhookEndpoint.id == endpoint_id, WebhookEndpoint.workspace_id == workspace.id)
+        .first()
+    )
     if endpoint is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Webhook endpoint not found"
@@ -196,10 +244,19 @@ async def disable_webhook(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Disable a webhook endpoint without deleting delivery history."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
-    endpoint = db.query(WebhookEndpoint).filter(WebhookEndpoint.id == endpoint_id).first()
+    workspace = _authorized_webhook_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    endpoint = (
+        db.query(WebhookEndpoint)
+        .filter(WebhookEndpoint.id == endpoint_id, WebhookEndpoint.workspace_id == workspace.id)
+        .first()
+    )
     if endpoint is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Webhook endpoint not found"
@@ -230,9 +287,18 @@ async def list_webhook_deliveries(
     limit: int = 50,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Return recent outbound webhook deliveries."""
-    query = db.query(WebhookDelivery)
+    workspace = _authorized_webhook_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    query = db.query(WebhookDelivery).join(
+        WebhookEndpoint, WebhookDelivery.endpoint_id == WebhookEndpoint.id
+    )
+    query = query.filter(WebhookEndpoint.workspace_id == workspace.id)
     if endpoint_id is not None:
         query = query.filter(WebhookDelivery.endpoint_id == endpoint_id)
     if delivery_status:
@@ -251,14 +317,33 @@ async def test_webhook(
     request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Queue and immediately attempt a test delivery for an endpoint."""
-    workspace = assign_default_workspace_to_unscoped_rows(db)
+    workspace = _authorized_webhook_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    endpoint = (
+        db.query(WebhookEndpoint)
+        .filter(WebhookEndpoint.id == endpoint_id, WebhookEndpoint.workspace_id == workspace.id)
+        .first()
+    )
+    if endpoint is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Webhook endpoint not found"
+        )
     try:
         delivery = queue_test_webhook(db, endpoint_id)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-    delivered = deliver_due_webhooks(db, endpoint_id=endpoint_id, limit=1)
+    delivered = deliver_due_webhooks(
+        db,
+        endpoint_id=endpoint_id,
+        workspace_id=workspace.id,
+        limit=1,
+    )
     record_workspace_audit_log(
         db,
         workspace=workspace,
@@ -278,7 +363,17 @@ async def process_due_webhooks(
     limit: int = 25,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> Dict[str, Any]:
     """Attempt due pending webhook deliveries."""
-    deliveries = deliver_due_webhooks(db, limit=max(1, min(limit, 100)))
+    workspace = _authorized_webhook_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    deliveries = deliver_due_webhooks(
+        db,
+        workspace_id=workspace.id,
+        limit=max(1, min(limit, 100)),
+    )
     return {"deliveries": [delivery_to_dict(delivery) for delivery in deliveries]}

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -144,7 +144,7 @@ class ForensicReport(Base):
     domain = relationship("Domain", back_populates="forensic_reports")
 
     __table_args__ = (
-        UniqueConstraint("report_id", name="uq_forensic_reports_report_id"),
+        UniqueConstraint("domain_id", "report_id", name="uq_forensic_reports_domain_report"),
         Index("ix_forensic_reports_domain_arrival", "domain_id", "arrival_date"),
         Index("ix_forensic_reports_failure_source", "auth_failure", "source_ip"),
     )
@@ -181,7 +181,12 @@ class TLSReport(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint("report_id", "policy_domain", name="uq_tls_reports_report_domain"),
+        UniqueConstraint(
+            "domain_id",
+            "report_id",
+            "policy_domain",
+            name="uq_tls_reports_domain_report_policy",
+        ),
         Index("ix_tls_reports_domain_dates", "domain_id", "begin_date", "end_date"),
         Index("ix_tls_reports_policy_domain_dates", "policy_domain", "begin_date", "end_date"),
     )

--- a/backend/app/models/webhook.py
+++ b/backend/app/models/webhook.py
@@ -11,6 +11,7 @@ class WebhookEndpoint(Base):
     __tablename__ = "webhook_endpoints"
 
     id = Column(Integer, primary_key=True, index=True)
+    workspace_id = Column(Integer, ForeignKey("workspaces.id"), nullable=True, index=True)
     name = Column(String(120), nullable=False)
     url = Column(Text, nullable=False)
     secret = Column(Text, nullable=False)
@@ -24,7 +25,10 @@ class WebhookEndpoint(Base):
     last_failure_at = Column(DateTime, nullable=True, index=True)
     failure_count = Column(Integer, default=0, nullable=False)
 
-    __table_args__ = (Index("ix_webhook_endpoints_enabled_events", "enabled", "event_types"),)
+    __table_args__ = (
+        Index("ix_webhook_endpoints_enabled_events", "enabled", "event_types"),
+        Index("ix_webhook_endpoints_workspace_enabled", "workspace_id", "enabled"),
+    )
 
     def __repr__(self):
         return f"<WebhookEndpoint {self.name} enabled={self.enabled}>"

--- a/backend/app/services/cloudflare_dns.py
+++ b/backend/app/services/cloudflare_dns.py
@@ -70,10 +70,17 @@ def build_cloudflare_provider(db: Session) -> CloudflareDNSProvider:
     )
 
 
-async def discover_cloudflare_zones(db: Session) -> List[Dict[str, Any]]:
+async def discover_cloudflare_zones(
+    db: Session,
+    *,
+    workspace_id: Optional[int] = None,
+) -> List[Dict[str, Any]]:
     """Return zones visible to the configured Cloudflare token with import state."""
     provider = build_cloudflare_provider(db)
-    known_domains = {name for (name,) in db.query(Domain.name).all()}
+    known_query = db.query(Domain.name)
+    if workspace_id is not None:
+        known_query = known_query.filter(Domain.workspace_id == workspace_id)
+    known_domains = {name for (name,) in known_query.all()}
     zones = await provider.list_zones()
     return [
         {
@@ -92,10 +99,13 @@ async def import_cloudflare_domains(
     db: Session,
     *,
     requested_domains: Optional[List[str]] = None,
+    workspace_id: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Create Domain rows for Cloudflare zones, returning imported and existing names."""
-    zones = await discover_cloudflare_zones(db)
-    workspace = assign_default_workspace_to_unscoped_rows(db)
+    if workspace_id is None:
+        workspace = assign_default_workspace_to_unscoped_rows(db)
+        workspace_id = workspace.id
+    zones = await discover_cloudflare_zones(db, workspace_id=workspace_id)
     requested = {domain.strip().lower() for domain in requested_domains or [] if domain.strip()}
     imported: List[str] = []
     existing: List[str] = []
@@ -108,11 +118,11 @@ async def import_cloudflare_domains(
             continue
         domain = (
             db.query(Domain)
-            .filter(Domain.name == name, Domain.workspace_id == workspace.id)
+            .filter(Domain.name == name, Domain.workspace_id == workspace_id)
             .first()
         )
         if domain is None:
-            db.add(Domain(name=name, active=True, verified=True, workspace_id=workspace.id))
+            db.add(Domain(name=name, active=True, verified=True, workspace_id=workspace_id))
             imported.append(name)
         else:
             existing.append(name)

--- a/backend/app/services/forensic_persistence.py
+++ b/backend/app/services/forensic_persistence.py
@@ -11,17 +11,29 @@ from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 from app.utils.domain_validator import DomainValidationError, validate_domain
 
 
-def forensic_report_exists(db: Session, report_id: str) -> bool:
+def forensic_report_exists(
+    db: Session,
+    report_id: str,
+    *,
+    workspace_id: Optional[int] = None,
+) -> bool:
     """Return True when a forensic report ID is already persisted."""
     if not str(report_id or "").strip():
         return False
-    return (
-        db.query(ForensicReport.id).filter(ForensicReport.report_id == report_id).first()
-        is not None
-    )
+    query = db.query(ForensicReport.id).filter(ForensicReport.report_id == report_id)
+    if workspace_id is not None:
+        query = query.join(Domain, ForensicReport.domain_id == Domain.id).filter(
+            Domain.workspace_id == workspace_id
+        )
+    return query.first() is not None
 
 
-def _domain_for_report(db: Session, domain_name: Optional[str]) -> Optional[Domain]:
+def _domain_for_report(
+    db: Session,
+    domain_name: Optional[str],
+    *,
+    workspace_id: Optional[int] = None,
+) -> Optional[Domain]:
     if not domain_name:
         return None
     normalized = domain_name.lower().strip(".")
@@ -29,20 +41,27 @@ def _domain_for_report(db: Session, domain_name: Optional[str]) -> Optional[Doma
     if not is_valid and error_code != DomainValidationError.DNS_RESOLUTION_FAILED:
         return None
 
-    workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+    if workspace_id is None:
+        workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+        workspace_id = workspace.id
     domain = (
         db.query(Domain)
-        .filter(Domain.name == normalized, Domain.workspace_id == workspace.id)
+        .filter(Domain.name == normalized, Domain.workspace_id == workspace_id)
         .first()
     )
     if domain is None:
-        domain = Domain(name=normalized, workspace_id=workspace.id)
+        domain = Domain(name=normalized, workspace_id=workspace_id)
         db.add(domain)
         db.flush()
     return domain
 
 
-def save_forensic_report(db: Session, report: Dict[str, Any]) -> tuple[ForensicReport, bool]:
+def save_forensic_report(
+    db: Session,
+    report: Dict[str, Any],
+    *,
+    workspace_id: Optional[int] = None,
+) -> tuple[ForensicReport, bool]:
     """Persist a parsed forensic report.
 
     Returns ``(row, created)``. The caller owns the transaction and should
@@ -52,11 +71,16 @@ def save_forensic_report(db: Session, report: Dict[str, Any]) -> tuple[ForensicR
     if not report_id:
         raise ValueError("Forensic report_id is required")
 
-    existing = db.query(ForensicReport).filter(ForensicReport.report_id == report_id).first()
+    existing_query = db.query(ForensicReport).filter(ForensicReport.report_id == report_id)
+    if workspace_id is not None:
+        existing_query = existing_query.join(Domain, ForensicReport.domain_id == Domain.id).filter(
+            Domain.workspace_id == workspace_id
+        )
+    existing = existing_query.first()
     if existing is not None:
         return existing, False
 
-    domain = _domain_for_report(db, report.get("reported_domain"))
+    domain = _domain_for_report(db, report.get("reported_domain"), workspace_id=workspace_id)
     feedback_headers = report.get("feedback_headers")
     if isinstance(feedback_headers, dict):
         feedback_headers = json.dumps(feedback_headers, sort_keys=True)
@@ -87,7 +111,12 @@ def save_forensic_report(db: Session, report: Dict[str, Any]) -> tuple[ForensicR
         db.flush()
     except IntegrityError:
         db.rollback()
-        existing = db.query(ForensicReport).filter(ForensicReport.report_id == report_id).first()
+        existing_query = db.query(ForensicReport).filter(ForensicReport.report_id == report_id)
+        if workspace_id is not None:
+            existing_query = existing_query.join(
+                Domain, ForensicReport.domain_id == Domain.id
+            ).filter(Domain.workspace_id == workspace_id)
+        existing = existing_query.first()
         if existing is not None:
             return existing, False
         raise

--- a/backend/app/services/tls_report_persistence.py
+++ b/backend/app/services/tls_report_persistence.py
@@ -44,24 +44,35 @@ TLS_REPORT_PRIVACY_CONTROLS = {
 }
 
 
-def tls_report_exists(db: Session, report_id: str, policy_domain: str) -> bool:
+def tls_report_exists(
+    db: Session,
+    report_id: str,
+    policy_domain: str,
+    *,
+    workspace_id: Optional[int] = None,
+) -> bool:
     """Return True when a TLS report policy entry already exists."""
     normalized_report_id = str(report_id or "").strip()
     normalized_domain = str(policy_domain or "").strip().lower().strip(".")
     if not normalized_report_id or not normalized_domain:
         return False
-    return (
-        db.query(TLSReport.id)
-        .filter(
-            TLSReport.report_id == normalized_report_id,
-            TLSReport.policy_domain == normalized_domain,
-        )
-        .first()
-        is not None
+    query = db.query(TLSReport.id).filter(
+        TLSReport.report_id == normalized_report_id,
+        TLSReport.policy_domain == normalized_domain,
     )
+    if workspace_id is not None:
+        query = query.join(Domain, TLSReport.domain_id == Domain.id).filter(
+            Domain.workspace_id == workspace_id
+        )
+    return query.first() is not None
 
 
-def _domain_for_report(db: Session, domain_name: Optional[str]) -> Optional[Domain]:
+def _domain_for_report(
+    db: Session,
+    domain_name: Optional[str],
+    *,
+    workspace_id: Optional[int] = None,
+) -> Optional[Domain]:
     if not domain_name:
         return None
     normalized = domain_name.lower().strip(".")
@@ -69,14 +80,16 @@ def _domain_for_report(db: Session, domain_name: Optional[str]) -> Optional[Doma
     if not is_valid and error_code != DomainValidationError.DNS_RESOLUTION_FAILED:
         return None
 
-    workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+    if workspace_id is None:
+        workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+        workspace_id = workspace.id
     domain = (
         db.query(Domain)
-        .filter(Domain.name == normalized, Domain.workspace_id == workspace.id)
+        .filter(Domain.name == normalized, Domain.workspace_id == workspace_id)
         .first()
     )
     if domain is None:
-        domain = Domain(name=normalized, workspace_id=workspace.id)
+        domain = Domain(name=normalized, workspace_id=workspace_id)
         db.add(domain)
         db.flush()
     return domain
@@ -86,24 +99,27 @@ def _save_policy_report(
     db: Session,
     parsed_report: Dict[str, Any],
     policy: Dict[str, Any],
+    *,
+    workspace_id: Optional[int] = None,
 ) -> tuple[Optional[TLSReport], bool]:
     report_id = str(parsed_report.get("report_id") or "").strip()
     policy_domain = str(policy.get("policy_domain") or "").strip().lower().strip(".")
     if not report_id or not policy_domain:
         return None, False
 
-    existing = (
-        db.query(TLSReport)
-        .filter(
-            TLSReport.report_id == report_id,
-            TLSReport.policy_domain == policy_domain,
-        )
-        .first()
+    existing_query = db.query(TLSReport).filter(
+        TLSReport.report_id == report_id,
+        TLSReport.policy_domain == policy_domain,
     )
+    if workspace_id is not None:
+        existing_query = existing_query.join(Domain, TLSReport.domain_id == Domain.id).filter(
+            Domain.workspace_id == workspace_id
+        )
+    existing = existing_query.first()
     if existing is not None:
         return existing, False
 
-    domain = _domain_for_report(db, policy_domain)
+    domain = _domain_for_report(db, policy_domain, workspace_id=workspace_id)
     row = TLSReport(
         domain_id=domain.id if domain else None,
         report_id=report_id,
@@ -136,21 +152,27 @@ def _save_policy_report(
         db.flush()
     except IntegrityError:
         db.rollback()
-        existing = (
-            db.query(TLSReport)
-            .filter(
-                TLSReport.report_id == report_id,
-                TLSReport.policy_domain == policy_domain,
-            )
-            .first()
+        existing_query = db.query(TLSReport).filter(
+            TLSReport.report_id == report_id,
+            TLSReport.policy_domain == policy_domain,
         )
+        if workspace_id is not None:
+            existing_query = existing_query.join(Domain, TLSReport.domain_id == Domain.id).filter(
+                Domain.workspace_id == workspace_id
+            )
+        existing = existing_query.first()
         if existing is not None:
             return existing, False
         raise
     return row, True
 
 
-def save_tls_report(db: Session, parsed_report: Dict[str, Any]) -> Dict[str, Any]:
+def save_tls_report(
+    db: Session,
+    parsed_report: Dict[str, Any],
+    *,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
     """Persist parsed TLS report policy entries.
 
     One TLS-RPT JSON can carry multiple policy domains. Each policy is stored
@@ -161,7 +183,12 @@ def save_tls_report(db: Session, parsed_report: Dict[str, Any]) -> Dict[str, Any
     created = 0
     skipped = 0
     for policy in parsed_report.get("policies") or []:
-        row, was_created = _save_policy_report(db, parsed_report, policy)
+        row, was_created = _save_policy_report(
+            db,
+            parsed_report,
+            policy,
+            workspace_id=workspace_id,
+        )
         if row is None:
             skipped += 1
             continue
@@ -231,9 +258,7 @@ def _report_rows(
     )
     if domain:
         normalized = domain.lower().strip(".")
-        query = query.filter(
-            (Domain.name == normalized) | (TLSReport.policy_domain == normalized)
-        )
+        query = query.filter((Domain.name == normalized) | (TLSReport.policy_domain == normalized))
     return query.order_by(TLSReport.begin_date.desc().nullslast(), TLSReport.id.desc()).all()
 
 

--- a/backend/app/services/webhook_events.py
+++ b/backend/app/services/webhook_events.py
@@ -118,6 +118,7 @@ def validate_webhook_url(url: str) -> str:
 def create_webhook_endpoint(
     db: Session,
     *,
+    workspace_id: Optional[int] = None,
     name: str,
     url: str,
     secret: Optional[str] = None,
@@ -136,6 +137,7 @@ def create_webhook_endpoint(
         raise ValueError("Webhook signing secret must be at least 16 characters")
 
     endpoint = WebhookEndpoint(
+        workspace_id=workspace_id,
         name=clean_name,
         url=_encrypt(clean_url),
         secret=_encrypt(raw_secret),
@@ -215,11 +217,15 @@ def enqueue_webhook_event(
     event_type: str,
     payload: Dict[str, Any],
     idempotency_key: Optional[str] = None,
+    workspace_id: Optional[int] = None,
 ) -> List[WebhookDelivery]:
     """Create pending deliveries for all enabled endpoints matching an event."""
     if event_type not in SUPPORTED_EVENT_TYPES:
         raise ValueError(f"Unsupported webhook event type: {event_type}")
-    endpoints = db.query(WebhookEndpoint).filter(WebhookEndpoint.enabled.is_(True)).all()
+    endpoints_query = db.query(WebhookEndpoint).filter(WebhookEndpoint.enabled.is_(True))
+    if workspace_id is not None:
+        endpoints_query = endpoints_query.filter(WebhookEndpoint.workspace_id == workspace_id)
+    endpoints = endpoints_query.all()
     event_payload = build_event_payload(event_type, payload)
     key = idempotency_key or default_idempotency_key(event_type, event_payload)
     deliveries: List[WebhookDelivery] = []
@@ -375,6 +381,7 @@ def deliver_due_webhooks(
     *,
     limit: int = 25,
     endpoint_id: Optional[int] = None,
+    workspace_id: Optional[int] = None,
     sender: WebhookSender = default_webhook_sender,
 ) -> List[WebhookDelivery]:
     """Deliver pending webhook deliveries whose retry time has arrived."""
@@ -385,6 +392,9 @@ def deliver_due_webhooks(
     )
     if endpoint_id is not None:
         query = query.filter(WebhookDelivery.endpoint_id == endpoint_id)
+    if workspace_id is not None:
+        query = query.join(WebhookEndpoint, WebhookDelivery.endpoint_id == WebhookEndpoint.id)
+        query = query.filter(WebhookEndpoint.workspace_id == workspace_id)
     deliveries = (
         query.order_by(WebhookDelivery.next_attempt_at, WebhookDelivery.id).limit(limit).all()
     )
@@ -420,6 +430,7 @@ def endpoint_to_dict(endpoint: WebhookEndpoint) -> Dict[str, Any]:
     raw_url = _decrypt(endpoint.url)
     return {
         "id": endpoint.id,
+        "workspace_id": endpoint.workspace_id,
         "name": endpoint.name,
         "url": _redact_url(raw_url),
         "event_types": parse_event_types(endpoint.event_types),

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -14,6 +14,7 @@ from app.models.dns_cache import DNSRecordChange, DNSRecordSnapshot
 from app.models.domain import Domain
 from app.models.setting import Setting
 from app.models.user import User
+from app.models.workspace import Workspace
 from app.services import cloudflare_dns
 from app.services.cloudflare_dns import analyze_dns_records, sync_dns_record_changes
 from app.services.workspaces import get_or_create_default_workspace
@@ -237,7 +238,11 @@ def test_build_cloudflare_provider_requires_token(db_session):
 
 
 def test_discover_cloudflare_zones_marks_imported_and_filters_invalid(db_session):
-    db_session.add(Domain(name=DOMAIN))
+    default_workspace = get_or_create_default_workspace(db_session)
+    selected_workspace = Workspace(slug="cf-selected", name="CF Selected", active=True)
+    db_session.add(selected_workspace)
+    db_session.flush()
+    db_session.add(Domain(name=DOMAIN, workspace_id=default_workspace.id))
     db_session.commit()
     provider = FakeCloudflareProvider(
         zones=[
@@ -253,6 +258,12 @@ def test_discover_cloudflare_zones_marks_imported_and_filters_invalid(db_session
 
     with patch("app.services.cloudflare_dns.build_cloudflare_provider", return_value=provider):
         zones = asyncio.run(cloudflare_dns.discover_cloudflare_zones(db_session))
+        selected_zones = asyncio.run(
+            cloudflare_dns.discover_cloudflare_zones(
+                db_session,
+                workspace_id=selected_workspace.id,
+            )
+        )
 
     assert zones == [
         {
@@ -263,13 +274,14 @@ def test_discover_cloudflare_zones_marks_imported_and_filters_invalid(db_session
             "imported": True,
         }
     ]
+    assert selected_zones[0]["imported"] is False
 
 
 def test_import_cloudflare_domains_imports_requested_and_skips_others(db_session):
     db_session.add(Domain(name=DOMAIN))
     db_session.commit()
 
-    async def fake_discover(_db):
+    async def fake_discover(_db, workspace_id=None):
         return [
             {"id": "zone-1", "name": DOMAIN, "imported": True},
             {"id": "zone-2", "name": "new.example", "imported": False},

--- a/backend/app/tests/test_forensics_api.py
+++ b/backend/app/tests/test_forensics_api.py
@@ -7,7 +7,9 @@ from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
 from app.api.api_v1.endpoints import forensics as forensics_endpoint
+from app.models.domain import Domain
 from app.models.report import ForensicReport
+from app.models.workspace import Workspace
 from app.services.forensic_parser import ForensicParser
 from app.services.forensic_persistence import (
     forensic_report_exists,
@@ -65,6 +67,62 @@ def test_list_and_detail_forensic_reports(authed_client):
     detail_response = authed_client.get(f"/api/v1/forensics/{item['id']}")
     assert detail_response.status_code == 200
     assert detail_response.json()["reported_domain"] == "example.com"
+
+
+def test_forensic_reports_respect_selected_workspace_header(authed_client, db_session):
+    selected_workspace = Workspace(
+        slug="selected-forensics",
+        name="Selected Forensics",
+        active=True,
+    )
+    db_session.add(selected_workspace)
+    db_session.flush()
+    selected_header = {"X-DMARQ-Workspace-ID": str(selected_workspace.id)}
+    selected_content = SAMPLE_FORENSIC_EMAIL.replace(b"example.com", b"selected.example")
+
+    default_upload = authed_client.post(
+        "/api/v1/forensics/upload",
+        files={"file": ("report.eml", SAMPLE_FORENSIC_EMAIL, "message/rfc822")},
+    )
+    selected_upload = authed_client.post(
+        "/api/v1/forensics/upload",
+        headers=selected_header,
+        files={"file": ("report.eml", selected_content, "message/rfc822")},
+    )
+
+    assert default_upload.status_code == 200
+    assert selected_upload.status_code == 200
+    assert db_session.query(ForensicReport).count() == 2
+
+    selected_domain = (
+        db_session.query(Domain)
+        .filter(Domain.name == "selected.example", Domain.workspace_id == selected_workspace.id)
+        .one()
+    )
+    selected_report = (
+        db_session.query(ForensicReport)
+        .filter(ForensicReport.domain_id == selected_domain.id)
+        .one()
+    )
+
+    default_list = authed_client.get("/api/v1/forensics?domain=example.com")
+    selected_list = authed_client.get(
+        "/api/v1/forensics?domain=selected.example",
+        headers=selected_header,
+    )
+    default_detail = authed_client.get(f"/api/v1/forensics/{selected_report.id}")
+    selected_detail = authed_client.get(
+        f"/api/v1/forensics/{selected_report.id}",
+        headers=selected_header,
+    )
+
+    assert default_list.status_code == 200
+    assert default_list.json()["total"] == 1
+    assert selected_list.status_code == 200
+    assert selected_list.json()["total"] == 1
+    assert selected_list.json()["reports"][0]["id"] == selected_report.id
+    assert default_detail.status_code == 404
+    assert selected_detail.status_code == 200
 
 
 def test_list_forensic_reports_filters_failure_fields(authed_client, db_session):
@@ -256,11 +314,15 @@ def test_upload_forensic_report_rejects_invalid_email(authed_client):
 def test_upload_forensic_report_handles_save_duplicate_race(authed_client, monkeypatch):
     parsed = ForensicParser.parse_bytes(SAMPLE_FORENSIC_EMAIL)
     row = ForensicReport(report_id=parsed["report_id"], reported_domain=parsed["reported_domain"])
-    monkeypatch.setattr(forensics_endpoint, "forensic_report_exists", lambda *_args: False)
+    monkeypatch.setattr(
+        forensics_endpoint,
+        "forensic_report_exists",
+        lambda *_args, **_kwargs: False,
+    )
     monkeypatch.setattr(
         forensics_endpoint,
         "save_forensic_report",
-        lambda *_args: (row, False),
+        lambda *_args, **_kwargs: (row, False),
     )
 
     response = authed_client.post(

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -146,6 +146,7 @@ def test_admin_api_token_management_is_workspace_scoped(
     )
     db_session.add(other_workspace)
     db_session.flush()
+    other_header = {"X-DMARQ-Workspace-ID": str(other_workspace.id)}
     other_token = create_api_token(
         db_session,
         name="other workspace token",
@@ -169,6 +170,26 @@ def test_admin_api_token_management_is_workspace_scoped(
     assert denied_revoke.status_code == 404
     db_session.refresh(other_token.token)
     assert other_token.token.active is True
+
+    other_listed = authed_client.get("/api/v1/api-tokens", headers=other_header)
+    assert other_listed.status_code == 200
+    assert [row["name"] for row in other_listed.json()["tokens"]] == ["other workspace token"]
+
+    other_created = authed_client.post(
+        "/api/v1/api-tokens",
+        headers=other_header,
+        json={"name": "selected workspace token", "scopes": [READ_REPORTS_SCOPE]},
+    )
+    assert other_created.status_code == 201
+    assert other_created.json()["metadata"]["workspace_id"] == other_workspace.id
+
+    selected_revoke = authed_client.delete(
+        f"/api/v1/api-tokens/{other_token.token.id}",
+        headers=other_header,
+    )
+    assert selected_revoke.status_code == 200
+    db_session.refresh(other_token.token)
+    assert other_token.token.active is False
 
 
 def test_api_token_workspace_role_is_limited_to_matching_workspace(db_session):

--- a/backend/app/tests/test_tls_reports_api.py
+++ b/backend/app/tests/test_tls_reports_api.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 from fastapi import HTTPException
@@ -6,13 +7,14 @@ from fastapi.testclient import TestClient
 from app.api.api_v1.endpoints import tls_reports as tls_endpoint
 from app.models.domain import Domain
 from app.models.report import TLSReport, TLSReportFailure
+from app.models.workspace import Workspace
 from app.services.tls_report_parser import TLSReportParser
 from app.services.tls_report_persistence import (
     save_tls_report,
     summarize_tls_reports,
     tls_report_exists,
 )
-from app.tests.test_tls_report_parser import sample_tls_report_bytes
+from app.tests.test_tls_report_parser import SAMPLE_TLS_REPORT, sample_tls_report_bytes
 
 
 def test_upload_tls_report_persists_policy_and_failure_details(authed_client, db_session):
@@ -70,6 +72,56 @@ def test_tls_report_summary_groups_failures_and_domains(authed_client):
     assert data["top_failures"][0]["affected_domains"] == ["example.com"]
     assert data["affected_domains"][0]["failure_rate"] > 0
     assert "sender or recipient addresses" in data["privacy"]["not_stored"]
+
+
+def test_tls_reports_respect_selected_workspace_header(authed_client, db_session):
+    selected_workspace = Workspace(
+        slug="selected-tls",
+        name="Selected TLS",
+        active=True,
+    )
+    db_session.add(selected_workspace)
+    db_session.flush()
+    selected_header = {"X-DMARQ-Workspace-ID": str(selected_workspace.id)}
+    selected_report = json.loads(json.dumps(SAMPLE_TLS_REPORT))
+    selected_report["policies"][0]["policy"]["policy-domain"] = "Selected.example."
+    selected_report["policies"][0]["policy"]["mx-host"] = ["mx.selected.example"]
+    selected_bytes = sample_tls_report_bytes(selected_report)
+
+    default_upload = authed_client.post(
+        "/api/v1/tls-reports/upload",
+        files={"file": ("tls-report.json", sample_tls_report_bytes(), "application/json")},
+    )
+    selected_upload = authed_client.post(
+        "/api/v1/tls-reports/upload",
+        headers=selected_header,
+        files={"file": ("tls-report.json", selected_bytes, "application/json")},
+    )
+
+    assert default_upload.status_code == 200
+    assert selected_upload.status_code == 200
+    assert db_session.query(TLSReport).count() == 2
+
+    default_list = authed_client.get("/api/v1/tls-reports?domain=example.com")
+    selected_list = authed_client.get(
+        "/api/v1/tls-reports?domain=selected.example",
+        headers=selected_header,
+    )
+    default_summary = authed_client.get("/api/v1/tls-reports/summary?domain=example.com")
+    selected_summary = authed_client.get(
+        "/api/v1/tls-reports/summary?domain=selected.example",
+        headers=selected_header,
+    )
+
+    assert default_list.status_code == 200
+    assert default_list.json()["total"] == 1
+    assert selected_list.status_code == 200
+    assert selected_list.json()["total"] == 1
+    assert selected_list.json()["reports"][0]["domain"] == "selected.example"
+    assert default_summary.status_code == 200
+    assert default_summary.json()["totals"]["reports"] == 1
+    assert selected_summary.status_code == 200
+    assert selected_summary.json()["totals"]["reports"] == 1
 
 
 def test_list_tls_reports_filters_by_domain(authed_client, db_session):

--- a/backend/app/tests/test_webhooks.py
+++ b/backend/app/tests/test_webhooks.py
@@ -4,6 +4,7 @@ import json
 from fastapi.testclient import TestClient
 
 from app.models.webhook import WebhookDelivery
+from app.models.workspace import Workspace
 from app.services.webhook_events import (
     DELIVERY_ABANDONED,
     DELIVERY_DELIVERED,
@@ -207,7 +208,7 @@ def test_admin_webhook_endpoints_hide_secrets_and_show_delivery_status(
     assert listed.json()["endpoints"][0]["url"] == "https://ops.example/hooks/dmarq"
     assert body["secret"] not in listed.text
 
-    def fake_deliver_due_webhooks(db, endpoint_id=None, limit=25):
+    def fake_deliver_due_webhooks(db, endpoint_id=None, limit=25, workspace_id=None):
         delivery = (
             db.query(WebhookDelivery)
             .filter(WebhookDelivery.endpoint_id == endpoint_id)
@@ -277,7 +278,7 @@ def test_admin_webhook_update_disable_filter_and_process(
     missing_test = authed_client.post("/api/v1/webhooks/9999/test")
     assert missing_test.status_code == 404
 
-    def fake_process(db, endpoint_id=None, limit=25):
+    def fake_process(db, endpoint_id=None, limit=25, workspace_id=None):
         delivery = queue_test_webhook(db, created["id"])
         delivery.status = DELIVERY_DELIVERED
         delivery.attempt_count = 1
@@ -306,3 +307,79 @@ def test_admin_webhook_update_disable_filter_and_process(
 
     missing_delete = authed_client.delete("/api/v1/webhooks/9999")
     assert missing_delete.status_code == 404
+
+
+def test_admin_webhook_endpoints_respect_selected_workspace_header(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Webhook endpoints and deliveries stay inside the selected workspace."""
+    selected_workspace = Workspace(
+        slug="selected-webhooks",
+        name="Selected Webhooks",
+        active=True,
+    )
+    db_session.add(selected_workspace)
+    db_session.flush()
+    selected_header = {"X-DMARQ-Workspace-ID": str(selected_workspace.id)}
+
+    default_created = authed_client.post(
+        "/api/v1/webhooks",
+        json={"name": "default hook", "url": "https://default.example/hooks/dmarq"},
+    ).json()
+    assert default_created["workspace_id"] is not None
+    selected_created = authed_client.post(
+        "/api/v1/webhooks",
+        headers=selected_header,
+        json={"name": "selected hook", "url": "https://selected.example/hooks/dmarq"},
+    )
+    assert selected_created.status_code == 200
+    selected_body = selected_created.json()
+    assert selected_body["workspace_id"] == selected_workspace.id
+
+    default_list = authed_client.get("/api/v1/webhooks")
+    selected_list = authed_client.get("/api/v1/webhooks", headers=selected_header)
+    assert [item["name"] for item in default_list.json()["endpoints"]] == ["default hook"]
+    assert [item["name"] for item in selected_list.json()["endpoints"]] == ["selected hook"]
+
+    default_update = authed_client.put(
+        f"/api/v1/webhooks/{selected_body['id']}",
+        json={"name": "wrong workspace"},
+    )
+    assert default_update.status_code == 404
+
+    def fake_deliver_due_webhooks(db, endpoint_id=None, limit=25, workspace_id=None):
+        query = db.query(WebhookDelivery)
+        if endpoint_id is not None:
+            query = query.filter(WebhookDelivery.endpoint_id == endpoint_id)
+        delivery = query.order_by(WebhookDelivery.id.desc()).first()
+        delivery.status = DELIVERY_DELIVERED
+        delivery.attempt_count = 1
+        db.commit()
+        db.refresh(delivery)
+        return [delivery]
+
+    monkeypatch.setattr(
+        "app.api.api_v1.endpoints.webhooks.deliver_due_webhooks",
+        fake_deliver_due_webhooks,
+    )
+    selected_test = authed_client.post(
+        f"/api/v1/webhooks/{selected_body['id']}/test",
+        headers=selected_header,
+    )
+    assert selected_test.status_code == 200
+
+    default_history = authed_client.get("/api/v1/webhooks/deliveries")
+    selected_history = authed_client.get("/api/v1/webhooks/deliveries", headers=selected_header)
+    assert default_history.json()["deliveries"] == []
+    assert len(selected_history.json()["deliveries"]) == 1
+
+    default_disable = authed_client.delete(f"/api/v1/webhooks/{selected_body['id']}")
+    selected_disable = authed_client.delete(
+        f"/api/v1/webhooks/{selected_body['id']}",
+        headers=selected_header,
+    )
+    assert default_disable.status_code == 404
+    assert selected_disable.status_code == 200
+    assert selected_disable.json()["enabled"] is False

--- a/backend/app/tests/test_workspace_audit.py
+++ b/backend/app/tests/test_workspace_audit.py
@@ -10,8 +10,7 @@ from app.models.domain import Domain
 from app.models.organization import Organization, OrganizationMembership
 from app.models.user import User
 from app.models.workspace import Workspace
-from app.models.workspace_access import WorkspaceMembership
-from app.models.workspace_access import WorkspaceAuditLog
+from app.models.workspace_access import WorkspaceAuditLog, WorkspaceMembership
 from app.services.workspace_access import (
     PERMISSION_REPORTS_READ,
     PERMISSION_WORKSPACE_ADMIN,
@@ -343,11 +342,14 @@ def test_organization_role_resolution_uses_org_workspace_and_superuser_paths(
         == ""
     )
 
-    assert organization_ids_for_permission(
-        db_session,
-        {"auth_type": "api_key"},
-        PERMISSION_WORKSPACE_ADMIN,
-    ) is None
+    assert (
+        organization_ids_for_permission(
+            db_session,
+            {"auth_type": "api_key"},
+            PERMISSION_WORKSPACE_ADMIN,
+        )
+        is None
+    )
     assert (
         organization_ids_for_permission(
             db_session,
@@ -433,6 +435,51 @@ def test_workspace_audit_logs_enforce_membership(test_app, db_session: Session):
     with _client_as_user(test_app, db_session, outsider) as client:
         response = client.get("/api/v1/audit/logs")
         assert response.status_code == 403
+
+
+def test_workspace_audit_logs_respect_selected_workspace_header(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Audit log reads only return events from the selected workspace."""
+    default_workspace = get_or_create_default_workspace(db_session)
+    selected_workspace = Workspace(
+        slug="selected-audit-workspace",
+        name="Selected Audit Workspace",
+        active=True,
+    )
+    db_session.add(selected_workspace)
+    db_session.flush()
+
+    record_workspace_audit_log(
+        db_session,
+        workspace=default_workspace,
+        action="default.event",
+        entity_type="setting",
+        entity_id="default",
+        entity_name="Default",
+        commit=False,
+    )
+    record_workspace_audit_log(
+        db_session,
+        workspace=selected_workspace,
+        action="selected.event",
+        entity_type="setting",
+        entity_id="selected",
+        entity_name="Selected",
+        commit=True,
+    )
+
+    default_response = authed_client.get("/api/v1/audit/logs?entity_type=setting")
+    selected_response = authed_client.get(
+        "/api/v1/audit/logs?entity_type=setting",
+        headers={"X-DMARQ-Workspace-ID": str(selected_workspace.id)},
+    )
+
+    assert default_response.status_code == 200
+    assert [event["action"] for event in default_response.json()["audit"]] == ["default.event"]
+    assert selected_response.status_code == 200
+    assert [event["action"] for event in selected_response.json()["audit"]] == ["selected.event"]
 
 
 def test_workspace_audit_logs_support_jwt_membership_and_defer_migration(
@@ -548,6 +595,39 @@ def test_notification_setting_audit_is_workspace_scoped_and_redacted(
     assert events[0]["ip_address"] == "203.0.113.5"
     assert events[0]["details"]["new_value"] == "[redacted]"
     assert "password@example.com" not in str(events)
+
+
+def test_notification_setting_audit_respects_selected_workspace_header(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Notification setting audit events land in the selected workspace."""
+    get_or_create_default_workspace(db_session)
+    selected_workspace = Workspace(
+        slug="selected-setting-audit",
+        name="Selected Setting Audit",
+        active=True,
+    )
+    db_session.add(selected_workspace)
+    db_session.commit()
+    selected_header = {"X-DMARQ-Workspace-ID": str(selected_workspace.id)}
+
+    response = authed_client.put(
+        "/api/v1/settings/notifications.apprise_enabled",
+        json={"value": "true"},
+        headers=selected_header,
+    )
+    default_audit = authed_client.get("/api/v1/audit/logs?entity_type=setting")
+    selected_audit = authed_client.get(
+        "/api/v1/audit/logs?entity_type=setting",
+        headers=selected_header,
+    )
+
+    assert response.status_code == 200
+    assert default_audit.status_code == 200
+    assert default_audit.json()["audit"] == []
+    assert selected_audit.status_code == 200
+    assert [event["action"] for event in selected_audit.json()["audit"]] == ["setting.changed"]
 
 
 def test_api_token_create_and_revoke_are_audited_without_raw_token(


### PR DESCRIPTION
## Summary
- propagate the selected workspace header through API token management, audit logs, forensic/TLS reports, Cloudflare domain discovery/import, webhooks, and AI/MCP audit contexts
- scope webhook endpoints to workspaces and make outbound delivery processing workspace-aware
- allow matching external forensic/TLS report IDs in different workspaces by moving uniqueness to domain/workspace-owned records
- keep settings values deployment-global for now, while ensuring settings change audit entries land in the selected workspace

## Validation
- black --check on changed Python files
- isort --check-only on changed Python files
- flake8 on changed Python files
- git diff --check
- pytest backend/app/tests/test_ai_mcp.py backend/app/tests/test_public_api.py backend/app/tests/test_workspace_audit.py backend/app/tests/test_forensics_api.py backend/app/tests/test_tls_reports_api.py backend/app/tests/test_webhooks.py backend/app/tests/test_cloudflare_dns.py -q (90 passed)
- Alembic upgrade head against a temporary SQLite database

Closes #238