### PR TITLE
Fix workspace-scoped report ownership follow-ups

### DIFF
--- a/backend/alembic/versions/7b8c9d0e1f2a_scope_report_uniqueness_by_workspace.py
+++ b/backend/alembic/versions/7b8c9d0e1f2a_scope_report_uniqueness_by_workspace.py
@@ -6,15 +6,13 @@ Create Date: 2026-06-28 00:00:00.000000
 
 """
 
-from typing import Sequence, Union
-
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "7b8c9d0e1f2a"
-down_revision: Union[str, Sequence[str], None] = "6a7b8c9d0e1f"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+revision = "7b8c9d0e1f2a"
+down_revision = "6a7b8c9d0e1f"
+branch_labels = None
+depends_on = None
 
 
 def upgrade() -> None:

--- a/backend/alembic/versions/8c9d0e1f2a3b_add_webhook_workspace_scope.py
+++ b/backend/alembic/versions/8c9d0e1f2a3b_add_webhook_workspace_scope.py
@@ -6,23 +6,36 @@ Create Date: 2026-06-28 00:05:00.000000
 
 """
 
-from typing import Sequence, Union
-
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "8c9d0e1f2a3b"
-down_revision: Union[str, Sequence[str], None] = "7b8c9d0e1f2a"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+revision = "8c9d0e1f2a3b"
+down_revision = "7b8c9d0e1f2a"
+branch_labels = None
+depends_on = None
 
 
 def _default_workspace_id_sql() -> str:
     return "(SELECT id FROM workspaces WHERE slug = 'default' LIMIT 1)"
 
 
+def _ensure_default_workspace() -> None:
+    op.execute("""
+        INSERT INTO workspaces (slug, name, description, active, created_at, updated_at)
+        SELECT
+            'default',
+            'Default Workspace',
+            'Automatically created for existing single-tenant installs.',
+            TRUE,
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        WHERE NOT EXISTS (SELECT 1 FROM workspaces WHERE slug = 'default')
+        """)
+
+
 def upgrade() -> None:
     """Attach existing webhook endpoints to the default workspace."""
+    _ensure_default_workspace()
     with op.batch_alter_table("webhook_endpoints") as batch_op:
         batch_op.add_column(sa.Column("workspace_id", sa.Integer(), nullable=True))
         batch_op.create_foreign_key(
@@ -36,7 +49,12 @@ def upgrade() -> None:
             "ix_webhook_endpoints_workspace_enabled",
             ["workspace_id", "enabled"],
         )
-    op.execute(f"UPDATE webhook_endpoints SET workspace_id = {_default_workspace_id_sql()}")
+    op.execute(
+        f"UPDATE webhook_endpoints SET workspace_id = {_default_workspace_id_sql()} "
+        "WHERE workspace_id IS NULL"
+    )
+    with op.batch_alter_table("webhook_endpoints") as batch_op:
+        batch_op.alter_column("workspace_id", existing_type=sa.Integer(), nullable=False)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/9d0e1f2a3b4c_enforce_workspace_scoped_report_integrity.py
+++ b/backend/alembic/versions/9d0e1f2a3b4c_enforce_workspace_scoped_report_integrity.py
@@ -39,6 +39,14 @@ def upgrade() -> None:
         f"UPDATE webhook_endpoints SET workspace_id = {_default_workspace_id_sql()} "
         "WHERE workspace_id IS NULL"
     )
+    op.execute("""
+        DELETE FROM tls_report_failures
+        WHERE report_id IN (
+            SELECT id FROM tls_reports WHERE domain_id IS NULL
+        )
+        """)
+    op.execute("DELETE FROM tls_reports WHERE domain_id IS NULL")
+    op.execute("DELETE FROM forensic_reports WHERE domain_id IS NULL")
 
     with op.batch_alter_table("webhook_endpoints") as batch_op:
         batch_op.alter_column("workspace_id", existing_type=sa.Integer(), nullable=False)

--- a/backend/alembic/versions/9d0e1f2a3b4c_enforce_workspace_scoped_report_integrity.py
+++ b/backend/alembic/versions/9d0e1f2a3b4c_enforce_workspace_scoped_report_integrity.py
@@ -39,6 +39,12 @@ def upgrade() -> None:
         f"UPDATE webhook_endpoints SET workspace_id = {_default_workspace_id_sql()} "
         "WHERE workspace_id IS NULL"
     )
+    op.execute(
+        "DELETE FROM tls_report_failures "
+        "WHERE report_id IN (SELECT id FROM tls_reports WHERE domain_id IS NULL)"
+    )
+    op.execute("DELETE FROM tls_reports WHERE domain_id IS NULL")
+    op.execute("DELETE FROM forensic_reports WHERE domain_id IS NULL")
 
     with op.batch_alter_table("webhook_endpoints") as batch_op:
         batch_op.alter_column("workspace_id", existing_type=sa.Integer(), nullable=False)

--- a/backend/alembic/versions/9d0e1f2a3b4c_enforce_workspace_scoped_report_integrity.py
+++ b/backend/alembic/versions/9d0e1f2a3b4c_enforce_workspace_scoped_report_integrity.py
@@ -1,0 +1,58 @@
+"""enforce workspace-scoped report integrity
+
+Revision ID: 9d0e1f2a3b4c
+Revises: 8c9d0e1f2a3b
+Create Date: 2026-06-28 00:40:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "9d0e1f2a3b4c"
+down_revision = "8c9d0e1f2a3b"
+branch_labels = None
+depends_on = None
+
+
+def _default_workspace_id_sql() -> str:
+    return "(SELECT id FROM workspaces WHERE slug = 'default' LIMIT 1)"
+
+
+def _ensure_default_workspace() -> None:
+    op.execute("""
+        INSERT INTO workspaces (slug, name, description, active, created_at, updated_at)
+        SELECT
+            'default',
+            'Default Workspace',
+            'Automatically created for existing single-tenant installs.',
+            TRUE,
+            CURRENT_TIMESTAMP,
+            CURRENT_TIMESTAMP
+        WHERE NOT EXISTS (SELECT 1 FROM workspaces WHERE slug = 'default')
+        """)
+
+
+def upgrade() -> None:
+    """Prevent tenant-scoped rows from retaining NULL workspace/domain owners."""
+    _ensure_default_workspace()
+    op.execute(
+        f"UPDATE webhook_endpoints SET workspace_id = {_default_workspace_id_sql()} "
+        "WHERE workspace_id IS NULL"
+    )
+
+    with op.batch_alter_table("webhook_endpoints") as batch_op:
+        batch_op.alter_column("workspace_id", existing_type=sa.Integer(), nullable=False)
+    with op.batch_alter_table("forensic_reports") as batch_op:
+        batch_op.alter_column("domain_id", existing_type=sa.Integer(), nullable=False)
+    with op.batch_alter_table("tls_reports") as batch_op:
+        batch_op.alter_column("domain_id", existing_type=sa.Integer(), nullable=False)
+
+
+def downgrade() -> None:
+    """Allow legacy NULL owners again."""
+    with op.batch_alter_table("tls_reports") as batch_op:
+        batch_op.alter_column("domain_id", existing_type=sa.Integer(), nullable=True)
+    with op.batch_alter_table("forensic_reports") as batch_op:
+        batch_op.alter_column("domain_id", existing_type=sa.Integer(), nullable=True)
+    with op.batch_alter_table("webhook_endpoints") as batch_op:
+        batch_op.alter_column("workspace_id", existing_type=sa.Integer(), nullable=True)

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -9,7 +9,7 @@ OAuth2 helper endpoints (authorize-url, callback, fetch).
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
@@ -46,6 +46,8 @@ from app.services.workspaces import (
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+_OAUTH_STATE_ALGORITHM = "HS256"
+_OAUTH_STATE_TTL = timedelta(minutes=10)
 
 
 # ---------------------------------------------------------------------------
@@ -249,12 +251,23 @@ def _authorized_mail_source_workspace(
     )
 
 
+def _oauth_state_signing_key() -> str:
+    """Scope OAuth state tokens away from admin auth tokens using the same secret."""
+    return f"{get_settings().SECRET_KEY}:mail-source-oauth-state"
+
+
 def _oauth_state(workspace_id: int, source_id: int) -> str:
     """Return a signed OAuth state value bound to one workspace and source."""
+    now = datetime.now(timezone.utc)
     token = jwt.encode(
-        {"source_id": int(source_id), "workspace_id": int(workspace_id)},
-        get_settings().SECRET_KEY,
-        algorithm="HS256",
+        {
+            "source_id": int(source_id),
+            "workspace_id": int(workspace_id),
+            "iat": now,
+            "exp": now + _OAUTH_STATE_TTL,
+        },
+        _oauth_state_signing_key(),
+        algorithm=_OAUTH_STATE_ALGORITHM,
     )
     return f"v1.{token}"
 
@@ -278,8 +291,8 @@ def _signed_oauth_state_workspace_id(state_value: str, source_id: int) -> int:
     try:
         payload = jwt.decode(
             token,
-            get_settings().SECRET_KEY,
-            algorithms=["HS256"],
+            _oauth_state_signing_key(),
+            algorithms=[_OAUTH_STATE_ALGORITHM],
             options={"verify_aud": False},
         )
         workspace_id = int(payload["workspace_id"])

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -112,7 +112,7 @@ class ForensicReport(Base):
     __tablename__ = "forensic_reports"
 
     id = Column(Integer, primary_key=True, index=True)
-    domain_id = Column(Integer, ForeignKey("domains.id"), nullable=True, index=True)
+    domain_id = Column(Integer, ForeignKey("domains.id"), nullable=False, index=True)
 
     # Report metadata
     report_id = Column(String, nullable=False, index=True)
@@ -159,7 +159,7 @@ class TLSReport(Base):
     __tablename__ = "tls_reports"
 
     id = Column(Integer, primary_key=True, index=True)
-    domain_id = Column(Integer, ForeignKey("domains.id"), nullable=True, index=True)
+    domain_id = Column(Integer, ForeignKey("domains.id"), nullable=False, index=True)
 
     report_id = Column(String, nullable=False, index=True)
     org_name = Column(String, nullable=True, index=True)

--- a/backend/app/models/webhook.py
+++ b/backend/app/models/webhook.py
@@ -11,7 +11,7 @@ class WebhookEndpoint(Base):
     __tablename__ = "webhook_endpoints"
 
     id = Column(Integer, primary_key=True, index=True)
-    workspace_id = Column(Integer, ForeignKey("workspaces.id"), nullable=True, index=True)
+    workspace_id = Column(Integer, ForeignKey("workspaces.id"), nullable=False, index=True)
     name = Column(String(120), nullable=False)
     url = Column(Text, nullable=False)
     secret = Column(Text, nullable=False)

--- a/backend/app/services/forensic_persistence.py
+++ b/backend/app/services/forensic_persistence.py
@@ -81,12 +81,14 @@ def save_forensic_report(
         return existing, False
 
     domain = _domain_for_report(db, report.get("reported_domain"), workspace_id=workspace_id)
+    if domain is None:
+        raise ValueError("Forensic reported_domain is invalid or missing")
     feedback_headers = report.get("feedback_headers")
     if isinstance(feedback_headers, dict):
         feedback_headers = json.dumps(feedback_headers, sort_keys=True)
 
     row = ForensicReport(
-        domain_id=domain.id if domain else None,
+        domain_id=domain.id,
         report_id=report_id,
         source_email=report.get("source_email"),
         feedback_type=report.get("feedback_type"),

--- a/backend/app/services/tls_report_persistence.py
+++ b/backend/app/services/tls_report_persistence.py
@@ -120,8 +120,10 @@ def _save_policy_report(
         return existing, False
 
     domain = _domain_for_report(db, policy_domain, workspace_id=workspace_id)
+    if domain is None:
+        return None, False
     row = TLSReport(
-        domain_id=domain.id if domain else None,
+        domain_id=domain.id,
         report_id=report_id,
         org_name=parsed_report.get("org_name"),
         contact_info=parsed_report.get("contact_info"),

--- a/backend/app/services/webhook_events.py
+++ b/backend/app/services/webhook_events.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 
 from app.core.credential_encryption import decrypt_secret, encrypt_secret, is_encrypted_secret
 from app.models.webhook import WebhookDelivery, WebhookEndpoint
+from app.services.workspaces import get_or_create_default_workspace
 
 EVENT_REPORT_IMPORTED = "dmarq.report.imported"
 EVENT_SENDER_NEW = "dmarq.sender.new"
@@ -115,6 +116,12 @@ def validate_webhook_url(url: str) -> str:
     return clean_url
 
 
+def _webhook_workspace_id(db: Session, workspace_id: Optional[int]) -> int:
+    if workspace_id is not None:
+        return int(workspace_id)
+    return get_or_create_default_workspace(db, commit=False).id
+
+
 def create_webhook_endpoint(
     db: Session,
     *,
@@ -135,9 +142,10 @@ def create_webhook_endpoint(
     raw_secret = secret.strip() if secret else generate_webhook_secret()
     if len(raw_secret) < 16:
         raise ValueError("Webhook signing secret must be at least 16 characters")
+    resolved_workspace_id = _webhook_workspace_id(db, workspace_id)
 
     endpoint = WebhookEndpoint(
-        workspace_id=workspace_id,
+        workspace_id=resolved_workspace_id,
         name=clean_name,
         url=_encrypt(clean_url),
         secret=_encrypt(raw_secret),
@@ -222,10 +230,15 @@ def enqueue_webhook_event(
     """Create pending deliveries for all enabled endpoints matching an event."""
     if event_type not in SUPPORTED_EVENT_TYPES:
         raise ValueError(f"Unsupported webhook event type: {event_type}")
-    endpoints_query = db.query(WebhookEndpoint).filter(WebhookEndpoint.enabled.is_(True))
-    if workspace_id is not None:
-        endpoints_query = endpoints_query.filter(WebhookEndpoint.workspace_id == workspace_id)
-    endpoints = endpoints_query.all()
+    resolved_workspace_id = _webhook_workspace_id(db, workspace_id)
+    endpoints = (
+        db.query(WebhookEndpoint)
+        .filter(
+            WebhookEndpoint.enabled.is_(True),
+            WebhookEndpoint.workspace_id == resolved_workspace_id,
+        )
+        .all()
+    )
     event_payload = build_event_payload(event_type, payload)
     key = idempotency_key or default_idempotency_key(event_type, event_payload)
     deliveries: List[WebhookDelivery] = []

--- a/backend/app/tests/test_forensics_api.py
+++ b/backend/app/tests/test_forensics_api.py
@@ -400,15 +400,20 @@ def test_save_forensic_report_duplicate_and_invalid_domain_paths(db_session):
     invalid = dict(parsed)
     invalid["report_id"] = "ruf-invalid-domain"
     invalid["reported_domain"] = "bad domain"
-    row, invalid_created = save_forensic_report(db_session, invalid)
-    assert invalid_created is True
-    assert row.domain_id is None
+    with pytest.raises(ValueError, match="reported_domain"):
+        save_forensic_report(db_session, invalid)
 
 
 def test_save_forensic_report_reraises_unexpected_integrity_errors(db_session, monkeypatch):
     parsed = ForensicParser.parse_bytes(SAMPLE_FORENSIC_EMAIL)
     parsed["report_id"] = "ruf-race-without-existing-row"
-    parsed["reported_domain"] = ""
+    workspace = Workspace(slug="integrity-workspace", name="Integrity Workspace", active=True)
+    db_session.add(workspace)
+    db_session.flush()
+    domain = Domain(name="integrity.example", workspace_id=workspace.id)
+    db_session.add(domain)
+    db_session.flush()
+    parsed["reported_domain"] = "integrity.example"
 
     def raise_integrity_error():
         raise IntegrityError("insert", {}, Exception("unique"))

--- a/backend/app/tests/test_forensics_api.py
+++ b/backend/app/tests/test_forensics_api.py
@@ -17,6 +17,7 @@ from app.services.forensic_persistence import (
     save_forensic_report,
 )
 from app.services.forensic_redaction import ForensicRedactionPolicy
+from app.services.workspaces import get_or_create_default_workspace
 from app.tests.test_forensic_parser import SAMPLE_FORENSIC_EMAIL
 
 
@@ -407,9 +408,7 @@ def test_save_forensic_report_duplicate_and_invalid_domain_paths(db_session):
 def test_save_forensic_report_reraises_unexpected_integrity_errors(db_session, monkeypatch):
     parsed = ForensicParser.parse_bytes(SAMPLE_FORENSIC_EMAIL)
     parsed["report_id"] = "ruf-race-without-existing-row"
-    workspace = Workspace(slug="integrity-workspace", name="Integrity Workspace", active=True)
-    db_session.add(workspace)
-    db_session.flush()
+    workspace = get_or_create_default_workspace(db_session, commit=False)
     domain = Domain(name="integrity.example", workspace_id=workspace.id)
     db_session.add(domain)
     db_session.flush()

--- a/backend/app/tests/test_forensics_api.py
+++ b/backend/app/tests/test_forensics_api.py
@@ -421,4 +421,4 @@ def test_save_forensic_report_reraises_unexpected_integrity_errors(db_session, m
     monkeypatch.setattr(db_session, "flush", raise_integrity_error)
 
     with pytest.raises(IntegrityError):
-        save_forensic_report(db_session, parsed)
+        save_forensic_report(db_session, parsed, workspace_id=workspace.id)

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -5,7 +5,7 @@ Tests for MailSource model and mail-sources API endpoints.
 import asyncio
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 from unittest.mock import MagicMock, patch
@@ -83,6 +83,40 @@ class TestOAuthStateHelpers:
 
         assert exc.value.status_code == 400
         assert exc.value.detail == "OAuth state does not match the requested mail source."
+
+    def test_signed_oauth_state_rejects_expired_token(self):
+        now = datetime.now(timezone.utc)
+        expired = mail_sources_endpoint.jwt.encode(
+            {
+                "source_id": 7,
+                "workspace_id": 42,
+                "iat": now - timedelta(minutes=20),
+                "exp": now - timedelta(minutes=10),
+            },
+            mail_sources_endpoint._oauth_state_signing_key(),
+            algorithm=mail_sources_endpoint._OAUTH_STATE_ALGORITHM,
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            mail_sources_endpoint._workspace_id_from_oauth_state(
+                f"v1.{expired}",
+                source_id=7,
+            )
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "Invalid OAuth state."
+
+    def test_signed_oauth_state_uses_dedicated_signing_key(self):
+        state = mail_sources_endpoint._oauth_state(workspace_id=42, source_id=7)
+        token = state.removeprefix("v1.")
+
+        with pytest.raises(mail_sources_endpoint.JWTError):
+            mail_sources_endpoint.jwt.decode(
+                token,
+                mail_sources_endpoint.get_settings().SECRET_KEY,
+                algorithms=[mail_sources_endpoint._OAUTH_STATE_ALGORITHM],
+                options={"verify_aud": False},
+            )
 
     @pytest.mark.parametrize(
         ("state", "source_id", "expected_workspace_id"),

--- a/backend/app/tests/test_tls_reports_api.py
+++ b/backend/app/tests/test_tls_reports_api.py
@@ -183,6 +183,13 @@ def test_tls_report_persistence_helpers(db_session):
     summary = summarize_tls_reports(db_session, domain="example.com")
     assert summary["totals"]["successful_sessions"] == 125
 
+    invalid = dict(parsed)
+    invalid["report_id"] = "tls-invalid-domain"
+    invalid["policies"] = [dict(parsed["policies"][0], policy_domain="bad domain")]
+    skipped = save_tls_report(db_session, invalid)
+    assert skipped["created"] == 0
+    assert skipped["skipped"] == 1
+
 
 def test_upload_tls_report_rejects_invalid_file_type(authed_client):
     response = authed_client.post(

--- a/backend/app/tests/test_webhooks.py
+++ b/backend/app/tests/test_webhooks.py
@@ -128,6 +128,36 @@ def test_webhook_idempotency_skips_duplicate_deliveries(db_session):
     assert db_session.query(WebhookDelivery).count() == 1
 
 
+def test_webhook_events_without_workspace_stay_in_default_workspace(db_session):
+    default_endpoint, _ = create_webhook_endpoint(
+        db_session,
+        name="default receiver",
+        url="https://default.example/webhook",
+        event_types=[EVENT_ALERT_CREATED],
+    )
+    other_workspace = Workspace(slug="webhook-other", name="Webhook Other", active=True)
+    db_session.add(other_workspace)
+    db_session.flush()
+    other_endpoint, _ = create_webhook_endpoint(
+        db_session,
+        workspace_id=other_workspace.id,
+        name="other receiver",
+        url="https://other.example/webhook",
+        event_types=[EVENT_ALERT_CREATED],
+    )
+
+    deliveries = enqueue_webhook_event(
+        db_session,
+        event_type=EVENT_ALERT_CREATED,
+        payload={"domain": "example.com"},
+        idempotency_key="default-only",
+    )
+
+    assert default_endpoint.workspace_id is not None
+    assert other_endpoint.workspace_id == other_workspace.id
+    assert [delivery.endpoint_id for delivery in deliveries] == [default_endpoint.id]
+
+
 def test_webhook_validation_update_and_abandoned_delivery(db_session):
     """Endpoint helpers validate input, update secrets, and abandon disabled endpoints."""
     assert normalize_event_types([]) == ["*"]


### PR DESCRIPTION
## Summary
- default unscoped webhook creation/enqueueing to the default workspace and always filter outbound events by workspace
- reject unscoped forensic reports and skip invalid TLS policy domains before persistence
- enforce non-null webhook/report ownership in models and migrations, including a follow-up integrity migration
- remove Alembic type annotations that CodeQL flags as unused globals

## Validation
- black on changed files
- isort on changed files
- flake8 on changed files
- pytest backend/app/tests/test_webhooks.py backend/app/tests/test_forensics_api.py backend/app/tests/test_tls_reports_api.py -q (39 passed)
- git diff --check
- PYTHONPATH=backend DATABASE_URL=sqlite:////tmp/dmarq-pr274-followup-alembic.sqlite python -m alembic -c backend/alembic.ini upgrade head

Follow-up for review findings on #274.