### PR TITLE
feat(onboarding): bootstrap starter organizations

### DIFF
--- a/backend/app/api/api_v1/endpoints/onboarding.py
+++ b/backend/app/api/api_v1/endpoints/onboarding.py
@@ -31,10 +31,19 @@ class OnboardingWorkspace(BaseModel):
     description: Optional[str] = None
 
 
+class OnboardingOrganization(BaseModel):
+    """Organization target for an onboarding plan."""
+
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
 class OnboardingPlanRequest(BaseModel):
     """Request body for rendering or applying an onboarding template."""
 
     template_id: str
+    organization: Optional[OnboardingOrganization] = None
     workspace: OnboardingWorkspace
     variables: Dict[str, Any] = Field(default_factory=dict)
     domains: Optional[List[Dict[str, Any]]] = None
@@ -65,6 +74,7 @@ def _build_plan_or_422(payload: OnboardingPlanRequest) -> Dict[str, Any]:
     try:
         plan = build_onboarding_plan(
             template_id=payload.template_id,
+            organization=payload.organization.model_dump() if payload.organization else None,
             workspace=payload.workspace.model_dump(),
             variables=payload.variables,
             domains=payload.domains,
@@ -113,6 +123,11 @@ async def apply_workspace_onboarding(
     plan = _build_plan_or_422(payload)
     try:
         result = apply_onboarding_plan(db, plan=plan, auth_context=_auth, request=request)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
     except IntegrityError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -43,6 +43,21 @@ DEFAULT_SELF_HOSTED_ENTITLEMENTS: Dict[str, str] = {
     "retention_days": "400",
 }
 
+STARTER_PLAN_CODE = "starter"
+STARTER_PLAN_ENTITLEMENTS: Dict[str, str] = {
+    "aggregate_reports": "true",
+    "forensic_reports": "true",
+    "dns_linting": "true",
+    "alerts": "true",
+    "monitored_domains": "1",
+    "mail_sources": "1",
+    "users": "1",
+    "retention_days": "90",
+    "api_tokens": "false",
+    "webhooks": "false",
+    "sso": "false",
+}
+
 PROVIDER_SUBSCRIPTION_STATUSES = {
     "trialing",
     "active",
@@ -104,6 +119,37 @@ def get_or_create_self_hosted_plan(db: Session, *, commit: bool = True) -> Plan:
         currency="EUR",
         retention_days=400,
         features="aggregate_reports,forensic_reports,dns_linting,alerts,multi_workspace",
+    )
+    db.add(plan)
+    if commit:
+        db.commit()
+        db.refresh(plan)
+    else:
+        db.flush()
+    return plan
+
+
+def get_or_create_starter_plan(db: Session, *, commit: bool = True) -> Plan:
+    """Return the built-in starter plan used by SaaS/customer onboarding."""
+    plan = db.query(Plan).filter(Plan.code == STARTER_PLAN_CODE).first()
+    if plan:
+        return plan
+
+    plan = Plan(
+        code=STARTER_PLAN_CODE,
+        name="Starter",
+        description=(
+            "Default first workspace plan for guided DMARC onboarding without "
+            "external billing activation."
+        ),
+        billing_mode=BILLING_MODE_MANUAL_CONTRACT,
+        public=True,
+        active=True,
+        currency="EUR",
+        included_sending_domains=1,
+        included_users=1,
+        retention_days=90,
+        features="aggregate_reports,forensic_reports,dns_linting,alerts",
     )
     db.add(plan)
     if commit:

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -163,6 +163,11 @@ def _auth_user(db: Session, auth_context: dict) -> Optional[User]:
     return None
 
 
+def user_for_auth_context(db: Session, auth_context: dict) -> Optional[User]:
+    """Return the active local user represented by an auth context, when available."""
+    return _auth_user(db, auth_context)
+
+
 def _normalize_organization_role(role: str) -> str:
     normalized = (role or "").strip().lower()
     return ORGANIZATION_ROLE_ALIASES.get(normalized, normalized)

--- a/backend/app/services/workspace_onboarding.py
+++ b/backend/app/services/workspace_onboarding.py
@@ -10,8 +10,19 @@ from sqlalchemy.orm import Session
 
 from app.models.domain import Domain
 from app.models.mail_source import MailSource
+from app.models.organization import Organization, OrganizationMembership
 from app.models.setting import Setting
 from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
+from app.services.organizations import (
+    BILLING_MODE_MANUAL_CONTRACT,
+    STARTER_PLAN_ENTITLEMENTS,
+    ensure_billing_account,
+    ensure_entitlements,
+    ensure_subscription,
+    get_or_create_starter_plan,
+)
+from app.services.workspace_access import ROLE_WORKSPACE_OWNER, user_for_auth_context
 from app.services.workspace_audit import record_workspace_audit_log, sanitize_audit_details
 from app.services.workspaces import normalize_workspace_slug, workspace_domain_query
 from app.utils.domain_validator import validate_domain_config
@@ -63,6 +74,7 @@ WORKSPACE_ONBOARDING_TEMPLATES: List[Dict[str, Any]] = [
         "variables": [
             {"name": "domain", "required": True, "example": "example.com"},
             {"name": "workspace_name", "required": False, "example": "Example Client"},
+            {"name": "dns_provider", "required": False, "example": "Cloudflare"},
             {"name": "report_mailbox", "required": False, "example": "dmarc@example.com"},
             {"name": "imap_server", "required": False, "example": "imap.example.com"},
             {"name": "imap_username", "required": False, "example": "dmarc@example.com"},
@@ -150,6 +162,7 @@ WORKSPACE_ONBOARDING_TEMPLATES: List[Dict[str, Any]] = [
         "variables": [
             {"name": "domain", "required": True, "example": "example.com"},
             {"name": "workspace_name", "required": False, "example": "Example Client"},
+            {"name": "dns_provider", "required": False, "example": "Cloudflare"},
         ],
         "domains": [
             {
@@ -241,11 +254,26 @@ def _workspace_context(
     slug = normalize_workspace_slug(str(workspace.get("slug") or workspace_name))
     context.setdefault("workspace_name", workspace_name or slug)
     context.setdefault("domain", "")
+    context.setdefault("dns_provider", "")
     context.setdefault("report_mailbox", "")
     context.setdefault("imap_server", "")
     context.setdefault("imap_username", context.get("report_mailbox", ""))
     context.setdefault("imap_password", "")
     return slug, workspace_name, context
+
+
+def _organization_context(
+    organization: Optional[Dict[str, Any]],
+    workspace_plan: Dict[str, Any],
+) -> Dict[str, Any]:
+    organization = organization or {}
+    name = str(organization.get("name") or workspace_plan["name"]).strip()
+    slug_source = organization.get("slug") or name or workspace_plan["slug"]
+    return {
+        "slug": normalize_workspace_slug(str(slug_source)),
+        "name": name or workspace_plan["name"],
+        "description": organization.get("description"),
+    }
 
 
 def _required_variable_errors(template: Dict[str, Any], variables: Dict[str, Any]) -> List[str]:
@@ -377,9 +405,121 @@ def _validated_sections(
     return domains, sources, notifications, domain_errors + source_errors + notification_errors
 
 
+def _actionable_tasks(
+    plan: Dict[str, Any],
+    *,
+    domain_results: Optional[Iterable[Dict[str, Any]]] = None,
+    source_results: Optional[Iterable[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    domain_by_name = {item["name"]: item for item in domain_results or []}
+    source_by_name = {item["name"]: item for item in source_results or []}
+    domains = plan.get("domains") or []
+    sources = plan.get("mail_sources") or []
+    dns_provider = (plan.get("variables") or {}).get("dns_provider") or "your DNS provider"
+    tasks: List[Dict[str, Any]] = []
+
+    for domain in domains:
+        name = domain["name"]
+        result = domain_by_name.get(name, {})
+        tasks.append(
+            {
+                "id": f"verify-domain-dns:{name}",
+                "category": "domains",
+                "status": "pending",
+                "title": f"Verify DNS records for {name}",
+                "description": (
+                    f"Review DMARC, SPF, and DKIM in {dns_provider}; keep production "
+                    "monitoring pending until ownership is verified."
+                ),
+                "href": f"/domains/{name}",
+                "api_hint": f"/api/v1/domains/{result.get('id', ':domain_id')}/dns",
+                "target": {
+                    "type": "domain",
+                    "name": name,
+                    "id": result.get("id"),
+                    "requires_verification": True,
+                },
+            }
+        )
+
+    for source in sources:
+        name = source["name"]
+        result = source_by_name.get(name, {})
+        tasks.append(
+            {
+                "id": f"connect-mail-source:{name}",
+                "category": "mail_sources",
+                "status": "pending",
+                "title": f"Connect {name}",
+                "description": (
+                    "Add the report inbox credentials, run a connection test, and enable "
+                    "polling after the first successful import."
+                ),
+                "href": "/mail-sources",
+                "api_hint": f"/api/v1/mail-sources/{result.get('id', ':source_id')}/test",
+                "target": {
+                    "type": "mail_source",
+                    "name": name,
+                    "id": result.get("id"),
+                },
+            }
+        )
+        tasks.append(
+            {
+                "id": f"run-initial-import:{name}",
+                "category": "mail_sources",
+                "status": "pending",
+                "title": f"Run the first import for {name}",
+                "description": "Import the latest aggregate reports and confirm DMARQ parsed them.",
+                "href": "/reports",
+                "api_hint": f"/api/v1/mail-sources/{result.get('id', ':source_id')}/import",
+                "target": {
+                    "type": "mail_source",
+                    "name": name,
+                    "id": result.get("id"),
+                },
+            }
+        )
+
+    if plan.get("notification_defaults"):
+        tasks.append(
+            {
+                "id": "configure-notification-target",
+                "category": "notifications",
+                "status": "pending",
+                "title": "Configure alert delivery",
+                "description": (
+                    "Add Apprise targets and send a test notification before relying on alerts."
+                ),
+                "href": "/settings/notifications",
+                "api_hint": "/api/v1/settings/notifications/test",
+                "target": {"type": "notification_settings"},
+            }
+        )
+
+    if not sources:
+        tasks.append(
+            {
+                "id": "document-report-inbox",
+                "category": "mail_sources",
+                "status": "pending",
+                "title": "Document the future report inbox",
+                "description": (
+                    "Capture the RUA/RUF destination before enabling automated report ingestion."
+                ),
+                "href": "/mail-sources",
+                "api_hint": "/api/v1/mail-sources",
+                "target": {"type": "mail_source"},
+            }
+        )
+
+    return tasks
+
+
 def build_onboarding_plan(  # pylint: disable=too-many-locals
     *,
     template_id: str,
+    organization: Optional[Dict[str, Any]] = None,
     workspace: Dict[str, Any],
     variables: Optional[Dict[str, Any]] = None,
     domains: Optional[List[Dict[str, Any]]] = None,
@@ -395,6 +535,14 @@ def build_onboarding_plan(  # pylint: disable=too-many-locals
         errors.append("workspace.slug or workspace.name is required")
     if not workspace_name:
         errors.append("workspace.name is required")
+    workspace_plan = {
+        "slug": slug,
+        "name": workspace_name,
+        "description": workspace.get("description"),
+    }
+    organization_plan = _organization_context(organization, workspace_plan)
+    if not organization_plan["slug"]:
+        errors.append("organization.slug or organization.name is required")
     errors.extend(_required_variable_errors(template, variables))
     rendered_domains, rendered_sources, rendered_notifications = _render_sections(
         template,
@@ -408,29 +556,58 @@ def build_onboarding_plan(  # pylint: disable=too-many-locals
     )
     errors.extend(section_errors)
 
-    return {
+    plan = {
         "schema_version": ONBOARDING_SCHEMA_VERSION,
         "template_id": template_id,
         "template_name": template["name"],
-        "workspace": {
-            "slug": slug,
-            "name": workspace_name,
-            "description": workspace.get("description"),
-        },
+        "organization": organization_plan,
+        "workspace": workspace_plan,
+        "variables": variables,
         "domains": validated_domains,
         "mail_sources": validated_sources,
         "notification_defaults": safe_notifications,
         "checklist": copy.deepcopy(template.get("checklist", [])),
+        "tasks": [],
         "overwrite_existing": overwrite_existing,
         "errors": errors,
     }
+    plan["tasks"] = _actionable_tasks(plan)
+    return plan
 
 
-def _ensure_workspace(db: Session, workspace_plan: Dict[str, Any]) -> Tuple[Workspace, str]:
+def _ensure_organization(db: Session, organization_plan: Dict[str, Any]) -> Tuple[Organization, str]:
+    organization = (
+        db.query(Organization).filter(Organization.slug == organization_plan["slug"]).first()
+    )
+    if organization:
+        return organization, "existing"
+    organization = Organization(
+        slug=organization_plan["slug"],
+        name=organization_plan["name"],
+        description=organization_plan.get("description"),
+        active=True,
+    )
+    db.add(organization)
+    db.flush()
+    return organization, "created"
+
+
+def _ensure_workspace(
+    db: Session,
+    workspace_plan: Dict[str, Any],
+    organization: Organization,
+) -> Tuple[Workspace, str]:
     workspace = db.query(Workspace).filter(Workspace.slug == workspace_plan["slug"]).first()
     if workspace:
+        if workspace.organization_id is None:
+            workspace.organization_id = organization.id
+            db.flush()
+            return workspace, "linked_existing"
+        if workspace.organization_id != organization.id:
+            raise ValueError("Workspace is already attached to another organization")
         return workspace, "existing"
     workspace = Workspace(
+        organization_id=organization.id,
         slug=workspace_plan["slug"],
         name=workspace_plan["name"],
         description=workspace_plan.get("description"),
@@ -555,6 +732,128 @@ def _apply_notification_defaults(
     return results
 
 
+def _ensure_owner_memberships(
+    db: Session,
+    *,
+    organization: Organization,
+    workspace: Workspace,
+    auth_context: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    owner = user_for_auth_context(db, auth_context or {})
+    if owner is None:
+        return {"status": "skipped", "reason": "no authenticated local user"}
+
+    organization_membership = (
+        db.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.organization_id == organization.id,
+            OrganizationMembership.user_id == owner.id,
+        )
+        .first()
+    )
+    organization_status = "existing"
+    if organization_membership is None:
+        organization_membership = OrganizationMembership(
+            organization_id=organization.id,
+            user_id=owner.id,
+            role="organization_owner",
+            active=True,
+        )
+        db.add(organization_membership)
+        organization_status = "created"
+    else:
+        if organization_membership.role != "organization_owner":
+            organization_membership.role = "organization_owner"
+            organization_status = "updated"
+        if not organization_membership.active:
+            organization_membership.active = True
+            organization_status = "reactivated"
+
+    workspace_membership = (
+        db.query(WorkspaceMembership)
+        .filter(
+            WorkspaceMembership.workspace_id == workspace.id,
+            WorkspaceMembership.user_id == owner.id,
+        )
+        .first()
+    )
+    workspace_status = "existing"
+    if workspace_membership is None:
+        workspace_membership = WorkspaceMembership(
+            workspace_id=workspace.id,
+            user_id=owner.id,
+            role=ROLE_WORKSPACE_OWNER,
+            active=True,
+        )
+        db.add(workspace_membership)
+        workspace_status = "created"
+    else:
+        if workspace_membership.role != ROLE_WORKSPACE_OWNER:
+            workspace_membership.role = ROLE_WORKSPACE_OWNER
+            workspace_status = "updated"
+        if not workspace_membership.active:
+            workspace_membership.active = True
+            workspace_status = "reactivated"
+
+    if owner.workspace_id is None:
+        owner.workspace_id = workspace.id
+    db.flush()
+    return {
+        "status": "ready",
+        "user_id": owner.id,
+        "email": owner.email,
+        "organization_membership": organization_status,
+        "workspace_membership": workspace_status,
+    }
+
+
+def _ensure_starter_subscription(
+    db: Session,
+    *,
+    organization: Organization,
+) -> Dict[str, Any]:
+    plan = get_or_create_starter_plan(db, commit=False)
+    account = ensure_billing_account(
+        db,
+        organization,
+        billing_mode=BILLING_MODE_MANUAL_CONTRACT,
+        commit=False,
+    )
+    subscription = ensure_subscription(
+        db,
+        organization,
+        plan,
+        account,
+        commit=False,
+    )
+    entitlements = ensure_entitlements(
+        db,
+        organization,
+        subscription,
+        STARTER_PLAN_ENTITLEMENTS,
+        commit=False,
+    )
+    db.flush()
+    return {
+        "billing_account": {
+            "id": account.id,
+            "billing_mode": account.billing_mode,
+            "status": account.status,
+            "invoice_delivery_mode": account.invoice_delivery_mode,
+        },
+        "subscription": {
+            "id": subscription.id,
+            "status": subscription.status,
+            "plan_code": plan.code,
+            "billing_mode": subscription.billing_mode,
+        },
+        "entitlements": {
+            entitlement.key: entitlement.value
+            for entitlement in sorted(entitlements, key=lambda item: item.key)
+        },
+    }
+
+
 def apply_onboarding_plan(
     db: Session,
     *,
@@ -566,7 +865,15 @@ def apply_onboarding_plan(
     if plan.get("errors"):
         raise ValueError("Cannot apply an invalid onboarding plan")
     try:
-        workspace, workspace_status = _ensure_workspace(db, plan["workspace"])
+        organization, organization_status = _ensure_organization(db, plan["organization"])
+        workspace, workspace_status = _ensure_workspace(db, plan["workspace"], organization)
+        owner_result = _ensure_owner_memberships(
+            db,
+            organization=organization,
+            workspace=workspace,
+            auth_context=auth_context,
+        )
+        commercial_result = _ensure_starter_subscription(db, organization=organization)
         domain_results = _apply_domains(db, workspace=workspace, domain_plans=plan["domains"])
         source_results = _apply_mail_sources(
             db,
@@ -584,9 +891,15 @@ def apply_onboarding_plan(
             return {
                 "applied": False,
                 "workspace": plan["workspace"],
+                "organization": plan["organization"],
                 "errors": [item["message"] for item in conflicts],
                 "results": {"domains": domain_results},
             }
+        tasks = _actionable_tasks(
+            plan,
+            domain_results=domain_results,
+            source_results=source_results,
+        )
         record_workspace_audit_log(
             db,
             workspace=workspace,
@@ -596,11 +909,15 @@ def apply_onboarding_plan(
             entity_name=workspace.slug,
             details={
                 "template_id": plan["template_id"],
+                "organization_status": organization_status,
                 "workspace_status": workspace_status,
+                "owner": owner_result,
+                "subscription": commercial_result["subscription"],
                 "domains": domain_results,
                 "mail_sources": source_results,
                 "notification_defaults": notification_results,
                 "checklist_ids": [item["id"] for item in plan.get("checklist", [])],
+                "task_ids": [item["id"] for item in tasks],
             },
             auth_context=auth_context,
             request=request,
@@ -616,17 +933,28 @@ def apply_onboarding_plan(
             "applied": True,
             "schema_version": plan["schema_version"],
             "template_id": plan["template_id"],
+            "organization": {
+                "id": organization.id,
+                "slug": organization.slug,
+                "name": organization.name,
+                "status": organization_status,
+            },
             "workspace": {
                 "id": workspace.id,
                 "slug": workspace.slug,
                 "name": workspace.name,
                 "status": workspace_status,
             },
+            "owner": owner_result,
+            "billing_account": commercial_result["billing_account"],
+            "subscription": commercial_result["subscription"],
+            "entitlements": commercial_result["entitlements"],
             "results": {
                 "domains": domain_results,
                 "mail_sources": source_results,
                 "notification_defaults": notification_results,
             },
             "checklist": plan.get("checklist", []),
+            "tasks": tasks,
         }
     )

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -19,7 +19,9 @@ from app.services.organizations import (
     BILLING_MODE_SELF_HOSTED,
     DEFAULT_ORGANIZATION_SLUG,
     SELF_HOSTED_PLAN_CODE,
+    STARTER_PLAN_CODE,
     bootstrap_default_commercial_foundation,
+    get_or_create_starter_plan,
     list_organization_summaries,
 )
 from app.services.workspace_access import ROLE_AUDITOR
@@ -93,6 +95,15 @@ def test_bootstrap_default_commercial_foundation_is_idempotent(db_session: Sessi
     assert db_session.query(Plan).count() == 1
     assert db_session.query(BillingAccount).count() == 1
     assert db_session.query(Subscription).count() == 1
+
+
+def test_get_or_create_starter_plan_commits_public_saas_plan(db_session: Session):
+    plan = get_or_create_starter_plan(db_session)
+
+    assert plan.code == STARTER_PLAN_CODE
+    assert plan.public is True
+    assert plan.retention_days == 90
+    assert db_session.query(Plan).filter(Plan.code == STARTER_PLAN_CODE).one().id == plan.id
 
 
 def test_list_organization_summaries_materializes_account_state(db_session: Session):

--- a/backend/app/tests/test_workspace_onboarding.py
+++ b/backend/app/tests/test_workspace_onboarding.py
@@ -1,11 +1,47 @@
+from contextlib import contextmanager
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.database import get_db
+from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.mail_source import MailSource
+from app.models.organization import (
+    Entitlement,
+    Organization,
+    OrganizationMembership,
+    Plan,
+    Subscription,
+)
 from app.models.setting import Setting
+from app.models.user import User
 from app.models.workspace import Workspace
-from app.models.workspace_access import WorkspaceAuditLog
+from app.models.workspace_access import WorkspaceAuditLog, WorkspaceMembership
+from app.services.organizations import STARTER_PLAN_CODE
+from app.services.workspace_access import ROLE_WORKSPACE_OWNER
+from app.services.workspace_onboarding import apply_onboarding_plan, build_onboarding_plan
+
+
+@contextmanager
+def _client_as_user(test_app, db_session: Session, user: User):
+    async def mock_admin_auth():
+        return {"auth_type": "session", "user_id": user.id}
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    original_overrides = dict(test_app.dependency_overrides)
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    try:
+        with TestClient(test_app) as client:
+            yield client
+    finally:
+        test_app.dependency_overrides = original_overrides
 
 
 def _standard_payload(**overrides):
@@ -18,6 +54,7 @@ def _standard_payload(**overrides):
         },
         "variables": {
             "domain": "Example.COM",
+            "dns_provider": "Cloudflare",
             "report_mailbox": "dmarc@example.com",
             "imap_server": "imap.example.com",
             "imap_password": "super-secret-password",
@@ -53,10 +90,14 @@ def test_onboarding_preview_renders_without_persisting(
 
     assert response.status_code == 200
     plan = response.json()["plan"]
+    assert plan["organization"]["slug"] == "client-one"
     assert plan["workspace"]["slug"] == "client-one"
     assert plan["domains"][0]["name"] == "example.com"
     assert plan["mail_sources"][0]["password"] == "[redacted]"
+    assert plan["tasks"][0]["href"] == "/domains/example.com"
+    assert plan["tasks"][0]["target"]["requires_verification"] is True
     assert "super-secret-password" not in str(plan)
+    assert db_session.query(Organization).count() == 0
     assert db_session.query(Workspace).count() == 0
     assert db_session.query(Domain).count() == 0
 
@@ -69,6 +110,26 @@ def test_onboarding_rejects_invalid_domain(authed_client: TestClient):
 
     assert response.status_code == 422
     assert "invalid domain" in str(response.json()["detail"])
+
+
+def test_dns_only_onboarding_tasks_document_future_report_inbox(authed_client: TestClient):
+    """DNS-only onboarding still returns actionable setup tasks."""
+    response = authed_client.post(
+        "/api/v1/onboarding/preview",
+        json={
+            "template_id": "dns_only_assessment",
+            "workspace": {"name": "DNS Client"},
+            "variables": {
+                "domain": "dns-client.example",
+                "dns_provider": "Route 53",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    task_ids = {task["id"] for task in response.json()["plan"]["tasks"]}
+    assert "verify-domain-dns:dns-client.example" in task_ids
+    assert "document-report-inbox" in task_ids
 
 
 def test_apply_onboarding_creates_workspace_assets_and_audit(
@@ -85,14 +146,32 @@ def test_apply_onboarding_creates_workspace_assets_and_audit(
     assert response.status_code == 200
     result = response.json()["result"]
     assert result["applied"] is True
+    assert result["organization"]["slug"] == "client-one"
     assert result["workspace"]["slug"] == "client-one"
+    assert result["owner"]["status"] == "skipped"
+    assert result["subscription"]["plan_code"] == STARTER_PLAN_CODE
+    assert result["entitlements"]["monitored_domains"] == "1"
     assert result["results"]["domains"][0]["status"] == "created"
     assert result["results"]["mail_sources"][0]["status"] == "created"
+    assert result["tasks"][0]["href"] == "/domains/example.com"
     assert "super-secret-password" not in str(result)
 
+    organization = db_session.query(Organization).filter(Organization.slug == "client-one").one()
     workspace = db_session.query(Workspace).filter(Workspace.slug == "client-one").one()
     domain = db_session.query(Domain).filter(Domain.name == "example.com").one()
     source = db_session.query(MailSource).filter(MailSource.name == "Client One DMARC inbox").one()
+    starter_plan = db_session.query(Plan).filter(Plan.code == STARTER_PLAN_CODE).one()
+    subscription = (
+        db_session.query(Subscription)
+        .filter(Subscription.organization_id == organization.id)
+        .one()
+    )
+    entitlement_keys = {
+        entitlement.key
+        for entitlement in db_session.query(Entitlement)
+        .filter(Entitlement.organization_id == organization.id)
+        .all()
+    }
     setting = (
         db_session.query(Setting)
         .filter(Setting.key == "notifications.alert_missing_reports_enabled")
@@ -104,6 +183,9 @@ def test_apply_onboarding_creates_workspace_assets_and_audit(
         .one()
     )
 
+    assert workspace.organization_id == organization.id
+    assert subscription.plan_id == starter_plan.id
+    assert {"aggregate_reports", "dns_linting", "monitored_domains"} <= entitlement_keys
     assert domain.workspace_id == workspace.id
     assert domain.dkim_selectors == "google,selector1"
     assert source.workspace_id == workspace.id
@@ -131,8 +213,200 @@ def test_apply_onboarding_is_idempotent_for_existing_assets(
     assert result["results"]["domains"][0]["status"] == "existing"
     assert result["results"]["mail_sources"][0]["status"] == "existing"
     assert db_session.query(Workspace).count() == 1
+    assert db_session.query(Organization).count() == 1
+    assert db_session.query(Subscription).count() == 1
     assert db_session.query(Domain).count() == 1
     assert db_session.query(MailSource).count() == 1
+
+
+def test_apply_onboarding_bootstraps_owner_memberships(test_app, db_session: Session):
+    """Session users become owners of the new organization and workspace."""
+    user = User(email="owner@example.com", is_active=True, is_verified=True)
+    db_session.add(user)
+    db_session.commit()
+
+    payload = _standard_payload(
+        organization={
+            "slug": "acme",
+            "name": "Acme Inc",
+            "description": "Managed customer account",
+        }
+    )
+    with _client_as_user(test_app, db_session, user) as client:
+        first = client.post("/api/v1/onboarding/apply", json=payload)
+        second = client.post("/api/v1/onboarding/apply", json=payload)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    result = first.json()["result"]
+    assert result["organization"]["slug"] == "acme"
+    assert result["owner"]["status"] == "ready"
+    assert result["owner"]["email"] == "owner@example.com"
+    assert result["owner"]["organization_membership"] == "created"
+    assert result["owner"]["workspace_membership"] == "created"
+
+    organization = db_session.query(Organization).filter(Organization.slug == "acme").one()
+    workspace = db_session.query(Workspace).filter(Workspace.slug == "client-one").one()
+    db_session.refresh(user)
+    assert user.workspace_id == workspace.id
+    assert (
+        db_session.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.organization_id == organization.id,
+            OrganizationMembership.user_id == user.id,
+            OrganizationMembership.role == "organization_owner",
+            OrganizationMembership.active.is_(True),
+        )
+        .count()
+        == 1
+    )
+    assert (
+        db_session.query(WorkspaceMembership)
+        .filter(
+            WorkspaceMembership.workspace_id == workspace.id,
+            WorkspaceMembership.user_id == user.id,
+            WorkspaceMembership.role == ROLE_WORKSPACE_OWNER,
+            WorkspaceMembership.active.is_(True),
+        )
+        .count()
+        == 1
+    )
+    assert db_session.query(OrganizationMembership).count() == 1
+    assert db_session.query(WorkspaceMembership).count() == 1
+
+
+def test_apply_onboarding_repairs_existing_inactive_owner_memberships(
+    test_app,
+    db_session: Session,
+):
+    """Existing non-owner inactive memberships are promoted back to owner access."""
+    organization = Organization(slug="acme", name="Acme", active=True)
+    workspace = Workspace(
+        slug="client-one",
+        name="Client One",
+        organization=organization,
+        active=True,
+    )
+    user = User(email="owner@example.com", is_active=True, is_verified=True)
+    db_session.add_all([organization, workspace, user])
+    db_session.flush()
+    db_session.add_all(
+        [
+            OrganizationMembership(
+                organization_id=organization.id,
+                user_id=user.id,
+                role="organization_auditor",
+                active=False,
+            ),
+            WorkspaceMembership(
+                workspace_id=workspace.id,
+                user_id=user.id,
+                role="auditor",
+                active=False,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, user) as client:
+        response = client.post(
+            "/api/v1/onboarding/apply",
+            json=_standard_payload(organization={"slug": "acme", "name": "Acme"}),
+        )
+
+    assert response.status_code == 200
+    owner = response.json()["result"]["owner"]
+    assert owner["organization_membership"] == "reactivated"
+    assert owner["workspace_membership"] == "reactivated"
+    org_membership = db_session.query(OrganizationMembership).one()
+    workspace_membership = db_session.query(WorkspaceMembership).one()
+    assert org_membership.role == "organization_owner"
+    assert org_membership.active is True
+    assert workspace_membership.role == ROLE_WORKSPACE_OWNER
+    assert workspace_membership.active is True
+
+
+def test_apply_onboarding_rejects_workspace_owned_by_another_organization(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Onboarding does not attach an existing workspace across tenant boundaries."""
+    organization = Organization(slug="other", name="Other", active=True)
+    db_session.add(organization)
+    db_session.flush()
+    db_session.add(
+        Workspace(
+            slug="client-one",
+            name="Client One",
+            organization_id=organization.id,
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    response = authed_client.post(
+        "/api/v1/onboarding/apply",
+        json=_standard_payload(organization={"slug": "new-owner", "name": "New Owner"}),
+    )
+
+    assert response.status_code == 409
+    assert "already attached" in response.json()["detail"]
+
+
+def test_apply_onboarding_links_existing_unscoped_workspace(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Older unscoped workspaces can be adopted by the requested organization."""
+    db_session.add(Workspace(slug="client-one", name="Client One", active=True))
+    db_session.commit()
+
+    response = authed_client.post("/api/v1/onboarding/apply", json=_standard_payload())
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["workspace"]["status"] == "linked_existing"
+    organization = db_session.query(Organization).filter(Organization.slug == "client-one").one()
+    workspace = db_session.query(Workspace).filter(Workspace.slug == "client-one").one()
+    assert workspace.organization_id == organization.id
+
+
+def test_apply_onboarding_rolls_back_on_domain_conflict(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Domain ownership conflicts leave no partial starter organization behind."""
+    organization = Organization(slug="other", name="Other", active=True)
+    workspace = Workspace(slug="other", name="Other", organization=organization, active=True)
+    db_session.add_all([organization, workspace])
+    db_session.flush()
+    db_session.add(Domain(workspace_id=workspace.id, name="example.com", active=True))
+    db_session.commit()
+
+    response = authed_client.post("/api/v1/onboarding/apply", json=_standard_payload())
+
+    assert response.status_code == 409
+    assert "Domain is already owned by another workspace" in str(response.json()["detail"])
+    assert db_session.query(Organization).filter(Organization.slug == "client-one").count() == 0
+    assert db_session.query(Workspace).filter(Workspace.slug == "client-one").count() == 0
+
+
+def test_apply_onboarding_rejects_invalid_service_plan(db_session: Session):
+    """The service refuses invalid plans before writing any account state."""
+    plan = build_onboarding_plan(
+        template_id="standard_monitoring",
+        workspace={"name": ""},
+        variables={"domain": "example.com"},
+    )
+
+    assert "workspace.name is required" in plan["errors"]
+    try:
+        apply_onboarding_plan(db_session, plan=plan, auth_context={"auth_type": "api_key"})
+    except ValueError as exc:
+        assert "invalid onboarding plan" in str(exc)
+    else:
+        raise AssertionError("invalid onboarding plan was applied")
+    assert db_session.query(Organization).count() == 0
 
 
 def test_onboarding_notification_overwrite_is_explicit(


### PR DESCRIPTION
## Summary
- add a built-in Starter plan and starter entitlement bundle for first-workspace onboarding
- extend onboarding preview/apply with an organization target, DNS-provider-aware setup tasks, and actionable links
- make apply create/link the organization, workspace, owner memberships, billing account, starter subscription, and entitlements atomically where a session user exists
- keep API-key/self-hosted onboarding working without requiring Stripe or an external billing provider

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_workspace_onboarding.py backend/app/tests/test_organization_foundations.py -q`
- `.venv/bin/python -m pytest backend/app/tests -q`
- `git diff --check`
- `.venv/bin/python -m compileall -q backend/app/api/api_v1/endpoints/onboarding.py backend/app/services/organizations.py backend/app/services/workspace_access.py backend/app/services/workspace_onboarding.py backend/app/tests/test_workspace_onboarding.py`

Refs #239


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding now supports targeting an organization, with richer plan details and generated setup tasks.
  * Workspace setup can now include DNS provider context and starter billing setup during onboarding.
  * Applied onboarding now returns more complete status details for organization, workspace, owner, subscription, and entitlements.

* **Bug Fixes**
  * Onboarding apply now returns a clear conflict response when setup cannot be completed.
  * Re-running onboarding is more consistent, helping avoid duplicate setup records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->