### PR TITLE
feat(onboarding): require verified domains for mail source activation

### DIFF
--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -21,6 +21,7 @@ from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.redaction import sanitize_for_log
 from app.core.security import require_admin_auth
+from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
 from app.services.gmail_client import GmailClient
@@ -41,6 +42,7 @@ from app.services.workspace_access import (
 )
 from app.services.workspace_audit import changed_fields, record_workspace_audit_log
 from app.services.workspaces import (
+    workspace_domain_query,
     workspace_mail_source_query,
 )
 
@@ -221,6 +223,31 @@ def _get_source_or_404(source_id: int, db: Session, workspace=None) -> MailSourc
             detail=f"Mail source {source_id} not found",
         )
     return source
+
+
+def _raise_if_workspace_domains_unverified(db: Session, workspace, *, action: str) -> None:
+    """Require configured domains to be verified before production mail-source use."""
+    domains = (
+        workspace_domain_query(db, workspace)
+        .filter(Domain.active.is_(True))
+        .order_by(Domain.name)
+        .all()
+    )
+    unverified_domains = [domain.name for domain in domains if not domain.verified]
+    if not unverified_domains:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "code": "domain_verification_required",
+            "message": (
+                "Verify domain ownership before enabling or fetching production "
+                "DMARC report mail sources."
+            ),
+            "action": action,
+            "unverified_domains": unverified_domains,
+        },
+    )
 
 
 def _selected_workspace_id(selected_workspace: Optional[str]) -> Optional[int]:
@@ -625,6 +652,8 @@ async def create_mail_source(
         db,
         _selected_workspace_id(selected_workspace),
     )
+    if payload.enabled:
+        _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.create_enabled")
     source = MailSource(
         workspace_id=workspace.id,
         name=payload.name,
@@ -722,6 +751,7 @@ async def fetch_mail_source(
         _auth, db, _selected_workspace_id(selected_workspace)
     )
     source = _get_source_or_404(source_id, db, workspace)
+    _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.fetch")
     results = _fetch_source(source, db, days)
     logger.info(
         "Manual fetch for source id=%d: processed=%d reports_found=%d "
@@ -760,6 +790,8 @@ async def update_mail_source(
     update_data = payload.model_dump(exclude_unset=True)
     if "method" in update_data and update_data["method"]:
         update_data["method"] = update_data["method"].upper()
+    if update_data.get("enabled") is True:
+        _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.update_enabled")
 
     for field, value in update_data.items():
         setattr(source, field, value)
@@ -825,6 +857,8 @@ async def toggle_mail_source(
         _auth, db, _selected_workspace_id(selected_workspace)
     )
     source = _get_source_or_404(source_id, db, workspace)
+    if not source.enabled:
+        _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.toggle_enabled")
     source.enabled = not source.enabled
     source.updated_at = datetime.utcnow()
     db.commit()
@@ -1285,6 +1319,7 @@ async def m365_fetch_reports(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="This endpoint is only available for M365_GRAPH sources.",
         )
+    _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.m365_fetch")
 
     results = _fetch_m365_source(source, db, days=days)
     logger.info(
@@ -1600,6 +1635,7 @@ async def gmail_fetch_reports(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="This endpoint is only available for GMAIL_API sources.",
         )
+    _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.gmail_fetch")
     if not source.gmail_access_token:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -21,6 +21,7 @@ from app.api.api_v1.endpoints import mail_sources as mail_sources_endpoint
 from app.core.credential_encryption import is_encrypted_secret
 from app.core.database import get_db
 from app.core.security import require_admin_auth
+from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
 from app.models.user import User
@@ -180,6 +181,24 @@ def _add_membership(db_session: Session, workspace: Workspace, user: User, role:
     db_session.add(membership)
     db_session.flush()
     return membership
+
+
+def _add_domain(
+    db_session: Session,
+    workspace: Workspace,
+    *,
+    name: str = "example.com",
+    verified: bool = False,
+) -> Domain:
+    domain = Domain(
+        workspace_id=workspace.id,
+        name=name,
+        active=True,
+        verified=verified,
+    )
+    db_session.add(domain)
+    db_session.commit()
+    return domain
 
 
 class TestMailSourceModel:
@@ -731,6 +750,46 @@ class TestMailSourcesAPIAuthed:
         assert resp.status_code == 201
         assert resp.json()["method"] == "IMAP"
 
+    def test_create_enabled_source_requires_verified_domains(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        workspace = get_or_create_default_workspace(db_session)
+        _add_domain(db_session, workspace, verified=False)
+
+        blocked = authed_client.post(
+            "/api/v1/mail-sources",
+            json={"name": "Blocked IMAP", "method": "IMAP", "enabled": True},
+        )
+        disabled = authed_client.post(
+            "/api/v1/mail-sources",
+            json={"name": "Staged IMAP", "method": "IMAP", "enabled": False},
+        )
+
+        assert blocked.status_code == 409
+        detail = blocked.json()["detail"]
+        assert detail["code"] == "domain_verification_required"
+        assert detail["unverified_domains"] == ["example.com"]
+        assert disabled.status_code == 201
+        assert disabled.json()["enabled"] is False
+
+    def test_create_enabled_source_allows_verified_domains(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        workspace = get_or_create_default_workspace(db_session)
+        _add_domain(db_session, workspace, verified=True)
+
+        response = authed_client.post(
+            "/api/v1/mail-sources",
+            json={"name": "Verified IMAP", "method": "IMAP", "enabled": True},
+        )
+
+        assert response.status_code == 201
+        assert response.json()["enabled"] is True
+
     # ------------------------------------------------------------------
     # Get single
     # ------------------------------------------------------------------
@@ -843,6 +902,32 @@ class TestMailSourcesAPIAuthed:
         assert update_resp.status_code == 200
         assert update_resp.json()["method"] == "POP3"
 
+    def test_update_enable_requires_verified_domains(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        workspace = get_or_create_default_workspace(db_session)
+        _add_domain(db_session, workspace, verified=False)
+        source = MailSource(
+            workspace_id=workspace.id,
+            name="Staged IMAP",
+            method="IMAP",
+            enabled=False,
+        )
+        db_session.add(source)
+        db_session.commit()
+
+        response = authed_client.put(
+            f"/api/v1/mail-sources/{source.id}",
+            json={"enabled": True},
+        )
+
+        db_session.refresh(source)
+        assert response.status_code == 409
+        assert response.json()["detail"]["code"] == "domain_verification_required"
+        assert source.enabled is False
+
     def test_update_nonexistent_source_returns_404(self, authed_client: TestClient):
         resp = authed_client.put("/api/v1/mail-sources/99999", json={"name": "x"})
         assert resp.status_code == 404
@@ -898,6 +983,29 @@ class TestMailSourcesAPIAuthed:
         toggle_resp2 = authed_client.post(f"/api/v1/mail-sources/{source_id}/toggle")
         assert toggle_resp2.status_code == 200
         assert toggle_resp2.json()["enabled"] is True
+
+    def test_toggle_enable_requires_verified_domains(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        workspace = get_or_create_default_workspace(db_session)
+        _add_domain(db_session, workspace, verified=False)
+        source = MailSource(
+            workspace_id=workspace.id,
+            name="Toggle staged",
+            method="IMAP",
+            enabled=False,
+        )
+        db_session.add(source)
+        db_session.commit()
+
+        response = authed_client.post(f"/api/v1/mail-sources/{source.id}/toggle")
+
+        db_session.refresh(source)
+        assert response.status_code == 409
+        assert response.json()["detail"]["action"] == "mail_source.toggle_enabled"
+        assert source.enabled is False
 
     def test_toggle_nonexistent_returns_404(self, authed_client: TestClient):
         resp = authed_client.post("/api/v1/mail-sources/99999/toggle")
@@ -1847,6 +1955,60 @@ class TestMicrosoft365GraphMailSource:
 
 class TestManualSourceFetchEndpoint:
     """Tests for POST /api/v1/mail-sources/{source_id}/fetch."""
+
+    def test_fetch_requires_verified_domains(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        workspace = get_or_create_default_workspace(db_session)
+        _add_domain(db_session, workspace, verified=False)
+        source = MailSource(
+            workspace_id=workspace.id,
+            name="Unverified fetch",
+            method="IMAP",
+            server="imap.example.com",
+            enabled=True,
+        )
+        db_session.add(source)
+        db_session.commit()
+
+        with patch("app.api.api_v1.endpoints.mail_sources.IMAPClient") as mock_imap:
+            response = authed_client.post(f"/api/v1/mail-sources/{source.id}/fetch?days=30")
+
+        assert response.status_code == 409
+        assert response.json()["detail"]["action"] == "mail_source.fetch"
+        mock_imap.assert_not_called()
+
+    def test_provider_fetches_require_verified_domains(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        workspace = get_or_create_default_workspace(db_session)
+        _add_domain(db_session, workspace, verified=False)
+        gmail_source = MailSource(
+            workspace_id=workspace.id,
+            name="Unverified Gmail",
+            method="GMAIL_API",
+            enabled=True,
+        )
+        m365_source = MailSource(
+            workspace_id=workspace.id,
+            name="Unverified M365",
+            method="M365_GRAPH",
+            enabled=True,
+        )
+        db_session.add_all([gmail_source, m365_source])
+        db_session.commit()
+
+        gmail_response = authed_client.post(f"/api/v1/mail-sources/{gmail_source.id}/gmail/fetch")
+        m365_response = authed_client.post(f"/api/v1/mail-sources/{m365_source.id}/m365/fetch")
+
+        assert gmail_response.status_code == 409
+        assert gmail_response.json()["detail"]["action"] == "mail_source.gmail_fetch"
+        assert m365_response.status_code == 409
+        assert m365_response.json()["detail"]["action"] == "mail_source.m365_fetch"
 
     def test_fetch_imap_source(self, authed_client: TestClient, caplog):
         create_resp = authed_client.post(


### PR DESCRIPTION
## Summary
- add a backend production-use gate for configured workspaces with unverified domains
- block creating/enabling/toggling mail sources live and manual fetches until all active domains are verified
- keep disabled source staging and legacy mail-source-only workspaces working
- return structured API feedback with `domain_verification_required` and the unverified domain list

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_mail_sources.py backend/app/tests/test_workspace_onboarding.py -q`
- `.venv/bin/python -m pytest backend/app/tests -q`
- `git diff --check`
- `.venv/bin/python -m compileall -q backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py`

Refs #239
