### PR TITLE
Fix onboarding review follow-ups

### DIFF
--- a/backend/app/templates/onboarding.html
+++ b/backend/app/templates/onboarding.html
@@ -240,8 +240,8 @@ function workspaceOnboarding() {
                 if (storedValue !== null) {
                     this.form[field] = storedValue;
                 }
+                this.$watch(`form.${field}`, () => this.persistDraft());
             });
-            this.$watch('form', () => this.persistDraft());
         },
         draftFields() {
             return [

--- a/backend/app/templates/onboarding.html
+++ b/backend/app/templates/onboarding.html
@@ -235,12 +235,32 @@ function workspaceOnboarding() {
             return this.previewing || this.applying;
         },
         init() {
-            this.form.organizationName = localStorage.getItem('dmarq.onboarding.organizationName') || '';
-            this.form.workspaceName = localStorage.getItem('dmarq.onboarding.workspaceName') || '';
-            this.form.domain = localStorage.getItem('dmarq.onboarding.domain') || '';
+            this.draftFields().forEach((field) => {
+                const storedValue = localStorage.getItem(`dmarq.onboarding.${field}`);
+                if (storedValue !== null) {
+                    this.form[field] = storedValue;
+                }
+            });
+            this.$watch('form', () => this.persistDraft());
+        },
+        draftFields() {
+            return [
+                'organizationName',
+                'workspaceName',
+                'workspaceDescription',
+                'domain',
+                'dnsProvider',
+                'reportMailbox',
+                'mailSourcePath',
+                'imapServer',
+                'imapUsername',
+            ];
+        },
+        normalizeDomain(value) {
+            return value.trim().replace(/^\.+|\.+$/g, '').toLowerCase();
         },
         payload() {
-            const domain = this.form.domain.trim().toLowerCase();
+            const domain = this.normalizeDomain(this.form.domain);
             const workspaceName = this.form.workspaceName.trim() || this.form.organizationName.trim() || domain;
             const organizationName = this.form.organizationName.trim() || workspaceName;
             const reportMailbox = this.form.reportMailbox.trim() || (domain ? `dmarc@${domain}` : '');
@@ -267,7 +287,7 @@ function workspaceOnboarding() {
             };
         },
         validate() {
-            if (!this.form.domain.trim()) {
+            if (!this.normalizeDomain(this.form.domain)) {
                 throw new Error('Domain is required.');
             }
             if (!this.form.workspaceName.trim() && !this.form.organizationName.trim()) {
@@ -340,9 +360,9 @@ function workspaceOnboarding() {
             }));
         },
         persistDraft() {
-            localStorage.setItem('dmarq.onboarding.organizationName', this.form.organizationName);
-            localStorage.setItem('dmarq.onboarding.workspaceName', this.form.workspaceName);
-            localStorage.setItem('dmarq.onboarding.domain', this.form.domain);
+            this.draftFields().forEach((field) => {
+                localStorage.setItem(`dmarq.onboarding.${field}`, this.form[field] || '');
+            });
         },
     };
 }

--- a/backend/app/templates/setup.html
+++ b/backend/app/templates/setup.html
@@ -136,7 +136,9 @@
                         </div>
                         <div class="flex flex-wrap gap-3">
                             <a href="/login" class="btn btn-primary">Sign in</a>
+                            {% if logto_configured %}
                             <a href="/onboarding" class="btn btn-secondary">Start workspace onboarding</a>
+                            {% endif %}
                             <a href="/" class="btn btn-outline">Open dashboard</a>
                         </div>
                     </div>

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -92,6 +92,20 @@ class TestSetupPage:
         assert "/api/v1/setup/status" in response.text
         assert "/api/v1/setup/admin" in response.text
         assert "/api/v1/setup/system" in response.text
+        assert "/onboarding" not in response.text
+
+    def test_setup_page_links_onboarding_when_logto_is_configured(self, monkeypatch):
+        from app.main import app as main_app
+        from app.main import settings as main_settings
+
+        monkeypatch.setattr(main_settings, "LOGTO_ENDPOINT", "https://logto.example.test")
+        monkeypatch.setattr(main_settings, "LOGTO_APP_ID", "app-id")
+        monkeypatch.setattr(main_settings, "LOGTO_APP_SECRET", "app-secret")
+
+        with TestClient(main_app) as test_client:
+            response = test_client.get("/setup")
+
+        assert response.status_code == 200
         assert "/onboarding" in response.text
 
     def test_onboarding_page_renders_workspace_bootstrap_flow(self):
@@ -111,6 +125,8 @@ class TestSetupPage:
         assert "workspaceOnboarding()" in response.text
         assert "/api/v1/onboarding/preview" in response.text
         assert "/api/v1/onboarding/apply" in response.text
+        assert "draftFields()" in response.text
+        assert "normalizeDomain(value)" in response.text
         assert "dmarq.selectedWorkspaceId" in response.text
 
 

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -79,8 +79,13 @@ class TestSetupStatus:
 class TestSetupPage:
     """Tests for the rendered setup page."""
 
-    def test_setup_page_renders_guided_wizard(self):
+    def test_setup_page_renders_guided_wizard(self, monkeypatch):
         from app.main import app as main_app
+        from app.main import settings as main_settings
+
+        monkeypatch.setattr(main_settings, "LOGTO_ENDPOINT", None)
+        monkeypatch.setattr(main_settings, "LOGTO_APP_ID", None)
+        monkeypatch.setattr(main_settings, "LOGTO_APP_SECRET", None)
 
         with TestClient(main_app) as test_client:
             response = test_client.get("/setup")


### PR DESCRIPTION
## Summary
- hide the setup-page onboarding CTA unless Logto is configured and the route is reachable
- normalize domains in the onboarding UI like the backend does
- persist only whitelisted non-secret onboarding draft fields as they change

## Validation
- node --check on extracted onboarding template script
- patch reviewed against main

Follow-up for review comments on #278.