### PR TITLE
Add Stripe billing webhook foundation

### DIFF
--- a/backend/app/api/api_v1/api.py
+++ b/backend/app/api/api_v1/api.py
@@ -5,6 +5,7 @@ from app.api.api_v1.endpoints import (
     api_tokens,
     audit,
     auth,
+    billing,
     domains,
     forensics,
     health,
@@ -32,6 +33,7 @@ api_router = APIRouter()
 
 # Include all endpoint routers
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
+api_router.include_router(billing.router, prefix="/billing", tags=["billing"])
 api_router.include_router(ai.router, prefix="/ai", tags=["ai"])
 api_router.include_router(api_tokens.router, prefix="/api-tokens", tags=["api-tokens"])
 api_router.include_router(audit.router, prefix="/audit", tags=["audit"])

--- a/backend/app/api/api_v1/endpoints/billing.py
+++ b/backend/app/api/api_v1/endpoints/billing.py
@@ -1,0 +1,172 @@
+"""Direct billing endpoints."""
+
+import json
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import require_admin_auth
+from app.models.organization import Organization
+from app.services.stripe_billing import (
+    StripeBillingError,
+    StripeNotConfiguredError,
+    StripeSignatureError,
+    apply_stripe_event,
+    create_stripe_checkout_session,
+    create_stripe_portal_session,
+    stripe_public_config,
+    verify_stripe_signature,
+)
+from app.services.workspace_access import (
+    PERMISSION_WORKSPACE_ADMIN,
+    require_organization_permission,
+)
+
+router = APIRouter()
+
+
+class BillingStripeConfigResponse(BaseModel):
+    """API-safe Stripe Billing configuration response."""
+
+    stripe: Dict[str, Any]
+
+
+class StripeCheckoutRequest(BaseModel):
+    """Create a Stripe Checkout subscription session."""
+
+    organization_id: int
+    price_id: str
+    success_url: str
+    cancel_url: str
+
+
+class StripePortalRequest(BaseModel):
+    """Create a Stripe Customer Portal session."""
+
+    organization_id: int
+    return_url: str
+
+
+class StripeHostedSessionResponse(BaseModel):
+    """Stripe hosted session response."""
+
+    session: Dict[str, Any]
+
+
+class StripeWebhookResponse(BaseModel):
+    """Verified Stripe webhook application response."""
+
+    result: Dict[str, Any]
+
+
+def _organization_or_404(db: Session, organization_id: int) -> Organization:
+    organization = (
+        db.query(Organization)
+        .filter(Organization.id == organization_id, Organization.active.is_(True))
+        .first()
+    )
+    if organization is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found",
+        )
+    return organization
+
+
+def _stripe_error(exc: StripeBillingError) -> HTTPException:
+    if isinstance(exc, StripeNotConfiguredError):
+        return HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        )
+    return HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=str(exc),
+    )
+
+
+@router.get("/stripe/config", response_model=BillingStripeConfigResponse)
+async def get_stripe_billing_config(
+    _auth: dict = Depends(require_admin_auth),
+) -> BillingStripeConfigResponse:
+    """Return non-secret Stripe Billing configuration status."""
+    return {"stripe": stripe_public_config()}
+
+
+@router.post("/stripe/checkout", response_model=StripeHostedSessionResponse)
+async def create_checkout_session(
+    payload: StripeCheckoutRequest,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+) -> StripeHostedSessionResponse:
+    """Create a Stripe Checkout session for a direct-billed subscription."""
+    organization = _organization_or_404(db, payload.organization_id)
+    require_organization_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, organization)
+    try:
+        session = create_stripe_checkout_session(
+            db,
+            organization=organization,
+            price_id=payload.price_id,
+            success_url=payload.success_url,
+            cancel_url=payload.cancel_url,
+        )
+    except StripeBillingError as exc:
+        raise _stripe_error(exc) from exc
+    return {"session": session}
+
+
+@router.post("/stripe/portal", response_model=StripeHostedSessionResponse)
+async def create_portal_session(
+    payload: StripePortalRequest,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+) -> StripeHostedSessionResponse:
+    """Create a Stripe Customer Portal session for a direct-billed organization."""
+    organization = _organization_or_404(db, payload.organization_id)
+    require_organization_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, organization)
+    try:
+        session = create_stripe_portal_session(
+            db,
+            organization=organization,
+            return_url=payload.return_url,
+        )
+    except StripeBillingError as exc:
+        raise _stripe_error(exc) from exc
+    return {"session": session}
+
+
+@router.post("/stripe/webhook", response_model=StripeWebhookResponse)
+async def receive_stripe_webhook(
+    request: Request,
+    stripe_signature: Optional[str] = Header(None, alias="Stripe-Signature"),
+    db: Session = Depends(get_db),
+) -> StripeWebhookResponse:
+    """Receive and apply a verified Stripe Billing webhook."""
+    body = await request.body()
+    try:
+        verify_stripe_signature(body, stripe_signature)
+    except StripeNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+    except StripeSignatureError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    try:
+        event = json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Stripe webhook JSON",
+        ) from exc
+    try:
+        result = apply_stripe_event(db, event)
+    except StripeBillingError as exc:
+        raise _stripe_error(exc) from exc
+    return {"result": result}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -54,6 +54,13 @@ class Settings(BaseSettings):
     CLOUDFLARE_ZONE_ID: Optional[str] = None
     WEBHOOK_SECRET: Optional[str] = None
 
+    # Optional Stripe Billing integration. Self-hosted and provider-billed
+    # deployments work without these values.
+    STRIPE_SECRET_KEY: Optional[str] = None
+    STRIPE_WEBHOOK_SECRET: Optional[str] = None
+    STRIPE_PRICE_PLAN_MAP: Optional[str] = None
+    STRIPE_API_BASE_URL: str = "https://api.stripe.com/v1"
+
     # Admin API Key (optional)
     # If set, this key is used directly instead of generating a random one at startup.
     # Use: openssl rand -hex 32

--- a/backend/app/services/stripe_billing.py
+++ b/backend/app/services/stripe_billing.py
@@ -1,0 +1,485 @@
+"""Optional Stripe Billing integration helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.models.organization import BillingAccount, BillingEvent, Organization, Plan, Subscription
+from app.services.organizations import (
+    BILLING_MODE_DIRECT_STRIPE,
+    STARTER_PLAN_CODE,
+    STARTER_PLAN_ENTITLEMENTS,
+    ensure_billing_account,
+    ensure_entitlements,
+)
+
+STRIPE_PROVIDER_ID = "stripe"
+STRIPE_SIGNATURE_TOLERANCE_SECONDS = 300
+ACTIVE_STRIPE_STATUSES = {"active", "trialing"}
+TERMINAL_STRIPE_STATUSES = {"canceled", "incomplete_expired", "unpaid"}
+
+
+class StripeBillingError(ValueError):
+    """Base Stripe billing integration error."""
+
+
+class StripeNotConfiguredError(StripeBillingError):
+    """Raised when Stripe-only actions are requested without Stripe credentials."""
+
+
+class StripeSignatureError(StripeBillingError):
+    """Raised when a webhook signature cannot be verified."""
+
+
+def stripe_is_configured() -> bool:
+    """Return True when direct Stripe API calls can be made."""
+    return bool(get_settings().STRIPE_SECRET_KEY)
+
+
+def stripe_webhooks_configured() -> bool:
+    """Return True when inbound Stripe webhook verification is configured."""
+    return bool(get_settings().STRIPE_WEBHOOK_SECRET)
+
+
+def stripe_price_plan_map() -> Dict[str, str]:
+    """Return the configured Stripe price-to-plan mapping."""
+    raw = get_settings().STRIPE_PRICE_PLAN_MAP
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise StripeBillingError("STRIPE_PRICE_PLAN_MAP must be valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise StripeBillingError("STRIPE_PRICE_PLAN_MAP must be a JSON object")
+    return {
+        str(price_id).strip(): str(plan_code).strip()
+        for price_id, plan_code in parsed.items()
+        if str(price_id).strip() and str(plan_code).strip()
+    }
+
+
+def stripe_public_config() -> Dict[str, Any]:
+    """Return API-safe Stripe configuration metadata."""
+    mapping = stripe_price_plan_map()
+    return {
+        "configured": stripe_is_configured(),
+        "webhooks_configured": stripe_webhooks_configured(),
+        "price_plan_map": mapping,
+    }
+
+
+def _require_stripe_api_configured() -> str:
+    secret_key = get_settings().STRIPE_SECRET_KEY
+    if not secret_key:
+        raise StripeNotConfiguredError("Stripe Billing is not configured")
+    return secret_key
+
+
+def _plan_code_for_price(price_id: str) -> str:
+    mapping = stripe_price_plan_map()
+    plan_code = mapping.get(price_id)
+    if not plan_code:
+        raise StripeBillingError("Stripe price is not configured for a local plan")
+    return plan_code
+
+
+def _stripe_post(path: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    settings = get_settings()
+    secret_key = _require_stripe_api_configured()
+    response = httpx.post(
+        f"{settings.STRIPE_API_BASE_URL.rstrip('/')}/{path.lstrip('/')}",
+        data=data,
+        auth=(secret_key, ""),
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _get_or_create_direct_plan(db: Session, *, code: str, price_id: Optional[str]) -> Plan:
+    plan = db.query(Plan).filter(Plan.code == code).first()
+    if plan:
+        return plan
+    plan = Plan(
+        code=code,
+        name=code.replace("_", " ").replace("-", " ").title(),
+        description="Direct Stripe Billing plan mapped from Stripe configuration.",
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        public=True,
+        active=True,
+        currency="EUR",
+    )
+    db.add(plan)
+    db.flush()
+    return plan
+
+
+def _entitlements_for_plan(plan: Plan) -> Dict[str, str]:
+    if plan.code == STARTER_PLAN_CODE:
+        return dict(STARTER_PLAN_ENTITLEMENTS)
+    entitlements: Dict[str, str] = {}
+    if plan.included_sending_domains is not None:
+        entitlements["sending_domains"] = str(plan.included_sending_domains)
+    if plan.included_message_volume is not None:
+        entitlements["aggregate_messages"] = str(plan.included_message_volume)
+    if plan.included_users is not None:
+        entitlements["users"] = str(plan.included_users)
+    if plan.retention_days is not None:
+        entitlements["retention_days"] = str(plan.retention_days)
+    for feature in (plan.features or "").split(","):
+        feature = feature.strip()
+        if feature:
+            entitlements[feature] = "true"
+    return entitlements
+
+
+def _set_subscription_entitlements(
+    db: Session,
+    organization: Organization,
+    subscription: Subscription,
+) -> None:
+    if subscription.status in ACTIVE_STRIPE_STATUSES:
+        ensure_entitlements(
+            db,
+            organization,
+            subscription,
+            _entitlements_for_plan(subscription.plan),
+            commit=False,
+        )
+        return
+    if subscription.status in TERMINAL_STRIPE_STATUSES:
+        for entitlement in subscription.entitlements:
+            entitlement.active = False
+
+
+def create_stripe_checkout_session(
+    db: Session,
+    *,
+    organization: Organization,
+    price_id: str,
+    success_url: str,
+    cancel_url: str,
+) -> Dict[str, Any]:
+    """Create a hosted Stripe Checkout subscription session."""
+    plan_code = _plan_code_for_price(price_id)
+    plan = _get_or_create_direct_plan(db, code=plan_code, price_id=price_id)
+    account = ensure_billing_account(
+        db,
+        organization,
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        commit=False,
+    )
+    account.status = "pending_checkout"
+    account.invoice_delivery_mode = "stripe"
+    data: Dict[str, Any] = {
+        "mode": "subscription",
+        "success_url": success_url,
+        "cancel_url": cancel_url,
+        "client_reference_id": str(organization.id),
+        "line_items[0][price]": price_id,
+        "line_items[0][quantity]": "1",
+        "metadata[organization_id]": str(organization.id),
+        "metadata[plan_code]": plan.code,
+        "subscription_data[metadata][organization_id]": str(organization.id),
+        "subscription_data[metadata][plan_code]": plan.code,
+    }
+    if account.stripe_customer_id:
+        data["customer"] = account.stripe_customer_id
+    else:
+        data["customer_creation"] = "always"
+    session = _stripe_post("checkout/sessions", data)
+    db.commit()
+    db.refresh(account)
+    return {
+        "id": session.get("id"),
+        "url": session.get("url"),
+        "mode": session.get("mode", "subscription"),
+        "organization_id": organization.id,
+        "billing_account_id": account.id,
+        "plan_code": plan.code,
+        "price_id": price_id,
+    }
+
+
+def create_stripe_portal_session(
+    db: Session,
+    *,
+    organization: Organization,
+    return_url: str,
+) -> Dict[str, Any]:
+    """Create a hosted Stripe Customer Portal session."""
+    _require_stripe_api_configured()
+    account = (
+        db.query(BillingAccount)
+        .filter(
+            BillingAccount.organization_id == organization.id,
+            BillingAccount.billing_mode == BILLING_MODE_DIRECT_STRIPE,
+        )
+        .order_by(BillingAccount.id.asc())
+        .first()
+    )
+    if account is None or not account.stripe_customer_id:
+        raise StripeBillingError("Organization does not have a Stripe customer yet")
+    session = _stripe_post(
+        "billing_portal/sessions",
+        {"customer": account.stripe_customer_id, "return_url": return_url},
+    )
+    return {
+        "id": session.get("id"),
+        "url": session.get("url"),
+        "organization_id": organization.id,
+        "billing_account_id": account.id,
+    }
+
+
+def _signature_parts(signature_header: str) -> Dict[str, list[str]]:
+    parts: Dict[str, list[str]] = {}
+    for item in signature_header.split(","):
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        parts.setdefault(key, []).append(value)
+    return parts
+
+
+def verify_stripe_signature(
+    body: bytes,
+    signature_header: Optional[str],
+    *,
+    now: Optional[int] = None,
+) -> None:
+    """Verify Stripe's signed webhook payload."""
+    secret = get_settings().STRIPE_WEBHOOK_SECRET
+    if not secret:
+        raise StripeNotConfiguredError("Stripe webhooks are not configured")
+    if not signature_header:
+        raise StripeSignatureError("Missing Stripe-Signature header")
+    parts = _signature_parts(signature_header)
+    timestamps = parts.get("t") or []
+    signatures = parts.get("v1") or []
+    if not timestamps or not signatures:
+        raise StripeSignatureError("Invalid Stripe-Signature header")
+    try:
+        timestamp = int(timestamps[0])
+    except ValueError as exc:
+        raise StripeSignatureError("Invalid Stripe-Signature timestamp") from exc
+    if abs((now or int(time.time())) - timestamp) > STRIPE_SIGNATURE_TOLERANCE_SECONDS:
+        raise StripeSignatureError("Stripe-Signature timestamp is outside tolerance")
+    signed_payload = f"{timestamp}.{body.decode('utf-8')}".encode("utf-8")
+    expected = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
+    if not any(hmac.compare_digest(expected, signature) for signature in signatures):
+        raise StripeSignatureError("Invalid Stripe-Signature")
+
+
+def _timestamp(value: Any) -> Optional[datetime]:
+    if value in (None, ""):
+        return None
+    try:
+        return datetime.utcfromtimestamp(int(value))
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _event_payload_summary(event: Dict[str, Any]) -> str:
+    data_object = (event.get("data") or {}).get("object") or {}
+    object_id = (
+        data_object.get("id") or data_object.get("subscription") or data_object.get("customer")
+    )
+    return f"{event.get('type', 'stripe.event')} object={object_id or 'unknown'}"
+
+
+def _find_organization(db: Session, data_object: Dict[str, Any]) -> Optional[Organization]:
+    metadata = data_object.get("metadata") or {}
+    organization_id = metadata.get("organization_id") or data_object.get("client_reference_id")
+    if organization_id:
+        try:
+            return db.query(Organization).filter(Organization.id == int(organization_id)).first()
+        except (TypeError, ValueError):
+            return None
+    customer_id = data_object.get("customer")
+    if customer_id:
+        account = (
+            db.query(BillingAccount)
+            .filter(BillingAccount.stripe_customer_id == customer_id)
+            .first()
+        )
+        return account.organization if account else None
+    return None
+
+
+def _price_id_from_subscription_object(data_object: Dict[str, Any]) -> Optional[str]:
+    items = (data_object.get("items") or {}).get("data") or []
+    if not items:
+        return None
+    price = items[0].get("price") or {}
+    return price.get("id")
+
+
+def _plan_for_stripe_object(db: Session, data_object: Dict[str, Any]) -> Plan:
+    metadata = data_object.get("metadata") or {}
+    plan_code = metadata.get("plan_code")
+    price_id = _price_id_from_subscription_object(data_object)
+    if not plan_code and price_id:
+        plan_code = _plan_code_for_price(price_id)
+    if not plan_code:
+        raise StripeBillingError("Stripe event is missing local plan metadata")
+    return _get_or_create_direct_plan(db, code=str(plan_code), price_id=price_id)
+
+
+def _upsert_stripe_subscription(
+    db: Session,
+    *,
+    organization: Organization,
+    data_object: Dict[str, Any],
+    status_override: Optional[str] = None,
+) -> Subscription:
+    customer_id = data_object.get("customer")
+    account = ensure_billing_account(
+        db,
+        organization,
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        commit=False,
+    )
+    account.status = "active"
+    account.invoice_delivery_mode = "stripe"
+    if customer_id:
+        account.stripe_customer_id = customer_id
+    stripe_subscription_id = data_object.get("subscription") or data_object.get("id")
+    subscription = None
+    if stripe_subscription_id:
+        subscription = (
+            db.query(Subscription)
+            .filter(Subscription.stripe_subscription_id == stripe_subscription_id)
+            .first()
+        )
+    if subscription is None:
+        plan = _plan_for_stripe_object(db, data_object)
+        subscription = Subscription(
+            organization_id=organization.id,
+            plan_id=plan.id,
+            billing_account=account,
+            billing_mode=BILLING_MODE_DIRECT_STRIPE,
+            stripe_subscription_id=stripe_subscription_id,
+            status=status_override or data_object.get("status") or "active",
+        )
+        db.add(subscription)
+        db.flush()
+    else:
+        if data_object.get("metadata") or _price_id_from_subscription_object(data_object):
+            subscription.plan = _plan_for_stripe_object(db, data_object)
+        subscription.billing_account = account
+        subscription.billing_mode = BILLING_MODE_DIRECT_STRIPE
+        subscription.status = status_override or data_object.get("status") or subscription.status
+    subscription.external_product_code = _price_id_from_subscription_object(data_object)
+    subscription.current_period_start = _timestamp(data_object.get("current_period_start"))
+    subscription.current_period_end = _timestamp(data_object.get("current_period_end"))
+    subscription.canceled_at = _timestamp(data_object.get("canceled_at"))
+    _set_subscription_entitlements(db, organization, subscription)
+    return subscription
+
+
+def _record_billing_event(
+    db: Session,
+    event: Dict[str, Any],
+    *,
+    organization: Optional[Organization],
+    subscription: Optional[Subscription],
+    status: str,
+) -> BillingEvent:
+    row = BillingEvent(
+        organization_id=organization.id if organization else None,
+        subscription_id=subscription.id if subscription else None,
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        event_type=str(event.get("type") or "stripe.event"),
+        provider_id=STRIPE_PROVIDER_ID,
+        external_event_id=event.get("id"),
+        status=status,
+        payload_summary=_event_payload_summary(event),
+    )
+    db.add(row)
+    return row
+
+
+def apply_stripe_event(db: Session, event: Dict[str, Any]) -> Dict[str, Any]:
+    """Apply a verified Stripe webhook event to local billing state."""
+    event_id = event.get("id")
+    if event_id:
+        existing = (
+            db.query(BillingEvent)
+            .filter(
+                BillingEvent.provider_id == STRIPE_PROVIDER_ID,
+                BillingEvent.external_event_id == event_id,
+            )
+            .first()
+        )
+        if existing:
+            return {"status": "duplicate", "billing_event_id": existing.id}
+
+    event_type = str(event.get("type") or "")
+    data_object = (event.get("data") or {}).get("object") or {}
+    organization = _find_organization(db, data_object)
+    subscription: Optional[Subscription] = None
+    status = "ignored"
+
+    if event_type == "checkout.session.completed" and organization is not None:
+        subscription = _upsert_stripe_subscription(
+            db,
+            organization=organization,
+            data_object=data_object,
+            status_override="active",
+        )
+        status = "applied"
+    elif event_type.startswith("customer.subscription.") and organization is not None:
+        subscription = _upsert_stripe_subscription(
+            db,
+            organization=organization,
+            data_object=data_object,
+        )
+        status = "applied"
+    elif event_type == "invoice.payment_succeeded" and organization is not None:
+        subscription = _upsert_stripe_subscription(
+            db,
+            organization=organization,
+            data_object=data_object,
+            status_override="active",
+        )
+        status = "applied"
+    elif event_type == "invoice.payment_failed" and organization is not None:
+        subscription = _upsert_stripe_subscription(
+            db,
+            organization=organization,
+            data_object=data_object,
+            status_override="past_due",
+        )
+        status = "applied"
+    elif organization is None:
+        status = "unmatched"
+
+    billing_event = _record_billing_event(
+        db,
+        event,
+        organization=organization,
+        subscription=subscription,
+        status=status,
+    )
+    db.commit()
+    db.refresh(billing_event)
+    if subscription is not None:
+        db.refresh(subscription)
+    return {
+        "status": status,
+        "event_type": event_type,
+        "billing_event_id": billing_event.id,
+        "organization_id": organization.id if organization else None,
+        "subscription_id": subscription.id if subscription else None,
+    }

--- a/backend/app/tests/test_stripe_billing.py
+++ b/backend/app/tests/test_stripe_billing.py
@@ -1,0 +1,760 @@
+import hashlib
+import hmac
+import json
+import time
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.organization import (
+    BillingAccount,
+    BillingEvent,
+    Entitlement,
+    Organization,
+    Plan,
+    Subscription,
+)
+from app.services.organizations import BILLING_MODE_DIRECT_STRIPE, STARTER_PLAN_CODE
+from app.services.stripe_billing import StripeBillingError, stripe_price_plan_map
+
+
+def _stripe_settings(**overrides):
+    data = {
+        "STRIPE_SECRET_KEY": "sk_test_123",
+        "STRIPE_WEBHOOK_SECRET": "whsec_test",
+        "STRIPE_PRICE_PLAN_MAP": json.dumps({"price_starter": STARTER_PLAN_CODE}),
+        "STRIPE_API_BASE_URL": "https://api.stripe.test/v1",
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def _stripe_signature(payload: dict, secret: str = "whsec_test") -> tuple[bytes, str]:
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    timestamp = int(time.time())
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        f"{timestamp}.{body.decode('utf-8')}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return body, f"t={timestamp},v1={digest}"
+
+
+def test_stripe_config_reports_optional_state(authed_client: TestClient, monkeypatch):
+    monkeypatch.setattr(
+        "app.services.stripe_billing.get_settings",
+        lambda: _stripe_settings(STRIPE_SECRET_KEY=None, STRIPE_WEBHOOK_SECRET=None),
+    )
+
+    response = authed_client.get("/api/v1/billing/stripe/config")
+
+    assert response.status_code == 200
+    payload = response.json()["stripe"]
+    assert payload["configured"] is False
+    assert payload["webhooks_configured"] is False
+    assert payload["price_plan_map"] == {"price_starter": STARTER_PLAN_CODE}
+
+
+def test_stripe_price_plan_map_validates_json(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.stripe_billing.get_settings",
+        lambda: _stripe_settings(STRIPE_PRICE_PLAN_MAP="[not-json"),
+    )
+
+    with pytest.raises(StripeBillingError, match="valid JSON"):
+        stripe_price_plan_map()
+
+    monkeypatch.setattr(
+        "app.services.stripe_billing.get_settings",
+        lambda: _stripe_settings(STRIPE_PRICE_PLAN_MAP='["price_starter"]'),
+    )
+
+    with pytest.raises(StripeBillingError, match="JSON object"):
+        stripe_price_plan_map()
+
+
+def test_stripe_checkout_is_unavailable_without_credentials(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="acme", name="Acme", active=True)
+    db_session.add(organization)
+    db_session.commit()
+    monkeypatch.setattr(
+        "app.services.stripe_billing.get_settings",
+        lambda: _stripe_settings(STRIPE_SECRET_KEY=None),
+    )
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/checkout",
+        json={
+            "organization_id": organization.id,
+            "price_id": "price_starter",
+            "success_url": "https://app.example/billing/success",
+            "cancel_url": "https://app.example/billing/cancel",
+        },
+    )
+
+    assert response.status_code == 503
+    assert "not configured" in response.json()["detail"]
+
+
+def test_stripe_checkout_creates_hosted_session_request_and_pending_account(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="direct", name="Direct", active=True)
+    db_session.add(organization)
+    db_session.commit()
+    posted = {}
+
+    def fake_post(url, data, auth, timeout):
+        posted.update({"url": url, "data": data, "auth": auth, "timeout": timeout})
+        return httpx.Response(
+            200,
+            json={"id": "cs_test_123", "url": "https://checkout.stripe.test/session"},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    monkeypatch.setattr("app.services.stripe_billing.httpx.post", fake_post)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/checkout",
+        json={
+            "organization_id": organization.id,
+            "price_id": "price_starter",
+            "success_url": "https://app.example/billing/success",
+            "cancel_url": "https://app.example/billing/cancel",
+        },
+    )
+
+    assert response.status_code == 200
+    session = response.json()["session"]
+    assert session["id"] == "cs_test_123"
+    assert session["url"] == "https://checkout.stripe.test/session"
+    assert posted["url"] == "https://api.stripe.test/v1/checkout/sessions"
+    assert posted["auth"] == ("sk_test_123", "")
+    assert posted["data"]["line_items[0][price]"] == "price_starter"
+    assert posted["data"]["metadata[organization_id]"] == str(organization.id)
+    account = db_session.query(BillingAccount).filter_by(organization_id=organization.id).one()
+    assert account.billing_mode == BILLING_MODE_DIRECT_STRIPE
+    assert account.status == "pending_checkout"
+    assert account.invoice_delivery_mode == "stripe"
+
+
+def test_stripe_checkout_reuses_existing_customer(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="existing-customer", name="Existing Customer", active=True)
+    db_session.add(organization)
+    db_session.flush()
+    db_session.add(
+        BillingAccount(
+            organization_id=organization.id,
+            billing_mode=BILLING_MODE_DIRECT_STRIPE,
+            stripe_customer_id="cus_existing",
+        )
+    )
+    db_session.commit()
+    posted = {}
+
+    def fake_post(url, data, auth, timeout):
+        posted.update({"url": url, "data": data, "auth": auth, "timeout": timeout})
+        return httpx.Response(
+            200,
+            json={"id": "cs_existing", "url": "https://checkout.stripe.test/existing"},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    monkeypatch.setattr("app.services.stripe_billing.httpx.post", fake_post)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/checkout",
+        json={
+            "organization_id": organization.id,
+            "price_id": "price_starter",
+            "success_url": "https://app.example/billing/success",
+            "cancel_url": "https://app.example/billing/cancel",
+        },
+    )
+
+    assert response.status_code == 200
+    assert posted["data"]["customer"] == "cus_existing"
+    assert "customer_creation" not in posted["data"]
+
+
+def test_stripe_checkout_rejects_unmapped_price(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="unmapped", name="Unmapped", active=True)
+    db_session.add(organization)
+    db_session.commit()
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/checkout",
+        json={
+            "organization_id": organization.id,
+            "price_id": "price_unknown",
+            "success_url": "https://app.example/billing/success",
+            "cancel_url": "https://app.example/billing/cancel",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "not configured" in response.json()["detail"]
+
+
+def test_stripe_checkout_rejects_unknown_organization(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/checkout",
+        json={
+            "organization_id": 999999,
+            "price_id": "price_starter",
+            "success_url": "https://app.example/billing/success",
+            "cancel_url": "https://app.example/billing/cancel",
+        },
+    )
+
+    assert response.status_code == 404
+
+
+def test_stripe_portal_creates_hosted_session(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="portal", name="Portal", active=True)
+    db_session.add(organization)
+    db_session.flush()
+    account = BillingAccount(
+        organization_id=organization.id,
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        stripe_customer_id="cus_portal",
+    )
+    db_session.add(account)
+    db_session.commit()
+    posted = {}
+
+    def fake_post(url, data, auth, timeout):
+        posted.update({"url": url, "data": data, "auth": auth, "timeout": timeout})
+        return httpx.Response(
+            200,
+            json={"id": "bps_test_123", "url": "https://billing.stripe.test/session"},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    monkeypatch.setattr("app.services.stripe_billing.httpx.post", fake_post)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/portal",
+        json={
+            "organization_id": organization.id,
+            "return_url": "https://app.example/billing",
+        },
+    )
+
+    assert response.status_code == 200
+    session = response.json()["session"]
+    assert session["id"] == "bps_test_123"
+    assert session["url"] == "https://billing.stripe.test/session"
+    assert posted["url"] == "https://api.stripe.test/v1/billing_portal/sessions"
+    assert posted["auth"] == ("sk_test_123", "")
+    assert posted["data"] == {
+        "customer": "cus_portal",
+        "return_url": "https://app.example/billing",
+    }
+
+
+def test_stripe_portal_rejects_missing_customer(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="portal-missing", name="Portal Missing", active=True)
+    db_session.add(organization)
+    db_session.commit()
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/portal",
+        json={
+            "organization_id": organization.id,
+            "return_url": "https://app.example/billing",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Stripe customer" in response.json()["detail"]
+
+
+def test_stripe_webhook_rejects_invalid_signature(authed_client: TestClient, monkeypatch):
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=b'{"id":"evt_bad"}',
+        headers={"Stripe-Signature": "t=1,v1=bad"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_stripe_webhook_requires_configured_secret(authed_client: TestClient, monkeypatch):
+    monkeypatch.setattr(
+        "app.services.stripe_billing.get_settings",
+        lambda: _stripe_settings(STRIPE_WEBHOOK_SECRET=None),
+    )
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=b'{"id":"evt_unconfigured"}',
+        headers={"Stripe-Signature": "t=1,v1=bad"},
+    )
+
+    assert response.status_code == 503
+
+
+def test_stripe_webhook_rejects_invalid_json(authed_client: TestClient, monkeypatch):
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    timestamp = int(time.time())
+    body = b"{not-json"
+    digest = hmac.new(
+        b"whsec_test",
+        f"{timestamp}.{body.decode('utf-8')}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": f"t={timestamp},v1={digest}"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid Stripe webhook JSON"
+
+
+def test_stripe_checkout_completed_webhook_materializes_subscription_and_entitlements(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="webhook", name="Webhook", active=True)
+    db_session.add(organization)
+    db_session.commit()
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    event = {
+        "id": "evt_checkout",
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "id": "cs_test_123",
+                "customer": "cus_123",
+                "subscription": "sub_123",
+                "client_reference_id": str(organization.id),
+                "metadata": {
+                    "organization_id": str(organization.id),
+                    "plan_code": STARTER_PLAN_CODE,
+                },
+            }
+        },
+    }
+    body, signature = _stripe_signature(event)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": signature},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["result"]["status"] == "applied"
+    account = db_session.query(BillingAccount).filter_by(organization_id=organization.id).one()
+    assert account.stripe_customer_id == "cus_123"
+    assert account.billing_mode == BILLING_MODE_DIRECT_STRIPE
+    assert account.status == "active"
+    subscription = account.subscriptions[0]
+    assert subscription.stripe_subscription_id == "sub_123"
+    assert subscription.status == "active"
+    assert subscription.plan.code == STARTER_PLAN_CODE
+    entitlement_keys = {
+        entitlement.key
+        for entitlement in db_session.query(Entitlement)
+        .filter(Entitlement.organization_id == organization.id)
+        .all()
+    }
+    assert {"aggregate_reports", "dns_linting", "monitored_domains"} <= entitlement_keys
+    event_row = db_session.query(BillingEvent).filter_by(external_event_id="evt_checkout").one()
+    assert event_row.status == "applied"
+
+
+def test_stripe_subscription_webhook_maps_price_to_plan_without_metadata(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="price-map", name="Price Map", active=True)
+    db_session.add(organization)
+    db_session.commit()
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    event = {
+        "id": "evt_price_map",
+        "type": "customer.subscription.created",
+        "data": {
+            "object": {
+                "id": "sub_price",
+                "customer": "cus_price",
+                "status": "trialing",
+                "current_period_start": 1_717_200_000,
+                "current_period_end": 1_719_792_000,
+                "metadata": {"organization_id": str(organization.id)},
+                "items": {"data": [{"price": {"id": "price_starter"}}]},
+            }
+        },
+    }
+    body, signature = _stripe_signature(event)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": signature},
+    )
+
+    assert response.status_code == 200
+    subscription = (
+        db_session.query(Subscription).filter_by(stripe_subscription_id="sub_price").one()
+    )
+    assert subscription.status == "trialing"
+    assert subscription.plan.code == STARTER_PLAN_CODE
+    assert subscription.external_product_code == "price_starter"
+    assert subscription.current_period_start is not None
+    assert subscription.current_period_end is not None
+
+
+def test_stripe_invoice_payment_failed_updates_existing_subscription_from_customer(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="invoice-failed", name="Invoice Failed", active=True)
+    plan = Plan(code=STARTER_PLAN_CODE, name="Starter", billing_mode=BILLING_MODE_DIRECT_STRIPE)
+    db_session.add_all([organization, plan])
+    db_session.flush()
+    account = BillingAccount(
+        organization_id=organization.id,
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        stripe_customer_id="cus_invoice",
+    )
+    subscription = Subscription(
+        organization_id=organization.id,
+        billing_account=account,
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        plan=plan,
+        stripe_subscription_id="sub_invoice",
+        status="active",
+    )
+    db_session.add_all([account, subscription])
+    db_session.commit()
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    event = {
+        "id": "evt_invoice_failed",
+        "type": "invoice.payment_failed",
+        "data": {"object": {"customer": "cus_invoice", "subscription": "sub_invoice"}},
+    }
+    body, signature = _stripe_signature(event)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": signature},
+    )
+
+    assert response.status_code == 200
+    db_session.refresh(subscription)
+    assert subscription.status == "past_due"
+    event_row = (
+        db_session.query(BillingEvent).filter_by(external_event_id="evt_invoice_failed").one()
+    )
+    assert event_row.subscription_id == subscription.id
+
+
+def test_stripe_invoice_payment_succeeded_marks_existing_subscription_active(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="invoice-paid", name="Invoice Paid", active=True)
+    plan = Plan(code=STARTER_PLAN_CODE, name="Starter", billing_mode=BILLING_MODE_DIRECT_STRIPE)
+    db_session.add_all([organization, plan])
+    db_session.flush()
+    account = BillingAccount(
+        organization_id=organization.id,
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        stripe_customer_id="cus_paid",
+    )
+    subscription = Subscription(
+        organization_id=organization.id,
+        billing_account=account,
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        plan=plan,
+        stripe_subscription_id="sub_paid",
+        status="past_due",
+    )
+    db_session.add_all([account, subscription])
+    db_session.commit()
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    event = {
+        "id": "evt_invoice_paid",
+        "type": "invoice.payment_succeeded",
+        "data": {"object": {"customer": "cus_paid", "subscription": "sub_paid"}},
+    }
+    body, signature = _stripe_signature(event)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": signature},
+    )
+
+    assert response.status_code == 200
+    db_session.refresh(subscription)
+    assert subscription.status == "active"
+
+
+def test_stripe_active_subscription_materializes_custom_plan_entitlements(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="custom-plan", name="Custom Plan", active=True)
+    plan = Plan(
+        code="scale",
+        name="Scale",
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        included_sending_domains=25,
+        included_message_volume=250000,
+        included_users=10,
+        retention_days=180,
+        features="alerts, api_access",
+    )
+    db_session.add_all([organization, plan])
+    db_session.commit()
+    monkeypatch.setattr(
+        "app.services.stripe_billing.get_settings",
+        lambda: _stripe_settings(STRIPE_PRICE_PLAN_MAP=json.dumps({"price_scale": "scale"})),
+    )
+    event = {
+        "id": "evt_custom_plan",
+        "type": "customer.subscription.created",
+        "data": {
+            "object": {
+                "id": "sub_custom",
+                "customer": "cus_custom",
+                "status": "active",
+                "metadata": {"organization_id": str(organization.id), "plan_code": "scale"},
+                "items": {"data": [{"price": {"id": "price_scale"}}]},
+            }
+        },
+    }
+    body, signature = _stripe_signature(event)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": signature},
+    )
+
+    assert response.status_code == 200
+    entitlements = {
+        entitlement.key: entitlement.value
+        for entitlement in db_session.query(Entitlement)
+        .filter(Entitlement.organization_id == organization.id)
+        .all()
+    }
+    assert entitlements["sending_domains"] == "25"
+    assert entitlements["aggregate_messages"] == "250000"
+    assert entitlements["users"] == "10"
+    assert entitlements["retention_days"] == "180"
+    assert entitlements["alerts"] == "true"
+    assert entitlements["api_access"] == "true"
+
+
+def test_stripe_canceled_subscription_disables_entitlements(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="cancelled", name="Cancelled", active=True)
+    db_session.add(organization)
+    db_session.commit()
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    active_event = {
+        "id": "evt_cancel_setup",
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "customer": "cus_cancel",
+                "subscription": "sub_cancel",
+                "client_reference_id": str(organization.id),
+                "metadata": {
+                    "organization_id": str(organization.id),
+                    "plan_code": STARTER_PLAN_CODE,
+                },
+            }
+        },
+    }
+    body, signature = _stripe_signature(active_event)
+    assert (
+        authed_client.post(
+            "/api/v1/billing/stripe/webhook",
+            content=body,
+            headers={"Stripe-Signature": signature},
+        ).status_code
+        == 200
+    )
+    canceled_event = {
+        "id": "evt_cancelled",
+        "type": "customer.subscription.deleted",
+        "data": {
+            "object": {
+                "id": "sub_cancel",
+                "customer": "cus_cancel",
+                "status": "canceled",
+                "canceled_at": 1_717_200_000,
+                "metadata": {
+                    "organization_id": str(organization.id),
+                    "plan_code": STARTER_PLAN_CODE,
+                },
+            }
+        },
+    }
+    body, signature = _stripe_signature(canceled_event)
+
+    response = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": signature},
+    )
+
+    assert response.status_code == 200
+    subscription = (
+        db_session.query(Subscription).filter_by(stripe_subscription_id="sub_cancel").one()
+    )
+    assert subscription.status == "canceled"
+    assert subscription.canceled_at is not None
+    assert all(not entitlement.active for entitlement in subscription.entitlements)
+
+
+def test_stripe_webhook_records_unmatched_and_ignored_events(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    organization = Organization(slug="ignored", name="Ignored", active=True)
+    db_session.add(organization)
+    db_session.commit()
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    unmatched_event = {
+        "id": "evt_unmatched",
+        "type": "customer.subscription.updated",
+        "data": {"object": {"id": "sub_missing", "customer": "cus_missing"}},
+    }
+    body, signature = _stripe_signature(unmatched_event)
+
+    unmatched = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": signature},
+    )
+
+    ignored_event = {
+        "id": "evt_ignored",
+        "type": "customer.created",
+        "data": {
+            "object": {
+                "id": "cus_ignored",
+                "metadata": {"organization_id": str(organization.id)},
+            }
+        },
+    }
+    body, signature = _stripe_signature(ignored_event)
+    ignored = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": signature},
+    )
+
+    assert unmatched.status_code == 200
+    assert unmatched.json()["result"]["status"] == "unmatched"
+    assert ignored.status_code == 200
+    assert ignored.json()["result"]["status"] == "ignored"
+    assert db_session.query(BillingEvent).filter_by(external_event_id="evt_unmatched").one().status
+    assert db_session.query(BillingEvent).filter_by(external_event_id="evt_ignored").one().status
+
+
+def test_stripe_subscription_webhook_is_idempotent(
+    authed_client: TestClient, db_session, monkeypatch
+):
+    organization = Organization(slug="idempotent", name="Idempotent", active=True)
+    plan = Plan(code=STARTER_PLAN_CODE, name="Starter", billing_mode=BILLING_MODE_DIRECT_STRIPE)
+    db_session.add_all([organization, plan])
+    db_session.flush()
+    account = BillingAccount(
+        organization_id=organization.id,
+        billing_mode=BILLING_MODE_DIRECT_STRIPE,
+        stripe_customer_id="cus_456",
+    )
+    db_session.add(account)
+    db_session.commit()
+    monkeypatch.setattr("app.services.stripe_billing.get_settings", _stripe_settings)
+    event = {
+        "id": "evt_sub",
+        "type": "customer.subscription.updated",
+        "data": {
+            "object": {
+                "id": "sub_456",
+                "customer": "cus_456",
+                "status": "past_due",
+                "metadata": {
+                    "organization_id": str(organization.id),
+                    "plan_code": STARTER_PLAN_CODE,
+                },
+            }
+        },
+    }
+    body, signature = _stripe_signature(event)
+
+    first = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": signature},
+    )
+    second = authed_client.post(
+        "/api/v1/billing/stripe/webhook",
+        content=body,
+        headers={"Stripe-Signature": signature},
+    )
+
+    assert first.status_code == 200
+    assert first.json()["result"]["status"] == "applied"
+    assert second.status_code == 200
+    assert second.json()["result"]["status"] == "duplicate"
+    assert db_session.query(BillingEvent).filter_by(external_event_id="evt_sub").count() == 1
+    assert account.subscriptions[0].status == "past_due"


### PR DESCRIPTION
## Summary
- add optional Stripe Billing configuration for direct-billed deployments while leaving self-hosted/provider-billed installs credential-free
- add admin-gated Stripe Checkout and Customer Portal session endpoints
- add signed Stripe webhook ingestion that idempotently materializes local billing accounts, subscriptions, entitlements, and billing events

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_stripe_billing.py backend/app/tests/test_organization_foundations.py backend/app/tests/test_provider_billing_usage.py -q`
- `.venv/bin/python -m compileall -q backend/app/services/stripe_billing.py backend/app/api/api_v1/endpoints/billing.py backend/app/tests/test_stripe_billing.py`
- `git diff --check`
- `.venv/bin/python -m flake8 backend/app`
- `cd backend && ../.venv/bin/python -m pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=80` (1028 passed, 96.48% coverage)

Refs #240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added billing endpoints for checking payment setup, starting checkout, opening the customer portal, and processing payment webhooks.
  * Introduced optional payment-provider settings so billing can be enabled through configuration.

* **Bug Fixes**
  * Improved webhook validation and error handling for invalid signatures, missing setup, and duplicate events.
  * Made billing updates idempotent to prevent repeated webhook processing from creating duplicates.

* **Tests**
  * Added coverage for billing configuration, checkout flows, webhook handling, and subscription updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->