### PR TITLE
feat(provider): add customer provisioning lifecycle

### DIFF
--- a/backend/app/api/api_v1/endpoints/provider.py
+++ b/backend/app/api/api_v1/endpoints/provider.py
@@ -10,6 +10,7 @@ from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.services.organizations import (
     build_usage_export,
+    provision_provider_customer,
     update_external_subscription_state,
     usage_period_for_current_month,
 )
@@ -39,6 +40,28 @@ class ProviderSubscriptionStateUpdate(BaseModel):
 
 class ProviderSubscriptionStateResponse(BaseModel):
     """Provider subscription lifecycle update response."""
+
+    result: Dict[str, Any]
+
+
+class ProviderCustomerProvisionRequest(BaseModel):
+    """Provider request to provision or refresh a billed customer tenant."""
+
+    external_customer_id: str
+    external_subscription_id: str
+    organization_slug: str
+    organization_name: str
+    workspace_slug: Optional[str] = None
+    workspace_name: Optional[str] = None
+    provider_id: Optional[str] = None
+    plan_code: str = "starter"
+    external_product_code: Optional[str] = None
+    external_event_id: Optional[str] = None
+    payload_summary: Optional[str] = None
+
+
+class ProviderCustomerProvisionResponse(BaseModel):
+    """Provider customer provisioning response."""
 
     result: Dict[str, Any]
 
@@ -101,6 +124,36 @@ async def get_provider_account_billing_usage(
             organization_ids=organization_ids,
         )
     }
+
+
+@router.post("/customers", response_model=ProviderCustomerProvisionResponse)
+async def provision_provider_customer_endpoint(
+    payload: ProviderCustomerProvisionRequest,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+) -> ProviderCustomerProvisionResponse:
+    """Provision a provider-billed organization and default workspace."""
+    try:
+        result = provision_provider_customer(
+            db,
+            external_customer_id=payload.external_customer_id,
+            external_subscription_id=payload.external_subscription_id,
+            organization_slug=payload.organization_slug,
+            organization_name=payload.organization_name,
+            workspace_slug=payload.workspace_slug,
+            workspace_name=payload.workspace_name,
+            provider_id=payload.provider_id,
+            plan_code=payload.plan_code,
+            external_product_code=payload.external_product_code,
+            external_event_id=payload.external_event_id,
+            payload_summary=payload.payload_summary,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    return {"result": result}
 
 
 @router.post(

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -22,6 +22,7 @@ from app.models.organization import (
 from app.models.report import DMARCReport, ForensicReport, ReportRecord
 from app.models.user import User
 from app.models.workspace import Workspace
+from app.services.workspaces import normalize_workspace_slug
 
 DEFAULT_ORGANIZATION_SLUG = "default"
 DEFAULT_ORGANIZATION_NAME = "Default Organization"
@@ -78,6 +79,20 @@ def _sanitize_payload_summary(payload_summary: Optional[str]) -> Optional[str]:
         return None
     escaped = escape(normalized, quote=True)
     return escaped[:MAX_PROVIDER_PAYLOAD_SUMMARY_LENGTH]
+
+
+def _normalize_required_slug(value: str, *, field_name: str) -> str:
+    slug = normalize_workspace_slug(value)
+    if not slug:
+        raise ValueError(f"{field_name} is required")
+    return slug
+
+
+def _clean_required(value: str, *, field_name: str) -> str:
+    clean = (value or "").strip()
+    if not clean:
+        raise ValueError(f"{field_name} is required")
+    return clean
 
 
 def get_or_create_default_organization(db: Session, *, commit: bool = True) -> Organization:
@@ -445,6 +460,314 @@ def organization_summary(db: Session, organization: Organization) -> Dict[str, A
                 or 0
             ),
         },
+    }
+
+
+def _billing_event_to_dict(event: BillingEvent) -> Dict[str, Any]:
+    return {
+        "id": event.id,
+        "event_type": event.event_type,
+        "provider_id": event.provider_id,
+        "external_event_id": event.external_event_id,
+        "status": event.status,
+    }
+
+
+def _find_provider_event(
+    db: Session,
+    *,
+    provider_id: Optional[str],
+    external_event_id: Optional[str],
+) -> Optional[BillingEvent]:
+    if not external_event_id:
+        return None
+    event_query = db.query(BillingEvent).filter(
+        BillingEvent.event_type == "provider.customer_provisioned",
+        BillingEvent.external_event_id == external_event_id,
+    )
+    if provider_id:
+        event_query = event_query.filter(BillingEvent.provider_id == provider_id)
+    return event_query.order_by(BillingEvent.id.asc()).first()
+
+
+def _find_provider_account(
+    db: Session,
+    *,
+    provider_id: Optional[str],
+    external_customer_id: str,
+) -> Optional[BillingAccount]:
+    account_query = db.query(BillingAccount).filter(
+        BillingAccount.external_customer_id == external_customer_id
+    )
+    if provider_id:
+        account_query = account_query.filter(BillingAccount.provider_id == provider_id)
+    return account_query.order_by(BillingAccount.id.asc()).first()
+
+
+def _provider_replay_response(
+    db: Session,
+    *,
+    event: BillingEvent,
+    provider_id: Optional[str],
+    external_customer_id: str,
+) -> Dict[str, Any]:
+    organization = None
+    if event.organization_id:
+        organization = (
+            db.query(Organization).filter(Organization.id == event.organization_id).first()
+        )
+    if organization is None:
+        account = _find_provider_account(
+            db,
+            provider_id=provider_id,
+            external_customer_id=external_customer_id,
+        )
+        organization = account.organization if account else None
+    return {
+        "created": False,
+        "idempotent_replay": True,
+        "organization": organization_summary(db, organization) if organization else None,
+        "billing_event": _billing_event_to_dict(event),
+    }
+
+
+def _resolve_provider_organization_and_account(
+    db: Session,
+    *,
+    provider_id: Optional[str],
+    external_customer_id: str,
+    organization_slug: str,
+    organization_name: str,
+) -> tuple[Organization, BillingAccount, bool]:
+    account = _find_provider_account(
+        db,
+        provider_id=provider_id,
+        external_customer_id=external_customer_id,
+    )
+    if account:
+        organization = account.organization
+        created = False
+    else:
+        organization = db.query(Organization).filter(Organization.slug == organization_slug).first()
+        created = organization is None
+        if organization is None:
+            organization = Organization(slug=organization_slug, name=organization_name, active=True)
+            db.add(organization)
+            db.flush()
+        else:
+            conflicting_account = (
+                db.query(BillingAccount)
+                .filter(
+                    BillingAccount.organization_id == organization.id,
+                    BillingAccount.external_customer_id.isnot(None),
+                    BillingAccount.external_customer_id != external_customer_id,
+                )
+                .first()
+            )
+            if conflicting_account:
+                raise ValueError("organization_slug is already linked to another provider customer")
+        account = BillingAccount(
+            organization_id=organization.id,
+            billing_mode=BILLING_MODE_PROVIDER_RESALE,
+            status="active",
+            provider_id=provider_id,
+            external_customer_id=external_customer_id,
+            invoice_delivery_mode="provider_invoice",
+        )
+        db.add(account)
+        db.flush()
+        created = True
+
+    organization.name = organization_name
+    organization.active = True
+    account.status = "active"
+    account.billing_mode = BILLING_MODE_PROVIDER_RESALE
+    account.provider_id = provider_id
+    account.external_customer_id = external_customer_id
+    account.invoice_delivery_mode = "provider_invoice"
+    return organization, account, created
+
+
+def _resolve_provider_workspace(
+    db: Session,
+    *,
+    organization: Organization,
+    workspace_slug: str,
+    workspace_name: str,
+) -> tuple[Workspace, bool]:
+    workspace = db.query(Workspace).filter(Workspace.slug == workspace_slug).first()
+    if workspace and workspace.organization_id != organization.id:
+        raise ValueError("workspace_slug is already linked to another organization")
+    if workspace is None:
+        workspace = Workspace(
+            slug=workspace_slug,
+            name=workspace_name,
+            organization_id=organization.id,
+            active=True,
+        )
+        db.add(workspace)
+        return workspace, True
+    workspace.name = workspace_name
+    workspace.organization_id = organization.id
+    workspace.active = True
+    return workspace, False
+
+
+def _resolve_provider_plan(db: Session, *, plan_code: str) -> Plan:
+    plan = db.query(Plan).filter(Plan.code == plan_code, Plan.active.is_(True)).first()
+    if plan:
+        return plan
+    if plan_code == STARTER_PLAN_CODE:
+        return get_or_create_starter_plan(db, commit=False)
+    raise ValueError("plan_code does not exist or is inactive")
+
+
+def _resolve_provider_subscription(
+    db: Session,
+    *,
+    organization: Organization,
+    account: BillingAccount,
+    plan: Plan,
+    external_subscription_id: str,
+    plan_code: str = STARTER_PLAN_CODE,
+    external_product_code: Optional[str] = None,
+) -> tuple[Subscription, bool]:
+    subscription = (
+        db.query(Subscription)
+        .filter(Subscription.external_subscription_id == external_subscription_id)
+        .first()
+    )
+    if subscription and subscription.organization_id != organization.id:
+        raise ValueError("external_subscription_id is already linked to another organization")
+    if subscription is None:
+        subscription = Subscription(
+            organization_id=organization.id,
+            plan_id=plan.id,
+            billing_account_id=account.id,
+            billing_mode=BILLING_MODE_PROVIDER_RESALE,
+            status="active",
+            current_period_start=datetime.utcnow(),
+            external_subscription_id=external_subscription_id,
+            external_product_code=(external_product_code or plan_code).strip() or plan_code,
+        )
+        db.add(subscription)
+        return subscription, True
+    subscription.plan_id = plan.id
+    subscription.billing_account_id = account.id
+    subscription.billing_mode = BILLING_MODE_PROVIDER_RESALE
+    subscription.status = "active"
+    subscription.external_product_code = (
+        external_product_code or subscription.external_product_code or plan_code
+    ).strip() or plan_code
+    subscription.canceled_at = None
+    return subscription, False
+
+
+def provision_provider_customer(
+    db: Session,
+    *,
+    external_customer_id: str,
+    external_subscription_id: str,
+    organization_slug: str,
+    organization_name: str,
+    workspace_slug: Optional[str] = None,
+    workspace_name: Optional[str] = None,
+    provider_id: Optional[str] = None,
+    plan_code: str = STARTER_PLAN_CODE,
+    external_product_code: Optional[str] = None,
+    external_event_id: Optional[str] = None,
+    payload_summary: Optional[str] = None,
+    commit: bool = True,
+) -> Dict[str, Any]:
+    """Provision or update a provider-billed customer tenant idempotently."""
+    provider = (provider_id or "").strip() or None
+    external_customer = _clean_required(
+        external_customer_id,
+        field_name="external_customer_id",
+    )
+    external_subscription = _clean_required(
+        external_subscription_id,
+        field_name="external_subscription_id",
+    )
+    org_slug = _normalize_required_slug(organization_slug, field_name="organization_slug")
+    org_name = _clean_required(organization_name, field_name="organization_name")
+    ws_slug = _normalize_required_slug(
+        workspace_slug or f"{org_slug}-workspace",
+        field_name="workspace_slug",
+    )
+    ws_name = (workspace_name or f"{org_name} Workspace").strip()
+    plan_key = (plan_code or STARTER_PLAN_CODE).strip()
+
+    replay_event = _find_provider_event(
+        db,
+        provider_id=provider,
+        external_event_id=external_event_id,
+    )
+    if replay_event:
+        return _provider_replay_response(
+            db,
+            event=replay_event,
+            provider_id=provider,
+            external_customer_id=external_customer,
+        )
+
+    organization, account, created_account = _resolve_provider_organization_and_account(
+        db,
+        provider_id=provider,
+        external_customer_id=external_customer,
+        organization_slug=org_slug,
+        organization_name=org_name,
+    )
+    _, created_workspace = _resolve_provider_workspace(
+        db,
+        organization=organization,
+        workspace_slug=ws_slug,
+        workspace_name=ws_name,
+    )
+    db.flush()
+
+    plan = _resolve_provider_plan(db, plan_code=plan_key)
+    subscription, created_subscription = _resolve_provider_subscription(
+        db,
+        organization=organization,
+        account=account,
+        plan=plan,
+        external_subscription_id=external_subscription,
+        plan_code=plan_key,
+        external_product_code=external_product_code,
+    )
+    db.flush()
+
+    ensure_entitlements(
+        db,
+        organization,
+        subscription,
+        STARTER_PLAN_ENTITLEMENTS,
+        commit=False,
+    )
+    event = BillingEvent(
+        organization_id=organization.id,
+        subscription_id=subscription.id,
+        billing_mode=BILLING_MODE_PROVIDER_RESALE,
+        event_type="provider.customer_provisioned",
+        provider_id=provider,
+        external_event_id=external_event_id,
+        status="applied",
+        payload_summary=_sanitize_payload_summary(payload_summary),
+    )
+    db.add(event)
+    if commit:
+        db.commit()
+        db.refresh(organization)
+        db.refresh(event)
+    else:
+        db.flush()
+
+    return {
+        "created": created_account or created_workspace or created_subscription,
+        "idempotent_replay": False,
+        "organization": organization_summary(db, organization),
+        "billing_event": _billing_event_to_dict(event),
     }
 
 

--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -8,7 +8,14 @@ from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
-from app.models.organization import BillingAccount, BillingEvent, Organization, Plan, Subscription
+from app.models.organization import (
+    BillingAccount,
+    BillingEvent,
+    Entitlement,
+    Organization,
+    Plan,
+    Subscription,
+)
 from app.models.report import DMARCReport, ForensicReport, ReportRecord
 from app.models.user import User
 from app.models.workspace import Workspace
@@ -18,6 +25,7 @@ from app.services.organizations import (
     MAX_PROVIDER_PAYLOAD_SUMMARY_LENGTH,
     bootstrap_default_commercial_foundation,
     build_usage_export,
+    provision_provider_customer,
     update_external_subscription_state,
 )
 from app.services.workspace_access import ROLE_AUDITOR, ROLE_WORKSPACE_OWNER
@@ -83,6 +91,180 @@ def _add_provider_customer(
     db_session.add_all([workspace, account, subscription])
     db_session.flush()
     return organization, workspace, subscription
+
+
+def test_provider_customer_provisioning_creates_provider_billed_tenant(
+    db_session: Session,
+):
+    result = provision_provider_customer(
+        db_session,
+        provider_id="isp-demo",
+        external_customer_id="cust-new-123",
+        external_subscription_id="sub-new-123",
+        external_event_id="evt-provision-1",
+        organization_slug="New Customer LLC",
+        organization_name="New Customer LLC",
+        workspace_slug="New Customer Primary",
+        workspace_name="New Customer Primary",
+        payload_summary="created from hosting control panel",
+    )
+
+    organization = (
+        db_session.query(Organization).filter(Organization.slug == "new-customer-llc").one()
+    )
+    workspace = db_session.query(Workspace).filter(Workspace.slug == "new-customer-primary").one()
+    account = (
+        db_session.query(BillingAccount)
+        .filter(BillingAccount.external_customer_id == "cust-new-123")
+        .one()
+    )
+    subscription = (
+        db_session.query(Subscription)
+        .filter(Subscription.external_subscription_id == "sub-new-123")
+        .one()
+    )
+    entitlements = {
+        entitlement.key: entitlement.value
+        for entitlement in db_session.query(Entitlement)
+        .filter(Entitlement.organization_id == organization.id)
+        .all()
+    }
+    event = db_session.query(BillingEvent).filter_by(external_event_id="evt-provision-1").one()
+
+    assert result["created"] is True
+    assert result["organization"]["slug"] == "new-customer-llc"
+    assert organization.active is True
+    assert workspace.organization_id == organization.id
+    assert account.billing_mode == BILLING_MODE_PROVIDER_RESALE
+    assert account.provider_id == "isp-demo"
+    assert account.invoice_delivery_mode == "provider_invoice"
+    assert subscription.billing_mode == BILLING_MODE_PROVIDER_RESALE
+    assert subscription.stripe_subscription_id is None
+    assert entitlements["forensic_reports"] == "true"
+    assert entitlements["retention_days"] == "90"
+    assert event.event_type == "provider.customer_provisioned"
+    assert event.payload_summary == "created from hosting control panel"
+
+    usage = build_usage_export(
+        db_session,
+        period="2026-06",
+        external_customer_id="cust-new-123",
+    )
+    assert usage["organizations"][0]["organization"]["slug"] == "new-customer-llc"
+
+
+def test_provider_customer_provisioning_replays_provider_event_without_duplicates(
+    db_session: Session,
+):
+    first = provision_provider_customer(
+        db_session,
+        provider_id="isp-demo",
+        external_customer_id="cust-replay",
+        external_subscription_id="sub-replay",
+        external_event_id="evt-replay",
+        organization_slug="Replay Customer",
+        organization_name="Replay Customer",
+    )
+
+    replay = provision_provider_customer(
+        db_session,
+        provider_id="isp-demo",
+        external_customer_id="cust-replay",
+        external_subscription_id="sub-replay",
+        external_event_id="evt-replay",
+        organization_slug="Replay Customer Renamed",
+        organization_name="Replay Customer Renamed",
+    )
+
+    assert first["idempotent_replay"] is False
+    assert replay["idempotent_replay"] is True
+    assert replay["billing_event"]["external_event_id"] == "evt-replay"
+    assert (
+        db_session.query(Organization).filter(Organization.slug.like("replay-customer%")).count()
+        == 1
+    )
+    assert (
+        db_session.query(BillingEvent)
+        .filter(BillingEvent.external_event_id == "evt-replay")
+        .count()
+        == 1
+    )
+
+
+def test_provider_customer_provisioning_rejects_conflicting_identifiers(
+    db_session: Session,
+):
+    provision_provider_customer(
+        db_session,
+        provider_id="isp-demo",
+        external_customer_id="cust-conflict",
+        external_subscription_id="sub-conflict",
+        organization_slug="conflict-customer",
+        organization_name="Conflict Customer",
+        workspace_slug="conflict-workspace",
+    )
+
+    with pytest.raises(ValueError, match="organization_slug"):
+        provision_provider_customer(
+            db_session,
+            provider_id="isp-demo",
+            external_customer_id="cust-other",
+            external_subscription_id="sub-other",
+            organization_slug="conflict-customer",
+            organization_name="Conflict Customer",
+        )
+
+    with pytest.raises(ValueError, match="external_subscription_id"):
+        provision_provider_customer(
+            db_session,
+            provider_id="isp-demo",
+            external_customer_id="cust-third",
+            external_subscription_id="sub-conflict",
+            organization_slug="third-customer",
+            organization_name="Third Customer",
+        )
+
+
+def test_provider_customer_provisioning_endpoint_creates_customer(
+    test_app,
+    db_session: Session,
+):
+    user = User(email="provider-provisioner@example.com", is_active=True, is_verified=True)
+    db_session.add(user)
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, user) as client:
+        response = client.post(
+            "/api/v1/provider/customers",
+            json={
+                "provider_id": "isp-demo",
+                "external_customer_id": "cust-endpoint",
+                "external_subscription_id": "sub-endpoint",
+                "external_event_id": "evt-endpoint",
+                "organization_slug": "Endpoint Customer",
+                "organization_name": "Endpoint Customer",
+                "workspace_slug": "Endpoint Customer Workspace",
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()["result"]
+        assert body["organization"]["billing_accounts"][0]["external_customer_id"] == (
+            "cust-endpoint"
+        )
+
+        replay = client.post(
+            "/api/v1/provider/customers",
+            json={
+                "provider_id": "isp-demo",
+                "external_customer_id": "cust-endpoint",
+                "external_subscription_id": "sub-endpoint",
+                "external_event_id": "evt-endpoint",
+                "organization_slug": "Endpoint Customer",
+                "organization_name": "Endpoint Customer",
+            },
+        )
+        assert replay.status_code == 200
+        assert replay.json()["result"]["idempotent_replay"] is True
 
 
 def test_provider_usage_export_computes_monthly_metrics(db_session: Session):

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,3 +35,6 @@ Opt-in AI summaries and read-only MCP automation are covered in [AI and MCP Auto
 
 The current product direction across self-hosted, hosted SaaS, ISP/OEM,
 billing, and multi-tenant work is captured in the [Product Roadmap](development/roadmap.md).
+
+ISP, MSP, and hosting-control-panel lifecycle integrations are documented in
+[Provider Integrations](reference/provider-integrations.md).

--- a/docs/reference/provider-integrations.md
+++ b/docs/reference/provider-integrations.md
@@ -1,0 +1,80 @@
+# Provider Integrations
+
+DMARQ can be operated as a provider-billed service for ISP, MSP, and hosting
+control-panel environments. In this mode, the provider owns the commercial
+relationship and DMARQ stores external customer and subscription identifiers
+instead of requiring Stripe customer records for every end customer.
+
+Provider endpoints live under `/api/v1/provider` and require administrator
+access. Provider-scoped machine tokens are tracked separately on the roadmap;
+until then, expose these endpoints only through trusted automation or an
+internal integration layer.
+
+## Provision A Customer
+
+```text
+POST /api/v1/provider/customers
+```
+
+Request:
+
+```json
+{
+  "provider_id": "isp-demo",
+  "external_customer_id": "cust_123",
+  "external_subscription_id": "sub_123",
+  "external_event_id": "evt_123",
+  "organization_slug": "customer-one",
+  "organization_name": "Customer One",
+  "workspace_slug": "customer-one-primary",
+  "workspace_name": "Customer One Primary",
+  "plan_code": "starter"
+}
+```
+
+The endpoint creates or refreshes:
+
+- an active organization
+- a default workspace for the customer
+- a provider-resale billing account with `invoice_delivery_mode=provider_invoice`
+- a provider-resale subscription with the external subscription id
+- starter entitlements
+- an auditable `provider.customer_provisioned` billing event
+
+`external_event_id` makes provisioning safe to retry. If the same provider event
+is received again, DMARQ returns the existing customer summary with
+`idempotent_replay=true` and does not create duplicate tenant records.
+
+## Update Subscription State
+
+```text
+POST /api/v1/provider/subscriptions/{external_subscription_id}/state
+```
+
+Request:
+
+```json
+{
+  "status": "suspended",
+  "provider_id": "isp-demo",
+  "external_event_id": "evt_456",
+  "payload_summary": "provider reported overdue invoice"
+}
+```
+
+Supported states are `trialing`, `active`, `past_due_provider_reported`,
+`suspended`, `canceled`, and `terminated`. Each update records a billing event
+without storing the raw provider payload.
+
+## Monthly Usage Export
+
+```text
+GET /api/v1/provider/billing/usage?period=2026-06
+GET /api/v1/provider/billing/accounts/{external_customer_id}/usage?period=2026-06
+```
+
+Usage exports are deterministic for a billing period and include workspace,
+domain, aggregate report, message volume, forensic report, and active user
+metrics. The payload is intended for provider-side monthly invoicing, including
+WHMCS-style billing runs or custom ISP account-management systems.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
     - Configuration: deployment/configuration.md
   - Technical Reference:
     - API Reference: reference/api.md
+    - Provider Integrations: reference/provider-integrations.md
     - SIEM Integrations: reference/siem-integrations.md
     - Ticketing and Chatops: reference/ticketing-chatops-integrations.md
     - Microsoft 365 Graph Connector: reference/microsoft365-graph-connector.md


### PR DESCRIPTION
## Summary
- add POST /api/v1/provider/customers for provider-billed customer provisioning
- create/refresh organization, workspace, provider billing account, subscription, starter entitlements, and audit event idempotently
- document provider provisioning, subscription state updates, and monthly usage exports

Refs #241

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_provider_billing_usage.py -q
- .venv/bin/python -m pytest backend/app/tests -q
- .venv/bin/python -m flake8 backend/app/services/organizations.py backend/app/api/api_v1/endpoints/provider.py backend/app/tests/test_provider_billing_usage.py
- .venv/bin/python -m black --check backend/app/services/organizations.py backend/app/api/api_v1/endpoints/provider.py backend/app/tests/test_provider_billing_usage.py
- .venv/bin/python -m compileall backend/app/services/organizations.py backend/app/api/api_v1/endpoints/provider.py backend/app/tests/test_provider_billing_usage.py
- git diff --check

## Notes
- MkDocs build was not run locally because mkdocs is not installed in the repo venv.
- Provider-scoped machine tokens remain open under #241; this endpoint currently requires administrator access.