### PR TITLE
fix(provider): scope customer provisioning reviews

### DIFF
--- a/backend/app/api/api_v1/endpoints/provider.py
+++ b/backend/app/api/api_v1/endpoints/provider.py
@@ -47,13 +47,13 @@ class ProviderSubscriptionStateResponse(BaseModel):
 class ProviderCustomerProvisionRequest(BaseModel):
     """Provider request to provision or refresh a billed customer tenant."""
 
+    provider_id: str
     external_customer_id: str
     external_subscription_id: str
     organization_slug: str
     organization_name: str
     workspace_slug: Optional[str] = None
     workspace_name: Optional[str] = None
-    provider_id: Optional[str] = None
     plan_code: str = "starter"
     external_product_code: Optional[str] = None
     external_event_id: Optional[str] = None

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -476,39 +476,45 @@ def _billing_event_to_dict(event: BillingEvent) -> Dict[str, Any]:
 def _find_provider_event(
     db: Session,
     *,
-    provider_id: Optional[str],
+    provider_id: str,
     external_event_id: Optional[str],
 ) -> Optional[BillingEvent]:
     if not external_event_id:
         return None
-    event_query = db.query(BillingEvent).filter(
-        BillingEvent.event_type == "provider.customer_provisioned",
-        BillingEvent.external_event_id == external_event_id,
+    return (
+        db.query(BillingEvent)
+        .filter(
+            BillingEvent.event_type == "provider.customer_provisioned",
+            BillingEvent.external_event_id == external_event_id,
+            BillingEvent.provider_id == provider_id,
+        )
+        .order_by(BillingEvent.id.asc())
+        .first()
     )
-    if provider_id:
-        event_query = event_query.filter(BillingEvent.provider_id == provider_id)
-    return event_query.order_by(BillingEvent.id.asc()).first()
 
 
 def _find_provider_account(
     db: Session,
     *,
-    provider_id: Optional[str],
+    provider_id: str,
     external_customer_id: str,
 ) -> Optional[BillingAccount]:
-    account_query = db.query(BillingAccount).filter(
-        BillingAccount.external_customer_id == external_customer_id
+    return (
+        db.query(BillingAccount)
+        .filter(
+            BillingAccount.external_customer_id == external_customer_id,
+            BillingAccount.provider_id == provider_id,
+        )
+        .order_by(BillingAccount.id.asc())
+        .first()
     )
-    if provider_id:
-        account_query = account_query.filter(BillingAccount.provider_id == provider_id)
-    return account_query.order_by(BillingAccount.id.asc()).first()
 
 
 def _provider_replay_response(
     db: Session,
     *,
     event: BillingEvent,
-    provider_id: Optional[str],
+    provider_id: str,
     external_customer_id: str,
 ) -> Dict[str, Any]:
     organization = None
@@ -534,7 +540,7 @@ def _provider_replay_response(
 def _resolve_provider_organization_and_account(
     db: Session,
     *,
-    provider_id: Optional[str],
+    provider_id: str,
     external_customer_id: str,
     organization_slug: str,
     organization_name: str,
@@ -576,7 +582,6 @@ def _resolve_provider_organization_and_account(
         )
         db.add(account)
         db.flush()
-        created = True
 
     organization.name = organization_name
     organization.active = True
@@ -672,7 +677,7 @@ def provision_provider_customer(
     organization_name: str,
     workspace_slug: Optional[str] = None,
     workspace_name: Optional[str] = None,
-    provider_id: Optional[str] = None,
+    provider_id: str,
     plan_code: str = STARTER_PLAN_CODE,
     external_product_code: Optional[str] = None,
     external_event_id: Optional[str] = None,
@@ -680,7 +685,7 @@ def provision_provider_customer(
     commit: bool = True,
 ) -> Dict[str, Any]:
     """Provision or update a provider-billed customer tenant idempotently."""
-    provider = (provider_id or "").strip() or None
+    provider = _clean_required(provider_id, field_name="provider_id")
     external_customer = _clean_required(
         external_customer_id,
         field_name="external_customer_id",
@@ -695,8 +700,13 @@ def provision_provider_customer(
         workspace_slug or f"{org_slug}-workspace",
         field_name="workspace_slug",
     )
-    ws_name = (workspace_name or f"{org_name} Workspace").strip()
+    ws_name = _clean_required(
+        workspace_name if workspace_name is not None else f"{org_name} Workspace",
+        field_name="workspace_name",
+    )
     plan_key = (plan_code or STARTER_PLAN_CODE).strip()
+    if plan_key != STARTER_PLAN_CODE:
+        raise ValueError("plan_code must be starter until provider entitlements are configurable")
 
     replay_event = _find_provider_event(
         db,

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -552,10 +552,9 @@ def _resolve_provider_organization_and_account(
     )
     if account:
         organization = account.organization
-        created = False
+        account_created = False
     else:
         organization = db.query(Organization).filter(Organization.slug == organization_slug).first()
-        created = organization is None
         if organization is None:
             organization = Organization(slug=organization_slug, name=organization_name, active=True)
             db.add(organization)
@@ -582,6 +581,7 @@ def _resolve_provider_organization_and_account(
         )
         db.add(account)
         db.flush()
+        account_created = True
 
     organization.name = organization_name
     organization.active = True
@@ -590,7 +590,7 @@ def _resolve_provider_organization_and_account(
     account.provider_id = provider_id
     account.external_customer_id = external_customer_id
     account.invoice_delivery_mode = "provider_invoice"
-    return organization, account, created
+    return organization, account, account_created
 
 
 def _resolve_provider_workspace(

--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -225,6 +225,82 @@ def test_provider_customer_provisioning_rejects_conflicting_identifiers(
         )
 
 
+def test_provider_customer_provisioning_requires_provider_scope(
+    db_session: Session,
+):
+    with pytest.raises(ValueError, match="provider_id"):
+        provision_provider_customer(
+            db_session,
+            provider_id=" ",
+            external_customer_id="cust-no-provider",
+            external_subscription_id="sub-no-provider",
+            organization_slug="No Provider Customer",
+            organization_name="No Provider Customer",
+        )
+
+
+def test_provider_customer_provisioning_rejects_blank_workspace_name(
+    db_session: Session,
+):
+    with pytest.raises(ValueError, match="workspace_name"):
+        provision_provider_customer(
+            db_session,
+            provider_id="isp-demo",
+            external_customer_id="cust-blank-workspace",
+            external_subscription_id="sub-blank-workspace",
+            organization_slug="Blank Workspace Customer",
+            organization_name="Blank Workspace Customer",
+            workspace_name=" ",
+        )
+
+
+def test_provider_customer_provisioning_rejects_non_starter_plan(
+    db_session: Session,
+):
+    with pytest.raises(ValueError, match="plan_code must be starter"):
+        provision_provider_customer(
+            db_session,
+            provider_id="isp-demo",
+            external_customer_id="cust-enterprise-plan",
+            external_subscription_id="sub-enterprise-plan",
+            organization_slug="Enterprise Plan Customer",
+            organization_name="Enterprise Plan Customer",
+            plan_code="enterprise",
+        )
+
+
+def test_provider_customer_provisioning_scopes_replays_by_provider(
+    db_session: Session,
+):
+    first = provision_provider_customer(
+        db_session,
+        provider_id="isp-demo",
+        external_customer_id="cust-provider-scoped",
+        external_subscription_id="sub-provider-scoped-a",
+        external_event_id="evt-provider-scoped",
+        organization_slug="Provider Scoped A",
+        organization_name="Provider Scoped A",
+    )
+    second = provision_provider_customer(
+        db_session,
+        provider_id="msp-demo",
+        external_customer_id="cust-provider-scoped",
+        external_subscription_id="sub-provider-scoped-b",
+        external_event_id="evt-provider-scoped",
+        organization_slug="Provider Scoped B",
+        organization_name="Provider Scoped B",
+    )
+
+    assert first["idempotent_replay"] is False
+    assert second["idempotent_replay"] is False
+    assert (
+        db_session.query(BillingAccount)
+        .filter(BillingAccount.external_customer_id == "cust-provider-scoped")
+        .count()
+        == 2
+    )
+
+
 def test_provider_customer_provisioning_endpoint_creates_customer(
     test_app,
     db_session: Session,
@@ -265,6 +341,27 @@ def test_provider_customer_provisioning_endpoint_creates_customer(
         )
         assert replay.status_code == 200
         assert replay.json()["result"]["idempotent_replay"] is True
+
+
+def test_provider_customer_provisioning_endpoint_requires_provider_id(
+    test_app,
+    db_session: Session,
+):
+    user = User(email="provider-requires-scope@example.com", is_active=True, is_verified=True)
+    db_session.add(user)
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, user) as client:
+        response = client.post(
+            "/api/v1/provider/customers",
+            json={
+                "external_customer_id": "cust-missing-provider",
+                "external_subscription_id": "sub-missing-provider",
+                "organization_slug": "Missing Provider Customer",
+                "organization_name": "Missing Provider Customer",
+            },
+        )
+        assert response.status_code == 422
 
 
 def test_provider_usage_export_computes_monthly_metrics(db_session: Session):

--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -239,6 +239,37 @@ def test_provider_customer_provisioning_requires_provider_scope(
         )
 
 
+def test_provider_customer_provisioning_reports_created_for_existing_organization_account(
+    db_session: Session,
+):
+    organization = Organization(
+        slug="existing-provider-customer",
+        name="Existing Provider Customer",
+        active=True,
+    )
+    db_session.add(organization)
+    db_session.flush()
+
+    result = provision_provider_customer(
+        db_session,
+        provider_id="isp-demo",
+        external_customer_id="cust-existing-org",
+        external_subscription_id="sub-existing-org",
+        organization_slug="existing-provider-customer",
+        organization_name="Existing Provider Customer",
+    )
+
+    assert result["created"] is True
+    assert (
+        db_session.query(BillingAccount)
+        .filter(
+            BillingAccount.organization_id == organization.id,
+            BillingAccount.external_customer_id == "cust-existing-org",
+        )
+        .one()
+    )
+
+
 def test_provider_customer_provisioning_rejects_blank_workspace_name(
     db_session: Session,
 ):


### PR DESCRIPTION
## Summary
- require provider_id for provider customer provisioning at API and service boundaries
- keep provider replay/account lookups provider-scoped and reject blank workspace names
- reject non-starter provider plan codes until entitlement mapping exists
- add regression coverage for provider scoping and validation cases

## Validation
- .venv/bin/python -m black --check backend/app/services/organizations.py backend/app/api/api_v1/endpoints/provider.py backend/app/tests/test_provider_billing_usage.py
- .venv/bin/python -m pytest backend/app/tests/test_provider_billing_usage.py -q
- .venv/bin/python -m flake8 backend/app/services/organizations.py backend/app/api/api_v1/endpoints/provider.py backend/app/tests/test_provider_billing_usage.py
- .venv/bin/python -m compileall backend/app/services/organizations.py backend/app/api/api_v1/endpoints/provider.py backend/app/tests/test_provider_billing_usage.py
- git diff --check

Follow-up for review findings on #281 after it was merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider customer provisioning now requires a provider ID and returns an error when it’s missing.
  * Improved validation for blank workspace names and unsupported plans.
  * Replay handling is now correctly scoped so the same customer can be handled separately per provider.

* **New Features**
  * Provider customer provisioning now enforces stricter request checks to reduce misconfigured account setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->