### PR TITLE
feat(provider): add scoped machine tokens

### DIFF
--- a/backend/app/api/api_v1/endpoints/provider.py
+++ b/backend/app/api/api_v1/endpoints/provider.py
@@ -2,12 +2,21 @@
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
-from app.core.security import require_admin_auth
+from app.core.security import require_admin_auth, require_provider_auth
+from app.models.api_token import APIToken
+from app.services.api_tokens import (
+    PROVIDER_READ_SCOPE,
+    PROVIDER_SCOPES,
+    PROVIDER_WRITE_SCOPE,
+    create_api_token,
+    revoke_api_token,
+    token_to_dict,
+)
 from app.services.organizations import (
     build_usage_export,
     provision_provider_customer,
@@ -21,6 +30,8 @@ from app.services.workspace_access import (
 )
 
 router = APIRouter()
+require_provider_read_auth = require_provider_auth(PROVIDER_READ_SCOPE)
+require_provider_write_auth = require_provider_auth(PROVIDER_WRITE_SCOPE)
 
 
 class ProviderUsageResponse(BaseModel):
@@ -42,6 +53,43 @@ class ProviderSubscriptionStateResponse(BaseModel):
     """Provider subscription lifecycle update response."""
 
     result: Dict[str, Any]
+
+
+class ProviderAPITokenCreateRequest(BaseModel):
+    """Request body for creating a provider-scoped machine token."""
+
+    name: str = Field(..., min_length=1, max_length=120)
+    scopes: List[str] = Field(default_factory=lambda: sorted(PROVIDER_SCOPES))
+
+
+class ProviderAPITokenResponse(BaseModel):
+    """API-safe provider token metadata."""
+
+    id: int
+    workspace_id: Optional[int] = None
+    name: str
+    key_prefix: str
+    scopes: List[str]
+    active: bool
+    created_at: str
+    last_used_at: Optional[str] = None
+    last_used_ip: Optional[str] = None
+    usage_count: int
+    revoked_at: Optional[str] = None
+
+
+class ProviderAPITokenCreateResponse(BaseModel):
+    """New provider token response. The secret is returned once."""
+
+    token: str
+    metadata: ProviderAPITokenResponse
+
+
+class ProviderAPITokenListResponse(BaseModel):
+    """List of provider API token metadata rows."""
+
+    tokens: List[ProviderAPITokenResponse]
+    available_scopes: List[str]
 
 
 class ProviderCustomerProvisionRequest(BaseModel):
@@ -87,17 +135,101 @@ def _usage_or_400(
         ) from exc
 
 
-@router.get("/billing/usage", response_model=ProviderUsageResponse)
-async def get_provider_billing_usage(
-    period: Optional[str] = Query(
-        None,
-        description="Billing period in YYYY-MM format; defaults to the current month.",
-    ),
+def _provider_organization_ids(
+    db: Session,
+    auth: Dict[str, Any],
+    permission: str,
+) -> Optional[List[int]]:
+    """Return workspace-derived organization scope unless a provider token is used."""
+    if auth.get("auth_type") == "provider_api_token":
+        return None
+    return organization_ids_for_permission(db, auth, permission)
+
+
+@router.get("/api-tokens", response_model=ProviderAPITokenListResponse)
+async def list_provider_api_tokens(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
+) -> ProviderAPITokenListResponse:
+    """List provider machine-token metadata without exposing raw secrets."""
+    rows = (
+        db.query(APIToken)
+        .filter(
+            APIToken.workspace_id.is_(None),
+            APIToken.scopes.contains("provider:"),
+        )
+        .order_by(APIToken.created_at.desc(), APIToken.id.desc())
+        .all()
+    )
+    return ProviderAPITokenListResponse(
+        tokens=[ProviderAPITokenResponse(**token_to_dict(row)) for row in rows],
+        available_scopes=sorted(PROVIDER_SCOPES),
+    )
+
+
+@router.post(
+    "/api-tokens",
+    response_model=ProviderAPITokenCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_provider_api_token(
+    payload: ProviderAPITokenCreateRequest,
+    _request: Request,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+) -> ProviderAPITokenCreateResponse:
+    """Create a global provider-scoped machine token."""
+    try:
+        created = create_api_token(
+            db,
+            name=payload.name,
+            scopes=payload.scopes,
+            allowed_scopes=PROVIDER_SCOPES,
+            global_token=True,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    return ProviderAPITokenCreateResponse(
+        token=created.secret,
+        metadata=ProviderAPITokenResponse(**token_to_dict(created.token)),
+    )
+
+
+@router.delete("/api-tokens/{token_id}", status_code=status.HTTP_200_OK)
+async def revoke_provider_api_token(
+    token_id: int,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Revoke a provider-scoped machine token."""
+    token = (
+        db.query(APIToken)
+        .filter(
+            APIToken.id == token_id,
+            APIToken.workspace_id.is_(None),
+            APIToken.scopes.contains("provider:"),
+        )
+        .first()
+    )
+    if token is None or not revoke_api_token(db, token_id, workspace_id=None):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Provider API token not found",
+        )
+    return {"revoked": True}
+
+
+@router.get("/billing/usage", response_model=ProviderUsageResponse)
+async def get_provider_billing_usage(
+    period: Optional[str] = None,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_provider_read_auth),
 ) -> ProviderUsageResponse:
     """Return idempotent monthly usage metrics for provider billing systems."""
-    organization_ids = organization_ids_for_permission(db, _auth, PERMISSION_AUDIT_READ)
+    organization_ids = _provider_organization_ids(db, _auth, PERMISSION_AUDIT_READ)
     return {"usage": _usage_or_400(db, period=period, organization_ids=organization_ids)}
 
 
@@ -107,15 +239,12 @@ async def get_provider_billing_usage(
 )
 async def get_provider_account_billing_usage(
     external_customer_id: str,
-    period: Optional[str] = Query(
-        None,
-        description="Billing period in YYYY-MM format; defaults to the current month.",
-    ),
+    period: Optional[str] = None,
     db: Session = Depends(get_db),
-    _auth: dict = Depends(require_admin_auth),
+    _auth: dict = Depends(require_provider_read_auth),
 ) -> ProviderUsageResponse:
     """Return usage metrics for one provider-billed external customer."""
-    organization_ids = organization_ids_for_permission(db, _auth, PERMISSION_AUDIT_READ)
+    organization_ids = _provider_organization_ids(db, _auth, PERMISSION_AUDIT_READ)
     return {
         "usage": _usage_or_400(
             db,
@@ -130,7 +259,7 @@ async def get_provider_account_billing_usage(
 async def provision_provider_customer_endpoint(
     payload: ProviderCustomerProvisionRequest,
     db: Session = Depends(get_db),
-    _auth: dict = Depends(require_admin_auth),
+    _auth: dict = Depends(require_provider_write_auth),
 ) -> ProviderCustomerProvisionResponse:
     """Provision a provider-billed organization and default workspace."""
     try:
@@ -164,10 +293,10 @@ async def update_provider_subscription_state(
     external_subscription_id: str,
     payload: ProviderSubscriptionStateUpdate,
     db: Session = Depends(get_db),
-    _auth: dict = Depends(require_admin_auth),
+    _auth: dict = Depends(require_provider_write_auth),
 ) -> ProviderSubscriptionStateResponse:
     """Apply a provider-reported subscription lifecycle state."""
-    organization_ids = organization_ids_for_permission(db, _auth, PERMISSION_WORKSPACE_ADMIN)
+    organization_ids = _provider_organization_ids(db, _auth, PERMISSION_WORKSPACE_ADMIN)
     try:
         result = update_external_subscription_state(
             db,

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -267,6 +267,63 @@ def require_api_token_scope(required_scope: str) -> Callable:
     return _require_api_token_scope
 
 
+def _api_token_context_for_scope(
+    db: Session,
+    *,
+    request: Request,
+    api_key: Optional[str],
+    required_scope: str,
+    auth_type: str,
+) -> Optional[dict]:
+    """Return a scoped persistent API-token auth context when the key matches."""
+    if not api_key:
+        return None
+
+    token = find_api_token(db, api_key)
+    if token is None:
+        return None
+
+    scopes = parse_scopes(token.scopes)
+    if required_scope not in scopes:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"API token requires scope: {required_scope}",
+        )
+
+    client_host = request.client.host if request.client else None
+    record_api_token_use(db, token, ip_address=client_host)
+    return {
+        "auth_type": auth_type,
+        "token_id": token.id,
+        "workspace_id": token.workspace_id,
+        "token_name": token.name,
+        "scopes": sorted(scopes),
+    }
+
+
+def require_provider_auth(required_scope: str) -> Callable:
+    """Build a dependency accepting provider API tokens or administrator auth."""
+
+    async def _require_provider_auth(
+        request: Request,
+        db: Session = Depends(get_db),
+        api_key: Optional[str] = Security(api_key_header),
+        bearer: Optional[HTTPAuthorizationCredentials] = Security(security_bearer),
+    ) -> dict:
+        token_context = _api_token_context_for_scope(
+            db,
+            request=request,
+            api_key=api_key,
+            required_scope=required_scope,
+            auth_type="provider_api_token",
+        )
+        if token_context is not None:
+            return token_context
+        return await require_admin_auth(request, api_key=api_key, bearer=bearer)
+
+    return _require_provider_auth
+
+
 def create_access_token(subject: Union[str, Any], expires_delta: timedelta = None) -> str:
     """
     Create a JWT access token for authentication

--- a/backend/app/services/api_tokens.py
+++ b/backend/app/services/api_tokens.py
@@ -17,6 +17,8 @@ READ_REPORTS_SCOPE = "reports:read"
 READ_POSTURE_SCOPE = "posture:read"
 READ_TLS_SCOPE = "tls-reports:read"
 MCP_READ_SCOPE = "mcp:read"
+PROVIDER_READ_SCOPE = "provider:read"
+PROVIDER_WRITE_SCOPE = "provider:write"
 
 PUBLIC_READ_SCOPES = {
     READ_REPORTS_SCOPE,
@@ -24,6 +26,11 @@ PUBLIC_READ_SCOPES = {
     READ_TLS_SCOPE,
     MCP_READ_SCOPE,
 }
+PROVIDER_SCOPES = {
+    PROVIDER_READ_SCOPE,
+    PROVIDER_WRITE_SCOPE,
+}
+ALL_API_TOKEN_SCOPES = PUBLIC_READ_SCOPES | PROVIDER_SCOPES
 
 
 @dataclass
@@ -34,10 +41,15 @@ class CreatedAPIToken:
     secret: str
 
 
-def normalize_scopes(scopes: Iterable[str]) -> List[str]:
+def normalize_scopes(
+    scopes: Iterable[str],
+    *,
+    allowed_scopes: Optional[Set[str]] = None,
+) -> List[str]:
     """Normalize and validate requested API token scopes."""
+    allowed = allowed_scopes or PUBLIC_READ_SCOPES
     normalized = sorted({scope.strip().lower() for scope in scopes if scope and scope.strip()})
-    invalid = [scope for scope in normalized if scope not in PUBLIC_READ_SCOPES]
+    invalid = [scope for scope in normalized if scope not in allowed]
     if invalid:
         raise ValueError(f"Unsupported API token scope: {', '.join(invalid)}")
     if not normalized:
@@ -45,9 +57,13 @@ def normalize_scopes(scopes: Iterable[str]) -> List[str]:
     return normalized
 
 
-def scopes_to_string(scopes: Iterable[str]) -> str:
+def scopes_to_string(
+    scopes: Iterable[str],
+    *,
+    allowed_scopes: Optional[Set[str]] = None,
+) -> str:
     """Serialize scopes for storage."""
-    return ",".join(normalize_scopes(scopes))
+    return ",".join(normalize_scopes(scopes, allowed_scopes=allowed_scopes))
 
 
 def parse_scopes(value: str) -> Set[str]:
@@ -79,12 +95,14 @@ def create_api_token(
     name: str,
     scopes: Iterable[str],
     workspace_id: Optional[int] = None,
+    allowed_scopes: Optional[Set[str]] = None,
+    global_token: bool = False,
 ) -> CreatedAPIToken:
     """Create a persistent API token and return the raw secret once."""
     clean_name = name.strip()
     if not clean_name:
         raise ValueError("Token name is required")
-    if workspace_id is None:
+    if workspace_id is None and not global_token:
         workspace_id = get_or_create_default_workspace(db, commit=False).id
     secret = generate_public_api_key()
     token = APIToken(
@@ -92,7 +110,7 @@ def create_api_token(
         name=clean_name,
         key_hash=hash_api_key(secret),
         key_prefix=secret[:12],
-        scopes=scopes_to_string(scopes),
+        scopes=scopes_to_string(scopes, allowed_scopes=allowed_scopes),
         active=True,
     )
     db.add(token)

--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -5,8 +5,10 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.api.api_v1.endpoints import provider as provider_endpoints
 from app.core.database import get_db
 from app.core.security import require_admin_auth
+from app.models.api_token import APIToken
 from app.models.domain import Domain
 from app.models.organization import (
     BillingAccount,
@@ -20,6 +22,13 @@ from app.models.report import DMARCReport, ForensicReport, ReportRecord
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
+from app.services.api_tokens import (
+    PROVIDER_READ_SCOPE,
+    PROVIDER_SCOPES,
+    PROVIDER_WRITE_SCOPE,
+    READ_REPORTS_SCOPE,
+    create_api_token,
+)
 from app.services.organizations import (
     BILLING_MODE_PROVIDER_RESALE,
     MAX_PROVIDER_PAYLOAD_SUMMARY_LENGTH,
@@ -45,6 +54,8 @@ def _client_as_user(test_app, db_session: Session, user: User):
     original_overrides = dict(test_app.dependency_overrides)
     test_app.dependency_overrides[get_db] = override_get_db
     test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    test_app.dependency_overrides[provider_endpoints.require_provider_read_auth] = mock_admin_auth
+    test_app.dependency_overrides[provider_endpoints.require_provider_write_auth] = mock_admin_auth
     try:
         with TestClient(test_app) as client:
             yield client
@@ -91,6 +102,165 @@ def _add_provider_customer(
     db_session.add_all([workspace, account, subscription])
     db_session.flush()
     return organization, workspace, subscription
+
+
+def _create_provider_token(
+    db_session: Session,
+    *,
+    name: str = "provider automation",
+    scopes=None,
+):
+    return create_api_token(
+        db_session,
+        name=name,
+        scopes=scopes or sorted(PROVIDER_SCOPES),
+        allowed_scopes=PROVIDER_SCOPES,
+        global_token=True,
+    )
+
+
+def test_admin_can_create_list_and_revoke_provider_api_tokens(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    created = authed_client.post(
+        "/api/v1/provider/api-tokens",
+        json={"name": "isp control panel", "scopes": [PROVIDER_READ_SCOPE, PROVIDER_WRITE_SCOPE]},
+    )
+
+    assert created.status_code == 201
+    body = created.json()
+    assert body["token"].startswith("dmarq_")
+    assert body["metadata"]["workspace_id"] is None
+    assert body["metadata"]["scopes"] == [PROVIDER_READ_SCOPE, PROVIDER_WRITE_SCOPE]
+    assert "key_hash" not in body["metadata"]
+
+    token = db_session.query(APIToken).filter(APIToken.id == body["metadata"]["id"]).one()
+    assert token.workspace_id is None
+
+    listed = authed_client.get("/api/v1/provider/api-tokens")
+    assert listed.status_code == 200
+    assert listed.json()["available_scopes"] == [PROVIDER_READ_SCOPE, PROVIDER_WRITE_SCOPE]
+    assert [row["name"] for row in listed.json()["tokens"]] == ["isp control panel"]
+
+    revoked = authed_client.delete(f"/api/v1/provider/api-tokens/{body['metadata']['id']}")
+    assert revoked.status_code == 200
+    db_session.refresh(token)
+    assert token.active is False
+
+
+def test_provider_api_token_management_rejects_public_scopes(
+    authed_client: TestClient,
+):
+    response = authed_client.post(
+        "/api/v1/provider/api-tokens",
+        json={"name": "wrong token", "scopes": [READ_REPORTS_SCOPE]},
+    )
+
+    assert response.status_code == 422
+    assert READ_REPORTS_SCOPE in response.json()["detail"]
+
+
+def test_provider_read_token_can_export_usage_without_workspace_membership(
+    client: TestClient,
+    db_session: Session,
+):
+    first_org, _, _ = _add_provider_customer(
+        db_session,
+        slug="provider-visible-a",
+        external_customer_id="cust-visible-a",
+        external_subscription_id="sub-visible-a",
+    )
+    second_org, _, _ = _add_provider_customer(
+        db_session,
+        slug="provider-visible-b",
+        external_customer_id="cust-visible-b",
+        external_subscription_id="sub-visible-b",
+    )
+    token = _create_provider_token(db_session, scopes=[PROVIDER_READ_SCOPE])
+    db_session.commit()
+
+    response = client.get(
+        "/api/v1/provider/billing/usage?period=2026-06",
+        headers={"X-API-Key": token.secret},
+    )
+
+    assert response.status_code == 200
+    organization_ids = {
+        item["organization"]["id"] for item in response.json()["usage"]["organizations"]
+    }
+    assert {first_org.id, second_org.id}.issubset(organization_ids)
+    db_session.refresh(token.token)
+    assert token.token.usage_count == 1
+    assert token.token.last_used_at is not None
+
+
+def test_provider_write_token_can_provision_and_update_subscription(
+    client: TestClient,
+    db_session: Session,
+):
+    token = _create_provider_token(
+        db_session,
+        scopes=[PROVIDER_READ_SCOPE, PROVIDER_WRITE_SCOPE],
+    )
+    db_session.commit()
+
+    provisioned = client.post(
+        "/api/v1/provider/customers",
+        headers={"X-API-Key": token.secret},
+        json={
+            "provider_id": "isp-token",
+            "external_customer_id": "cust-token",
+            "external_subscription_id": "sub-token",
+            "external_event_id": "evt-token-provision",
+            "organization_slug": "Token Provisioned",
+            "organization_name": "Token Provisioned",
+        },
+    )
+    assert provisioned.status_code == 200
+    assert provisioned.json()["result"]["organization"]["slug"] == "token-provisioned"
+
+    updated = client.post(
+        "/api/v1/provider/subscriptions/sub-token/state",
+        headers={"X-API-Key": token.secret},
+        json={
+            "status": "suspended",
+            "provider_id": "isp-token",
+            "external_event_id": "evt-token-suspended",
+        },
+    )
+    assert updated.status_code == 200
+    assert updated.json()["result"]["new_status"] == "suspended"
+
+    subscription = (
+        db_session.query(Subscription)
+        .filter(Subscription.external_subscription_id == "sub-token")
+        .one()
+    )
+    assert subscription.status == "suspended"
+
+
+def test_provider_read_token_cannot_mutate_provider_lifecycle(
+    client: TestClient,
+    db_session: Session,
+):
+    token = _create_provider_token(db_session, scopes=[PROVIDER_READ_SCOPE])
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/provider/customers",
+        headers={"X-API-Key": token.secret},
+        json={
+            "provider_id": "isp-token",
+            "external_customer_id": "cust-read-only",
+            "external_subscription_id": "sub-read-only",
+            "organization_slug": "Read Only Provider",
+            "organization_name": "Read Only Provider",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == f"API token requires scope: {PROVIDER_WRITE_SCOPE}"
 
 
 def test_provider_customer_provisioning_creates_provider_billed_tenant(
@@ -468,8 +638,17 @@ def test_provider_usage_export_accepts_empty_authorized_organization_scope(
     assert usage["organizations"] == []
 
 
-def test_provider_usage_endpoint_rejects_bad_period(authed_client: TestClient):
-    response = authed_client.get("/api/v1/provider/billing/usage?period=2026")
+def test_provider_usage_endpoint_rejects_bad_period(
+    client: TestClient,
+    db_session: Session,
+):
+    token = _create_provider_token(db_session, scopes=[PROVIDER_READ_SCOPE])
+    db_session.commit()
+
+    response = client.get(
+        "/api/v1/provider/billing/usage?period=2026",
+        headers={"X-API-Key": token.secret},
+    )
 
     assert response.status_code == 400
     assert "YYYY-MM" in response.json()["detail"]

--- a/docs/reference/provider-integrations.md
+++ b/docs/reference/provider-integrations.md
@@ -5,16 +5,43 @@ control-panel environments. In this mode, the provider owns the commercial
 relationship and DMARQ stores external customer and subscription identifiers
 instead of requiring Stripe customer records for every end customer.
 
-Provider endpoints live under `/api/v1/provider` and require administrator
-access. Provider-scoped machine tokens are tracked separately on the roadmap;
-until then, expose these endpoints only through trusted automation or an
-internal integration layer.
+Provider endpoints live under `/api/v1/provider`. Administrators can use the
+normal admin session/API key, while ISP/MSP automation should use global
+provider-scoped machine tokens with `provider:read` and/or `provider:write`.
+
+## Provider Machine Tokens
+
+```text
+GET /api/v1/provider/api-tokens
+POST /api/v1/provider/api-tokens
+DELETE /api/v1/provider/api-tokens/{token_id}
+```
+
+Token management requires administrator access. Provider tokens are global,
+not workspace-scoped, and are intended for trusted provider control panels,
+billing runs, and hosting-management integrations.
+
+Request:
+
+```json
+{
+  "name": "ISP control panel",
+  "scopes": ["provider:read", "provider:write"]
+}
+```
+
+The raw token is returned only once. Store it in the provider-side secret store
+and send it as `X-API-Key` when calling provider lifecycle and usage endpoints.
+Use `provider:read` for usage exports and `provider:write` for customer
+provisioning or subscription state changes.
 
 ## Provision A Customer
 
 ```text
 POST /api/v1/provider/customers
 ```
+
+Required token scope: `provider:write`.
 
 Request:
 
@@ -51,6 +78,8 @@ is received again, DMARQ returns the existing customer summary with
 POST /api/v1/provider/subscriptions/{external_subscription_id}/state
 ```
 
+Required token scope: `provider:write`.
+
 Request:
 
 ```json
@@ -73,8 +102,9 @@ GET /api/v1/provider/billing/usage?period=2026-06
 GET /api/v1/provider/billing/accounts/{external_customer_id}/usage?period=2026-06
 ```
 
+Required token scope: `provider:read`.
+
 Usage exports are deterministic for a billing period and include workspace,
 domain, aggregate report, message volume, forensic report, and active user
 metrics. The payload is intended for provider-side monthly invoicing, including
 WHMCS-style billing runs or custom ISP account-management systems.
-


### PR DESCRIPTION
## Summary
- add global provider machine-token scopes: `provider:read` and `provider:write`
- add admin-managed `/api/v1/provider/api-tokens` create/list/revoke endpoints
- allow provider tokens to call usage export, customer provisioning, and subscription state endpoints without workspace membership
- update provider integration docs with token setup and required scopes

Refs #241

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_provider_billing_usage.py backend/app/tests/test_public_api.py -q
- .venv/bin/python -m pytest backend/app/tests -q
- .venv/bin/python -m flake8 backend/app/services/api_tokens.py backend/app/core/security.py backend/app/api/api_v1/endpoints/provider.py backend/app/tests/test_provider_billing_usage.py
- .venv/bin/python -m black --check backend/app/services/api_tokens.py backend/app/core/security.py backend/app/api/api_v1/endpoints/provider.py backend/app/tests/test_provider_billing_usage.py
- .venv/bin/python -m compileall backend/app/services/api_tokens.py backend/app/core/security.py backend/app/api/api_v1/endpoints/provider.py backend/app/tests/test_provider_billing_usage.py
- git diff --check

## Issue #241 status
This closes the provider-token gap. Remaining #241 work after this is WHMCS/TMF-specific module artifacts and any deeper state-enforcement behavior that overlaps with #242.