### PR TITLE
fix(provider): tighten provider token scoping

### DIFF
--- a/backend/app/api/api_v1/endpoints/provider.py
+++ b/backend/app/api/api_v1/endpoints/provider.py
@@ -1,5 +1,6 @@
 """Provider and ISP integration endpoints."""
 
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -14,7 +15,6 @@ from app.services.api_tokens import (
     PROVIDER_SCOPES,
     PROVIDER_WRITE_SCOPE,
     create_api_token,
-    revoke_api_token,
     token_to_dict,
 )
 from app.services.organizations import (
@@ -214,11 +214,14 @@ async def revoke_provider_api_token(
         )
         .first()
     )
-    if token is None or not revoke_api_token(db, token_id, workspace_id=None):
+    if token is None or not token.active:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Provider API token not found",
         )
+    token.active = False
+    token.revoked_at = datetime.utcnow()
+    db.commit()
     return {"revoked": True}
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -284,18 +284,15 @@ def _api_token_context_for_scope(
     if token is None:
         return None
 
-    if require_global_token and token.workspace_id is not None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Provider API token must be global",
-        )
-
     scopes = parse_scopes(token.scopes)
     if required_scope not in scopes:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"API token requires scope: {required_scope}",
         )
+
+    if require_global_token and token.workspace_id is not None:
+        return None
 
     client_host = request.client.host if request.client else None
     record_api_token_use(db, token, ip_address=client_host)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -274,6 +274,7 @@ def _api_token_context_for_scope(
     api_key: Optional[str],
     required_scope: str,
     auth_type: str,
+    require_global_token: bool = False,
 ) -> Optional[dict]:
     """Return a scoped persistent API-token auth context when the key matches."""
     if not api_key:
@@ -282,6 +283,12 @@ def _api_token_context_for_scope(
     token = find_api_token(db, api_key)
     if token is None:
         return None
+
+    if require_global_token and token.workspace_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Provider API token must be global",
+        )
 
     scopes = parse_scopes(token.scopes)
     if required_scope not in scopes:
@@ -316,6 +323,7 @@ def require_provider_auth(required_scope: str) -> Callable:
             api_key=api_key,
             required_scope=required_scope,
             auth_type="provider_api_token",
+            require_global_token=True,
         )
         if token_context is not None:
             return token_context

--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -161,6 +161,26 @@ def test_provider_api_token_management_rejects_public_scopes(
     assert READ_REPORTS_SCOPE in response.json()["detail"]
 
 
+def test_provider_api_token_management_does_not_revoke_workspace_scoped_tokens(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    created = create_api_token(
+        db_session,
+        name="workspace provider token",
+        scopes=[PROVIDER_READ_SCOPE],
+        allowed_scopes=PROVIDER_SCOPES,
+    )
+    db_session.commit()
+
+    response = authed_client.delete(f"/api/v1/provider/api-tokens/{created.token.id}")
+
+    assert response.status_code == 404
+    db_session.refresh(created.token)
+    assert created.token.active is True
+    assert created.token.revoked_at is None
+
+
 def test_provider_read_token_can_export_usage_without_workspace_membership(
     client: TestClient,
     db_session: Session,
@@ -193,6 +213,36 @@ def test_provider_read_token_can_export_usage_without_workspace_membership(
     db_session.refresh(token.token)
     assert token.token.usage_count == 1
     assert token.token.last_used_at is not None
+
+
+def test_workspace_scoped_provider_scope_token_cannot_bypass_provider_scoping(
+    client: TestClient,
+    db_session: Session,
+):
+    _add_provider_customer(
+        db_session,
+        slug="provider-hidden",
+        external_customer_id="cust-hidden",
+        external_subscription_id="sub-hidden",
+    )
+    token = create_api_token(
+        db_session,
+        name="workspace scoped provider token",
+        scopes=[PROVIDER_READ_SCOPE],
+        allowed_scopes=PROVIDER_SCOPES,
+    )
+    db_session.commit()
+
+    response = client.get(
+        "/api/v1/provider/billing/usage?period=2026-06",
+        headers={"X-API-Key": token.secret},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Provider API token must be global"
+    db_session.refresh(token.token)
+    assert token.token.usage_count == 0
+    assert token.token.last_used_at is None
 
 
 def test_provider_write_token_can_provision_and_update_subscription(

--- a/backend/app/tests/test_provider_billing_usage.py
+++ b/backend/app/tests/test_provider_billing_usage.py
@@ -215,7 +215,7 @@ def test_provider_read_token_can_export_usage_without_workspace_membership(
     assert token.token.last_used_at is not None
 
 
-def test_workspace_scoped_provider_scope_token_cannot_bypass_provider_scoping(
+def test_workspace_scoped_provider_scope_token_falls_back_to_admin_auth(
     client: TestClient,
     db_session: Session,
 ):
@@ -238,8 +238,8 @@ def test_workspace_scoped_provider_scope_token_cannot_bypass_provider_scoping(
         headers={"X-API-Key": token.secret},
     )
 
-    assert response.status_code == 403
-    assert response.json()["detail"] == "Provider API token must be global"
+    assert response.status_code == 401
+    assert response.json()["detail"].startswith("Authentication required")
     db_session.refresh(token.token)
     assert token.token.usage_count == 0
     assert token.token.last_used_at is None


### PR DESCRIPTION
## Summary
- require provider API tokens to be global before accepting them as provider-token auth
- revoke provider tokens using the already scoped token row instead of a second looser lookup
- add regressions for workspace-scoped provider-scope tokens and provider-token revocation

## Validation
- python3 -m compileall backend/app/core/security.py backend/app/api/api_v1/endpoints/provider.py backend/app/tests/test_provider_billing_usage.py
- git diff --check

Note: local pytest/black/flake8 modules are not installed in the available Python environment, so full validation is delegated to GitHub CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider API token revocation now records the revocation time and correctly marks tokens as inactive.
  * Workspace-scoped provider API tokens can no longer be used where a global provider token is required.
  * Attempts to revoke non-provider-scoped tokens now return a not-found response without altering the token.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->