### PR TITLE
docs(provider): add WHMCS and TMF integration mapping

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -66,6 +66,14 @@ through the `/public` path and avoid UI-specific payloads.
 Successful public API calls update the token's last-used timestamp, source IP,
 and usage count for auditing.
 
+### Provider API
+
+Provider, ISP, MSP, and hosting-control-panel integrations use
+`/api/v1/provider` endpoints and provider-scoped machine tokens. See
+[Provider Integrations](provider-integrations.md) for customer provisioning,
+subscription state updates, WHMCS-style lifecycle mapping, TMF-style OSS/BSS
+mapping, and monthly provider billing exports.
+
 ### API Tokens
 
 #### List API Tokens

--- a/docs/reference/provider-integrations.md
+++ b/docs/reference/provider-integrations.md
@@ -108,3 +108,86 @@ Usage exports are deterministic for a billing period and include workspace,
 domain, aggregate report, message volume, forensic report, and active user
 metrics. The payload is intended for provider-side monthly invoicing, including
 WHMCS-style billing runs or custom ISP account-management systems.
+
+## WHMCS Integration Contract
+
+DMARQ does not require an end-customer Stripe record when the billing account
+uses `provider_resale`, `provider_whmcs`, or `provider_tmf`. WHMCS remains the
+system of record for invoices, payment state, taxes, credits, and customer
+communications. DMARQ stores only the provider identifiers needed to reconcile
+the tenant, subscription, and usage period.
+
+Recommended WHMCS module mapping:
+
+| WHMCS module action | DMARQ endpoint | Required scope | Provider fields |
+| --- | --- | --- | --- |
+| CreateAccount | `POST /api/v1/provider/customers` | `provider:write` | `provider_id`, `external_customer_id`, `external_subscription_id`, `external_event_id` |
+| SuspendAccount | `POST /api/v1/provider/subscriptions/{external_subscription_id}/state` | `provider:write` | `status=suspended`, `external_event_id` |
+| UnsuspendAccount | `POST /api/v1/provider/subscriptions/{external_subscription_id}/state` | `provider:write` | `status=active`, `external_event_id` |
+| TerminateAccount | `POST /api/v1/provider/subscriptions/{external_subscription_id}/state` | `provider:write` | `status=terminated`, `external_event_id` |
+| Usage billing cron | `GET /api/v1/provider/billing/accounts/{external_customer_id}/usage?period=YYYY-MM` | `provider:read` | `period`, `provider_id` |
+| Provider-wide reconciliation | `GET /api/v1/provider/billing/usage?period=YYYY-MM` | `provider:read` | `period`, `provider_id` |
+
+Use the WHMCS service id or subscription id as `external_subscription_id`, and
+the WHMCS client id as `external_customer_id`. Use a stable WHMCS hook or module
+event id as `external_event_id`; if WHMCS does not provide one, construct a
+stable value from the action, service id, target state, and invoice or run id.
+
+The WHMCS module should not store the raw DMARQ provider token in module logs,
+ticket notes, admin activity text, or client-visible custom fields. Store it in
+the provider control-panel secret store and rotate it by creating a replacement
+provider token before revoking the old one.
+
+## ISP And OSS/BSS Mapping
+
+For mid-sized ISP and telco deployments, DMARQ should sit behind the provider's
+existing customer portal, billing stack, and operations tooling. The provider
+portal owns customer identity and commercial state; DMARQ owns DMARC report
+ingestion, DNS posture, workspace isolation, and auditable lifecycle events.
+
+The following mapping keeps DMARQ aligned with common TM Forum Open API style
+systems without requiring DMARQ to implement those standards directly:
+
+| Provider concept | DMARQ field or endpoint | Notes |
+| --- | --- | --- |
+| Product catalog offer | `plan_code`, `external_product_code` | Map DMARQ Starter/Pro/Business/ISP bundles to provider product catalog entries. |
+| Customer account | `external_customer_id` on the billing account | Keep legal customer and invoice ownership in the provider system. |
+| Billing account | `invoice_delivery_mode=provider_invoice` | DMARQ usage exports feed the provider invoice or monthly bill. |
+| Product or service order | `POST /api/v1/provider/customers` | Provision the organization and first workspace from an accepted provider order. |
+| Product inventory item | `external_subscription_id` | Use this as the durable DMARQ subscription reference for suspend/reactivate/cancel. |
+| Service state | subscription `status` | Push `active`, `past_due_provider_reported`, `suspended`, `canceled`, or `terminated` from the provider system. |
+| Customer bill usage | monthly usage export endpoints | Import deterministic per-period usage into the provider billing run. |
+
+TM Forum-aligned environments commonly model these areas through customer,
+product catalog, product ordering, product inventory, account management, and
+customer bill management APIs. DMARQ's provider API is intentionally narrower:
+it accepts the resulting identifiers and state transitions, then returns usage
+that the provider can attach to its own invoice lines.
+
+## Billing And Lifecycle Rules
+
+Provider-billed accounts should follow these rules:
+
+- DMARQ must not create Stripe customers for provider-billed end customers.
+- Provider events must include `external_event_id` so retries are idempotent.
+- DMARQ should store a sanitized `payload_summary`, not raw provider webhook
+  bodies.
+- Suspended accounts remain auditable and recoverable; terminated accounts are
+  treated as closed subscriptions and should not receive new ingestion work.
+- Usage export jobs may be rerun for the same period without changing totals
+  unless new source data for that period was imported after the prior export.
+- Provider-side invoice disputes should be resolved in the provider billing
+  system; DMARQ can regenerate the period usage payload for reconciliation.
+
+## Minimal Provider Module Flow
+
+1. Create one provider machine token with `provider:read` and `provider:write`.
+2. Store the token in the provider control-panel secret store.
+3. On service activation, call `POST /api/v1/provider/customers`.
+4. Save the returned DMARQ organization, workspace, billing account, and
+   subscription ids in provider-side service metadata.
+5. On overdue payment, cancellation, or manual operator action, call the
+   subscription state endpoint with a fresh `external_event_id`.
+6. During the monthly billing run, fetch account usage for each active provider
+   subscription and attach the returned metrics to the provider invoice.
+7. Run the provider-wide usage export as a reconciliation report after billing.


### PR DESCRIPTION
## Summary
- document WHMCS lifecycle action mapping for provider provisioning, suspension, reactivation, termination, and billing cron usage
- document ISP/OSS/BSS mapping for provider-owned billing systems and TM Forum-style integration boundaries
- cross-link the provider API contract from the API reference

## Validation
- `git diff --check`
- `rg -n "WHMCS|TMF|Provider API|OSS/BSS|external_event_id" docs/reference/provider-integrations.md docs/reference/api.md`
- `python -m mkdocs build --strict` could not run locally because this checkout's virtual environment does not include MkDocs

Closes #241
