### PR TITLE
docs(provider): clarify provider API parameters

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -69,7 +69,8 @@ and usage count for auditing.
 ### Provider API
 
 Provider, ISP, MSP, and hosting-control-panel integrations use
-`/api/v1/provider` endpoints and provider-scoped machine tokens. See
+`/provider` endpoints under the `/api/v1` base URL and provider-scoped machine
+tokens. See
 [Provider Integrations](provider-integrations.md) for customer provisioning,
 subscription state updates, WHMCS-style lifecycle mapping, TMF-style OSS/BSS
 mapping, and monthly provider billing exports.

--- a/docs/reference/provider-integrations.md
+++ b/docs/reference/provider-integrations.md
@@ -125,8 +125,8 @@ Recommended WHMCS module mapping:
 | SuspendAccount | `POST /api/v1/provider/subscriptions/{external_subscription_id}/state` | `provider:write` | `status=suspended`, `external_event_id` |
 | UnsuspendAccount | `POST /api/v1/provider/subscriptions/{external_subscription_id}/state` | `provider:write` | `status=active`, `external_event_id` |
 | TerminateAccount | `POST /api/v1/provider/subscriptions/{external_subscription_id}/state` | `provider:write` | `status=terminated`, `external_event_id` |
-| Usage billing cron | `GET /api/v1/provider/billing/accounts/{external_customer_id}/usage?period=YYYY-MM` | `provider:read` | `period`, `provider_id` |
-| Provider-wide reconciliation | `GET /api/v1/provider/billing/usage?period=YYYY-MM` | `provider:read` | `period`, `provider_id` |
+| Usage billing cron | `GET /api/v1/provider/billing/accounts/{external_customer_id}/usage?period=YYYY-MM` | `provider:read` | `period` |
+| Provider-wide reconciliation | `GET /api/v1/provider/billing/usage?period=YYYY-MM` | `provider:read` | `period` |
 
 Use the WHMCS service id or subscription id as `external_subscription_id`, and
 the WHMCS client id as `external_customer_id`. Use a stable WHMCS hook or module


### PR DESCRIPTION
## Summary
- remove provider_id from WHMCS usage export parameter mapping because the provider token scopes those GET calls
- clarify the API reference Provider API section as /provider under the /api/v1 base URL

## Validation
- git diff --check

Follow-up for Copilot comments on merged PR #285.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the API reference for provider integrations, updating the documented provider-scoped path wording to match the current `/api/v1` format.
  * Refined the provider integration contract reference by removing an outdated provider field from the documented billing and reconciliation tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->