### PR TITLE
docs(provider): smooth provider API wording

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -69,11 +69,10 @@ and usage count for auditing.
 ### Provider API
 
 Provider, ISP, MSP, and hosting-control-panel integrations use
-`/provider` endpoints under the `/api/v1` base URL and provider-scoped machine
-tokens. See
-[Provider Integrations](provider-integrations.md) for customer provisioning,
-subscription state updates, WHMCS-style lifecycle mapping, TMF-style OSS/BSS
-mapping, and monthly provider billing exports.
+`/provider` endpoints under the `/api/v1` base URL with provider-scoped
+machine tokens. See [Provider Integrations](provider-integrations.md) for
+customer provisioning, subscription state updates, WHMCS-style lifecycle
+mapping, TMF-style OSS/BSS mapping, and monthly provider billing exports.
 
 ### API Tokens
 


### PR DESCRIPTION
## Summary
- clarify that /provider endpoints are used under the /api/v1 base URL with provider-scoped machine tokens
- keep the Provider Integrations link attached to the sentence for cleaner Markdown flow

## Validation
- git diff --check

Follow-up for Copilot's grammar note on merged PR #286.