### PR TITLE
feat(billing): expose account state and block read-only mutations

### DIFF
--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -68,6 +68,10 @@ PROVIDER_SUBSCRIPTION_STATUSES = {
     "terminated",
 }
 MAX_PROVIDER_PAYLOAD_SUMMARY_LENGTH = 500
+ACCOUNT_ACTIVE_STATUSES = {"active", "trialing"}
+ACCOUNT_GRACE_STATUSES = {"past_due_provider_reported"}
+ACCOUNT_READ_ONLY_STATUSES = {"suspended", "canceled", "terminated"}
+ACCOUNT_CLOSED_STATUSES = {"canceled", "terminated"}
 
 
 def _sanitize_payload_summary(payload_summary: Optional[str]) -> Optional[str]:
@@ -402,6 +406,70 @@ def _subscription_to_dict(subscription: Subscription) -> Dict[str, Any]:
     }
 
 
+def _primary_subscription(subscriptions: Iterable[Subscription]) -> Optional[Subscription]:
+    subscription_list = list(subscriptions)
+    for status_group in (
+        ACCOUNT_ACTIVE_STATUSES,
+        ACCOUNT_GRACE_STATUSES,
+        {"suspended"},
+        ACCOUNT_CLOSED_STATUSES,
+    ):
+        for subscription in subscription_list:
+            if subscription.status in status_group:
+                return subscription
+    return subscription_list[0] if subscription_list else None
+
+
+def account_state_for_subscriptions(subscriptions: Iterable[Subscription]) -> Dict[str, Any]:
+    """Return the effective commercial state used by UI and write guards."""
+    subscription = _primary_subscription(subscriptions)
+    if subscription is None:
+        return {
+            "status": "unconfigured",
+            "billing_mode": None,
+            "plan_code": None,
+            "read_only": False,
+            "can_mutate": True,
+            "can_export": True,
+            "grace_period": False,
+            "closed": False,
+            "reason": "No active subscription has been configured for this organization.",
+            "blocking_subscription_id": None,
+        }
+
+    status_value = subscription.status
+    read_only = status_value in ACCOUNT_READ_ONLY_STATUSES
+    grace_period = status_value in ACCOUNT_GRACE_STATUSES
+    closed = status_value in ACCOUNT_CLOSED_STATUSES
+    if read_only:
+        reason = (
+            "This organization's subscription is read-only. Users can view and "
+            "export existing data, but mutating actions are blocked until billing "
+            "or provider state is restored."
+        )
+    elif grace_period:
+        reason = (
+            "This organization's subscription is in a provider-reported grace "
+            "state. Mutating actions still work, but operators should resolve "
+            "billing before the account becomes read-only."
+        )
+    else:
+        reason = "This organization's subscription allows normal workspace changes."
+
+    return {
+        "status": status_value,
+        "billing_mode": subscription.billing_mode,
+        "plan_code": subscription.plan.code if subscription.plan else None,
+        "read_only": read_only,
+        "can_mutate": not read_only,
+        "can_export": True,
+        "grace_period": grace_period,
+        "closed": closed,
+        "reason": reason,
+        "blocking_subscription_id": subscription.id if read_only else None,
+    }
+
+
 def organization_summary(db: Session, organization: Organization) -> Dict[str, Any]:
     """Return an API-safe organization/account summary."""
     workspaces = (
@@ -442,6 +510,7 @@ def organization_summary(db: Session, organization: Organization) -> Dict[str, A
         "workspaces": [_workspace_to_dict(workspace) for workspace in workspaces],
         "billing_accounts": [_billing_account_to_dict(account) for account in billing_accounts],
         "subscriptions": [_subscription_to_dict(subscription) for subscription in subscriptions],
+        "account_state": account_state_for_subscriptions(subscriptions),
         "entitlements": {
             entitlement.key: {
                 "value": entitlement.value,

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -7,10 +7,11 @@ from typing import Any, Dict, List, Optional, Set
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.models.organization import Organization, OrganizationMembership
+from app.models.organization import Organization, OrganizationMembership, Subscription
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
+from app.services.organizations import account_state_for_subscriptions
 from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
 ROLE_WORKSPACE_OWNER = "workspace_owner"
@@ -27,6 +28,14 @@ PERMISSION_INTEGRATIONS_WRITE = "integrations:write"
 PERMISSION_AUDIT_READ = "audit:read"
 PERMISSION_REPORTS_READ = "reports:read"
 PERMISSION_REPORTS_WRITE = "reports:write"
+TENANT_MUTATION_PERMISSIONS = {
+    PERMISSION_WORKSPACE_ADMIN,
+    PERMISSION_DOMAINS_WRITE,
+    PERMISSION_MAIL_SOURCES_WRITE,
+    PERMISSION_NOTIFICATIONS_WRITE,
+    PERMISSION_INTEGRATIONS_WRITE,
+    PERMISSION_REPORTS_WRITE,
+}
 
 ROLE_PERMISSIONS: Dict[str, Set[str]] = {
     ROLE_WORKSPACE_OWNER: {
@@ -223,10 +232,47 @@ def require_workspace_permission(
     else:
         role = role_for_auth_context(auth_context)
     if role_allows(role, permission):
+        require_workspace_account_mutation_allowed(permission, db, workspace)
         return
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
         detail=f"Workspace permission required: {permission}",
+    )
+
+
+def require_workspace_account_mutation_allowed(
+    permission: str,
+    db: Optional[Session],
+    workspace: Optional[Workspace],
+) -> None:
+    """Block tenant mutations while the organization subscription is read-only."""
+    if permission not in TENANT_MUTATION_PERMISSIONS:
+        return
+    if db is None or workspace is None or workspace.organization_id is None:
+        return
+
+    subscriptions = (
+        db.query(Subscription)
+        .filter(
+            Subscription.organization_id == workspace.organization_id,
+        )
+        .order_by(Subscription.updated_at.desc(), Subscription.created_at.desc())
+        .all()
+    )
+    account_state = account_state_for_subscriptions(subscriptions)
+    if account_state["can_mutate"]:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_402_PAYMENT_REQUIRED,
+        detail={
+            "code": "account_read_only",
+            "message": account_state["reason"],
+            "subscription_status": account_state["status"],
+            "subscription_id": account_state["blocking_subscription_id"],
+            "organization_id": workspace.organization_id,
+            "can_export": account_state["can_export"],
+        },
     )
 
 

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -1,5 +1,7 @@
 from contextlib import contextmanager
 
+import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -20,11 +22,18 @@ from app.services.organizations import (
     DEFAULT_ORGANIZATION_SLUG,
     SELF_HOSTED_PLAN_CODE,
     STARTER_PLAN_CODE,
+    account_state_for_subscriptions,
     bootstrap_default_commercial_foundation,
     get_or_create_starter_plan,
     list_organization_summaries,
+    organization_summary,
 )
-from app.services.workspace_access import ROLE_AUDITOR
+from app.services.workspace_access import (
+    PERMISSION_DOMAINS_WRITE,
+    PERMISSION_REPORTS_READ,
+    ROLE_AUDITOR,
+    require_workspace_permission,
+)
 
 
 @contextmanager
@@ -115,6 +124,125 @@ def test_list_organization_summaries_materializes_account_state(db_session: Sess
     assert summaries[0]["billing_accounts"][0]["billing_mode"] == BILLING_MODE_SELF_HOSTED
     assert summaries[0]["subscriptions"][0]["plan"]["code"] == SELF_HOSTED_PLAN_CODE
     assert summaries[0]["entitlements"]["aggregate_reports"]["value"] == "true"
+    assert summaries[0]["account_state"]["status"] == "active"
+    assert summaries[0]["account_state"]["can_mutate"] is True
+    assert summaries[0]["account_state"]["can_export"] is True
+
+
+def test_account_state_reports_provider_grace_without_blocking(db_session: Session):
+    plan = get_or_create_starter_plan(db_session)
+    organization = Organization(slug="grace", name="Grace", active=True)
+    account = BillingAccount(
+        organization=organization,
+        billing_mode="provider_resale",
+        status="active",
+        invoice_delivery_mode="provider_invoice",
+    )
+    subscription = Subscription(
+        organization=organization,
+        billing_account=account,
+        plan=plan,
+        billing_mode="provider_resale",
+        status="past_due_provider_reported",
+    )
+    db_session.add_all([organization, account, subscription])
+    db_session.commit()
+
+    state = account_state_for_subscriptions([subscription])
+
+    assert state["status"] == "past_due_provider_reported"
+    assert state["grace_period"] is True
+    assert state["read_only"] is False
+    assert state["can_mutate"] is True
+
+
+def test_account_state_reports_suspended_as_read_only(db_session: Session):
+    plan = get_or_create_starter_plan(db_session)
+    organization = Organization(slug="suspended", name="Suspended", active=True)
+    account = BillingAccount(
+        organization=organization,
+        billing_mode="provider_resale",
+        status="active",
+        invoice_delivery_mode="provider_invoice",
+    )
+    subscription = Subscription(
+        organization=organization,
+        billing_account=account,
+        plan=plan,
+        billing_mode="provider_resale",
+        status="suspended",
+    )
+    db_session.add_all([organization, account, subscription])
+    db_session.commit()
+
+    summary = organization_summary(db_session, organization)
+
+    assert summary["account_state"]["status"] == "suspended"
+    assert summary["account_state"]["read_only"] is True
+    assert summary["account_state"]["can_mutate"] is False
+    assert summary["account_state"]["can_export"] is True
+
+
+def test_workspace_write_permission_blocks_read_only_subscription(db_session: Session):
+    plan = get_or_create_starter_plan(db_session)
+    organization = Organization(slug="locked", name="Locked", active=True)
+    workspace = Workspace(slug="locked-main", name="Locked Main", organization=organization)
+    account = BillingAccount(
+        organization=organization,
+        billing_mode="provider_resale",
+        status="active",
+        invoice_delivery_mode="provider_invoice",
+    )
+    subscription = Subscription(
+        organization=organization,
+        billing_account=account,
+        plan=plan,
+        billing_mode="provider_resale",
+        status="terminated",
+    )
+    db_session.add_all([organization, workspace, account, subscription])
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_workspace_permission(
+            {"auth_type": "api_key"},
+            PERMISSION_DOMAINS_WRITE,
+            db_session,
+            workspace,
+        )
+
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.detail["code"] == "account_read_only"
+    assert exc_info.value.detail["subscription_status"] == "terminated"
+    assert exc_info.value.detail["can_export"] is True
+
+
+def test_workspace_read_permission_allows_read_only_subscription(db_session: Session):
+    plan = get_or_create_starter_plan(db_session)
+    organization = Organization(slug="readable", name="Readable", active=True)
+    workspace = Workspace(slug="readable-main", name="Readable Main", organization=organization)
+    account = BillingAccount(
+        organization=organization,
+        billing_mode="provider_resale",
+        status="active",
+        invoice_delivery_mode="provider_invoice",
+    )
+    subscription = Subscription(
+        organization=organization,
+        billing_account=account,
+        plan=plan,
+        billing_mode="provider_resale",
+        status="suspended",
+    )
+    db_session.add_all([organization, workspace, account, subscription])
+    db_session.commit()
+
+    require_workspace_permission(
+        {"auth_type": "api_key"},
+        PERMISSION_REPORTS_READ,
+        db_session,
+        workspace,
+    )
 
 
 def test_organization_endpoints_are_scoped_to_accessible_tenants(test_app, db_session: Session):


### PR DESCRIPTION
## Summary
- expose computed `account_state` on organization summaries so UI/API consumers can see active, grace, read-only, and closed billing states
- block tenant workspace mutations when the effective subscription is `suspended`, `canceled`, or `terminated`, while preserving read/export access
- keep `past_due_provider_reported` as a visible grace state that still allows mutation

## Validation
- `python3 -m py_compile backend/app/services/organizations.py backend/app/services/workspace_access.py backend/app/tests/test_organization_foundations.py`
- `PYTHONPATH=backend .venv/bin/pytest backend/app/tests/test_organization_foundations.py -q`
- `.venv/bin/black --check backend/app/services/organizations.py backend/app/services/workspace_access.py backend/app/tests/test_organization_foundations.py`
- `.venv/bin/isort --check-only backend/app/services/organizations.py backend/app/services/workspace_access.py backend/app/tests/test_organization_foundations.py`
- `git diff --check`

Refs #242
