### PR TITLE
fix(billing): tighten workspace account guard

### DIFF
--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -420,7 +420,11 @@ def _primary_subscription(subscriptions: Iterable[Subscription]) -> Optional[Sub
     return subscription_list[0] if subscription_list else None
 
 
-def account_state_for_subscriptions(subscriptions: Iterable[Subscription]) -> Dict[str, Any]:
+def account_state_for_subscriptions(
+    subscriptions: Iterable[Subscription],
+    *,
+    include_plan_code: bool = True,
+) -> Dict[str, Any]:
     """Return the effective commercial state used by UI and write guards."""
     subscription = _primary_subscription(subscriptions)
     if subscription is None:
@@ -453,13 +457,20 @@ def account_state_for_subscriptions(subscriptions: Iterable[Subscription]) -> Di
             "state. Mutating actions still work, but operators should resolve "
             "billing before the account becomes read-only."
         )
-    else:
+    elif status_value in ACCOUNT_ACTIVE_STATUSES:
         reason = "This organization's subscription allows normal workspace changes."
+    else:
+        reason = (
+            "This organization's subscription status is not classified as "
+            "read-only. Workspace changes currently remain allowed."
+        )
 
     return {
         "status": status_value,
         "billing_mode": subscription.billing_mode,
-        "plan_code": subscription.plan.code if subscription.plan else None,
+        "plan_code": (
+            subscription.plan.code if include_plan_code and subscription.plan else None
+        ),
         "read_only": read_only,
         "can_mutate": not read_only,
         "can_export": True,

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -271,8 +271,8 @@ def require_workspace_account_mutation_allowed(
         )
         .order_by(
             status_priority.asc(),
-            Subscription.updated_at.desc(),
-            Subscription.created_at.desc(),
+            Subscription.updated_at.desc().nullslast(),
+            Subscription.created_at.desc().nullslast(),
         )
         .first()
     )

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Set
 
 from fastapi import HTTPException, status
+from sqlalchemy import case
 from sqlalchemy.orm import Session
 
 from app.models.organization import Organization, OrganizationMembership, Subscription
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
-from app.services.organizations import account_state_for_subscriptions
+from app.services.organizations import (
+    ACCOUNT_ACTIVE_STATUSES,
+    ACCOUNT_CLOSED_STATUSES,
+    ACCOUNT_GRACE_STATUSES,
+    account_state_for_subscriptions,
+)
 from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
 ROLE_WORKSPACE_OWNER = "workspace_owner"
@@ -226,7 +232,7 @@ def require_workspace_permission(
     db: Optional[Session] = None,
     workspace: Optional[Workspace] = None,
 ) -> None:
-    """Raise HTTP 403 when the current role does not grant a permission."""
+    """Raise HTTP 403 for missing access or HTTP 402 for read-only accounts."""
     if db is not None and workspace is not None:
         role = role_for_workspace(db, auth_context, workspace)
     else:
@@ -251,15 +257,29 @@ def require_workspace_account_mutation_allowed(
     if db is None or workspace is None or workspace.organization_id is None:
         return
 
-    subscriptions = (
+    status_priority = case(
+        (Subscription.status.in_(ACCOUNT_ACTIVE_STATUSES), 0),
+        (Subscription.status.in_(ACCOUNT_GRACE_STATUSES), 1),
+        (Subscription.status == "suspended", 2),
+        (Subscription.status.in_(ACCOUNT_CLOSED_STATUSES), 3),
+        else_=4,
+    )
+    subscription = (
         db.query(Subscription)
         .filter(
             Subscription.organization_id == workspace.organization_id,
         )
-        .order_by(Subscription.updated_at.desc(), Subscription.created_at.desc())
-        .all()
+        .order_by(
+            status_priority.asc(),
+            Subscription.updated_at.desc(),
+            Subscription.created_at.desc(),
+        )
+        .first()
     )
-    account_state = account_state_for_subscriptions(subscriptions)
+    account_state = account_state_for_subscriptions(
+        [subscription] if subscription is not None else [],
+        include_plan_code=False,
+    )
     if account_state["can_mutate"]:
         return
 

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -156,6 +156,37 @@ def test_account_state_reports_provider_grace_without_blocking(db_session: Sessi
     assert state["can_mutate"] is True
 
 
+def test_account_state_reports_unclassified_status_without_active_reason(
+    db_session: Session,
+):
+    plan = get_or_create_starter_plan(db_session)
+    organization = Organization(slug="past-due", name="Past Due", active=True)
+    account = BillingAccount(
+        organization=organization,
+        billing_mode="stripe",
+        status="active",
+        invoice_delivery_mode="stripe_invoice",
+    )
+    subscription = Subscription(
+        organization=organization,
+        billing_account=account,
+        plan=plan,
+        billing_mode="stripe",
+        status="past_due",
+    )
+    db_session.add_all([organization, account, subscription])
+    db_session.commit()
+
+    state = account_state_for_subscriptions([subscription], include_plan_code=False)
+
+    assert state["status"] == "past_due"
+    assert state["plan_code"] is None
+    assert state["read_only"] is False
+    assert state["can_mutate"] is True
+    assert "not classified as read-only" in state["reason"]
+    assert "normal workspace changes" not in state["reason"]
+
+
 def test_account_state_reports_suspended_as_read_only(db_session: Session):
     plan = get_or_create_starter_plan(db_session)
     organization = Organization(slug="suspended", name="Suspended", active=True)
@@ -215,6 +246,51 @@ def test_workspace_write_permission_blocks_read_only_subscription(db_session: Se
     assert exc_info.value.detail["code"] == "account_read_only"
     assert exc_info.value.detail["subscription_status"] == "terminated"
     assert exc_info.value.detail["can_export"] is True
+
+
+def test_workspace_write_permission_uses_primary_subscription_priority(
+    db_session: Session,
+):
+    plan = get_or_create_starter_plan(db_session)
+    organization = Organization(slug="mixed", name="Mixed", active=True)
+    workspace = Workspace(slug="mixed-main", name="Mixed Main", organization=organization)
+    account = BillingAccount(
+        organization=organization,
+        billing_mode="provider_resale",
+        status="active",
+        invoice_delivery_mode="provider_invoice",
+    )
+    active_subscription = Subscription(
+        organization=organization,
+        billing_account=account,
+        plan=plan,
+        billing_mode="provider_resale",
+        status="active",
+    )
+    terminated_subscription = Subscription(
+        organization=organization,
+        billing_account=account,
+        plan=plan,
+        billing_mode="provider_resale",
+        status="terminated",
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            account,
+            active_subscription,
+            terminated_subscription,
+        ]
+    )
+    db_session.commit()
+
+    require_workspace_permission(
+        {"auth_type": "api_key"},
+        PERMISSION_DOMAINS_WRITE,
+        db_session,
+        workspace,
+    )
 
 
 def test_workspace_read_permission_allows_read_only_subscription(db_session: Session):


### PR DESCRIPTION
## Summary
- query only the effective subscription when checking workspace mutation permissions
- avoid loading subscription plan details in the hot mutation guard path
- clarify non-read-only unknown subscription status reasons and the 402/403 permission docstring

## Tests
- `.venv/bin/python -m pytest backend/app/tests/test_organization_foundations.py -q`
- `.venv/bin/python -m compileall backend/app/services/organizations.py backend/app/services/workspace_access.py backend/app/tests/test_organization_foundations.py`
- `git diff --check`

Follow-up for Copilot review feedback on #288.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account status handling so only the most relevant subscription is used for workspace write-access checks.
  * Refined read-only and mutation access responses to better match subscription status and avoid incorrect lockouts.
  * Adjusted account state messaging for non-standard subscription states, making status explanations clearer.
* **Tests**
  * Added coverage for muted plan-code output in account state results.
  * Added coverage for workspace permission checks with multiple subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->