### PR TITLE
test(billing): cover disabled webhook gated actions

### DIFF
--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -180,7 +180,7 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
                 workspace_id=workspace.id,
                 name="hook",
                 url="https://hooks.example/dmarq",
-                secret="stored",
+                secret="stored",  # noqa: S106 - test fixture value, not a real secret
                 event_types="*",
                 enabled=True,
             ),

--- a/backend/app/tests/test_webhooks.py
+++ b/backend/app/tests/test_webhooks.py
@@ -321,6 +321,16 @@ def test_admin_webhook_creation_respects_plan_entitlement(
     assert updated.json()["detail"]["code"] == "feature_not_included"
     assert updated.json()["detail"]["feature"] == "webhooks"
 
+    tested = authed_client.post(f"/api/v1/webhooks/{endpoint.id}/test")
+    assert tested.status_code == 402
+    assert tested.json()["detail"]["code"] == "feature_not_included"
+    assert tested.json()["detail"]["feature"] == "webhooks"
+
+    processed = authed_client.post("/api/v1/webhooks/deliveries/process")
+    assert processed.status_code == 402
+    assert processed.json()["detail"]["code"] == "feature_not_included"
+    assert processed.json()["detail"]["feature"] == "webhooks"
+
     disabled = authed_client.delete(f"/api/v1/webhooks/{endpoint.id}")
     assert disabled.status_code == 200
     assert disabled.json()["enabled"] is False


### PR DESCRIPTION
## Summary
- cover disabled webhooks for update, test, and process endpoints
- scope the test-only webhook secret literal with a Ruff S106 suppression

## Validation
- python3 -m py_compile backend/app/tests/test_organization_foundations.py backend/app/tests/test_webhooks.py

Follow-up for CodeRabbit comments left on merged PR #290.