### PR TITLE
feat(billing): enforce monitored domain quotas

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -89,7 +89,10 @@ def _authorized_domain_read_workspace(
 
 
 def _raise_plan_limit_error(exc: OrganizationPlanLimitError) -> None:
-    raise HTTPException(status_code=status.HTTP_402_PAYMENT_REQUIRED, detail=exc.to_detail())
+    raise HTTPException(
+        status_code=status.HTTP_402_PAYMENT_REQUIRED,
+        detail=exc.to_detail(),
+    ) from exc
 
 
 def _normalize_reported_policy(policy_value: Any) -> Optional[str]:

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -33,6 +33,10 @@ from app.services.dns_resolver import (
     get_default_provider,
 )
 from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
+from app.services.organizations import (
+    OrganizationPlanLimitError,
+    require_organization_plan_limit,
+)
 from app.services.report_persistence import (
     hydrate_report_store_from_db,
 )
@@ -82,6 +86,10 @@ def _authorized_domain_read_workspace(
         PERMISSION_REPORTS_READ,
         selected_workspace_id=selected_workspace_id,
     )
+
+
+def _raise_plan_limit_error(exc: OrganizationPlanLimitError) -> None:
+    raise HTTPException(status_code=status.HTTP_402_PAYMENT_REQUIRED, detail=exc.to_detail())
 
 
 def _normalize_reported_policy(policy_value: Any) -> Optional[str]:
@@ -1312,6 +1320,15 @@ async def create_domain(
             status_code=status.HTTP_409_CONFLICT,
             detail="Domain is already monitored",
         )
+    if workspace.organization:
+        try:
+            require_organization_plan_limit(
+                db,
+                workspace.organization,
+                "monitored_domains",
+            )
+        except OrganizationPlanLimitError as exc:
+            _raise_plan_limit_error(exc)
 
     selectors = ",".join(
         selector.strip()
@@ -1730,6 +1747,8 @@ async def import_cloudflare_domain_zones(
             requested_domains=payload.domains,
             workspace_id=workspace.id,
         )
+    except OrganizationPlanLimitError as exc:
+        _raise_plan_limit_error(exc)
     except LookupError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/api/api_v1/endpoints/onboarding.py
+++ b/backend/app/api/api_v1/endpoints/onboarding.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.core.security import require_admin_auth
+from app.services.organizations import OrganizationPlanLimitError
 from app.services.workspace_access import (
     PERMISSION_WORKSPACE_ADMIN,
     require_workspace_permission,
@@ -123,6 +124,11 @@ async def apply_workspace_onboarding(
     plan = _build_plan_or_422(payload)
     try:
         result = apply_onboarding_plan(db, plan=plan, auth_context=_auth, request=request)
+    except OrganizationPlanLimitError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=exc.to_detail(),
+        ) from exc
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/backend/app/api/api_v1/endpoints/onboarding.py
+++ b/backend/app/api/api_v1/endpoints/onboarding.py
@@ -125,6 +125,7 @@ async def apply_workspace_onboarding(
     try:
         result = apply_onboarding_plan(db, plan=plan, auth_context=_auth, request=request)
     except OrganizationPlanLimitError as exc:
+        db.rollback()
         raise HTTPException(
             status_code=status.HTTP_402_PAYMENT_REQUIRED,
             detail=exc.to_detail(),

--- a/backend/app/services/cloudflare_dns.py
+++ b/backend/app/services/cloudflare_dns.py
@@ -114,29 +114,40 @@ async def import_cloudflare_domains(
     imported: List[str] = []
     existing: List[str] = []
     skipped: List[str] = []
+    candidate_names: List[str] = []
 
     for zone in zones:
         name = str(zone["name"]).lower()
         if requested and name not in requested:
             skipped.append(name)
             continue
-        domain = (
-            db.query(Domain)
-            .filter(Domain.name == name, Domain.workspace_id == workspace_id)
-            .first()
+        candidate_names.append(name)
+
+    existing_names = set()
+    if candidate_names:
+        existing_names = {
+            row[0]
+            for row in (
+                db.query(Domain.name)
+                .filter(Domain.name.in_(candidate_names), Domain.workspace_id == workspace_id)
+                .all()
+            )
+        }
+    new_names = [name for name in candidate_names if name not in existing_names]
+    if workspace and workspace.organization and new_names:
+        require_organization_plan_limit(
+            db,
+            workspace.organization,
+            "monitored_domains",
+            increment=len(new_names),
         )
-        if domain is None:
-            if workspace and workspace.organization:
-                require_organization_plan_limit(
-                    db,
-                    workspace.organization,
-                    "monitored_domains",
-                )
-            db.add(Domain(name=name, active=True, verified=True, workspace_id=workspace_id))
-            db.flush()
-            imported.append(name)
-        else:
+
+    for name in candidate_names:
+        if name in existing_names:
             existing.append(name)
+        else:
+            db.add(Domain(name=name, active=True, verified=True, workspace_id=workspace_id))
+            imported.append(name)
 
     db.commit()
     return {

--- a/backend/app/services/cloudflare_dns.py
+++ b/backend/app/services/cloudflare_dns.py
@@ -15,11 +15,13 @@ from app.core.credential_encryption import decrypt_secret
 from app.models.dns_cache import DNSRecordChange, DNSRecordSnapshot
 from app.models.domain import Domain
 from app.models.setting import Setting
+from app.models.workspace import Workspace
 from app.services.dns_resolver import (
     CloudflareDNSProvider,
     extract_dmarc_policy,
     parse_dmarc_record_tags,
 )
+from app.services.organizations import require_organization_plan_limit
 from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
 PROVIDER_NAME = "cloudflare"
@@ -105,6 +107,8 @@ async def import_cloudflare_domains(
     if workspace_id is None:
         workspace = assign_default_workspace_to_unscoped_rows(db)
         workspace_id = workspace.id
+    else:
+        workspace = db.query(Workspace).filter(Workspace.id == workspace_id).first()
     zones = await discover_cloudflare_zones(db, workspace_id=workspace_id)
     requested = {domain.strip().lower() for domain in requested_domains or [] if domain.strip()}
     imported: List[str] = []
@@ -122,7 +126,14 @@ async def import_cloudflare_domains(
             .first()
         )
         if domain is None:
+            if workspace and workspace.organization:
+                require_organization_plan_limit(
+                    db,
+                    workspace.organization,
+                    "monitored_domains",
+                )
             db.add(Domain(name=name, active=True, verified=True, workspace_id=workspace_id))
+            db.flush()
             imported.append(name)
         else:
             existing.append(name)

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -75,6 +75,7 @@ ACCOUNT_ACTIVE_STATUSES = {"active", "trialing"}
 ACCOUNT_GRACE_STATUSES = {"past_due_provider_reported"}
 ACCOUNT_READ_ONLY_STATUSES = {"suspended", "canceled", "terminated"}
 ACCOUNT_CLOSED_STATUSES = {"canceled", "terminated"}
+ENFORCED_PLAN_LIMITS = {"api_tokens", "monitored_domains", "webhooks"}
 FEATURE_ENTITLEMENT_ALIASES: Dict[str, tuple[str, ...]] = {
     "api_tokens": ("api_tokens", "api_access"),
     "webhooks": ("webhooks",),
@@ -87,6 +88,45 @@ PLAN_LIMIT_ENTITLEMENT_ALIASES: Dict[str, tuple[str, ...]] = {
     "webhooks": FEATURE_ENTITLEMENT_ALIASES["webhooks"],
     "retention_days": ("retention_days",),
 }
+
+
+class OrganizationPlanLimitError(ValueError):
+    """Raised when a plan limit would be exceeded by a mutation."""
+
+    def __init__(
+        self,
+        *,
+        metric: str,
+        current: int,
+        limit: int,
+        attempted: int,
+        unit: str,
+        entitlement_key: Optional[str],
+    ):
+        self.metric = metric
+        self.current = current
+        self.limit = limit
+        self.attempted = attempted
+        self.unit = unit
+        self.entitlement_key = entitlement_key
+        super().__init__(
+            f"Plan limit for {metric} would be exceeded "
+            f"({current} current + {attempted} requested > {limit} {unit})"
+        )
+
+    def to_detail(self) -> Dict[str, Any]:
+        """Return an API-safe detail payload."""
+        return {
+            "code": "plan_limit_exceeded",
+            "metric": self.metric,
+            "current": self.current,
+            "limit": self.limit,
+            "attempted": self.attempted,
+            "unit": self.unit,
+            "entitlement_key": self.entitlement_key,
+            "can_export": True,
+            "message": str(self),
+        }
 
 
 def _sanitize_payload_summary(payload_summary: Optional[str]) -> Optional[str]:
@@ -671,11 +711,57 @@ def _plan_limits_for_organization(
             current=current_values.get(metric, 0),
             limit=_entitlement_limit(entitlement.value),
             unit="days" if metric == "retention_days" else "count",
-            enforced=metric in {"api_tokens", "webhooks"},
+            enforced=metric in ENFORCED_PLAN_LIMITS,
         )
         limits[metric]["source"] = entitlement.source
         limits[metric]["entitlement_key"] = entitlement.key
     return limits
+
+
+def organization_plan_limit(
+    db: Session,
+    organization: Organization,
+    metric: str,
+) -> Optional[Dict[str, Any]]:
+    """Return the current plan-limit payload for one metric, if configured."""
+    entitlements = _active_entitlements_query(db, organization).all()
+    workspaces = (
+        db.query(Workspace)
+        .filter(Workspace.organization_id == organization.id)
+        .order_by(Workspace.slug.asc())
+        .all()
+    )
+    return _plan_limits_for_organization(db, organization, workspaces, entitlements).get(metric)
+
+
+def require_organization_plan_limit(
+    db: Session,
+    organization: Organization,
+    metric: str,
+    *,
+    increment: int = 1,
+) -> None:
+    """Raise when a mutation would exceed a configured organization plan limit."""
+    if increment <= 0:
+        return
+    limit_payload = organization_plan_limit(db, organization, metric)
+    if not limit_payload:
+        return
+    limit = limit_payload.get("limit")
+    if limit is None:
+        return
+    current = int(limit_payload.get("current") or 0)
+    attempted = int(increment)
+    if current + attempted <= int(limit):
+        return
+    raise OrganizationPlanLimitError(
+        metric=metric,
+        current=current,
+        limit=int(limit),
+        attempted=attempted,
+        unit=str(limit_payload.get("unit") or "count"),
+        entitlement_key=limit_payload.get("entitlement_key"),
+    )
 
 
 def organization_summary(

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -744,7 +744,13 @@ def require_organization_plan_limit(
     """Raise when a mutation would exceed a configured organization plan limit."""
     if increment <= 0:
         return
-    limit_payload = organization_plan_limit(db, organization, metric)
+    locked_organization = (
+        db.query(Organization)
+        .filter(Organization.id == organization.id)
+        .with_for_update()
+        .one_or_none()
+    )
+    limit_payload = organization_plan_limit(db, locked_organization or organization, metric)
     if not limit_payload:
         return
     limit = limit_payload.get("limit")

--- a/backend/app/services/workspace_onboarding.py
+++ b/backend/app/services/workspace_onboarding.py
@@ -21,6 +21,7 @@ from app.services.organizations import (
     ensure_entitlements,
     ensure_subscription,
     get_or_create_starter_plan,
+    require_organization_plan_limit,
 )
 from app.services.workspace_access import ROLE_WORKSPACE_OWNER, user_for_auth_context
 from app.services.workspace_audit import record_workspace_audit_log, sanitize_audit_details
@@ -575,7 +576,9 @@ def build_onboarding_plan(  # pylint: disable=too-many-locals
     return plan
 
 
-def _ensure_organization(db: Session, organization_plan: Dict[str, Any]) -> Tuple[Organization, str]:
+def _ensure_organization(
+    db: Session, organization_plan: Dict[str, Any]
+) -> Tuple[Organization, str]:
     organization = (
         db.query(Organization).filter(Organization.slug == organization_plan["slug"]).first()
     )
@@ -644,6 +647,12 @@ def _apply_domains(
                 }
             )
             continue
+        if workspace.organization:
+            require_organization_plan_limit(
+                db,
+                workspace.organization,
+                "monitored_domains",
+            )
         domain = Domain(
             workspace_id=workspace.id,
             name=item["name"],

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -12,11 +12,13 @@ from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.dns_cache import DNSRecordChange, DNSRecordSnapshot
 from app.models.domain import Domain
+from app.models.organization import Entitlement, Organization
 from app.models.setting import Setting
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.services import cloudflare_dns
 from app.services.cloudflare_dns import analyze_dns_records, sync_dns_record_changes
+from app.services.organizations import OrganizationPlanLimitError
 from app.services.workspaces import get_or_create_default_workspace
 
 DOMAIN = "example.com"
@@ -300,6 +302,46 @@ def test_import_cloudflare_domains_imports_requested_and_skips_others(db_session
     assert result["existing"] == []
     assert sorted(result["skipped"]) == [DOMAIN, "skip.example"]
     assert db_session.query(Domain).filter(Domain.name == "new.example").first() is not None
+
+
+def test_import_cloudflare_domains_respects_monitored_domain_plan_limit(db_session):
+    organization = Organization(slug="cf-quota", name="CF Quota", active=True)
+    workspace = Workspace(slug="cf-quota", name="CF Quota", organization=organization, active=True)
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="monitored_domains",
+                value="1",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    db_session.add(Domain(name="existing.example", workspace_id=workspace.id, active=True))
+    db_session.commit()
+
+    async def fake_discover(_db, workspace_id=None):
+        return [{"id": "zone-1", "name": "new.example", "imported": False}]
+
+    with patch("app.services.cloudflare_dns.discover_cloudflare_zones", new=fake_discover):
+        try:
+            asyncio.run(
+                cloudflare_dns.import_cloudflare_domains(
+                    db_session,
+                    requested_domains=["new.example"],
+                    workspace_id=workspace.id,
+                )
+            )
+        except OrganizationPlanLimitError as exc:
+            assert exc.to_detail()["metric"] == "monitored_domains"
+            assert exc.to_detail()["current"] == 1
+            assert exc.to_detail()["limit"] == 1
+        else:
+            raise AssertionError("Expected monitored domain plan limit")
 
 
 def test_get_zone_for_domain_uses_configured_zone_id_even_if_zone_lookup_fails(db_session):

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -19,6 +19,7 @@ from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.api.api_v1.endpoints.domains import _domain_names_for_summary, _spf_fix_hint
 from app.models.dns_cache import DNSCache, DNSRecordChange
 from app.models.domain import Domain
+from app.models.organization import Entitlement, Organization
 from app.models.report import DMARCReport, ReportRecord
 from app.models.workspace import Workspace
 from app.services.bimi import BIMIResult
@@ -775,6 +776,45 @@ def test_domain_detail_data_endpoints_support_manually_configured_domain(
     assert sources.json()["sources"] == []
     assert selectors.status_code == 200
     assert selectors.json() == {"selectors": [], "report_selectors": []}
+
+
+def test_create_domain_respects_monitored_domain_plan_limit(
+    authed_client: TestClient,
+    db_session,
+):
+    organization = Organization(slug="default", name="Default Organization", active=True)
+    workspace = Workspace(
+        slug="default",
+        name="Default Workspace",
+        organization=organization,
+        active=True,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Domain(name="first.example", workspace=workspace, active=True),
+            Entitlement(
+                organization=organization,
+                key="monitored_domains",
+                value="1",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    second = authed_client.post("/api/v1/domains/domains", json={"name": "second.example"})
+
+    assert second.status_code == 402
+    detail = second.json()["detail"]
+    assert detail["code"] == "plan_limit_exceeded"
+    assert detail["metric"] == "monitored_domains"
+    assert detail["current"] == 1
+    assert detail["limit"] == 1
+    assert detail["attempted"] == 1
+    assert detail["can_export"] is True
 
 
 @pytest.mark.parametrize(

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -23,6 +23,7 @@ from app.models.workspace_access import WorkspaceMembership
 from app.services.organizations import (
     BILLING_MODE_SELF_HOSTED,
     DEFAULT_ORGANIZATION_SLUG,
+    OrganizationPlanLimitError,
     SELF_HOSTED_PLAN_CODE,
     STARTER_PLAN_CODE,
     OrganizationPlanLimitError,
@@ -32,6 +33,7 @@ from app.services.organizations import (
     list_organization_summaries,
     organization_plan_limit,
     organization_summary,
+    require_organization_plan_limit,
     require_organization_feature,
     require_organization_plan_limit,
 )
@@ -204,6 +206,115 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     assert limits["webhooks"]["current"] == 1
     assert limits["webhooks"]["limit"] == 0
     assert limits["webhooks"]["enforced"] is True
+
+
+def test_organization_plan_limit_returns_configured_metric(db_session: Session):
+    organization = Organization(slug="single-limit", name="Single Limit", active=True)
+    workspace = Workspace(
+        slug="single-limit-main",
+        name="Single Limit Main",
+        organization=organization,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Domain(workspace=workspace, name="one.example", active=True),
+            Entitlement(
+                organization=organization,
+                key="monitored_domains",
+                value="2",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    limit = organization_plan_limit(db_session, organization, "monitored_domains")
+
+    assert limit is not None
+    assert limit["current"] == 1
+    assert limit["limit"] == 2
+    assert limit["remaining"] == 1
+    assert limit["entitlement_key"] == "monitored_domains"
+
+
+def test_require_organization_plan_limit_allows_unmetered_and_available_capacity(
+    db_session: Session,
+):
+    organization = Organization(slug="limit-allowed", name="Limit Allowed", active=True)
+    workspace = Workspace(
+        slug="limit-allowed-main",
+        name="Limit Allowed Main",
+        organization=organization,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="monitored_domains",
+                value="2",
+                source="plan",
+                active=True,
+            ),
+            Entitlement(
+                organization=organization,
+                key="retention_days",
+                value="unlimited",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    require_organization_plan_limit(db_session, organization, "monitored_domains")
+    require_organization_plan_limit(db_session, organization, "retention_days")
+    require_organization_plan_limit(db_session, organization, "missing_metric")
+    require_organization_plan_limit(db_session, organization, "monitored_domains", increment=0)
+
+
+def test_require_organization_plan_limit_raises_with_api_safe_detail(db_session: Session):
+    organization = Organization(slug="limit-blocked", name="Limit Blocked", active=True)
+    workspace = Workspace(
+        slug="limit-blocked-main",
+        name="Limit Blocked Main",
+        organization=organization,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Domain(workspace=workspace, name="one.example", active=True),
+            Entitlement(
+                organization=organization,
+                key="monitored_domains",
+                value="1",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    with pytest.raises(OrganizationPlanLimitError) as exc_info:
+        require_organization_plan_limit(db_session, organization, "monitored_domains")
+
+    assert exc_info.value.to_detail() == {
+        "code": "plan_limit_exceeded",
+        "metric": "monitored_domains",
+        "current": 1,
+        "limit": 1,
+        "attempted": 1,
+        "unit": "count",
+        "entitlement_key": "monitored_domains",
+        "can_export": True,
+        "message": "Plan limit for monitored_domains would be exceeded "
+        "(1 current + 1 requested > 1 count)",
+    }
 
 
 def test_organization_summary_handles_unbounded_and_missing_entitlements(

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -23,7 +23,6 @@ from app.models.workspace_access import WorkspaceMembership
 from app.services.organizations import (
     BILLING_MODE_SELF_HOSTED,
     DEFAULT_ORGANIZATION_SLUG,
-    OrganizationPlanLimitError,
     SELF_HOSTED_PLAN_CODE,
     STARTER_PLAN_CODE,
     OrganizationPlanLimitError,
@@ -33,7 +32,6 @@ from app.services.organizations import (
     list_organization_summaries,
     organization_plan_limit,
     organization_summary,
-    require_organization_plan_limit,
     require_organization_feature,
     require_organization_plan_limit,
 )

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -25,12 +25,15 @@ from app.services.organizations import (
     DEFAULT_ORGANIZATION_SLUG,
     SELF_HOSTED_PLAN_CODE,
     STARTER_PLAN_CODE,
+    OrganizationPlanLimitError,
     account_state_for_subscriptions,
     bootstrap_default_commercial_foundation,
     get_or_create_starter_plan,
     list_organization_summaries,
+    organization_plan_limit,
     organization_summary,
     require_organization_feature,
+    require_organization_plan_limit,
 )
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
@@ -193,6 +196,7 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     assert limits["monitored_domains"]["current"] == 1
     assert limits["monitored_domains"]["limit"] == 1
     assert limits["monitored_domains"]["status"] == "warning"
+    assert limits["monitored_domains"]["enforced"] is True
     assert limits["api_tokens"]["current"] == 1
     assert limits["api_tokens"]["limit"] == 0
     assert limits["api_tokens"]["status"] == "exceeded"
@@ -242,6 +246,131 @@ def test_organization_summary_handles_unbounded_and_missing_entitlements(
     assert limits["retention_days"]["status"] == "ok"
     assert limits["mail_sources"]["limit"] is None
     assert limits["mail_sources"]["source"] == "override"
+
+
+def test_require_organization_plan_limit_allows_unconfigured_and_unlimited_limits(
+    db_session: Session,
+):
+    organization = Organization(slug="quota-open", name="Quota Open", active=True)
+    workspace = Workspace(slug="quota-open-main", name="Quota Open Main", organization=organization)
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="mail_sources",
+                value="unlimited",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    assert organization_plan_limit(db_session, organization, "monitored_domains") is None
+    require_organization_plan_limit(
+        db_session,
+        organization,
+        "monitored_domains",
+    )
+    require_organization_plan_limit(
+        db_session,
+        organization,
+        "mail_sources",
+        increment=100,
+    )
+    require_organization_plan_limit(
+        db_session,
+        organization,
+        "mail_sources",
+        increment=0,
+    )
+
+
+def test_require_organization_plan_limit_raises_structured_limit_error(
+    db_session: Session,
+):
+    organization = Organization(slug="quota-blocked", name="Quota Blocked", active=True)
+    workspace = Workspace(
+        slug="quota-blocked-main",
+        name="Quota Blocked Main",
+        organization=organization,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="monitored_domains",
+                value="2",
+                source="plan",
+                active=True,
+            ),
+            Domain(workspace=workspace, name="one.example", active=True),
+            Domain(workspace=workspace, name="two.example", active=True),
+        ]
+    )
+    db_session.commit()
+
+    with pytest.raises(OrganizationPlanLimitError) as exc_info:
+        require_organization_plan_limit(
+            db_session,
+            organization,
+            "monitored_domains",
+        )
+
+    assert str(exc_info.value) == (
+        "Plan limit for monitored_domains would be exceeded " "(2 current + 1 requested > 2 count)"
+    )
+    assert exc_info.value.to_detail() == {
+        "code": "plan_limit_exceeded",
+        "metric": "monitored_domains",
+        "current": 2,
+        "limit": 2,
+        "attempted": 1,
+        "unit": "count",
+        "entitlement_key": "monitored_domains",
+        "can_export": True,
+        "message": (
+            "Plan limit for monitored_domains would be exceeded "
+            "(2 current + 1 requested > 2 count)"
+        ),
+    }
+
+
+def test_require_organization_plan_limit_allows_within_limit_increment(
+    db_session: Session,
+):
+    organization = Organization(slug="quota-room", name="Quota Room", active=True)
+    workspace = Workspace(slug="quota-room-main", name="Quota Room Main", organization=organization)
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="monitored_domains",
+                value="2",
+                source="plan",
+                active=True,
+            ),
+            Domain(workspace=workspace, name="one.example", active=True),
+        ]
+    )
+    db_session.commit()
+
+    limit = organization_plan_limit(db_session, organization, "monitored_domains")
+
+    assert limit is not None
+    assert limit["current"] == 1
+    assert limit["remaining"] == 1
+    require_organization_plan_limit(
+        db_session,
+        organization,
+        "monitored_domains",
+    )
 
 
 def test_duplicate_active_entitlements_use_latest_row(db_session: Session):

--- a/backend/app/tests/test_workspace_onboarding.py
+++ b/backend/app/tests/test_workspace_onboarding.py
@@ -198,6 +198,7 @@ def test_apply_onboarding_creates_workspace_assets_and_audit(
 
 def test_apply_onboarding_respects_monitored_domain_plan_limit(
     authed_client: TestClient,
+    db_session: Session,
 ):
     """Starter onboarding cannot create more monitored domains than the plan allows."""
     response = authed_client.post(
@@ -218,6 +219,14 @@ def test_apply_onboarding_respects_monitored_domain_plan_limit(
     assert detail["limit"] == 1
     assert detail["attempted"] == 1
     assert detail["can_export"] is True
+    assert db_session.query(Organization).filter(Organization.slug == "client-one").count() == 0
+    assert db_session.query(Workspace).filter(Workspace.slug == "client-one").count() == 0
+    assert (
+        db_session.query(Domain)
+        .filter(Domain.name.in_(["one.example", "two.example"]))
+        .count()
+        == 0
+    )
 
 
 def test_apply_onboarding_is_idempotent_for_existing_assets(

--- a/backend/app/tests/test_workspace_onboarding.py
+++ b/backend/app/tests/test_workspace_onboarding.py
@@ -162,9 +162,7 @@ def test_apply_onboarding_creates_workspace_assets_and_audit(
     source = db_session.query(MailSource).filter(MailSource.name == "Client One DMARC inbox").one()
     starter_plan = db_session.query(Plan).filter(Plan.code == STARTER_PLAN_CODE).one()
     subscription = (
-        db_session.query(Subscription)
-        .filter(Subscription.organization_id == organization.id)
-        .one()
+        db_session.query(Subscription).filter(Subscription.organization_id == organization.id).one()
     )
     entitlement_keys = {
         entitlement.key
@@ -196,6 +194,30 @@ def test_apply_onboarding_creates_workspace_assets_and_audit(
     assert audit.workspace_id == workspace.id
     assert audit.ip_address == "198.51.100.25"
     assert "super-secret-password" not in (audit.details or "")
+
+
+def test_apply_onboarding_respects_monitored_domain_plan_limit(
+    authed_client: TestClient,
+):
+    """Starter onboarding cannot create more monitored domains than the plan allows."""
+    response = authed_client.post(
+        "/api/v1/onboarding/apply",
+        json=_standard_payload(
+            domains=[
+                {"name": "one.example", "description": "Primary domain"},
+                {"name": "two.example", "description": "Second domain"},
+            ]
+        ),
+    )
+
+    assert response.status_code == 402
+    detail = response.json()["detail"]
+    assert detail["code"] == "plan_limit_exceeded"
+    assert detail["metric"] == "monitored_domains"
+    assert detail["current"] == 1
+    assert detail["limit"] == 1
+    assert detail["attempted"] == 1
+    assert detail["can_export"] is True
 
 
 def test_apply_onboarding_is_idempotent_for_existing_assets(

--- a/backend/app/tests/test_workspace_onboarding.py
+++ b/backend/app/tests/test_workspace_onboarding.py
@@ -222,9 +222,7 @@ def test_apply_onboarding_respects_monitored_domain_plan_limit(
     assert db_session.query(Organization).filter(Organization.slug == "client-one").count() == 0
     assert db_session.query(Workspace).filter(Workspace.slug == "client-one").count() == 0
     assert (
-        db_session.query(Domain)
-        .filter(Domain.name.in_(["one.example", "two.example"]))
-        .count()
+        db_session.query(Domain).filter(Domain.name.in_(["one.example", "two.example"])).count()
         == 0
     )
 


### PR DESCRIPTION
Refs #242.

This slice enforces the monitored domain plan limit on domain creation paths while preserving read/export behavior.

Changes:
- Add a shared organization plan-limit guard with structured 402 detail payloads.
- Mark monitored_domains as an enforced plan limit in organization summaries.
- Enforce monitored-domain quota for manual domain creation, Cloudflare domain import, and workspace onboarding domain creation.
- Add focused regressions for all three creation paths.

Validation:
- python3 -m py_compile on touched files
- black --check on touched files
- isort --check-only on touched files
- flake8 on touched files
- PYTHONPATH=backend .venv/bin/pytest backend/app/tests/test_dns_endpoints.py backend/app/tests/test_workspace_onboarding.py backend/app/tests/test_cloudflare_dns.py -q (90 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plan-limit enforcement for monitored domains during domain creation, Cloudflare imports, and onboarding.
  * Users now receive a structured payment-required response when a limit is exceeded.

* **Bug Fixes**
  * Improved handling so domain onboarding and import flows fail gracefully when organization limits are reached.
  * Cloudflare imports now respect the selected workspace and its organization limits.

* **Tests**
  * Expanded coverage for plan-limit checks, including limit-exceeded responses and structured error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->