### PR TITLE
feat(billing): enforce user seat quotas

### DIFF
--- a/backend/app/api/api_v1/endpoints/memberships.py
+++ b/backend/app/api/api_v1/endpoints/memberships.py
@@ -13,6 +13,11 @@ from app.models.organization import Organization, OrganizationMembership
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
+from app.services.organizations import (
+    OrganizationPlanLimitError,
+    organization_user_has_active_seat,
+    require_organization_plan_limit,
+)
 from app.services.workspace_access import (
     PERMISSION_WORKSPACE_ADMIN,
     ROLE_ANALYST,
@@ -192,6 +197,31 @@ def _organization_membership_to_response(row: OrganizationMembership) -> Members
     )
 
 
+def _raise_plan_limit_error(db: Session, exc: OrganizationPlanLimitError) -> None:
+    db.rollback()
+    raise HTTPException(
+        status_code=status.HTTP_402_PAYMENT_REQUIRED,
+        detail=exc.to_detail(),
+    ) from exc
+
+
+def _require_user_seat_capacity(
+    db: Session,
+    organization: Optional[Organization],
+    user: User,
+    *,
+    active: bool,
+    activate_user: bool = False,
+) -> None:
+    if organization is None or not active:
+        return
+    if not activate_user and not user.is_active:
+        return
+    if user.is_active and organization_user_has_active_seat(db, organization, user):
+        return
+    require_organization_plan_limit(db, organization, "users")
+
+
 def _find_or_create_invited_user(
     db: Session,
     payload: MembershipInviteRequest,
@@ -212,7 +242,7 @@ def _find_or_create_invited_user(
             email=email,
             logto_id=payload.logto_id,
             full_name=payload.full_name,
-            is_active=True,
+            is_active=False,
             is_verified=False,
             is_superuser=False,
         )
@@ -225,9 +255,147 @@ def _find_or_create_invited_user(
         user.logto_id = payload.logto_id
     if payload.full_name and not user.full_name:
         user.full_name = payload.full_name
-    user.is_active = True
     db.flush()
     return user
+
+
+def _upsert_workspace_membership_row(
+    *,
+    db: Session,
+    workspace: Workspace,
+    user: User,
+    role: str,
+    active: bool,
+    request: Request,
+    auth_context: dict,
+    activate_user: bool = False,
+) -> WorkspaceMembership:
+    membership = (
+        db.query(WorkspaceMembership)
+        .filter(
+            WorkspaceMembership.workspace_id == workspace.id,
+            WorkspaceMembership.user_id == user.id,
+        )
+        .first()
+    )
+    old = {"role": membership.role, "active": membership.active} if membership is not None else None
+    try:
+        _require_user_seat_capacity(
+            db,
+            workspace.organization,
+            user,
+            active=active,
+            activate_user=activate_user,
+        )
+    except OrganizationPlanLimitError as exc:
+        _raise_plan_limit_error(db, exc)
+    if activate_user:
+        user.is_active = True
+    if membership is None:
+        membership = WorkspaceMembership(
+            workspace_id=workspace.id,
+            user_id=user.id,
+            role=role,
+            active=active,
+        )
+        db.add(membership)
+    else:
+        membership.role = role
+        membership.active = active
+    try:
+        db.flush()
+    except IntegrityError as exc:  # pragma: no cover - database race fallback
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Workspace membership already exists",
+        ) from exc
+    record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action="workspace.membership_upserted",
+        entity_type="workspace_membership",
+        entity_id=membership.id,
+        entity_name=user.email,
+        details={"old": old, "new": {"role": role, "active": active}},
+        auth_context=auth_context,
+        request=request,
+    )
+    db.commit()
+    db.refresh(membership)
+    return membership
+
+
+def _upsert_organization_membership_row(
+    *,
+    db: Session,
+    organization: Organization,
+    user: User,
+    role: str,
+    active: bool,
+    request: Request,
+    auth_context: dict,
+    activate_user: bool = False,
+) -> OrganizationMembership:
+    membership = (
+        db.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.organization_id == organization.id,
+            OrganizationMembership.user_id == user.id,
+        )
+        .first()
+    )
+    old = {"role": membership.role, "active": membership.active} if membership is not None else None
+    try:
+        _require_user_seat_capacity(
+            db,
+            organization,
+            user,
+            active=active,
+            activate_user=activate_user,
+        )
+    except OrganizationPlanLimitError as exc:
+        _raise_plan_limit_error(db, exc)
+    if activate_user:
+        user.is_active = True
+    if membership is None:
+        membership = OrganizationMembership(
+            organization_id=organization.id,
+            user_id=user.id,
+            role=role,
+            active=active,
+        )
+        db.add(membership)
+    else:
+        membership.role = role
+        membership.active = active
+    try:
+        db.flush()
+    except IntegrityError as exc:  # pragma: no cover - database race fallback
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Organization membership already exists",
+        ) from exc
+    audit_workspace = _audit_workspace_for_organization(db, organization)
+    record_workspace_audit_log(
+        db,
+        workspace=audit_workspace,
+        action="organization.membership_upserted",
+        entity_type="organization_membership",
+        entity_id=membership.id,
+        entity_name=user.email,
+        details={
+            "organization_id": organization.id,
+            "old": old,
+            "new": {"role": role, "active": active},
+        },
+        auth_context=auth_context,
+        request=request,
+    )
+    db.commit()
+    db.refresh(membership)
+    return membership
 
 
 @router.get("/workspaces/{workspace_id}", response_model=MembershipListResponse)
@@ -274,47 +442,15 @@ async def upsert_workspace_membership(
     _ensure_workspace_accepts_mutation(workspace)
     user = _user_or_404(db, user_id)
     role = _normalize_role(payload.role, WORKSPACE_ROLES)
-    membership = (
-        db.query(WorkspaceMembership)
-        .filter(
-            WorkspaceMembership.workspace_id == workspace.id,
-            WorkspaceMembership.user_id == user.id,
-        )
-        .first()
-    )
-    old = {"role": membership.role, "active": membership.active} if membership is not None else None
-    if membership is None:
-        membership = WorkspaceMembership(
-            workspace_id=workspace.id,
-            user_id=user.id,
-            role=role,
-            active=payload.active,
-        )
-        db.add(membership)
-    else:
-        membership.role = role
-        membership.active = payload.active
-    try:
-        db.flush()
-    except IntegrityError as exc:
-        db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Workspace membership already exists",
-        ) from exc
-    record_workspace_audit_log(
-        db,
+    membership = _upsert_workspace_membership_row(
+        db=db,
         workspace=workspace,
-        action="workspace.membership_upserted",
-        entity_type="workspace_membership",
-        entity_id=membership.id,
-        entity_name=user.email,
-        details={"old": old, "new": {"role": role, "active": payload.active}},
-        auth_context=_auth,
+        user=user,
+        role=role,
+        active=payload.active,
         request=request,
+        auth_context=_auth,
     )
-    db.commit()
-    db.refresh(membership)
     return _workspace_membership_to_response(membership)
 
 
@@ -330,16 +466,19 @@ async def invite_workspace_member(
     workspace = _workspace_or_404(db, workspace_id)
     require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, workspace)
     _ensure_workspace_accepts_mutation(workspace)
+    role = _normalize_role(payload.role, WORKSPACE_ROLES)
     user = _find_or_create_invited_user(db, payload)
-    upsert = MembershipUpsertRequest(user_id=user.id, role=payload.role, active=True)
-    return await upsert_workspace_membership(
-        workspace_id=workspace_id,
-        user_id=user.id,
-        payload=upsert,
-        request=request,
+    membership = _upsert_workspace_membership_row(
         db=db,
-        _auth=_auth,
+        workspace=workspace,
+        user=user,
+        role=role,
+        active=True,
+        request=request,
+        auth_context=_auth,
+        activate_user=True,
     )
+    return _workspace_membership_to_response(membership)
 
 
 @router.delete("/workspaces/{workspace_id}/users/{user_id}", response_model=MembershipResponse)
@@ -431,52 +570,15 @@ async def upsert_organization_membership(
     require_organization_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, organization)
     user = _user_or_404(db, user_id)
     role = _normalize_role(payload.role, ORGANIZATION_ROLES)
-    membership = (
-        db.query(OrganizationMembership)
-        .filter(
-            OrganizationMembership.organization_id == organization.id,
-            OrganizationMembership.user_id == user.id,
-        )
-        .first()
-    )
-    old = {"role": membership.role, "active": membership.active} if membership is not None else None
-    if membership is None:
-        membership = OrganizationMembership(
-            organization_id=organization.id,
-            user_id=user.id,
-            role=role,
-            active=payload.active,
-        )
-        db.add(membership)
-    else:
-        membership.role = role
-        membership.active = payload.active
-    try:
-        db.flush()
-    except IntegrityError as exc:
-        db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Organization membership already exists",
-        ) from exc
-    audit_workspace = _audit_workspace_for_organization(db, organization)
-    record_workspace_audit_log(
-        db,
-        workspace=audit_workspace,
-        action="organization.membership_upserted",
-        entity_type="organization_membership",
-        entity_id=membership.id,
-        entity_name=user.email,
-        details={
-            "organization_id": organization.id,
-            "old": old,
-            "new": {"role": role, "active": payload.active},
-        },
-        auth_context=_auth,
+    membership = _upsert_organization_membership_row(
+        db=db,
+        organization=organization,
+        user=user,
+        role=role,
+        active=payload.active,
         request=request,
+        auth_context=_auth,
     )
-    db.commit()
-    db.refresh(membership)
     return _organization_membership_to_response(membership)
 
 
@@ -491,16 +593,19 @@ async def invite_organization_member(
     """Invite or link a user by email and assign an organization role."""
     organization = _organization_or_404(db, organization_id)
     require_organization_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, organization)
+    role = _normalize_role(payload.role, ORGANIZATION_ROLES)
     user = _find_or_create_invited_user(db, payload)
-    upsert = MembershipUpsertRequest(user_id=user.id, role=payload.role, active=True)
-    return await upsert_organization_membership(
-        organization_id=organization_id,
-        user_id=user.id,
-        payload=upsert,
-        request=request,
+    membership = _upsert_organization_membership_row(
         db=db,
-        _auth=_auth,
+        organization=organization,
+        user=user,
+        role=role,
+        active=True,
+        request=request,
+        auth_context=_auth,
+        activate_user=True,
     )
+    return _organization_membership_to_response(membership)
 
 
 @router.delete(

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -17,6 +17,7 @@ from app.models.organization import (
     BillingEvent,
     Entitlement,
     Organization,
+    OrganizationMembership,
     Plan,
     Subscription,
     UsageRecord,
@@ -25,6 +26,7 @@ from app.models.report import DMARCReport, ForensicReport, ReportRecord
 from app.models.user import User
 from app.models.webhook import WebhookEndpoint
 from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
 from app.services.workspaces import normalize_workspace_slug
 
 DEFAULT_ORGANIZATION_SLUG = "default"
@@ -75,7 +77,7 @@ ACCOUNT_ACTIVE_STATUSES = {"active", "trialing"}
 ACCOUNT_GRACE_STATUSES = {"past_due_provider_reported"}
 ACCOUNT_READ_ONLY_STATUSES = {"suspended", "canceled", "terminated"}
 ACCOUNT_CLOSED_STATUSES = {"canceled", "terminated"}
-ENFORCED_PLAN_LIMITS = {"api_tokens", "monitored_domains", "webhooks"}
+ENFORCED_PLAN_LIMITS = {"api_tokens", "monitored_domains", "users", "webhooks"}
 FEATURE_ENTITLEMENT_ALIASES: Dict[str, tuple[str, ...]] = {
     "api_tokens": ("api_tokens", "api_access"),
     "webhooks": ("webhooks",),
@@ -648,6 +650,64 @@ def require_organization_feature(
     )
 
 
+def _active_user_ids_for_organization(
+    db: Session,
+    organization: Organization,
+    workspaces: Optional[List[Workspace]] = None,
+) -> set[int]:
+    """Return active user IDs that currently consume seats for an organization."""
+    if workspaces is None:
+        workspaces = (
+            db.query(Workspace)
+            .filter(Workspace.organization_id == organization.id)
+            .order_by(Workspace.slug.asc())
+            .all()
+        )
+    workspace_ids = [workspace.id for workspace in workspaces]
+    workspace_filter = workspace_ids or [-1]
+
+    user_ids = {
+        user_id
+        for (user_id,) in db.query(User.id)
+        .filter(User.workspace_id.in_(workspace_filter), User.is_active.is_(True))
+        .all()
+    }
+    user_ids.update(
+        user_id
+        for (user_id,) in db.query(WorkspaceMembership.user_id)
+        .join(User, WorkspaceMembership.user_id == User.id)
+        .filter(
+            WorkspaceMembership.workspace_id.in_(workspace_filter),
+            WorkspaceMembership.active.is_(True),
+            User.is_active.is_(True),
+        )
+        .all()
+    )
+    user_ids.update(
+        user_id
+        for (user_id,) in db.query(OrganizationMembership.user_id)
+        .join(User, OrganizationMembership.user_id == User.id)
+        .filter(
+            OrganizationMembership.organization_id == organization.id,
+            OrganizationMembership.active.is_(True),
+            User.is_active.is_(True),
+        )
+        .all()
+    )
+    return user_ids
+
+
+def organization_user_has_active_seat(
+    db: Session,
+    organization: Organization,
+    user: User,
+) -> bool:
+    """Return whether a user already consumes one active seat in an organization."""
+    if not user.is_active:
+        return False
+    return user.id in _active_user_ids_for_organization(db, organization)
+
+
 def _plan_limits_for_organization(
     db: Session,
     organization: Organization,
@@ -672,12 +732,7 @@ def _plan_limits_for_organization(
             .scalar()
             or 0
         ),
-        "users": (
-            db.query(func.count(User.id))
-            .filter(User.workspace_id.in_(workspace_filter), User.is_active.is_(True))
-            .scalar()
-            or 0
-        ),
+        "users": (len(_active_user_ids_for_organization(db, organization, workspaces))),
         "api_tokens": (
             db.query(func.count(APIToken.id))
             .filter(APIToken.workspace_id.in_(workspace_filter), APIToken.active.is_(True))

--- a/backend/app/tests/test_memberships_api.py
+++ b/backend/app/tests/test_memberships_api.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.core.security import require_admin_auth
-from app.models.organization import Organization, OrganizationMembership
+from app.models.organization import Entitlement, Organization, OrganizationMembership
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog, WorkspaceMembership
@@ -139,6 +139,11 @@ def test_workspace_membership_api_invites_updates_and_deactivates(
         assert deactivated.status_code == 200
         assert deactivated.json()["active"] is False
 
+        missing_membership = owner_client.delete(
+            f"/api/v1/memberships/workspaces/{workspace.id}/users/999999"
+        )
+        assert missing_membership.status_code == 404
+
     assert (
         role_for_workspace(
             db_session,
@@ -199,6 +204,99 @@ def test_workspace_membership_api_validates_payload_and_invite_identity_conflict
         assert linked.json()["user"]["email"] == "legacy-logto@example.com"
 
 
+def test_workspace_membership_invite_respects_user_seat_plan_limit(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(slug="workspace-seat-limit", name="Workspace Seat Limit")
+    workspace = Workspace(
+        slug="workspace-seat-limit-main",
+        name="Workspace Seat Limit Main",
+        organization=organization,
+        active=True,
+    )
+    owner = _add_user(db_session, "workspace-seat-owner@example.com")
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="users",
+                value="1",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    _add_workspace_membership(db_session, workspace, owner, ROLE_WORKSPACE_OWNER)
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        response = owner_client.post(
+            f"/api/v1/memberships/workspaces/{workspace.id}/invites",
+            json={"email": "workspace-seat-new@example.com", "role": ROLE_ANALYST},
+        )
+
+    assert response.status_code == 402
+    detail = response.json()["detail"]
+    assert detail["code"] == "plan_limit_exceeded"
+    assert detail["metric"] == "users"
+    assert detail["current"] == 1
+    assert detail["limit"] == 1
+    assert detail["can_export"] is True
+    assert (
+        db_session.query(User).filter(User.email == "workspace-seat-new@example.com").first()
+        is None
+    )
+    assert db_session.query(WorkspaceMembership).count() == 1
+
+
+def test_workspace_membership_allows_existing_active_seat_with_full_quota(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(
+        slug="workspace-seat-reuse",
+        name="Workspace Seat Reuse",
+        active=True,
+    )
+    workspace = Workspace(
+        slug="workspace-seat-reuse-main",
+        name="Workspace Seat Reuse Main",
+        organization=organization,
+        active=True,
+    )
+    owner = _add_user(db_session, "workspace-seat-reuse-owner@example.com")
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="users",
+                value="1",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    _add_workspace_membership(db_session, workspace, owner, ROLE_WORKSPACE_OWNER)
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        response = owner_client.put(
+            f"/api/v1/memberships/workspaces/{workspace.id}/users/{owner.id}",
+            json={"user_id": owner.id, "role": ROLE_ANALYST},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["role"] == ROLE_ANALYST
+    assert db_session.query(WorkspaceMembership).count() == 1
+
+
 def test_organization_membership_api_audits_and_deactivates(
     test_app,
     db_session: Session,
@@ -245,6 +343,13 @@ def test_organization_membership_api_audits_and_deactivates(
         assert updated.status_code == 200
         assert updated.json()["role"] == "organization_auditor"
 
+        updated_again = owner_client.put(
+            f"/api/v1/memberships/organizations/{organization.id}/users/{target.id}",
+            json={"user_id": target.id, "role": "billing_admin"},
+        )
+        assert updated_again.status_code == 200
+        assert updated_again.json()["role"] == "billing_admin"
+
         listed = owner_client.get(f"/api/v1/memberships/organizations/{organization.id}")
         assert listed.status_code == 200
         assert len(listed.json()["memberships"]) == 3
@@ -267,6 +372,182 @@ def test_organization_membership_api_audits_and_deactivates(
     audit_actions = {row.action for row in db_session.query(WorkspaceAuditLog).all()}
     assert "organization.membership_upserted" in audit_actions
     assert "organization.membership_deactivated" in audit_actions
+
+
+def test_organization_membership_invite_respects_user_seat_plan_limit(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(slug="organization-seat-limit", name="Organization Seat Limit")
+    workspace = Workspace(
+        slug="organization-seat-limit-workspace",
+        name="Organization Seat Limit Workspace",
+        organization=organization,
+        active=True,
+    )
+    owner = _add_user(db_session, "organization-seat-owner@example.com")
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="users",
+                value="1",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=owner.id,
+            role="organization_owner",
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        response = owner_client.post(
+            f"/api/v1/memberships/organizations/{organization.id}/invites",
+            json={"email": "organization-seat-new@example.com", "role": "organization_auditor"},
+        )
+
+    assert response.status_code == 402
+    detail = response.json()["detail"]
+    assert detail["code"] == "plan_limit_exceeded"
+    assert detail["metric"] == "users"
+    assert detail["current"] == 1
+    assert detail["limit"] == 1
+    assert (
+        db_session.query(User).filter(User.email == "organization-seat-new@example.com").first()
+        is None
+    )
+    assert db_session.query(OrganizationMembership).count() == 1
+
+
+def test_organization_invite_existing_inactive_user_respects_seat_limit(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(
+        slug="organization-inactive-seat-limit",
+        name="Organization Inactive Seat Limit",
+    )
+    workspace = Workspace(
+        slug="organization-inactive-seat-limit-workspace",
+        name="Organization Inactive Seat Limit Workspace",
+        organization=organization,
+        active=True,
+    )
+    owner = _add_user(db_session, "organization-inactive-seat-owner@example.com")
+    inactive = User(
+        email="organization-inactive-seat-user@example.com",
+        is_active=False,
+        is_verified=False,
+        is_superuser=False,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            inactive,
+            Entitlement(
+                organization=organization,
+                key="users",
+                value="1",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=owner.id,
+            role="organization_owner",
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        response = owner_client.post(
+            f"/api/v1/memberships/organizations/{organization.id}/invites",
+            json={
+                "email": "organization-inactive-seat-user@example.com",
+                "role": "organization_auditor",
+                "logto_id": "logto-inactive-seat",
+                "full_name": "Inactive Seat User",
+            },
+        )
+
+    assert response.status_code == 402
+    detail = response.json()["detail"]
+    assert detail["code"] == "plan_limit_exceeded"
+    assert detail["metric"] == "users"
+    db_session.refresh(inactive)
+    assert inactive.is_active is False
+    assert inactive.logto_id is None
+    assert inactive.full_name is None
+    assert db_session.query(OrganizationMembership).count() == 1
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        direct_response = owner_client.put(
+            f"/api/v1/memberships/organizations/{organization.id}/users/{inactive.id}",
+            json={"user_id": inactive.id, "role": "organization_auditor"},
+        )
+
+    assert direct_response.status_code == 200
+    db_session.refresh(inactive)
+    assert inactive.is_active is False
+    assert db_session.query(OrganizationMembership).count() == 2
+
+
+def test_organization_membership_api_validates_payload_and_missing_membership(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(
+        slug="organization-membership-validation",
+        name="Organization Membership Validation",
+        active=True,
+    )
+    workspace = Workspace(
+        slug="organization-membership-validation-workspace",
+        name="Organization Membership Validation Workspace",
+        organization=organization,
+        active=True,
+    )
+    owner = _add_user(db_session, "organization-validation-owner@example.com")
+    target = _add_user(db_session, "organization-validation-target@example.com")
+    db_session.add_all([organization, workspace])
+    db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=owner.id,
+            role="organization_owner",
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        mismatched_user = owner_client.put(
+            f"/api/v1/memberships/organizations/{organization.id}/users/{target.id}",
+            json={"user_id": owner.id, "role": "organization_auditor"},
+        )
+        assert mismatched_user.status_code == 422
+
+        missing_membership = owner_client.delete(
+            f"/api/v1/memberships/organizations/{organization.id}/users/{target.id}"
+        )
+        assert missing_membership.status_code == 404
 
 
 def test_organization_membership_api_reuses_inactive_audit_workspace(
@@ -303,10 +584,15 @@ def test_organization_membership_api_reuses_inactive_audit_workspace(
         )
         assert updated.status_code == 200
 
-    assert db_session.query(Workspace).filter(Workspace.organization_id == organization.id).count() == 1
-    audit = db_session.query(WorkspaceAuditLog).filter(
-        WorkspaceAuditLog.action == "organization.membership_upserted"
-    ).one()
+    assert (
+        db_session.query(Workspace).filter(Workspace.organization_id == organization.id).count()
+        == 1
+    )
+    audit = (
+        db_session.query(WorkspaceAuditLog)
+        .filter(WorkspaceAuditLog.action == "organization.membership_upserted")
+        .one()
+    )
     assert audit.workspace_id == inactive_workspace.id
 
 

--- a/backend/app/tests/test_memberships_api.py
+++ b/backend/app/tests/test_memberships_api.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.api.api_v1.endpoints import memberships as memberships_endpoint
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.organization import Entitlement, Organization, OrganizationMembership
@@ -70,6 +71,65 @@ def _add_workspace_membership(
     db_session.add(membership)
     db_session.flush()
     return membership
+
+
+def test_require_user_seat_capacity_skips_non_consuming_memberships(
+    db_session: Session,
+    monkeypatch,
+):
+    organization = Organization(slug="seat-helper", name="Seat Helper")
+    user = User(email="seat-helper@example.com", is_active=True, is_verified=True)
+    inactive_user = User(
+        email="inactive-seat-helper@example.com",
+        is_active=False,
+        is_verified=True,
+    )
+    db_session.add_all([organization, user, inactive_user])
+    db_session.flush()
+    calls: list[tuple[int, str]] = []
+
+    monkeypatch.setattr(
+        memberships_endpoint,
+        "organization_user_has_active_seat",
+        lambda _db, _organization, _user: _user.id == user.id,
+    )
+    monkeypatch.setattr(
+        memberships_endpoint,
+        "require_organization_plan_limit",
+        lambda _db, checked_organization, metric: calls.append((checked_organization.id, metric)),
+    )
+
+    memberships_endpoint._require_user_seat_capacity(db_session, None, user, active=True)
+    memberships_endpoint._require_user_seat_capacity(
+        db_session,
+        organization,
+        user,
+        active=False,
+    )
+    memberships_endpoint._require_user_seat_capacity(
+        db_session,
+        organization,
+        inactive_user,
+        active=True,
+    )
+    memberships_endpoint._require_user_seat_capacity(
+        db_session,
+        organization,
+        user,
+        active=True,
+    )
+
+    assert calls == []
+
+    memberships_endpoint._require_user_seat_capacity(
+        db_session,
+        organization,
+        inactive_user,
+        active=True,
+        activate_user=True,
+    )
+
+    assert calls == [(organization.id, "users")]
 
 
 def test_workspace_membership_api_invites_updates_and_deactivates(

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -32,6 +32,7 @@ from app.services.organizations import (
     list_organization_summaries,
     organization_plan_limit,
     organization_summary,
+    organization_user_has_active_seat,
     require_organization_feature,
     require_organization_plan_limit,
 )
@@ -243,6 +244,39 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     assert limits["webhooks"]["current"] == 1
     assert limits["webhooks"]["limit"] == 0
     assert limits["webhooks"]["enforced"] is True
+
+
+def test_organization_user_has_active_seat_requires_active_user(db_session: Session):
+    organization = Organization(slug="seat-detection", name="Seat Detection", active=True)
+    workspace = Workspace(
+        slug="seat-detection-main",
+        name="Seat Detection Main",
+        organization=organization,
+    )
+    active_user = User(email="seat-active@example.com", is_active=True, is_verified=True)
+    inactive_user = User(email="seat-inactive@example.com", is_active=False, is_verified=True)
+    db_session.add_all([organization, workspace, active_user, inactive_user])
+    db_session.flush()
+    db_session.add_all(
+        [
+            WorkspaceMembership(
+                workspace_id=workspace.id,
+                user_id=active_user.id,
+                role=ROLE_WORKSPACE_OWNER,
+                active=True,
+            ),
+            WorkspaceMembership(
+                workspace_id=workspace.id,
+                user_id=inactive_user.id,
+                role=ROLE_WORKSPACE_OWNER,
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    assert organization_user_has_active_seat(db_session, organization, active_user) is True
+    assert organization_user_has_active_seat(db_session, organization, inactive_user) is False
 
 
 def test_organization_plan_limit_returns_configured_metric(db_session: Session):

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -13,6 +13,7 @@ from app.models.organization import (
     BillingAccount,
     Entitlement,
     Organization,
+    OrganizationMembership,
     Plan,
     Subscription,
 )
@@ -170,7 +171,7 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
             Entitlement(
                 organization=organization,
                 key="users",
-                value="2",
+                value="3",
                 source="plan",
                 active=True,
             ),
@@ -178,6 +179,11 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     )
     db_session.flush()
     active_user = User(email="active-seat@example.com", is_active=True, is_verified=True)
+    organization_user = User(
+        email="organization-seat@example.com",
+        is_active=True,
+        is_verified=True,
+    )
     inactive_user = User(email="inactive-seat@example.com", is_active=False, is_verified=True)
     legacy_user = User(
         workspace_id=workspace.id,
@@ -188,6 +194,7 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     db_session.add_all(
         [
             active_user,
+            organization_user,
             inactive_user,
             legacy_user,
             Domain(workspace_id=workspace.id, name="example.com", active=True),
@@ -224,6 +231,12 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
                 role=ROLE_WORKSPACE_OWNER,
                 active=True,
             ),
+            OrganizationMembership(
+                organization_id=organization.id,
+                user_id=organization_user.id,
+                role="organization_auditor",
+                active=True,
+            ),
         ]
     )
     db_session.commit()
@@ -238,8 +251,8 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     assert limits["api_tokens"]["limit"] == 0
     assert limits["api_tokens"]["status"] == "exceeded"
     assert limits["api_tokens"]["enforced"] is True
-    assert limits["users"]["current"] == 2
-    assert limits["users"]["limit"] == 2
+    assert limits["users"]["current"] == 3
+    assert limits["users"]["limit"] == 3
     assert limits["users"]["enforced"] is True
     assert limits["webhooks"]["current"] == 1
     assert limits["webhooks"]["limit"] == 0

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -39,6 +39,7 @@ from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
     PERMISSION_REPORTS_READ,
     ROLE_AUDITOR,
+    ROLE_WORKSPACE_OWNER,
     require_workspace_permission,
 )
 
@@ -165,11 +166,29 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
                 source="plan",
                 active=True,
             ),
+            Entitlement(
+                organization=organization,
+                key="users",
+                value="2",
+                source="plan",
+                active=True,
+            ),
         ]
     )
     db_session.flush()
+    active_user = User(email="active-seat@example.com", is_active=True, is_verified=True)
+    inactive_user = User(email="inactive-seat@example.com", is_active=False, is_verified=True)
+    legacy_user = User(
+        workspace_id=workspace.id,
+        email="legacy-seat@example.com",
+        is_active=True,
+        is_verified=True,
+    )
     db_session.add_all(
         [
+            active_user,
+            inactive_user,
+            legacy_user,
             Domain(workspace_id=workspace.id, name="example.com", active=True),
             APIToken(
                 workspace_id=workspace.id,
@@ -189,6 +208,23 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
             ),
         ]
     )
+    db_session.flush()
+    db_session.add_all(
+        [
+            WorkspaceMembership(
+                workspace_id=workspace.id,
+                user_id=active_user.id,
+                role=ROLE_WORKSPACE_OWNER,
+                active=True,
+            ),
+            WorkspaceMembership(
+                workspace_id=workspace.id,
+                user_id=inactive_user.id,
+                role=ROLE_WORKSPACE_OWNER,
+                active=True,
+            ),
+        ]
+    )
     db_session.commit()
 
     limits = organization_summary(db_session, organization)["plan_limits"]
@@ -201,6 +237,9 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     assert limits["api_tokens"]["limit"] == 0
     assert limits["api_tokens"]["status"] == "exceeded"
     assert limits["api_tokens"]["enforced"] is True
+    assert limits["users"]["current"] == 2
+    assert limits["users"]["limit"] == 2
+    assert limits["users"]["enforced"] is True
     assert limits["webhooks"]["current"] == 1
     assert limits["webhooks"]["limit"] == 0
     assert limits["webhooks"]["enforced"] is True


### PR DESCRIPTION
Refs #242.

This slice enforces the users/seats plan limit on membership write paths while preserving read/list and deactivation behavior.

Changes:
- Count active seats from legacy workspace users plus active workspace and organization memberships.
- Mark `users` as an enforced plan limit in organization summaries.
- Enforce the `users` limit for workspace and organization member invites/upserts before activating invited users.
- Roll back invited shadow-user creation when quota enforcement returns `402 plan_limit_exceeded`.
- Add focused regressions for workspace invites, organization invites, and membership-based seat usage summaries.

Validation:
- `python3 -m py_compile backend/app/services/organizations.py backend/app/api/api_v1/endpoints/memberships.py`
- `black --check` on touched files
- `isort --check-only` on touched files
- `flake8` on touched files
- `PYTHONPATH=backend .venv/bin/pytest backend/app/tests/test_memberships_api.py backend/app/tests/test_membership_inactive_workspaces.py backend/app/tests/test_workspace_onboarding.py backend/app/tests/test_organization_foundations.py -q` (45 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization and workspace user-seat limits to membership and invite flows.
  * Invites now create new users as inactive until they’re activated through the membership process.
  * Plan-limit summaries now include user-seat usage.

* **Bug Fixes**
  * Existing active members can still be updated when seat capacity is full.
  * Membership actions now return clearer errors for missing records, payload mismatches, and plan-limit violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->