### PR TITLE
feat(billing): surface plan limit warnings

### DIFF
--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -598,9 +598,49 @@ def _limit_status(current: int, limit: Optional[int]) -> str:
         return "ok"
     if current > limit:
         return "exceeded"
-    if limit > 0 and current >= max(1, int(limit * 0.8)):
+    if limit > 0 and current >= _limit_warning_threshold(limit):
         return "warning"
     return "ok"
+
+
+def _limit_warning_threshold(limit: Optional[int]) -> Optional[int]:
+    if limit is None:
+        return None
+    if limit <= 0:
+        return 0
+    return max(1, int(limit * 0.8))
+
+
+def _limit_usage_percent(current: int, limit: Optional[int]) -> Optional[float]:
+    if limit is None:
+        return None
+    if limit <= 0:
+        return 100.0 if current > 0 else 0.0
+    return round((current / limit) * 100, 1)
+
+
+def _metric_label(metric: str) -> str:
+    return metric.replace("_", " ")
+
+
+def _metric_verb(metric: str) -> str:
+    return "is" if metric == "retention_days" else "are"
+
+
+def _limit_message(metric: str, current: int, limit: Optional[int], status: str) -> Optional[str]:
+    if limit is None or status == "ok":
+        return None
+    label = _metric_label(metric)
+    verb = _metric_verb(metric)
+    if status == "exceeded":
+        return (
+            f"{label} {verb} over the plan limit ({current}/{limit}). "
+            "Exports remain available; reduce usage or upgrade the plan."
+        )
+    remaining = max(0, limit - current)
+    if remaining == 0:
+        return f"{label} {verb} at the plan limit ({current}/{limit})."
+    return f"{label} {verb} approaching the plan limit ({current}/{limit}); {remaining} remaining."
 
 
 def _limit_payload(
@@ -611,14 +651,20 @@ def _limit_payload(
     unit: str = "count",
     enforced: bool = True,
 ) -> Dict[str, Any]:
+    current_value = int(current or 0)
+    status = _limit_status(current_value, limit)
     return {
         "metric": metric,
-        "current": int(current or 0),
+        "current": current_value,
         "limit": limit,
-        "remaining": None if limit is None else max(0, limit - int(current or 0)),
+        "remaining": None if limit is None else max(0, limit - current_value),
         "unit": unit,
-        "status": _limit_status(int(current or 0), limit),
+        "status": status,
         "enforced": enforced,
+        "near_limit": status in {"warning", "exceeded"},
+        "usage_percent": _limit_usage_percent(current_value, limit),
+        "warning_threshold": _limit_warning_threshold(limit),
+        "message": _limit_message(metric, current_value, limit, status),
     }
 
 

--- a/backend/app/templates/members.html
+++ b/backend/app/templates/members.html
@@ -86,6 +86,15 @@
                         <p class="text-xs font-semibold uppercase text-[#5f5c78]">Current Scope</p>
                         <p class="mt-2 font-semibold text-[#120d36]" x-text="scopeLabel()"></p>
                         <p class="mt-1 text-sm text-[#5f5c78]" x-text="scopeDescription()"></p>
+                        <template x-if="seatLimitWarning()">
+                            <div class="mt-3 rounded-md border border-[#f2c280] bg-[#fff8eb] p-3 text-sm text-[#7a4a12]">
+                                <div class="flex items-start justify-between gap-3">
+                                    <span x-text="seatLimitWarning().message"></span>
+                                    <span class="shrink-0 rounded-full bg-white px-2 py-1 text-xs font-semibold"
+                                          x-text="`${seatLimitWarning().remaining} left`"></span>
+                                </div>
+                            </div>
+                        </template>
                     </div>
                 </div>
             {% endcall %}
@@ -459,6 +468,16 @@ function membershipApp() {
                 return 'Organization roles apply across tenant-level account and billing surfaces.';
             }
             return 'Workspace roles control reports, domains, mail sources, settings, and audit access.';
+        },
+
+        planLimit(metric) {
+            return this.currentOrganization()?.plan_limits?.[metric] || null;
+        },
+
+        seatLimitWarning() {
+            const limit = this.planLimit('users');
+            if (!limit || !limit.near_limit || !limit.message) return null;
+            return limit;
         },
 
         roleLabel(role) {

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -247,13 +247,20 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     assert limits["monitored_domains"]["limit"] == 1
     assert limits["monitored_domains"]["status"] == "warning"
     assert limits["monitored_domains"]["enforced"] is True
+    assert limits["monitored_domains"]["near_limit"] is True
+    assert limits["monitored_domains"]["usage_percent"] == 100.0
+    assert limits["monitored_domains"]["warning_threshold"] == 1
+    assert "at the plan limit" in limits["monitored_domains"]["message"]
     assert limits["api_tokens"]["current"] == 1
     assert limits["api_tokens"]["limit"] == 0
     assert limits["api_tokens"]["status"] == "exceeded"
     assert limits["api_tokens"]["enforced"] is True
+    assert limits["api_tokens"]["near_limit"] is True
+    assert "over the plan limit" in limits["api_tokens"]["message"]
     assert limits["users"]["current"] == 3
     assert limits["users"]["limit"] == 3
     assert limits["users"]["enforced"] is True
+    assert limits["users"]["message"] == "users are at the plan limit (3/3)."
     assert limits["webhooks"]["current"] == 1
     assert limits["webhooks"]["limit"] == 0
     assert limits["webhooks"]["enforced"] is True
@@ -290,6 +297,50 @@ def test_organization_user_has_active_seat_requires_active_user(db_session: Sess
 
     assert organization_user_has_active_seat(db_session, organization, active_user) is True
     assert organization_user_has_active_seat(db_session, organization, inactive_user) is False
+
+
+def test_organization_plan_limit_warning_payload_is_actionable(db_session: Session):
+    organization = Organization(slug="limit-warning", name="Limit Warning", active=True)
+    workspace = Workspace(
+        slug="limit-warning-main",
+        name="Limit Warning Main",
+        organization=organization,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="monitored_domains",
+                value="5",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    for index in range(4):
+        db_session.add(
+            Domain(
+                workspace_id=workspace.id,
+                name=f"warning-{index}.example",
+                active=True,
+            )
+        )
+    db_session.commit()
+
+    limit = organization_plan_limit(db_session, organization, "monitored_domains")
+
+    assert limit is not None
+    assert limit["status"] == "warning"
+    assert limit["near_limit"] is True
+    assert limit["remaining"] == 1
+    assert limit["usage_percent"] == 80.0
+    assert limit["warning_threshold"] == 4
+    assert limit["message"] == (
+        "monitored domains are approaching the plan limit (4/5); 1 remaining."
+    )
 
 
 def test_organization_plan_limit_returns_configured_metric(db_session: Session):


### PR DESCRIPTION
## Summary

- add structured warning metadata to organization plan-limit payloads (`near_limit`, `usage_percent`, `warning_threshold`, and actionable messages)
- show user-seat warnings on the Members page before operators invite or link users
- cover warning/exceeded payload behavior in organization foundation tests

## Validation

- `python3 -m py_compile backend/app/services/organizations.py`
- `.venv/bin/black --check backend/app/services/organizations.py backend/app/tests/test_organization_foundations.py`
- `.venv/bin/isort --check-only backend/app/services/organizations.py backend/app/tests/test_organization_foundations.py`
- `.venv/bin/flake8 backend/app/services/organizations.py backend/app/tests/test_organization_foundations.py`
- `PYTHONPATH=backend .venv/bin/pytest backend/app/tests/test_organization_foundations.py -q`

Part of #242.