### PR TITLE
fix(billing): surface plan limit warnings in organization list

### DIFF
--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -623,18 +623,18 @@ def _metric_label(metric: str) -> str:
     return metric.replace("_", " ")
 
 
-def _metric_verb(metric: str) -> str:
-    return "is" if metric == "retention_days" else "are"
+def _metric_verb() -> str:
+    return "are"
 
 
 def _limit_message(metric: str, current: int, limit: Optional[int], status: str) -> Optional[str]:
     if limit is None or status == "ok":
         return None
     label = _metric_label(metric)
-    verb = _metric_verb(metric)
+    verb = _metric_verb()
     if status == "exceeded":
         return (
-            f"{label} {verb} over the plan limit ({current}/{limit}). "
+            f"{label} {verb} over the plan limit ({current} used, limit {limit}). "
             "Exports remain available; reduce usage or upgrade the plan."
         )
     remaining = max(0, limit - current)
@@ -1261,10 +1261,7 @@ def list_organization_summaries(db: Session) -> List[Dict[str, Any]]:
     """Return all organizations with local commercial state materialized."""
     bootstrap_default_commercial_foundation(db)
     organizations = db.query(Organization).order_by(Organization.slug.asc()).all()
-    return [
-        organization_summary(db, organization, include_plan_limits=False)
-        for organization in organizations
-    ]
+    return [organization_summary(db, organization) for organization in organizations]
 
 
 def list_scoped_organization_summaries(
@@ -1278,10 +1275,7 @@ def list_scoped_organization_summaries(
         if not organization_ids:
             return []
         query = query.filter(Organization.id.in_(organization_ids))
-    return [
-        organization_summary(db, organization, include_plan_limits=False)
-        for organization in query.all()
-    ]
+    return [organization_summary(db, organization) for organization in query.all()]
 
 
 def parse_usage_period(period: str) -> tuple[datetime, datetime]:

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -759,33 +759,41 @@ def _plan_limits_for_organization(
     organization: Organization,
     workspaces: List[Workspace],
     entitlements: List[Entitlement],
+    metrics: Optional[Iterable[str]] = None,
 ) -> Dict[str, Dict[str, Any]]:
     entitlement_map = _entitlements_by_key(entitlements)
     workspace_ids = [workspace.id for workspace in workspaces]
     workspace_filter = workspace_ids or [-1]
-    active_workspace_count = sum(1 for workspace in workspaces if workspace.active)
+    metric_filter = set(metrics) if metrics is not None else set(PLAN_LIMIT_ENTITLEMENT_ALIASES)
 
-    current_values = {
-        "monitored_domains": (
+    current_values: Dict[str, int] = {}
+    if "monitored_domains" in metric_filter:
+        current_values["monitored_domains"] = (
             db.query(func.count(Domain.id))
             .filter(Domain.workspace_id.in_(workspace_filter), Domain.active.is_(True))
             .scalar()
             or 0
-        ),
-        "mail_sources": (
+        )
+    if "mail_sources" in metric_filter:
+        current_values["mail_sources"] = (
             db.query(func.count(MailSource.id))
             .filter(MailSource.workspace_id.in_(workspace_filter), MailSource.enabled.is_(True))
             .scalar()
             or 0
-        ),
-        "users": (len(_active_user_ids_for_organization(db, organization, workspaces))),
-        "api_tokens": (
+        )
+    if "users" in metric_filter:
+        current_values["users"] = len(
+            _active_user_ids_for_organization(db, organization, workspaces)
+        )
+    if "api_tokens" in metric_filter:
+        current_values["api_tokens"] = (
             db.query(func.count(APIToken.id))
             .filter(APIToken.workspace_id.in_(workspace_filter), APIToken.active.is_(True))
             .scalar()
             or 0
-        ),
-        "webhooks": (
+        )
+    if "webhooks" in metric_filter:
+        current_values["webhooks"] = (
             db.query(func.count(WebhookEndpoint.id))
             .filter(
                 WebhookEndpoint.workspace_id.in_(workspace_filter),
@@ -793,15 +801,16 @@ def _plan_limits_for_organization(
             )
             .scalar()
             or 0
-        ),
-        "retention_days": max(
+        )
+    if "retention_days" in metric_filter:
+        current_values["retention_days"] = max(
             [workspace.report_retention_days or 0 for workspace in workspaces] or [0]
-        ),
-    }
-    current_values["workspaces"] = active_workspace_count
+        )
 
     limits: Dict[str, Dict[str, Any]] = {}
     for metric, aliases in PLAN_LIMIT_ENTITLEMENT_ALIASES.items():
+        if metric not in metric_filter:
+            continue
         entitlement = next(
             (entitlement_map.get(alias) for alias in aliases if alias in entitlement_map), None
         )
@@ -876,6 +885,7 @@ def organization_summary(
     organization: Organization,
     *,
     include_plan_limits: bool = True,
+    include_plan_limit_metrics: Optional[Iterable[str]] = None,
 ) -> Dict[str, Any]:
     """Return an API-safe organization/account summary."""
     workspaces = (
@@ -935,6 +945,7 @@ def organization_summary(
             organization,
             workspaces,
             entitlements,
+            metrics=include_plan_limit_metrics,
         )
     return summary
 
@@ -1261,7 +1272,10 @@ def list_organization_summaries(db: Session) -> List[Dict[str, Any]]:
     """Return all organizations with local commercial state materialized."""
     bootstrap_default_commercial_foundation(db)
     organizations = db.query(Organization).order_by(Organization.slug.asc()).all()
-    return [organization_summary(db, organization) for organization in organizations]
+    return [
+        organization_summary(db, organization, include_plan_limit_metrics=("users",))
+        for organization in organizations
+    ]
 
 
 def list_scoped_organization_summaries(
@@ -1275,7 +1289,10 @@ def list_scoped_organization_summaries(
         if not organization_ids:
             return []
         query = query.filter(Organization.id.in_(organization_ids))
-    return [organization_summary(db, organization) for organization in query.all()]
+    return [
+        organization_summary(db, organization, include_plan_limit_metrics=("users",))
+        for organization in query.all()
+    ]
 
 
 def parse_usage_period(period: str) -> tuple[datetime, datetime]:

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -137,7 +137,8 @@ def test_list_organization_summaries_materializes_account_state(db_session: Sess
     assert summaries[0]["account_state"]["status"] == "active"
     assert summaries[0]["account_state"]["can_mutate"] is True
     assert summaries[0]["account_state"]["can_export"] is True
-    assert "plan_limits" not in summaries[0]
+    assert "plan_limits" in summaries[0]
+    assert summaries[0]["plan_limits"]["retention_days"]["status"] == "ok"
 
 
 def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
@@ -257,6 +258,8 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     assert limits["api_tokens"]["enforced"] is True
     assert limits["api_tokens"]["near_limit"] is True
     assert "over the plan limit" in limits["api_tokens"]["message"]
+    assert "(1/0)" not in limits["api_tokens"]["message"]
+    assert "1 used, limit 0" in limits["api_tokens"]["message"]
     assert limits["users"]["current"] == 3
     assert limits["users"]["limit"] == 3
     assert limits["users"]["enforced"] is True
@@ -341,6 +344,35 @@ def test_organization_plan_limit_warning_payload_is_actionable(db_session: Sessi
     assert limit["message"] == (
         "monitored domains are approaching the plan limit (4/5); 1 remaining."
     )
+
+
+def test_organization_summary_uses_plural_retention_limit_message(db_session: Session):
+    organization = Organization(slug="retention-limit", name="Retention Limit", active=True)
+    workspace = Workspace(
+        slug="retention-limit-main",
+        name="Retention Limit Main",
+        organization=organization,
+        report_retention_days=90,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="retention_days",
+                value="90",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    limits = organization_summary(db_session, organization)["plan_limits"]
+
+    assert limits["retention_days"]["status"] == "warning"
+    assert limits["retention_days"]["message"] == "retention days are at the plan limit (90/90)."
 
 
 def test_organization_plan_limit_returns_configured_metric(db_session: Session):

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -138,7 +138,6 @@ def test_list_organization_summaries_materializes_account_state(db_session: Sess
     assert summaries[0]["account_state"]["can_mutate"] is True
     assert summaries[0]["account_state"]["can_export"] is True
     assert "plan_limits" in summaries[0]
-    assert summaries[0]["plan_limits"]["retention_days"]["status"] == "ok"
 
 
 def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
@@ -267,6 +266,14 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     assert limits["webhooks"]["current"] == 1
     assert limits["webhooks"]["limit"] == 0
     assert limits["webhooks"]["enforced"] is True
+
+    list_summary = next(
+        summary
+        for summary in list_organization_summaries(db_session)
+        if summary["slug"] == "limits"
+    )
+    assert list_summary["plan_limits"]["users"]["message"] == "users are at the plan limit (3/3)."
+    assert "api_tokens" not in list_summary["plan_limits"]
 
 
 def test_organization_user_has_active_seat_requires_active_user(db_session: Session):


### PR DESCRIPTION
## Summary
- include a lightweight `users` plan-limit payload in organization list/scoped list summaries so the members page can render seat-limit warnings from `/api/v1/organizations`
- keep full plan-limit payloads on organization detail summaries to avoid adding all aggregate queries to list endpoints
- make plan-limit messages use plural wording for retention days
- avoid confusing zero-limit fractions such as `(1/0)` in exceeded messages

## Validation
- `git diff --check`
- `python3 -m py_compile backend/app/services/organizations.py backend/app/tests/test_organization_foundations.py`
- checked line lengths against the project 100-character limit

Note: the focused local pytest run hangs during the local Python 3.14 FastAPI/Pydantic import path before collecting tests; relying on GitHub Actions for full test execution.
