### PR TITLE
feat(billing): enforce retention plan limits

### DIFF
--- a/backend/app/api/api_v1/endpoints/operator.py
+++ b/backend/app/api/api_v1/endpoints/operator.py
@@ -11,6 +11,10 @@ from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.workspace import Workspace
 from app.services.demo_data import build_demo_multi_user_deployment
+from app.services.organizations import (
+    OrganizationPlanLimitError,
+    require_organization_retention_limit,
+)
 from app.services.workspace_access import (
     PERMISSION_AUDIT_READ,
     PERMISSION_WORKSPACE_ADMIN,
@@ -64,6 +68,14 @@ def _workspace_or_404(db: Session, workspace_id: int) -> Workspace:
     return workspace
 
 
+def _raise_plan_limit_error(db: Session, exc: OrganizationPlanLimitError) -> None:
+    db.rollback()
+    raise HTTPException(
+        status_code=status.HTTP_402_PAYMENT_REQUIRED,
+        detail=exc.to_detail(),
+    ) from exc
+
+
 @router.get("/workspaces", response_model=OperatorWorkspacesResponse)
 async def list_operator_workspaces(
     db: Session = Depends(get_db),
@@ -114,6 +126,19 @@ async def update_workspace_retention(
     """Update workspace retention controls and audit the change."""
     workspace = _workspace_or_404(db, workspace_id)
     require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, workspace)
+    if workspace.organization is not None:
+        try:
+            require_organization_retention_limit(
+                db,
+                workspace.organization,
+                max(
+                    payload.aggregate_reports_days,
+                    payload.forensic_reports_days,
+                    payload.tls_reports_days,
+                ),
+            )
+        except OrganizationPlanLimitError as exc:
+            _raise_plan_limit_error(db, exc)
     old_retention = retention_to_dict(workspace)
     workspace.report_retention_days = payload.aggregate_reports_days
     workspace.forensic_retention_days = payload.forensic_reports_days

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -77,7 +77,13 @@ ACCOUNT_ACTIVE_STATUSES = {"active", "trialing"}
 ACCOUNT_GRACE_STATUSES = {"past_due_provider_reported"}
 ACCOUNT_READ_ONLY_STATUSES = {"suspended", "canceled", "terminated"}
 ACCOUNT_CLOSED_STATUSES = {"canceled", "terminated"}
-ENFORCED_PLAN_LIMITS = {"api_tokens", "monitored_domains", "users", "webhooks"}
+ENFORCED_PLAN_LIMITS = {
+    "api_tokens",
+    "monitored_domains",
+    "retention_days",
+    "users",
+    "webhooks",
+}
 FEATURE_ENTITLEMENT_ALIASES: Dict[str, tuple[str, ...]] = {
     "api_tokens": ("api_tokens", "api_access"),
     "webhooks": ("webhooks",),
@@ -804,7 +810,16 @@ def _plan_limits_for_organization(
         )
     if "retention_days" in metric_filter:
         current_values["retention_days"] = max(
-            [workspace.report_retention_days or 0 for workspace in workspaces] or [0]
+            [
+                value or 0
+                for workspace in workspaces
+                for value in (
+                    workspace.report_retention_days,
+                    workspace.forensic_retention_days,
+                    workspace.tls_report_retention_days,
+                )
+            ]
+            or [0]
         )
 
     limits: Dict[str, Dict[str, Any]] = {}
@@ -876,6 +891,45 @@ def require_organization_plan_limit(
         limit=int(limit),
         attempted=attempted,
         unit=str(limit_payload.get("unit") or "count"),
+        entitlement_key=limit_payload.get("entitlement_key"),
+    )
+
+
+def require_organization_retention_limit(
+    db: Session,
+    organization: Organization,
+    requested_days: int,
+) -> None:
+    """Raise when a requested retention window exceeds the organization's plan."""
+    if requested_days <= 0:
+        return
+    locked_organization = (
+        db.query(Organization)
+        .filter(Organization.id == organization.id)
+        .with_for_update()
+        .one_or_none()
+    )
+    limit_payload = organization_plan_limit(
+        db,
+        locked_organization or organization,
+        "retention_days",
+    )
+    if not limit_payload:
+        return
+    limit = limit_payload.get("limit")
+    if limit is None:
+        return
+    requested = int(requested_days)
+    limit_value = int(limit)
+    if requested <= limit_value:
+        return
+    current = int(limit_payload.get("current") or 0)
+    raise OrganizationPlanLimitError(
+        metric="retention_days",
+        current=current,
+        limit=limit_value,
+        attempted=max(0, requested - current),
+        unit="days",
         entitlement_key=limit_payload.get("entitlement_key"),
     )
 

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -661,6 +661,60 @@ def test_require_organization_retention_limit_allows_safe_requests(
     require_organization_retention_limit(db_session, bounded, 0)
 
 
+def test_require_organization_retention_limit_raises_structured_limit_error(
+    db_session: Session,
+):
+    organization = Organization(
+        slug="retention-blocked",
+        name="Retention Blocked",
+        active=True,
+    )
+    workspace = Workspace(
+        slug="retention-blocked-main",
+        name="Retention Blocked Main",
+        organization=organization,
+        report_retention_days=30,
+        forensic_retention_days=30,
+        tls_report_retention_days=30,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="retention_days",
+                value="90",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    with pytest.raises(OrganizationPlanLimitError) as exc_info:
+        require_organization_retention_limit(db_session, organization, 120)
+
+    assert str(exc_info.value) == (
+        "Plan limit for retention_days would be exceeded "
+        "(30 current + 90 requested > 90 days)"
+    )
+    assert exc_info.value.to_detail() == {
+        "code": "plan_limit_exceeded",
+        "metric": "retention_days",
+        "current": 30,
+        "limit": 90,
+        "attempted": 90,
+        "unit": "days",
+        "entitlement_key": "retention_days",
+        "can_export": True,
+        "message": (
+            "Plan limit for retention_days would be exceeded "
+            "(30 current + 90 requested > 90 days)"
+        ),
+    }
+
+
 def test_require_organization_plan_limit_raises_structured_limit_error(
     db_session: Session,
 ):

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -36,6 +36,7 @@ from app.services.organizations import (
     organization_user_has_active_seat,
     require_organization_feature,
     require_organization_plan_limit,
+    require_organization_retention_limit,
 )
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
@@ -360,6 +361,8 @@ def test_organization_summary_uses_plural_retention_limit_message(db_session: Se
         name="Retention Limit Main",
         organization=organization,
         report_retention_days=90,
+        forensic_retention_days=90,
+        tls_report_retention_days=90,
     )
     db_session.add_all(
         [
@@ -533,6 +536,43 @@ def test_organization_summary_handles_unbounded_and_missing_entitlements(
     assert limits["mail_sources"]["source"] == "override"
 
 
+def test_organization_summary_counts_largest_retention_window(db_session: Session):
+    organization = Organization(slug="retention-window", name="Retention Window", active=True)
+    workspace = Workspace(
+        slug="retention-window-main",
+        name="Retention Window Main",
+        organization=organization,
+        report_retention_days=30,
+        forensic_retention_days=60,
+        tls_report_retention_days=120,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="retention_days",
+                value="90",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    limit = organization_plan_limit(db_session, organization, "retention_days")
+
+    assert limit is not None
+    assert limit["current"] == 120
+    assert limit["limit"] == 90
+    assert limit["remaining"] == 0
+    assert limit["status"] == "exceeded"
+    assert limit["enforced"] is True
+    assert limit["unit"] == "days"
+    assert "over the plan limit" in limit["message"]
+
+
 def test_require_organization_plan_limit_allows_unconfigured_and_unlimited_limits(
     db_session: Session,
 ):
@@ -571,6 +611,54 @@ def test_require_organization_plan_limit_allows_unconfigured_and_unlimited_limit
         "mail_sources",
         increment=0,
     )
+
+
+def test_require_organization_retention_limit_allows_safe_requests(
+    db_session: Session,
+):
+    unconfigured = Organization(
+        slug="retention-unconfigured",
+        name="Retention Unconfigured",
+        active=True,
+    )
+    bounded = Organization(slug="retention-bounded", name="Retention Bounded", active=True)
+    bounded_workspace = Workspace(
+        slug="retention-bounded-main",
+        name="Retention Bounded Main",
+        organization=bounded,
+        report_retention_days=30,
+        forensic_retention_days=30,
+        tls_report_retention_days=30,
+    )
+    unlimited = Organization(slug="retention-unlimited", name="Retention Unlimited", active=True)
+    db_session.add_all(
+        [
+            unconfigured,
+            bounded,
+            bounded_workspace,
+            unlimited,
+            Entitlement(
+                organization=bounded,
+                key="retention_days",
+                value="90",
+                source="plan",
+                active=True,
+            ),
+            Entitlement(
+                organization=unlimited,
+                key="retention_days",
+                value="unlimited",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    require_organization_retention_limit(db_session, unconfigured, 365)
+    require_organization_retention_limit(db_session, bounded, 90)
+    require_organization_retention_limit(db_session, unlimited, 3650)
+    require_organization_retention_limit(db_session, bounded, 0)
 
 
 def test_require_organization_plan_limit_raises_structured_limit_error(

--- a/backend/app/tests/test_workspace_operator.py
+++ b/backend/app/tests/test_workspace_operator.py
@@ -7,6 +7,7 @@ from app.models.alert import AlertHistory
 from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
+from app.models.organization import Entitlement, Organization
 from app.models.report import DMARCReport
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
@@ -159,3 +160,59 @@ def test_workspace_retention_update_is_audited(
     assert audit.workspace_id == workspace.id
     assert audit.ip_address == "203.0.113.9"
     assert "730" in (audit.details or "")
+
+
+def test_workspace_retention_update_respects_plan_limit(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Operators cannot raise retention beyond the organization plan."""
+    organization = Organization(slug="retention-plan", name="Retention Plan", active=True)
+    workspace = Workspace(
+        slug="retention-plan-main",
+        name="Retention Plan Main",
+        organization=organization,
+        report_retention_days=30,
+        forensic_retention_days=30,
+        tls_report_retention_days=30,
+        active=True,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="retention_days",
+                value="90",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    response = authed_client.put(
+        f"/api/v1/operator/workspaces/{workspace.id}/retention",
+        json={
+            "aggregate_reports_days": 120,
+            "forensic_reports_days": 60,
+            "tls_reports_days": 90,
+        },
+    )
+
+    assert response.status_code == 402
+    detail = response.json()["detail"]
+    assert detail["code"] == "plan_limit_exceeded"
+    assert detail["metric"] == "retention_days"
+    assert detail["current"] == 30
+    assert detail["limit"] == 90
+    assert detail["attempted"] == 90
+    assert detail["unit"] == "days"
+    assert detail["entitlement_key"] == "retention_days"
+    assert detail["can_export"] is True
+    db_session.refresh(workspace)
+    assert workspace.report_retention_days == 30
+    assert workspace.forensic_retention_days == 30
+    assert workspace.tls_report_retention_days == 30
+    assert db_session.query(WorkspaceAuditLog).count() == 0


### PR DESCRIPTION
## Summary

- Enforce the organization `retention_days` entitlement when operators update workspace retention settings.
- Count the largest aggregate, forensic, or TLS retention window in organization plan-limit summaries.
- Return the existing structured `402 plan_limit_exceeded` response before writing retention changes or audit rows.

## Validation

- `python3 -m py_compile backend/app/services/organizations.py backend/app/api/api_v1/endpoints/operator.py backend/app/tests/test_organization_foundations.py backend/app/tests/test_workspace_operator.py`
- `.venv/bin/black --check backend/app/services/organizations.py backend/app/api/api_v1/endpoints/operator.py backend/app/tests/test_organization_foundations.py backend/app/tests/test_workspace_operator.py`
- `.venv/bin/isort --check-only backend/app/services/organizations.py backend/app/api/api_v1/endpoints/operator.py backend/app/tests/test_organization_foundations.py backend/app/tests/test_workspace_operator.py`
- `.venv/bin/flake8 backend/app/services/organizations.py backend/app/api/api_v1/endpoints/operator.py backend/app/tests/test_organization_foundations.py backend/app/tests/test_workspace_operator.py`
- `PYTHONPATH=backend .venv/bin/pytest backend/app/tests/test_organization_foundations.py backend/app/tests/test_workspace_operator.py -q` (`27 passed`)

Refs #242