### PR TITLE
feat(billing): enforce message volume plan limits

### DIFF
--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -10,6 +10,7 @@ from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.services.dmarc_parser import DMARCParser
+from app.services.organizations import OrganizationPlanLimitError
 from app.services.report_persistence import (
     delete_persisted_report,
     hydrate_report_store_from_db,
@@ -94,14 +95,27 @@ def _save_uploaded_report(
     try:
         save_parsed_report(db, report, workspace_id=workspace_id)
         db.commit()
+    except OrganizationPlanLimitError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=exc.to_detail(),
+        ) from exc
     except IntegrityError as exc:
         db.rollback()
         try:
             _raise_if_domain_owned_by_other_workspace(db, domain, workspace_id)
         except HTTPException as conflict:
             raise conflict from exc
-        save_parsed_report(db, report, workspace_id=workspace_id)
-        db.commit()
+        try:
+            save_parsed_report(db, report, workspace_id=workspace_id)
+            db.commit()
+        except OrganizationPlanLimitError as plan_exc:
+            db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                detail=plan_exc.to_detail(),
+            ) from plan_exc
 
 
 def _hydrated_report_store(db: Session, workspace) -> ReportStore:

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -89,6 +89,14 @@ def _raise_if_domain_owned_by_other_workspace(db: Session, domain: str, workspac
         raise _domain_workspace_conflict(domain)
 
 
+def _raise_plan_limit_payment_required(db: Session, exc: OrganizationPlanLimitError) -> None:
+    db.rollback()
+    raise HTTPException(
+        status_code=status.HTTP_402_PAYMENT_REQUIRED,
+        detail=exc.to_detail(),
+    ) from exc
+
+
 def _save_uploaded_report(
     db: Session, report: Dict[str, Any], domain: str, workspace_id: int
 ) -> None:
@@ -96,11 +104,7 @@ def _save_uploaded_report(
         save_parsed_report(db, report, workspace_id=workspace_id)
         db.commit()
     except OrganizationPlanLimitError as exc:
-        db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_402_PAYMENT_REQUIRED,
-            detail=exc.to_detail(),
-        ) from exc
+        _raise_plan_limit_payment_required(db, exc)
     except IntegrityError as exc:
         db.rollback()
         try:
@@ -111,11 +115,7 @@ def _save_uploaded_report(
             save_parsed_report(db, report, workspace_id=workspace_id)
             db.commit()
         except OrganizationPlanLimitError as plan_exc:
-            db.rollback()
-            raise HTTPException(
-                status_code=status.HTTP_402_PAYMENT_REQUIRED,
-                detail=plan_exc.to_detail(),
-            ) from plan_exc
+            _raise_plan_limit_payment_required(db, plan_exc)
 
 
 def _hydrated_report_store(db: Session, workspace) -> ReportStore:

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -782,6 +782,7 @@ def _aggregate_messages_for_period(
             Domain.workspace_id.in_(workspace_ids),
             DMARCReport.processed_at >= period_start,
             DMARCReport.processed_at < period_end,
+            ReportRecord.count > 0,
         )
         .scalar()
         or 0
@@ -792,8 +793,13 @@ def _period_plan_limit_usage(
     db: Session,
     workspace_ids: List[int],
     metric_filter: set[str],
+    entitlement_map: Dict[str, Entitlement],
 ) -> tuple[Dict[str, int], Dict[str, Dict[str, str]]]:
     if "aggregate_messages" not in metric_filter:
+        return {}, {}
+    if not any(
+        alias in entitlement_map for alias in PLAN_LIMIT_ENTITLEMENT_ALIASES["aggregate_messages"]
+    ):
         return {}, {}
     usage_period = usage_period_for_current_month()
     usage_period_start, usage_period_end = parse_usage_period(usage_period)
@@ -829,7 +835,12 @@ def _plan_limits_for_organization(
     metric_filter = set(metrics) if metrics is not None else set(PLAN_LIMIT_ENTITLEMENT_ALIASES)
 
     current_values: Dict[str, int] = {}
-    period_values, period_contexts = _period_plan_limit_usage(db, workspace_ids, metric_filter)
+    period_values, period_contexts = _period_plan_limit_usage(
+        db,
+        workspace_ids,
+        metric_filter,
+        entitlement_map,
+    )
     current_values.update(period_values)
     if "monitored_domains" in metric_filter:
         current_values["monitored_domains"] = (

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -78,6 +78,7 @@ ACCOUNT_GRACE_STATUSES = {"past_due_provider_reported"}
 ACCOUNT_READ_ONLY_STATUSES = {"suspended", "canceled", "terminated"}
 ACCOUNT_CLOSED_STATUSES = {"canceled", "terminated"}
 ENFORCED_PLAN_LIMITS = {
+    "aggregate_messages",
     "api_tokens",
     "monitored_domains",
     "retention_days",
@@ -89,12 +90,17 @@ FEATURE_ENTITLEMENT_ALIASES: Dict[str, tuple[str, ...]] = {
     "webhooks": ("webhooks",),
 }
 PLAN_LIMIT_ENTITLEMENT_ALIASES: Dict[str, tuple[str, ...]] = {
+    "aggregate_messages": ("aggregate_messages", "message_volume", "included_message_volume"),
     "monitored_domains": ("monitored_domains", "sending_domains"),
     "mail_sources": ("mail_sources",),
     "users": ("users",),
     "api_tokens": FEATURE_ENTITLEMENT_ALIASES["api_tokens"],
     "webhooks": FEATURE_ENTITLEMENT_ALIASES["webhooks"],
     "retention_days": ("retention_days",),
+}
+PLAN_LIMIT_UNITS = {
+    "aggregate_messages": "messages",
+    "retention_days": "days",
 }
 
 
@@ -760,6 +766,56 @@ def organization_user_has_active_seat(
     return user.id in _active_user_ids_for_organization(db, organization)
 
 
+def _aggregate_messages_for_period(
+    db: Session,
+    workspace_ids: List[int],
+    period_start: datetime,
+    period_end: datetime,
+) -> int:
+    if not workspace_ids:
+        return 0
+    return int(
+        db.query(func.sum(ReportRecord.count))
+        .join(DMARCReport, ReportRecord.report_id == DMARCReport.id)
+        .join(Domain, DMARCReport.domain_id == Domain.id)
+        .filter(
+            Domain.workspace_id.in_(workspace_ids),
+            DMARCReport.processed_at >= period_start,
+            DMARCReport.processed_at < period_end,
+        )
+        .scalar()
+        or 0
+    )
+
+
+def _period_plan_limit_usage(
+    db: Session,
+    workspace_ids: List[int],
+    metric_filter: set[str],
+) -> tuple[Dict[str, int], Dict[str, Dict[str, str]]]:
+    if "aggregate_messages" not in metric_filter:
+        return {}, {}
+    usage_period = usage_period_for_current_month()
+    usage_period_start, usage_period_end = parse_usage_period(usage_period)
+    return (
+        {
+            "aggregate_messages": _aggregate_messages_for_period(
+                db,
+                workspace_ids,
+                usage_period_start,
+                usage_period_end,
+            )
+        },
+        {
+            "aggregate_messages": {
+                "period": usage_period,
+                "period_start": usage_period_start.isoformat(),
+                "period_end": usage_period_end.isoformat(),
+            }
+        },
+    )
+
+
 def _plan_limits_for_organization(
     db: Session,
     organization: Organization,
@@ -773,6 +829,8 @@ def _plan_limits_for_organization(
     metric_filter = set(metrics) if metrics is not None else set(PLAN_LIMIT_ENTITLEMENT_ALIASES)
 
     current_values: Dict[str, int] = {}
+    period_values, period_contexts = _period_plan_limit_usage(db, workspace_ids, metric_filter)
+    current_values.update(period_values)
     if "monitored_domains" in metric_filter:
         current_values["monitored_domains"] = (
             db.query(func.count(Domain.id))
@@ -835,11 +893,12 @@ def _plan_limits_for_organization(
             metric=metric,
             current=current_values.get(metric, 0),
             limit=_entitlement_limit(entitlement.value),
-            unit="days" if metric == "retention_days" else "count",
+            unit=PLAN_LIMIT_UNITS.get(metric, "count"),
             enforced=metric in ENFORCED_PLAN_LIMITS,
         )
         limits[metric]["source"] = entitlement.source
         limits[metric]["entitlement_key"] = entitlement.key
+        limits[metric].update(period_contexts.get(metric, {}))
     return limits
 
 

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -81,22 +81,28 @@ def _policy_parts(report: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _record_message_count(record: Dict[str, Any]) -> int:
+    try:
+        count = int(record.get("count") or 0)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError("DMARC record count must be an integer") from exc
+    if count < 0:
+        raise ValueError("DMARC record count cannot be negative")
+    return count
+
+
 def _aggregate_message_count(report: Dict[str, Any]) -> int:
-    total = 0
-    for record in report.get("records") or []:
-        try:
-            total += int(record.get("count") or 0)
-        except (AttributeError, TypeError, ValueError):
-            continue
-    return total
+    return sum(_record_message_count(record) for record in report.get("records") or [])
 
 
 def _require_message_volume_limit(
     db: Session,
     *,
-    workspace_id: int,
+    workspace_id: Optional[int],
     report: Dict[str, Any],
 ) -> None:
+    if workspace_id is None:
+        return
     increment = _aggregate_message_count(report)
     if increment <= 0:
         return
@@ -207,7 +213,7 @@ def save_parsed_report(
             ReportRecord(
                 report_id=db_report.id,
                 source_ip=record.get("source_ip") or "unknown",
-                count=int(record.get("count") or 0),
+                count=_record_message_count(record),
                 disposition=record.get("disposition") or "none",
                 dkim=record.get("dkim_result") or record.get("dkim") or "unknown",
                 spf=record.get("spf_result") or record.get("spf") or "unknown",

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -7,7 +7,9 @@ from sqlalchemy.orm import Session, selectinload
 from app.core.config import get_settings
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
+from app.models.workspace import Workspace
 from app.services.demo_data import seed_demo_report_store
+from app.services.organizations import require_organization_plan_limit
 from app.services.report_store import ReportStore
 from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
@@ -79,6 +81,36 @@ def _policy_parts(report: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _aggregate_message_count(report: Dict[str, Any]) -> int:
+    total = 0
+    for record in report.get("records") or []:
+        try:
+            total += int(record.get("count") or 0)
+        except (AttributeError, TypeError, ValueError):
+            continue
+    return total
+
+
+def _require_message_volume_limit(
+    db: Session,
+    *,
+    workspace_id: int,
+    report: Dict[str, Any],
+) -> None:
+    increment = _aggregate_message_count(report)
+    if increment <= 0:
+        return
+    workspace = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    if workspace is None or workspace.organization is None:
+        return
+    require_organization_plan_limit(
+        db,
+        workspace.organization,
+        "aggregate_messages",
+        increment=increment,
+    )
+
+
 def report_exists(
     db: Session,
     domain_name: str,
@@ -136,6 +168,8 @@ def save_parsed_report(
     )
     if existing is not None:
         return existing, False
+
+    _require_message_volume_limit(db, workspace_id=workspace_id, report=report)
 
     begin_ts = _parse_timestamp(report.get("begin_timestamp") or report.get("begin_date"))
     end_ts = _parse_timestamp(report.get("end_timestamp") or report.get("end_date"))

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -262,6 +262,15 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
                 header_from="example.com",
             ),
             ReportRecord(
+                report_id=current_report.id,
+                source_ip="203.0.113.12",
+                count=-500,
+                disposition="none",
+                dkim="fail",
+                spf="fail",
+                header_from="example.com",
+            ),
+            ReportRecord(
                 report_id=prior_report.id,
                 source_ip="203.0.113.11",
                 count=50,
@@ -920,21 +929,13 @@ def test_save_parsed_report_enforces_aggregate_message_volume_limit(
                 "policy": {"p": "none", "pct": "100"},
                 "records": [
                     {
-                        "source_ip": "203.0.113.19",
-                        "count": "not-a-number",
-                        "disposition": "none",
-                        "dkim_result": "fail",
-                        "spf_result": "fail",
-                        "header_from": "volume.example",
-                    },
-                    {
                         "source_ip": "203.0.113.20",
                         "count": 25,
                         "disposition": "none",
                         "dkim_result": "pass",
                         "spf_result": "pass",
                         "header_from": "volume.example",
-                    },
+                    }
                 ],
             },
             workspace_id=workspace.id,
@@ -956,6 +957,58 @@ def test_save_parsed_report_enforces_aggregate_message_volume_limit(
     }
     assert (
         db_session.query(DMARCReport).filter(DMARCReport.report_id == "new-volume").first() is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("count", "message"),
+    [
+        (-1, "DMARC record count cannot be negative"),
+        ("not-a-number", "DMARC record count must be an integer"),
+    ],
+)
+def test_save_parsed_report_rejects_invalid_aggregate_message_counts(
+    db_session: Session,
+    count,
+    message,
+):
+    organization = Organization(slug="negative-volume", name="Negative Volume", active=True)
+    workspace = Workspace(
+        slug="negative-volume-main",
+        name="Negative Volume Main",
+        organization=organization,
+    )
+    domain = Domain(workspace=workspace, name="negative.example", active=True)
+    db_session.add_all([organization, workspace, domain])
+    db_session.flush()
+
+    with pytest.raises(ValueError, match=message):
+        save_parsed_report(
+            db_session,
+            {
+                "domain": "negative.example",
+                "report_id": "negative-volume",
+                "org_name": "Reporter",
+                "policy": {"p": "none", "pct": "100"},
+                "records": [
+                    {
+                        "source_ip": "203.0.113.30",
+                        "count": count,
+                        "disposition": "none",
+                        "dkim_result": "fail",
+                        "spf_result": "fail",
+                        "header_from": "negative.example",
+                    }
+                ],
+            },
+            workspace_id=workspace.id,
+        )
+
+    assert (
+        db_session.query(DMARCReport)
+        .filter(DMARCReport.report_id == "negative-volume")
+        .first()
+        is None
     )
 
 

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import date, datetime, timedelta
 
 import pytest
 from fastapi import HTTPException
@@ -17,6 +18,7 @@ from app.models.organization import (
     Plan,
     Subscription,
 )
+from app.models.report import DMARCReport, ReportRecord
 from app.models.user import User
 from app.models.webhook import WebhookEndpoint
 from app.models.workspace import Workspace
@@ -38,6 +40,7 @@ from app.services.organizations import (
     require_organization_plan_limit,
     require_organization_retention_limit,
 )
+from app.services.report_persistence import save_parsed_report
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
     PERMISSION_REPORTS_READ,
@@ -144,6 +147,7 @@ def test_list_organization_summaries_materializes_account_state(db_session: Sess
 def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     organization = Organization(slug="limits", name="Limits", active=True)
     workspace = Workspace(slug="limits-main", name="Limits Main", organization=organization)
+    domain = Domain(workspace=workspace, name="example.com", active=True)
     db_session.add_all(
         [
             organization,
@@ -176,6 +180,13 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
                 source="plan",
                 active=True,
             ),
+            Entitlement(
+                organization=organization,
+                key="aggregate_messages",
+                value="100",
+                source="plan",
+                active=True,
+            ),
         ]
     )
     db_session.flush()
@@ -198,7 +209,7 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
             organization_user,
             inactive_user,
             legacy_user,
-            Domain(workspace_id=workspace.id, name="example.com", active=True),
+            domain,
             APIToken(
                 workspace_id=workspace.id,
                 name="existing",
@@ -218,6 +229,49 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
         ]
     )
     db_session.flush()
+    today = date.today()
+    current_period_start = datetime(today.year, today.month, 1, 12, 0, 0)
+    prior_period = current_period_start - timedelta(days=1)
+    current_report = DMARCReport(
+        domain_id=domain.id,
+        report_id="current-message-volume",
+        org_name="Reporter",
+        begin_date=1,
+        end_date=2,
+        processed_at=current_period_start,
+    )
+    prior_report = DMARCReport(
+        domain_id=domain.id,
+        report_id="prior-message-volume",
+        org_name="Reporter",
+        begin_date=1,
+        end_date=2,
+        processed_at=prior_period,
+    )
+    db_session.add_all([current_report, prior_report])
+    db_session.flush()
+    db_session.add_all(
+        [
+            ReportRecord(
+                report_id=current_report.id,
+                source_ip="203.0.113.10",
+                count=80,
+                disposition="none",
+                dkim="pass",
+                spf="pass",
+                header_from="example.com",
+            ),
+            ReportRecord(
+                report_id=prior_report.id,
+                source_ip="203.0.113.11",
+                count=50,
+                disposition="none",
+                dkim="pass",
+                spf="pass",
+                header_from="example.com",
+            ),
+        ]
+    )
     db_session.add_all(
         [
             WorkspaceMembership(
@@ -267,6 +321,14 @@ def test_organization_summary_exposes_plan_limit_usage(db_session: Session):
     assert limits["webhooks"]["current"] == 1
     assert limits["webhooks"]["limit"] == 0
     assert limits["webhooks"]["enforced"] is True
+    assert limits["aggregate_messages"]["current"] == 80
+    assert limits["aggregate_messages"]["limit"] == 100
+    assert limits["aggregate_messages"]["unit"] == "messages"
+    assert limits["aggregate_messages"]["status"] == "warning"
+    assert limits["aggregate_messages"]["enforced"] is True
+    assert limits["aggregate_messages"]["period"] == f"{today.year:04d}-{today.month:02d}"
+    assert "period_start" in limits["aggregate_messages"]
+    assert "period_end" in limits["aggregate_messages"]
 
     list_summary = next(
         summary
@@ -696,8 +758,7 @@ def test_require_organization_retention_limit_raises_structured_limit_error(
         require_organization_retention_limit(db_session, organization, 120)
 
     assert str(exc_info.value) == (
-        "Plan limit for retention_days would be exceeded "
-        "(30 current + 90 requested > 90 days)"
+        "Plan limit for retention_days would be exceeded " "(30 current + 90 requested > 90 days)"
     )
     assert exc_info.value.to_detail() == {
         "code": "plan_limit_exceeded",
@@ -797,6 +858,104 @@ def test_require_organization_plan_limit_allows_within_limit_increment(
         db_session,
         organization,
         "monitored_domains",
+    )
+
+
+def test_save_parsed_report_enforces_aggregate_message_volume_limit(
+    db_session: Session,
+):
+    organization = Organization(slug="message-volume", name="Message Volume", active=True)
+    workspace = Workspace(
+        slug="message-volume-main",
+        name="Message Volume Main",
+        organization=organization,
+    )
+    domain = Domain(workspace=workspace, name="volume.example", active=True)
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            domain,
+            Entitlement(
+                organization=organization,
+                key="aggregate_messages",
+                value="100",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    today = date.today()
+    existing_report = DMARCReport(
+        domain_id=domain.id,
+        report_id="existing-volume",
+        org_name="Reporter",
+        begin_date=1,
+        end_date=2,
+        processed_at=datetime(today.year, today.month, 1, 12, 0, 0),
+    )
+    db_session.add(existing_report)
+    db_session.flush()
+    db_session.add(
+        ReportRecord(
+            report_id=existing_report.id,
+            source_ip="203.0.113.10",
+            count=80,
+            disposition="none",
+            dkim="pass",
+            spf="pass",
+            header_from="volume.example",
+        )
+    )
+    db_session.commit()
+
+    with pytest.raises(OrganizationPlanLimitError) as exc_info:
+        save_parsed_report(
+            db_session,
+            {
+                "domain": "volume.example",
+                "report_id": "new-volume",
+                "org_name": "Reporter",
+                "policy": {"p": "none", "pct": "100"},
+                "records": [
+                    {
+                        "source_ip": "203.0.113.19",
+                        "count": "not-a-number",
+                        "disposition": "none",
+                        "dkim_result": "fail",
+                        "spf_result": "fail",
+                        "header_from": "volume.example",
+                    },
+                    {
+                        "source_ip": "203.0.113.20",
+                        "count": 25,
+                        "disposition": "none",
+                        "dkim_result": "pass",
+                        "spf_result": "pass",
+                        "header_from": "volume.example",
+                    },
+                ],
+            },
+            workspace_id=workspace.id,
+        )
+
+    assert exc_info.value.to_detail() == {
+        "code": "plan_limit_exceeded",
+        "metric": "aggregate_messages",
+        "current": 80,
+        "limit": 100,
+        "attempted": 25,
+        "unit": "messages",
+        "entitlement_key": "aggregate_messages",
+        "can_export": True,
+        "message": (
+            "Plan limit for aggregate_messages would be exceeded "
+            "(80 current + 25 requested > 100 messages)"
+        ),
+    }
+    assert (
+        db_session.query(DMARCReport).filter(DMARCReport.report_id == "new-volume").first() is None
     )
 
 

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -1,6 +1,7 @@
 import io
 import zipfile
 from contextlib import contextmanager
+from datetime import date, datetime
 
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
@@ -10,10 +11,12 @@ from app.api.api_v1.endpoints import reports as reports_endpoint
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
+from app.models.organization import Entitlement, Organization
 from app.models.report import DMARCReport, ReportRecord
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
+from app.services.organizations import OrganizationPlanLimitError
 from app.services.report_persistence import persisted_report_to_dict, save_parsed_report
 from app.services.report_store import ReportStore
 from app.services.workspace_access import ROLE_ANALYST
@@ -121,6 +124,71 @@ def test_upload_report_success(authed_client: TestClient):
     data = response.json()
     assert data["success"] is True
     assert data["domain"] == "example.com"
+
+
+def test_upload_report_returns_plan_limit_detail_for_message_volume(
+    authed_client: TestClient,
+    db_session,
+):
+    """Uploading a report over the monthly message-volume limit returns a structured 402."""
+    organization = Organization(slug="upload-volume-limit", name="Upload Volume Limit")
+    workspace = get_or_create_default_workspace(db_session)
+    workspace.organization = organization
+    domain = Domain(workspace=workspace, name="example.com", active=True)
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            domain,
+            Entitlement(
+                organization=organization,
+                key="aggregate_messages",
+                value="81",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    today = date.today()
+    report = DMARCReport(
+        domain_id=domain.id,
+        report_id="existing-upload-volume",
+        org_name="Reporter",
+        begin_date=1,
+        end_date=2,
+        processed_at=datetime(today.year, today.month, 1, 12, 0, 0),
+    )
+    db_session.add(report)
+    db_session.flush()
+    db_session.add(
+        ReportRecord(
+            report_id=report.id,
+            source_ip="203.0.113.10",
+            count=80,
+            disposition="none",
+            dkim="pass",
+            spf="pass",
+            header_from="example.com",
+        )
+    )
+    db_session.commit()
+
+    response = authed_client.post(
+        "/api/v1/reports/upload",
+        files={"file": ("report.zip", _make_zip(SAMPLE_XML), "application/zip")},
+    )
+
+    assert response.status_code == 402
+    detail = response.json()["detail"]
+    assert detail["code"] == "plan_limit_exceeded"
+    assert detail["metric"] == "aggregate_messages"
+    assert detail["current"] == 80
+    assert detail["limit"] == 81
+    assert detail["attempted"] == 2
+    assert detail["unit"] == "messages"
+    assert detail["can_export"] is True
+    assert db_session.query(DMARCReport).filter_by(report_id="123456789").count() == 0
 
 
 def test_report_routes_enforce_workspace_read_and_write_roles(test_app, db_session):
@@ -336,6 +404,45 @@ def test_upload_report_recovers_from_same_workspace_domain_race(
     assert response.json()["domain"] == "example.com"
     assert db_session.query(Domain).filter(Domain.name == "example.com").count() == 1
     assert db_session.query(DMARCReport).filter_by(report_id="123456789").count() == 1
+
+
+def test_upload_report_translates_retry_plan_limit_error(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """A retried upload still returns structured quota detail when the retry is over limit."""
+    get_or_create_default_workspace(db_session)
+    db_session.commit()
+    call_count = 0
+
+    def raced_save(db, report, *, workspace_id=None):  # pylint: disable=unused-argument
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise IntegrityError("insert", {}, Exception("UNIQUE constraint failed: domains.name"))
+        raise OrganizationPlanLimitError(
+            metric="aggregate_messages",
+            current=80,
+            limit=81,
+            attempted=2,
+            unit="messages",
+            entitlement_key="aggregate_messages",
+        )
+
+    monkeypatch.setattr(reports_endpoint, "save_parsed_report", raced_save)
+
+    response = authed_client.post(
+        "/api/v1/reports/upload",
+        files={"file": ("report.zip", _make_zip(SAMPLE_XML), "application/zip")},
+    )
+
+    assert response.status_code == 402
+    detail = response.json()["detail"]
+    assert detail["code"] == "plan_limit_exceeded"
+    assert detail["metric"] == "aggregate_messages"
+    assert detail["can_export"] is True
+    assert call_count == 2
 
 
 def test_upload_persists_rfc9990_optional_fields(authed_client: TestClient, db_session):


### PR DESCRIPTION
## Summary
- expose current-month aggregate message volume as an enforced organization plan-limit metric
- enforce the aggregate message entitlement before persisting new aggregate reports across shared ingestion
- return structured 402 plan-limit responses for manual report uploads

## Validation
- .venv/bin/python -m black --check backend/app/services/organizations.py backend/app/services/report_persistence.py backend/app/api/api_v1/endpoints/reports.py backend/app/tests/test_organization_foundations.py
- .venv/bin/python -m compileall -q backend/app/services/organizations.py backend/app/services/report_persistence.py backend/app/api/api_v1/endpoints/reports.py backend/app/tests/test_organization_foundations.py
- .venv/bin/python -m pytest backend/app/tests/test_organization_foundations.py backend/app/tests/test_reports_api.py backend/app/tests/test_provider_billing_usage.py -q

Closes part of #242.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization plan-limit tracking for message volume over the current billing period.
  * Plan-limit details now include period information and clearer units for usage metrics.

* **Bug Fixes**
  * Report uploads now stop and return a payment-required response when an organization exceeds its message-volume limit.
  * After resolving upload conflicts, the system now rechecks limits before saving the report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->