### PR TITLE
[codex] Gate SSO identity linking by entitlement

### DIFF
--- a/backend/app/api/api_v1/endpoints/memberships.py
+++ b/backend/app/api/api_v1/endpoints/memberships.py
@@ -16,6 +16,7 @@ from app.models.workspace_access import WorkspaceMembership
 from app.services.organizations import (
     OrganizationPlanLimitError,
     organization_user_has_active_seat,
+    require_organization_feature,
     require_organization_plan_limit,
 )
 from app.services.workspace_access import (
@@ -203,6 +204,28 @@ def _raise_plan_limit_error(db: Session, exc: OrganizationPlanLimitError) -> Non
         status_code=status.HTTP_402_PAYMENT_REQUIRED,
         detail=exc.to_detail(),
     ) from exc
+
+
+def _require_sso_identity_linking(
+    db: Session,
+    organization: Optional[Organization],
+    payload: MembershipInviteRequest,
+) -> None:
+    if organization is None or not payload.logto_id:
+        return
+    try:
+        require_organization_feature(db, organization, "sso")
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={
+                "code": "feature_not_included",
+                "feature": "sso",
+                "message": str(exc),
+                "can_export": True,
+            },
+        ) from exc
 
 
 def _require_user_seat_capacity(
@@ -467,6 +490,7 @@ async def invite_workspace_member(
     require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, workspace)
     _ensure_workspace_accepts_mutation(workspace)
     role = _normalize_role(payload.role, WORKSPACE_ROLES)
+    _require_sso_identity_linking(db, workspace.organization, payload)
     user = _find_or_create_invited_user(db, payload)
     membership = _upsert_workspace_membership_row(
         db=db,
@@ -594,6 +618,7 @@ async def invite_organization_member(
     organization = _organization_or_404(db, organization_id)
     require_organization_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, organization)
     role = _normalize_role(payload.role, ORGANIZATION_ROLES)
+    _require_sso_identity_linking(db, organization, payload)
     user = _find_or_create_invited_user(db, payload)
     membership = _upsert_organization_membership_row(
         db=db,

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -87,6 +87,7 @@ ENFORCED_PLAN_LIMITS = {
 }
 FEATURE_ENTITLEMENT_ALIASES: Dict[str, tuple[str, ...]] = {
     "api_tokens": ("api_tokens", "api_access"),
+    "sso": ("sso", "single_sign_on", "oidc", "logto"),
     "webhooks": ("webhooks",),
 }
 PLAN_LIMIT_ENTITLEMENT_ALIASES: Dict[str, tuple[str, ...]] = {

--- a/backend/app/tests/test_memberships_api.py
+++ b/backend/app/tests/test_memberships_api.py
@@ -264,6 +264,67 @@ def test_workspace_membership_api_validates_payload_and_invite_identity_conflict
         assert linked.json()["user"]["email"] == "legacy-logto@example.com"
 
 
+def test_workspace_membership_invite_requires_sso_entitlement_for_logto_identity(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(slug="workspace-sso-disabled", name="Workspace SSO Disabled")
+    workspace = Workspace(
+        slug="workspace-sso-disabled-main",
+        name="Workspace SSO Disabled Main",
+        organization=organization,
+        active=True,
+    )
+    owner = _add_user(db_session, "workspace-sso-owner@example.com")
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="sso",
+                value="false",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    _add_workspace_membership(db_session, workspace, owner, ROLE_WORKSPACE_OWNER)
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        blocked = owner_client.post(
+            f"/api/v1/memberships/workspaces/{workspace.id}/invites",
+            json={
+                "email": "workspace-logto-disabled@example.com",
+                "role": ROLE_ANALYST,
+                "logto_id": "logto-workspace-disabled",
+            },
+        )
+        assert blocked.status_code == 402
+        detail = blocked.json()["detail"]
+        assert detail["code"] == "feature_not_included"
+        assert detail["feature"] == "sso"
+        assert detail["can_export"] is True
+
+        email_only = owner_client.post(
+            f"/api/v1/memberships/workspaces/{workspace.id}/invites",
+            json={
+                "email": "workspace-email-only@example.com",
+                "role": ROLE_ANALYST,
+            },
+        )
+        assert email_only.status_code == 200
+        assert email_only.json()["user"]["logto_id"] is None
+
+    assert (
+        db_session.query(User).filter(User.email == "workspace-logto-disabled@example.com").first()
+        is None
+    )
+    assert db_session.query(User).filter(User.email == "workspace-email-only@example.com").first()
+
+
 def test_workspace_membership_invite_respects_user_seat_plan_limit(
     test_app,
     db_session: Session,
@@ -432,6 +493,78 @@ def test_organization_membership_api_audits_and_deactivates(
     audit_actions = {row.action for row in db_session.query(WorkspaceAuditLog).all()}
     assert "organization.membership_upserted" in audit_actions
     assert "organization.membership_deactivated" in audit_actions
+
+
+def test_organization_membership_invite_requires_sso_entitlement_for_logto_identity(
+    test_app,
+    db_session: Session,
+):
+    organization = Organization(slug="organization-sso-disabled", name="Organization SSO Disabled")
+    workspace = Workspace(
+        slug="organization-sso-disabled-workspace",
+        name="Organization SSO Disabled Workspace",
+        organization=organization,
+        active=True,
+    )
+    owner = _add_user(db_session, "organization-sso-owner@example.com")
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="sso",
+                value="false",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=owner.id,
+            role="organization_owner",
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, owner) as owner_client:
+        blocked = owner_client.post(
+            f"/api/v1/memberships/organizations/{organization.id}/invites",
+            json={
+                "email": "organization-logto-disabled@example.com",
+                "role": "organization_auditor",
+                "logto_id": "logto-organization-disabled",
+            },
+        )
+        assert blocked.status_code == 402
+        detail = blocked.json()["detail"]
+        assert detail["code"] == "feature_not_included"
+        assert detail["feature"] == "sso"
+        assert detail["can_export"] is True
+
+        email_only = owner_client.post(
+            f"/api/v1/memberships/organizations/{organization.id}/invites",
+            json={
+                "email": "organization-email-only@example.com",
+                "role": "organization_auditor",
+            },
+        )
+        assert email_only.status_code == 200
+        assert email_only.json()["user"]["logto_id"] is None
+
+    assert (
+        db_session.query(User)
+        .filter(User.email == "organization-logto-disabled@example.com")
+        .first()
+        is None
+    )
+    assert (
+        db_session.query(User).filter(User.email == "organization-email-only@example.com").first()
+    )
 
 
 def test_organization_membership_invite_respects_user_seat_plan_limit(


### PR DESCRIPTION
## What changed
- Adds SSO entitlement aliases (`sso`, `single_sign_on`, `oidc`, `logto`) to the organization feature gate.
- Blocks workspace and organization membership invites that include `logto_id` when the organization plan disables SSO.
- Keeps regular email-only membership invites working for the same plans.
- Adds focused tests proving blocked SSO identity-linking does not leave partial local user records behind.

## Why
Issue #242 tracks entitlement enforcement beyond raw usage quotas. SSO identity linking was still usable through membership invite APIs even when starter-style entitlements set `sso=false`.

## Validation
- `.venv/bin/pytest backend/app/tests/test_memberships_api.py -q`
- `.venv/bin/black --check backend/app/api/api_v1/endpoints/memberships.py backend/app/services/organizations.py backend/app/tests/test_memberships_api.py`
- `.venv/bin/python -m compileall -q backend/app/api/api_v1/endpoints/memberships.py backend/app/services/organizations.py`
- `git diff --check`

Closes part of #242.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invitation flows now check whether SSO is available before accepting an invite that includes an identity link.
  * If SSO isn’t included, the invite is blocked with a clear feature-unavailable response, while standard email-only invites still work.
  * Added support for additional SSO-related entitlement labels so organization access checks are more accurate.
* **Tests**
  * Added coverage for invite behavior when SSO is disabled and when only email-based invites are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->