### PR TITLE
[codex] Gate advanced integration endpoints by entitlement

### DIFF
--- a/backend/app/api/api_v1/endpoints/integrations.py
+++ b/backend/app/api/api_v1/endpoints/integrations.py
@@ -1,21 +1,68 @@
 """Integration template endpoints."""
 
-from fastapi import APIRouter, Depends
+from typing import Optional
 
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
 from app.core.security import require_admin_auth
+from app.services.organizations import require_organization_feature
 from app.services.siem_templates import get_siem_templates
 from app.services.ticketing_chatops_templates import get_ticketing_chatops_templates
+from app.services.workspace_access import (
+    PERMISSION_REPORTS_READ,
+    parse_selected_workspace_id,
+    resolve_authorized_workspace,
+)
 
 router = APIRouter()
 
 
+def _require_advanced_integrations(
+    db: Session,
+    auth_context: dict,
+    selected_workspace: Optional[str],
+) -> None:
+    workspace = resolve_authorized_workspace(
+        db,
+        auth_context,
+        PERMISSION_REPORTS_READ,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    if workspace.organization is None:
+        return
+    try:
+        require_organization_feature(db, workspace.organization, "advanced_integrations")
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={
+                "code": "feature_not_included",
+                "feature": "advanced_integrations",
+                "message": str(exc),
+                "can_export": True,
+            },
+        ) from exc
+
+
 @router.get("/siem/templates")
-async def siem_templates(_auth: dict = Depends(require_admin_auth)):
+async def siem_templates(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+):
     """Return versioned schemas and examples for SIEM ingestion."""
+    _require_advanced_integrations(db, _auth, selected_workspace)
     return get_siem_templates()
 
 
 @router.get("/ticketing-chatops/templates")
-async def ticketing_chatops_templates(_auth: dict = Depends(require_admin_auth)):
+async def ticketing_chatops_templates(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+):
     """Return ticketing and chatops workflow templates."""
+    _require_advanced_integrations(db, _auth, selected_workspace)
     return get_ticketing_chatops_templates()

--- a/backend/app/api/api_v1/endpoints/mcp.py
+++ b/backend/app/api/api_v1/endpoints/mcp.py
@@ -16,6 +16,7 @@ from app.services.ai_assistance import (
     get_assistance_config,
 )
 from app.services.api_tokens import MCP_READ_SCOPE
+from app.services.organizations import require_organization_feature
 from app.services.report_persistence import hydrate_report_store_from_db
 from app.services.report_store import ReportStore
 from app.services.workspace_access import PERMISSION_REPORTS_READ, resolve_authorized_workspace
@@ -80,6 +81,23 @@ def _require_mcp_enabled(db: Session) -> None:
         )
 
 
+def _require_advanced_integrations(db: Session, workspace) -> None:
+    if workspace.organization is None:
+        return
+    try:
+        require_organization_feature(db, workspace.organization, "advanced_integrations")
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={
+                "code": "feature_not_included",
+                "feature": "advanced_integrations",
+                "message": str(exc),
+                "can_export": True,
+            },
+        ) from exc
+
+
 def _list_domains(db: Session, *, workspace_id: Optional[int] = None) -> Dict[str, Any]:
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store, workspace_id=workspace_id)
@@ -107,6 +125,12 @@ async def mcp_jsonrpc(
 ) -> Dict[str, Any]:
     """Handle a small read-only MCP tool surface over JSON-RPC."""
     _require_mcp_enabled(db)
+    workspace = resolve_authorized_workspace(
+        db,
+        _auth,
+        PERMISSION_REPORTS_READ,
+    )
+    _require_advanced_integrations(db, workspace)
     if payload.method == "initialize":
         return _jsonrpc_response(
             payload.id,
@@ -126,11 +150,6 @@ async def mcp_jsonrpc(
 
     name = payload.params.get("name")
     arguments = payload.params.get("arguments") or {}
-    workspace = resolve_authorized_workspace(
-        db,
-        _auth,
-        PERMISSION_REPORTS_READ,
-    )
     try:
         if name == "list_domains":
             result = _list_domains(db, workspace_id=workspace.id)

--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -59,6 +59,7 @@ STARTER_PLAN_ENTITLEMENTS: Dict[str, str] = {
     "mail_sources": "1",
     "users": "1",
     "retention_days": "90",
+    "advanced_integrations": "false",
     "api_tokens": "false",
     "webhooks": "false",
     "sso": "false",
@@ -86,6 +87,14 @@ ENFORCED_PLAN_LIMITS = {
     "webhooks",
 }
 FEATURE_ENTITLEMENT_ALIASES: Dict[str, tuple[str, ...]] = {
+    "advanced_integrations": (
+        "advanced_integrations",
+        "advanced_integration",
+        "integrations",
+        "mcp",
+        "siem",
+        "ticketing_chatops",
+    ),
     "api_tokens": ("api_tokens", "api_access"),
     "sso": ("sso", "single_sign_on", "oidc", "logto"),
     "webhooks": ("webhooks",),

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -1,7 +1,9 @@
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.models.organization import Entitlement, Organization
 from app.models.setting import Setting
+from app.models.workspace import Workspace
 from app.services.api_tokens import MCP_READ_SCOPE, create_api_token
 from app.services.report_store import ReportStore
 
@@ -167,3 +169,46 @@ def test_mcp_requires_enabled_scoped_token(client: TestClient, db_session: Sessi
     assert called.status_code == 200
     result = called.json()["result"]["content"][0]["json"]
     assert result["summary"]["domain"] == DOMAIN
+
+
+def test_mcp_requires_advanced_integrations_entitlement(client: TestClient, db_session: Session):
+    organization = Organization(slug="mcp-disabled", name="MCP Disabled", active=True)
+    workspace = Workspace(
+        slug="mcp-disabled-main",
+        name="MCP Disabled Main",
+        organization=organization,
+        active=True,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="advanced_integrations",
+                value="false",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.flush()
+    token = create_api_token(
+        db_session,
+        name="mcp disabled client",
+        scopes=[MCP_READ_SCOPE],
+        workspace_id=workspace.id,
+    )
+    _set_setting(db_session, "mcp.enabled", "true", "mcp")
+
+    response = client.post(
+        "/api/v1/mcp",
+        headers={"X-API-Key": token.secret},
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+
+    assert response.status_code == 402
+    detail = response.json()["detail"]
+    assert detail["code"] == "feature_not_included"
+    assert detail["feature"] == "advanced_integrations"
+    assert detail["can_export"] is True

--- a/backend/app/tests/test_siem_templates.py
+++ b/backend/app/tests/test_siem_templates.py
@@ -1,7 +1,10 @@
 import json
 
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
+from app.models.organization import Entitlement, Organization
+from app.models.workspace import Workspace
 from app.services.siem_templates import (
     SIEM_EVENT_TYPES,
     SIEM_SCHEMA_VERSION,
@@ -72,9 +75,7 @@ def test_siem_alert_schema_requires_metadata_when_alert_is_present():
     assert "alert.status is not supported" not in errors
 
     assert (
-        validate_siem_event(
-            {**event, "alert": {"title": "", "detail": "", "status": "active"}}
-        )
+        validate_siem_event({**event, "alert": {"title": "", "detail": "", "status": "active"}})
         == []
     )
 
@@ -90,9 +91,9 @@ def test_splunk_template_requires_relay_to_add_hec_authorization():
     splunk_template = templates["config_templates"]["splunk_hec"]
 
     assert splunk_template["delivery_model"] == "relay_required"
-    assert "splunk.example:8088/services/collector/event" not in splunk_template[
-        "webhook_url_pattern"
-    ]
+    assert (
+        "splunk.example:8088/services/collector/event" not in splunk_template["webhook_url_pattern"]
+    )
     assert splunk_template["headers"] == {}
     assert "Authorization" not in splunk_template.get("headers", {})
     assert splunk_template["headers_added_by_relay"]["Authorization"].startswith("Splunk ")
@@ -116,6 +117,45 @@ def test_siem_templates_endpoint_returns_common_configs(authed_client: TestClien
     }
     assert body["event_examples"]["compliance_drop"]["redaction"]["pii_redacted"] is True
     assert "raw report" in " ".join(body["redaction_guidance"]).lower()
+
+
+def test_siem_templates_endpoint_requires_advanced_integrations_entitlement(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Tenant-scoped SIEM templates are gated as advanced integrations."""
+    organization = Organization(slug="siem-disabled", name="SIEM Disabled", active=True)
+    workspace = Workspace(
+        slug="siem-disabled-main",
+        name="SIEM Disabled Main",
+        organization=organization,
+        active=True,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="advanced_integrations",
+                value="false",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    response = authed_client.get(
+        "/api/v1/integrations/siem/templates",
+        headers={"X-DMARQ-Workspace-ID": str(workspace.id)},
+    )
+
+    assert response.status_code == 402
+    detail = response.json()["detail"]
+    assert detail["code"] == "feature_not_included"
+    assert detail["feature"] == "advanced_integrations"
+    assert detail["can_export"] is True
 
 
 def test_siem_templates_endpoint_requires_admin_auth(client: TestClient):

--- a/backend/app/tests/test_ticketing_chatops_templates.py
+++ b/backend/app/tests/test_ticketing_chatops_templates.py
@@ -1,7 +1,10 @@
 import json
 
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
+from app.models.organization import Entitlement, Organization
+from app.models.workspace import Workspace
 from app.services.ticketing_chatops_templates import (
     TICKETING_CHATOPS_SCHEMA_VERSION,
     WORKFLOW_EVENT_TYPES,
@@ -113,6 +116,45 @@ def test_ticketing_chatops_endpoint_returns_workflow_templates(
     }
     assert body["payload_templates"]["jira"]["operation"] == "create_or_update_issue"
     assert body["payload_templates"]["slack"]["thread_key"] == "{dedupe_key}"
+
+
+def test_ticketing_chatops_endpoint_requires_advanced_integrations_entitlement(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Tenant-scoped ticketing/chatops templates are gated as advanced integrations."""
+    organization = Organization(slug="chatops-disabled", name="ChatOps Disabled", active=True)
+    workspace = Workspace(
+        slug="chatops-disabled-main",
+        name="ChatOps Disabled Main",
+        organization=organization,
+        active=True,
+    )
+    db_session.add_all(
+        [
+            organization,
+            workspace,
+            Entitlement(
+                organization=organization,
+                key="advanced_integrations",
+                value="false",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    response = authed_client.get(
+        "/api/v1/integrations/ticketing-chatops/templates",
+        headers={"X-DMARQ-Workspace-ID": str(workspace.id)},
+    )
+
+    assert response.status_code == 402
+    detail = response.json()["detail"]
+    assert detail["code"] == "feature_not_included"
+    assert detail["feature"] == "advanced_integrations"
+    assert detail["can_export"] is True
 
 
 def test_ticketing_chatops_endpoint_requires_admin_auth(client: TestClient):


### PR DESCRIPTION
## What changed
- Adds an `advanced_integrations` feature entitlement alias, including `advanced_integration`, `integrations`, `mcp`, `siem`, and `ticketing_chatops` aliases.
- Marks Starter plans as `advanced_integrations=false` by default.
- Gates SIEM and ticketing/chatops template endpoints by the selected workspace organization entitlement.
- Gates MCP JSON-RPC access by the API token workspace organization entitlement before returning initialize/tool metadata or tool results.
- Keeps legacy unscoped/self-hosted workspaces without an organization backward-compatible.

## Why
Issue #242 tracks making plan entitlements enforce real product behavior. Advanced integration surfaces were still available once their local setting/auth gate was satisfied, even when a tenant plan should not include those integrations.

## Validation
- `.venv/bin/pytest backend/app/tests/test_ai_mcp.py backend/app/tests/test_siem_templates.py backend/app/tests/test_ticketing_chatops_templates.py backend/app/tests/test_organization_foundations.py -q`
- `.venv/bin/black --check backend/app/api/api_v1/endpoints/integrations.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/organizations.py backend/app/tests/test_ai_mcp.py backend/app/tests/test_siem_templates.py backend/app/tests/test_ticketing_chatops_templates.py`
- `.venv/bin/python -m compileall -q backend/app/api/api_v1/endpoints/integrations.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/organizations.py`
- `git diff --check`

Closes part of #242.
