### PR TITLE
Add support for attachments with inline content disposition

### DIFF
--- a/backend/app/services/imap_client.py
+++ b/backend/app/services/imap_client.py
@@ -628,7 +628,7 @@ class IMAPClient:
         reports_found = 0
 
         for part in msg.walk():
-            if part.get_content_disposition() != "attachment":
+            if part.get_content_disposition() not in ["attachment", "inline"]:
                 continue
 
             filename = part.get_filename()

--- a/backend/app/services/imap_client.py
+++ b/backend/app/services/imap_client.py
@@ -403,7 +403,7 @@ class IMAPClient:
         """
         for part in msg.walk():
             content_disposition = part.get_content_disposition()
-            if content_disposition == "attachment":
+            if content_disposition in ["attachment", "inline"]:
                 filename = part.get_filename()
                 if filename:
                     # Decode filename if needed

--- a/backend/app/tests/test_imap_client.py
+++ b/backend/app/tests/test_imap_client.py
@@ -14,6 +14,7 @@ from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from zipfile import ZipFile
+from gzip import GzipFile
 
 import pytest
 
@@ -79,6 +80,13 @@ def _make_zip_content(xml_bytes: bytes, filename: str = "report.xml") -> bytes:
     buf = BytesIO()
     with ZipFile(buf, "w") as zf:
         zf.writestr(filename, xml_bytes)
+    return buf.getvalue()
+
+
+def _make_gzip_content(xml_bytes: bytes, filename: str = "report.xml") -> bytes:
+    buf = BytesIO()
+    with GzipFile(filename=filename, mode="w", fileobj=buf) as zf:
+        zf.write(xml_bytes)
     return buf.getvalue()
 
 
@@ -493,6 +501,15 @@ class TestProcessAttachments:
         zip_content = _make_zip_content(MINIMAL_DMARC_XML, "report.xml")
         msg = email.message_from_bytes(
             _make_email_with_attachment("report.zip", zip_content, "application/zip")
+        )
+        count = client._process_attachments(msg)
+        assert count == 1
+
+    def test_processes_gzip_attachment(self):
+        client = self._make_client()
+        gzip_content = _make_gzip_content(MINIMAL_DMARC_XML, "report.xml")
+        msg = email.message_from_bytes(
+            _make_email_with_attachment("report.gz", gzip_content, "application/gzip")
         )
         count = client._process_attachments(msg)
         assert count == 1

--- a/backend/app/tests/test_imap_client.py
+++ b/backend/app/tests/test_imap_client.py
@@ -96,13 +96,14 @@ def _make_email_with_attachment(
     content_type: str = "application/xml",
     subject: str = "DMARC Report",
     from_addr: str = "noreply@example.com",
+    disposition_type: str = "attachment"
 ) -> bytes:
     msg = MIMEMultipart()
     msg["Subject"] = subject
     msg["From"] = from_addr
     msg.attach(MIMEText("DMARC report attached."))
     part = MIMEApplication(content, Name=filename)
-    part["Content-Disposition"] = f'attachment; filename="{filename}"'
+    part["Content-Disposition"] = f'{disposition_type}; filename="{filename}"'
     part.set_type(content_type)
     msg.attach(part)
     return msg.as_bytes()
@@ -510,6 +511,15 @@ class TestProcessAttachments:
         gzip_content = _make_gzip_content(MINIMAL_DMARC_XML, "report.xml")
         msg = email.message_from_bytes(
             _make_email_with_attachment("report.gz", gzip_content, "application/gzip")
+        )
+        count = client._process_attachments(msg)
+        assert count == 1
+
+    def test_processes_gzip_inline(self):
+        client = self._make_client()
+        gzip_content = _make_gzip_content(MINIMAL_DMARC_XML, "report.xml")
+        msg = email.message_from_bytes(
+            _make_email_with_attachment("report.gz", gzip_content, "application/gzip", disposition_type="inline")
         )
         count = client._process_attachments(msg)
         assert count == 1


### PR DESCRIPTION
## Description
I sometimes receive mails with the dmarc report attached with disposition-type `inline`. This PR allows `inline` as well as `attachment`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made
- Adds `inline` as a valid disposition-type
- Adds test for gzipped attachment
- Adds test for `inline` attachment

## Testing Performed
Besides the automated tests, I verified that dmarc reports from Fastmail (which uses `inline`) are parsed.

### Test Environment
- Python Version: 3.13
- Database: Postgres
- OS: Docker running on Fedora

## Security Considerations
- [ ] This PR has been reviewed for security vulnerabilities
- [ ] No sensitive data is exposed
- [ ] Input validation is implemented
- [ ] Authentication/authorization is properly handled
- [x] N/A - No security implications

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance impact acceptable for the functionality
- [ ] Performance concerns (explain below)

## Documentation
- [ ] Updated relevant documentation
- [ ] Added inline code comments for complex logic
- [ ] Updated API documentation (if applicable)
- [ ] Updated README.md (if applicable)
- [x] No documentation changes needed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## AI Assistance (if applicable)
<!-- If you used AI coding assistants, please note it here -->
- [ ] AI tools were used (GitHub Copilot, Cursor, etc.)
- [ ] All AI-generated code has been reviewed for security and correctness
- [ ] Tests were added for AI-generated code
- [x] N/A - No AI assistance used

## Additional Notes
<!-- Any additional information that reviewers should know -->

## Breaking Changes
<!-- If this is a breaking change, describe what breaks and migration steps -->

## Deployment Notes
<!-- Special deployment considerations or database migrations required -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DMARC reports are now processed from both standard attachments and inline email parts, improving report ingestion reliability.
  * Gzip-compressed DMARC reports are now supported when received as attachments or inline content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->