### PR TITLE
[codex] Surface billing ownership in admin UI

### DIFF
--- a/backend/app/services/organizations.py
+++ b/backend/app/services/organizations.py
@@ -38,6 +38,57 @@ BILLING_MODE_PROVIDER_RESALE = "provider_resale"
 BILLING_MODE_PROVIDER_WHMCS = "provider_whmcs"
 BILLING_MODE_PROVIDER_TMF = "provider_tmf"
 BILLING_MODE_SELF_HOSTED = "self_hosted_license"
+BILLING_OWNER_MODES: Dict[str, Dict[str, Any]] = {
+    BILLING_MODE_DIRECT_STRIPE: {
+        "label": "Direct Stripe",
+        "owner_type": "dmarq",
+        "owner": "DMARQ direct billing",
+        "invoice_label": "Stripe customer portal",
+        "can_manage_in_app": True,
+    },
+    "stripe": {
+        "label": "Direct Stripe",
+        "owner_type": "dmarq",
+        "owner": "DMARQ direct billing",
+        "invoice_label": "Stripe customer portal",
+        "can_manage_in_app": True,
+    },
+    BILLING_MODE_MANUAL_CONTRACT: {
+        "label": "Manual contract",
+        "owner_type": "dmarq",
+        "owner": "DMARQ contract invoice",
+        "invoice_label": "Manual invoice",
+        "can_manage_in_app": False,
+    },
+    BILLING_MODE_PROVIDER_RESALE: {
+        "label": "Provider resale",
+        "owner_type": "provider",
+        "owner": "Provider-billed customer",
+        "invoice_label": "Provider monthly bill",
+        "can_manage_in_app": False,
+    },
+    BILLING_MODE_PROVIDER_WHMCS: {
+        "label": "WHMCS provider",
+        "owner_type": "provider",
+        "owner": "Hosting provider billing system",
+        "invoice_label": "Provider WHMCS invoice",
+        "can_manage_in_app": False,
+    },
+    BILLING_MODE_PROVIDER_TMF: {
+        "label": "TM Forum provider",
+        "owner_type": "provider",
+        "owner": "TM Forum integrated provider",
+        "invoice_label": "Provider BSS invoice",
+        "can_manage_in_app": False,
+    },
+    BILLING_MODE_SELF_HOSTED: {
+        "label": "Self-hosted license",
+        "owner_type": "self_hosted",
+        "owner": "Local self-hosted deployment",
+        "invoice_label": "Internal license record",
+        "can_manage_in_app": False,
+    },
+}
 
 SELF_HOSTED_PLAN_CODE = "self_hosted"
 DEFAULT_SELF_HOSTED_ENTITLEMENTS: Dict[str, str] = {
@@ -497,6 +548,79 @@ def _primary_subscription(subscriptions: Iterable[Subscription]) -> Optional[Sub
             if subscription.status in status_group:
                 return subscription
     return subscription_list[0] if subscription_list else None
+
+
+def _primary_billing_account(
+    billing_accounts: Iterable[BillingAccount],
+    subscriptions: Iterable[Subscription],
+) -> Optional[BillingAccount]:
+    account_list = list(billing_accounts)
+    subscription = _primary_subscription(subscriptions)
+    if subscription and subscription.billing_account:
+        return subscription.billing_account
+    for status in ("active", "trialing"):
+        for account in account_list:
+            if account.status == status:
+                return account
+    return account_list[0] if account_list else None
+
+
+def _billing_owner_summary(
+    billing_accounts: Iterable[BillingAccount],
+    subscriptions: Iterable[Subscription],
+) -> Dict[str, Any]:
+    account = _primary_billing_account(billing_accounts, subscriptions)
+    subscription = _primary_subscription(subscriptions)
+    mode = (
+        account.billing_mode
+        if account
+        else subscription.billing_mode if subscription else "unconfigured"
+    )
+    metadata = BILLING_OWNER_MODES.get(
+        mode,
+        {
+            "label": mode.replace("_", " ").title() if mode else "Unconfigured",
+            "owner_type": "external",
+            "owner": "External billing owner",
+            "invoice_label": "External invoice",
+            "can_manage_in_app": False,
+        },
+    )
+    if account is None and subscription is None:
+        return {
+            "billing_mode": "unconfigured",
+            "billing_mode_label": "Unconfigured",
+            "owner_type": "unconfigured",
+            "owner": "No billing owner configured",
+            "status": "unconfigured",
+            "invoice_delivery_mode": None,
+            "invoice_delivery_label": "Not configured",
+            "provider_id": None,
+            "external_customer_id": None,
+            "stripe_customer_id": None,
+            "subscription_id": None,
+            "subscription_status": None,
+            "plan_code": None,
+            "plan_name": None,
+            "can_manage_in_app": False,
+        }
+    return {
+        "billing_mode": mode,
+        "billing_mode_label": metadata["label"],
+        "owner_type": metadata["owner_type"],
+        "owner": metadata["owner"],
+        "status": account.status if account else subscription.status,
+        "invoice_delivery_mode": account.invoice_delivery_mode if account else None,
+        "invoice_delivery_label": metadata["invoice_label"],
+        "provider_id": account.provider_id if account else None,
+        "external_customer_id": account.external_customer_id if account else None,
+        "stripe_customer_id": account.stripe_customer_id if account else None,
+        "subscription_id": subscription.id if subscription else None,
+        "subscription_status": subscription.status if subscription else None,
+        "plan_code": subscription.plan.code if subscription else None,
+        "plan_name": subscription.plan.name if subscription else None,
+        "can_manage_in_app": metadata["can_manage_in_app"],
+    }
 
 
 def account_state_for_subscriptions(
@@ -1053,6 +1177,7 @@ def organization_summary(
         "workspaces": [_workspace_to_dict(workspace) for workspace in workspaces],
         "billing_accounts": [_billing_account_to_dict(account) for account in billing_accounts],
         "subscriptions": [_subscription_to_dict(subscription) for subscription in subscriptions],
+        "billing_owner": _billing_owner_summary(billing_accounts, subscriptions),
         "account_state": account_state_for_subscriptions(subscriptions),
         "entitlements": {
             entitlement.key: {

--- a/backend/app/templates/members.html
+++ b/backend/app/templates/members.html
@@ -36,69 +36,162 @@
     </template>
 
     <div class="grid grid-cols-1 gap-6 xl:grid-cols-[22rem_1fr]">
-        {% call card() %}
-            {% call card_header() %}
-                {% call card_title() %}Tenant Scope{% endcall %}
-                {% call card_description() %}Choose the organization or workspace to manage.{% endcall %}
-            {% endcall %}
-            {% call card_content() %}
-                <div class="space-y-4">
-                    <div class="join w-full">
-                        <button type="button"
-                                class="btn join-item flex-1"
-                                :class="scope === 'workspace' ? 'btn-primary' : 'btn-outline'"
-                                @click="setScope('workspace')">
-                            Workspace
-                        </button>
-                        <button type="button"
-                                class="btn join-item flex-1"
-                                :class="scope === 'organization' ? 'btn-primary' : 'btn-outline'"
-                                @click="setScope('organization')">
-                            Organization
-                        </button>
-                    </div>
+        <div class="space-y-6">
+            {% call card() %}
+                {% call card_header() %}
+                    {% call card_title() %}Tenant Scope{% endcall %}
+                    {% call card_description() %}Choose the organization or workspace to manage.{% endcall %}
+                {% endcall %}
+                {% call card_content() %}
+                    <div class="space-y-4">
+                        <div class="join w-full">
+                            <button type="button"
+                                    class="btn join-item flex-1"
+                                    :class="scope === 'workspace' ? 'btn-primary' : 'btn-outline'"
+                                    @click="setScope('workspace')">
+                                Workspace
+                            </button>
+                            <button type="button"
+                                    class="btn join-item flex-1"
+                                    :class="scope === 'organization' ? 'btn-primary' : 'btn-outline'"
+                                    @click="setScope('organization')">
+                                Organization
+                            </button>
+                        </div>
 
-                    <label class="form-control">
-                        <span class="label-text mb-2 font-semibold">Organization</span>
-                        <select class="select select-bordered w-full"
-                                x-model="selectedOrgId"
-                                @change="selectOrganization(selectedOrgId)">
-                            <template x-for="organization in organizations" :key="organization.id">
-                                <option :value="organization.id" x-text="organization.name"></option>
-                            </template>
-                        </select>
-                    </label>
-
-                    <template x-if="scope === 'workspace'">
                         <label class="form-control">
-                            <span class="label-text mb-2 font-semibold">Workspace</span>
+                            <span class="label-text mb-2 font-semibold">Organization</span>
                             <select class="select select-bordered w-full"
-                                    x-model="selectedWorkspaceId"
-                                    @change="loadMemberships()">
-                                <template x-for="workspace in currentWorkspaces()" :key="workspace.id">
-                                    <option :value="workspace.id" x-text="workspace.name"></option>
+                                    x-model="selectedOrgId"
+                                    @change="selectOrganization(selectedOrgId)">
+                                <template x-for="organization in organizations" :key="organization.id">
+                                    <option :value="organization.id" x-text="organization.name"></option>
                                 </template>
                             </select>
                         </label>
-                    </template>
 
-                    <div class="rounded-lg border border-[#e6e3df] bg-[#f9f8f6] p-4">
-                        <p class="text-xs font-semibold uppercase text-[#5f5c78]">Current Scope</p>
-                        <p class="mt-2 font-semibold text-[#120d36]" x-text="scopeLabel()"></p>
-                        <p class="mt-1 text-sm text-[#5f5c78]" x-text="scopeDescription()"></p>
-                        <template x-if="seatLimitWarning()">
-                            <div class="mt-3 rounded-md border border-[#f2c280] bg-[#fff8eb] p-3 text-sm text-[#7a4a12]">
-                                <div class="flex items-start justify-between gap-3">
-                                    <span x-text="seatLimitWarning().message"></span>
-                                    <span class="shrink-0 rounded-full bg-white px-2 py-1 text-xs font-semibold"
-                                          x-text="`${seatLimitWarning().remaining} left`"></span>
+                        <template x-if="scope === 'workspace'">
+                            <label class="form-control">
+                                <span class="label-text mb-2 font-semibold">Workspace</span>
+                                <select class="select select-bordered w-full"
+                                        x-model="selectedWorkspaceId"
+                                        @change="loadMemberships()">
+                                    <template x-for="workspace in currentWorkspaces()" :key="workspace.id">
+                                        <option :value="workspace.id" x-text="workspace.name"></option>
+                                    </template>
+                                </select>
+                            </label>
+                        </template>
+
+                        <div class="rounded-lg border border-[#e6e3df] bg-[#f9f8f6] p-4">
+                            <p class="text-xs font-semibold uppercase text-[#5f5c78]">Current Scope</p>
+                            <p class="mt-2 font-semibold text-[#120d36]" x-text="scopeLabel()"></p>
+                            <p class="mt-1 text-sm text-[#5f5c78]" x-text="scopeDescription()"></p>
+                            <template x-if="seatLimitWarning()">
+                                <div class="mt-3 rounded-md border border-[#f2c280] bg-[#fff8eb] p-3 text-sm text-[#7a4a12]">
+                                    <div class="flex items-start justify-between gap-3">
+                                        <span x-text="seatLimitWarning().message"></span>
+                                        <span class="shrink-0 rounded-full bg-white px-2 py-1 text-xs font-semibold"
+                                              x-text="`${seatLimitWarning().remaining} left`"></span>
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+                {% endcall %}
+            {% endcall %}
+
+            {% call card() %}
+                {% call card_header() %}
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            {% call card_title() %}Billing & Plan{% endcall %}
+                            {% call card_description() %}Owner, invoice path, and active limits for this organization.{% endcall %}
+                        </div>
+                        <span class="badge"
+                              :class="ownerBadgeClass()"
+                              x-text="currentBillingOwner().billing_mode_label || 'Unconfigured'"></span>
+                    </div>
+                {% endcall %}
+                {% call card_content() %}
+                    <div class="space-y-4">
+                        <div class="rounded-lg border border-[#e6e3df] bg-[#f9f8f6] p-4">
+                            <p class="text-xs font-semibold uppercase text-[#5f5c78]">Billing owner</p>
+                            <p class="mt-2 font-semibold text-[#120d36]" x-text="currentBillingOwner().owner || 'No billing owner configured'"></p>
+                            <div class="mt-3 grid gap-3 text-sm text-[#5f5c78]">
+                                <div class="flex items-center justify-between gap-3">
+                                    <span>Invoice path</span>
+                                    <span class="text-right font-semibold text-[#120d36]"
+                                          x-text="currentBillingOwner().invoice_delivery_label || 'Not configured'"></span>
+                                </div>
+                                <div class="flex items-center justify-between gap-3">
+                                    <span>Account status</span>
+                                    <span class="badge badge-sm"
+                                          :class="stateBadgeClass()"
+                                          x-text="accountStateLabel()"></span>
+                                </div>
+                                <div class="flex items-center justify-between gap-3" x-show="currentBillingOwner().provider_id">
+                                    <span>Provider</span>
+                                    <span class="max-w-40 truncate text-right font-semibold text-[#120d36]"
+                                          x-text="currentBillingOwner().provider_id"></span>
+                                </div>
+                                <div class="flex items-center justify-between gap-3" x-show="currentBillingOwner().external_customer_id || currentBillingOwner().stripe_customer_id">
+                                    <span>Customer ID</span>
+                                    <span class="max-w-40 truncate text-right font-mono text-xs text-[#120d36]"
+                                          x-text="currentBillingOwner().external_customer_id || currentBillingOwner().stripe_customer_id"></span>
                                 </div>
                             </div>
+                        </div>
+
+                        <div class="rounded-lg border border-[#e6e3df] bg-white p-4">
+                            <p class="text-xs font-semibold uppercase text-[#5f5c78]">Plan</p>
+                            <p class="mt-2 font-semibold text-[#120d36]" x-text="currentBillingOwner().plan_name || 'No plan configured'"></p>
+                            <p class="mt-1 text-sm text-[#5f5c78]"
+                               x-text="currentBillingOwner().subscription_status ? `Subscription ${currentBillingOwner().subscription_status}` : 'No subscription state available'"></p>
+                        </div>
+
+                        <template x-if="isAccountRestricted()">
+                            <div class="rounded-lg border border-[#f2c280] bg-[#fff8eb] p-4 text-sm text-[#7a4a12]">
+                                <p class="font-semibold" x-text="currentAccountState().read_only ? 'Read-only account' : 'Grace period'"></p>
+                                <p class="mt-1" x-text="currentAccountState().reason"></p>
+                            </div>
                         </template>
+
+                        <div>
+                            <div class="mb-3 flex items-center justify-between">
+                                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Plan limits</p>
+                                <span class="text-xs text-[#5f5c78]" x-text="`${planLimitRows().length} tracked`"></span>
+                            </div>
+                            <template x-if="planLimitRows().length === 0">
+                                <div class="rounded-lg border border-dashed border-[#d8d5d0] bg-[#f9f8f6] p-4 text-sm text-[#5f5c78]">
+                                    No visible plan limits.
+                                </div>
+                            </template>
+                            <div class="space-y-3">
+                                <template x-for="limit in planLimitRows()" :key="limit.metric">
+                                    <div class="rounded-lg border border-[#e6e3df] bg-white p-3">
+                                        <div class="flex items-start justify-between gap-3">
+                                            <div>
+                                                <p class="font-semibold text-[#120d36]" x-text="limit.label"></p>
+                                                <p class="text-xs text-[#5f5c78]" x-text="limit.enforced ? 'Enforced' : 'Visible'"></p>
+                                            </div>
+                                            <span class="shrink-0 text-sm font-semibold text-[#120d36]"
+                                                  x-text="formatLimitUsage(limit)"></span>
+                                        </div>
+                                        <div class="mt-3 h-2 overflow-hidden rounded-full bg-[#ebe9e6]">
+                                            <div class="h-full rounded-full"
+                                                 :class="limitTrackClass(limit)"
+                                                 :style="`width: ${Math.min(limit.usage_percent || 0, 100)}%`"></div>
+                                        </div>
+                                        <p class="mt-2 text-xs text-[#7a4a12]" x-show="limit.message" x-text="limit.message"></p>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
                     </div>
-                </div>
+                {% endcall %}
             {% endcall %}
-        {% endcall %}
+        </div>
 
         <div class="space-y-6">
             {% call card() %}
@@ -444,6 +537,14 @@ function membershipApp() {
             return organization ? (organization.workspaces || []) : [];
         },
 
+        currentBillingOwner() {
+            return this.currentOrganization()?.billing_owner || {};
+        },
+
+        currentAccountState() {
+            return this.currentOrganization()?.account_state || {};
+        },
+
         workspaceCount() {
             return this.organizations.reduce((count, organization) => {
                 return count + (organization.workspaces || []).length;
@@ -474,10 +575,84 @@ function membershipApp() {
             return this.currentOrganization()?.plan_limits?.[metric] || null;
         },
 
+        planLimitRows() {
+            const limits = this.currentOrganization()?.plan_limits || {};
+            return Object.entries(limits)
+                .map(([metric, limit]) => ({
+                    metric,
+                    label: this.planLimitLabel(metric),
+                    current: limit.current,
+                    limit: limit.limit,
+                    unit: limit.unit || '',
+                    enforced: Boolean(limit.enforced),
+                    near_limit: Boolean(limit.near_limit),
+                    usage_percent: Number(limit.usage_percent || 0),
+                    message: limit.message || '',
+                }))
+                .sort((left, right) => left.label.localeCompare(right.label));
+        },
+
         seatLimitWarning() {
             const limit = this.planLimit('users');
             if (!limit || !limit.near_limit || !limit.message) return null;
             return limit;
+        },
+
+        planLimitLabel(metric) {
+            const labels = {
+                aggregate_messages: 'Monthly messages',
+                api_tokens: 'API tokens',
+                mail_sources: 'Mail sources',
+                monitored_domains: 'Monitored domains',
+                retention_days: 'Retention',
+                users: 'Seats',
+                webhooks: 'Webhooks',
+            };
+            return labels[metric] || metric.replaceAll('_', ' ');
+        },
+
+        formatLimitValue(value, unit) {
+            if (value === null || value === undefined) return 'unlimited';
+            if (typeof value === 'boolean') return value ? 'enabled' : 'disabled';
+            const suffix = unit ? ` ${unit}` : '';
+            return `${value}${suffix}`;
+        },
+
+        formatLimitUsage(limit) {
+            return `${this.formatLimitValue(limit.current, limit.unit)} / ${this.formatLimitValue(limit.limit, limit.unit)}`;
+        },
+
+        limitTrackClass(limit) {
+            if (limit.limit === null || limit.limit === undefined) return 'bg-[#2c9aa3]';
+            if (limit.usage_percent >= 100) return 'bg-[#ff6333]';
+            if (limit.near_limit) return 'bg-[#f2a23a]';
+            return 'bg-[#2c9aa3]';
+        },
+
+        ownerBadgeClass() {
+            const ownerType = this.currentBillingOwner().owner_type;
+            if (ownerType === 'provider') return 'badge-info';
+            if (ownerType === 'self_hosted') return 'badge-success';
+            if (ownerType === 'dmarq') return 'badge-primary';
+            return 'badge-ghost';
+        },
+
+        accountStateLabel() {
+            const state = this.currentAccountState();
+            return state.status ? state.status.replaceAll('_', ' ') : 'unconfigured';
+        },
+
+        stateBadgeClass() {
+            const state = this.currentAccountState();
+            if (state.read_only || state.closed) return 'badge-error';
+            if (state.grace_period) return 'badge-warning';
+            if (state.can_mutate) return 'badge-success';
+            return 'badge-ghost';
+        },
+
+        isAccountRestricted() {
+            const state = this.currentAccountState();
+            return Boolean(state.read_only || state.grace_period);
         },
 
         roleLabel(role) {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -26,6 +26,10 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert "/api/v1/organizations" in template
     assert "/api/v1/memberships/organizations/" in template
     assert "/api/v1/memberships/workspaces/" in template
+    assert "Billing & Plan" in template
+    assert "currentBillingOwner().owner" in template
+    assert "planLimitRows()" in template
+    assert "invoice_delivery_label" in template
     assert 'x-text="membership.user.email"' in template
     assert '@change="updateMembership(membership, membership.active)"' in template
     assert '@change="updateMembership(membership, true)"' not in template

--- a/backend/app/tests/test_organization_foundations.py
+++ b/backend/app/tests/test_organization_foundations.py
@@ -24,6 +24,11 @@ from app.models.webhook import WebhookEndpoint
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
 from app.services.organizations import (
+    BILLING_MODE_DIRECT_STRIPE,
+    BILLING_MODE_MANUAL_CONTRACT,
+    BILLING_MODE_PROVIDER_RESALE,
+    BILLING_MODE_PROVIDER_TMF,
+    BILLING_MODE_PROVIDER_WHMCS,
     BILLING_MODE_SELF_HOSTED,
     DEFAULT_ORGANIZATION_SLUG,
     SELF_HOSTED_PLAN_CODE,
@@ -137,6 +142,8 @@ def test_list_organization_summaries_materializes_account_state(db_session: Sess
     assert summaries[0]["slug"] == DEFAULT_ORGANIZATION_SLUG
     assert summaries[0]["billing_accounts"][0]["billing_mode"] == BILLING_MODE_SELF_HOSTED
     assert summaries[0]["subscriptions"][0]["plan"]["code"] == SELF_HOSTED_PLAN_CODE
+    assert summaries[0]["billing_owner"]["billing_mode"] == BILLING_MODE_SELF_HOSTED
+    assert summaries[0]["billing_owner"]["owner_type"] == "self_hosted"
     assert summaries[0]["entitlements"]["aggregate_reports"]["value"] == "true"
     assert summaries[0]["account_state"]["status"] == "active"
     assert summaries[0]["account_state"]["can_mutate"] is True
@@ -1005,9 +1012,7 @@ def test_save_parsed_report_rejects_invalid_aggregate_message_counts(
         )
 
     assert (
-        db_session.query(DMARCReport)
-        .filter(DMARCReport.report_id == "negative-volume")
-        .first()
+        db_session.query(DMARCReport).filter(DMARCReport.report_id == "negative-volume").first()
         is None
     )
 
@@ -1067,6 +1072,109 @@ def test_account_state_reports_provider_grace_without_blocking(db_session: Sessi
     assert state["grace_period"] is True
     assert state["read_only"] is False
     assert state["can_mutate"] is True
+
+
+def test_organization_summary_exposes_billing_ownership(db_session: Session):
+    plan = get_or_create_starter_plan(db_session)
+    organization = Organization(slug="provider-owner", name="Provider Owner", active=True)
+    account = BillingAccount(
+        organization=organization,
+        billing_mode=BILLING_MODE_PROVIDER_WHMCS,
+        status="active",
+        provider_id="whmcs-demo",
+        external_customer_id="cust-42",
+        invoice_delivery_mode="provider_invoice",
+    )
+    subscription = Subscription(
+        organization=organization,
+        billing_account=account,
+        plan=plan,
+        billing_mode=BILLING_MODE_PROVIDER_WHMCS,
+        status="active",
+        external_subscription_id="sub-42",
+    )
+    db_session.add_all([organization, account, subscription])
+    db_session.commit()
+
+    summary = organization_summary(db_session, organization)
+
+    assert summary["billing_owner"]["billing_mode"] == BILLING_MODE_PROVIDER_WHMCS
+    assert summary["billing_owner"]["billing_mode_label"] == "WHMCS provider"
+    assert summary["billing_owner"]["owner_type"] == "provider"
+    assert summary["billing_owner"]["owner"] == "Hosting provider billing system"
+    assert summary["billing_owner"]["invoice_delivery_mode"] == "provider_invoice"
+    assert summary["billing_owner"]["invoice_delivery_label"] == "Provider WHMCS invoice"
+    assert summary["billing_owner"]["provider_id"] == "whmcs-demo"
+    assert summary["billing_owner"]["external_customer_id"] == "cust-42"
+    assert summary["billing_owner"]["subscription_status"] == "active"
+    assert summary["billing_owner"]["plan_code"] == STARTER_PLAN_CODE
+    assert summary["billing_owner"]["can_manage_in_app"] is False
+
+
+@pytest.mark.parametrize(
+    ("billing_mode", "expected_label", "expected_owner_type", "expected_in_app"),
+    [
+        (BILLING_MODE_DIRECT_STRIPE, "Direct Stripe", "dmarq", True),
+        ("stripe", "Direct Stripe", "dmarq", True),
+        (BILLING_MODE_MANUAL_CONTRACT, "Manual contract", "dmarq", False),
+        (BILLING_MODE_PROVIDER_RESALE, "Provider resale", "provider", False),
+        (BILLING_MODE_PROVIDER_TMF, "TM Forum provider", "provider", False),
+        (BILLING_MODE_SELF_HOSTED, "Self-hosted license", "self_hosted", False),
+        ("partner_portal", "Partner Portal", "external", False),
+    ],
+)
+def test_organization_summary_labels_billing_owner_modes(
+    db_session: Session,
+    billing_mode: str,
+    expected_label: str,
+    expected_owner_type: str,
+    expected_in_app: bool,
+):
+    plan = get_or_create_starter_plan(db_session)
+    safe_slug = billing_mode.replace("_", "-")
+    organization = Organization(slug=f"billing-{safe_slug}", name=f"Billing {billing_mode}")
+    account = BillingAccount(
+        organization=organization,
+        billing_mode=billing_mode,
+        status="trialing",
+        invoice_delivery_mode="internal",
+    )
+    subscription = Subscription(
+        organization=organization,
+        billing_account=account,
+        plan=plan,
+        billing_mode=billing_mode,
+        status="trialing",
+    )
+    db_session.add_all([organization, account, subscription])
+    db_session.commit()
+
+    owner = organization_summary(db_session, organization)["billing_owner"]
+
+    assert owner["billing_mode"] == billing_mode
+    assert owner["billing_mode_label"] == expected_label
+    assert owner["owner_type"] == expected_owner_type
+    assert owner["status"] == "trialing"
+    assert owner["subscription_status"] == "trialing"
+    assert owner["can_manage_in_app"] is expected_in_app
+
+
+def test_organization_summary_reports_unconfigured_billing_owner(db_session: Session):
+    organization = Organization(slug="billing-unconfigured", name="Billing Unconfigured")
+    db_session.add(organization)
+    db_session.commit()
+
+    owner = organization_summary(db_session, organization)["billing_owner"]
+
+    assert owner["billing_mode"] == "unconfigured"
+    assert owner["billing_mode_label"] == "Unconfigured"
+    assert owner["owner_type"] == "unconfigured"
+    assert owner["owner"] == "No billing owner configured"
+    assert owner["status"] == "unconfigured"
+    assert owner["invoice_delivery_mode"] is None
+    assert owner["subscription_status"] is None
+    assert owner["plan_code"] is None
+    assert owner["can_manage_in_app"] is False
 
 
 def test_account_state_reports_unclassified_status_without_active_reason(


### PR DESCRIPTION
## Summary
- add an explicit `billing_owner` summary to organization payloads for Stripe, contract, provider, WHMCS, TMF, and self-hosted billing modes
- surface billing ownership, invoice path, account state, subscription status, and plan-limit usage on the Members/admin page
- cover the new payload and template wiring with focused tests

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_organization_foundations.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_api.py -q`
- `.venv/bin/python -m black --check backend/app/services/organizations.py backend/app/tests/test_organization_foundations.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

Closes the remaining billing/admin visibility slice of #242.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added billing owner details to organization summaries and the Members page.
  * Introduced a new “Billing & Plan” card showing owner status, invoice details, account identifiers, and plan usage/seat limits.
  * Added clearer labels and indicators for billing mode, account state, and whether billing can be managed in the app.

* **Bug Fixes**
  * Improved how the app selects and displays the most relevant billing account when multiple accounts or subscriptions exist.
  * Added fallback handling for organizations without billing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->