### PR TITLE
[codex] Add enterprise audit export

### DIFF
--- a/backend/app/api/api_v1/endpoints/audit.py
+++ b/backend/app/api/api_v1/endpoints/audit.py
@@ -1,8 +1,11 @@
 """Workspace RBAC and audit endpoints."""
 
+import csv
+from io import StringIO
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi.responses import Response
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -15,7 +18,7 @@ from app.services.workspace_access import (
     require_workspace_permission,
     resolve_authorized_workspace,
 )
-from app.services.workspace_audit import list_workspace_audit_logs
+from app.services.workspace_audit import build_enterprise_audit_export, list_workspace_audit_logs
 from app.services.workspaces import assign_default_workspace_to_unscoped_rows, get_default_workspace
 
 router = APIRouter()
@@ -31,6 +34,22 @@ class WorkspaceAuditLogResponse(BaseModel):
     """Workspace audit log list response."""
 
     audit: List[Dict[str, Any]]
+
+
+ENTERPRISE_AUDIT_EXPORT_FIELDS = [
+    "category",
+    "workspace_id",
+    "organization_id",
+    "actor_type",
+    "actor_id",
+    "action",
+    "entity_type",
+    "entity_id",
+    "entity_name",
+    "details",
+    "ip_address",
+    "created_at",
+]
 
 
 def _authorized_audit_workspace(
@@ -91,3 +110,37 @@ async def get_workspace_audit_logs(
             entity_type=entity_type,
         )
     }
+
+
+@router.get("/export")
+async def export_enterprise_audit_logs(
+    limit: int = Query(1000, ge=1, le=5000),
+    action: Optional[str] = None,
+    entity_type: Optional[str] = None,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+):
+    """Export sanitized enterprise audit rows for the selected workspace/account."""
+    workspace = _authorized_audit_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    rows = build_enterprise_audit_export(
+        db,
+        workspace=workspace,
+        limit=limit,
+        action=action,
+        entity_type=entity_type,
+    )
+    output = StringIO()
+    writer = csv.DictWriter(output, fieldnames=ENTERPRISE_AUDIT_EXPORT_FIELDS)
+    writer.writeheader()
+    writer.writerows(rows)
+    filename = f"{workspace.slug.replace('/', '_')}-enterprise-audit.csv"
+    return Response(
+        output.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/app/services/workspace_audit.py
+++ b/backend/app/services/workspace_audit.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Iterable, List, Optional
 from fastapi import Request
 from sqlalchemy.orm import Session
 
+from app.models.organization import BillingEvent, Entitlement
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 
@@ -155,6 +156,147 @@ def list_workspace_audit_logs(
         .all()
     )
     return [audit_log_to_dict(row) for row in rows]
+
+
+def _iso(value: Optional[datetime]) -> Optional[str]:
+    return value.isoformat() if value else None
+
+
+def _enterprise_audit_row(
+    *,
+    category: str,
+    workspace_id: Optional[int],
+    organization_id: Optional[int],
+    actor_type: str,
+    actor_id: Optional[str],
+    action: str,
+    entity_type: str,
+    entity_id: Optional[Any],
+    entity_name: Optional[str],
+    details: Optional[Dict[str, Any]],
+    ip_address: Optional[str],
+    created_at: Optional[datetime],
+) -> Dict[str, Any]:
+    safe_details = sanitize_audit_details(details or {})
+    return {
+        "category": category,
+        "workspace_id": workspace_id,
+        "organization_id": organization_id,
+        "actor_type": actor_type,
+        "actor_id": actor_id,
+        "action": action,
+        "entity_type": entity_type,
+        "entity_id": str(entity_id) if entity_id is not None else None,
+        "entity_name": entity_name,
+        "details": json.dumps(safe_details, sort_keys=True),
+        "ip_address": ip_address,
+        "created_at": _iso(created_at),
+    }
+
+
+def build_enterprise_audit_export(
+    db: Session,
+    *,
+    workspace: Workspace,
+    limit: int = 1000,
+    action: Optional[str] = None,
+    entity_type: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Return sanitized audit rows suitable for enterprise CSV exports."""
+    row_limit = max(1, min(limit, 5000))
+    rows: List[Dict[str, Any]] = []
+    organization_id = workspace.organization_id
+    audit_query = db.query(WorkspaceAuditLog).filter(WorkspaceAuditLog.workspace_id == workspace.id)
+    if action:
+        audit_query = audit_query.filter(WorkspaceAuditLog.action == action)
+    if entity_type:
+        audit_query = audit_query.filter(WorkspaceAuditLog.entity_type == entity_type)
+    for audit_row in (
+        audit_query.order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
+        .limit(row_limit)
+        .all()
+    ):
+        rows.append(
+            _enterprise_audit_row(
+                category="workspace_audit",
+                workspace_id=audit_row.workspace_id,
+                organization_id=organization_id,
+                actor_type=audit_row.actor_type,
+                actor_id=audit_row.actor_id,
+                action=audit_row.action,
+                entity_type=audit_row.entity_type,
+                entity_id=audit_row.entity_id,
+                entity_name=audit_row.entity_name,
+                details=audit_log_to_dict(audit_row)["details"],
+                ip_address=audit_row.ip_address,
+                created_at=audit_row.created_at,
+            )
+        )
+
+    if organization_id is not None:
+        for billing_event in (
+            db.query(BillingEvent)
+            .filter(BillingEvent.organization_id == organization_id)
+            .order_by(BillingEvent.created_at.desc(), BillingEvent.id.desc())
+            .limit(row_limit)
+            .all()
+        ):
+            rows.append(
+                _enterprise_audit_row(
+                    category="billing_event",
+                    workspace_id=None,
+                    organization_id=organization_id,
+                    actor_type="system",
+                    actor_id=billing_event.provider_id or billing_event.billing_mode,
+                    action=billing_event.event_type,
+                    entity_type="billing_event",
+                    entity_id=billing_event.id,
+                    entity_name=billing_event.external_event_id,
+                    details={
+                        "billing_mode": billing_event.billing_mode,
+                        "provider_id": billing_event.provider_id,
+                        "external_event_id": billing_event.external_event_id,
+                        "status": billing_event.status,
+                        "payload_summary_present": bool(billing_event.payload_summary),
+                        "subscription_id": billing_event.subscription_id,
+                    },
+                    ip_address=None,
+                    created_at=billing_event.created_at,
+                )
+            )
+        for entitlement in (
+            db.query(Entitlement)
+            .filter(Entitlement.organization_id == organization_id)
+            .order_by(Entitlement.updated_at.desc().nullslast(), Entitlement.id.desc())
+            .limit(row_limit)
+            .all()
+        ):
+            rows.append(
+                _enterprise_audit_row(
+                    category="entitlement",
+                    workspace_id=None,
+                    organization_id=organization_id,
+                    actor_type="system",
+                    actor_id=entitlement.source,
+                    action="entitlement.active" if entitlement.active else "entitlement.inactive",
+                    entity_type="entitlement",
+                    entity_id=entitlement.id,
+                    entity_name=entitlement.key,
+                    details={
+                        "key": entitlement.key,
+                        "value": entitlement.value,
+                        "source": entitlement.source,
+                        "subscription_id": entitlement.subscription_id,
+                        "effective_from": _iso(entitlement.effective_from),
+                        "expires_at": _iso(entitlement.expires_at),
+                    },
+                    ip_address=None,
+                    created_at=entitlement.updated_at or entitlement.created_at,
+                )
+            )
+
+    rows.sort(key=lambda row: (row["created_at"] or "", row["category"]), reverse=True)
+    return rows[:row_limit]
 
 
 def changed_fields(fields: Iterable[str]) -> List[str]:

--- a/backend/app/tests/test_workspace_audit.py
+++ b/backend/app/tests/test_workspace_audit.py
@@ -1,5 +1,7 @@
+import csv
 import json
 from contextlib import contextmanager
+from io import StringIO
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -7,7 +9,7 @@ from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
-from app.models.organization import Organization, OrganizationMembership
+from app.models.organization import BillingEvent, Entitlement, Organization, OrganizationMembership
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog, WorkspaceMembership
@@ -681,6 +683,112 @@ def test_webhook_changes_are_audited_without_signing_secret(authed_client: TestC
     serialized = str(audit.json())
     assert "very-secret-webhook-signing-value" not in serialized
     assert "another-secret-webhook-value" not in serialized
+
+
+def test_enterprise_audit_export_includes_account_security_events(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Enterprise CSV export combines sanitized workspace, billing, and entitlement rows."""
+    organization = Organization(slug="enterprise-audit", name="Enterprise Audit")
+    workspace = Workspace(
+        slug="enterprise-audit-main",
+        name="Enterprise Audit Main",
+        organization=organization,
+    )
+    db_session.add_all([organization, workspace])
+    db_session.flush()
+    record_workspace_audit_log(
+        db_session,
+        workspace=workspace,
+        action="organization.membership_upserted",
+        entity_type="organization_membership",
+        entity_id="42",
+        entity_name="admin@example.com",
+        auth_context={"auth_type": "api_key"},
+        details={
+            "new": {"role": "organization_admin", "active": True},
+            "api_token": "raw-token-value",
+        },
+        commit=False,
+    )
+    db_session.add_all(
+        [
+            BillingEvent(
+                organization_id=organization.id,
+                billing_mode="provider_resale",
+                event_type="provider.customer_provisioned",
+                provider_id="isp-demo",
+                external_event_id="evt-enterprise-audit",
+                status="applied",
+                payload_summary="provisioned access_token=raw-provider-token",
+            ),
+            Entitlement(
+                organization=organization,
+                key="sso",
+                value="true",
+                source="plan",
+                active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    response = authed_client.get(
+        "/api/v1/audit/export",
+        headers={"X-DMARQ-Workspace-ID": str(workspace.id)},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "enterprise-audit-main-enterprise-audit.csv" in response.headers["content-disposition"]
+    rows = list(csv.DictReader(StringIO(response.text)))
+    categories = {row["category"] for row in rows}
+    actions = {row["action"] for row in rows}
+    assert {"workspace_audit", "billing_event", "entitlement"}.issubset(categories)
+    assert "organization.membership_upserted" in actions
+    assert "provider.customer_provisioned" in actions
+    assert "entitlement.active" in actions
+    serialized = response.text
+    assert "raw-token-value" not in serialized
+    assert "raw-provider-token" not in serialized
+    assert "[redacted]" in serialized
+
+
+def test_enterprise_audit_export_respects_workspace_filters(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """CSV export keeps existing audit filters for selected workspace rows."""
+    workspace = get_or_create_default_workspace(db_session)
+    record_workspace_audit_log(
+        db_session,
+        workspace=workspace,
+        action="setting.changed",
+        entity_type="setting",
+        entity_id="notifications.apprise_enabled",
+        details={"new_value": "true"},
+        commit=True,
+    )
+    record_workspace_audit_log(
+        db_session,
+        workspace=workspace,
+        action="webhook.created",
+        entity_type="webhook_endpoint",
+        entity_id="1",
+        details={"url": "https://example.com"},
+        commit=True,
+    )
+
+    response = authed_client.get(
+        "/api/v1/audit/export?action=webhook.created&entity_type=webhook_endpoint",
+        headers={"X-DMARQ-Workspace-ID": str(workspace.id)},
+    )
+
+    assert response.status_code == 200
+    rows = list(csv.DictReader(StringIO(response.text)))
+    assert [row["action"] for row in rows] == ["webhook.created"]
+    assert [row["entity_type"] for row in rows] == ["webhook_endpoint"]
 
 
 def test_manual_selector_changes_are_audited(authed_client: TestClient):


### PR DESCRIPTION
## Summary
- add `/api/v1/audit/export` as a selected-workspace CSV export for enterprise security audits
- include sanitized workspace audit rows plus organization billing/provider events and entitlement records when the selected workspace belongs to an organization
- avoid exporting raw provider payload summaries and keep secret-like audit details redacted

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_workspace_audit.py backend/app/tests/test_api.py -q`
- `.venv/bin/python -m black --check backend/app/api/api_v1/endpoints/audit.py backend/app/services/workspace_audit.py backend/app/tests/test_workspace_audit.py`
- `.venv/bin/python -m compileall backend/app/api/api_v1/endpoints/audit.py backend/app/services/workspace_audit.py`
- `git diff --check`

First bounded slice for #243.