### PR TITLE
[codex] Add guided demo persona drilldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Included:
 - `DEMO_MODE=true` seeds deterministic, rolling demo data for `dmarq.org` and `dmarq.com`
 - Demo data fills the dashboard, domain details, DNS posture, aggregate reports,
   forensic reports, TLS reports, exports, and linting views
+- The dashboard starts in a single-user, multi-domain view and can zoom out into
+  SaaS, managed-service, ISP/reseller, and self-hosted deployment examples
+- Demo visitors can switch generated personas to see which accounts, workspaces,
+  billing profiles, and domains different users would experience
+- A guided dashboard tour walks through the opinionated product flow from domain
+  posture to sender evidence and account drill-down
 - The public demo is read-only so visitors can explore without modifying data
 
 ### ⚙️ Web-Based Setup Wizard

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
@@ -1165,11 +1166,12 @@ async def get_domains_summary(
         store,
         workspace_id=workspace.id,
     )
+    demo_mode = get_settings().DEMO_MODE
     domains = _domain_names_for_summary(
         db,
         store,
         workspace,
-        include_unscoped_report_domains=False,
+        include_unscoped_report_domains=demo_mode,
     )
     summaries = store.get_all_domain_summaries()
 

--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -62,6 +62,46 @@ def build_demo_multi_user_deployment() -> Dict[str, Any]:
             "retention_days": 90,
         },
         "roles": list(DEMO_MULTI_USER_ROLES),
+        "default_viewer": "single-user-multiple-domains",
+        "zoom_levels": [
+            {
+                "level": "workspace",
+                "label": "Single user, multiple domains",
+                "description": (
+                    "Default demo view: one administrator tracks dmarq.org and "
+                    "dmarq.com before zooming out to accounts and billing."
+                ),
+            },
+            {
+                "level": "account",
+                "label": "Account and team view",
+                "description": "Organizations, users, workspaces, roles, and billing ownership.",
+            },
+            {
+                "level": "provider",
+                "label": "ISP / managed provider view",
+                "description": (
+                    "Provider operators see many customer workspaces and export usage "
+                    "to external monthly billing."
+                ),
+            },
+        ],
+        "domain_showcase": [
+            {
+                "domain": "dmarq.org",
+                "workspace_slug": "dmarq-org",
+                "organization_slug": "dmarq-foundation",
+                "posture": "quarantine with strict subdomain policy",
+                "story": "Mostly healthy production mail with newsletter DKIM drift.",
+            },
+            {
+                "domain": "dmarq.com",
+                "workspace_slug": "dmarq-com",
+                "organization_slug": "dmarq-foundation",
+                "posture": "monitoring before enforcement",
+                "story": "Commercial mail is still in p=none while senders are aligned.",
+            },
+        ],
         "billing_modes": [
             {
                 "mode": "direct_stripe",
@@ -100,6 +140,11 @@ def build_demo_multi_user_deployment() -> Dict[str, Any]:
                 "name": "DMARQ Foundation",
                 "deployment_model": "dmarq_cloud",
                 "billing_mode": "direct_stripe",
+                "demo_story": (
+                    "The default demo account: one admin, two domains, normal SaaS billing, "
+                    "and enough report history to inspect trends before enforcement."
+                ),
+                "default_persona": "single-user-multiple-domains",
                 "plan": {
                     "code": "business",
                     "name": "Business",
@@ -144,26 +189,42 @@ def build_demo_multi_user_deployment() -> Dict[str, Any]:
                             "newsletter DKIM selector intermittently fails",
                             "legacy CRM source should be retired or isolated",
                         ],
-                    }
+                    },
+                    {
+                        "slug": "dmarq-com",
+                        "name": "dmarq.com Commercial Mail",
+                        "domains": ["dmarq.com"],
+                        "health": "monitoring",
+                        "primary_findings": [
+                            "policy is still p=none while marketing sources are being aligned",
+                            "unknown forwarder appears on low-volume days",
+                        ],
+                    },
                 ],
                 "users": [
                     {
                         "name": "Alex Morgan",
                         "email": "alex@dmarq.example",
                         "roles": ["organization_owner", "workspace_admin"],
-                        "workspaces": ["dmarq-org"],
+                        "workspaces": ["dmarq-org", "dmarq-com"],
+                        "demo_persona": "single-user-multiple-domains",
+                        "can_impersonate": True,
                     },
                     {
                         "name": "Mira Chen",
                         "email": "mira@dmarq.example",
                         "roles": ["analyst"],
-                        "workspaces": ["dmarq-org"],
+                        "workspaces": ["dmarq-org", "dmarq-com"],
+                        "demo_persona": "domain-analyst",
+                        "can_impersonate": True,
                     },
                     {
                         "name": "Sam Rivera",
                         "email": "sam.audit@dmarq.example",
                         "roles": ["auditor"],
-                        "workspaces": ["dmarq-org"],
+                        "workspaces": ["dmarq-org", "dmarq-com"],
+                        "demo_persona": "read-only-auditor",
+                        "can_impersonate": True,
                     },
                 ],
                 "usage": [
@@ -188,6 +249,11 @@ def build_demo_multi_user_deployment() -> Dict[str, Any]:
                 "name": "DMARQ Commercial",
                 "deployment_model": "managed_service",
                 "billing_mode": "manual_contract",
+                "demo_story": (
+                    "A managed-service customer where DMARQ operations and customer staff "
+                    "share visibility while invoicing remains contract based."
+                ),
+                "default_persona": "managed-service-analyst",
                 "plan": {
                     "code": "enterprise",
                     "name": "Enterprise",
@@ -270,6 +336,11 @@ def build_demo_multi_user_deployment() -> Dict[str, Any]:
                 "name": "Northstar ISP Demo",
                 "deployment_model": "isp_resale",
                 "billing_mode": "provider_resale",
+                "demo_story": (
+                    "An ISP operator can zoom across many customer workspaces, then open "
+                    "one subaccount to experience what that customer sees."
+                ),
+                "default_persona": "isp-operator",
                 "plan": {
                     "code": "provider-growth",
                     "name": "Provider Growth",
@@ -382,18 +453,24 @@ def build_demo_multi_user_deployment() -> Dict[str, Any]:
                         "email": "nora.ops@northstar.example",
                         "roles": ["provider_operator"],
                         "workspaces": ["bakery-example", "lawfirm-example"],
+                        "demo_persona": "isp-operator",
+                        "can_impersonate": True,
                     },
                     {
                         "name": "Chris Becker",
                         "email": "chris.billing@northstar.example",
                         "roles": ["billing_admin"],
                         "workspaces": [],
+                        "demo_persona": "provider-billing",
+                        "can_impersonate": True,
                     },
                     {
                         "name": "Taylor Brooks",
                         "email": "taylor@bakery.example",
                         "roles": ["workspace_admin"],
                         "workspaces": ["bakery-example"],
+                        "demo_persona": "customer-admin",
+                        "can_impersonate": True,
                     },
                 ],
                 "usage": [
@@ -420,25 +497,158 @@ def build_demo_multi_user_deployment() -> Dict[str, Any]:
                     },
                 ],
             },
+            {
+                "slug": "studio-self-hosted",
+                "name": "Studio Self-Hosted",
+                "deployment_model": "self_hosted",
+                "billing_mode": "self_hosted_license",
+                "demo_story": (
+                    "A single-company installation with local users, no provider billing, "
+                    "and multiple internal domains managed from one dashboard."
+                ),
+                "default_persona": "self-hosted-admin",
+                "plan": {
+                    "code": "community-self-hosted",
+                    "name": "Self-hosted",
+                    "price": {"monthly": 0, "annual": 0, "currency": "EUR"},
+                    "included": {
+                        "domains": 10,
+                        "users": 10,
+                        "aggregate_messages": 500_000,
+                        "retention_days": 180,
+                    },
+                },
+                "billing": {
+                    "status": "local",
+                    "next_invoice_date": None,
+                    "current_period_total_cents": 0,
+                    "invoice_delivery_mode": "not_applicable",
+                    "external_customer_id": None,
+                },
+                "billing_profile": {
+                    "profile_id": "bp-demo-self-hosted",
+                    "display_name": "Self-hosted local deployment",
+                    "invoice_owner": "Customer",
+                    "billing_contact": "ops@studio.example",
+                    "collection_model": "none",
+                    "payment_rail": "not_applicable",
+                    "invoice_reference": "local-demo",
+                    "next_invoice_action": "renew_local_license_if_enabled",
+                },
+                "entitlements": {
+                    "domains": {"used": 4, "included": 10},
+                    "users": {"used": 4, "included": 10},
+                    "aggregate_messages": {"used": 88_410, "included": 500_000},
+                    "retention_days": {"used": 90, "included": 180},
+                },
+                "workspaces": [
+                    {
+                        "slug": "studio-main",
+                        "name": "Studio Production Mail",
+                        "domains": ["studio.example", "mail.studio.example"],
+                        "health": "healthy",
+                        "primary_findings": ["ready for reject after one more monitoring week"],
+                    },
+                    {
+                        "slug": "studio-lab",
+                        "name": "Studio Lab and Test Mail",
+                        "domains": ["lab.studio.example", "alerts.studio.example"],
+                        "health": "warning",
+                        "primary_findings": [
+                            "test sender has SPF alignment only",
+                            "DKIM selector should be rotated before enforcement",
+                        ],
+                    },
+                ],
+                "users": [
+                    {
+                        "name": "Elena Weiss",
+                        "email": "elena@studio.example",
+                        "roles": ["organization_owner", "workspace_admin"],
+                        "workspaces": ["studio-main", "studio-lab"],
+                        "demo_persona": "self-hosted-admin",
+                        "can_impersonate": True,
+                    },
+                    {
+                        "name": "Mateo Klein",
+                        "email": "mateo@studio.example",
+                        "roles": ["analyst"],
+                        "workspaces": ["studio-main"],
+                        "demo_persona": "self-hosted-analyst",
+                        "can_impersonate": True,
+                    },
+                    {
+                        "name": "Iris Novak",
+                        "email": "iris.audit@studio.example",
+                        "roles": ["auditor"],
+                        "workspaces": ["studio-main", "studio-lab"],
+                        "demo_persona": "self-hosted-auditor",
+                        "can_impersonate": True,
+                    },
+                ],
+                "usage": [
+                    {
+                        "metric": "aggregate_messages",
+                        "period_start": period_start.isoformat(),
+                        "period_end": today.isoformat(),
+                        "quantity": 88_410,
+                        "unit": "messages",
+                    },
+                    {
+                        "metric": "dns_snapshots",
+                        "period_start": period_start.isoformat(),
+                        "period_end": today.isoformat(),
+                        "quantity": 96,
+                        "unit": "snapshots",
+                    },
+                ],
+            },
         ],
         "viewer_scenarios": [
             {
-                "label": "DMARQaaS account owner",
+                "id": "single-user-multiple-domains",
+                "label": "Single user, multiple domains",
                 "email": "alex@dmarq.example",
                 "visible_organizations": ["dmarq-foundation"],
                 "default_workspace": "dmarq-org",
+                "default_domain": "dmarq.org",
+                "zoom_level": "workspace",
             },
             {
+                "id": "managed-service-analyst",
                 "label": "Managed-service analyst",
                 "email": "priya@dmarq.example",
                 "visible_organizations": ["dmarq-commercial"],
                 "default_workspace": "dmarq-com",
+                "default_domain": "dmarq.com",
+                "zoom_level": "account",
             },
             {
+                "id": "isp-operator",
                 "label": "ISP operator",
                 "email": "nora.ops@northstar.example",
                 "visible_organizations": ["northstar-isp"],
                 "default_workspace": "lawfirm-example",
+                "default_domain": "lawfirm.example",
+                "zoom_level": "provider",
+            },
+            {
+                "id": "customer-admin",
+                "label": "ISP customer admin",
+                "email": "taylor@bakery.example",
+                "visible_organizations": ["northstar-isp"],
+                "default_workspace": "bakery-example",
+                "default_domain": "bakery.example",
+                "zoom_level": "workspace",
+            },
+            {
+                "id": "self-hosted-admin",
+                "label": "Self-hosted admin",
+                "email": "elena@studio.example",
+                "visible_organizations": ["studio-self-hosted"],
+                "default_workspace": "studio-main",
+                "default_domain": "studio.example",
+                "zoom_level": "workspace",
             },
         ],
     }

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 <div class="dashboard-page space-y-6" x-data="dashboardApp()">
-    <div class="rounded-lg bg-white p-4 shadow-sm" x-show="hasDomainData" x-cloak>
+    <div class="rounded-lg bg-white p-4 shadow-sm" x-show="hasDomainData" x-cloak data-tour="date-filter">
         <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div class="grid gap-1">
                 <label class="text-sm font-semibold text-[#120d36]" for="dashboard-date-interval">
@@ -22,7 +22,9 @@
                             x-model="dateInterval"
                             @change="handleDateIntervalChange()">
                         <template x-for="option in dateIntervalOptions" :key="option.value">
-                            <option :value="option.value" x-text="option.label"></option>
+                            <option :value="option.value"
+                                    :selected="option.value === dateInterval"
+                                    x-text="option.label"></option>
                         </template>
                     </select>
                     <template x-if="dateInterval === 'custom'">
@@ -48,8 +50,67 @@
         </div>
     </div>
 
+    <div class="rounded-lg bg-white p-5 shadow-sm" x-show="demoDeployment" x-cloak data-tour="demo-orientation">
+        <div class="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+            <div class="max-w-3xl">
+                <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]">Demo experience</p>
+                <h2 class="mt-1 text-2xl font-semibold tracking-normal text-[#07071f]">
+                    <span x-text="selectedDemoScenario()?.label || 'Single user, multiple domains'"></span>
+                </h2>
+                <p class="mt-2 text-sm text-[#5f5c78]"
+                   x-text="selectedDemoScenarioDescription()"></p>
+            </div>
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-end" data-tour="demo-persona">
+                <div class="grid gap-1">
+                    <label class="text-sm font-semibold text-[#120d36]" for="demo-persona">
+                        View as
+                    </label>
+                    <select id="demo-persona"
+                            class="min-w-64 rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm font-semibold text-[#120d36]"
+                            x-model="selectedDemoScenarioId"
+                            @change="applyDemoScenario()">
+                        <template x-for="scenario in demoScenarios()" :key="scenario.id || scenario.label">
+                            <option :value="scenario.id || scenario.label" x-text="`${scenario.label} · ${scenario.email}`"></option>
+                        </template>
+                    </select>
+                </div>
+                <button type="button"
+                        class="whitespace-nowrap rounded-md bg-[#272a5f] px-4 py-2 text-sm font-semibold text-white hover:bg-[#171346]"
+                        @click="startDemoTour()">
+                    Start tour
+                </button>
+            </div>
+        </div>
+        <div class="mt-5 grid gap-3 lg:grid-cols-3" data-tour="demo-zoom">
+            <template x-for="level in demoZoomLevels()" :key="level.level">
+                <button type="button"
+                        class="rounded-md border p-4 text-left transition hover:border-[#2f9da5] hover:shadow-sm"
+                        :class="selectedDemoZoomLevel === level.level ? 'border-[#2f9da5] bg-[#edf7f7]' : 'border-[#dfdfdf] bg-white'"
+                        @click="selectDemoZoomLevel(level.level)">
+                    <p class="text-sm font-semibold text-[#120d36]" x-text="level.label"></p>
+                    <p class="mt-1 text-sm text-[#5f5c78]" x-text="level.description"></p>
+                </button>
+            </template>
+        </div>
+        <div class="mt-5 grid gap-3 md:grid-cols-2" data-tour="demo-domains">
+            <template x-for="domain in demoDomainShowcase()" :key="domain.domain">
+                <a class="rounded-md border border-[#dfdfdf] p-4 transition hover:border-[#2f9da5] hover:shadow-sm"
+                   :href="`/domains/${encodeURIComponent(domain.domain)}`">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <p class="text-lg font-semibold text-[#120d36]" x-text="domain.domain"></p>
+                            <p class="mt-1 text-sm text-[#5f5c78]" x-text="domain.story"></p>
+                        </div>
+                        <span class="rounded-full bg-[#f4f3f2] px-3 py-1 text-xs font-semibold text-[#5f5c78]"
+                              x-text="domain.posture"></span>
+                    </div>
+                </a>
+            </template>
+        </div>
+    </div>
+
     <div class="grid grid-cols-1 gap-6 xl:grid-cols-12" x-show="hasDomainData" x-cloak>
-        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6">
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6" data-tour="compliance-chart">
             <div class="mb-3 grid gap-2 sm:flex sm:items-start sm:justify-between sm:gap-4">
                 <h2 class="min-w-0 text-2xl font-semibold tracking-normal text-[#07071f]">
                     DMARC Compliance Rate
@@ -78,7 +139,7 @@
             </div>
         </section>
 
-        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3" data-tour="enforcement">
             <div class="flex items-start justify-between gap-3">
                 <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Enforcement Rate</h2>
                 <a href="/domains" class="mt-1 text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Review</a>
@@ -96,7 +157,7 @@
             </div>
         </section>
 
-        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3" data-tour="dns-health">
             <div class="flex flex-col gap-3">
                 <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">DNS Record Health</h2>
                 <div class="flex flex-wrap items-center gap-2">
@@ -137,7 +198,7 @@
             </div>
         </section>
 
-        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6">
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6" data-tour="volume-trends">
             <div class="flex items-start justify-between gap-3">
                 <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Volume &amp; Trends</h2>
                 <a href="/reports" class="mt-1 text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open reports</a>
@@ -155,7 +216,7 @@
             </div>
         </section>
 
-        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3">
+        <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-3" data-tour="top-sources">
             <div class="flex items-start justify-between gap-3">
                 <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Top Sending Sources</h2>
                 <a href="/reports" class="mt-1 text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Investigate</a>
@@ -185,12 +246,12 @@
         <div id="change-summary-list" class="grid gap-3 md:grid-cols-3"></div>
     </div>
 
-    <div class="rounded-lg bg-white p-6 shadow-sm" x-show="demoDeployment" x-cloak>
+    <div class="rounded-lg bg-white p-6 shadow-sm" x-show="demoDeployment" x-cloak data-tour="tenant-zoom">
         <div class="mb-5 flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
             <div>
-                <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Multi-User Deployment</h2>
+                <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Deployment Zoom</h2>
                 <p class="text-sm text-[#5f5c78]">
-                    SaaS, managed-service, and ISP billing views using generated demo data
+                    Click into SaaS, ISP, and self-hosted accounts, then view the product as one of their users.
                 </p>
             </div>
             <a href="/api/v1/operator/demo/multi-user"
@@ -201,7 +262,7 @@
         <div class="mb-5 grid gap-3 md:grid-cols-4">
             <div class="rounded-md bg-[#f4f3f2] p-3">
                 <p class="text-xs uppercase tracking-wide text-[#5f5c78]">Organizations</p>
-                <p class="mt-1 text-2xl font-semibold text-[#120d36]" x-text="demoOrganizations().length"></p>
+                <p class="mt-1 text-2xl font-semibold text-[#120d36]" x-text="visibleDemoOrganizations().length"></p>
             </div>
             <div class="rounded-md bg-[#f4f3f2] p-3">
                 <p class="text-xs uppercase tracking-wide text-[#5f5c78]">Workspaces</p>
@@ -217,8 +278,9 @@
             </div>
         </div>
         <div class="grid gap-4 xl:grid-cols-3">
-            <template x-for="organization in demoOrganizations()" :key="organization.slug">
-                <article class="rounded-md border border-[#dfdfdf] p-4 transition hover:border-[#2f9da5] hover:shadow-sm">
+            <template x-for="organization in visibleDemoOrganizations()" :key="organization.slug">
+                <article class="rounded-md border p-4 transition hover:border-[#2f9da5] hover:shadow-sm"
+                         :class="selectedDemoOrganizationSlug === organization.slug ? 'border-[#2f9da5] shadow-sm' : 'border-[#dfdfdf]'">
                     <div class="mb-4 flex items-start justify-between gap-3">
                         <div class="min-w-0">
                             <h3 class="truncate text-lg font-semibold text-[#120d36]" x-text="organization.name"></h3>
@@ -228,6 +290,7 @@
                         <span class="rounded-full bg-[#edf7f7] px-3 py-1 text-xs font-semibold text-[#247982]"
                               x-text="formatDemoLabel(organization.billing_mode)"></span>
                     </div>
+                    <p class="mb-4 text-sm text-[#5f5c78]" x-text="organization.demo_story"></p>
                     <div class="grid grid-cols-2 gap-3 text-sm">
                         <div class="rounded-md bg-[#f4f3f2] p-3">
                             <p class="text-[#5f5c78]">Plan</p>
@@ -294,6 +357,18 @@
                             </div>
                         </template>
                     </div>
+                    <div class="mt-4 flex flex-wrap gap-2">
+                        <button type="button"
+                                class="rounded-md bg-[#272a5f] px-3 py-2 text-sm font-semibold text-white hover:bg-[#171346]"
+                                @click="selectDemoOrganization(organization.slug)">
+                            Open account
+                        </button>
+                        <button type="button"
+                                class="rounded-md border border-[#dfdfdf] px-3 py-2 text-sm font-semibold text-[#2f9da5] hover:border-[#2f9da5]"
+                                @click="impersonateFirstDemoUser(organization.slug)">
+                            View as user
+                        </button>
+                    </div>
                     <div class="mt-4 space-y-2" x-show="organization.provider_customers?.length">
                         <p class="text-xs uppercase tracking-wide text-[#5f5c78]">Provider billing samples</p>
                         <template x-for="customer in organization.provider_customers" :key="customer.external_customer_id">
@@ -313,10 +388,76 @@
                 </article>
             </template>
         </div>
+        <div class="mt-5 rounded-lg border border-[#dfdfdf] bg-[#fbfbfb] p-5" x-show="selectedDemoOrganization()" x-cloak data-tour="tenant-detail">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                    <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]">Account detail</p>
+                    <h3 class="mt-1 text-2xl font-semibold text-[#120d36]" x-text="selectedDemoOrganization()?.name"></h3>
+                    <p class="mt-2 max-w-3xl text-sm text-[#5f5c78]" x-text="selectedDemoOrganization()?.demo_story"></p>
+                </div>
+                <div class="grid gap-1">
+                    <label class="text-sm font-semibold text-[#120d36]" for="demo-user-switcher">Impersonate</label>
+                    <select id="demo-user-switcher"
+                            class="min-w-64 rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm font-semibold text-[#120d36]"
+                            x-model="selectedDemoUserEmail"
+                            @change="applyDemoUserSelection()">
+                        <template x-for="user in selectedDemoOrganizationUsers()" :key="user.email">
+                            <option :value="user.email" x-text="`${user.name} · ${formatDemoLabel((user.roles || [])[0])}`"></option>
+                        </template>
+                    </select>
+                </div>
+            </div>
+            <div class="mt-5 grid gap-4 lg:grid-cols-3">
+                <div class="rounded-md bg-white p-4">
+                    <p class="text-xs uppercase tracking-wide text-[#5f5c78]">Current user</p>
+                    <p class="mt-2 text-lg font-semibold text-[#120d36]" x-text="selectedDemoUser()?.name || 'Select a user'"></p>
+                    <p class="mt-1 text-sm text-[#5f5c78]" x-text="selectedDemoUser()?.email || ''"></p>
+                    <div class="mt-3 flex flex-wrap gap-2">
+                        <template x-for="role in selectedDemoUser()?.roles || []" :key="role">
+                            <span class="rounded-full bg-[#f4f3f2] px-3 py-1 text-xs font-semibold text-[#120d36]"
+                                  x-text="formatDemoLabel(role)"></span>
+                        </template>
+                    </div>
+                </div>
+                <div class="rounded-md bg-white p-4">
+                    <p class="text-xs uppercase tracking-wide text-[#5f5c78]">Billing profile</p>
+                    <p class="mt-2 text-lg font-semibold text-[#120d36]" x-text="selectedDemoOrganization()?.billing_profile?.display_name"></p>
+                    <p class="mt-1 text-sm text-[#5f5c78]" x-text="selectedDemoOrganization()?.billing_profile?.invoice_reference"></p>
+                    <p class="mt-3 text-sm font-semibold text-[#2f9da5]"
+                       x-text="`${selectedDemoOrganization()?.billing_profile?.invoice_owner || 'Owner'} · ${formatDemoLabel(selectedDemoOrganization()?.billing_profile?.collection_model)}`"></p>
+                </div>
+                <div class="rounded-md bg-white p-4">
+                    <p class="text-xs uppercase tracking-wide text-[#5f5c78]">Visible workspaces</p>
+                    <div class="mt-3 space-y-2">
+                        <template x-for="workspace in selectedDemoVisibleWorkspaces()" :key="workspace.slug">
+                            <div class="rounded-md border border-[#e6e3e1] p-3">
+                                <p class="font-semibold text-[#120d36]" x-text="workspace.name"></p>
+                                <p class="mt-1 text-sm text-[#5f5c78]" x-text="(workspace.domains || []).join(', ')"></p>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+            </div>
+            <div class="mt-5 grid gap-3 md:grid-cols-2" x-show="selectedDemoOrganization()?.provider_customers?.length">
+                <template x-for="customer in selectedDemoOrganization()?.provider_customers || []" :key="customer.external_customer_id">
+                    <button type="button"
+                            class="rounded-md border border-[#dfdfdf] bg-white p-4 text-left transition hover:border-[#2f9da5] hover:shadow-sm"
+                            @click="selectDemoProviderCustomer(customer)">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <p class="font-semibold text-[#120d36]" x-text="customer.name"></p>
+                                <p class="mt-1 text-sm text-[#5f5c78]" x-text="`${customer.subscription_tier} · ${formatDemoLabel(customer.billing_status)}`"></p>
+                            </div>
+                            <span class="font-semibold text-[#120d36]" x-text="formatMoney(customer.monthly_charge_cents, selectedDemoOrganization()?.plan?.price?.currency)"></span>
+                        </div>
+                    </button>
+                </template>
+            </div>
+        </div>
     </div>
     
     <!-- Domain Compliance Table -->
-    <div x-show="hasDomainData" x-cloak>
+    <div x-show="hasDomainData" x-cloak data-tour="domain-table">
         {% call card() %}
             {% call card_header() %}
                 <div class="flex items-center justify-between">
@@ -410,6 +551,37 @@
             {% endcall %}
         {% endcall %}
     </div>
+
+    <div x-show="demoTourActive"
+         x-cloak
+         class="fixed inset-0 z-50 pointer-events-none"
+         @keydown.escape.window="closeDemoTour()">
+        <div class="absolute inset-0 bg-[#07071f]/45"></div>
+        <div class="absolute left-1/2 top-28 w-[min(92vw,30rem)] -translate-x-1/2 rounded-lg bg-white p-5 shadow-xl pointer-events-auto md:left-auto md:right-8 md:translate-x-0">
+            <div class="flex items-start justify-between gap-4">
+                <div>
+                    <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]"
+                       x-text="`Step ${demoTourStepIndex + 1} of ${demoTourSteps.length}`"></p>
+                    <h3 class="mt-1 text-xl font-semibold text-[#120d36]" x-text="currentDemoTourStep()?.title"></h3>
+                </div>
+                <button type="button"
+                        class="rounded-md px-2 py-1 text-lg text-[#5f5c78] hover:bg-[#f4f3f2]"
+                        aria-label="Close guided demo"
+                        @click="closeDemoTour()">×</button>
+            </div>
+            <p class="mt-3 text-sm text-[#5f5c78]" x-text="currentDemoTourStep()?.body"></p>
+            <div class="mt-5 flex items-center justify-between gap-3">
+                <button type="button"
+                        class="rounded-md border border-[#dfdfdf] px-3 py-2 text-sm font-semibold text-[#120d36] disabled:opacity-40"
+                        :disabled="demoTourStepIndex === 0"
+                        @click="previousDemoTourStep()">Back</button>
+                <button type="button"
+                        class="rounded-md bg-[#272a5f] px-4 py-2 text-sm font-semibold text-white hover:bg-[#171346]"
+                        @click="nextDemoTourStep()"
+                        x-text="demoTourStepIndex + 1 >= demoTourSteps.length ? 'Finish' : 'Next'"></button>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock %}
 
@@ -424,6 +596,49 @@ function dashboardApp() {
         domains: [],
         selectedDnsDomain: '',
         demoDeployment: null,
+        selectedDemoScenarioId: 'single-user-multiple-domains',
+        selectedDemoZoomLevel: 'workspace',
+        selectedDemoOrganizationSlug: '',
+        selectedDemoUserEmail: '',
+        demoTourActive: false,
+        demoTourStepIndex: 0,
+        demoTourSteps: [
+            {
+                selector: '[data-tour="demo-orientation"]',
+                title: 'Start with the normal customer view',
+                body: 'The default demo is one user managing multiple domains, so dmarq.org and dmarq.com stay front and center.'
+            },
+            {
+                selector: '[data-tour="date-filter"]',
+                title: 'Change the evidence window',
+                body: 'Use sensible ranges or custom dates to inspect current incidents, week-to-date activity, or the full rolling demo history.'
+            },
+            {
+                selector: '[data-tour="compliance-chart"]',
+                title: 'Read the DMARC posture first',
+                body: 'Compliance, message volume, reports, and trends show whether the domain is ready for stronger enforcement.'
+            },
+            {
+                selector: '[data-tour="dns-health"]',
+                title: 'Check DNS health by domain',
+                body: 'Pick a domain and jump to its detail page to inspect SPF, DKIM, DMARC policy, and lint findings.'
+            },
+            {
+                selector: '[data-tour="top-sources"]',
+                title: 'Investigate senders',
+                body: 'Top sources surface the systems sending mail on behalf of the selected account and where authentication breaks.'
+            },
+            {
+                selector: '[data-tour="tenant-zoom"]',
+                title: 'Zoom out to accounts',
+                body: 'Switch from the daily operator view to SaaS, ISP, managed-service, and self-hosted deployment models.'
+            },
+            {
+                selector: '[data-tour="tenant-detail"]',
+                title: 'Impersonate demo users',
+                body: 'Open an account and view it as an owner, analyst, auditor, ISP operator, or customer admin.'
+            }
+        ],
         dateInterval: 'last_30_days',
         customStartDate: '',
         customEndDate: '',
@@ -587,6 +802,7 @@ function dashboardApp() {
                 if (!response.ok) return;
                 const data = await response.json();
                 this.demoDeployment = data.deployment || null;
+                this.applyDemoScenario();
             } catch (error) {
                 this.demoDeployment = null;
             }
@@ -889,22 +1105,169 @@ function dashboardApp() {
             return this.demoDeployment?.organizations || [];
         },
 
+        visibleDemoOrganizations() {
+            const scenario = this.selectedDemoScenario();
+            const visible = scenario?.visible_organizations || [];
+            if (!visible.length) return this.demoOrganizations();
+            return this.demoOrganizations().filter(organization => visible.includes(organization.slug));
+        },
+
+        demoScenarios() {
+            return this.demoDeployment?.viewer_scenarios || [];
+        },
+
+        demoZoomLevels() {
+            return this.demoDeployment?.zoom_levels || [];
+        },
+
+        demoDomainShowcase() {
+            return this.demoDeployment?.domain_showcase || [];
+        },
+
+        selectedDemoScenario() {
+            const scenarios = this.demoScenarios();
+            return scenarios.find(scenario => (scenario.id || scenario.label) === this.selectedDemoScenarioId)
+                || scenarios[0]
+                || null;
+        },
+
+        selectedDemoScenarioDescription() {
+            const scenario = this.selectedDemoScenario();
+            const level = this.demoZoomLevels().find(item => item.level === this.selectedDemoZoomLevel);
+            if (!scenario && !level) return 'Explore generated DMARQ demo data.';
+            const scope = level?.description || '';
+            const workspace = scenario?.default_workspace
+                ? ` Default workspace: ${this.formatDemoLabel(scenario.default_workspace)}.`
+                : '';
+            return `${scope}${workspace}`.trim();
+        },
+
+        selectDemoZoomLevel(level) {
+            this.selectedDemoZoomLevel = level || 'workspace';
+            if (level === 'provider') {
+                const providerScenario = this.demoScenarios().find(scenario => scenario.zoom_level === 'provider');
+                if (providerScenario) {
+                    this.selectedDemoScenarioId = providerScenario.id || providerScenario.label;
+                    this.applyDemoScenario();
+                }
+            }
+        },
+
+        applyDemoScenario() {
+            const scenario = this.selectedDemoScenario();
+            if (!scenario) {
+                this.selectedDemoOrganizationSlug = this.demoOrganizations()[0]?.slug || '';
+                this.selectedDemoUserEmail = '';
+                return;
+            }
+            this.selectedDemoZoomLevel = scenario.zoom_level || this.selectedDemoZoomLevel || 'workspace';
+            const organizationSlug = scenario.visible_organizations?.[0] || this.demoOrganizations()[0]?.slug || '';
+            this.selectDemoOrganization(organizationSlug, { preserveUser: true });
+            const user = this.selectedDemoOrganizationUsers()
+                .find(candidate => candidate.email === scenario.email)
+                || this.selectedDemoOrganizationUsers()[0];
+            this.selectedDemoUserEmail = user?.email || '';
+            if (scenario.default_domain && this.domains.some(domain => domain.domain_name === scenario.default_domain)) {
+                this.selectedDnsDomain = scenario.default_domain;
+                this.updateDnsHealth();
+            }
+        },
+
+        selectDemoOrganization(slug, options = {}) {
+            this.selectedDemoOrganizationSlug = slug || this.visibleDemoOrganizations()[0]?.slug || '';
+            const users = this.selectedDemoOrganizationUsers();
+            if (!options.preserveUser || !users.some(user => user.email === this.selectedDemoUserEmail)) {
+                this.selectedDemoUserEmail = users[0]?.email || '';
+            }
+            this.$nextTick(() => this.ensureTourTargetVisible('[data-tour="tenant-detail"]'));
+        },
+
+        selectedDemoOrganization() {
+            return this.demoOrganizations().find(
+                organization => organization.slug === this.selectedDemoOrganizationSlug
+            ) || this.visibleDemoOrganizations()[0] || null;
+        },
+
+        selectedDemoOrganizationUsers() {
+            return this.selectedDemoOrganization()?.users || [];
+        },
+
+        selectedDemoUser() {
+            return this.selectedDemoOrganizationUsers().find(user => user.email === this.selectedDemoUserEmail)
+                || this.selectedDemoOrganizationUsers()[0]
+                || null;
+        },
+
+        selectedDemoVisibleWorkspaces() {
+            const organization = this.selectedDemoOrganization();
+            const user = this.selectedDemoUser();
+            if (!organization) return [];
+            const workspaces = organization.workspaces || [];
+            const userWorkspaces = user?.workspaces || [];
+            if (!user || !userWorkspaces.length) return workspaces;
+            return workspaces.filter(workspace => userWorkspaces.includes(workspace.slug));
+        },
+
+        applyDemoUserSelection() {
+            const user = this.selectedDemoUser();
+            const firstWorkspace = this.selectedDemoVisibleWorkspaces()[0];
+            const firstDomain = firstWorkspace?.domains?.[0];
+            if (firstDomain && this.domains.some(domain => domain.domain_name === firstDomain)) {
+                this.selectedDnsDomain = firstDomain;
+                this.updateDnsHealth();
+            }
+            if (user?.demo_persona) {
+                const matchingScenario = this.demoScenarios().find(
+                    scenario => scenario.email === user.email || scenario.id === user.demo_persona
+                );
+                if (matchingScenario) {
+                    this.selectedDemoScenarioId = matchingScenario.id || matchingScenario.label;
+                    this.selectedDemoZoomLevel = matchingScenario.zoom_level || this.selectedDemoZoomLevel;
+                }
+            }
+        },
+
+        impersonateFirstDemoUser(slug) {
+            this.selectDemoOrganization(slug);
+            this.selectedDemoUserEmail = this.selectedDemoOrganizationUsers()[0]?.email || '';
+            this.applyDemoUserSelection();
+        },
+
+        selectDemoProviderCustomer(customer) {
+            const organization = this.selectedDemoOrganization();
+            if (!organization || !customer) return;
+            const workspace = (organization.workspaces || []).find(
+                item => item.slug === customer.workspace_slug
+            );
+            const customerUser = (organization.users || []).find(user =>
+                (user.workspaces || []).includes(customer.workspace_slug)
+            );
+            if (customerUser) {
+                this.selectedDemoUserEmail = customerUser.email;
+            }
+            const firstDomain = workspace?.domains?.[0];
+            if (firstDomain && this.domains.some(domain => domain.domain_name === firstDomain)) {
+                this.selectedDnsDomain = firstDomain;
+                this.updateDnsHealth();
+            }
+        },
+
         demoWorkspaceTotal() {
-            return this.demoOrganizations().reduce(
+            return this.visibleDemoOrganizations().reduce(
                 (total, organization) => total + (organization.workspaces?.length || 0),
                 0
             );
         },
 
         demoUserTotal() {
-            return this.demoOrganizations().reduce(
+            return this.visibleDemoOrganizations().reduce(
                 (total, organization) => total + (organization.users?.length || 0),
                 0
             );
         },
 
         demoMonthlyTotal() {
-            return this.demoOrganizations().reduce(
+            return this.visibleDemoOrganizations().reduce(
                 (total, organization) => total + (organization.billing?.current_period_total_cents || 0),
                 0
             );
@@ -925,6 +1288,67 @@ function dashboardApp() {
                 ? ` / ${this.formatLargeNumber(entitlement.included)}`
                 : '';
             return `${this.formatDemoLabel(usage.metric)} ${used}${limit} ${usage.unit || ''}`.trim();
+        },
+
+        startDemoTour() {
+            this.demoTourActive = true;
+            this.demoTourStepIndex = 0;
+            this.activateDemoTourStep();
+        },
+
+        closeDemoTour() {
+            this.demoTourActive = false;
+            this.clearDemoTourTarget();
+        },
+
+        currentDemoTourStep() {
+            return this.demoTourSteps[this.demoTourStepIndex] || this.demoTourSteps[0] || null;
+        },
+
+        nextDemoTourStep() {
+            if (this.demoTourStepIndex + 1 >= this.demoTourSteps.length) {
+                this.closeDemoTour();
+                return;
+            }
+            this.demoTourStepIndex += 1;
+            this.activateDemoTourStep();
+        },
+
+        previousDemoTourStep() {
+            if (this.demoTourStepIndex === 0) return;
+            this.demoTourStepIndex -= 1;
+            this.activateDemoTourStep();
+        },
+
+        activateDemoTourStep() {
+            this.clearDemoTourTarget();
+            const step = this.currentDemoTourStep();
+            if (!step?.selector) return;
+            this.ensureTourTargetVisible(step.selector);
+            this.$nextTick(() => {
+                const target = document.querySelector(step.selector);
+                if (!target) return;
+                target.classList.add('dmarq-tour-target');
+                target.style.position = target.style.position || 'relative';
+                target.style.zIndex = '60';
+                target.style.boxShadow = '0 0 0 4px rgba(47, 157, 165, 0.35)';
+            });
+        },
+
+        clearDemoTourTarget() {
+            document.querySelectorAll('.dmarq-tour-target').forEach(target => {
+                target.classList.remove('dmarq-tour-target');
+                target.style.zIndex = '';
+                target.style.boxShadow = '';
+            });
+        },
+
+        ensureTourTargetVisible(selector) {
+            this.$nextTick(() => {
+                const target = document.querySelector(selector);
+                if (!target) return;
+                target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            });
         },
 
         domainHref(domain) {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -51,7 +51,10 @@ def test_base_template_propagates_selected_workspace_context():
 def test_dashboard_renders_demo_billing_profiles_without_html_injection():
     template = (Path(__file__).resolve().parents[1] / "templates" / "index.html").read_text()
 
-    assert "Multi-User Deployment" in template
+    assert "Deployment Zoom" in template
+    assert "Demo experience" in template
+    assert "Start tour" in template
+    assert "selectedDemoUserEmail" in template
     assert "Provider billing samples" in template
     assert "billing_profile.display_name" in template
     assert "formatDemoUsage(organization, usage)" in template

--- a/backend/app/tests/test_demo_multi_user_deployment.py
+++ b/backend/app/tests/test_demo_multi_user_deployment.py
@@ -20,10 +20,20 @@ def test_demo_multi_user_deployment_has_saas_and_isp_scenarios():
     deployment = build_demo_multi_user_deployment()
 
     organizations = {org["slug"]: org for org in deployment["organizations"]}
-    assert {"dmarq-foundation", "dmarq-commercial", "northstar-isp"} <= set(organizations)
+    assert {
+        "dmarq-foundation",
+        "dmarq-commercial",
+        "northstar-isp",
+        "studio-self-hosted",
+    } <= set(organizations)
     assert organizations["dmarq-foundation"]["billing_mode"] == "direct_stripe"
     assert organizations["northstar-isp"]["billing_mode"] == "provider_resale"
-    assert organizations["dmarq-foundation"]["workspaces"][0]["domains"] == ["dmarq.org"]
+    foundation_domains = {
+        domain
+        for workspace in organizations["dmarq-foundation"]["workspaces"]
+        for domain in workspace["domains"]
+    }
+    assert {"dmarq.org", "dmarq.com"} <= foundation_domains
     assert organizations["dmarq-commercial"]["workspaces"][0]["domains"] == ["dmarq.com"]
     assert any(scenario["label"] == "ISP operator" for scenario in deployment["viewer_scenarios"])
 
@@ -35,6 +45,7 @@ def test_demo_multi_user_deployment_includes_billing_profiles_and_entitlements()
     foundation = organizations["dmarq-foundation"]
     commercial = organizations["dmarq-commercial"]
     northstar = organizations["northstar-isp"]
+    self_hosted = organizations["studio-self-hosted"]
 
     assert foundation["billing_profile"]["collection_model"] == "self_service_subscription"
     assert foundation["billing_profile"]["payment_rail"] == "card_on_file"
@@ -44,6 +55,8 @@ def test_demo_multi_user_deployment_includes_billing_profiles_and_entitlements()
     assert northstar["billing_profile"]["collection_model"] == "provider_pass_through"
     assert northstar["billing_profile"]["payment_rail"] == "isp_monthly_invoice"
     assert northstar["entitlements"]["customer_workspaces"]["used"] == 42
+    assert self_hosted["billing_profile"]["collection_model"] == "none"
+    assert self_hosted["billing_profile"]["invoice_owner"] == "Customer"
 
 
 def test_demo_multi_user_deployment_showcases_provider_customer_billing():
@@ -59,6 +72,38 @@ def test_demo_multi_user_deployment_showcases_provider_customer_billing():
     }
     assert all(customer["monthly_charge_cents"] > 0 for customer in customers)
     assert all(customer["external_customer_id"].startswith("ns-cust-") for customer in customers)
+
+
+def test_demo_multi_user_deployment_has_opinionated_default_and_impersonation():
+    deployment = build_demo_multi_user_deployment()
+
+    assert deployment["default_viewer"] == "single-user-multiple-domains"
+    assert [level["level"] for level in deployment["zoom_levels"]] == [
+        "workspace",
+        "account",
+        "provider",
+    ]
+    assert {row["domain"] for row in deployment["domain_showcase"]} == {"dmarq.org", "dmarq.com"}
+
+    scenarios = {scenario["id"]: scenario for scenario in deployment["viewer_scenarios"]}
+    assert scenarios["single-user-multiple-domains"]["visible_organizations"] == [
+        "dmarq-foundation"
+    ]
+    assert scenarios["single-user-multiple-domains"]["default_domain"] == "dmarq.org"
+    assert "self-hosted-admin" in scenarios
+
+    users = [
+        user
+        for organization in deployment["organizations"]
+        for user in organization["users"]
+        if user.get("can_impersonate")
+    ]
+    assert users
+    assert {user["demo_persona"] for user in users} >= {
+        "single-user-multiple-domains",
+        "isp-operator",
+        "self-hosted-admin",
+    }
 
 
 def test_operator_demo_multi_user_endpoint_returns_showcase(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -9,6 +9,7 @@ DNS lookups are mocked so no real network calls are made.
 """
 
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -916,6 +917,31 @@ def test_summary_endpoint_uses_manual_selectors(authed_client: TestClient, db_se
     assert response.status_code == 200
     assert "manualsel" in captured_selectors
     assert "google" in captured_selectors
+
+
+def test_summary_endpoint_returns_demo_domains_in_demo_mode(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    """Demo mode should surface generated dmarq.org and dmarq.com reports."""
+    monkeypatch.setattr(
+        "app.api.api_v1.endpoints.domains.get_settings",
+        lambda: SimpleNamespace(DEMO_MODE=True),
+    )
+    monkeypatch.setattr(
+        "app.services.report_persistence.get_settings",
+        lambda: SimpleNamespace(DEMO_MODE=True),
+    )
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.get_default_provider",
+        return_value=AsyncMock(check_domain=AsyncMock(return_value=MOCK_DNS_RESULT)),
+    ):
+        response = authed_client.get("/api/v1/domains/summary")
+
+    assert response.status_code == 200
+    domains = {item["domain_name"] for item in response.json()["domains"]}
+    assert {"dmarq.org", "dmarq.com"} <= domains
 
 
 def test_summary_endpoint_respects_selected_workspace_header(

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -96,6 +96,13 @@ Reporting summaries. Public demo deployments should also keep the demo
 read-only guard enabled by leaving `DEMO_MODE=true`; mutating requests are
 blocked so visitors cannot upload, delete, or reconfigure demo content.
 
+The public dashboard uses the same demo payload to present a guided product
+tour. The default view is a single user managing multiple domains, with
+`dmarq.org` and `dmarq.com` visible immediately. Visitors can then zoom out to
+SaaS, managed-service, ISP/reseller, or self-hosted deployment examples and
+switch generated personas to inspect the account, workspace, billing, and
+domain scope that each user would see.
+
 ### Notification Configuration
 
 DMARQ stores notification targets in the web settings table. Configure them under

--- a/docs/reference/workspaces.md
+++ b/docs/reference/workspaces.md
@@ -163,17 +163,21 @@ Operators can update these controls with
 `PUT /api/v1/operator/workspaces/{workspace_id}/retention`. Updates are written
 to the workspace audit log as `workspace.retention_updated`.
 
-`GET /api/v1/operator/demo/multi-user` returns generated demo data for three
-deployment models:
+`GET /api/v1/operator/demo/multi-user` returns generated demo data for four
+deployment models and the dashboard persona switcher:
 
-- direct DMARQaaS subscription for `dmarq.org`
+- direct DMARQaaS subscription with a single-user, multi-domain view for
+  `dmarq.org` and `dmarq.com`
 - managed-service account for `dmarq.com`
 - ISP/reseller deployment with provider-owned billing and multiple customer
   workspaces
+- self-hosted deployment with local users, local billing ownership, and multiple
+  internal domains
 
 The endpoint is read-only and uses generated identities, provider IDs, and
 invoice references. The dashboard uses it opportunistically to display a
-multi-user deployment showcase on demo instances.
+multi-user deployment showcase on demo instances, including account drill-down,
+provider customer samples, and generated user impersonation scenarios.
 
 Provider billing integrations can read monthly usage with
 `GET /api/v1/provider/billing/usage?period=YYYY-MM`. A single external customer


### PR DESCRIPTION
## Summary
- restore demo dashboard population for dmarq.org and dmarq.com by allowing demo report domains through the domain summary endpoint
- add an opinionated demo experience: single-user multi-domain default, zoom levels, SaaS/managed/ISP/self-hosted demo deployments, account drill-down, and generated user persona switching
- add a lightweight guided dashboard tour without adding a new frontend dependency
- update README and demo/operator docs to describe the new demo flow

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py::test_summary_endpoint_returns_demo_domains_in_demo_mode backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_demo_data.py backend/app/tests/test_stats_endpoints.py -q
- .venv/bin/python -m black --check backend/app/api/api_v1/endpoints/domains.py backend/app/services/demo_data.py backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_dns_endpoints.py
- git diff --check
- local DEMO_MODE=true browser check: dmarq.org/dmarq.com dashboard data, persona switcher, ISP drill-down, guided tour overlay, no console errors beyond existing Tailwind CDN warning