### PR TITLE
feat: add dashboard health score action plan

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -33,6 +33,7 @@ from app.services.dns_resolver import (
     extract_dmarc_policy,
     get_default_provider,
 )
+from app.services.health_score import build_health_summary, score_domain_health
 from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
 from app.services.organizations import (
     OrganizationPlanLimitError,
@@ -437,6 +438,7 @@ class DomainSummaryResponse(BaseModel):
     overall_pass_rate: float
     reports_processed: int
     domains: List[Dict[str, Any]]
+    health_summary: Dict[str, Any] = Field(default_factory=dict)
 
 
 class SelectorRequest(BaseModel):
@@ -1219,30 +1221,30 @@ async def get_domains_summary(
         dmarc_policy = live_policy or reported_policy or "none"
 
         # Format domain data for frontend
-        domains_list.append(
-            {
-                "id": domain_name,
-                "domain_name": domain_name,
-                "total_emails": summary.get("total_count", 0),
-                "passed_count": summary.get("passed_count", 0),
-                "failed_count": summary.get("failed_count", 0),
-                "pass_rate": summary.get("compliance_rate", 0),
-                "report_count": summary.get("reports_processed", 0),
-                # Real DNS status
-                "dmarc_status": dns.dmarc,
-                "dmarc_policy": dmarc_policy,
-                "spf_status": dns.spf,
-                "dkim_status": dns.dkim,
-                "dns_cached": getattr(dns, "cached", False),
-                "dns_checked_at": (
-                    getattr(dns, "checked_at", None).isoformat()
-                    if getattr(dns, "checked_at", None)
-                    else None
-                ),
-                "dmarc_warnings": dns.dmarc_warnings,
-                "dmarc_suggestions": dns.dmarc_suggestions,
-            }
-        )
+        domain_row = {
+            "id": domain_name,
+            "domain_name": domain_name,
+            "total_emails": summary.get("total_count", 0),
+            "passed_count": summary.get("passed_count", 0),
+            "failed_count": summary.get("failed_count", 0),
+            "pass_rate": summary.get("compliance_rate", 0),
+            "report_count": summary.get("reports_processed", 0),
+            # Real DNS status
+            "dmarc_status": dns.dmarc,
+            "dmarc_policy": dmarc_policy,
+            "spf_status": dns.spf,
+            "dkim_status": dns.dkim,
+            "dns_cached": getattr(dns, "cached", False),
+            "dns_checked_at": (
+                getattr(dns, "checked_at", None).isoformat()
+                if getattr(dns, "checked_at", None)
+                else None
+            ),
+            "dmarc_warnings": dns.dmarc_warnings,
+            "dmarc_suggestions": dns.dmarc_suggestions,
+        }
+        domain_row["health"] = score_domain_health(domain_row)
+        domains_list.append(domain_row)
 
     # Calculate overall pass rate
     overall_pass_rate = 0
@@ -1255,6 +1257,7 @@ async def get_domains_summary(
         overall_pass_rate=overall_pass_rate,
         reports_processed=total_reports,
         domains=domains_list,
+        health_summary=build_health_summary(domains_list),
     )
 
 

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -1,0 +1,263 @@
+"""Health scoring for dashboard and domain posture summaries."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+ACTIVE_POLICIES = {"quarantine", "reject"}
+
+
+def health_grade(score: int, *, policy: Optional[str] = None, critical_actions: int = 0) -> str:
+    """Return an SSL-Labs-style grade for a bounded health score."""
+    policy_name = (policy or "").lower()
+    if score >= 97 and policy_name == "reject" and critical_actions == 0:
+        return "A+"
+    if score >= 93:
+        return "A"
+    if score >= 90:
+        return "A-"
+    if score >= 87:
+        return "B+"
+    if score >= 83:
+        return "B"
+    if score >= 80:
+        return "B-"
+    if score >= 70:
+        return "C"
+    if score >= 60:
+        return "D"
+    return "F"
+
+
+def _bounded(value: Any, *, lower: float = 0.0, upper: float = 100.0) -> float:
+    try:
+        number = float(value or 0)
+    except (TypeError, ValueError):
+        number = 0.0
+    return max(lower, min(upper, number))
+
+
+def _policy_factor(policy: Optional[str]) -> float:
+    policy_name = (policy or "").lower()
+    if policy_name == "reject":
+        return 100.0
+    if policy_name == "quarantine":
+        return 88.0
+    if policy_name == "none":
+        return 55.0
+    return 25.0
+
+
+def _dns_factor(domain: Dict[str, Any]) -> float:
+    checks = [
+        bool(domain.get("dmarc_status")),
+        bool(domain.get("spf_status")),
+        bool(domain.get("dkim_status")),
+    ]
+    base = (sum(1 for check in checks if check) / len(checks)) * 100
+    warning_penalty = min(25, len(domain.get("dmarc_warnings") or []) * 8)
+    return _bounded(base - warning_penalty)
+
+
+def _confidence_factor(domain: Dict[str, Any]) -> float:
+    emails = int(domain.get("total_emails") or 0)
+    reports = int(domain.get("report_count") or domain.get("reports_processed") or 0)
+    if reports >= 14 and emails >= 1000:
+        return 100.0
+    if reports >= 7 and emails >= 250:
+        return 90.0
+    if reports >= 3 and emails > 0:
+        return 78.0
+    if reports > 0 or emails > 0:
+        return 62.0
+    return 30.0
+
+
+def _score_cap(domain: Dict[str, Any], confidence: float) -> int:
+    policy = str(domain.get("dmarc_policy") or "").lower()
+    cap = 100
+    if policy == "quarantine":
+        cap = min(cap, 92)
+    elif policy == "none":
+        cap = min(cap, 74)
+    elif policy not in ACTIVE_POLICIES:
+        cap = min(cap, 59)
+    if confidence < 70:
+        cap = min(cap, 79)
+    return cap
+
+
+def _action(
+    *,
+    action_type: str,
+    severity: str,
+    title: str,
+    detail: str,
+    next_step: str,
+    score_impact: int,
+    domain: str,
+    evidence: Optional[List[Dict[str, str]]] = None,
+) -> Dict[str, Any]:
+    return {
+        "type": action_type,
+        "severity": severity,
+        "title": title,
+        "detail": detail,
+        "next_step": next_step,
+        "score_impact": score_impact,
+        "domain": domain,
+        "evidence": evidence or [],
+    }
+
+
+def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
+    domain_name = str(domain.get("domain_name") or domain.get("id") or "domain")
+    pass_rate = _bounded(domain.get("pass_rate"))
+    policy = str(domain.get("dmarc_policy") or "missing").lower()
+    actions: List[Dict[str, Any]] = []
+
+    if not domain.get("dmarc_status"):
+        actions.append(
+            _action(
+                action_type="missing_dmarc",
+                severity="critical",
+                title="Publish a DMARC policy record",
+                detail="The domain cannot receive a strong health grade without a valid DMARC record.",
+                next_step="Publish a v=DMARC1 record with rua reporting and start in p=none if needed.",
+                score_impact=25,
+                domain=domain_name,
+            )
+        )
+    if not domain.get("spf_status"):
+        actions.append(
+            _action(
+                action_type="missing_spf",
+                severity="high",
+                title="Fix SPF coverage",
+                detail="SPF is missing or unhealthy for this domain.",
+                next_step="Publish or repair the SPF TXT record for legitimate sending infrastructure.",
+                score_impact=12,
+                domain=domain_name,
+            )
+        )
+    if not domain.get("dkim_status"):
+        actions.append(
+            _action(
+                action_type="missing_dkim",
+                severity="high",
+                title="Fix DKIM selector coverage",
+                detail="DKIM selectors from report data are not fully healthy.",
+                next_step="Publish the missing selector or rotate the service DKIM configuration.",
+                score_impact=12,
+                domain=domain_name,
+            )
+        )
+    if pass_rate < 90 and int(domain.get("total_emails") or 0) > 0:
+        actions.append(
+            _action(
+                action_type="low_compliance",
+                severity="high" if pass_rate < 75 else "medium",
+                title="Investigate failing senders",
+                detail=f"DMARC pass rate is {pass_rate:.1f}%, below the 90% enforcement target.",
+                next_step="Open the domain detail page and fix the top failing sources before tightening policy.",
+                score_impact=18 if pass_rate < 75 else 10,
+                domain=domain_name,
+                evidence=[
+                    {"label": "pass_rate", "value": f"{pass_rate:.1f}%"},
+                    {"label": "failed", "value": str(domain.get("failed_count") or 0)},
+                ],
+            )
+        )
+    if policy == "none":
+        actions.append(
+            _action(
+                action_type="policy_none",
+                severity="medium",
+                title="Move out of monitoring mode",
+                detail="p=none keeps DMARQ in observation mode and caps the health grade.",
+                next_step="After known senders pass DMARC, stage p=quarantine and then p=reject.",
+                score_impact=14,
+                domain=domain_name,
+                evidence=[{"label": "policy", "value": "p=none"}],
+            )
+        )
+    if domain.get("dmarc_warnings"):
+        actions.append(
+            _action(
+                action_type="dmarc_lint",
+                severity="medium",
+                title="Resolve DMARC lint warnings",
+                detail="The DMARC record has lint warnings that reduce operator confidence.",
+                next_step="Review the DNS health details and publish a corrected DMARC record.",
+                score_impact=8,
+                domain=domain_name,
+                evidence=[
+                    {"label": "warnings", "value": str(len(domain.get("dmarc_warnings") or []))}
+                ],
+            )
+        )
+
+    return sorted(actions, key=lambda item: item["score_impact"], reverse=True)
+
+
+def score_domain_health(domain: Dict[str, Any]) -> Dict[str, Any]:
+    """Score a single domain summary row."""
+    pass_rate = _bounded(domain.get("pass_rate"))
+    dns = _dns_factor(domain)
+    policy = _policy_factor(domain.get("dmarc_policy"))
+    confidence = _confidence_factor(domain)
+    raw_score = round((pass_rate * 0.45) + (dns * 0.20) + (policy * 0.25) + (confidence * 0.10))
+    score = min(raw_score, _score_cap(domain, confidence))
+    actions = _domain_actions(domain)
+    critical_actions = sum(1 for action in actions if action["severity"] == "critical")
+    policy_name = str(domain.get("dmarc_policy") or "missing").lower()
+
+    return {
+        "domain": domain.get("domain_name") or domain.get("id"),
+        "score": int(score),
+        "grade": health_grade(int(score), policy=policy_name, critical_actions=critical_actions),
+        "status": "healthy" if score >= 90 else "attention" if score >= 70 else "critical",
+        "factors": {
+            "dmarc_compliance": round(pass_rate, 1),
+            "dns_posture": round(dns, 1),
+            "policy_strength": round(policy, 1),
+            "report_confidence": round(confidence, 1),
+        },
+        "actions": actions[:5],
+    }
+
+
+def build_health_summary(domains: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Build system-level health from domain summary rows."""
+    domain_health = [score_domain_health(domain) for domain in domains]
+    by_domain = {
+        str(item.get("domain")): item for item in domain_health if item.get("domain") is not None
+    }
+    total_weight = sum(max(1, int(domain.get("total_emails") or 0)) for domain in domains)
+    if total_weight:
+        score = round(
+            sum(
+                by_domain[str(domain.get("domain_name") or domain.get("id"))]["score"]
+                * max(1, int(domain.get("total_emails") or 0))
+                for domain in domains
+                if str(domain.get("domain_name") or domain.get("id")) in by_domain
+            )
+            / total_weight
+        )
+    else:
+        score = 0
+
+    all_actions = [action for item in domain_health for action in item.get("actions", [])]
+    all_actions.sort(key=lambda item: item["score_impact"], reverse=True)
+    critical_actions = sum(1 for action in all_actions if action["severity"] == "critical")
+    attention_domains = sum(1 for item in domain_health if item["score"] < 90)
+
+    return {
+        "score": int(score),
+        "grade": health_grade(int(score), critical_actions=critical_actions),
+        "status": "healthy" if score >= 90 else "attention" if score >= 70 else "critical",
+        "attention_domains": attention_domains,
+        "domain_count": len(domain_health),
+        "domains": domain_health,
+        "top_actions": all_actions[:5],
+    }

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -109,6 +109,88 @@
         </div>
     </div>
 
+    <section class="rounded-lg bg-white p-6 shadow-sm" x-show="healthSummary && hasDomainData" x-cloak data-tour="health-score">
+        <div class="grid gap-6 xl:grid-cols-[18rem_minmax(0,1fr)]">
+            <div class="rounded-lg bg-[#f4f3f2] p-5">
+                <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]">System Health</p>
+                <div class="mt-4 flex items-end gap-4">
+                    <div class="text-6xl font-bold leading-none text-[#120d36]" x-text="healthSummary?.score ?? 0"></div>
+                    <div class="pb-1">
+                        <div class="inline-flex min-w-16 justify-center rounded-md px-3 py-1 text-2xl font-bold"
+                             :class="gradeClass(healthSummary?.grade)"
+                             x-text="healthSummary?.grade || 'F'"></div>
+                        <p class="mt-2 text-sm font-semibold capitalize text-[#5f5c78]" x-text="healthSummary?.status || 'unknown'"></p>
+                    </div>
+                </div>
+                <p class="mt-4 text-sm text-[#5f5c78]">
+                    <span x-text="healthSummary?.attention_domains || 0"></span>
+                    <span> of </span>
+                    <span x-text="healthSummary?.domain_count || 0"></span>
+                    <span> domains need attention.</span>
+                </p>
+            </div>
+            <div class="grid gap-5 xl:grid-cols-[minmax(0,1fr)_22rem]">
+                <div>
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Action Plan</h2>
+                            <p class="mt-1 text-sm text-[#5f5c78]">Prioritized fixes with expected score impact.</p>
+                        </div>
+                        <a href="/domains" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open domains</a>
+                    </div>
+                    <div class="mt-4 grid gap-3">
+                        <template x-if="!(healthSummary?.top_actions || []).length">
+                            <div class="rounded-md border border-[#e6e3e1] p-4 text-sm text-[#5f5c78]">
+                                No immediate remediation actions. Keep monitoring reports and DNS drift.
+                            </div>
+                        </template>
+                        <template x-for="action in (healthSummary?.top_actions || []).slice(0, 3)" :key="action.domain + action.type">
+                            <a class="rounded-md border border-[#e6e3e1] p-4 transition hover:border-[#2f9da5] hover:shadow-sm"
+                               :href="`/domains/${encodeURIComponent(action.domain)}`">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div>
+                                        <p class="text-xs font-semibold uppercase tracking-wide"
+                                           :class="severityClass(action.severity)"
+                                           x-text="action.severity"></p>
+                                        <h3 class="mt-1 font-semibold text-[#120d36]" x-text="action.title"></h3>
+                                    </div>
+                                    <span class="rounded-full bg-[#edf7f7] px-3 py-1 text-xs font-semibold text-[#247982]">
+                                        +<span x-text="action.score_impact"></span>
+                                    </span>
+                                </div>
+                                <p class="mt-2 text-sm text-[#5f5c78]" x-text="action.detail"></p>
+                                <p class="mt-2 text-sm font-semibold text-[#272a5f]" x-text="action.next_step"></p>
+                                <p class="mt-2 text-xs text-[#5f5c78]" x-text="action.domain"></p>
+                            </a>
+                        </template>
+                    </div>
+                </div>
+                <div>
+                    <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Domain Grades</h2>
+                    <div class="mt-4 space-y-3">
+                        <template x-for="domainHealth in healthDomains()" :key="domainHealth.domain">
+                            <a class="flex items-center justify-between gap-3 rounded-md border border-[#e6e3e1] p-3 transition hover:border-[#2f9da5]"
+                               :href="`/domains/${encodeURIComponent(domainHealth.domain)}`">
+                                <div class="min-w-0">
+                                    <p class="truncate font-semibold text-[#120d36]" x-text="domainHealth.domain"></p>
+                                    <p class="mt-1 text-xs capitalize text-[#5f5c78]" x-text="domainHealth.status"></p>
+                                </div>
+                                <div class="text-right">
+                                    <div class="inline-flex min-w-12 justify-center rounded-md px-2 py-1 text-lg font-bold"
+                                         :class="gradeClass(domainHealth.grade)"
+                                         x-text="domainHealth.grade"></div>
+                                    <p class="mt-1 text-xs text-[#5f5c78]">
+                                        <span x-text="domainHealth.score"></span><span>/100</span>
+                                    </p>
+                                </div>
+                            </a>
+                        </template>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <div class="grid grid-cols-1 gap-6 xl:grid-cols-12" x-show="hasDomainData" x-cloak>
         <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6" data-tour="compliance-chart">
             <div class="mb-3 grid gap-2 sm:flex sm:items-start sm:justify-between sm:gap-4">
@@ -477,6 +559,7 @@
                         {% call tr() %}
                             {% call th() %}Domain{% endcall %}
                             {% call th() %}Emails{% endcall %}
+                            {% call th() %}Grade{% endcall %}
                             {% call th() %}Pass Rate{% endcall %}
                             {% call th() %}Failed{% endcall %}
                             {% call th() %}Reports{% endcall %}
@@ -594,6 +677,7 @@ function dashboardApp() {
         volumeTrendChart: null,
         complianceTrendChart: null,
         domains: [],
+        healthSummary: null,
         selectedDnsDomain: '',
         demoDeployment: null,
         selectedDemoScenarioId: 'single-user-multiple-domains',
@@ -713,6 +797,7 @@ function dashboardApp() {
                 
                 if (data && data.domains && data.domains.length > 0) {
                     this.domains = data.domains || [];
+                    this.healthSummary = data.health_summary || null;
                     if (!this.domains.some(domain => domain.domain_name === this.selectedDnsDomain)) {
                         this.selectedDnsDomain = this.domains[0]?.domain_name || '';
                     }
@@ -726,6 +811,7 @@ function dashboardApp() {
                     });
                 } else {
                     this.domains = [];
+                    this.healthSummary = null;
                     this.selectedDnsDomain = '';
                     this.hasDomainData = false;
                     this.clearDashboardCharts();
@@ -735,6 +821,7 @@ function dashboardApp() {
             } catch (error) {
                 console.error('Error fetching domain summary:', error);
                 this.domains = [];
+                this.healthSummary = null;
                 this.selectedDnsDomain = '';
                 this.hasDomainData = false;
                 this.clearDashboardCharts();
@@ -1099,6 +1186,27 @@ function dashboardApp() {
 
         formatDemoLabel(value) {
             return String(value || '').replaceAll('_', ' ');
+        },
+
+        healthDomains() {
+            return this.healthSummary?.domains || [];
+        },
+
+        gradeClass(grade) {
+            const value = String(grade || 'F');
+            if (value.startsWith('A')) return 'bg-[#dff3e8] text-[#1f6f45]';
+            if (value.startsWith('B')) return 'bg-[#edf7f7] text-[#247982]';
+            if (value.startsWith('C')) return 'bg-[#fff7df] text-[#8a6418]';
+            if (value.startsWith('D')) return 'bg-[#fff1ea] text-[#b8431d]';
+            return 'bg-[#ffe8e8] text-[#9f2525]';
+        },
+
+        severityClass(severity) {
+            const value = String(severity || '').toLowerCase();
+            if (value === 'critical') return 'text-[#9f2525]';
+            if (value === 'high') return 'text-[#b8431d]';
+            if (value === 'medium') return 'text-[#8a6418]';
+            return 'text-[#247982]';
         },
 
         demoOrganizations() {
@@ -1569,6 +1677,7 @@ function dashboardApp() {
 
                 row.appendChild(this.createDomainNameCell(domain.domain_name));
                 row.appendChild(this.createTextCell(this.formatLargeNumber(domain.total_emails || 0)));
+                row.appendChild(this.createGradeCell(domain.health));
                 row.appendChild(this.createPassRateCell(domain.pass_rate || 0));
                 row.appendChild(this.createTextCell(this.formatLargeNumber(domain.failed_count || 0)));
                 row.appendChild(this.createTextCell(this.formatLargeNumber(domain.report_count || 0)));
@@ -1587,6 +1696,27 @@ function dashboardApp() {
             content.textContent = domainName || 'Unknown';
             cell.appendChild(content);
 
+            return cell;
+        },
+
+        createGradeCell(health) {
+            const cell = document.createElement('td');
+            cell.className = 'table-cell';
+
+            const wrapper = document.createElement('div');
+            wrapper.className = 'flex flex-col gap-1';
+
+            const badge = document.createElement('span');
+            badge.className = `inline-flex w-fit min-w-10 justify-center rounded-md px-2 py-1 text-xs font-bold ${this.gradeClass(health?.grade)}`;
+            badge.textContent = health?.grade || 'F';
+            wrapper.appendChild(badge);
+
+            const score = document.createElement('span');
+            score.className = 'text-xs text-muted-foreground whitespace-nowrap';
+            score.textContent = `${health?.score ?? 0}/100`;
+            wrapper.appendChild(score);
+
+            cell.appendChild(wrapper);
             return cell;
         },
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -940,8 +940,12 @@ def test_summary_endpoint_returns_demo_domains_in_demo_mode(
         response = authed_client.get("/api/v1/domains/summary")
 
     assert response.status_code == 200
-    domains = {item["domain_name"] for item in response.json()["domains"]}
+    data = response.json()
+    domains = {item["domain_name"] for item in data["domains"]}
     assert {"dmarq.org", "dmarq.com"} <= domains
+    assert data["health_summary"]["score"] > 0
+    assert data["health_summary"]["grade"] in {"A+", "A", "A-", "B+", "B", "B-", "C", "D", "F"}
+    assert all("health" in item for item in data["domains"])
 
 
 def test_summary_endpoint_respects_selected_workspace_header(

--- a/backend/app/tests/test_health_score.py
+++ b/backend/app/tests/test_health_score.py
@@ -1,0 +1,86 @@
+from app.services.health_score import build_health_summary, health_grade, score_domain_health
+
+
+def test_health_grade_reserves_a_plus_for_reject_without_critical_actions():
+    assert health_grade(99, policy="reject", critical_actions=0) == "A+"
+    assert health_grade(99, policy="quarantine", critical_actions=0) == "A"
+    assert health_grade(99, policy="reject", critical_actions=1) == "A"
+
+
+def test_policy_none_caps_domain_score_and_creates_action():
+    health = score_domain_health(
+        {
+            "domain_name": "example.com",
+            "total_emails": 25_000,
+            "failed_count": 0,
+            "pass_rate": 99.2,
+            "report_count": 30,
+            "dmarc_status": True,
+            "spf_status": True,
+            "dkim_status": True,
+            "dmarc_policy": "none",
+            "dmarc_warnings": [],
+        }
+    )
+
+    assert health["score"] == 74
+    assert health["grade"] == "C"
+    assert any(action["type"] == "policy_none" for action in health["actions"])
+
+
+def test_low_compliance_and_missing_dns_create_prioritized_actions():
+    health = score_domain_health(
+        {
+            "domain_name": "broken.example",
+            "total_emails": 1000,
+            "failed_count": 500,
+            "pass_rate": 50.0,
+            "report_count": 10,
+            "dmarc_status": False,
+            "spf_status": False,
+            "dkim_status": True,
+            "dmarc_policy": "missing",
+            "dmarc_warnings": [],
+        }
+    )
+
+    action_types = [action["type"] for action in health["actions"]]
+
+    assert health["grade"] == "F"
+    assert action_types[:2] == ["missing_dmarc", "low_compliance"]
+    assert "missing_spf" in action_types
+
+
+def test_build_health_summary_weights_domain_scores_by_volume():
+    summary = build_health_summary(
+        [
+            {
+                "domain_name": "large.example",
+                "total_emails": 100_000,
+                "failed_count": 100,
+                "pass_rate": 99.9,
+                "report_count": 30,
+                "dmarc_status": True,
+                "spf_status": True,
+                "dkim_status": True,
+                "dmarc_policy": "reject",
+                "dmarc_warnings": [],
+            },
+            {
+                "domain_name": "small.example",
+                "total_emails": 100,
+                "failed_count": 80,
+                "pass_rate": 20.0,
+                "report_count": 3,
+                "dmarc_status": True,
+                "spf_status": False,
+                "dkim_status": False,
+                "dmarc_policy": "none",
+                "dmarc_warnings": ["External rua destination is not authorized."],
+            },
+        ]
+    )
+
+    assert summary["score"] >= 95
+    assert summary["attention_domains"] == 1
+    assert summary["top_actions"]


### PR DESCRIPTION
## Summary

- adds a health scoring service with 0-100 score, A+ through F grade mapping, factor breakdown, and prioritized remediation actions
- returns `health_summary` and per-domain `health` data from `/api/v1/domains/summary`
- adds a dashboard System Health / Action Plan / Domain Grades section and a grade column in Domain Compliance
- covers scoring boundaries and demo-mode health payloads with tests

Closes #304 as a first concrete slice for the health score/action-plan experience.

## Validation

- `python -m pytest backend/app/tests/test_health_score.py backend/app/tests/test_dns_endpoints.py::test_summary_endpoint_returns_demo_domains_in_demo_mode backend/app/tests/test_dashboard_template_security.py -q`
- `python -m black --check backend/app/services/health_score.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_health_score.py backend/app/tests/test_dns_endpoints.py`
- `git diff --check`
- local demo-mode API/browser check at `http://127.0.0.1:8031`: dashboard rendered System Health `85/B`, dmarq.org `A-`, dmarq.com `C`, and linked remediation actions

## Notes

This intentionally keeps score history, named sender intelligence, and deeper DNS lint actions for the follow-up issues #306, #307, and #308.
