### PR TITLE
feat: identify named sending services

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -43,6 +43,7 @@ from app.services.report_persistence import (
     hydrate_report_store_from_db,
 )
 from app.services.report_store import ReportStore
+from app.services.sender_intelligence import identify_sender
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
     PERMISSION_REPORTS_READ,
@@ -396,6 +397,21 @@ class SourceRecommendation(BaseModel):
     action: str
 
 
+class SenderIdentity(BaseModel):
+    """Recognized sender identity for a sending source."""
+
+    id: str
+    name: str
+    provider: Optional[str] = None
+    category: str
+    status: str
+    confidence: int
+    reason: str
+    evidence: List[str] = Field(default_factory=list)
+    remediation_hint: str
+    docs_url: Optional[str] = None
+
+
 class SourceEntry(BaseModel):
     """Summary of a sending source"""
 
@@ -413,6 +429,7 @@ class SourceEntry(BaseModel):
     dmarc_fail_count: int = 0
     disposition_counts: Dict[str, int] = Field(default_factory=dict)
     hostname: Optional[str] = None
+    sender: SenderIdentity
     spf_fix_hint: Optional[str] = None
     recommendations: List[SourceRecommendation] = Field(default_factory=list)
 
@@ -2076,6 +2093,7 @@ def _source_recommendations(
     source: Dict[str, Any],
     hostname: Optional[str],
     spf_fix_hint: Optional[str],
+    sender: Optional[Dict[str, Any]] = None,
 ) -> List[SourceRecommendation]:
     """Build clear next steps for common DMARC source patterns."""
     spf_result = source.get("spf_result", "unknown")
@@ -2089,8 +2107,56 @@ def _source_recommendations(
     dmarc_passed = source.get("dmarc_pass_count", 0) > 0 or dmarc_result == "pass"
 
     recommendations: List[SourceRecommendation] = []
+    recommendations.extend(_sender_identity_recommendations(sender, dmarc_failed, hostname))
+    provider_recommendation = _provider_remediation_recommendation(sender, dmarc_failed)
+    if provider_recommendation:
+        recommendations.append(provider_recommendation)
+    spf_recommendation = _spf_only_recommendation(spf_result, dkim_result, dmarc_passed)
+    if spf_recommendation:
+        recommendations.append(spf_recommendation)
+    dkim_recommendation = _dkim_only_recommendation(
+        spf_result, dkim_result, dmarc_passed, spf_fix_hint
+    )
+    if dkim_recommendation:
+        recommendations.append(dkim_recommendation)
+    full_fail_recommendation = _full_fail_recommendation(
+        spf_result, dkim_result, dmarc_failed, spf_fix_hint
+    )
+    if full_fail_recommendation:
+        recommendations.append(full_fail_recommendation)
+    if dmarc_failed and (disposition == "none" or disposition_counts.get("none", 0) > 0):
+        recommendations.append(_policy_not_enforced_recommendation())
 
-    if not hostname and dmarc_failed:
+    return recommendations
+
+
+def _sender_identity_recommendations(
+    sender: Optional[Dict[str, Any]],
+    dmarc_failed: bool,
+    hostname: Optional[str],
+) -> List[SourceRecommendation]:
+    recommendations: List[SourceRecommendation] = []
+    if sender and sender.get("status") == "ambiguous":
+        recommendations.append(
+            SourceRecommendation(
+                type="ambiguous_sender",
+                severity="warning",
+                title="Confirm sender ownership",
+                detail=sender["reason"],
+                action=sender["remediation_hint"],
+            )
+        )
+    if sender and sender.get("status") in {"unknown", "suspicious"} and dmarc_failed:
+        recommendations.append(
+            SourceRecommendation(
+                type="unknown_sender",
+                severity="error" if sender.get("status") == "suspicious" else "warning",
+                title="Identify unknown sender",
+                detail=sender["reason"],
+                action=sender["remediation_hint"],
+            )
+        )
+    if not sender and not hostname and dmarc_failed:
         recommendations.append(
             SourceRecommendation(
                 type="unknown_source",
@@ -2106,75 +2172,110 @@ def _source_recommendations(
                 ),
             )
         )
+    return recommendations
 
-    if (
+
+def _provider_remediation_recommendation(
+    sender: Optional[Dict[str, Any]],
+    dmarc_failed: bool,
+) -> Optional[SourceRecommendation]:
+    if not sender or sender.get("status") != "known" or not dmarc_failed:
+        return None
+    return SourceRecommendation(
+        type="provider_remediation",
+        severity="warning",
+        title=f"Fix {sender['name']} authentication",
+        detail=(
+            f"{sender['name']} is recognized, but some mail from this source is "
+            "not passing DMARC."
+        ),
+        action=sender["remediation_hint"],
+    )
+
+
+def _spf_only_recommendation(
+    spf_result: str,
+    dkim_result: str,
+    dmarc_passed: bool,
+) -> Optional[SourceRecommendation]:
+    if not (
         spf_result == "pass"
         and dkim_result in {"fail", "mixed", "unknown", "none"}
         and dmarc_passed
     ):
-        recommendations.append(
-            SourceRecommendation(
-                type="spf_only_pass",
-                severity="info",
-                title="SPF-only DMARC pass",
-                detail="DMARC is passing through SPF, but DKIM is not reliably passing for this source.",
-                action=(
-                    "Enable DKIM signing for this sending service so messages keep passing "
-                    "if SPF alignment changes."
-                ),
-            )
-        )
+        return None
+    return SourceRecommendation(
+        type="spf_only_pass",
+        severity="info",
+        title="SPF-only DMARC pass",
+        detail="DMARC is passing through SPF, but DKIM is not reliably passing for this source.",
+        action=(
+            "Enable DKIM signing for this sending service so messages keep passing "
+            "if SPF alignment changes."
+        ),
+    )
 
-    if (
+
+def _dkim_only_recommendation(
+    spf_result: str,
+    dkim_result: str,
+    dmarc_passed: bool,
+    spf_fix_hint: Optional[str],
+) -> Optional[SourceRecommendation]:
+    if not (
         dkim_result == "pass"
         and spf_result in {"fail", "mixed", "unknown", "none"}
         and dmarc_passed
     ):
-        action = "Authorize this service in SPF, or confirm SPF is intentionally handled elsewhere."
-        if spf_fix_hint:
-            action = f"Add {spf_fix_hint} to your SPF record if this service is legitimate."
-        recommendations.append(
-            SourceRecommendation(
-                type="dkim_only_pass",
-                severity="info",
-                title="DKIM-only DMARC pass",
-                detail="DMARC is passing through DKIM, but SPF is not reliably passing for this source.",
-                action=action,
-            )
-        )
+        return None
+    action = "Authorize this service in SPF, or confirm SPF is intentionally handled elsewhere."
+    if spf_fix_hint:
+        action = f"Add {spf_fix_hint} to your SPF record if this service is legitimate."
+    return SourceRecommendation(
+        type="dkim_only_pass",
+        severity="info",
+        title="DKIM-only DMARC pass",
+        detail="DMARC is passing through DKIM, but SPF is not reliably passing for this source.",
+        action=action,
+    )
 
-    if spf_result == "fail" and dkim_result == "fail" and dmarc_failed:
+
+def _full_fail_recommendation(
+    spf_result: str,
+    dkim_result: str,
+    dmarc_failed: bool,
+    spf_fix_hint: Optional[str],
+) -> Optional[SourceRecommendation]:
+    if not (spf_result == "fail" and dkim_result == "fail" and dmarc_failed):
+        return None
+    action = (
+        "Do not authorize this source until you confirm it is legitimate; then configure "
+        "both SPF authorization and DKIM signing."
+    )
+    if spf_fix_hint:
         action = (
-            "Do not authorize this source until you confirm it is legitimate; then configure "
-            "both SPF authorization and DKIM signing."
+            f"If legitimate, add {spf_fix_hint} to SPF and enable DKIM signing for this service."
         )
-        if spf_fix_hint:
-            action = f"If legitimate, add {spf_fix_hint} to SPF and enable DKIM signing for this service."
-        recommendations.append(
-            SourceRecommendation(
-                type="full_fail",
-                severity="error",
-                title="Full DMARC failure",
-                detail="Neither SPF nor DKIM is passing, so this mail fails DMARC.",
-                action=action,
-            )
-        )
+    return SourceRecommendation(
+        type="full_fail",
+        severity="error",
+        title="Full DMARC failure",
+        detail="Neither SPF nor DKIM is passing, so this mail fails DMARC.",
+        action=action,
+    )
 
-    if dmarc_failed and (disposition == "none" or disposition_counts.get("none", 0) > 0):
-        recommendations.append(
-            SourceRecommendation(
-                type="policy_not_enforced",
-                severity="warning",
-                title="Policy not enforced",
-                detail="Some failed mail was accepted because the applied DMARC disposition was none.",
-                action=(
-                    "After legitimate sources are passing consistently, move the domain policy "
-                    "toward quarantine or reject."
-                ),
-            )
-        )
 
-    return recommendations
+def _policy_not_enforced_recommendation() -> SourceRecommendation:
+    return SourceRecommendation(
+        type="policy_not_enforced",
+        severity="warning",
+        title="Policy not enforced",
+        detail="Some failed mail was accepted because the applied DMARC disposition was none.",
+        action=(
+            "After legitimate sources are passing consistently, move the domain policy "
+            "toward quarantine or reject."
+        ),
+    )
 
 
 async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Optional[str]:
@@ -2222,6 +2323,7 @@ async def get_domain_sources(
         spf_result = source.get("spf_result", "unknown")
         dkim_result = source.get("dkim_result", "unknown")
         spf_fix_hint = _spf_fix_hint(ip, spf_result, source.get("spf_fail_count", 0))
+        sender = identify_sender(ip, source, hostname=hostname, domain=domain_id)
         source_entries.append(
             SourceEntry(
                 ip=ip,
@@ -2239,8 +2341,9 @@ async def get_domain_sources(
                 dmarc_fail_count=source.get("dmarc_fail_count", 0),
                 disposition_counts=source.get("disposition_counts", {}),
                 hostname=hostname,
+                sender=SenderIdentity(**sender),
                 spf_fix_hint=spf_fix_hint,
-                recommendations=_source_recommendations(ip, source, hostname, spf_fix_hint),
+                recommendations=_source_recommendations(ip, source, hostname, spf_fix_hint, sender),
             )
         )
 

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -746,13 +746,13 @@ class DemoDNSProvider(BaseDNSProvider):
 
     async def lookup_ptr(self, ip: str) -> Optional[str]:
         ptr_records = {
-            "203.0.113.10": "primary-saas.demo.dmarq.org",
-            "203.0.113.44": "newsletter.demo.dmarq.org",
-            "198.51.100.23": "ticketing.demo.dmarq.org",
+            "203.0.113.10": "primary-saas.mail.dmarq.org",
+            "203.0.113.44": "mail123.mcsv.net",
+            "198.51.100.23": "support-mail.zendesk.com",
             "192.0.2.66": "legacy-crm.demo.dmarq.org",
-            "203.0.113.75": "workspace-mail.demo.dmarq.com",
-            "198.51.100.88": "marketing.demo.dmarq.com",
-            "192.0.2.114": "billing.demo.dmarq.com",
+            "203.0.113.75": "mail-qv1-f75.google.com",
+            "198.51.100.88": "campaign.mcsv.net",
+            "192.0.2.114": "smtp.stripe.com",
             "198.51.100.199": "unknown-forwarder.demo.dmarq.com",
         }
         return ptr_records.get(ip)

--- a/backend/app/services/report_store.py
+++ b/backend/app/services/report_store.py
@@ -22,6 +22,103 @@ def _dominant_result(counts: Dict[str, int], default: str = "none") -> str:
     return max(counts.items(), key=lambda item: item[1])[0]
 
 
+def _add_unique(target: List[str], value: Any) -> None:
+    """Append a non-empty string value once, preserving first-seen order."""
+    if value is None:
+        return
+    text = str(value).strip()
+    if text and text not in target:
+        target.append(text)
+
+
+def _new_source_stats() -> Dict[str, Any]:
+    return {
+        "count": 0,
+        "spf_pass_count": 0,
+        "spf_fail_count": 0,
+        "spf_unknown_count": 0,
+        "dkim_pass_count": 0,
+        "dkim_fail_count": 0,
+        "dkim_unknown_count": 0,
+        "dmarc_pass_count": 0,
+        "dmarc_fail_count": 0,
+        "disposition_counts": {},
+        "spf_result": "none",
+        "dkim_result": "none",
+        "dmarc_result": "none",
+        "disposition": "none",
+        "spf_domains": [],
+        "dkim_domains": [],
+        "dkim_selectors": [],
+        "header_from_domains": [],
+        "envelope_from_domains": [],
+        "extensions": {},
+    }
+
+
+def _merge_source_metadata(source: Dict[str, Any], record: Dict[str, Any]) -> None:
+    _add_unique(source["header_from_domains"], record.get("header_from"))
+    _add_unique(source["envelope_from_domains"], record.get("envelope_from"))
+    for spf_auth in record.get("spf") or []:
+        if isinstance(spf_auth, dict):
+            _add_unique(source["spf_domains"], spf_auth.get("domain"))
+    for dkim_auth in record.get("dkim") or []:
+        if isinstance(dkim_auth, dict):
+            _add_unique(source["dkim_domains"], dkim_auth.get("domain"))
+            _add_unique(source["dkim_selectors"], dkim_auth.get("selector"))
+    for key, value in (record.get("extensions") or {}).items():
+        if key not in source["extensions"] and value is not None:
+            source["extensions"][str(key)] = str(value)
+
+
+def _update_source_from_record(source: Dict[str, Any], record: Dict[str, Any]) -> None:
+    count = int(record.get("count") or 0)
+    spf_result = record.get("spf_result", "unknown") or "unknown"
+    dkim_result = record.get("dkim_result", "unknown") or "unknown"
+    disposition = record.get("disposition", "none") or "none"
+
+    source["count"] += count
+
+    if spf_result == "pass":
+        source["spf_pass_count"] += count
+    elif spf_result == "fail":
+        source["spf_fail_count"] += count
+    else:
+        source["spf_unknown_count"] += count
+
+    if dkim_result == "pass":
+        source["dkim_pass_count"] += count
+    elif dkim_result == "fail":
+        source["dkim_fail_count"] += count
+    else:
+        source["dkim_unknown_count"] += count
+
+    if spf_result == "pass" or dkim_result == "pass":
+        source["dmarc_pass_count"] += count
+    else:
+        source["dmarc_fail_count"] += count
+
+    disposition_counts = source["disposition_counts"]
+    disposition_counts[disposition] = disposition_counts.get(disposition, 0) + count
+
+    source["spf_result"] = _auth_status_from_counts(
+        source["spf_pass_count"],
+        source["spf_fail_count"],
+        source["spf_unknown_count"],
+    )
+    source["dkim_result"] = _auth_status_from_counts(
+        source["dkim_pass_count"],
+        source["dkim_fail_count"],
+        source["dkim_unknown_count"],
+    )
+    source["dmarc_result"] = _auth_status_from_counts(
+        source["dmarc_pass_count"],
+        source["dmarc_fail_count"],
+    )
+    source["disposition"] = _dominant_result(disposition_counts)
+    _merge_source_metadata(source, record)
+
+
 class ReportStore:
     """
     In-memory store for DMARC reports
@@ -95,67 +192,8 @@ class ReportStore:
             for record in report.get("records", []):
                 source_ip = record.get("source_ip", "unknown")
                 if source_ip not in sources:
-                    sources[source_ip] = {
-                        "count": 0,
-                        "spf_pass_count": 0,
-                        "spf_fail_count": 0,
-                        "spf_unknown_count": 0,
-                        "dkim_pass_count": 0,
-                        "dkim_fail_count": 0,
-                        "dkim_unknown_count": 0,
-                        "dmarc_pass_count": 0,
-                        "dmarc_fail_count": 0,
-                        "disposition_counts": {},
-                        "spf_result": "none",
-                        "dkim_result": "none",
-                        "dmarc_result": "none",
-                        "disposition": "none",
-                    }
-                count = int(record.get("count") or 0)
-                spf_result = record.get("spf_result", "unknown") or "unknown"
-                dkim_result = record.get("dkim_result", "unknown") or "unknown"
-                disposition = record.get("disposition", "none") or "none"
-                source = sources[source_ip]
-
-                source["count"] += count
-
-                if spf_result == "pass":
-                    source["spf_pass_count"] += count
-                elif spf_result == "fail":
-                    source["spf_fail_count"] += count
-                else:
-                    source["spf_unknown_count"] += count
-
-                if dkim_result == "pass":
-                    source["dkim_pass_count"] += count
-                elif dkim_result == "fail":
-                    source["dkim_fail_count"] += count
-                else:
-                    source["dkim_unknown_count"] += count
-
-                if spf_result == "pass" or dkim_result == "pass":
-                    source["dmarc_pass_count"] += count
-                else:
-                    source["dmarc_fail_count"] += count
-
-                disposition_counts = source["disposition_counts"]
-                disposition_counts[disposition] = disposition_counts.get(disposition, 0) + count
-
-                source["spf_result"] = _auth_status_from_counts(
-                    source["spf_pass_count"],
-                    source["spf_fail_count"],
-                    source["spf_unknown_count"],
-                )
-                source["dkim_result"] = _auth_status_from_counts(
-                    source["dkim_pass_count"],
-                    source["dkim_fail_count"],
-                    source["dkim_unknown_count"],
-                )
-                source["dmarc_result"] = _auth_status_from_counts(
-                    source["dmarc_pass_count"],
-                    source["dmarc_fail_count"],
-                )
-                source["disposition"] = _dominant_result(disposition_counts)
+                    sources[source_ip] = _new_source_stats()
+                _update_source_from_record(sources[source_ip], record)
 
         total = summary["total_count"]
         summary["compliance_rate"] = (

--- a/backend/app/services/sender_intelligence.py
+++ b/backend/app/services/sender_intelligence.py
@@ -1,0 +1,326 @@
+"""Named sender identification and remediation hints for DMARC sources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class SenderProfile:
+    """Static sender profile matched against report and DNS evidence."""
+
+    id: str
+    name: str
+    provider: str
+    category: str
+    hostname_tokens: Sequence[str]
+    domain_tokens: Sequence[str]
+    selector_tokens: Sequence[str]
+    extension_tokens: Sequence[str]
+    remediation_hint: str
+    docs_url: Optional[str] = None
+
+
+SENDER_PROFILES: Sequence[SenderProfile] = (
+    SenderProfile(
+        id="google-workspace",
+        name="Google Workspace",
+        provider="Google",
+        category="mailbox_provider",
+        hostname_tokens=("google.com", "googlemail.com", "googleusercontent.com"),
+        domain_tokens=("_spf.google.com", "google.com"),
+        selector_tokens=("google",),
+        extension_tokens=("workspace-mail",),
+        remediation_hint=(
+            "Check Google Workspace DKIM signing and make sure the domain SPF record "
+            "authorizes Google's sending include before tightening DMARC policy."
+        ),
+        docs_url="https://support.google.com/a/answer/174124",
+    ),
+    SenderProfile(
+        id="microsoft-365",
+        name="Microsoft 365",
+        provider="Microsoft",
+        category="mailbox_provider",
+        hostname_tokens=("outlook.com", "protection.outlook.com", "microsoft.com"),
+        domain_tokens=("spf.protection.outlook.com", "outlook.com", "microsoft.com"),
+        selector_tokens=("selector1", "selector2"),
+        extension_tokens=("microsoft-365",),
+        remediation_hint=(
+            "Verify Microsoft 365 DKIM is enabled for the domain and that SPF includes "
+            "spf.protection.outlook.com only once."
+        ),
+        docs_url="https://learn.microsoft.com/en-us/defender-office-365/email-authentication-dkim-configure",
+    ),
+    SenderProfile(
+        id="amazon-ses",
+        name="Amazon SES",
+        provider="Amazon Web Services",
+        category="transactional_email",
+        hostname_tokens=("amazonses.com", "amazonaws.com"),
+        domain_tokens=("amazonses.com",),
+        selector_tokens=("amazonses", "ses"),
+        extension_tokens=("amazon-ses",),
+        remediation_hint=(
+            "Verify the SES identity, publish all DKIM CNAME records, and authorize the "
+            "SES MAIL FROM domain in SPF if you use custom bounce handling."
+        ),
+        docs_url="https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dkim.html",
+    ),
+    SenderProfile(
+        id="sendgrid",
+        name="SendGrid",
+        provider="Twilio SendGrid",
+        category="transactional_email",
+        hostname_tokens=("sendgrid.net",),
+        domain_tokens=("sendgrid.net",),
+        selector_tokens=("s1", "s2", "sendgrid"),
+        extension_tokens=("sendgrid",),
+        remediation_hint=(
+            "Complete SendGrid domain authentication, publish the DKIM CNAMEs, and keep "
+            "SPF aligned with the authenticated return-path domain."
+        ),
+        docs_url="https://docs.sendgrid.com/ui/account-and-settings/how-to-set-up-domain-authentication",
+    ),
+    SenderProfile(
+        id="mailchimp",
+        name="Mailchimp",
+        provider="Intuit Mailchimp",
+        category="marketing_email",
+        hostname_tokens=("mcsv.net", "mandrillapp.com", "mailchimp.com"),
+        domain_tokens=("mandrillapp.com", "mailchimp.com"),
+        selector_tokens=("mailchimp", "mandrill", "news"),
+        extension_tokens=("newsletter", "marketing"),
+        remediation_hint=(
+            "Authenticate the sending domain in Mailchimp and confirm both DKIM selectors "
+            "plus the Mailchimp SPF include are published before enforcement."
+        ),
+        docs_url="https://mailchimp.com/help/set-up-email-domain-authentication/",
+    ),
+    SenderProfile(
+        id="zendesk",
+        name="Zendesk",
+        provider="Zendesk",
+        category="support_email",
+        hostname_tokens=("zendesk.com",),
+        domain_tokens=("zendesk.com",),
+        selector_tokens=("zendesk",),
+        extension_tokens=("ticketing",),
+        remediation_hint=(
+            "Enable Zendesk email authentication for the support address and publish the "
+            "provided DKIM CNAMEs for aligned helpdesk mail."
+        ),
+        docs_url="https://support.zendesk.com/hc/en-us/articles/4408843623194",
+    ),
+    SenderProfile(
+        id="stripe",
+        name="Stripe",
+        provider="Stripe",
+        category="transactional_email",
+        hostname_tokens=("stripe.com",),
+        domain_tokens=("stripe.com",),
+        selector_tokens=("stripe",),
+        extension_tokens=("billing",),
+        remediation_hint=(
+            "Use Stripe's domain authentication records for receipt and billing mail, then "
+            "confirm DKIM alignment before moving the domain to reject."
+        ),
+        docs_url="https://docs.stripe.com/email-domain-authentication",
+    ),
+    SenderProfile(
+        id="salesforce",
+        name="Salesforce",
+        provider="Salesforce",
+        category="crm_email",
+        hostname_tokens=("salesforce.com", "exacttarget.com"),
+        domain_tokens=("salesforce.com", "exacttarget.com"),
+        selector_tokens=("salesforce", "exacttarget"),
+        extension_tokens=("salesforce",),
+        remediation_hint=(
+            "Complete Salesforce DKIM key activation and sender authentication for the "
+            "org before treating CRM mail as enforcement-ready."
+        ),
+        docs_url="https://help.salesforce.com/s/articleView?id=sf.emailadmin_dkim_key.htm",
+    ),
+)
+
+
+def _normalized_values(values: Iterable[Any]) -> List[str]:
+    normalized = []
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip().lower()
+        if text:
+            normalized.append(text)
+    return normalized
+
+
+def _contains_any(haystack: Iterable[str], needles: Sequence[str]) -> List[str]:
+    matches = []
+    for value in haystack:
+        for needle in needles:
+            if needle and needle.lower() in value:
+                matches.append(value)
+                break
+    return matches
+
+
+def _profile_score(
+    profile: SenderProfile,
+    hostname: Optional[str],
+    source: Dict[str, Any],
+) -> tuple[int, List[str]]:
+    host_values = _normalized_values([hostname])
+    domain_values = _normalized_values(
+        list(source.get("spf_domains") or [])
+        + list(source.get("dkim_domains") or [])
+        + list(source.get("envelope_from_domains") or [])
+    )
+    selector_values = _normalized_values(source.get("dkim_selectors") or [])
+    extension_values = _normalized_values((source.get("extensions") or {}).values())
+
+    evidence: List[str] = []
+    score = 0
+
+    host_matches = _contains_any(host_values, profile.hostname_tokens)
+    if host_matches:
+        score += 45
+        evidence.append(f"PTR hostname matched {host_matches[0]}")
+
+    domain_matches = _contains_any(domain_values, profile.domain_tokens)
+    if domain_matches:
+        score += 30
+        evidence.append(f"Authentication domain matched {domain_matches[0]}")
+
+    selector_matches = _contains_any(selector_values, profile.selector_tokens)
+    if selector_matches:
+        score += 20
+        evidence.append(f"DKIM selector matched {selector_matches[0]}")
+
+    extension_matches = _contains_any(extension_values, profile.extension_tokens)
+    if extension_matches:
+        score += 25
+        evidence.append(f"Report metadata matched {extension_matches[0]}")
+
+    return min(score, 100), evidence
+
+
+def _owned_infrastructure(
+    domain: Optional[str], hostname: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    if not domain or not hostname:
+        return None
+    normalized_domain = domain.lower().strip(".")
+    normalized_hostname = hostname.lower().strip(".")
+    if not normalized_hostname.endswith(normalized_domain):
+        return None
+    return {
+        "id": "owned-infrastructure",
+        "name": "Owned infrastructure",
+        "provider": normalized_domain,
+        "category": "owned_infrastructure",
+        "status": "known",
+        "confidence": 70,
+        "reason": "PTR hostname is under the monitored domain.",
+        "evidence": [f"PTR hostname matched {hostname}"],
+        "remediation_hint": (
+            "Confirm this host is part of your authorized mail estate, then keep SPF and "
+            "DKIM aligned before tightening DMARC."
+        ),
+        "docs_url": None,
+    }
+
+
+def identify_sender(
+    ip: str,
+    source: Dict[str, Any],
+    *,
+    hostname: Optional[str] = None,
+    domain: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return a named sender identity for a source row.
+
+    The function is deterministic and conservative: high-confidence known
+    senders are named, ambiguous matches are flagged, and unknown failing
+    sources stay visibly distinct from legitimate but misconfigured services.
+    """
+    profile_matches = []
+    for profile in SENDER_PROFILES:
+        score, evidence = _profile_score(profile, hostname, source)
+        if score >= 30:
+            profile_matches.append((score, profile, evidence))
+
+    profile_matches.sort(key=lambda item: item[0], reverse=True)
+    if profile_matches:
+        best_score, best_profile, best_evidence = profile_matches[0]
+        if len(profile_matches) > 1 and profile_matches[1][0] == best_score:
+            tied_names = sorted({best_profile.name, profile_matches[1][1].name})
+            return {
+                "id": "ambiguous-sender",
+                "name": "Ambiguous sender",
+                "provider": None,
+                "category": "unknown",
+                "status": "ambiguous",
+                "confidence": max(40, min(best_score, 60)),
+                "reason": "Multiple sender profiles matched with the same confidence.",
+                "evidence": [f"Matched: {', '.join(tied_names)}"],
+                "remediation_hint": (
+                    "Confirm the service owner before making DNS changes; do not authorize "
+                    "an ambiguous source based on IP alone."
+                ),
+                "docs_url": None,
+            }
+        return {
+            "id": best_profile.id,
+            "name": best_profile.name,
+            "provider": best_profile.provider,
+            "category": best_profile.category,
+            "status": "known",
+            "confidence": max(55, best_score),
+            "reason": "Sender matched known provider evidence.",
+            "evidence": best_evidence,
+            "remediation_hint": best_profile.remediation_hint,
+            "docs_url": best_profile.docs_url,
+        }
+
+    suspicious_hostname = bool(
+        hostname and any(token in hostname.lower() for token in ("unknown", "forwarder"))
+    )
+    owned = None if suspicious_hostname else _owned_infrastructure(domain, hostname)
+    if owned:
+        return owned
+
+    dmarc_failed = (
+        int(source.get("dmarc_fail_count", 0) or 0) > 0 or source.get("dmarc_result") == "fail"
+    )
+    if dmarc_failed and not hostname:
+        status = "suspicious"
+        reason = "DMARC failures came from a source without reverse DNS."
+    elif dmarc_failed:
+        status = "unknown"
+        reason = "DMARC failures came from an unrecognized sender."
+    else:
+        status = "unknown"
+        reason = "No known provider profile matched this source."
+
+    evidence = [f"Source IP {ip}"]
+    if hostname:
+        evidence.append(f"PTR hostname {hostname}")
+
+    return {
+        "id": "unknown-sender",
+        "name": "Unknown sender",
+        "provider": None,
+        "category": "unknown",
+        "status": status,
+        "confidence": 0,
+        "reason": reason,
+        "evidence": evidence,
+        "remediation_hint": (
+            "Identify the business owner for this source before authorizing it. If nobody "
+            "owns it, keep it blocked by DMARC enforcement."
+        ),
+        "docs_url": None,
+    }

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -502,6 +502,7 @@
                     {% call thead() %}
                         {% call tr() %}
                             {% call th() %}Source IP / Hostname{% endcall %}
+                            {% call th() %}Sender{% endcall %}
                             {% call th() %}Total Emails{% endcall %}
                             {% call th() %}SPF{% endcall %}
                             {% call th() %}DKIM{% endcall %}
@@ -513,7 +514,7 @@
                     {% call tbody() %}
                         <template x-if="sources.length === 0">
                             <tr>
-                                <td colspan="7" class="text-center py-4">
+                                <td colspan="8" class="text-center py-4">
                                     <div class="text-muted-foreground">No data available for this time period</div>
                                 </td>
                             </tr>
@@ -525,6 +526,29 @@
                                         <span class="font-mono text-sm" x-text="source.ip"></span>
                                         <template x-if="source.hostname">
                                             <span class="text-xs text-muted-foreground" x-text="source.hostname"></span>
+                                        </template>
+                                    </div>
+                                {% endcall %}
+                                {% call td() %}
+                                    <div class="min-w-52 space-y-1">
+                                        <div class="flex items-center gap-2">
+                                            <span class="font-semibold text-sm" x-text="source.sender?.name || 'Unknown sender'"></span>
+                                            <span
+                                                class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold"
+                                                :class="senderStatusClass(source.sender?.status)"
+                                                x-text="source.sender?.status || 'unknown'"
+                                            ></span>
+                                        </div>
+                                        <div class="text-xs text-muted-foreground">
+                                            <span x-text="source.sender?.provider || source.sender?.category || 'Unclassified'"></span>
+                                            <span> · </span>
+                                            <span x-text="(source.sender?.confidence || 0) + '% confidence'"></span>
+                                        </div>
+                                        <template x-if="source.sender?.evidence?.length">
+                                            <p class="text-xs text-muted-foreground" x-text="source.sender.evidence[0]"></p>
+                                        </template>
+                                        <template x-if="source.sender?.remediation_hint">
+                                            <p class="text-xs" x-text="source.sender.remediation_hint"></p>
                                         </template>
                                     </div>
                                 {% endcall %}
@@ -841,7 +865,14 @@ function domainDetailsApp(domainId) {
 
             return this.sources.filter(source => {
                 if (!this.filters.sourceFilter) return true;
-                return source.ip.toLowerCase().includes(this.filters.sourceFilter.toLowerCase());
+                const needle = this.filters.sourceFilter.toLowerCase();
+                return [
+                    source.ip,
+                    source.hostname,
+                    source.sender?.name,
+                    source.sender?.provider,
+                    source.sender?.status,
+                ].some(value => String(value || '').toLowerCase().includes(needle));
             });
         },
 
@@ -887,6 +918,13 @@ function domainDetailsApp(domainId) {
             if (severity === 'error') return 'bg-red-500';
             if (severity === 'warning') return 'bg-yellow-500';
             return 'bg-blue-500';
+        },
+
+        senderStatusClass(status) {
+            if (status === 'known') return 'bg-green-100 text-green-800';
+            if (status === 'ambiguous') return 'bg-yellow-100 text-yellow-800';
+            if (status === 'suspicious') return 'bg-red-100 text-red-800';
+            return 'bg-gray-100 text-gray-700';
         },
 
         async fetchDomainStats() {

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -349,8 +349,51 @@ def test_get_domain_sources_returns_recommendations(
     assert response.status_code == 200
     source = response.json()["sources"][0]
     recommendation_types = {item["type"] for item in source["recommendations"]}
-    assert recommendation_types == {"full_fail", "policy_not_enforced"}
+    assert recommendation_types == {"unknown_sender", "full_fail", "policy_not_enforced"}
+    assert source["sender"]["name"] == "Unknown sender"
+    assert source["sender"]["status"] == "unknown"
     assert source["spf_fix_hint"] == "ip4:192.0.2.10"
+
+
+def test_get_domain_sources_returns_sender_identity(
+    authed_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Endpoint names recognized sending services with evidence and remediation."""
+
+    async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
+        return "mail-qv1-f75.google.com"
+
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    report = {
+        **REPORT_DICT_POLICY,
+        "report_id": "rpt-google-source",
+        "records": [
+            {
+                "source_ip": "203.0.113.75",
+                "count": 12,
+                "disposition": "none",
+                "dkim_result": "pass",
+                "spf_result": "pass",
+                "header_from": DOMAIN,
+                "envelope_from": f"bounce.{DOMAIN}",
+                "dkim": [{"domain": DOMAIN, "selector": "google", "result": "pass"}],
+                "spf": [{"domain": "_spf.google.com", "scope": "mfrom", "result": "pass"}],
+            }
+        ],
+        "summary": {"total_count": 12, "passed_count": 12, "failed_count": 0},
+    }
+    ReportStore.get_instance().add_report(report)
+
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources")
+
+    assert response.status_code == 200
+    source = response.json()["sources"][0]
+    assert source["sender"]["id"] == "google-workspace"
+    assert source["sender"]["name"] == "Google Workspace"
+    assert source["sender"]["status"] == "known"
+    assert source["sender"]["confidence"] >= 90
+    assert source["sender"]["evidence"]
+    assert "Google Workspace DKIM" in source["sender"]["remediation_hint"]
 
 
 def test_source_recommendations_cover_common_cases():

--- a/backend/app/tests/test_sender_intelligence.py
+++ b/backend/app/tests/test_sender_intelligence.py
@@ -1,0 +1,70 @@
+from app.services.sender_intelligence import identify_sender
+
+
+def test_identify_sender_matches_known_provider_from_hostname_and_selector():
+    source = {
+        "dkim_selectors": ["google"],
+        "spf_domains": ["_spf.google.com"],
+        "dmarc_result": "pass",
+        "dmarc_fail_count": 0,
+    }
+
+    sender = identify_sender(
+        "203.0.113.75",
+        source,
+        hostname="mail-qv1-f75.google.com",
+        domain="example.com",
+    )
+
+    assert sender["id"] == "google-workspace"
+    assert sender["name"] == "Google Workspace"
+    assert sender["status"] == "known"
+    assert sender["confidence"] == 95
+    assert sender["evidence"]
+    assert "Google Workspace DKIM" in sender["remediation_hint"]
+
+
+def test_identify_sender_flags_ambiguous_provider_evidence():
+    source = {
+        "spf_domains": ["google.com", "stripe.com"],
+        "dmarc_result": "pass",
+    }
+
+    sender = identify_sender("203.0.113.7", source, hostname=None, domain="example.com")
+
+    assert sender["id"] == "ambiguous-sender"
+    assert sender["status"] == "ambiguous"
+    assert sender["confidence"] == 40
+    assert "Confirm the service owner" in sender["remediation_hint"]
+
+
+def test_identify_sender_keeps_unknown_failing_source_distinct():
+    source = {
+        "dmarc_result": "fail",
+        "dmarc_fail_count": 8,
+    }
+
+    sender = identify_sender("192.0.2.99", source, hostname=None, domain="example.com")
+
+    assert sender["id"] == "unknown-sender"
+    assert sender["status"] == "suspicious"
+    assert sender["confidence"] == 0
+    assert "before authorizing it" in sender["remediation_hint"]
+
+
+def test_identify_sender_recognizes_owned_infrastructure():
+    source = {
+        "dmarc_result": "pass",
+        "dmarc_fail_count": 0,
+    }
+
+    sender = identify_sender(
+        "203.0.113.10",
+        source,
+        hostname="primary-saas.mail.dmarq.org",
+        domain="dmarq.org",
+    )
+
+    assert sender["id"] == "owned-infrastructure"
+    assert sender["name"] == "Owned infrastructure"
+    assert sender["status"] == "known"


### PR DESCRIPTION
## Summary
- add deterministic sender intelligence for common DMARC senders and owned/unknown source classification
- include sender identity, confidence, evidence, and remediation hints in the domain sources API
- surface named senders in the domain detail source table and seed demo PTRs for Google, Mailchimp, Zendesk, Stripe, owned infra, and unknown sender cases

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_sender_intelligence.py backend/app/tests/test_report_store.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_demo_data.py backend/app/tests/test_dns_endpoints.py::test_summary_endpoint_returns_demo_domains_in_demo_mode -q
- .venv/bin/python -m black --check backend/app/services/sender_intelligence.py backend/app/services/report_store.py backend/app/services/dns_resolver.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_sender_intelligence.py backend/app/tests/test_domain_detail_endpoints.py
- git diff --check
- Local demo smoke: /api/v1/domains/dmarq.com/sources shows Google Workspace, Mailchimp, Stripe, and Unknown sender rows; browser snapshot confirms the Sender column renders.

Closes #306