### PR TITLE
fix: address health-score follow-ups from #316

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1246,6 +1246,8 @@ async def get_domains_summary(
         domain_row["health"] = score_domain_health(domain_row)
         domains_list.append(domain_row)
 
+    domain_health = [domain["health"] for domain in domains_list]
+
     # Calculate overall pass rate
     overall_pass_rate = 0
     if total_emails > 0:
@@ -1257,7 +1259,7 @@ async def get_domains_summary(
         overall_pass_rate=overall_pass_rate,
         reports_processed=total_reports,
         domains=domains_list,
-        health_summary=build_health_summary(domains_list),
+        health_summary=build_health_summary(domains_list, domain_health),
     )
 
 

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -251,14 +251,25 @@ def build_health_summary(
     by_domain = {
         str(item.get("domain")): item for item in domain_health if item.get("domain") is not None
     }
+
+    def _domain_key(domain: Dict[str, Any]) -> str:
+        return str(domain.get("domain_name") or domain.get("id"))
+
+    missing_health = [
+        _domain_key(domain) for domain in domains if _domain_key(domain) not in by_domain
+    ]
+    if missing_health:
+        raise ValueError(
+            f"Missing health payloads for domains: {', '.join(missing_health)}"
+        )
+
     total_weight = sum(max(1, int(domain.get("total_emails") or 0)) for domain in domains)
     if total_weight:
         score = round(
             sum(
-                by_domain[str(domain.get("domain_name") or domain.get("id"))]["score"]
+                by_domain[_domain_key(domain)]["score"]
                 * max(1, int(domain.get("total_emails") or 0))
                 for domain in domains
-                if str(domain.get("domain_name") or domain.get("id")) in by_domain
             )
             / total_weight
         )

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -37,6 +37,13 @@ def _bounded(value: Any, *, lower: float = 0.0, upper: float = 100.0) -> float:
     return max(lower, min(upper, number))
 
 
+def _effective_dmarc_policy(domain: Dict[str, Any]) -> str:
+    """Return the DMARC policy used for scoring, distinct from endpoint fallbacks."""
+    if not domain.get("dmarc_status"):
+        return "missing"
+    return str(domain.get("dmarc_policy") or "none").lower()
+
+
 def _policy_factor(policy: Optional[str]) -> float:
     policy_name = (policy or "").lower()
     if policy_name == "reject":
@@ -73,8 +80,8 @@ def _confidence_factor(domain: Dict[str, Any]) -> float:
     return 30.0
 
 
-def _score_cap(domain: Dict[str, Any], confidence: float) -> int:
-    policy = str(domain.get("dmarc_policy") or "").lower()
+def _score_cap(domain: Dict[str, Any], confidence: float, *, policy: Optional[str] = None) -> int:
+    policy = policy or _effective_dmarc_policy(domain)
     cap = 100
     if policy == "quarantine":
         cap = min(cap, 92)
@@ -168,7 +175,7 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 ],
             )
         )
-    if policy == "none":
+    if policy == "none" and domain.get("dmarc_status"):
         actions.append(
             _action(
                 action_type="policy_none",
@@ -200,17 +207,26 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
     return sorted(actions, key=lambda item: item["score_impact"], reverse=True)
 
 
+def _system_policy(domains: List[Dict[str, Any]]) -> Optional[str]:
+    """Return reject when every domain enforces p=reject so A+ is reachable system-wide."""
+    if not domains:
+        return None
+    if all(_effective_dmarc_policy(domain) == "reject" for domain in domains):
+        return "reject"
+    return None
+
+
 def score_domain_health(domain: Dict[str, Any]) -> Dict[str, Any]:
     """Score a single domain summary row."""
     pass_rate = _bounded(domain.get("pass_rate"))
     dns = _dns_factor(domain)
-    policy = _policy_factor(domain.get("dmarc_policy"))
+    policy_name = _effective_dmarc_policy(domain)
+    policy = _policy_factor(policy_name)
     confidence = _confidence_factor(domain)
     raw_score = round((pass_rate * 0.45) + (dns * 0.20) + (policy * 0.25) + (confidence * 0.10))
-    score = min(raw_score, _score_cap(domain, confidence))
+    score = min(raw_score, _score_cap(domain, confidence, policy=policy_name))
     actions = _domain_actions(domain)
     critical_actions = sum(1 for action in actions if action["severity"] == "critical")
-    policy_name = str(domain.get("dmarc_policy") or "missing").lower()
 
     return {
         "domain": domain.get("domain_name") or domain.get("id"),
@@ -227,9 +243,11 @@ def score_domain_health(domain: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def build_health_summary(domains: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """Build system-level health from domain summary rows."""
-    domain_health = [score_domain_health(domain) for domain in domains]
+def build_health_summary(
+    domains: List[Dict[str, Any]],
+    domain_health: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build system-level health from pre-computed per-domain health payloads."""
     by_domain = {
         str(item.get("domain")): item for item in domain_health if item.get("domain") is not None
     }
@@ -254,7 +272,11 @@ def build_health_summary(domains: List[Dict[str, Any]]) -> Dict[str, Any]:
 
     return {
         "score": int(score),
-        "grade": health_grade(int(score), critical_actions=critical_actions),
+        "grade": health_grade(
+            int(score),
+            policy=_system_policy(domains),
+            critical_actions=critical_actions,
+        ),
         "status": "healthy" if score >= 90 else "attention" if score >= 70 else "critical",
         "attention_domains": attention_domains,
         "domain_count": len(domain_health),

--- a/backend/app/tests/test_health_score.py
+++ b/backend/app/tests/test_health_score.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from app.services.health_score import build_health_summary, health_grade, score_domain_health
 
 
@@ -144,6 +146,12 @@ def test_build_health_summary_reuses_precomputed_domain_health():
     mock_score.assert_not_called()
     assert summary["domains"] is precomputed
     assert summary["score"] == 42
+
+
+def test_build_health_summary_raises_on_missing_health_payload():
+    domains = [{"domain_name": "a.com", "total_emails": 100}]
+    with pytest.raises(ValueError):
+        build_health_summary(domains, [])  # no matching health payload
 
 
 def test_build_health_summary_a_plus_reachable_at_system_level():

--- a/backend/app/tests/test_health_score.py
+++ b/backend/app/tests/test_health_score.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from app.services.health_score import build_health_summary, health_grade, score_domain_health
 
 
@@ -51,36 +53,129 @@ def test_low_compliance_and_missing_dns_create_prioritized_actions():
     assert "missing_spf" in action_types
 
 
-def test_build_health_summary_weights_domain_scores_by_volume():
-    summary = build_health_summary(
-        [
-            {
-                "domain_name": "large.example",
-                "total_emails": 100_000,
-                "failed_count": 100,
-                "pass_rate": 99.9,
-                "report_count": 30,
-                "dmarc_status": True,
-                "spf_status": True,
-                "dkim_status": True,
-                "dmarc_policy": "reject",
-                "dmarc_warnings": [],
-            },
-            {
-                "domain_name": "small.example",
-                "total_emails": 100,
-                "failed_count": 80,
-                "pass_rate": 20.0,
-                "report_count": 3,
-                "dmarc_status": True,
-                "spf_status": False,
-                "dkim_status": False,
-                "dmarc_policy": "none",
-                "dmarc_warnings": ["External rua destination is not authorized."],
-            },
-        ]
+def test_missing_dmarc_scores_worse_than_policy_none():
+    """Missing DMARC must penalize more than a real p=none monitoring record."""
+    shared = {
+        "domain_name": "example.com",
+        "total_emails": 25_000,
+        "failed_count": 0,
+        "pass_rate": 99.2,
+        "report_count": 30,
+        "spf_status": True,
+        "dkim_status": True,
+        "dmarc_warnings": [],
+    }
+    policy_none = score_domain_health(
+        {**shared, "dmarc_status": True, "dmarc_policy": "none"}
     )
+    missing_record = score_domain_health(
+        {**shared, "dmarc_status": False, "dmarc_policy": "none"}
+    )
+
+    assert missing_record["score"] < policy_none["score"]
+    assert any(action["type"] == "missing_dmarc" for action in missing_record["actions"])
+    assert not any(action["type"] == "policy_none" for action in missing_record["actions"])
+
+
+def test_build_health_summary_weights_domain_scores_by_volume():
+    domains = [
+        {
+            "domain_name": "large.example",
+            "total_emails": 100_000,
+            "failed_count": 100,
+            "pass_rate": 99.9,
+            "report_count": 30,
+            "dmarc_status": True,
+            "spf_status": True,
+            "dkim_status": True,
+            "dmarc_policy": "reject",
+            "dmarc_warnings": [],
+        },
+        {
+            "domain_name": "small.example",
+            "total_emails": 100,
+            "failed_count": 80,
+            "pass_rate": 20.0,
+            "report_count": 3,
+            "dmarc_status": True,
+            "spf_status": False,
+            "dkim_status": False,
+            "dmarc_policy": "none",
+            "dmarc_warnings": ["External rua destination is not authorized."],
+        },
+    ]
+    domain_health = [score_domain_health(domain) for domain in domains]
+    summary = build_health_summary(domains, domain_health)
 
     assert summary["score"] >= 95
     assert summary["attention_domains"] == 1
     assert summary["top_actions"]
+
+
+def test_build_health_summary_reuses_precomputed_domain_health():
+    """Summary must not re-score domains when health payloads are already supplied."""
+    domains = [
+        {
+            "domain_name": "cached.example",
+            "total_emails": 1000,
+            "pass_rate": 99.0,
+            "report_count": 10,
+            "dmarc_status": True,
+            "spf_status": True,
+            "dkim_status": True,
+            "dmarc_policy": "reject",
+            "dmarc_warnings": [],
+        }
+    ]
+    precomputed = [
+        {
+            "domain": "cached.example",
+            "score": 42,
+            "grade": "F",
+            "status": "critical",
+            "factors": {},
+            "actions": [],
+        }
+    ]
+
+    with patch("app.services.health_score.score_domain_health") as mock_score:
+        summary = build_health_summary(domains, precomputed)
+
+    mock_score.assert_not_called()
+    assert summary["domains"] is precomputed
+    assert summary["score"] == 42
+
+
+def test_build_health_summary_a_plus_reachable_at_system_level():
+    """System-level grade must reach A+ when all domains enforce reject at high scores."""
+    domains = [
+        {
+            "domain_name": "primary.example",
+            "total_emails": 100_000,
+            "failed_count": 0,
+            "pass_rate": 99.9,
+            "report_count": 30,
+            "dmarc_status": True,
+            "spf_status": True,
+            "dkim_status": True,
+            "dmarc_policy": "reject",
+            "dmarc_warnings": [],
+        },
+        {
+            "domain_name": "secondary.example",
+            "total_emails": 50_000,
+            "failed_count": 0,
+            "pass_rate": 99.5,
+            "report_count": 20,
+            "dmarc_status": True,
+            "spf_status": True,
+            "dkim_status": True,
+            "dmarc_policy": "reject",
+            "dmarc_warnings": [],
+        },
+    ]
+    domain_health = [score_domain_health(domain) for domain in domains]
+    summary = build_health_summary(domains, domain_health)
+
+    assert summary["score"] >= 97
+    assert summary["grade"] == "A+"


### PR DESCRIPTION
## Description
Addresses the three post-merge review follow-ups flagged on PR #316 in the dashboard health-score / action-plan logic.

## Related Issue
Closes #317

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made
- **Distinguish missing DMARC records from `p=none`:** a missing record was normalized to `dmarc_policy = "none"` before scoring, so `score_domain_health()` treated it like monitoring mode. Added `_effective_dmarc_policy()` to detect a missing record as a distinct state and penalize it harder (policy factor 25 / score cap 59 vs. `none`'s 55 / 74). The `missing_dmarc` action fires for missing records; `policy_none` no longer does.
- **Eliminate duplicate scoring / drift:** `/domains/summary` computed per-domain `health`, then `build_health_summary()` recomputed `score_domain_health()` for every domain. `build_health_summary()` now accepts the already-computed per-domain health payloads and the endpoint passes them through, so per-domain and system health can't drift.
- **Make A+ reachable at system level:** system-level `health_grade()` was called without a policy, making `A+` unreachable. Added `_system_policy()` (returns `reject` only when every domain enforces `p=reject`, `None` otherwise) and threaded it into the system grade.

## Testing Performed
- Added 3 unit tests in `test_health_score.py`:
  - `test_missing_dmarc_scores_worse_than_policy_none` — missing scores lower than `p=none`; `missing_dmarc` fires and `policy_none` does not.
  - `test_build_health_summary_reuses_precomputed_domain_health` — `score_domain_health()` is not re-called; the precomputed payload is reused.
  - `test_build_health_summary_a_plus_reachable_at_system_level` — asserts the system grade is literally `A+` for an all-reject, no-critical-actions portfolio.
- Full suite green: **1124 passed** locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain health summaries so overall results better reflect per-domain health and email volume.
  * Refined DMARC scoring to distinguish between missing policy data and `p=none`, and avoid showing monitoring-mode suggestions when not applicable.
  * Updated system-wide grading to more accurately reward stronger DMARC enforcement.

* **Tests**
  * Expanded coverage for DMARC scoring, health summary weighting, and top-tier system grades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->