### PR TITLE
fix: backport fork-audit security hardening

### DIFF
--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -16,10 +16,12 @@ GET  /account-portal   – Redirect to the Logto Account Center root.
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
+from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
@@ -41,6 +43,8 @@ settings = get_settings()
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 _SAFE_NEXT_PREFIXES = ("/",)  # only allow relative redirects after login
+_NEXT_COOKIE = "logto_next"
+_NEXT_COOKIE_MAX_AGE = 600
 
 
 def _safe_next(next_url: Optional[str]) -> str:
@@ -48,6 +52,29 @@ def _safe_next(next_url: Optional[str]) -> str:
     if next_url and next_url.startswith("/") and not next_url.startswith("//"):
         return next_url
     return "/"
+
+
+def _create_next_cookie(next_url: str) -> str:
+    """Create a short-lived signed cookie for the post-login redirect path."""
+    payload = {
+        "type": _NEXT_COOKIE,
+        "next": _safe_next(next_url),
+        "exp": datetime.utcnow() + timedelta(seconds=_NEXT_COOKIE_MAX_AGE),
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def _decode_next_cookie(value: Optional[str]) -> str:
+    """Validate the signed next cookie and return a safe redirect path."""
+    if not value:
+        return "/"
+    try:
+        payload = jwt.decode(value, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        if payload.get("type") != _NEXT_COOKIE:
+            return "/"
+        return _safe_next(payload.get("next"))
+    except (JWTError, TypeError, ValueError):
+        return "/"
 
 
 def _logto_not_configured() -> HTTPException:
@@ -100,11 +127,11 @@ async def sign_in(
     safe = _safe_next(next)
     if safe != "/":
         response.set_cookie(
-            key="logto_next",
-            value=safe,
+            key=_NEXT_COOKIE,
+            value=_create_next_cookie(safe),
             httponly=True,
             samesite="lax",
-            max_age=600,  # 10 minutes – must survive the Logto redirect round-trip
+            max_age=_NEXT_COOKIE_MAX_AGE,
         )
 
     return response
@@ -143,7 +170,7 @@ async def callback(
     user = sync_logto_user(claims, db)
 
     # Where to go after login
-    next_url = _safe_next(request.cookies.get("logto_next"))
+    next_url = _decode_next_cookie(request.cookies.get(_NEXT_COOKIE))
 
     response = RedirectResponse(url=next_url, status_code=302)
 
@@ -159,7 +186,7 @@ async def callback(
 
     # Clean up all temporary Logto & next cookies
     storage.clear_all_logto_cookies(response)
-    response.delete_cookie(key="logto_next", httponly=True, samesite="lax")
+    response.delete_cookie(key=_NEXT_COOKIE, httponly=True, samesite="lax")
 
     logger.info("User id=%d logged in via Logto.", user.id)
     return response

--- a/backend/app/api/api_v1/endpoints/imap.py
+++ b/backend/app/api/api_v1/endpoints/imap.py
@@ -9,6 +9,7 @@ from starlette.concurrency import run_in_threadpool
 from app.core.database import SessionLocal
 from app.core.security import require_admin_auth
 from app.services.imap_client import IMAPClient
+from app.services.mail_connector import sanitize_connector_error
 from app.services.mailbox_recovery import connection_test_response, import_result_diagnostic
 
 router = APIRouter()
@@ -43,6 +44,15 @@ def _fetch_imap_reports_sync(days: int, delete_emails: Optional[bool]) -> Dict[s
 def _fetch_imap_reports_background(days: int, delete_emails: Optional[bool]) -> None:
     """Fetch IMAP reports from a FastAPI background task."""
     _fetch_imap_reports_sync(days, delete_emails)
+
+
+def _public_import_errors(results: Dict[str, Any]) -> Optional[list[str]]:
+    """Return compact, non-sensitive connector diagnostics for API clients."""
+    errors = results.get("errors") or []
+    if not errors:
+        return None
+    diagnostic = import_result_diagnostic(results)
+    return [sanitize_connector_error(diagnostic["summary"])]
 
 
 @router.post("/test-connection")
@@ -108,7 +118,7 @@ async def fetch_imap_reports(
             "forensic_reports_found": int(results.get("forensic_reports_found", 0)),
             "duplicate_forensic_reports": int(results.get("duplicate_forensic_reports", 0)),
             "new_domains": results["new_domains"],
-            "errors": results["errors"] if "errors" in results and results["errors"] else None,
+            "errors": _public_import_errors(results),
             "diagnostic": diagnostic,
             "diagnostic_category": diagnostic["category"],
             "diagnostic_summary": diagnostic["summary"],

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -117,8 +117,7 @@ async def get_api_key(api_key_value: Optional[str] = Security(api_key_header)) -
         )
 
     if not verify_api_key(api_key_value):
-        suffix = api_key_value[-8:] if len(api_key_value) >= 8 else "invalid"
-        logger.warning("Invalid API key attempt: ...%s", suffix)
+        logger.warning("Invalid API key attempt.")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid API key",

--- a/backend/app/services/imap_client.py
+++ b/backend/app/services/imap_client.py
@@ -235,15 +235,19 @@ class IMAPClient:
 
                 stats["processed"] += 1
         except Exception as e:  # pylint: disable=broad-exception-caught
-            error_msg = f"Error processing email ID {email_id}: {str(e)}"
-            logger.error(error_msg)
-            stats["errors"].append(error_msg)
+            safe_email_id = sanitize_connector_error(email_id)
+            logger.error(
+                "Error processing IMAP email ID %s: %s",
+                safe_email_id,
+                sanitize_connector_error(e),
+            )
+            stats["errors"].append("Error processing one mailbox message.")
             self._append_detail(
                 stats,
                 status="error",
                 reason="message_processing_failed",
                 message_id=message_id,
-                error=str(e),
+                error="Message processing failed. Check server logs for details.",
             )
 
     def fetch_reports(self, days: int = 7) -> Dict[str, Any]:

--- a/backend/app/services/mail_connector.py
+++ b/backend/app/services/mail_connector.py
@@ -139,7 +139,8 @@ def connector_failure_stats(
     error: Optional[object] = None,
 ) -> Dict[str, Any]:
     """Return a standardized failed import payload for provider errors."""
-    safe_message = sanitize_connector_error(error if error is not None else message)
+    _ = error
+    safe_message = sanitize_connector_error(message)
     return {
         **stats,
         "success": False,

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -20,6 +20,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
+from app.api.api_v1.endpoints.auth import _create_next_cookie
+from app.core.config import get_settings
 from app.core.logto import (
     SESSION_COOKIE,
     CookieStorage,
@@ -280,6 +282,25 @@ class TestCallbackEndpoint:
         """After a successful callback the user is redirected to the stored next URL."""
         claims = self._make_mock_claims()
         mock_client = self._mock_client(claims=claims)
+        next_cookie = _create_next_cookie("/dashboard")
+        with patch("app.api.api_v1.endpoints.auth.settings") as mock_settings:
+            real_settings = get_settings()
+            mock_settings.logto_configured = True
+            mock_settings.SECRET_KEY = real_settings.SECRET_KEY
+            mock_settings.ALGORITHM = real_settings.ALGORITHM
+            with patch("app.api.api_v1.endpoints.auth.make_logto_client", return_value=mock_client):
+                res = client.get(
+                    "/api/v1/auth/callback?code=good",
+                    cookies={"logto_next": next_cookie},
+                    follow_redirects=False,
+                )
+        assert res.status_code == 302
+        assert res.headers["location"] == "/dashboard"
+
+    def test_callback_ignores_tampered_logto_next_cookie(self, client: TestClient):
+        """Unsigned or tampered next cookies must not control the post-login redirect."""
+        claims = self._make_mock_claims()
+        mock_client = self._mock_client(claims=claims)
         with patch("app.api.api_v1.endpoints.auth.settings") as mock_settings:
             mock_settings.logto_configured = True
             with patch("app.api.api_v1.endpoints.auth.make_logto_client", return_value=mock_client):
@@ -289,7 +310,7 @@ class TestCallbackEndpoint:
                     follow_redirects=False,
                 )
         assert res.status_code == 302
-        assert res.headers["location"] == "/dashboard"
+        assert res.headers["location"] == "/"
 
 
 # ── /api/v1/auth/sign-in ─────────────────────────────────────────────────────
@@ -361,9 +382,7 @@ class TestAuthDisabled:
             mock_settings.AUTH_DISABLED = True
             mock_req = MagicMock()
             mock_req.cookies = {}
-            result = asyncio.run(
-                require_admin_auth(request=mock_req, api_key=None, bearer=None)
-            )
+            result = asyncio.run(require_admin_auth(request=mock_req, api_key=None, bearer=None))
         assert result["auth_type"] == "disabled"
 
     def test_middleware_passes_all_requests_when_auth_disabled(self, client: TestClient):

--- a/backend/app/tests/test_gmail_client.py
+++ b/backend/app/tests/test_gmail_client.py
@@ -21,7 +21,7 @@ import pytest
 
 from app.models.report import DMARCReport, ForensicReport
 from app.models.setting import Setting
-from app.services.gmail_client import GmailClient, RETRYABLE_MESSAGE_FAILURE
+from app.services.gmail_client import RETRYABLE_MESSAGE_FAILURE, GmailClient
 from app.services.report_store import ReportStore
 from app.tests.test_data import SAMPLE_XML
 from app.tests.test_forensic_parser import SAMPLE_FORENSIC_EMAIL
@@ -731,7 +731,8 @@ class TestFetchReports:
             result = client.fetch_reports()
 
         assert result["success"] is False
-        assert "auth error" in result.get("error", "")
+        assert result.get("error") == "Failed to initialize Gmail API."
+        assert "auth error" not in str(result)
 
     def test_returns_failure_when_list_messages_raises(self):
         client = _make_client()
@@ -831,6 +832,38 @@ class TestFetchReports:
             result = client.fetch_reports()
 
         assert "newdomain.example" in result["new_domains"]
+
+    def test_fetch_reports_hides_raw_service_build_error(self):
+        client = _make_client()
+
+        with patch.object(
+            client,
+            "_build_service",
+            side_effect=RuntimeError("access_token=ya29.raw-secret"),
+        ):
+            result = client.fetch_reports()
+
+        assert result["success"] is False
+        assert result["errors"] == ["Failed to initialize Gmail API."]
+        assert "raw-secret" not in str(result)
+
+    def test_fetch_reports_hides_raw_message_list_error(self):
+        client = _make_client()
+        mock_service = MagicMock()
+
+        with (
+            patch.object(client, "_build_service", return_value=mock_service),
+            patch.object(
+                client,
+                "_list_dmarc_message_ids",
+                side_effect=RuntimeError("refresh_token=1//raw-refresh"),
+            ),
+        ):
+            result = client.fetch_reports()
+
+        assert result["success"] is False
+        assert result["errors"] == ["Failed to list Gmail messages."]
+        assert "raw-refresh" not in str(result)
 
 
 # ===========================================================================

--- a/backend/app/tests/test_imap_client.py
+++ b/backend/app/tests/test_imap_client.py
@@ -10,11 +10,11 @@ import imaplib
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from gzip import GzipFile
 from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from zipfile import ZipFile
-from gzip import GzipFile
 
 import pytest
 
@@ -96,7 +96,7 @@ def _make_email_with_attachment(
     content_type: str = "application/xml",
     subject: str = "DMARC Report",
     from_addr: str = "noreply@example.com",
-    disposition_type: str = "attachment"
+    disposition_type: str = "attachment",
 ) -> bytes:
     msg = MIMEMultipart()
     msg["Subject"] = subject
@@ -519,7 +519,9 @@ class TestProcessAttachments:
         client = self._make_client()
         gzip_content = _make_gzip_content(MINIMAL_DMARC_XML, "report.xml")
         msg = email.message_from_bytes(
-            _make_email_with_attachment("report.gz", gzip_content, "application/gzip", disposition_type="inline")
+            _make_email_with_attachment(
+                "report.gz", gzip_content, "application/gzip", disposition_type="inline"
+            )
         )
         count = client._process_attachments(msg)
         assert count == 1
@@ -946,3 +948,20 @@ class TestFetchReports:
         mock_mail.expunge.assert_not_called()
         assert result["success"] is True
         assert result["deleted"] == 0
+
+    def test_single_message_exception_uses_generic_result_error(self):
+        client = self._make_client()
+        mock_mail = MagicMock()
+        mock_mail.fetch.side_effect = RuntimeError("password=super-secret")
+        stats = {
+            "processed": 0,
+            "reports_found": 0,
+            "errors": [],
+            "details": [],
+        }
+
+        client._process_single_email(mock_mail, b"1", stats)
+
+        assert stats["errors"] == ["Error processing one mailbox message."]
+        assert "super-secret" not in str(stats)
+        assert stats["details"][0]["reason"] == "message_processing_failed"

--- a/backend/app/tests/test_imap_endpoints.py
+++ b/backend/app/tests/test_imap_endpoints.py
@@ -129,7 +129,7 @@ class TestImapFetchReports:
             "processed": 1,
             "reports_found": 0,
             "new_domains": [],
-            "errors": ["Could not parse email 1"],
+            "errors": ["Could not parse email 1 with password=super-secret"],
         }
 
         with (
@@ -141,6 +141,8 @@ class TestImapFetchReports:
         assert response.status_code == 200
         data = response.json()
         assert data["errors"] is not None
+        assert "super-secret" not in str(data["errors"])
+        assert "password" not in str(data["errors"]).lower()
         assert data["diagnostic_category"] == "parsing"
         assert data["recovery_steps"]
 

--- a/backend/app/tests/test_mail_connector.py
+++ b/backend/app/tests/test_mail_connector.py
@@ -47,7 +47,7 @@ def test_append_import_detail_redacts_secret_like_values():
     ]
 
 
-def test_connector_failure_stats_uses_redacted_error():
+def test_connector_failure_stats_uses_public_message_not_provider_error():
     stats = initial_import_stats()
     fake_token = "".join(["not", "-a-real", "-token"])
 
@@ -58,8 +58,9 @@ def test_connector_failure_stats_uses_redacted_error():
     )
 
     assert result["success"] is False
-    assert result["error"] == "Authorization: Bearer **redacted**"
-    assert result["errors"] == ["Authorization: Bearer **redacted**"]
+    assert result["error"] == "Provider failed."
+    assert result["errors"] == ["Provider failed."]
+    assert fake_token not in str(result)
 
 
 def test_ingested_id_helpers_normalize_values():

--- a/backend/app/tests/test_microsoft_graph_client.py
+++ b/backend/app/tests/test_microsoft_graph_client.py
@@ -554,7 +554,7 @@ class TestMicrosoftGraphFetchReports:
             "refresh_token": "new-refresh",
         }
 
-    def test_fetch_reports_surfaces_throttling_error(self, monkeypatch):
+    def test_fetch_reports_uses_generic_list_error(self, monkeypatch):
         def fake_request(method, url, headers=None, params=None, timeout=None):
             return httpx.Response(
                 429,
@@ -567,4 +567,5 @@ class TestMicrosoftGraphFetchReports:
         result = client.fetch_reports()
 
         assert result["success"] is False
-        assert "TooManyRequests" in result["error"]
+        assert result["error"] == "Failed to list Microsoft Graph messages."
+        assert "TooManyRequests" not in str(result)

--- a/backend/app/tests/test_stats_summarizer.py
+++ b/backend/app/tests/test_stats_summarizer.py
@@ -639,16 +639,18 @@ class TestStatsSummarizerCaching:
         thirty_day_cache = summarizer._get_cache_filename(period_days=30, cache_key="shared_window")
 
         assert seven_day_cache != thirty_day_cache
-        assert "7d_shared_window" in seven_day_cache
-        assert "30d_shared_window" in thirty_day_cache
+        assert "7d_key_" in os.path.basename(seven_day_cache)
+        assert "30d_key_" in os.path.basename(thirty_day_cache)
+        assert "shared_window" not in seven_day_cache
 
     def test_workspace_cache_keys_are_partitioned_and_invalidated(self, summarizer):
         summarizer.save_summary({"total_domains": 1, "change_summary": {}}, workspace_id=101)
         summarizer.save_summary({"total_domains": 2, "change_summary": {}}, workspace_id=202)
 
-        assert os.path.basename(summarizer._get_cache_filename(workspace_id=101)).startswith(
-            "workspace_101_global_summary"
-        )
+        cache_name = os.path.basename(summarizer._get_cache_filename(workspace_id=101))
+        assert cache_name.startswith("workspace_")
+        assert "_global_summary_" in cache_name
+        assert "101" not in cache_name
         assert summarizer.get_cached_summary(workspace_id=101)["total_domains"] == 1
         assert summarizer.get_cached_summary(workspace_id=202)["total_domains"] == 2
 
@@ -656,6 +658,23 @@ class TestStatsSummarizerCaching:
 
         assert summarizer.get_cached_summary(workspace_id=101) is None
         assert summarizer.get_cached_summary(workspace_id=202)["total_domains"] == 2
+
+    def test_cache_filename_hashes_domain_and_cache_key(self, summarizer):
+        filename = os.path.basename(
+            summarizer._get_cache_filename(
+                domain_id="../evil.example.com\nx",
+                period_days=14,
+                cache_key="custom_2026-06-01_2026-06-07",
+                workspace_id=123,
+            )
+        )
+
+        assert filename.endswith(".json")
+        assert ".." not in filename
+        assert "\n" not in filename
+        assert "evil.example.com" not in filename
+        assert "custom_2026" not in filename
+        assert "123" not in filename
 
     def test_old_cache_without_change_summary_is_refreshed(self, db_session, summarizer):
         _seed_new_source_records(db_session)

--- a/backend/app/utils/stats_summarizer.py
+++ b/backend/app/utils/stats_summarizer.py
@@ -1,13 +1,14 @@
 import json
 import logging
 import os
-import re
 from datetime import datetime, timedelta, timezone
+from hashlib import sha256
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import case, func
 from sqlalchemy.orm import Session
 
+from app.core.redaction import sanitize_for_log
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
 
@@ -95,7 +96,11 @@ class StatsSummarizer:
             with open(cache_file, "r", encoding="utf-8") as f:
                 return json.load(f)
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.warning("Error reading cache file %s: %s", cache_file, str(e))
+            logger.warning(
+                "Error reading stats cache file %s: %s",
+                sanitize_for_log(os.path.basename(cache_file)),
+                sanitize_for_log(e),
+            )
             return None
 
     def save_summary(
@@ -134,7 +139,11 @@ class StatsSummarizer:
 
             return True
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error("Error writing cache file %s: %s", cache_file, str(e))
+            logger.error(
+                "Error writing stats cache file %s: %s",
+                sanitize_for_log(os.path.basename(cache_file)),
+                sanitize_for_log(e),
+            )
             return False
 
     def invalidate_cache(
@@ -149,18 +158,33 @@ class StatsSummarizer:
             domain_id: Optional domain ID to invalidate specific domain cache
                        If None, invalidates global summary cache
         """
-        workspace_prefix = f"workspace_{workspace_id}_" if workspace_id is not None else ""
-        if domain_id is None:
-            self._remove_cache_files(f"{workspace_prefix}global_summary")
-        else:
-            safe_domain = domain_id.replace(".", "_").replace("/", "_")
-            self._remove_cache_files(f"{workspace_prefix}domain_{safe_domain}")
+        self._remove_cache_files(self._cache_scope_prefix(domain_id, workspace_id))
 
     def _remove_cache_files(self, prefix: str) -> None:
         """Remove cached summary files that begin with the provided prefix."""
         for filename in os.listdir(self.cache_dir):
             if filename.startswith(prefix) and filename.endswith(".json"):
                 os.remove(os.path.join(self.cache_dir, filename))
+
+    @staticmethod
+    def _hash_cache_part(value: object) -> str:
+        """Return a short deterministic cache identifier for user-controlled input."""
+        return sha256(str(value).encode("utf-8")).hexdigest()[:16]
+
+    def _cache_scope_prefix(
+        self,
+        domain_id: Optional[str] = None,
+        workspace_id: Optional[int] = None,
+    ) -> str:
+        """Return the stable filename prefix for a workspace/domain cache scope."""
+        workspace_part = (
+            f"workspace_{self._hash_cache_part(workspace_id)}"
+            if workspace_id is not None
+            else "workspace_all"
+        )
+        if domain_id is None:
+            return f"{workspace_part}_global_summary"
+        return f"{workspace_part}_domain_{self._hash_cache_part(domain_id)}"
 
     def _get_cache_filename(
         self,
@@ -182,15 +206,9 @@ class StatsSummarizer:
         period_days = max(1, int(period_days or 30))
         suffix = f"{period_days}d"
         if cache_key:
-            safe_key = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(cache_key)).strip("_")
-            if safe_key:
-                suffix = f"{suffix}_{safe_key}"
-        workspace_prefix = f"workspace_{workspace_id}_" if workspace_id is not None else ""
-        if domain_id is None:
-            return os.path.join(self.cache_dir, f"{workspace_prefix}global_summary_{suffix}.json")
-        # Sanitize domain_id to use as filename
-        safe_domain = domain_id.replace(".", "_").replace("/", "_")
-        return os.path.join(self.cache_dir, f"{workspace_prefix}domain_{safe_domain}_{suffix}.json")
+            suffix = f"{suffix}_key_{self._hash_cache_part(cache_key)}"
+        prefix = self._cache_scope_prefix(domain_id, workspace_id)
+        return os.path.join(self.cache_dir, f"{prefix}_{suffix}.json")
 
     def calculate_summary_statistics(
         self,


### PR DESCRIPTION
## Summary

Backports the still-useful security hardening ideas found during the fork audit, adapted to current DMARQ instead of cherry-picking stale code.

Implemented:
- sign the short-lived Logto `next` cookie and ignore unsigned/tampered redirect cookies
- return generic IMAP/Gmail connector import errors to API clients while keeping sanitized details in logs/import diagnostics
- stop logging invalid API-key suffixes
- hash StatsSummarizer cache filename components for domains, workspaces, and date-range cache keys
- add regression coverage for the updated public error and cache contracts

Credit:
- Inspired by `jimmybrancaccio/dmarq` hardening commits `b7c555f`, `02ae07f`, `96ed499`, `6770398`, `db3f8c6`, `5f1e071`, and `1727e14`.

Fork audit follow-ups created separately because they are larger product slices, not safe direct cherry-picks:
- #320 resumable mailbox backfill jobs and progress tracking, inspired by `scheef-tech/dmarq`
- #321 Cloudflare Email Worker inbound webhook docs, inspired by `yscheef/dmarq` and `scheef-tech/dmarq`

## Validation

- `.venv/bin/python -m black --check backend/app/api/api_v1/endpoints/auth.py backend/app/api/api_v1/endpoints/imap.py backend/app/core/security.py backend/app/services/imap_client.py backend/app/services/mail_connector.py backend/app/utils/stats_summarizer.py backend/app/tests/test_auth.py backend/app/tests/test_gmail_client.py backend/app/tests/test_imap_client.py backend/app/tests/test_imap_endpoints.py backend/app/tests/test_stats_summarizer.py`
- `.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/auth.py backend/app/api/api_v1/endpoints/imap.py backend/app/core/security.py backend/app/services/imap_client.py backend/app/services/mail_connector.py backend/app/utils/stats_summarizer.py backend/app/tests/test_auth.py backend/app/tests/test_gmail_client.py backend/app/tests/test_imap_client.py backend/app/tests/test_imap_endpoints.py backend/app/tests/test_stats_summarizer.py`
- `.venv/bin/flake8 backend/app/api/api_v1/endpoints/auth.py backend/app/api/api_v1/endpoints/imap.py backend/app/core/security.py backend/app/services/imap_client.py backend/app/services/mail_connector.py backend/app/utils/stats_summarizer.py backend/app/tests/test_auth.py backend/app/tests/test_gmail_client.py backend/app/tests/test_imap_client.py backend/app/tests/test_imap_endpoints.py backend/app/tests/test_stats_summarizer.py`
- `.venv/bin/python -m pytest backend/app/tests/test_auth.py backend/app/tests/test_imap_endpoints.py backend/app/tests/test_imap_client.py backend/app/tests/test_gmail_client.py backend/app/tests/test_stats_summarizer.py -q`
