### PR TITLE
fix: show domain health grades on detail pages

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -276,12 +276,24 @@ class OperatorPlaybook(BaseModel):
     evidence: List[DNSHealthEvidence] = Field(default_factory=list)
 
 
+class DomainHealthGrade(BaseModel):
+    """Dashboard-consistent health grade for a single monitored domain."""
+
+    domain: str
+    score: int
+    grade: str
+    status: str
+    factors: Dict[str, float] = Field(default_factory=dict)
+    actions: List[Dict[str, Any]] = Field(default_factory=list)
+
+
 class PostureDashboardResponse(BaseModel):
     """Evidence-first posture dashboard response for a domain."""
 
     domain: str
     status: str
     score: int
+    health: DomainHealthGrade
     summary: str
     coverage: List[PostureCoverageItem]
     recommendations: List[DNSHealthRecommendation]
@@ -1133,9 +1145,50 @@ def _operator_playbooks(
     ][:6]
 
 
+async def _build_domain_health_grade(
+    db: Session,
+    domain_id: str,
+    store: ReportStore,
+    *,
+    refresh: bool = False,
+) -> Dict[str, Any]:
+    """Build the dashboard-grade health object for a domain detail page."""
+    manual_selectors = _get_domain_selectors_from_db(db, domain_id)
+    report_selectors = _get_selectors_from_reports(store, domain_id)
+    combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
+    provider = get_default_provider(db)
+    dns, _, _ = await resolve_domain_dns_cached(
+        db,
+        provider,
+        domain_id,
+        selectors=combined_selectors,
+        refresh=refresh,
+    )
+    summary = store.get_domain_summary(domain_id)
+    live_policy = extract_dmarc_policy(dns.dmarc_record)
+    reported_policy = _normalize_reported_policy(summary.get("policy", {}))
+    domain_row = {
+        "id": domain_id,
+        "domain_name": domain_id,
+        "total_emails": summary.get("total_count", 0),
+        "passed_count": summary.get("passed_count", 0),
+        "failed_count": summary.get("failed_count", 0),
+        "pass_rate": summary.get("compliance_rate", 0),
+        "report_count": summary.get("reports_processed", 0),
+        "dmarc_status": dns.dmarc,
+        "dmarc_policy": live_policy or reported_policy or "none",
+        "spf_status": dns.spf,
+        "dkim_status": dns.dkim,
+        "dmarc_warnings": dns.dmarc_warnings,
+        "dmarc_suggestions": dns.dmarc_suggestions,
+    }
+    return score_domain_health(domain_row)
+
+
 def _build_posture_dashboard(
     domain_id: str,
     health: DNSHealthResponse,
+    domain_health: Dict[str, Any],
     changes: List[Dict[str, Any]],
 ) -> PostureDashboardResponse:
     passing = sum(1 for check in health.checks if check.status == "pass")
@@ -1155,6 +1208,7 @@ def _build_posture_dashboard(
         domain=domain_id,
         status=health.status,
         score=score,
+        health=domain_health,
         summary=_posture_summary(health),
         coverage=coverage,
         recommendations=health.recommendations,
@@ -1652,8 +1706,9 @@ async def get_domain_posture_dashboard(
         )
 
     health = await _build_domain_dns_health(db, store, domain_id, refresh=refresh)
+    domain_health = await _build_domain_health_grade(db, domain_id, store)
     changes = list_dns_record_changes(db, domain_id, limit=10)
-    return _build_posture_dashboard(domain_id, health, changes)
+    return _build_posture_dashboard(domain_id, health, domain_health, changes)
 
 
 @router.get("/{domain_id}/dns/mta-sts", response_model=MTAStsResponse)

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -148,17 +148,29 @@
                               :class="postureStatusClass"
                               x-text="posture.status || 'checking'"></span>
                         <div class="mt-1 text-xs text-base-content/60">
-                            <span x-text="posture.score"></span><span>/100</span>
+                            <span>Grade </span><span x-text="posture.health.grade || '-'"></span>
                         </div>
                     </div>
                 </div>
             {% endcall %}
             {% call card_content() %}
-                <div class="grid gap-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+                <div class="grid gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
                     <div class="rounded-lg bg-[#f4f3f2] p-4">
-                        <div class="text-sm text-[#5f5c78]">Posture score</div>
-                        <div class="mt-2 text-4xl font-bold text-[#120d36]" x-text="posture.score"></div>
-                        <p class="mt-2 text-sm text-[#5f5c78]" x-text="posture.summary"></p>
+                        <div class="text-sm text-[#5f5c78]">Domain health grade</div>
+                        <div class="mt-2 flex items-end gap-3">
+                            <div class="text-5xl font-bold text-[#120d36]" x-text="posture.health.grade || '-'"></div>
+                            <div class="pb-1 text-sm text-[#5f5c78]">
+                                <span x-text="posture.health.score"></span><span>/100</span>
+                            </div>
+                        </div>
+                        <div class="mt-3 flex flex-wrap gap-2 text-xs">
+                            <span class="rounded bg-white px-2 py-1 font-semibold text-[#272a5f]">
+                                <span x-text="posture.score"></span><span>/100 posture</span>
+                            </span>
+                            <span class="rounded bg-white px-2 py-1 font-semibold capitalize text-[#272a5f]"
+                                  x-text="posture.health.status || 'checking'"></span>
+                        </div>
+                        <p class="mt-3 text-sm text-[#5f5c78]" x-text="posture.summary"></p>
                     </div>
                     <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
                         <template x-for="item in posture.coverage" :key="item.key">
@@ -804,6 +816,13 @@ function domainDetailsApp(domainId) {
         posture: {
             status: '',
             score: 0,
+            health: {
+                grade: '',
+                score: 0,
+                status: '',
+                factors: {},
+                actions: []
+            },
             summary: '',
             coverage: [],
             recommendations: [],

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -744,6 +744,9 @@ def test_posture_dashboard_links_recommendations_changes_and_playbooks(
     data = response.json()
     assert data["status"] == "degraded"
     assert data["score"] == 80
+    assert data["health"]["domain"] == DOMAIN
+    assert data["health"]["grade"] in {"A+", "A", "A-", "B+", "B", "B-", "C", "D", "F"}
+    assert isinstance(data["health"]["score"], int)
     assert any(item["key"] == "spf" and item["href"] == "#dns-records" for item in data["coverage"])
     missing_spf_recommendation = next(
         item for item in data["recommendations"] if item["type"] == "missing_spf"


### PR DESCRIPTION
## Summary

Fixes the domain detail page so it shows the same domain health grade model used on the dashboard.

- adds `health` to `/api/v1/domains/{domain}/posture` with score, grade, status, factors, and actions
- keeps the existing posture coverage score separate as `posture.score`
- renders `Domain health grade`, e.g. `C` and `74/100`, on the detail page
- covers the posture response with a regression assertion

## Validation

- `.venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py backend/app/tests/test_health_score.py -q`
- local demo API: `/api/v1/domains/dmarq.com/posture` returns `health.grade=C`, `health.score=74`, and `score=60`
- Playwright local detail page check: `/domains/dmarq.com` renders `Grade C`, `Domain health grade`, `74/100`, and `60/100 posture`; 0 console errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new domain health grade to the Posture Dashboard, showing grade, score, status, factors, and recommended actions.
  * Updated the dashboard header and summary card to display the domain health grade alongside the existing posture score.
* **Bug Fixes**
  * Improved dashboard data handling so health details are always initialized and shown consistently.
* **Tests**
  * Expanded dashboard checks to verify the new health information is returned with expected values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->