### PR TITLE
fix: refresh posture health grade DNS

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1708,7 +1708,12 @@ async def get_domain_posture_dashboard(
         )
 
     health = await _build_domain_dns_health(db, store, domain_id, refresh=refresh)
-    domain_health = await _build_domain_health_grade(db, domain_id, store)
+    domain_health = await _build_domain_health_grade(
+        db,
+        domain_id,
+        store,
+        refresh=refresh,
+    )
     changes = list_dns_record_changes(db, domain_id, limit=10)
     return _build_posture_dashboard(domain_id, health, domain_health, changes)
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -757,6 +757,37 @@ def test_posture_dashboard_links_recommendations_changes_and_playbooks(
     assert any(playbook["key"] == "missing_spf" for playbook in data["playbooks"])
 
 
+def test_posture_dashboard_refreshes_health_grade_dns(
+    authed_client: TestClient,
+):
+    """refresh=true must refresh both posture checks and the domain health grade."""
+    checked_at = datetime(2026, 5, 23, 12, 0, 0)
+    resolver = AsyncMock(return_value=(MOCK_DNS_RESULT, False, checked_at))
+    mta_sts = MTAStsResult(status="missing")
+    bimi = BIMIResult(status="missing")
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains.resolve_domain_dns_cached",
+            new=resolver,
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(mta_sts, False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(bimi, False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/posture?refresh=true")
+
+    assert response.status_code == 200
+    assert response.json()["health"]["domain"] == DOMAIN
+    assert resolver.await_count == 2
+    assert all(call.kwargs["refresh"] is True for call in resolver.await_args_list)
+
+
 def test_posture_dashboard_returns_404_for_unknown_domain(authed_client: TestClient):
     response = authed_client.get("/api/v1/domains/unknown.example.com/posture")
 


### PR DESCRIPTION
## Description
Fixes a stale-health edge case in the domain posture endpoint. `/api/v1/domains/{domain}/posture?refresh=true` already refreshed the technical posture DNS checks, but the dashboard health grade reused the cached DNS path because the refresh flag was not forwarded.

Closes #324

## Changes Made
- Forward `refresh=refresh` into `_build_domain_health_grade()` from the posture endpoint.
- Add a regression test that asserts `refresh=true` refreshes both posture DNS checks and the health-grade DNS lookup.

## Testing Performed
- `.venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py backend/app/tests/test_health_score.py -q`
- `.venv/bin/python -m black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`
- `.venv/bin/python -m isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`
- `.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`