### PR TITLE
feat: add mail source backfill job state API

### DIFF
--- a/backend/alembic/versions/a0b1c2d3e4f5_add_mail_source_backfill_jobs.py
+++ b/backend/alembic/versions/a0b1c2d3e4f5_add_mail_source_backfill_jobs.py
@@ -1,0 +1,122 @@
+"""add mail source backfill jobs
+
+Revision ID: a0b1c2d3e4f5
+Revises: 9d0e1f2a3b4c
+Create Date: 2026-06-29 03:10:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a0b1c2d3e4f5"
+down_revision: Union[str, Sequence[str], None] = "9d0e1f2a3b4c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create persisted mailbox backfill progress rows."""
+    op.create_index(
+        "ix_mail_sources_id_workspace_id_unique",
+        "mail_sources",
+        ["id", "workspace_id"],
+        unique=True,
+    )
+    op.create_table(
+        "mail_source_backfill_jobs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("workspace_id", sa.Integer(), nullable=False),
+        sa.Column("mail_source_id", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=24), nullable=False, server_default="queued"),
+        sa.Column("trigger", sa.String(length=40), nullable=False, server_default="manual"),
+        sa.Column("requested_start", sa.DateTime(), nullable=True),
+        sa.Column("requested_end", sa.DateTime(), nullable=True),
+        sa.Column("requested_by", sa.String(length=120), nullable=True),
+        sa.Column("processed", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("reports_found", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("duplicate_reports", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("max_attempts", sa.Integer(), nullable=False, server_default="3"),
+        sa.Column("cursor", sa.String(length=255), nullable=True),
+        sa.Column("errors", sa.Text(), nullable=True),
+        sa.Column("details", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("cancelled_at", sa.DateTime(), nullable=True),
+        sa.Column("next_retry_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(
+            ["mail_source_id", "workspace_id"],
+            ["mail_sources.id", "mail_sources.workspace_id"],
+            name="fk_mail_source_backfill_source_workspace",
+        ),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_mail_source_backfill_jobs_id"), "mail_source_backfill_jobs", ["id"])
+    op.create_index(
+        op.f("ix_mail_source_backfill_jobs_workspace_id"),
+        "mail_source_backfill_jobs",
+        ["workspace_id"],
+    )
+    op.create_index(
+        op.f("ix_mail_source_backfill_jobs_mail_source_id"),
+        "mail_source_backfill_jobs",
+        ["mail_source_id"],
+    )
+    op.create_index(
+        op.f("ix_mail_source_backfill_jobs_status"),
+        "mail_source_backfill_jobs",
+        ["status"],
+    )
+    op.create_index(
+        op.f("ix_mail_source_backfill_jobs_created_at"),
+        "mail_source_backfill_jobs",
+        ["created_at"],
+    )
+    op.create_index(
+        "ix_mail_source_backfill_workspace_status",
+        "mail_source_backfill_jobs",
+        ["workspace_id", "status"],
+    )
+    op.create_index(
+        "ix_mail_source_backfill_source_status",
+        "mail_source_backfill_jobs",
+        ["mail_source_id", "status"],
+    )
+    op.create_index(
+        "ix_mail_source_backfill_retry",
+        "mail_source_backfill_jobs",
+        ["status", "next_retry_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop mailbox backfill progress rows."""
+    op.drop_index("ix_mail_source_backfill_retry", table_name="mail_source_backfill_jobs")
+    op.drop_index("ix_mail_source_backfill_source_status", table_name="mail_source_backfill_jobs")
+    op.drop_index(
+        "ix_mail_source_backfill_workspace_status",
+        table_name="mail_source_backfill_jobs",
+    )
+    op.drop_index(
+        op.f("ix_mail_source_backfill_jobs_created_at"), table_name="mail_source_backfill_jobs"
+    )
+    op.drop_index(
+        op.f("ix_mail_source_backfill_jobs_status"), table_name="mail_source_backfill_jobs"
+    )
+    op.drop_index(
+        op.f("ix_mail_source_backfill_jobs_mail_source_id"),
+        table_name="mail_source_backfill_jobs",
+    )
+    op.drop_index(
+        op.f("ix_mail_source_backfill_jobs_workspace_id"),
+        table_name="mail_source_backfill_jobs",
+    )
+    op.drop_index(op.f("ix_mail_source_backfill_jobs_id"), table_name="mail_source_backfill_jobs")
+    op.drop_table("mail_source_backfill_jobs")
+    op.drop_index("ix_mail_sources_id_workspace_id_unique", table_name="mail_sources")

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -23,6 +23,7 @@ from app.core.redaction import sanitize_for_log
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.mail_source import MailSource
+from app.models.mail_source_backfill import MailSourceBackfillJob
 from app.models.mail_source_import import MailSourceImport
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
@@ -50,6 +51,9 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 _OAUTH_STATE_ALGORITHM = "HS256"
 _OAUTH_STATE_TTL = timedelta(minutes=10)
+BACKFILL_RETRYABLE_STATUSES = {"failed", "cancelled", "backoff"}
+BACKFILL_CANCELABLE_STATUSES = {"queued", "running", "backoff"}
+BACKFILL_SUPPORTED_METHODS = {"IMAP", "GMAIL_API", "M365_GRAPH"}
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +174,42 @@ class MailSourceImportResponse(BaseModel):
     started_at: datetime
     finished_at: datetime
     created_at: datetime
+
+
+class MailSourceBackfillCreate(BaseModel):
+    """Request body for creating a resumable mailbox backfill job."""
+
+    requested_start: Optional[datetime] = None
+    requested_end: Optional[datetime] = None
+    max_attempts: int = 3
+
+
+class MailSourceBackfillResponse(BaseModel):
+    """Persisted progress state for one mailbox backfill job."""
+
+    id: int
+    workspace_id: int
+    mail_source_id: int
+    status: str
+    trigger: str
+    requested_start: Optional[datetime] = None
+    requested_end: Optional[datetime] = None
+    requested_by: Optional[str] = None
+    processed: int
+    reports_found: int
+    duplicate_reports: int
+    error_count: int
+    attempt_count: int
+    max_attempts: int
+    cursor: Optional[str] = None
+    errors: List[str]
+    details: List[Dict[str, str]]
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    cancelled_at: Optional[datetime] = None
+    next_retry_at: Optional[datetime] = None
+    created_at: datetime
+    updated_at: datetime
 
 
 # ---------------------------------------------------------------------------
@@ -482,6 +522,89 @@ def _import_to_response(row: MailSourceImport) -> MailSourceImportResponse:
     )
 
 
+def _auth_actor(auth_context: Dict[str, Any]) -> Optional[str]:
+    """Return a compact operator identifier for audit-friendly job metadata."""
+    for key in ("user_id", "sub", "email", "auth_type"):
+        value = auth_context.get(key)
+        if value not in (None, ""):
+            return str(value)[:120]
+    return None
+
+
+def _backfill_to_response(row: MailSourceBackfillJob) -> MailSourceBackfillResponse:
+    """Convert a backfill job ORM row to an API response."""
+    return MailSourceBackfillResponse(
+        id=row.id,
+        workspace_id=row.workspace_id,
+        mail_source_id=row.mail_source_id,
+        status=row.status,
+        trigger=row.trigger,
+        requested_start=row.requested_start,
+        requested_end=row.requested_end,
+        requested_by=row.requested_by,
+        processed=row.processed,
+        reports_found=row.reports_found,
+        duplicate_reports=row.duplicate_reports,
+        error_count=row.error_count,
+        attempt_count=row.attempt_count,
+        max_attempts=row.max_attempts,
+        cursor=row.cursor,
+        errors=_decode_json_list(row.errors),
+        details=_decode_json_details(row.details),
+        started_at=row.started_at,
+        finished_at=row.finished_at,
+        cancelled_at=row.cancelled_at,
+        next_retry_at=row.next_retry_at,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _validate_backfill_request(payload: MailSourceBackfillCreate) -> None:
+    if payload.max_attempts < 1 or payload.max_attempts > 10:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="max_attempts must be between 1 and 10.",
+        )
+    if payload.requested_start and payload.requested_end:
+        if payload.requested_start > payload.requested_end:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="requested_start must be before requested_end.",
+            )
+
+
+def _ensure_backfill_supported(source: MailSource) -> None:
+    if source.method not in BACKFILL_SUPPORTED_METHODS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Backfill jobs are not available for method '{source.method}'.",
+        )
+
+
+def _get_backfill_or_404(
+    job_id: int,
+    source: MailSource,
+    workspace,
+    db: Session,
+) -> MailSourceBackfillJob:
+    row = (
+        db.query(MailSourceBackfillJob)
+        .filter(
+            MailSourceBackfillJob.id == job_id,
+            MailSourceBackfillJob.mail_source_id == source.id,
+            MailSourceBackfillJob.workspace_id == workspace.id,
+        )
+        .first()
+    )
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Backfill job {job_id} not found",
+        )
+    return row
+
+
 def _fetch_response(source: MailSource, results: Dict[str, Any]) -> Dict[str, Any]:
     """Build the common response payload for a manual source fetch."""
     diagnostic = import_result_diagnostic(results)
@@ -733,6 +856,225 @@ async def list_mail_source_imports(
         .all()
     )
     return [_import_to_response(row) for row in rows]
+
+
+@router.get("/{source_id}/backfills", response_model=List[MailSourceBackfillResponse])
+async def list_mail_source_backfills(
+    source_id: int,
+    limit: int = Query(20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> List[MailSourceBackfillResponse]:
+    """Return recent resumable mailbox backfill jobs for one mail source."""
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_id(selected_workspace),
+    )
+    _get_source_or_404(source_id, db, workspace)
+    rows = (
+        db.query(MailSourceBackfillJob)
+        .filter(
+            MailSourceBackfillJob.mail_source_id == source_id,
+            MailSourceBackfillJob.workspace_id == workspace.id,
+        )
+        .order_by(MailSourceBackfillJob.created_at.desc(), MailSourceBackfillJob.id.desc())
+        .limit(limit)
+        .all()
+    )
+    return [_backfill_to_response(row) for row in rows]
+
+
+@router.post(
+    "/{source_id}/backfills",
+    response_model=MailSourceBackfillResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_mail_source_backfill(
+    source_id: int,
+    payload: MailSourceBackfillCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> MailSourceBackfillResponse:
+    """Queue a resumable mailbox backfill job without running the connector inline."""
+    _validate_backfill_request(payload)
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_id(selected_workspace),
+    )
+    source = _get_source_or_404(source_id, db, workspace)
+    _ensure_backfill_supported(source)
+    _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.backfill.create")
+
+    now = datetime.utcnow()
+    row = MailSourceBackfillJob(
+        workspace_id=workspace.id,
+        mail_source_id=source.id,
+        status="queued",
+        trigger="manual",
+        requested_start=payload.requested_start,
+        requested_end=payload.requested_end,
+        requested_by=_auth_actor(_auth),
+        max_attempts=payload.max_attempts,
+        errors="[]",
+        details="[]",
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    db.flush()
+    record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action="mail_source.backfill_queued",
+        entity_type="mail_source_backfill",
+        entity_id=row.id,
+        entity_name=source.name,
+        details={
+            "mail_source_id": source.id,
+            "requested_start": (
+                payload.requested_start.isoformat() if payload.requested_start else None
+            ),
+            "requested_end": payload.requested_end.isoformat() if payload.requested_end else None,
+        },
+        auth_context=_auth,
+        request=request,
+        commit=False,
+    )
+    db.commit()
+    db.refresh(row)
+    return _backfill_to_response(row)
+
+
+@router.get(
+    "/{source_id}/backfills/{job_id}",
+    response_model=MailSourceBackfillResponse,
+)
+async def get_mail_source_backfill(
+    source_id: int,
+    job_id: int,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> MailSourceBackfillResponse:
+    """Return one mailbox backfill job for a workspace-scoped mail source."""
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_id(selected_workspace),
+    )
+    source = _get_source_or_404(source_id, db, workspace)
+    row = _get_backfill_or_404(job_id, source, workspace, db)
+    return _backfill_to_response(row)
+
+
+@router.post(
+    "/{source_id}/backfills/{job_id}/cancel",
+    response_model=MailSourceBackfillResponse,
+)
+async def cancel_mail_source_backfill(
+    source_id: int,
+    job_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> MailSourceBackfillResponse:
+    """Mark a queued/running/backoff mailbox backfill job as cancelled."""
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_id(selected_workspace),
+    )
+    source = _get_source_or_404(source_id, db, workspace)
+    row = _get_backfill_or_404(job_id, source, workspace, db)
+    if row.status not in BACKFILL_CANCELABLE_STATUSES:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Backfill job in status '{row.status}' cannot be cancelled.",
+        )
+
+    now = datetime.utcnow()
+    row.status = "cancelled"
+    row.cancelled_at = now
+    row.finished_at = row.finished_at or now
+    row.next_retry_at = None
+    row.updated_at = now
+    record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action="mail_source.backfill_cancelled",
+        entity_type="mail_source_backfill",
+        entity_id=row.id,
+        entity_name=source.name,
+        details={"mail_source_id": source.id},
+        auth_context=_auth,
+        request=request,
+        commit=False,
+    )
+    db.commit()
+    db.refresh(row)
+    return _backfill_to_response(row)
+
+
+@router.post(
+    "/{source_id}/backfills/{job_id}/retry",
+    response_model=MailSourceBackfillResponse,
+)
+async def retry_mail_source_backfill(
+    source_id: int,
+    job_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> MailSourceBackfillResponse:
+    """Re-queue a failed, cancelled, or backoff mailbox backfill job."""
+    workspace = _authorized_mail_source_workspace(
+        _auth,
+        db,
+        _selected_workspace_id(selected_workspace),
+    )
+    source = _get_source_or_404(source_id, db, workspace)
+    row = _get_backfill_or_404(job_id, source, workspace, db)
+    if row.status not in BACKFILL_RETRYABLE_STATUSES:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Backfill job in status '{row.status}' cannot be retried.",
+        )
+    if row.attempt_count >= row.max_attempts:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Backfill job has reached max_attempts.",
+        )
+
+    now = datetime.utcnow()
+    row.status = "queued"
+    row.attempt_count += 1
+    row.started_at = None
+    row.cancelled_at = None
+    row.finished_at = None
+    row.next_retry_at = None
+    row.updated_at = now
+    record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action="mail_source.backfill_retried",
+        entity_type="mail_source_backfill",
+        entity_id=row.id,
+        entity_name=source.name,
+        details={"mail_source_id": source.id, "attempt_count": row.attempt_count},
+        auth_context=_auth,
+        request=request,
+        commit=False,
+    )
+    db.commit()
+    db.refresh(row)
+    return _backfill_to_response(row)
 
 
 @router.post("/{source_id}/fetch", response_model=Dict[str, Any])

--- a/backend/app/models/mail_source.py
+++ b/backend/app/models/mail_source.py
@@ -81,9 +81,17 @@ class MailSource(Base):
         back_populates="mail_source",
         cascade="all, delete-orphan",
     )
+    backfill_jobs = relationship(
+        "MailSourceBackfillJob",
+        back_populates="mail_source",
+        cascade="all, delete-orphan",
+    )
     workspace = relationship("Workspace", back_populates="mail_sources")
 
-    __table_args__ = (Index("ix_mail_sources_workspace_enabled", "workspace_id", "enabled"),)
+    __table_args__ = (
+        Index("ix_mail_sources_workspace_enabled", "workspace_id", "enabled"),
+        Index("ix_mail_sources_id_workspace_id_unique", "id", "workspace_id", unique=True),
+    )
 
     def __repr__(self):
         return f"<MailSource id={self.id} name={self.name!r} method={self.method!r}>"

--- a/backend/app/models/mail_source_backfill.py
+++ b/backend/app/models/mail_source_backfill.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class MailSourceBackfillJob(Base):
+    """Persisted progress row for a resumable mailbox backfill request."""
+
+    __tablename__ = "mail_source_backfill_jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    workspace_id = Column(Integer, ForeignKey("workspaces.id"), nullable=False, index=True)
+    mail_source_id = Column(Integer, nullable=False, index=True)
+
+    status = Column(String(length=24), nullable=False, default="queued", index=True)
+    trigger = Column(String(length=40), nullable=False, default="manual")
+    requested_start = Column(DateTime, nullable=True)
+    requested_end = Column(DateTime, nullable=True)
+    requested_by = Column(String(length=120), nullable=True)
+
+    processed = Column(Integer, nullable=False, default=0)
+    reports_found = Column(Integer, nullable=False, default=0)
+    duplicate_reports = Column(Integer, nullable=False, default=0)
+    error_count = Column(Integer, nullable=False, default=0)
+    attempt_count = Column(Integer, nullable=False, default=0)
+    max_attempts = Column(Integer, nullable=False, default=3)
+
+    cursor = Column(String(length=255), nullable=True)
+    errors = Column(Text, nullable=True)
+    details = Column(Text, nullable=True)
+
+    started_at = Column(DateTime, nullable=True)
+    finished_at = Column(DateTime, nullable=True)
+    cancelled_at = Column(DateTime, nullable=True)
+    next_retry_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow, index=True)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    mail_source = relationship("MailSource", back_populates="backfill_jobs")
+    workspace = relationship("Workspace", overlaps="backfill_jobs,mail_source")
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["mail_source_id", "workspace_id"],
+            ["mail_sources.id", "mail_sources.workspace_id"],
+            name="fk_mail_source_backfill_source_workspace",
+        ),
+        Index("ix_mail_source_backfill_workspace_status", "workspace_id", "status"),
+        Index("ix_mail_source_backfill_source_status", "mail_source_id", "status"),
+        Index("ix_mail_source_backfill_retry", "status", "next_retry_at"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<MailSourceBackfillJob id={self.id} source={self.mail_source_id} "
+            f"status={self.status!r}>"
+        )

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -13,6 +13,7 @@ import app.models.api_token  # noqa: F401  # pylint: disable=unused-import
 import app.models.dns_cache  # noqa: F401  # pylint: disable=unused-import
 import app.models.domain  # noqa: F401  # pylint: disable=unused-import
 import app.models.mail_source as _mail_source_model  # noqa: F401  # pylint: disable=unused-import
+import app.models.mail_source_backfill as _mail_source_backfill_model  # noqa: F401  # pylint: disable=unused-import
 import app.models.mail_source_import  # noqa: F401  # pylint: disable=unused-import
 import app.models.report  # noqa: F401  # pylint: disable=unused-import
 import app.models.setting  # noqa: F401  # pylint: disable=unused-import

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -23,6 +23,7 @@ from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.mail_source import MailSource
+from app.models.mail_source_backfill import MailSourceBackfillJob
 from app.models.mail_source_import import MailSourceImport
 from app.models.user import User
 from app.models.workspace import Workspace
@@ -476,6 +477,41 @@ class TestMailSourceImportModel:
         assert "**redacted**" in attempt.details
 
 
+class TestMailSourceBackfillModel:
+    """Unit tests for persisted mail source backfill progress rows."""
+
+    def test_create_backfill_job_row(self, db_session: Session):
+        workspace = get_or_create_default_workspace(db_session)
+        source = MailSource(
+            workspace_id=workspace.id,
+            name="Backfill Source",
+            method="IMAP",
+        )
+        db_session.add(source)
+        db_session.flush()
+
+        row = MailSourceBackfillJob(
+            workspace_id=workspace.id,
+            mail_source_id=source.id,
+            status="queued",
+            requested_by="operator@example.com",
+            processed=10,
+            reports_found=2,
+            duplicate_reports=1,
+            errors='["temporary failure"]',
+            details='[{"status": "queued"}]',
+        )
+        db_session.add(row)
+        db_session.commit()
+        db_session.refresh(row)
+
+        assert row.id is not None
+        assert row.workspace_id == workspace.id
+        assert row.mail_source_id == source.id
+        assert row.mail_source.name == "Backfill Source"
+        assert row.status == "queued"
+
+
 def test_mail_source_folder_input_has_no_pattern_validation():
     """The UI should not reject valid IMAP folder names containing spaces."""
     template = (Path(__file__).resolve().parents[1] / "templates" / "mail_sources.html").read_text()
@@ -869,6 +905,176 @@ class TestMailSourcesAPIAuthed:
     def test_list_import_history_unknown_source_returns_404(self, authed_client: TestClient):
         resp = authed_client.get("/api/v1/mail-sources/99999/imports")
         assert resp.status_code == 404
+
+    def test_create_and_list_backfill_job(self, authed_client: TestClient):
+        create_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            json={"name": "Backfill API", "method": "IMAP"},
+        )
+        source_id = create_resp.json()["id"]
+
+        response = authed_client.post(
+            f"/api/v1/mail-sources/{source_id}/backfills",
+            json={
+                "requested_start": "2026-05-01T00:00:00",
+                "requested_end": "2026-05-31T23:59:59",
+                "max_attempts": 4,
+            },
+        )
+
+        assert response.status_code == 201
+        job = response.json()
+        assert job["mail_source_id"] == source_id
+        assert job["status"] == "queued"
+        assert job["trigger"] == "manual"
+        assert job["requested_start"] == "2026-05-01T00:00:00"
+        assert job["requested_end"] == "2026-05-31T23:59:59"
+        assert job["max_attempts"] == 4
+        assert job["errors"] == []
+        assert job["details"] == []
+
+        list_response = authed_client.get(f"/api/v1/mail-sources/{source_id}/backfills")
+        get_response = authed_client.get(f"/api/v1/mail-sources/{source_id}/backfills/{job['id']}")
+
+        assert list_response.status_code == 200
+        assert [item["id"] for item in list_response.json()] == [job["id"]]
+        assert get_response.status_code == 200
+        assert get_response.json()["id"] == job["id"]
+
+    def test_backfill_jobs_respect_selected_workspace_header(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        get_or_create_default_workspace(db_session)
+        selected_workspace = Workspace(
+            slug="selected-backfill",
+            name="Selected Backfill",
+        )
+        db_session.add(selected_workspace)
+        db_session.commit()
+        selected_header = {"X-DMARQ-Workspace-ID": str(selected_workspace.id)}
+
+        create_response = authed_client.post(
+            "/api/v1/mail-sources",
+            headers=selected_header,
+            json={"name": "Selected Backfill IMAP", "method": "IMAP"},
+        )
+        source_id = create_response.json()["id"]
+        job_response = authed_client.post(
+            f"/api/v1/mail-sources/{source_id}/backfills",
+            headers=selected_header,
+            json={},
+        )
+        job_id = job_response.json()["id"]
+
+        default_list = authed_client.get(f"/api/v1/mail-sources/{source_id}/backfills")
+        selected_list = authed_client.get(
+            f"/api/v1/mail-sources/{source_id}/backfills",
+            headers=selected_header,
+        )
+        default_get = authed_client.get(f"/api/v1/mail-sources/{source_id}/backfills/{job_id}")
+
+        assert default_list.status_code == 404
+        assert selected_list.status_code == 200
+        assert [item["id"] for item in selected_list.json()] == [job_id]
+        assert default_get.status_code == 404
+
+    def test_cancel_and_retry_backfill_job(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        create_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            json={"name": "Backfill Lifecycle", "method": "IMAP"},
+        )
+        source_id = create_resp.json()["id"]
+        job_id = authed_client.post(
+            f"/api/v1/mail-sources/{source_id}/backfills",
+            json={"max_attempts": 2},
+        ).json()["id"]
+
+        cancel_response = authed_client.post(
+            f"/api/v1/mail-sources/{source_id}/backfills/{job_id}/cancel"
+        )
+        row = db_session.get(MailSourceBackfillJob, job_id)
+        row.started_at = datetime.utcnow()
+        db_session.commit()
+        retry_response = authed_client.post(
+            f"/api/v1/mail-sources/{source_id}/backfills/{job_id}/retry"
+        )
+
+        db_session.refresh(row)
+        assert cancel_response.status_code == 200
+        assert cancel_response.json()["status"] == "cancelled"
+        assert cancel_response.json()["cancelled_at"] is not None
+        assert retry_response.status_code == 200
+        assert retry_response.json()["status"] == "queued"
+        assert retry_response.json()["attempt_count"] == 1
+        assert retry_response.json()["started_at"] is None
+        assert row.status == "queued"
+        assert row.started_at is None
+
+    def test_backfill_rejects_invalid_window_and_unsupported_method(
+        self,
+        authed_client: TestClient,
+    ):
+        imap_id = authed_client.post(
+            "/api/v1/mail-sources",
+            json={"name": "Bad Backfill Window", "method": "IMAP"},
+        ).json()["id"]
+        pop_id = authed_client.post(
+            "/api/v1/mail-sources",
+            json={"name": "POP3 Backfill", "method": "POP3"},
+        ).json()["id"]
+
+        bad_window = authed_client.post(
+            f"/api/v1/mail-sources/{imap_id}/backfills",
+            json={
+                "requested_start": "2026-06-01T00:00:00",
+                "requested_end": "2026-05-01T00:00:00",
+            },
+        )
+        unsupported = authed_client.post(
+            f"/api/v1/mail-sources/{pop_id}/backfills",
+            json={},
+        )
+
+        assert bad_window.status_code == 422
+        assert unsupported.status_code == 400
+        assert "POP3" in unsupported.json()["detail"]
+
+    def test_retry_backfill_rejects_active_or_exhausted_jobs(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        create_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            json={"name": "Backfill Retry Guard", "method": "IMAP"},
+        )
+        source_id = create_resp.json()["id"]
+        queued_job = authed_client.post(
+            f"/api/v1/mail-sources/{source_id}/backfills",
+            json={},
+        ).json()
+
+        queued_retry = authed_client.post(
+            f"/api/v1/mail-sources/{source_id}/backfills/{queued_job['id']}/retry"
+        )
+
+        row = db_session.get(MailSourceBackfillJob, queued_job["id"])
+        row.status = "failed"
+        row.attempt_count = row.max_attempts
+        db_session.commit()
+        exhausted_retry = authed_client.post(
+            f"/api/v1/mail-sources/{source_id}/backfills/{queued_job['id']}/retry"
+        )
+
+        assert queued_retry.status_code == 409
+        assert exhausted_retry.status_code == 409
+        assert "max_attempts" in exhausted_retry.json()["detail"]
 
     def test_get_nonexistent_source_returns_404(self, authed_client: TestClient):
         resp = authed_client.get("/api/v1/mail-sources/99999")


### PR DESCRIPTION
Refs #320

## What changed
- Add a workspace-scoped mail_source_backfill_jobs table for resumable mailbox backfill progress.
- Add API endpoints to list, create, inspect, cancel, and retry backfill jobs for IMAP, Gmail API, and Microsoft 365 Graph mail sources.
- Add audit events and tests for lifecycle, workspace scoping, invalid windows, unsupported sources, and retry guards.

## Scope
This is the persistence and API lifecycle slice only. It does not run connector backfills yet, and it does not add the UI progress surface or demo examples.

## Validation
- ./.venv/bin/python -m pytest backend/app/tests/test_mail_sources.py -q
- ./.venv/bin/python -m black --check backend/app/api/api_v1/endpoints/mail_sources.py backend/app/models/mail_source.py backend/app/models/mail_source_backfill.py backend/app/tests/conftest.py backend/app/tests/test_mail_sources.py backend/alembic/versions/a0b1c2d3e4f5_add_mail_source_backfill_jobs.py
- ./.venv/bin/python -m isort --check-only backend/app/api/api_v1/endpoints/mail_sources.py backend/app/models/mail_source.py backend/app/models/mail_source_backfill.py backend/app/tests/conftest.py backend/app/tests/test_mail_sources.py backend/alembic/versions/a0b1c2d3e4f5_add_mail_source_backfill_jobs.py
- ./.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/mail_sources.py backend/app/models/mail_source.py backend/app/models/mail_source_backfill.py backend/app/tests/conftest.py backend/app/tests/test_mail_sources.py backend/alembic/versions/a0b1c2d3e4f5_add_mail_source_backfill_jobs.py
- DATABASE_URL=sqlite:////tmp/dmarq-backfill-alembic.db PYTHONPATH=backend ./.venv/bin/python -m alembic -c backend/alembic.ini upgrade head

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mailbox backfill job tracking, including job status, progress, retry, and cancellation support.
  * Added new API endpoints to create, list, view, cancel, and retry backfill jobs.
  * Backfill jobs now appear in mail source records for easier tracking.

* **Bug Fixes**
  * Enforced workspace scoping and validation for backfill requests.
  * Prevented retries for jobs that are still active or have exceeded their retry limit.

* **Tests**
  * Expanded automated coverage for backfill job creation, lifecycle actions, and access checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->