### PR TITLE
feat: add guided demo journey

### DIFF
--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -63,6 +63,78 @@ def build_demo_multi_user_deployment() -> Dict[str, Any]:
         },
         "roles": list(DEMO_MULTI_USER_ROLES),
         "default_viewer": "single-user-multiple-domains",
+        "journey_steps": [
+            {
+                "step": 1,
+                "label": "Start in the daily domain view",
+                "zoom_level": "workspace",
+                "scenario_id": "single-user-multiple-domains",
+                "organization_slug": "dmarq-foundation",
+                "workspace_slug": "dmarq-org",
+                "domain": "dmarq.org",
+                "action": "Inspect dmarq.org and dmarq.com as one administrator.",
+                "expected_takeaway": (
+                    "DMARQ first explains normal domain posture, sender alignment, "
+                    "and DNS actions for the account you own."
+                ),
+            },
+            {
+                "step": 2,
+                "label": "Zoom out to the account",
+                "zoom_level": "account",
+                "scenario_id": "managed-service-analyst",
+                "organization_slug": "dmarq-commercial",
+                "workspace_slug": "dmarq-com",
+                "domain": "dmarq.com",
+                "action": "Compare account billing, users, workspaces, and plan limits.",
+                "expected_takeaway": (
+                    "Managed-service teams need account ownership, role boundaries, "
+                    "and contract billing context next to DMARC evidence."
+                ),
+            },
+            {
+                "step": 3,
+                "label": "Zoom out to provider operations",
+                "zoom_level": "provider",
+                "scenario_id": "isp-operator",
+                "organization_slug": "northstar-isp",
+                "workspace_slug": "lawfirm-example",
+                "domain": "lawfirm.example",
+                "action": "Review ISP customers, bundled billing, and usage export samples.",
+                "expected_takeaway": (
+                    "Providers can operate many customer workspaces while billing "
+                    "through their existing monthly invoice systems."
+                ),
+            },
+            {
+                "step": 4,
+                "label": "Impersonate a customer user",
+                "zoom_level": "workspace",
+                "scenario_id": "customer-admin",
+                "organization_slug": "northstar-isp",
+                "workspace_slug": "bakery-example",
+                "domain": "bakery.example",
+                "action": "Switch into a customer admin view and confirm visible workspaces.",
+                "expected_takeaway": (
+                    "Support impersonation is explicit demo state, scoped to visible "
+                    "customer workspaces, and designed to be audited in production."
+                ),
+            },
+            {
+                "step": 5,
+                "label": "Compare self-hosted operations",
+                "zoom_level": "workspace",
+                "scenario_id": "self-hosted-admin",
+                "organization_slug": "studio-self-hosted",
+                "workspace_slug": "studio-main",
+                "domain": "studio.example",
+                "action": "Open the self-hosted profile with local billing ownership.",
+                "expected_takeaway": (
+                    "The same report and DNS workflows work without provider billing "
+                    "or hosted subscription ownership."
+                ),
+            },
+        ],
         "zoom_levels": [
             {
                 "level": "workspace",

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -107,6 +107,24 @@
                 </a>
             </template>
         </div>
+        <div class="mt-5" x-show="demoJourneySteps().length" x-cloak data-tour="demo-journey">
+            <p class="mb-3 text-xs font-semibold uppercase tracking-wide text-[#5f5c78]">Demo path</p>
+            <div class="grid gap-3 lg:grid-cols-5">
+                <template x-for="step in demoJourneySteps()" :key="step.step">
+                    <button type="button"
+                            class="rounded-md border border-[#dfdfdf] bg-white p-4 text-left transition hover:border-[#2f9da5] hover:shadow-sm"
+                            :class="selectedDemoScenarioId === step.scenario_id ? 'border-[#2f9da5] bg-[#edf7f7]' : ''"
+                            @click="selectDemoJourneyStep(step)">
+                        <div class="mb-3 inline-flex h-7 w-7 items-center justify-center rounded-full bg-[#272a5f] text-xs font-bold text-white"
+                             x-text="step.step"></div>
+                        <p class="text-sm font-semibold text-[#120d36]" x-text="step.label"></p>
+                        <p class="mt-2 text-xs text-[#5f5c78]" x-text="step.action"></p>
+                        <p class="mt-3 text-xs font-semibold text-[#2f9da5]"
+                           x-text="`${formatDemoLabel(step.zoom_level)} · ${step.domain}`"></p>
+                    </button>
+                </template>
+            </div>
+        </div>
     </div>
 
     <section class="rounded-lg bg-white p-6 shadow-sm" x-show="healthSummary && hasDomainData" x-cloak data-tour="health-score">
@@ -693,6 +711,11 @@ function dashboardApp() {
                 body: 'The default demo is one user managing multiple domains, so dmarq.org and dmarq.com stay front and center.'
             },
             {
+                selector: '[data-tour="demo-journey"]',
+                title: 'Follow the product story',
+                body: 'Use the demo path to move from the daily domain view to account, provider, impersonation, and self-hosted workflows.'
+            },
+            {
                 selector: '[data-tour="date-filter"]',
                 title: 'Change the evidence window',
                 body: 'Use sensible ranges or custom dates to inspect current incidents, week-to-date activity, or the full rolling demo history.'
@@ -1232,6 +1255,10 @@ function dashboardApp() {
             return this.demoDeployment?.domain_showcase || [];
         },
 
+        demoJourneySteps() {
+            return this.demoDeployment?.journey_steps || [];
+        },
+
         selectedDemoScenario() {
             const scenarios = this.demoScenarios();
             return scenarios.find(scenario => (scenario.id || scenario.label) === this.selectedDemoScenarioId)
@@ -1259,6 +1286,26 @@ function dashboardApp() {
                     this.applyDemoScenario();
                 }
             }
+        },
+
+        selectDemoJourneyStep(step) {
+            if (!step) return;
+            this.selectedDemoScenarioId = step.scenario_id || this.selectedDemoScenarioId;
+            this.selectedDemoZoomLevel = step.zoom_level || this.selectedDemoZoomLevel || 'workspace';
+            this.applyDemoScenario();
+            if (step.organization_slug) {
+                this.selectDemoOrganization(step.organization_slug, { preserveUser: true });
+            }
+            const scenario = this.selectedDemoScenario();
+            const user = this.selectedDemoOrganizationUsers()
+                .find(candidate => candidate.email === scenario?.email)
+                || this.selectedDemoOrganizationUsers()[0];
+            this.selectedDemoUserEmail = user?.email || '';
+            if (step.domain && this.domains.some(domain => domain.domain_name === step.domain)) {
+                this.selectedDnsDomain = step.domain;
+                this.updateDnsHealth();
+            }
+            this.$nextTick(() => this.ensureTourTargetVisible('[data-tour="tenant-detail"]'));
         },
 
         applyDemoScenario() {

--- a/backend/app/tests/test_demo_multi_user_deployment.py
+++ b/backend/app/tests/test_demo_multi_user_deployment.py
@@ -78,6 +78,13 @@ def test_demo_multi_user_deployment_has_opinionated_default_and_impersonation():
     deployment = build_demo_multi_user_deployment()
 
     assert deployment["default_viewer"] == "single-user-multiple-domains"
+    assert [step["scenario_id"] for step in deployment["journey_steps"]] == [
+        "single-user-multiple-domains",
+        "managed-service-analyst",
+        "isp-operator",
+        "customer-admin",
+        "self-hosted-admin",
+    ]
     assert [level["level"] for level in deployment["zoom_levels"]] == [
         "workspace",
         "account",
@@ -104,6 +111,27 @@ def test_demo_multi_user_deployment_has_opinionated_default_and_impersonation():
         "isp-operator",
         "self-hosted-admin",
     }
+
+
+def test_demo_multi_user_journey_steps_point_to_existing_demo_objects():
+    deployment = build_demo_multi_user_deployment()
+
+    organizations = {org["slug"]: org for org in deployment["organizations"]}
+    scenarios = {scenario["id"]: scenario for scenario in deployment["viewer_scenarios"]}
+    zoom_levels = {level["level"] for level in deployment["zoom_levels"]}
+
+    assert deployment["journey_steps"][0]["domain"] == "dmarq.org"
+    assert deployment["journey_steps"][0]["zoom_level"] == "workspace"
+    assert deployment["journey_steps"][-1]["organization_slug"] == "studio-self-hosted"
+    for step in deployment["journey_steps"]:
+        assert step["scenario_id"] in scenarios
+        assert step["zoom_level"] in zoom_levels
+        organization = organizations[step["organization_slug"]]
+        workspaces = {workspace["slug"]: workspace for workspace in organization["workspaces"]}
+        assert step["workspace_slug"] in workspaces
+        assert step["domain"] in workspaces[step["workspace_slug"]]["domains"]
+        assert step["action"]
+        assert step["expected_takeaway"]
 
 
 def test_operator_demo_multi_user_endpoint_returns_showcase(

--- a/docs/reference/workspaces.md
+++ b/docs/reference/workspaces.md
@@ -179,6 +179,13 @@ invoice references. The dashboard uses it opportunistically to display a
 multi-user deployment showcase on demo instances, including account drill-down,
 provider customer samples, and generated user impersonation scenarios.
 
+The response also includes `journey_steps`, an ordered product-story path used by
+the dashboard. The default path starts in the single-user, multi-domain
+`dmarq.org`/`dmarq.com` account, then zooms out through managed-service,
+provider, customer-impersonation, and self-hosted examples. Each step points to
+an existing demo scenario, organization, workspace, and domain so the UI can
+switch context without inventing state client-side.
+
 Provider billing integrations can read monthly usage with
 `GET /api/v1/provider/billing/usage?period=YYYY-MM`. A single external customer
 can be filtered with

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -72,6 +72,21 @@ forensic report summaries, SMTP TLS report summaries, DNS posture, and exports.
 It intentionally includes healthy senders, partially aligned senders, and a few
 misconfigurations so each dashboard panel has realistic content.
 
+The public demo is meant to start in the same place a normal self-service user
+would: one account with multiple domains. From there, the demo path on the
+dashboard walks through the larger deployment models:
+
+1. Start with `dmarq.org` and `dmarq.com` as a single-user, multi-domain account.
+2. Zoom out to an account view with users, roles, workspaces, plan limits, and billing ownership.
+3. Switch to an ISP/provider view with bundled customer workspaces and monthly billing export examples.
+4. Impersonate a demo customer user to see scoped workspace access.
+5. Compare the same DMARC workflows in a self-hosted deployment where billing remains local.
+
+All demo users, customer IDs, provider IDs, invoices, and domains outside
+`dmarq.org`/`dmarq.com` are generated examples. Support impersonation in the
+demo is explicit UI state; production impersonation should be audited and
+permission-gated.
+
 ## Customizing the Dashboard
 
 You can customize various aspects of the dashboard:


### PR DESCRIPTION
Refs #312

## What changed
- Add ordered `journey_steps` to the generated multi-user demo payload.
- Render a clickable Demo path on the dashboard that moves through single-user, managed-service, ISP, customer impersonation, and self-hosted scenarios.
- Add tests to ensure every journey step points to an existing scenario, organization, workspace, and domain.
- Document the demo personas and deployment path in the dashboard and workspace references.

## Scope
This is a product-story polish slice for #312. It does not close the full issue because deeper tenant drilldowns, audited production impersonation behavior, and broader demo data polish remain.

## Validation
- ./.venv/bin/python -m pytest backend/app/tests/test_demo_multi_user_deployment.py -q
- ./.venv/bin/python -m black --check backend/app/services/demo_data.py backend/app/tests/test_demo_multi_user_deployment.py
- ./.venv/bin/python -m isort --check-only backend/app/services/demo_data.py backend/app/tests/test_demo_multi_user_deployment.py
- ./.venv/bin/python -m flake8 backend/app/services/demo_data.py backend/app/tests/test_demo_multi_user_deployment.py