### PR TITLE
[codex] Clarify demo tenant drilldowns

### DIFF
--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -63,6 +63,17 @@ def build_demo_multi_user_deployment() -> Dict[str, Any]:
         },
         "roles": list(DEMO_MULTI_USER_ROLES),
         "default_viewer": "single-user-multiple-domains",
+        "impersonation_policy": {
+            "mode": "demo_only",
+            "audit_label": "support impersonation audit event",
+            "allowed_roles": ["organization_owner", "provider_operator"],
+            "scope": (
+                "Impersonation is shown as an explicit support workflow in the demo. "
+                "A production deployment must permission-gate the action, record the "
+                "operator, target user, organization, workspace, reason, and time, and "
+                "keep the customer-facing view read-only unless elevated separately."
+            ),
+        },
         "journey_steps": [
             {
                 "step": 1,

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -59,6 +59,13 @@
                 </h2>
                 <p class="mt-2 text-sm text-[#5f5c78]"
                    x-text="selectedDemoScenarioDescription()"></p>
+                <div class="mt-4 flex flex-wrap gap-2" x-show="selectedDemoOrganization()" x-cloak data-tour="demo-session-context">
+                    <span class="rounded-full bg-[#edf7f7] px-3 py-1 text-xs font-semibold text-[#247982]"
+                          x-text="demoSessionLabel()"></span>
+                    <span class="rounded-full bg-[#fff7df] px-3 py-1 text-xs font-semibold text-[#8a6418]"
+                          x-show="selectedDemoUser()"
+                          x-text="demoImpersonationNotice()"></span>
+                </div>
             </div>
             <div class="flex flex-col gap-3 sm:flex-row sm:items-end" data-tour="demo-persona">
                 <div class="grid gap-1">
@@ -113,7 +120,7 @@
                 <template x-for="step in demoJourneySteps()" :key="step.step">
                     <button type="button"
                             class="rounded-md border border-[#dfdfdf] bg-white p-4 text-left transition hover:border-[#2f9da5] hover:shadow-sm"
-                            :class="selectedDemoScenarioId === step.scenario_id ? 'border-[#2f9da5] bg-[#edf7f7]' : ''"
+                            :class="selectedDemoScenarioId === step.scenario_id && selectedDemoWorkspaceSlug === step.workspace_slug ? 'border-[#2f9da5] bg-[#edf7f7]' : ''"
                             @click="selectDemoJourneyStep(step)">
                         <div class="mb-3 inline-flex h-7 w-7 items-center justify-center rounded-full bg-[#272a5f] text-xs font-bold text-white"
                              x-text="step.step"></div>
@@ -530,11 +537,61 @@
                     <p class="text-xs uppercase tracking-wide text-[#5f5c78]">Visible workspaces</p>
                     <div class="mt-3 space-y-2">
                         <template x-for="workspace in selectedDemoVisibleWorkspaces()" :key="workspace.slug">
-                            <div class="rounded-md border border-[#e6e3e1] p-3">
-                                <p class="font-semibold text-[#120d36]" x-text="workspace.name"></p>
-                                <p class="mt-1 text-sm text-[#5f5c78]" x-text="(workspace.domains || []).join(', ')"></p>
-                            </div>
+                            <button type="button"
+                                    class="w-full rounded-md border p-3 text-left transition hover:border-[#2f9da5]"
+                                    :class="selectedDemoWorkspaceSlug === workspace.slug ? 'border-[#2f9da5] bg-[#edf7f7]' : 'border-[#e6e3e1] bg-white'"
+                                    @click="selectDemoWorkspace(workspace.slug)">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div class="min-w-0">
+                                        <p class="font-semibold text-[#120d36]" x-text="workspace.name"></p>
+                                        <p class="mt-1 text-sm text-[#5f5c78]" x-text="(workspace.domains || []).join(', ')"></p>
+                                    </div>
+                                    <span class="rounded-full px-2 py-1 text-xs font-semibold"
+                                          :class="workspace.health === 'critical' ? 'bg-[#fff1ea] text-[#b8431d]' : workspace.health === 'healthy' ? 'bg-[#edf7f7] text-[#247982]' : 'bg-[#f4f3f2] text-[#5f5c78]'"
+                                          x-text="workspace.health"></span>
+                                </div>
+                            </button>
                         </template>
+                    </div>
+                </div>
+            </div>
+            <div class="mt-5 rounded-md border border-[#e6e3e1] bg-white p-4" x-show="selectedDemoWorkspace()" x-cloak data-tour="tenant-workspace-drilldown">
+                <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                        <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]">Workspace drill-down</p>
+                        <h4 class="mt-1 text-xl font-semibold text-[#120d36]" x-text="selectedDemoWorkspace()?.name"></h4>
+                        <p class="mt-2 text-sm text-[#5f5c78]">
+                            This is the tenant scope the current demo user can inspect.
+                        </p>
+                    </div>
+                    <span class="w-fit rounded-full bg-[#f4f3f2] px-3 py-1 text-xs font-semibold text-[#5f5c78]"
+                          x-text="formatDemoLabel(selectedDemoWorkspace()?.health || 'unknown')"></span>
+                </div>
+                <div class="mt-4 grid gap-4 lg:grid-cols-2">
+                    <div>
+                        <p class="text-xs uppercase tracking-wide text-[#5f5c78]">Domains</p>
+                        <div class="mt-2 flex flex-wrap gap-2">
+                            <template x-for="domainName in selectedDemoWorkspaceDomains()" :key="domainName">
+                                <span class="inline-flex items-center gap-2 rounded-md border border-[#dfdfdf] px-3 py-2 text-sm">
+                                    <span class="font-semibold text-[#120d36]" x-text="domainName"></span>
+                                    <template x-if="hasLiveDomain(domainName)">
+                                        <a class="font-semibold text-[#2f9da5] hover:text-[#272a5f]"
+                                           :href="domainHrefByName(domainName)">Open detail</a>
+                                    </template>
+                                    <template x-if="!hasLiveDomain(domainName)">
+                                        <span class="rounded-full bg-[#fff7df] px-2 py-0.5 text-xs font-semibold text-[#8a6418]">Demo-only</span>
+                                    </template>
+                                </span>
+                            </template>
+                        </div>
+                    </div>
+                    <div>
+                        <p class="text-xs uppercase tracking-wide text-[#5f5c78]">Action cues</p>
+                        <div class="mt-2 space-y-2">
+                            <template x-for="finding in selectedDemoWorkspaceFindings()" :key="finding">
+                                <div class="rounded-md bg-[#f4f3f2] px-3 py-2 text-sm text-[#120d36]" x-text="finding"></div>
+                            </template>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -701,6 +758,7 @@ function dashboardApp() {
         selectedDemoScenarioId: 'single-user-multiple-domains',
         selectedDemoZoomLevel: 'workspace',
         selectedDemoOrganizationSlug: '',
+        selectedDemoWorkspaceSlug: '',
         selectedDemoUserEmail: '',
         demoTourActive: false,
         demoTourStepIndex: 0,
@@ -714,6 +772,11 @@ function dashboardApp() {
                 selector: '[data-tour="demo-journey"]',
                 title: 'Follow the product story',
                 body: 'Use the demo path to move from the daily domain view to account, provider, impersonation, and self-hosted workflows.'
+            },
+            {
+                selector: '[data-tour="demo-session-context"]',
+                title: 'Track the active scope',
+                body: 'The demo always shows which account, workspace, and user context is active before you drill into tenant data.'
             },
             {
                 selector: '[data-tour="date-filter"]',
@@ -744,6 +807,11 @@ function dashboardApp() {
                 selector: '[data-tour="tenant-detail"]',
                 title: 'Impersonate demo users',
                 body: 'Open an account and view it as an owner, analyst, auditor, ISP operator, or customer admin.'
+            },
+            {
+                selector: '[data-tour="tenant-workspace-drilldown"]',
+                title: 'Drill into tenant workspaces',
+                body: 'Workspace drill-downs show the visible domains, report-backed links, and demo-only customer examples.'
             }
         ],
         dateInterval: 'last_30_days',
@@ -1277,6 +1345,25 @@ function dashboardApp() {
             return `${scope}${workspace}`.trim();
         },
 
+        demoSessionLabel() {
+            const organization = this.selectedDemoOrganization();
+            const workspace = this.selectedDemoWorkspace();
+            const parts = [
+                organization?.name,
+                workspace?.name,
+                this.formatDemoLabel(this.selectedDemoZoomLevel)
+            ].filter(Boolean);
+            return parts.join(' / ') || 'Demo scope';
+        },
+
+        demoImpersonationNotice() {
+            const user = this.selectedDemoUser();
+            if (!user) return '';
+            const auditLabel = this.demoDeployment?.impersonation_policy?.audit_label
+                || 'audit log entry';
+            return `Viewing as ${user.name}; demo impersonation creates an ${auditLabel} in production.`;
+        },
+
         selectDemoZoomLevel(level) {
             this.selectedDemoZoomLevel = level || 'workspace';
             if (level === 'provider') {
@@ -1301,11 +1388,14 @@ function dashboardApp() {
                 .find(candidate => candidate.email === scenario?.email)
                 || this.selectedDemoOrganizationUsers()[0];
             this.selectedDemoUserEmail = user?.email || '';
+            if (step.workspace_slug) {
+                this.selectDemoWorkspace(step.workspace_slug);
+            }
             if (step.domain && this.domains.some(domain => domain.domain_name === step.domain)) {
                 this.selectedDnsDomain = step.domain;
                 this.updateDnsHealth();
             }
-            this.$nextTick(() => this.ensureTourTargetVisible('[data-tour="tenant-detail"]'));
+            this.$nextTick(() => this.ensureTourTargetVisible('[data-tour="tenant-workspace-drilldown"]'));
         },
 
         applyDemoScenario() {
@@ -1322,6 +1412,9 @@ function dashboardApp() {
                 .find(candidate => candidate.email === scenario.email)
                 || this.selectedDemoOrganizationUsers()[0];
             this.selectedDemoUserEmail = user?.email || '';
+            if (scenario.default_workspace) {
+                this.selectDemoWorkspace(scenario.default_workspace);
+            }
             if (scenario.default_domain && this.domains.some(domain => domain.domain_name === scenario.default_domain)) {
                 this.selectedDnsDomain = scenario.default_domain;
                 this.updateDnsHealth();
@@ -1334,7 +1427,22 @@ function dashboardApp() {
             if (!options.preserveUser || !users.some(user => user.email === this.selectedDemoUserEmail)) {
                 this.selectedDemoUserEmail = users[0]?.email || '';
             }
+            const visibleWorkspaces = this.selectedDemoVisibleWorkspaces();
+            if (!visibleWorkspaces.some(workspace => workspace.slug === this.selectedDemoWorkspaceSlug)) {
+                this.selectedDemoWorkspaceSlug = visibleWorkspaces[0]?.slug || '';
+            }
             this.$nextTick(() => this.ensureTourTargetVisible('[data-tour="tenant-detail"]'));
+        },
+
+        selectDemoWorkspace(slug) {
+            const workspaces = this.selectedDemoVisibleWorkspaces();
+            const workspace = workspaces.find(item => item.slug === slug) || workspaces[0] || null;
+            this.selectedDemoWorkspaceSlug = workspace?.slug || '';
+            const firstDomain = workspace?.domains?.[0];
+            if (firstDomain && this.hasLiveDomain(firstDomain)) {
+                this.selectedDnsDomain = firstDomain;
+                this.updateDnsHealth();
+            }
         },
 
         selectedDemoOrganization() {
@@ -1363,11 +1471,40 @@ function dashboardApp() {
             return workspaces.filter(workspace => userWorkspaces.includes(workspace.slug));
         },
 
+        selectedDemoWorkspace() {
+            const visible = this.selectedDemoVisibleWorkspaces();
+            return visible.find(workspace => workspace.slug === this.selectedDemoWorkspaceSlug)
+                || visible[0]
+                || null;
+        },
+
+        selectedDemoWorkspaceDomains() {
+            return this.selectedDemoWorkspace()?.domains || [];
+        },
+
+        selectedDemoWorkspaceFindings() {
+            return this.selectedDemoWorkspace()?.primary_findings || [];
+        },
+
+        domainByName(domainName) {
+            return this.domains.find(domain => domain.domain_name === domainName) || null;
+        },
+
+        hasLiveDomain(domainName) {
+            return Boolean(this.domainByName(domainName));
+        },
+
+        domainHrefByName(domainName) {
+            const domain = this.domainByName(domainName);
+            return domain ? this.domainHref(domain) : '#';
+        },
+
         applyDemoUserSelection() {
             const user = this.selectedDemoUser();
             const firstWorkspace = this.selectedDemoVisibleWorkspaces()[0];
             const firstDomain = firstWorkspace?.domains?.[0];
-            if (firstDomain && this.domains.some(domain => domain.domain_name === firstDomain)) {
+            this.selectedDemoWorkspaceSlug = firstWorkspace?.slug || '';
+            if (firstDomain && this.hasLiveDomain(firstDomain)) {
                 this.selectedDnsDomain = firstDomain;
                 this.updateDnsHealth();
             }
@@ -1401,7 +1538,8 @@ function dashboardApp() {
                 this.selectedDemoUserEmail = customerUser.email;
             }
             const firstDomain = workspace?.domains?.[0];
-            if (firstDomain && this.domains.some(domain => domain.domain_name === firstDomain)) {
+            this.selectDemoWorkspace(workspace?.slug);
+            if (firstDomain && this.hasLiveDomain(firstDomain)) {
                 this.selectedDnsDomain = firstDomain;
                 this.updateDnsHealth();
             }

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -55,6 +55,12 @@ def test_dashboard_renders_demo_billing_profiles_without_html_injection():
     assert "Demo experience" in template
     assert "Start tour" in template
     assert "selectedDemoUserEmail" in template
+    assert "selectedDemoWorkspaceSlug" in template
+    assert "Workspace drill-down" in template
+    assert "tenant-workspace-drilldown" in template
+    assert "hasLiveDomain(domainName)" in template
+    assert "Demo-only" in template
+    assert "demoImpersonationNotice()" in template
     assert "Provider billing samples" in template
     assert "billing_profile.display_name" in template
     assert "formatDemoUsage(organization, usage)" in template

--- a/backend/app/tests/test_demo_multi_user_deployment.py
+++ b/backend/app/tests/test_demo_multi_user_deployment.py
@@ -78,6 +78,12 @@ def test_demo_multi_user_deployment_has_opinionated_default_and_impersonation():
     deployment = build_demo_multi_user_deployment()
 
     assert deployment["default_viewer"] == "single-user-multiple-domains"
+    assert deployment["impersonation_policy"]["mode"] == "demo_only"
+    assert deployment["impersonation_policy"]["audit_label"] == (
+        "support impersonation audit event"
+    )
+    assert "operator" in deployment["impersonation_policy"]["scope"]
+    assert "target user" in deployment["impersonation_policy"]["scope"]
     assert [step["scenario_id"] for step in deployment["journey_steps"]] == [
         "single-user-multiple-domains",
         "managed-service-analyst",

--- a/docs/reference/workspaces.md
+++ b/docs/reference/workspaces.md
@@ -186,6 +186,14 @@ provider, customer-impersonation, and self-hosted examples. Each step points to
 an existing demo scenario, organization, workspace, and domain so the UI can
 switch context without inventing state client-side.
 
+The response also includes an `impersonation_policy` object for the public demo.
+It documents that impersonation is demo-only, names the production audit event
+that would be written, and describes the minimum production audit scope:
+operator, target user, organization, workspace, reason, and timestamp.
+Generated ISP and self-hosted tenant domains explain workspace scope and billing
+ownership; only domains backed by aggregate reports should link to live domain
+detail pages.
+
 Provider billing integrations can read monthly usage with
 `GET /api/v1/provider/billing/usage?period=YYYY-MM`. A single external customer
 can be filtered with

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -87,6 +87,12 @@ All demo users, customer IDs, provider IDs, invoices, and domains outside
 demo is explicit UI state; production impersonation should be audited and
 permission-gated.
 
+The account detail panel keeps the active organization, workspace, and viewed
+user visible while you move through the demo path. Workspaces can be selected
+directly; `dmarq.org` and `dmarq.com` link to report-backed domain detail pages,
+while ISP and self-hosted sample domains are marked as demo-only tenant context
+until the demo includes full report stores for those generated tenants.
+
 ## Customizing the Dashboard
 
 You can customize various aspects of the dashboard:


### PR DESCRIPTION
## Summary

Refs #312.

This continues the demo workflow polish with a small tenant drill-down slice:

- keeps the active demo organization, workspace, zoom level, and viewed user visible in the dashboard
- makes visible workspaces selectable in the account detail panel
- adds a workspace drill-down panel with domains, action cues, and health state
- distinguishes report-backed domains from demo-only ISP/self-hosted sample domains, so generated tenant domains no longer imply a broken detail-page link
- adds an explicit demo `impersonation_policy` object documenting that impersonation is demo-only and production usage must be audited
- updates dashboard/workspace documentation for the new demo behavior

## Validation

- `python -m pytest backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_dashboard_template_security.py -q`
- `python -m black --check backend/app/services/demo_data.py backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_dashboard_template_security.py`
- `python -m isort --check-only backend/app/services/demo_data.py backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_dashboard_template_security.py`
- `python -m flake8 backend/app/services/demo_data.py backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

## Notes

A local browser smoke was attempted, but the standalone local instance redirected to setup before the dashboard could be reached. I kept the change covered by focused payload/template tests and will smoke the deployed demo after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the demo dashboard with clearer session context, including workspace scope and impersonation status.
  * Added workspace selection and drill-down views so demo users can navigate tenant workspaces more easily.
  * Updated the public demo response to include a demo-only impersonation policy.

* **Bug Fixes**
  * Improved demo selection flows to keep organization, workspace, and DNS details in sync.
  * Refined active-step highlighting and scroll behavior in the demo tour for a smoother experience.

* **Documentation**
  * Clarified demo workspace and impersonation behavior in the dashboard and API reference docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->