### PR TITLE
[codex] Fix demo drilldown state after workspace switches

### DIFF
--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -119,8 +119,8 @@
             <div class="grid gap-3 lg:grid-cols-5">
                 <template x-for="step in demoJourneySteps()" :key="step.step">
                     <button type="button"
-                            class="rounded-md border border-[#dfdfdf] bg-white p-4 text-left transition hover:border-[#2f9da5] hover:shadow-sm"
-                            :class="selectedDemoScenarioId === step.scenario_id && selectedDemoWorkspaceSlug === step.workspace_slug ? 'border-[#2f9da5] bg-[#edf7f7]' : ''"
+                            class="rounded-md border p-4 text-left transition hover:border-[#2f9da5] hover:shadow-sm"
+                            :class="selectedDemoScenarioId === step.scenario_id && selectedDemoWorkspaceSlug === step.workspace_slug ? 'border-[#2f9da5] bg-[#edf7f7]' : 'border-[#dfdfdf] bg-white'"
                             @click="selectDemoJourneyStep(step)">
                         <div class="mb-3 inline-flex h-7 w-7 items-center justify-center rounded-full bg-[#272a5f] text-xs font-bold text-white"
                              x-text="step.step"></div>
@@ -1442,7 +1442,9 @@ function dashboardApp() {
             if (firstDomain && this.hasLiveDomain(firstDomain)) {
                 this.selectedDnsDomain = firstDomain;
                 this.updateDnsHealth();
+                return;
             }
+            this.selectedDnsDomain = '';
         },
 
         selectedDemoOrganization() {
@@ -1502,12 +1504,7 @@ function dashboardApp() {
         applyDemoUserSelection() {
             const user = this.selectedDemoUser();
             const firstWorkspace = this.selectedDemoVisibleWorkspaces()[0];
-            const firstDomain = firstWorkspace?.domains?.[0];
-            this.selectedDemoWorkspaceSlug = firstWorkspace?.slug || '';
-            if (firstDomain && this.hasLiveDomain(firstDomain)) {
-                this.selectedDnsDomain = firstDomain;
-                this.updateDnsHealth();
-            }
+            this.selectDemoWorkspace(firstWorkspace?.slug);
             if (user?.demo_persona) {
                 const matchingScenario = this.demoScenarios().find(
                     scenario => scenario.email === user.email || scenario.id === user.demo_persona
@@ -1537,12 +1534,7 @@ function dashboardApp() {
             if (customerUser) {
                 this.selectedDemoUserEmail = customerUser.email;
             }
-            const firstDomain = workspace?.domains?.[0];
             this.selectDemoWorkspace(workspace?.slug);
-            if (firstDomain && this.hasLiveDomain(firstDomain)) {
-                this.selectedDnsDomain = firstDomain;
-                this.updateDnsHealth();
-            }
         },
 
         demoWorkspaceTotal() {

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -273,6 +273,7 @@
                             class="min-w-0 rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm font-semibold text-[#120d36]"
                             x-model="selectedDnsDomain"
                             @change="updateDnsHealth()">
+                        <option value="">No report-backed domain selected</option>
                         <template x-for="domain in domains" :key="domain.domain_name || domain.id">
                             <option :value="domain.domain_name" x-text="domain.domain_name"></option>
                         </template>
@@ -830,7 +831,8 @@ function dashboardApp() {
         ],
 
         get selectedDnsDomainRecord() {
-            return this.domains.find(domain => domain.domain_name === this.selectedDnsDomain) || this.domains[0] || null;
+            if (!this.selectedDnsDomain) return null;
+            return this.domains.find(domain => domain.domain_name === this.selectedDnsDomain) || null;
         },
 
         get selectedDomainHref() {

--- a/backend/app/tests/test_demo_multi_user_deployment.py
+++ b/backend/app/tests/test_demo_multi_user_deployment.py
@@ -82,6 +82,10 @@ def test_demo_multi_user_deployment_has_opinionated_default_and_impersonation():
     assert deployment["impersonation_policy"]["audit_label"] == (
         "support impersonation audit event"
     )
+    assert deployment["impersonation_policy"]["allowed_roles"] == [
+        "organization_owner",
+        "provider_operator",
+    ]
     assert "operator" in deployment["impersonation_policy"]["scope"]
     assert "target user" in deployment["impersonation_policy"]["scope"]
     assert [step["scenario_id"] for step in deployment["journey_steps"]] == [


### PR DESCRIPTION
## Summary

Follow-up to #329 / v1.77.0 review comments.

- make demo journey-step selected styling deterministic by moving color-specific classes into both `:class` branches
- clear stale DNS context when the selected demo workspace has no report-backed live domain
- route demo user and provider-customer workspace switches through `selectDemoWorkspace()` as the single source of truth
- assert `impersonation_policy.allowed_roles` in the demo deployment test

## Validation

- `git diff --check`
- `python3 -m py_compile backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_dashboard_template_security.py backend/app/services/demo_data.py`

`python3 -m pytest backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_dashboard_template_security.py -q` could not run in the fresh automation checkout because `pytest` is not installed there.