### PR TITLE
[codex] Add advanced SPF DNS lint findings

### DIFF
--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import List, Optional
@@ -226,6 +227,177 @@ def _spf_terms(record: Optional[str]) -> List[str]:
     return [part.strip() for part in record.split() if part.strip()]
 
 
+def _spf_dns_lookup_terms(terms: List[str]) -> List[str]:
+    return [
+        term
+        for term in terms
+        if term.startswith(("include:", "a", "mx", "ptr", "exists:", "redirect="))
+    ]
+
+
+def _spf_include_domain(term: str) -> Optional[str]:
+    if term.startswith("include:"):
+        return term.split(":", 1)[1].strip().strip(".").lower() or None
+    return None
+
+
+def _spf_lookup_domain(term: str) -> Optional[str]:
+    if term.startswith(("include:", "exists:")):
+        return term.split(":", 1)[1].strip().strip(".").lower() or None
+    if term.startswith("redirect="):
+        return term.split("=", 1)[1].strip().strip(".").lower() or None
+    return None
+
+
+def _spf_all_policy_findings(
+    terms: List[str], target: DNSGuidanceRecord, record: Optional[str]
+) -> List[DNSLintFinding]:
+    findings: List[DNSLintFinding] = []
+    all_terms = [term for term in terms if term.endswith("all")]
+    if not all_terms:
+        findings.append(
+            _finding(
+                "spf_all_missing",
+                "warning",
+                "SPF all mechanism is missing",
+                "The SPF record does not end with an explicit all policy.",
+                "Choose -all after authorizing all senders, or ~all while still validating.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=[record or ""],
+            )
+        )
+    elif all_terms[-1].startswith("+") or all_terms[-1] == "all":
+        findings.append(
+            _finding(
+                "spf_all_too_permissive",
+                "error",
+                "SPF all mechanism is too permissive",
+                f"The SPF record uses {all_terms[-1]}, which authorizes every sender.",
+                "Replace +all with ~all during rollout or -all once sender coverage is complete.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=[record or ""],
+            )
+        )
+    elif all_terms[-1].startswith("?"):
+        findings.append(
+            _finding(
+                "spf_all_neutral",
+                "warning",
+                "SPF all mechanism is neutral",
+                "The SPF record ends with ?all, which provides weak sender guidance.",
+                "Use ~all while validating or -all after all senders are authorized.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=[record or ""],
+            )
+        )
+    return findings
+
+
+def _spf_lookup_budget_findings(
+    dns_lookup_terms: List[str], target: DNSGuidanceRecord
+) -> List[DNSLintFinding]:
+    findings: List[DNSLintFinding] = []
+    if len(dns_lookup_terms) > 10:
+        findings.append(
+            _finding(
+                "spf_dns_lookup_limit_exceeded",
+                "error",
+                "SPF DNS lookup budget is exceeded",
+                (
+                    "The SPF record uses "
+                    f"{len(dns_lookup_terms)} DNS-lookup mechanisms; SPF evaluation "
+                    "fails after 10."
+                ),
+                "Flatten or remove unused mechanisms before publishing the final SPF record.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=dns_lookup_terms,
+            )
+        )
+    if len(dns_lookup_terms) >= 8:
+        findings.append(
+            _finding(
+                "spf_dns_lookup_limit_risk",
+                "warning",
+                "SPF DNS lookup budget is exhausted or nearly exhausted",
+                (
+                    "The SPF record uses "
+                    f"{len(dns_lookup_terms)} of 10 available DNS-lookup mechanisms."
+                ),
+                "Remove unused includes or flatten stable sender ranges before adding new senders.",
+                "TXT",
+                target.name,
+                target_record=target,
+                evidence=dns_lookup_terms,
+            )
+        )
+    return findings
+
+
+def _spf_duplicate_include_findings(
+    terms: List[str], target: DNSGuidanceRecord
+) -> List[DNSLintFinding]:
+    include_domains = [
+        include_domain for term in terms if (include_domain := _spf_include_domain(term))
+    ]
+    duplicate_includes = sorted(
+        include_domain for include_domain, count in Counter(include_domains).items() if count > 1
+    )
+    if not duplicate_includes:
+        return []
+    return [
+        _finding(
+            "spf_duplicate_include",
+            "warning",
+            "SPF record repeats include mechanisms",
+            "The same SPF include appears more than once and wastes lookup budget.",
+            "Remove duplicate include mechanisms before adding more senders.",
+            "TXT",
+            target.name,
+            target_record=target,
+            evidence=duplicate_includes,
+        )
+    ]
+
+
+async def _spf_void_lookup_findings(
+    provider: BaseDNSProvider,
+    dns_lookup_terms: List[str],
+    target: DNSGuidanceRecord,
+) -> List[DNSLintFinding]:
+    void_lookup_terms: List[str] = []
+    for term in dns_lookup_terms:
+        lookup_domain = _spf_lookup_domain(term)
+        if not lookup_domain:
+            continue
+        try:
+            await provider.lookup_txt(lookup_domain)
+        except LookupError:
+            void_lookup_terms.append(term)
+    if not void_lookup_terms:
+        return []
+    return [
+        _finding(
+            "spf_void_lookup",
+            "warning",
+            "SPF record references empty lookup targets",
+            "One or more SPF include, exists, or redirect targets did not return TXT records.",
+            "Remove stale SPF references or repair the referenced sender-domain SPF records.",
+            "TXT",
+            target.name,
+            target_record=target,
+            evidence=void_lookup_terms,
+        )
+    ]
+
+
 async def _spf_findings(
     domain: str,
     provider: BaseDNSProvider,
@@ -269,69 +441,11 @@ async def _spf_findings(
         )
 
     terms = _spf_terms(result.spf_record)
-    all_terms = [term for term in terms if term.endswith("all")]
-    if not all_terms:
-        findings.append(
-            _finding(
-                "spf_all_missing",
-                "warning",
-                "SPF all mechanism is missing",
-                "The SPF record does not end with an explicit all policy.",
-                "Choose -all after authorizing all senders, or ~all while still validating.",
-                "TXT",
-                target.name,
-                target_record=target,
-                evidence=[result.spf_record or ""],
-            )
-        )
-    elif all_terms[-1].startswith("+") or all_terms[-1] == "all":
-        findings.append(
-            _finding(
-                "spf_all_too_permissive",
-                "error",
-                "SPF all mechanism is too permissive",
-                f"The SPF record uses {all_terms[-1]}, which authorizes every sender.",
-                "Replace +all with ~all during rollout or -all once sender coverage is complete.",
-                "TXT",
-                target.name,
-                target_record=target,
-                evidence=[result.spf_record or ""],
-            )
-        )
-    elif all_terms[-1].startswith("?"):
-        findings.append(
-            _finding(
-                "spf_all_neutral",
-                "warning",
-                "SPF all mechanism is neutral",
-                "The SPF record ends with ?all, which provides weak sender guidance.",
-                "Use ~all while validating or -all after all senders are authorized.",
-                "TXT",
-                target.name,
-                target_record=target,
-                evidence=[result.spf_record or ""],
-            )
-        )
-
-    dns_lookup_terms = [
-        term
-        for term in terms
-        if term.startswith(("include:", "a", "mx", "ptr", "exists:", "redirect="))
-    ]
-    if len(dns_lookup_terms) > 10:
-        findings.append(
-            _finding(
-                "spf_dns_lookup_limit_risk",
-                "warning",
-                "SPF DNS lookup budget may be exceeded",
-                "The SPF record has more than 10 DNS-lookup mechanisms.",
-                "Flatten or remove unused mechanisms before publishing the final SPF record.",
-                "TXT",
-                target.name,
-                target_record=target,
-                evidence=[result.spf_record or ""],
-            )
-        )
+    findings.extend(_spf_all_policy_findings(terms, target, result.spf_record))
+    dns_lookup_terms = _spf_dns_lookup_terms(terms)
+    findings.extend(_spf_lookup_budget_findings(dns_lookup_terms, target))
+    findings.extend(_spf_duplicate_include_findings(terms, target))
+    findings.extend(await _spf_void_lookup_findings(provider, dns_lookup_terms, target))
     return findings
 
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -344,6 +344,67 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: Tes
     }
 
 
+def test_dns_lint_endpoint_flags_advanced_spf_lookup_findings(
+    authed_client: TestClient,
+):
+    spf_record = (
+        "v=spf1 "
+        "include:_spf.one.example include:_spf.one.example "
+        "include:_spf.two.example include:_spf.three.example "
+        "include:_spf.four.example include:_spf.five.example "
+        "include:_spf.six.example include:_spf.seven.example "
+        "include:_spf.eight.example include:_spf.nine.example "
+        "include:_spf.ten.example include:missing.example -all"
+    )
+    result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record=spf_record,
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+    provider = AsyncMock()
+    provider.check_domain = AsyncMock(return_value=result)
+
+    async def _lookup_txt(name):
+        if name == DOMAIN:
+            return [spf_record]
+        if name == "_smtp._tls.example.com":
+            return ["v=TLSRPTv1; rua=mailto:tlsrpt@example.com"]
+        if name == "missing.example":
+            raise LookupError("missing SPF include")
+        return ["v=spf1 -all"]
+
+    provider.lookup_txt = AsyncMock(side_effect=_lookup_txt)
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains.get_default_provider",
+            return_value=provider,
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(MTAStsResult(status="pass"), False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(BIMIResult(status="pass"), False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/lint")
+
+    assert response.status_code == 200
+    data = response.json()
+    findings = {finding["code"]: finding for finding in data["findings"]}
+    assert data["status"] == "critical"
+    assert "spf_dns_lookup_limit_exceeded" in findings
+    assert "spf_duplicate_include" in findings
+    assert "spf_void_lookup" in findings
+    assert "_spf.one.example" in findings["spf_duplicate_include"]["evidence"]
+    assert "include:missing.example" in findings["spf_void_lookup"]["evidence"]
+
+
 def test_dns_lint_bulk_and_export(authed_client: TestClient):
     mta_sts = MTAStsResult(status="pass")
     bimi = BIMIResult(status="pass")


### PR DESCRIPTION
## Summary
- add SPF DNS lookup-budget linting for records that exceed or nearly exhaust the 10-lookup limit
- flag duplicate SPF include mechanisms and direct include/exists/redirect targets that return no TXT records
- add endpoint coverage for the new typed finding codes and evidence payloads

## Scope
This is a bounded SPF slice for #308. DKIM selector health, DMARC staging guidance, external reporting authorization, and deeper MTA-STS/TLS-RPT/BIMI action plans remain open under the parent issue.

Refs #308

## Validation
- `./.venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py -q`
- `./.venv/bin/python -m black --check backend/app/services/dns_guidance.py backend/app/tests/test_dns_endpoints.py`
- `./.venv/bin/python -m isort --check-only backend/app/services/dns_guidance.py backend/app/tests/test_dns_endpoints.py`
- `./.venv/bin/python -m flake8 backend/app/services/dns_guidance.py backend/app/tests/test_dns_endpoints.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPF DNS linting to catch more configuration issues, including excessive DNS lookups, duplicate `include` entries, and void lookups.
  * Refined SPF checks so findings now point to the specific mechanism or target involved, making warnings easier to understand.
  * Expanded DNS lint validation to better surface critical SPF problems during domain checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->