### PR TITLE
[codex] Clarify MTA-STS policy hosting guidance

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -805,19 +805,34 @@ def _mta_sts_recommendation(result: MTAStsResult) -> Optional[DNSHealthRecommend
     if result.status == "pass" and not result.warnings:
         return None
     severity = "warning" if result.status == "pass" else "error"
-    title = "MTA-STS policy needs review" if result.status == "pass" else "Publish MTA-STS"
-    detail = (
-        "; ".join(result.warnings)
-        if result.status == "pass"
-        else "; ".join(result.errors or ["MTA-STS is not configured or is not valid."])
-    )
-    action = (
-        "Move the policy to mode: enforce once MX coverage is confirmed."
-        if result.status == "pass"
-        else "Publish _mta-sts TXT and a valid HTTPS policy at the well-known URL."
-    )
+    if result.status == "pass":
+        title = "MTA-STS policy needs review"
+        detail = "; ".join(result.warnings)
+        action = "Move the policy to mode: enforce once MX coverage is confirmed."
+        recommendation_type = "mta_sts_review"
+    elif not result.dns_record:
+        title = "Publish MTA-STS"
+        detail = "; ".join(result.errors or ["MTA-STS is not configured."])
+        action = "Publish _mta-sts TXT and a valid HTTPS policy at the well-known URL."
+        recommendation_type = "missing_mta_sts"
+    elif result.policy_text is None:
+        title = "Host the MTA-STS policy"
+        detail = "; ".join(result.errors or ["The MTA-STS policy URL is not reachable."])
+        action = (
+            "Keep the existing _mta-sts TXT record if its id is current, then make "
+            f"{result.policy_url} reachable over HTTPS with a valid policy file."
+        )
+        recommendation_type = "mta_sts_policy_unreachable"
+    else:
+        title = "Fix the MTA-STS policy file"
+        detail = "; ".join(result.errors or ["The MTA-STS policy file is not valid."])
+        action = (
+            "Update the policy file so it includes version: STSv1, mode, max_age, "
+            "and at least one mx entry."
+        )
+        recommendation_type = "mta_sts_policy_invalid"
     return DNSHealthRecommendation(
-        type="mta_sts_review" if result.status == "pass" else "missing_mta_sts",
+        type=recommendation_type,
         severity=severity,
         title=title,
         detail=detail,
@@ -1096,6 +1111,16 @@ def _playbook_steps(recommendation: DNSHealthRecommendation) -> List[str]:
             "Publish _mta-sts TXT with a stable id value.",
             "Host a valid policy file at the linked well-known HTTPS URL.",
             "Start in testing mode, then move to enforce after MX coverage is verified.",
+        ],
+        "mta_sts_policy_unreachable": [
+            "Keep the existing _mta-sts TXT record unless the id needs rotation.",
+            "Create DNS for the mta-sts host and make the linked HTTPS policy URL reachable.",
+            "Serve a valid policy file, then rotate the TXT id to force receivers to refetch it.",
+        ],
+        "mta_sts_policy_invalid": [
+            "Open the linked policy file and correct invalid or missing fields.",
+            "Include version: STSv1, mode, max_age, and all expected MX patterns.",
+            "Rotate the _mta-sts TXT id after publishing the corrected policy.",
         ],
         "mta_sts_review": [
             "Open the linked policy evidence and confirm all MX hosts are covered.",

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -481,13 +481,27 @@ def _mta_sts_findings(
     target = _target_by_code(targets, "target_mta_sts")
     severity = "warning" if result.status == "pass" else "info"
     detail = "; ".join(result.warnings or result.errors or ["MTA-STS is not configured."])
+    if result.status == "pass":
+        recommendation = "Move the policy to mode: enforce once MX coverage is confirmed."
+    elif result.dns_record and result.policy_text is None:
+        recommendation = (
+            f"Make {result.policy_url} reachable over HTTPS with a valid policy file, "
+            "then rotate the _mta-sts TXT id when the policy changes."
+        )
+    elif result.dns_record:
+        recommendation = (
+            "Fix the MTA-STS policy file so it includes version: STSv1, mode, "
+            "max_age, and at least one mx entry."
+        )
+    else:
+        recommendation = "Publish _mta-sts TXT and validate the HTTPS policy before enforcing."
     return [
         _finding(
             "mta_sts_review" if result.status == "pass" else "mta_sts_missing",
             severity,
             "MTA-STS setup needs review" if result.status == "pass" else "MTA-STS is not ready",
             detail,
-            "Publish _mta-sts TXT and validate the HTTPS policy before enforcing.",
+            recommendation,
             "TXT",
             target.name,
             target_record=target,

--- a/backend/app/services/mta_sts.py
+++ b/backend/app/services/mta_sts.py
@@ -18,6 +18,12 @@ from app.services.dns_resolver import BaseDNSProvider
 _CACHE_KEY = "mta-sts-v1"
 _POLICY_TIMEOUT_SECONDS = 5.0
 _VALID_MODES = {"enforce", "testing", "none"}
+_DNS_RESOLUTION_ERROR_MARKERS = (
+    "name or service not known",
+    "temporary failure in name resolution",
+    "nodename nor servname",
+    "name does not resolve",
+)
 
 
 @dataclass
@@ -118,6 +124,26 @@ def parse_mta_sts_policy(  # noqa: C901
     return data, warnings, errors
 
 
+def _policy_fetch_error_message(domain: str, exc: Exception) -> str:
+    host = f"mta-sts.{domain}"
+    policy_url = f"https://{host}/.well-known/mta-sts.txt"
+    message = str(exc)
+    normalized = message.lower()
+    if any(marker in normalized for marker in _DNS_RESOLUTION_ERROR_MARKERS):
+        return (
+            f"MTA-STS policy host {host} could not be resolved. "
+            f"Publish DNS for {host} and serve {policy_url} over HTTPS."
+        )
+    if isinstance(exc, httpx.HTTPStatusError):
+        return (
+            "MTA-STS policy fetch failed: "
+            f"{policy_url} returned HTTP {exc.response.status_code}."
+        )
+    if isinstance(exc, httpx.TimeoutException):
+        return f"MTA-STS policy fetch timed out while requesting {policy_url}."
+    return f"MTA-STS policy fetch failed: {message}"
+
+
 async def check_mta_sts(domain: str, provider: BaseDNSProvider) -> MTAStsResult:
     """Resolve the MTA-STS TXT record and validate the HTTPS policy file."""
     result = MTAStsResult(policy_url=f"https://mta-sts.{domain}/.well-known/mta-sts.txt")
@@ -142,7 +168,7 @@ async def check_mta_sts(domain: str, provider: BaseDNSProvider) -> MTAStsResult:
             response.raise_for_status()
             result.policy_text = response.text
     except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException) as exc:
-        result.errors.append(f"MTA-STS policy fetch failed: {exc}")
+        result.errors.append(_policy_fetch_error_message(domain, exc))
         return result
 
     policy, policy_warnings, policy_errors = parse_mta_sts_policy(result.policy_text or "")

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -818,6 +818,47 @@ def test_posture_dashboard_links_recommendations_changes_and_playbooks(
     assert any(playbook["key"] == "missing_spf" for playbook in data["playbooks"])
 
 
+def test_posture_dashboard_distinguishes_mta_sts_policy_hosting_failure(
+    authed_client: TestClient,
+):
+    """A published _mta-sts TXT with an unreachable policy needs hosting guidance."""
+    mta_sts = MTAStsResult(
+        status="fail",
+        dns_record="v=STSv1; id=20260523",
+        policy_url=f"https://mta-sts.{DOMAIN}/.well-known/mta-sts.txt",
+        errors=[
+            f"MTA-STS policy host mta-sts.{DOMAIN} could not be resolved. "
+            f"Publish DNS for mta-sts.{DOMAIN} and serve "
+            f"https://mta-sts.{DOMAIN}/.well-known/mta-sts.txt over HTTPS."
+        ],
+    )
+    bimi = BIMIResult(status="pass", dns_record=f"v=BIMI1; l=https://{DOMAIN}/logo.svg; a=")
+
+    with (
+        _mock_dns(),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(mta_sts, False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(bimi, False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/posture")
+
+    assert response.status_code == 200
+    data = response.json()
+    recommendation = next(
+        item for item in data["recommendations"] if item["type"] == "mta_sts_policy_unreachable"
+    )
+    assert recommendation["title"] == "Host the MTA-STS policy"
+    assert "existing _mta-sts TXT record" in recommendation["action"]
+    assert f"https://mta-sts.{DOMAIN}/.well-known/mta-sts.txt" in recommendation["action"]
+    assert any(playbook["key"] == "mta_sts_policy_unreachable" for playbook in data["playbooks"])
+    assert all(item["type"] != "missing_mta_sts" for item in data["recommendations"])
+
+
 def test_posture_dashboard_refreshes_health_grade_dns(
     authed_client: TestClient,
 ):

--- a/backend/app/tests/test_mta_sts.py
+++ b/backend/app/tests/test_mta_sts.py
@@ -92,6 +92,20 @@ class _FakeAsyncClient:
         return self.response
 
 
+class _RaisingAsyncClient:
+    def __init__(self, exc):
+        self.exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def get(self, _url):
+        raise self.exc
+
+
 @pytest.mark.asyncio
 async def test_check_mta_sts_validates_dns_and_policy(monkeypatch):
     provider = AsyncMock()
@@ -191,6 +205,29 @@ async def test_check_mta_sts_reports_policy_fetch_error(monkeypatch):
     assert result.status == "fail"
     assert result.policy_text is None
     assert result.errors[0].startswith("MTA-STS policy fetch failed:")
+
+
+@pytest.mark.asyncio
+async def test_check_mta_sts_reports_policy_host_resolution_error(monkeypatch):
+    provider = AsyncMock()
+    provider.lookup_txt = AsyncMock(return_value=["v=STSv1; id=20260523"])
+    request = httpx.Request("GET", "https://mta-sts.example.com/.well-known/mta-sts.txt")
+    error = httpx.ConnectError("[Errno -2] Name or service not known", request=request)
+    monkeypatch.setattr(
+        "app.services.mta_sts.httpx.AsyncClient",
+        lambda **_: _RaisingAsyncClient(error),
+    )
+
+    result = await check_mta_sts("example.com", provider)
+
+    assert result.status == "fail"
+    assert result.dns_record == "v=STSv1; id=20260523"
+    assert result.policy_text is None
+    assert result.errors == [
+        "MTA-STS policy host mta-sts.example.com could not be resolved. "
+        "Publish DNS for mta-sts.example.com and serve "
+        "https://mta-sts.example.com/.well-known/mta-sts.txt over HTTPS."
+    ]
 
 
 @pytest.mark.asyncio

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -92,6 +92,8 @@ The domain detail page checks `_mta-sts.<domain>` and fetches the policy from `h
 
 DMARQ marks the check healthy when the TXT record contains `v=STSv1` with an `id`, the HTTPS policy is reachable, and the policy includes `version`, `mode`, `mx`, and `max_age`. Findings include the DNS record, policy URL, mode, MX patterns, and actionable guidance for missing records, fetch failures, invalid policies, or non-enforcing `testing`/`none` modes.
 
+When `_mta-sts.<domain>` exists but `mta-sts.<domain>` does not resolve or the HTTPS policy cannot be fetched, DMARQ treats this as a policy-hosting problem rather than a missing TXT record. Keep the TXT record if its `id` is current, publish DNS for `mta-sts.<domain>`, serve the policy at `/.well-known/mta-sts.txt`, and rotate the TXT `id` after changing the policy so receivers refetch it.
+
 MTA-STS posture uses the same cached DNS refresh behavior as the existing DNS health checks. Use the DNS refresh action when you publish or update a policy and need DMARQ to re-check immediately.
 
 ### BIMI Readiness


### PR DESCRIPTION
## Summary
- distinguish missing MTA-STS TXT records from unreachable HTTPS policy hosting in posture recommendations
- replace raw policy-host DNS resolution errors with operator-readable guidance for `mta-sts.<domain>`
- align DNS lint remediation text and user docs with the MTA-STS TXT + HTTPS policy split
- add regression coverage for `[Errno -2] Name or service not known` and the visible posture recommendation

## Why
A domain can have `_mta-sts.<domain>` published while `mta-sts.<domain>` does not resolve. That is a real MTA-STS policy-hosting problem, but the product previously surfaced it as the generic `Publish MTA-STS` action, which made it look like the TXT record was missing.

Refs #308

## Validation
- `./.venv/bin/python -m pytest backend/app/tests/test_mta_sts.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dns_guidance.py -q`
- `./.venv/bin/python -m black --check backend/app/services/mta_sts.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_mta_sts.py backend/app/tests/test_dns_endpoints.py`
- `./.venv/bin/python -m isort --check-only backend/app/services/mta_sts.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_mta_sts.py backend/app/tests/test_dns_endpoints.py`
- `./.venv/bin/python -m flake8 backend/app/services/mta_sts.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_mta_sts.py backend/app/tests/test_dns_endpoints.py`
- `git diff --check`
