### PR TITLE
[codex] Follow up MTA-STS policy host guidance

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -820,7 +820,8 @@ def _mta_sts_recommendation(result: MTAStsResult) -> Optional[DNSHealthRecommend
         detail = "; ".join(result.errors or ["The MTA-STS policy URL is not reachable."])
         action = (
             "Keep the existing _mta-sts TXT record if its id is current, then make "
-            f"{result.policy_url} reachable over HTTPS with a valid policy file."
+            f"{result.policy_url} reachable over HTTPS with a valid policy file. "
+            "Rotate the TXT id after publishing the policy so receivers refetch it."
         )
         recommendation_type = "mta_sts_policy_unreachable"
     else:

--- a/backend/app/services/mta_sts.py
+++ b/backend/app/services/mta_sts.py
@@ -167,7 +167,7 @@ async def check_mta_sts(domain: str, provider: BaseDNSProvider) -> MTAStsResult:
             response = await client.get(result.policy_url)
             response.raise_for_status()
             result.policy_text = response.text
-    except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException) as exc:
+    except (httpx.RequestError, httpx.HTTPStatusError) as exc:
         result.errors.append(_policy_fetch_error_message(domain, exc))
         return result
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -855,6 +855,7 @@ def test_posture_dashboard_distinguishes_mta_sts_policy_hosting_failure(
     assert recommendation["title"] == "Host the MTA-STS policy"
     assert "existing _mta-sts TXT record" in recommendation["action"]
     assert f"https://mta-sts.{DOMAIN}/.well-known/mta-sts.txt" in recommendation["action"]
+    assert "Rotate the TXT id" in recommendation["action"]
     assert any(playbook["key"] == "mta_sts_policy_unreachable" for playbook in data["playbooks"])
     assert all(item["type"] != "missing_mta_sts" for item in data["recommendations"])
 


### PR DESCRIPTION
## Summary
- remove redundant `httpx.TimeoutException` from the MTA-STS fetch exception tuple
- mention TXT id rotation directly in the visible unreachable-policy-host recommendation
- add regression coverage for the recommendation action text

## Validation
- `git diff --check`
- `python3 -m py_compile backend/app/services/mta_sts.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`

`python3 -m pytest backend/app/tests/test_dns_endpoints.py::test_posture_dashboard_distinguishes_mta_sts_policy_hosting_failure -q` could not run in this fresh checkout because `pytest` is not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guidance shown when an MTA-STS policy URL can’t be reached.
  * Refined error handling for MTA-STS policy checks so connection and HTTP failures are handled more consistently.

* **Tests**
  * Added coverage to verify the MTA-STS troubleshooting message includes the TXT record rotation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->