### PR TITLE
[codex] Add DKIM selector remediation plans

### DIFF
--- a/backend/app/api/api_v1/endpoints/ai.py
+++ b/backend/app/api/api_v1/endpoints/ai.py
@@ -13,6 +13,7 @@ from app.core.security import require_admin_auth
 from app.services.ai_assistance import (
     build_action_proposals,
     build_evidence_summary,
+    build_remediation_plan,
     build_safe_context,
     get_assistance_config,
 )
@@ -44,6 +45,12 @@ class ActionProposalResponse(BaseModel):
     domain: str
     action_tools_enabled: bool
     proposals: list[Dict[str, Any]]
+
+
+class RemediationPlanResponse(BaseModel):
+    """Step-by-step remediation plan response."""
+
+    plan: Dict[str, Any]
 
 
 class ProposalConfirmation(BaseModel):
@@ -134,6 +141,51 @@ async def get_domain_evidence_summary(
     )
     db.commit()
     return {"summary": summary}
+
+
+@router.get("/domains/{domain}/remediation-plan", response_model=RemediationPlanResponse)
+async def get_domain_remediation_plan(
+    domain: str,
+    request: Request,
+    finding_code: Optional[str] = None,
+    refresh: bool = False,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> RemediationPlanResponse:  # pylint: disable=too-many-positional-arguments
+    """Return a cached step-by-step remediation plan for DNS/posture findings."""
+    try:
+        plan = await build_remediation_plan(
+            db,
+            domain,
+            finding_code=finding_code,
+            refresh=refresh,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    workspace = _authorized_ai_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action="ai.remediation_plan_generated",
+        entity_type="domain",
+        entity_id=domain,
+        entity_name=domain,
+        details={
+            "provider": plan.get("provider"),
+            "cached": plan.get("cached", False),
+            "finding_code": finding_code,
+            "action_count": len(plan.get("actions") or []),
+        },
+        auth_context=_auth,
+        request=request,
+    )
+    db.commit()
+    return {"plan": plan}
 
 
 @router.get("/domains/{domain}/action-proposals", response_model=ActionProposalResponse)

--- a/backend/app/api/api_v1/endpoints/ai.py
+++ b/backend/app/api/api_v1/endpoints/ai.py
@@ -154,6 +154,7 @@ async def get_domain_remediation_plan(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> RemediationPlanResponse:  # pylint: disable=too-many-positional-arguments
     """Return a cached step-by-step remediation plan for DNS/posture findings."""
+    _require_ai_enabled(db)
     try:
         plan = await build_remediation_plan(
             db,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -176,6 +176,7 @@ class DNSLintFindingResponse(BaseModel):
     record_name: str
     target_record: Optional[DNSGuidanceRecordResponse] = None
     evidence: List[str] = Field(default_factory=list)
+    remediation_steps: List[str] = Field(default_factory=list)
 
 
 class DNSGuidanceResponse(BaseModel):
@@ -995,6 +996,8 @@ async def _build_domain_dns_guidance(
         dns_result,
         mta_sts_result,
         bimi_result,
+        monitored_selectors=combined_selectors,
+        observed_selectors=report_selectors,
     )
     return asdict(guidance)
 

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -137,7 +137,9 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
     {
         "key": "forensics.redaction_mode",
         "value": "balanced",
-        "description": "Forensic report email-address redaction mode: balanced, domain_only, or strict",
+        "description": (
+            "Forensic report email-address redaction mode: balanced, domain_only, or strict"
+        ),
         "value_type": "string",
         "category": "forensics",
     },
@@ -286,7 +288,7 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
     {
         "key": "ai.provider",
         "value": "template",
-        "description": "AI provider: template, local, or remote",
+        "description": "AI provider: template, local, remote, or litellm",
         "value_type": "string",
         "category": "ai",
     },
@@ -300,7 +302,9 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
     {
         "key": "ai.remote_base_url",
         "value": "",
-        "description": "Optional remote provider base URL; credentials should be injected by environment",
+        "description": (
+            "Optional remote provider base URL; credentials should be injected by environment"
+        ),
         "value_type": "string",
         "category": "ai",
     },
@@ -316,6 +320,13 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
         "value": "false",
         "description": "Allow human-confirmed action proposals to be recorded",
         "value_type": "boolean",
+        "category": "ai",
+    },
+    {
+        "key": "ai.remediation_cache_seconds",
+        "value": "86400",
+        "description": "Cache TTL for AI remediation plans; demo mode uses a longer fixed cache",
+        "value_type": "integer",
         "category": "ai",
     },
     {

--- a/backend/app/services/ai_assistance.py
+++ b/backend/app/services/ai_assistance.py
@@ -38,6 +38,7 @@ AI_DEFAULTS = {
 
 EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+-]+@([A-Z0-9.-]+\.[A-Z]{2,})\b", re.IGNORECASE)
 LONG_TOKEN_PATTERN = re.compile(r"\b[A-Za-z0-9._~+/=-]{24,}\b")
+REMEDIATION_CACHE_MAX_ENTRIES = 256
 _REMEDIATION_CACHE: Dict[str, tuple[float, Dict[str, Any]]] = {}
 
 
@@ -191,6 +192,7 @@ def _stable_cache_context(context: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _cache_get(key: str, ttl_seconds: int) -> Optional[Dict[str, Any]]:
+    _cache_prune(ttl_seconds)
     cached = _REMEDIATION_CACHE.get(key)
     if cached is None:
         return None
@@ -201,7 +203,25 @@ def _cache_get(key: str, ttl_seconds: int) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _cache_prune(ttl_seconds: int) -> None:
+    if ttl_seconds:
+        now = time.time()
+        expired_keys = [
+            key
+            for key, (created_at, _payload) in _REMEDIATION_CACHE.items()
+            if now - created_at > ttl_seconds
+        ]
+        for key in expired_keys:
+            _REMEDIATION_CACHE.pop(key, None)
+    while len(_REMEDIATION_CACHE) > REMEDIATION_CACHE_MAX_ENTRIES:
+        oldest_key = min(_REMEDIATION_CACHE, key=lambda item: _REMEDIATION_CACHE[item][0])
+        _REMEDIATION_CACHE.pop(oldest_key, None)
+
+
 def _cache_set(key: str, payload: Dict[str, Any]) -> None:
+    if len(_REMEDIATION_CACHE) >= REMEDIATION_CACHE_MAX_ENTRIES:
+        oldest_key = min(_REMEDIATION_CACHE, key=lambda item: _REMEDIATION_CACHE[item][0])
+        _REMEDIATION_CACHE.pop(oldest_key, None)
     _REMEDIATION_CACHE[key] = (time.time(), payload)
 
 

--- a/backend/app/services/ai_assistance.py
+++ b/backend/app/services/ai_assistance.py
@@ -5,15 +5,23 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from dataclasses import dataclass
+import time
+from dataclasses import asdict, dataclass
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.redaction import SENSITIVE_VALUE, redact_sensitive_text
 from app.models.domain import Domain
+from app.models.mail_source import MailSource
 from app.models.setting import Setting
+from app.services.bimi import check_bimi_cached
+from app.services.dns_cache import resolve_domain_dns_cached
+from app.services.dns_guidance import build_dns_guidance
+from app.services.dns_resolver import get_default_provider
+from app.services.mta_sts import check_mta_sts_cached
 from app.services.report_persistence import hydrate_report_store_from_db
 from app.services.report_store import ReportStore
 
@@ -24,11 +32,13 @@ AI_DEFAULTS = {
     "ai.remote_base_url": "",
     "ai.redaction_mode": "strict",
     "ai.action_tools_enabled": "false",
+    "ai.remediation_cache_seconds": "86400",
     "mcp.enabled": "false",
 }
 
 EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+-]+@([A-Z0-9.-]+\.[A-Z]{2,})\b", re.IGNORECASE)
 LONG_TOKEN_PATTERN = re.compile(r"\b[A-Za-z0-9._~+/=-]{24,}\b")
+_REMEDIATION_CACHE: Dict[str, tuple[float, Dict[str, Any]]] = {}
 
 
 @dataclass(frozen=True)
@@ -42,6 +52,7 @@ class AssistanceConfig:
     redaction_mode: str
     action_tools_enabled: bool
     mcp_enabled: bool
+    remediation_cache_seconds: int
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a UI/API-safe provider configuration."""
@@ -53,6 +64,7 @@ class AssistanceConfig:
             "redaction_mode": self.redaction_mode,
             "action_tools_enabled": self.action_tools_enabled,
             "mcp_enabled": self.mcp_enabled,
+            "remediation_cache_seconds": self.remediation_cache_seconds,
             "data_handling": {
                 "default_provider": "template",
                 "secrets_in_prompts": "never",
@@ -73,10 +85,17 @@ def _setting_bool(db: Session, key: str) -> bool:
     return _setting_value(db, key).strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _setting_int(db: Session, key: str, default: int) -> int:
+    try:
+        return max(0, int(_setting_value(db, key) or default))
+    except (TypeError, ValueError):
+        return default
+
+
 def get_assistance_config(db: Session) -> AssistanceConfig:
     """Load AI/MCP settings with safe defaults."""
     provider = (_setting_value(db, "ai.provider") or "template").strip().lower()
-    if provider not in {"template", "local", "remote"}:
+    if provider not in {"template", "local", "remote", "litellm"}:
         provider = "template"
     redaction_mode = (_setting_value(db, "ai.redaction_mode") or "strict").strip().lower()
     if redaction_mode not in {"strict", "balanced"}:
@@ -89,6 +108,7 @@ def get_assistance_config(db: Session) -> AssistanceConfig:
         redaction_mode=redaction_mode,
         action_tools_enabled=_setting_bool(db, "ai.action_tools_enabled"),
         mcp_enabled=_setting_bool(db, "mcp.enabled"),
+        remediation_cache_seconds=_setting_int(db, "ai.remediation_cache_seconds", 86400),
     )
 
 
@@ -122,6 +142,256 @@ def _evidence(label: str, value: Any, href: str) -> Dict[str, str]:
         "value": str(value),
         "href": href,
     }
+
+
+def _domain_selectors_from_db(db: Session, domain: str) -> List[str]:
+    row = db.query(Domain.dkim_selectors).filter(Domain.name == domain).first()
+    if row is None:
+        return []
+    return [selector.strip() for selector in (row[0] or "").split(",") if selector.strip()]
+
+
+def _selectors_from_reports(store: ReportStore, domain: str) -> List[str]:
+    selectors: List[str] = []
+    for report in store.get_domain_reports(domain):
+        for record in report.get("records", []):
+            for dkim_entry in record.get("dkim") or []:
+                if not isinstance(dkim_entry, dict):
+                    continue
+                selector = str(dkim_entry.get("selector") or "").strip()
+                if selector and selector not in selectors:
+                    selectors.append(selector)
+    return selectors
+
+
+def _mail_source_context(db: Session) -> List[Dict[str, Any]]:
+    rows = db.query(MailSource).filter(MailSource.enabled.is_(True)).order_by(MailSource.name).all()
+    return [
+        {
+            "name": source.name,
+            "method": source.method,
+            "server": source.server or None,
+            "folder": source.folder,
+            "polling_interval_minutes": source.polling_interval,
+            "last_checked": source.last_checked.isoformat() if source.last_checked else None,
+        }
+        for source in rows[:10]
+    ]
+
+
+def _remediation_cache_key(context: Dict[str, Any]) -> str:
+    serialized = json.dumps(context, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _stable_cache_context(context: Dict[str, Any]) -> Dict[str, Any]:
+    stable = dict(context)
+    stable["generated_at"] = "<generated>"
+    return stable
+
+
+def _cache_get(key: str, ttl_seconds: int) -> Optional[Dict[str, Any]]:
+    cached = _REMEDIATION_CACHE.get(key)
+    if cached is None:
+        return None
+    created_at, payload = cached
+    if ttl_seconds and time.time() - created_at <= ttl_seconds:
+        return payload
+    _REMEDIATION_CACHE.pop(key, None)
+    return None
+
+
+def _cache_set(key: str, payload: Dict[str, Any]) -> None:
+    _REMEDIATION_CACHE[key] = (time.time(), payload)
+
+
+def _template_remediation_plan(context: Dict[str, Any]) -> Dict[str, Any]:
+    findings = context["dns_guidance"]["findings"]
+    actions = []
+    for index, finding in enumerate(findings, start=1):
+        actions.append(
+            {
+                "id": f"remediate-{index}",
+                "finding_code": finding["code"],
+                "title": finding["title"],
+                "priority": finding["severity"],
+                "summary": finding["action"],
+                "steps": finding.get("remediation_steps")
+                or [
+                    "Review the linked evidence.",
+                    "Apply the smallest DNS or provider configuration change.",
+                    "Refresh DMARQ after propagation.",
+                ],
+                "evidence": finding.get("evidence", []),
+                "target_record": finding.get("target_record"),
+                "requires_human_change": True,
+            }
+        )
+    return {
+        "domain": context["domain"],
+        "provider": "template",
+        "cached": False,
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "summary": (
+            "DMARQ built this remediation plan from local DNS, report, and infrastructure "
+            "context. No remote model was used."
+        ),
+        "actions": actions,
+        "safe_context": context,
+    }
+
+
+async def _litellm_remediation_plan(
+    config: AssistanceConfig,
+    context: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    try:
+        import litellm  # pylint: disable=import-outside-toplevel  # type: ignore[import]
+    except ImportError:
+        return None
+
+    model = config.model or "gpt-4o-mini"
+    litellm.drop_params = True
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You generate concise, operational remediation plans for DMARC, SPF, "
+                "DKIM, MTA-STS, TLS-RPT, and BIMI findings. Never suggest automatic "
+                "DNS changes. Return only valid JSON with keys summary and actions. "
+                "Each action must include finding_code, title, priority, summary, "
+                "steps, evidence, target_record, and requires_human_change."
+            ),
+        },
+        {
+            "role": "user",
+            "content": json.dumps(context, sort_keys=True),
+        },
+    ]
+    kwargs: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": 0.2,
+        "response_format": {"type": "json_object"},
+        "timeout": 20,
+    }
+    if config.remote_base_url:
+        kwargs["api_base"] = config.remote_base_url
+    try:
+        response = await litellm.acompletion(**kwargs)
+        content = response["choices"][0]["message"]["content"]
+        parsed = json.loads(content)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None
+
+    actions = parsed.get("actions")
+    if not isinstance(actions, list):
+        return None
+    return {
+        "domain": context["domain"],
+        "provider": "litellm",
+        "model": model,
+        "cached": False,
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "summary": str(parsed.get("summary") or "AI-generated remediation plan."),
+        "actions": actions,
+        "safe_context": context,
+    }
+
+
+async def build_remediation_plan(  # pylint: disable=too-many-locals
+    db: Session,
+    domain: str,
+    *,
+    finding_code: Optional[str] = None,
+    refresh: bool = False,
+) -> Dict[str, Any]:
+    """Build a step-by-step remediation plan, optionally enhanced through LiteLLM."""
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store)
+    if not _domain_exists(db, store, domain):
+        raise ValueError("Domain not found")
+
+    config = get_assistance_config(db)
+    manual_selectors = _domain_selectors_from_db(db, domain)
+    report_selectors = _selectors_from_reports(store, domain)
+    combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
+    provider = get_default_provider(db)
+    dns_result, _, _ = await resolve_domain_dns_cached(
+        db,
+        provider,
+        domain,
+        selectors=combined_selectors,
+        refresh=refresh,
+    )
+    mta_sts_result, _, _ = await check_mta_sts_cached(db, provider, domain, refresh=refresh)
+    bimi_result, _, _ = await check_bimi_cached(db, provider, domain, refresh=refresh)
+    guidance = await build_dns_guidance(
+        domain,
+        provider,
+        dns_result,
+        mta_sts_result,
+        bimi_result,
+        monitored_selectors=combined_selectors,
+        observed_selectors=report_selectors,
+    )
+    finding_dicts = [asdict(finding) for finding in guidance.findings]
+    if finding_code:
+        finding_dicts = [finding for finding in finding_dicts if finding["code"] == finding_code]
+
+    context = redact_safe_value(
+        {
+            "domain": domain,
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "demo_mode": get_settings().DEMO_MODE,
+            "dns_provider": provider.__class__.__name__,
+            "mail_sources": _mail_source_context(db),
+            "dkim_selectors": {
+                "manual": manual_selectors,
+                "observed_from_reports": report_selectors,
+                "checked": dns_result.selectors_checked,
+                "resolved": dns_result.dkim_selectors,
+            },
+            "safe_summary": build_safe_context(db, domain)["summary"],
+            "dns_guidance": {
+                "status": guidance.status,
+                "findings": finding_dicts,
+                "target_records": [asdict(record) for record in guidance.target_records],
+            },
+            "constraints": {
+                "read_only_product_default": True,
+                "automatic_dns_changes": False,
+                "secrets_in_prompts": "never",
+                "raw_message_content": "never",
+            },
+        },
+        mode=config.redaction_mode,
+    )
+    cache_ttl = 30 * 24 * 60 * 60 if get_settings().DEMO_MODE else config.remediation_cache_seconds
+    cache_key = _remediation_cache_key(
+        {
+            "provider": config.provider,
+            "model": config.model,
+            "base_url_configured": bool(config.remote_base_url),
+            "context": _stable_cache_context(context),
+        }
+    )
+    cached = _cache_get(cache_key, cache_ttl)
+    if cached:
+        return {**cached, "cached": True}
+
+    plan = _template_remediation_plan(context)
+    if (
+        config.ai_enabled
+        and config.provider in {"remote", "local", "litellm"}
+        and not get_settings().DEMO_MODE
+    ):
+        llm_plan = await _litellm_remediation_plan(config, context)
+        if llm_plan is not None:
+            plan = llm_plan
+
+    _cache_set(cache_key, plan)
+    return plan
 
 
 def build_safe_context(db: Session, domain: str) -> Dict[str, Any]:

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from app.services.bimi import BIMIResult
 from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult, extract_dmarc_policy
@@ -37,6 +37,7 @@ class DNSLintFinding:
     record_name: str
     target_record: Optional[DNSGuidanceRecord] = None
     evidence: List[str] = field(default_factory=list)
+    remediation_steps: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -127,6 +128,7 @@ def _finding(
     *,
     target_record: Optional[DNSGuidanceRecord] = None,
     evidence: Optional[List[str]] = None,
+    remediation_steps: Optional[List[str]] = None,
 ) -> DNSLintFinding:
     return DNSLintFinding(
         code=code,
@@ -138,6 +140,106 @@ def _finding(
         record_name=record_name,
         target_record=target_record,
         evidence=list(evidence or []),
+        remediation_steps=list(remediation_steps or _default_remediation_steps(code)),
+    )
+
+
+def _default_remediation_steps(code: str) -> List[str]:
+    """Return deterministic operator steps for a lint finding."""
+    steps = {
+        "dmarc_missing": [
+            "Open the DNS zone for the affected domain.",
+            "Create one TXT record at _dmarc with a monitoring policy and rua mailbox.",
+            "Wait for DNS propagation, then refresh DMARQ DNS lint.",
+        ],
+        "spf_missing": [
+            "List every platform currently allowed to send mail for this domain.",
+            "Publish exactly one root TXT record beginning with v=spf1.",
+            "Use ~all during rollout or -all after all senders are verified.",
+        ],
+        "spf_multiple_records": [
+            "Copy all current SPF mechanisms into one planned SPF record.",
+            "Remove duplicate or obsolete mechanisms while preserving active senders.",
+            "Publish one root SPF TXT record and remove the extra SPF TXT values.",
+        ],
+        "spf_all_too_permissive": [
+            "Confirm which senders are legitimate from DMARQ sending-source evidence.",
+            "Replace +all with ~all while validating, or -all after coverage is complete.",
+            "Refresh DNS lint and watch failure trends for at least one report cycle.",
+        ],
+        "spf_dns_lookup_limit_exceeded": [
+            "Count every include, a, mx, ptr, exists, and redirect mechanism.",
+            "Remove unused includes and flatten stable sender ranges with the provider.",
+            "Keep the final SPF path below 10 DNS lookups before enforcement.",
+        ],
+        "spf_dns_lookup_limit_risk": [
+            "Identify which SPF includes are still actively used.",
+            "Remove duplicate or retired sender includes before adding new senders.",
+            "Document the remaining lookup budget for future sender onboarding.",
+        ],
+        "spf_duplicate_include": [
+            "Find the repeated include values in the SPF TXT record.",
+            "Keep one copy of each include and remove the duplicates.",
+            "Refresh DNS lint to confirm the SPF lookup budget improved.",
+        ],
+        "spf_void_lookup": [
+            "Open each referenced include, exists, or redirect target.",
+            "Remove targets that no longer publish TXT records.",
+            "Ask the sender provider for the current SPF include when the sender is still active.",
+        ],
+        "dkim_selector_missing": [
+            "Identify the sending provider that owns the selector from report evidence.",
+            "Open that provider's domain authentication settings and copy the DKIM TXT or CNAME.",
+            "Publish the selector record, then refresh DNS lint and confirm it resolves.",
+        ],
+        "dkim_selector_cname_broken": [
+            "Open the DNS CNAME record shown in evidence.",
+            "Compare its target with the current value in the sending provider admin page.",
+            "Replace stale targets or complete provider-side domain authentication.",
+        ],
+        "dkim_selector_key_too_short": [
+            "Check whether the sending provider supports 2048-bit DKIM keys.",
+            "Generate a replacement selector instead of editing the existing key in place.",
+            "Publish and validate the new selector before retiring the old selector.",
+        ],
+        "dkim_selector_stale": [
+            "Confirm whether the selector belongs to a retired sender or old key rotation.",
+            "Keep it only if a valid provider still uses it for aligned mail.",
+            "Remove retired selector records after checking one or more report cycles.",
+        ],
+        "mta_sts_missing": [
+            "Publish _mta-sts TXT with a stable id value.",
+            "Host a valid HTTPS policy at the well-known mta-sts hostname.",
+            "Start in testing mode and rotate the TXT id whenever the policy changes.",
+        ],
+        "tls_rpt_missing": [
+            "Choose the TLS report mailbox or HTTPS collector endpoint.",
+            "Publish one TXT record at _smtp._tls with v=TLSRPTv1 and rua.",
+            "Confirm DMARQ imports TLS reports after receivers start sending them.",
+        ],
+        "tls_rpt_multiple_records": [
+            "Merge all TLS-RPT rua destinations into one TXT record.",
+            "Remove duplicate _smtp._tls TXT records.",
+            "Refresh DNS lint to confirm only one TLS-RPT record remains.",
+        ],
+        "tls_rpt_rua_missing": [
+            "Choose where SMTP TLS reports should be delivered.",
+            "Add rua=mailto:... or rua=https://... to the TLS-RPT TXT value.",
+            "Refresh DMARQ after DNS propagation.",
+        ],
+        "bimi_missing": [
+            "Complete DMARC enforcement first.",
+            "Publish a default._bimi TXT record with an HTTPS SVG logo URL.",
+            "Add a certificate URL if the mailbox providers you care about require it.",
+        ],
+    }
+    return steps.get(
+        code,
+        [
+            "Open the linked DNS or report evidence in DMARQ.",
+            "Make the smallest provider-side change that addresses the finding.",
+            "Refresh DNS lint and monitor the next aggregate report cycle.",
+        ],
     )
 
 
@@ -449,13 +551,215 @@ async def _spf_findings(
     return findings
 
 
-def _dkim_findings(
-    result: DomainDNSResult, targets: List[DNSGuidanceRecord]
+def _dkim_record_tags(record: str) -> Dict[str, str]:
+    return {
+        part.split("=", 1)[0].strip().lower(): part.split("=", 1)[1].strip()
+        for part in record.split(";")
+        if "=" in part
+    }
+
+
+def _dkim_public_key_value(record: str) -> str:
+    tags = _dkim_record_tags(record)
+    return "".join((tags.get("p") or "").split())
+
+
+def _dkim_record_is_too_short(record: str) -> bool:
+    tags = _dkim_record_tags(record)
+    key_type = (tags.get("k") or "rsa").lower()
+    public_key = _dkim_public_key_value(record)
+    return key_type == "rsa" and bool(public_key) and len(public_key) < 216
+
+
+async def _dkim_selector_record(
+    provider: BaseDNSProvider, selector: str, domain: str
+) -> Optional[str]:
+    try:
+        records = await provider.lookup_txt(f"{selector}._domainkey.{domain}")
+    except LookupError:
+        return None
+    for record in records:
+        lowered = record.lower()
+        if "v=dkim1" in lowered or "p=" in lowered:
+            return record
+    return None
+
+
+def _dkim_record_findings(
+    selector: str,
+    record_name: str,
+    record: str,
+    target: DNSGuidanceRecord,
+    *,
+    has_report_evidence: bool,
+    observed_selector_set: set[str],
 ) -> List[DNSLintFinding]:
+    findings: List[DNSLintFinding] = []
+    if _dkim_record_is_too_short(record):
+        findings.append(
+            _finding(
+                "dkim_selector_key_too_short",
+                "warning",
+                "DKIM selector key is short",
+                (
+                    f"Selector {selector} resolves, but its RSA public key looks "
+                    "shorter than a normal 1024-bit key."
+                ),
+                (
+                    "Rotate this selector to a provider-generated 2048-bit DKIM key "
+                    "where supported."
+                ),
+                "TXT",
+                record_name,
+                target_record=target,
+                evidence=[record],
+            )
+        )
+    if has_report_evidence and selector not in observed_selector_set:
+        findings.append(
+            _finding(
+                "dkim_selector_stale",
+                "info",
+                "DKIM selector has no recent report traffic",
+                (
+                    f"Selector {selector} resolves in DNS but was not seen in recent "
+                    "DMARC aggregate report data."
+                ),
+                (
+                    "Confirm whether this sender is still active before keeping the "
+                    "selector published."
+                ),
+                "TXT",
+                record_name,
+                target_record=target,
+                evidence=[record],
+            )
+        )
+    return findings
+
+
+async def _dkim_cname_target(provider: BaseDNSProvider, record_name: str) -> Optional[str]:
+    cname_lookup = getattr(provider, "lookup_cname", None)
+    cname_target = await cname_lookup(record_name) if callable(cname_lookup) else None
+    return cname_target if isinstance(cname_target, str) else None
+
+
+async def _dkim_cname_finding(
+    provider: BaseDNSProvider,
+    selector: str,
+    record_name: str,
+    target: DNSGuidanceRecord,
+) -> Optional[DNSLintFinding]:
+    cname_target = await _dkim_cname_target(provider, record_name)
+    if not cname_target:
+        return None
+    try:
+        cname_records = await provider.lookup_txt(cname_target)
+    except LookupError:
+        cname_records = []
+    if any(
+        "v=dkim1" in cname_record.lower() or "p=" in cname_record.lower()
+        for cname_record in cname_records
+    ):
+        return None
+    return _finding(
+        "dkim_selector_cname_broken",
+        "warning",
+        "DKIM selector CNAME target is broken",
+        (
+            f"Selector {selector} points to {cname_target}, but the target "
+            "does not expose a DKIM TXT record."
+        ),
+        (
+            "Re-copy the provider DKIM CNAME target or complete provider-side "
+            "domain authentication."
+        ),
+        "CNAME",
+        record_name,
+        target_record=target,
+        evidence=[f"{record_name} -> {cname_target}"],
+    )
+
+
+def _dkim_missing_finding(
+    selector: str, record_name: str, target: DNSGuidanceRecord
+) -> DNSLintFinding:
+    return _finding(
+        "dkim_selector_missing",
+        "warning",
+        "DKIM selector is missing",
+        f"Selector {selector} was observed or configured but did not resolve.",
+        "Publish the provider's DKIM TXT or CNAME record for this selector.",
+        "TXT",
+        record_name,
+        target_record=target,
+    )
+
+
+async def _dkim_selector_findings(
+    provider: BaseDNSProvider,
+    domain: str,
+    result: DomainDNSResult,
+    target: DNSGuidanceRecord,
+    monitored_selectors: List[str],
+    observed_selectors: List[str],
+) -> List[DNSLintFinding]:
+    findings: List[DNSLintFinding] = []
+    resolved_selectors = set(result.dkim_selectors or [])
+    observed_selector_set = set(observed_selectors or [])
+    has_report_evidence = bool(observed_selector_set)
+
+    for selector in monitored_selectors:
+        record_name = f"{selector}._domainkey.{domain}"
+        record = await _dkim_selector_record(provider, selector, domain)
+        if record:
+            findings.extend(
+                _dkim_record_findings(
+                    selector,
+                    record_name,
+                    record,
+                    target,
+                    has_report_evidence=has_report_evidence,
+                    observed_selector_set=observed_selector_set,
+                )
+            )
+            continue
+
+        cname_finding = await _dkim_cname_finding(provider, selector, record_name, target)
+        if cname_finding:
+            findings.append(cname_finding)
+            continue
+
+        if selector not in resolved_selectors:
+            findings.append(_dkim_missing_finding(selector, record_name, target))
+    return findings
+
+
+async def _dkim_findings(
+    provider: BaseDNSProvider,
+    domain: str,
+    result: DomainDNSResult,
+    targets: List[DNSGuidanceRecord],
+    *,
+    monitored_selectors: Optional[List[str]] = None,
+    observed_selectors: Optional[List[str]] = None,
+) -> List[DNSLintFinding]:
+    target = _target_by_code(targets, "target_dkim")
+    selectors_for_detail = list(
+        dict.fromkeys(monitored_selectors or result.selectors_checked or [])
+    )
+    if result.dkim and selectors_for_detail:
+        return await _dkim_selector_findings(
+            provider,
+            domain,
+            result,
+            target,
+            selectors_for_detail,
+            list(dict.fromkeys(observed_selectors or [])),
+        )
     if result.dkim:
         return []
-    target = _target_by_code(targets, "target_dkim")
-    checked = ", ".join(result.selectors_checked or [])
+    checked = ", ".join(selectors_for_detail)
     detail = "No DKIM selector resolved for configured, observed, or common selectors."
     if checked:
         detail = f"{detail} Checked selectors: {checked}."
@@ -615,6 +919,9 @@ async def build_dns_guidance(
     result: DomainDNSResult,
     mta_sts: MTAStsResult,
     bimi: BIMIResult,
+    *,
+    monitored_selectors: Optional[List[str]] = None,
+    observed_selectors: Optional[List[str]] = None,
 ) -> DNSGuidanceResult:
     """Build typed DNS lint findings and target records for a domain."""
     normalized_domain = domain.strip().strip(".").lower()
@@ -622,7 +929,16 @@ async def build_dns_guidance(
     findings: List[DNSLintFinding] = []
     findings.extend(_dmarc_findings(normalized_domain, result, targets))
     findings.extend(await _spf_findings(normalized_domain, provider, result, targets))
-    findings.extend(_dkim_findings(result, targets))
+    findings.extend(
+        await _dkim_findings(
+            provider,
+            normalized_domain,
+            result,
+            targets,
+            monitored_selectors=monitored_selectors,
+            observed_selectors=observed_selectors,
+        )
+    )
     findings.extend(_mta_sts_findings(mta_sts, targets))
     findings.extend(await _tls_rpt_findings(normalized_domain, provider, targets))
     findings.extend(_bimi_findings(bimi, extract_dmarc_policy(result.dmarc_record), targets))

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -382,6 +382,15 @@ class BaseDNSProvider(ABC):
         """
         return None
 
+    async def lookup_cname(self, name: str) -> Optional[str]:
+        """Return the CNAME target for *name*, or ``None`` if unavailable.
+
+        Provider test doubles that only support TXT lookups can keep using the
+        base implementation. DNS guidance treats ``None`` as "no visible CNAME"
+        instead of a lookup failure.
+        """
+        return None
+
     async def check_dkim(
         self, domain: str, selectors: List[str]
     ) -> Tuple[bool, List[str], Optional[str]]:
@@ -512,6 +521,22 @@ class SystemDNSProvider(BaseDNSProvider):
                 for rdata in answers:
                     return str(rdata).rstrip(".")
         except (dns.exception.DNSException, ValueError):
+            pass
+        return None
+
+    async def lookup_cname(self, name: str) -> Optional[str]:
+        """Resolve a CNAME record for *name* via the system resolver."""
+        import dns.asyncresolver  # type: ignore[import]
+        import dns.exception  # type: ignore[import]
+
+        try:
+            answers = await dns.asyncresolver.resolve(
+                name, "CNAME", lifetime=DNS_TIMEOUT, raise_on_no_answer=False
+            )
+            if answers:
+                for rdata in answers:
+                    return str(rdata.target).rstrip(".")
+        except dns.exception.DNSException:
             pass
         return None
 
@@ -707,6 +732,29 @@ class CloudflareDNSProvider(BaseDNSProvider):
             pass
         return None
 
+    async def lookup_cname(self, name: str) -> Optional[str]:
+        """Resolve a CNAME record for *name* via Cloudflare's DoH endpoint."""
+        import httpx  # type: ignore[import]
+
+        params = {"name": name, "type": "CNAME"}
+        headers = {"Accept": "application/dns-json"}
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    self.CLOUDFLARE_DOH_URL,
+                    params=params,
+                    headers=headers,
+                    timeout=DNS_TIMEOUT,
+                )
+                response.raise_for_status()
+                data = response.json()
+                for answer in data.get("Answer", []):
+                    if answer.get("type") == 5:  # CNAME record type
+                        return answer.get("data", "").rstrip(".")
+        except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException):
+            pass
+        return None
+
 
 class DemoDNSProvider(BaseDNSProvider):
     """Deterministic DNS provider for the opt-in public demo mode."""
@@ -721,9 +769,19 @@ class DemoDNSProvider(BaseDNSProvider):
                 )
             ],
             "dmarq.org._report._dmarc.reports.dmarq.net": ["v=DMARC1"],
-            "selector1._domainkey.dmarq.org": ["v=DKIM1; k=rsa; p=DEMOSELECTOR1"],
+            "selector1._domainkey.dmarq.org": [
+                "v=DKIM1; k=rsa; p="
+                "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtestselector1demo"
+                "keymaterialforshowcasingahealthyselectornotforproductionuseonly"
+                "andlongenoughtoavoidweakkeywarnings1234567890abcdef"
+            ],
             "news._domainkey.dmarq.org": ["v=DKIM1; k=rsa; p=DEMONEWS"],
-            "zendesk._domainkey.dmarq.org": ["v=DKIM1; k=rsa; p=DEMOZENDESK"],
+            "zendesk._domainkey.dmarq.org": [
+                "v=DKIM1; k=rsa; p="
+                "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzendesksupportdemo"
+                "keymaterialforshowcasingahealthyselectornotforproductionuseonly"
+                "andlongenoughtoavoidweakkeywarningsabcdef1234567890"
+            ],
             "_mta-sts.dmarq.org": ["v=STSv1; id=20260625"],
             "_smtp._tls.dmarq.org": ["v=TLSRPTv1; rua=mailto:tlsrpt@dmarq.org"],
             "default._bimi.dmarq.org": [
@@ -733,9 +791,22 @@ class DemoDNSProvider(BaseDNSProvider):
             "_dmarc.dmarq.com": [
                 "v=DMARC1; p=none; rua=mailto:dmarc@reports.dmarq.org!50m; adkim=r; aspf=r"
             ],
-            "google._domainkey.dmarq.com": ["v=DKIM1; k=rsa; p=DEMOGOOGLE"],
-            "stripe._domainkey.dmarq.com": ["v=DKIM1; k=rsa; p=DEMOSTRIPE"],
+            "google._domainkey.dmarq.com": [
+                "v=DKIM1; k=rsa; p="
+                "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgoggledemo"
+                "keymaterialforshowcasingahealthyselectornotforproductionuseonly"
+                "andlongenoughtoavoidweakkeywarnings0987654321fedcba"
+            ],
+            "stripe._domainkey.dmarq.com": [
+                "v=DKIM1; k=rsa; p="
+                "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAstripedemo"
+                "keymaterialforshowcasingahealthyselectornotforproductionuseonly"
+                "andlongenoughtoavoidweakkeywarningsfedcba0987654321"
+            ],
             "_smtp._tls.dmarq.com": ["v=TLSRPTv1"],
+        }
+        self._cname_records = {
+            "mailchimp._domainkey.dmarq.com": "missing-mcsv._domainkey.mcsv.net",
         }
 
     async def lookup_txt(self, name: str) -> List[str]:
@@ -756,6 +827,10 @@ class DemoDNSProvider(BaseDNSProvider):
             "198.51.100.199": "unknown-forwarder.demo.dmarq.com",
         }
         return ptr_records.get(ip)
+
+    async def lookup_cname(self, name: str) -> Optional[str]:
+        normalized = _normalize_dns_name(name)
+        return self._cname_records.get(normalized)
 
 
 def _decrypt_setting_value(value: Optional[str]) -> Optional[str]:

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -536,8 +536,8 @@ class SystemDNSProvider(BaseDNSProvider):
             if answers:
                 for rdata in answers:
                     return str(rdata.target).rstrip(".")
-        except dns.exception.DNSException:
-            pass
+        except dns.exception.DNSException as exc:
+            logger.debug("CNAME lookup failed for %s: %s", _sanitize_for_log(name), exc)
         return None
 
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -432,6 +432,13 @@
                                             </div>
                                             <p class="mt-1 text-sm text-base-content/70" x-text="finding.detail"></p>
                                             <p class="mt-1 text-sm" x-text="finding.action"></p>
+                                            <template x-if="finding.remediation_steps && finding.remediation_steps.length">
+                                                <ol class="mt-2 list-decimal space-y-1 pl-5 text-sm text-base-content/75">
+                                                    <template x-for="step in finding.remediation_steps" :key="step">
+                                                        <li x-text="step"></li>
+                                                    </template>
+                                                </ol>
+                                            </template>
                                             <template x-if="finding.target_record">
                                                 <div class="mt-2 rounded bg-base-200 p-2">
                                                     <div class="flex flex-col gap-2 sm:flex-row sm:items-center">

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -434,7 +434,7 @@
                                             <p class="mt-1 text-sm" x-text="finding.action"></p>
                                             <template x-if="finding.remediation_steps && finding.remediation_steps.length">
                                                 <ol class="mt-2 list-decimal space-y-1 pl-5 text-sm text-base-content/75">
-                                                    <template x-for="step in finding.remediation_steps" :key="step">
+                                                    <template x-for="(step, stepIndex) in finding.remediation_steps" :key="finding.code + '-' + stepIndex">
                                                         <li x-text="step"></li>
                                                     </template>
                                                 </ol>

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock, patch
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -5,6 +7,9 @@ from app.models.organization import Entitlement, Organization
 from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.services.api_tokens import MCP_READ_SCOPE, create_api_token
+from app.services.bimi import BIMIResult
+from app.services.dns_resolver import DomainDNSResult
+from app.services.mta_sts import MTAStsResult
 from app.services.report_store import ReportStore
 
 DOMAIN = "example.com"
@@ -82,6 +87,51 @@ def test_ai_summary_is_evidence_first_and_redacted(
     assert body["recommendations"]
     assert body["recommendations"][0]["evidence"]
     assert "**redacted**" not in body["safe_context"]["domain"]
+
+
+def test_ai_remediation_plan_uses_template_and_cache(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    _seed_report_store()
+    _set_setting(db_session, "ai.remediation_cache_seconds", "86400", "ai")
+    provider = AsyncMock()
+    provider.check_domain = AsyncMock(
+        return_value=DomainDNSResult(
+            dmarc=True,
+            dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+            spf=True,
+            spf_record="v=spf1 -all",
+            dkim=False,
+            selectors_checked=["google"],
+        )
+    )
+    provider.lookup_txt = AsyncMock(side_effect=LookupError("not found"))
+    provider.lookup_cname = AsyncMock(return_value=None)
+
+    with (
+        patch("app.services.ai_assistance.get_default_provider", return_value=provider),
+        patch(
+            "app.services.ai_assistance.check_mta_sts_cached",
+            new=AsyncMock(return_value=(MTAStsResult(status="pass"), False, None)),
+        ),
+        patch(
+            "app.services.ai_assistance.check_bimi_cached",
+            new=AsyncMock(return_value=(BIMIResult(status="pass"), False, None)),
+        ),
+    ):
+        first = authed_client.get(f"/api/v1/ai/domains/{DOMAIN}/remediation-plan")
+        second = authed_client.get(f"/api/v1/ai/domains/{DOMAIN}/remediation-plan")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    first_plan = first.json()["plan"]
+    second_plan = second.json()["plan"]
+    assert first_plan["provider"] == "template"
+    assert first_plan["actions"]
+    assert first_plan["actions"][0]["steps"]
+    assert first_plan["safe_context"]["constraints"]["automatic_dns_changes"] is False
+    assert second_plan["cached"] is True
 
 
 def test_action_proposals_are_reviewable_and_not_mutating(

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -1,6 +1,7 @@
 import builtins
 import sys
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -11,8 +12,8 @@ from app.models.organization import Entitlement, Organization
 from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.services import ai_assistance
-from app.services.api_tokens import MCP_READ_SCOPE, create_api_token
 from app.services.ai_assistance import AssistanceConfig
+from app.services.api_tokens import MCP_READ_SCOPE, create_api_token
 from app.services.bimi import BIMIResult
 from app.services.dns_resolver import DomainDNSResult
 from app.services.mta_sts import MTAStsResult
@@ -234,6 +235,17 @@ def test_remediation_cache_prunes_expired_entries_and_oldest_entries():
     ai_assistance._REMEDIATION_CACHE.clear()
 
 
+def test_ai_remediation_plan_returns_404_for_unknown_domain(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    _set_setting(db_session, "ai.enabled", "true", "ai")
+
+    response = authed_client.get("/api/v1/ai/domains/unknown.example/remediation-plan")
+
+    assert response.status_code == 404
+
+
 @pytest.mark.asyncio
 async def test_litellm_remediation_plan_returns_valid_actions(monkeypatch):
     class FakeLiteLLM:
@@ -273,7 +285,11 @@ async def test_litellm_remediation_plan_returns_valid_actions(monkeypatch):
 
     plan = await ai_assistance._litellm_remediation_plan(
         config,
-        {"domain": DOMAIN, "dns_guidance": {"findings": []}},
+        {
+            "domain": DOMAIN,
+            "dns_guidance": {"findings": []},
+            "constraints": {"automatic_dns_changes": False},
+        },
     )
 
     assert plan is not None
@@ -281,6 +297,53 @@ async def test_litellm_remediation_plan_returns_valid_actions(monkeypatch):
     assert plan["model"] == "test-model"
     assert plan["actions"][0]["finding_code"] == "dkim_selector_missing"
     assert FakeLiteLLM.drop_params is True
+
+
+@pytest.mark.asyncio
+async def test_litellm_remediation_plan_parses_json_response(monkeypatch):
+    async def fake_acompletion(**_kwargs):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": (
+                            '{"summary":"Fix DKIM","actions":[{"finding_code":'
+                            '"dkim_selector_missing","title":"Publish DKIM",'
+                            '"priority":"warning","summary":"Publish selector",'
+                            '"steps":["Copy provider record"],"evidence":[],'
+                            '"target_record":null,"requires_human_change":true}]}'
+                        )
+                    }
+                }
+            ]
+        }
+
+    fake_litellm = SimpleNamespace(acompletion=fake_acompletion, drop_params=False)
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    config = AssistanceConfig(
+        ai_enabled=True,
+        provider="litellm",
+        model="gpt-test",
+        remote_base_url="https://llm.example.test/v1",
+        redaction_mode="strict",
+        action_tools_enabled=False,
+        mcp_enabled=False,
+        remediation_cache_seconds=86400,
+    )
+
+    plan = await ai_assistance._litellm_remediation_plan(
+        config,
+        {
+            "domain": DOMAIN,
+            "dns_guidance": {"findings": []},
+            "constraints": {"automatic_dns_changes": False},
+        },
+    )
+
+    assert plan is not None
+    assert plan["provider"] == "litellm"
+    assert plan["model"] == "gpt-test"
+    assert plan["actions"][0]["finding_code"] == "dkim_selector_missing"
 
 
 @pytest.mark.asyncio
@@ -306,7 +369,11 @@ async def test_litellm_remediation_plan_rejects_malformed_actions(monkeypatch):
 
     plan = await ai_assistance._litellm_remediation_plan(
         config,
-        {"domain": DOMAIN, "dns_guidance": {"findings": []}},
+        {
+            "domain": DOMAIN,
+            "dns_guidance": {"findings": []},
+            "constraints": {"automatic_dns_changes": False},
+        },
     )
 
     assert plan is None

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -1,5 +1,8 @@
+import sys
+import time
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -8,6 +11,7 @@ from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.services import ai_assistance
 from app.services.api_tokens import MCP_READ_SCOPE, create_api_token
+from app.services.ai_assistance import AssistanceConfig
 from app.services.bimi import BIMIResult
 from app.services.dns_resolver import DomainDNSResult
 from app.services.mta_sts import MTAStsResult
@@ -177,6 +181,101 @@ def test_ai_remediation_cache_is_bounded():
     assert len(ai_assistance._REMEDIATION_CACHE) == ai_assistance.REMEDIATION_CACHE_MAX_ENTRIES
     assert "key-0" not in ai_assistance._REMEDIATION_CACHE
     ai_assistance._REMEDIATION_CACHE.clear()
+
+
+def test_remediation_cache_prunes_expired_entries_and_oldest_entries():
+    ai_assistance._REMEDIATION_CACHE.clear()
+    ai_assistance._REMEDIATION_CACHE["expired"] = (time.time() - 120, {"stale": True})
+    ai_assistance._cache_set("fresh", {"stale": False})
+
+    assert ai_assistance._cache_get("expired", ttl_seconds=1) is None
+    assert ai_assistance._cache_get("fresh", ttl_seconds=1)["stale"] is False
+
+    ai_assistance._REMEDIATION_CACHE.clear()
+    for index in range(ai_assistance.REMEDIATION_CACHE_MAX_ENTRIES + 3):
+        ai_assistance._cache_set(f"key-{index}", {"index": index})
+
+    assert len(ai_assistance._REMEDIATION_CACHE) <= ai_assistance.REMEDIATION_CACHE_MAX_ENTRIES
+    assert "key-0" not in ai_assistance._REMEDIATION_CACHE
+    ai_assistance._REMEDIATION_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_litellm_remediation_plan_returns_valid_actions(monkeypatch):
+    class FakeLiteLLM:
+        drop_params = False
+
+        @staticmethod
+        async def acompletion(**_kwargs):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                '{"summary": "Review DNS posture.", "actions": '
+                                '[{"finding_code": "dkim_selector_missing", '
+                                '"title": "Publish selector", "priority": "high", '
+                                '"summary": "Publish the missing selector.", '
+                                '"steps": ["Create the TXT record."], '
+                                '"evidence": [], "target_record": null, '
+                                '"requires_human_change": true}]}'
+                            )
+                        }
+                    }
+                ]
+            }
+
+    monkeypatch.setitem(sys.modules, "litellm", FakeLiteLLM)
+    config = AssistanceConfig(
+        ai_enabled=True,
+        provider="litellm",
+        model="test-model",
+        remote_base_url="https://litellm.example.test",
+        redaction_mode="strict",
+        action_tools_enabled=False,
+        mcp_enabled=False,
+        remediation_cache_seconds=60,
+    )
+
+    plan = await ai_assistance._litellm_remediation_plan(
+        config,
+        {"domain": DOMAIN, "dns_guidance": {"findings": []}},
+    )
+
+    assert plan is not None
+    assert plan["provider"] == "litellm"
+    assert plan["model"] == "test-model"
+    assert plan["actions"][0]["finding_code"] == "dkim_selector_missing"
+    assert FakeLiteLLM.drop_params is True
+
+
+@pytest.mark.asyncio
+async def test_litellm_remediation_plan_rejects_malformed_actions(monkeypatch):
+    class FakeLiteLLM:
+        drop_params = False
+
+        @staticmethod
+        async def acompletion(**_kwargs):
+            return {"choices": [{"message": {"content": '{"summary": "No actions"}'}}]}
+
+    monkeypatch.setitem(sys.modules, "litellm", FakeLiteLLM)
+    config = AssistanceConfig(
+        ai_enabled=True,
+        provider="litellm",
+        model="",
+        remote_base_url="",
+        redaction_mode="strict",
+        action_tools_enabled=False,
+        mcp_enabled=False,
+        remediation_cache_seconds=60,
+    )
+
+    plan = await ai_assistance._litellm_remediation_plan(
+        config,
+        {"domain": DOMAIN, "dns_guidance": {"findings": []}},
+    )
+
+    assert plan is None
 
 
 def test_action_proposals_are_reviewable_and_not_mutating(

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -94,6 +94,7 @@ def test_ai_remediation_plan_uses_template_and_cache(
     db_session: Session,
 ):
     _seed_report_store()
+    _set_setting(db_session, "ai.enabled", "true", "ai")
     _set_setting(db_session, "ai.remediation_cache_seconds", "86400", "ai")
     provider = AsyncMock()
     provider.check_domain = AsyncMock(

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -1,3 +1,4 @@
+import builtins
 import sys
 import time
 from unittest.mock import AsyncMock, patch
@@ -75,6 +76,15 @@ def test_ai_summary_requires_explicit_opt_in(authed_client: TestClient):
     assert "AI assistance is disabled" in response.json()["detail"]
 
 
+def test_ai_context_requires_explicit_opt_in(authed_client: TestClient):
+    _seed_report_store()
+
+    response = authed_client.get(f"/api/v1/ai/domains/{DOMAIN}/context")
+
+    assert response.status_code == 403
+    assert "AI assistance is disabled" in response.json()["detail"]
+
+
 def test_ai_remediation_plan_requires_explicit_opt_in(authed_client: TestClient):
     _seed_report_store()
 
@@ -101,6 +111,18 @@ def test_ai_summary_is_evidence_first_and_redacted(
     assert body["recommendations"]
     assert body["recommendations"][0]["evidence"]
     assert "**redacted**" not in body["safe_context"]["domain"]
+
+
+def test_ai_summary_returns_not_found_for_unknown_domain(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    _set_setting(db_session, "ai.enabled", "true", "ai")
+
+    response = authed_client.get("/api/v1/ai/domains/missing.example/summary")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Domain not found"
 
 
 def test_ai_remediation_plan_uses_template_and_cache(
@@ -197,6 +219,18 @@ def test_remediation_cache_prunes_expired_entries_and_oldest_entries():
 
     assert len(ai_assistance._REMEDIATION_CACHE) <= ai_assistance.REMEDIATION_CACHE_MAX_ENTRIES
     assert "key-0" not in ai_assistance._REMEDIATION_CACHE
+
+    ai_assistance._REMEDIATION_CACHE.clear()
+    for index in range(ai_assistance.REMEDIATION_CACHE_MAX_ENTRIES + 2):
+        ai_assistance._REMEDIATION_CACHE[f"raw-{index}"] = (index, {"index": index})
+
+    ai_assistance._cache_prune(ttl_seconds=0)
+
+    assert len(ai_assistance._REMEDIATION_CACHE) == ai_assistance.REMEDIATION_CACHE_MAX_ENTRIES
+    assert "raw-0" not in ai_assistance._REMEDIATION_CACHE
+
+    ai_assistance._REMEDIATION_CACHE["stale"] = (time.time() - 120, {"stale": True})
+    assert ai_assistance._cache_get("stale", ttl_seconds=0) is None
     ai_assistance._REMEDIATION_CACHE.clear()
 
 
@@ -276,6 +310,184 @@ async def test_litellm_remediation_plan_rejects_malformed_actions(monkeypatch):
     )
 
     assert plan is None
+
+
+@pytest.mark.asyncio
+async def test_litellm_remediation_plan_returns_none_when_litellm_is_missing(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "litellm":
+            raise ImportError("missing litellm")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    config = AssistanceConfig(
+        ai_enabled=True,
+        provider="litellm",
+        model="",
+        remote_base_url="",
+        redaction_mode="strict",
+        action_tools_enabled=False,
+        mcp_enabled=False,
+        remediation_cache_seconds=60,
+    )
+
+    plan = await ai_assistance._litellm_remediation_plan(
+        config,
+        {"domain": DOMAIN, "dns_guidance": {"findings": []}},
+    )
+
+    assert plan is None
+
+
+@pytest.mark.asyncio
+async def test_litellm_remediation_plan_returns_none_on_bad_json(monkeypatch):
+    class FakeLiteLLM:
+        drop_params = False
+
+        @staticmethod
+        async def acompletion(**_kwargs):
+            return {"choices": [{"message": {"content": "not-json"}}]}
+
+    monkeypatch.setitem(sys.modules, "litellm", FakeLiteLLM)
+    config = AssistanceConfig(
+        ai_enabled=True,
+        provider="litellm",
+        model="",
+        remote_base_url="",
+        redaction_mode="strict",
+        action_tools_enabled=False,
+        mcp_enabled=False,
+        remediation_cache_seconds=60,
+    )
+
+    plan = await ai_assistance._litellm_remediation_plan(
+        config,
+        {"domain": DOMAIN, "dns_guidance": {"findings": []}},
+    )
+
+    assert plan is None
+
+
+def test_ai_remediation_plan_returns_not_found_for_unknown_domain(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    _set_setting(db_session, "ai.enabled", "true", "ai")
+
+    response = authed_client.get("/api/v1/ai/domains/missing.example/remediation-plan")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Domain not found"
+
+
+def test_ai_remediation_plan_can_use_litellm_provider(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    _seed_report_store()
+    _set_setting(db_session, "ai.enabled", "true", "ai")
+    _set_setting(db_session, "ai.provider", "litellm", "ai")
+    provider = AsyncMock()
+    provider.check_domain = AsyncMock(
+        return_value=DomainDNSResult(
+            dmarc=True,
+            dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+            spf=True,
+            spf_record="v=spf1 -all",
+            dkim=True,
+            dkim_selectors=["google"],
+            selectors_checked=["google"],
+        )
+    )
+    provider.lookup_txt = AsyncMock(return_value=["v=spf1 -all"])
+    provider.lookup_cname = AsyncMock(return_value=None)
+    llm_plan = {
+        "domain": DOMAIN,
+        "provider": "litellm",
+        "cached": False,
+        "generated_at": "2026-06-29T10:00:00Z",
+        "summary": "AI-generated plan.",
+        "actions": [],
+        "safe_context": {"domain": DOMAIN},
+    }
+
+    with (
+        patch("app.services.ai_assistance.get_default_provider", return_value=provider),
+        patch(
+            "app.services.ai_assistance.check_mta_sts_cached",
+            new=AsyncMock(return_value=(MTAStsResult(status="pass"), False, None)),
+        ),
+        patch(
+            "app.services.ai_assistance.check_bimi_cached",
+            new=AsyncMock(return_value=(BIMIResult(status="pass"), False, None)),
+        ),
+        patch(
+            "app.services.ai_assistance._litellm_remediation_plan",
+            new=AsyncMock(return_value=llm_plan),
+        ) as litellm_plan,
+    ):
+        response = authed_client.get(f"/api/v1/ai/domains/{DOMAIN}/remediation-plan")
+
+    assert response.status_code == 200
+    assert response.json()["plan"]["provider"] == "litellm"
+    litellm_plan.assert_awaited_once()
+
+
+def test_action_proposals_return_not_found_for_unknown_domain(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    _set_setting(db_session, "ai.enabled", "true", "ai")
+
+    response = authed_client.get("/api/v1/ai/domains/missing.example/action-proposals")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Domain not found"
+
+
+def test_assistance_config_normalizes_invalid_settings(db_session: Session):
+    _set_setting(db_session, "ai.provider", "surprise", "ai")
+    _set_setting(db_session, "ai.redaction_mode", "unsafe", "ai")
+    _set_setting(db_session, "ai.remediation_cache_seconds", "not-a-number", "ai")
+
+    config = ai_assistance.get_assistance_config(db_session)
+
+    assert config.provider == "template"
+    assert config.redaction_mode == "strict"
+    assert config.remediation_cache_seconds == 86400
+
+
+def test_report_selectors_ignore_malformed_entries():
+    store = ReportStore.get_instance()
+    store.add_report(
+        {
+            "domain": "selector.example",
+            "report_id": "selector-report",
+            "records": [
+                {
+                    "dkim": [
+                        "not-a-dict",
+                        {"selector": "alpha"},
+                        {"selector": "alpha"},
+                        {"selector": "beta"},
+                    ]
+                }
+            ],
+            "summary": {"total_count": 1, "passed_count": 0, "failed_count": 1},
+        }
+    )
+
+    assert ai_assistance._selectors_from_reports(store, "selector.example") == [
+        "alpha",
+        "beta",
+    ]
+
+
+def test_build_safe_context_returns_not_found_for_unknown_domain(db_session: Session):
+    with pytest.raises(ValueError, match="Domain not found"):
+        ai_assistance.build_safe_context(db_session, "missing.example")
 
 
 def test_action_proposals_are_reviewable_and_not_mutating(

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from app.models.organization import Entitlement, Organization
 from app.models.setting import Setting
 from app.models.workspace import Workspace
+from app.services import ai_assistance
 from app.services.api_tokens import MCP_READ_SCOPE, create_api_token
 from app.services.bimi import BIMIResult
 from app.services.dns_resolver import DomainDNSResult
@@ -66,6 +67,15 @@ def test_ai_settings_are_seeded(authed_client: TestClient):
 def test_ai_summary_requires_explicit_opt_in(authed_client: TestClient):
     _seed_report_store()
     response = authed_client.get(f"/api/v1/ai/domains/{DOMAIN}/summary")
+    assert response.status_code == 403
+    assert "AI assistance is disabled" in response.json()["detail"]
+
+
+def test_ai_remediation_plan_requires_explicit_opt_in(authed_client: TestClient):
+    _seed_report_store()
+
+    response = authed_client.get(f"/api/v1/ai/domains/{DOMAIN}/remediation-plan")
+
     assert response.status_code == 403
     assert "AI assistance is disabled" in response.json()["detail"]
 
@@ -133,6 +143,40 @@ def test_ai_remediation_plan_uses_template_and_cache(
     assert first_plan["actions"][0]["steps"]
     assert first_plan["safe_context"]["constraints"]["automatic_dns_changes"] is False
     assert second_plan["cached"] is True
+    focused = first_plan["actions"][0]["finding_code"]
+
+    with (
+        patch("app.services.ai_assistance.get_default_provider", return_value=provider),
+        patch(
+            "app.services.ai_assistance.check_mta_sts_cached",
+            new=AsyncMock(return_value=(MTAStsResult(status="pass"), False, None)),
+        ),
+        patch(
+            "app.services.ai_assistance.check_bimi_cached",
+            new=AsyncMock(return_value=(BIMIResult(status="pass"), False, None)),
+        ),
+    ):
+        filtered = authed_client.get(
+            f"/api/v1/ai/domains/{DOMAIN}/remediation-plan?finding_code={focused}"
+        )
+
+    assert filtered.status_code == 200
+    filtered_actions = filtered.json()["plan"]["actions"]
+    assert filtered_actions
+    assert {action["finding_code"] for action in filtered_actions} == {focused}
+
+
+def test_ai_remediation_cache_is_bounded():
+    ai_assistance._REMEDIATION_CACHE.clear()
+    for index in range(ai_assistance.REMEDIATION_CACHE_MAX_ENTRIES + 5):
+        ai_assistance._cache_set(
+            f"key-{index}",
+            {"domain": f"example-{index}.test", "actions": []},
+        )
+
+    assert len(ai_assistance._REMEDIATION_CACHE) == ai_assistance.REMEDIATION_CACHE_MAX_ENTRIES
+    assert "key-0" not in ai_assistance._REMEDIATION_CACHE
+    ai_assistance._REMEDIATION_CACHE.clear()
 
 
 def test_action_proposals_are_reviewable_and_not_mutating(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -81,6 +81,7 @@ def _mock_dns(result: DomainDNSResult = MOCK_DNS_RESULT):
     provider = AsyncMock()
     provider.check_domain = AsyncMock(return_value=result)
     provider.lookup_txt = AsyncMock(side_effect=LookupError("MTA-STS not configured"))
+    provider.lookup_cname = AsyncMock(return_value=None)
     return patch(
         "app.api.api_v1.endpoints.domains.get_default_provider",
         return_value=provider,
@@ -342,6 +343,11 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: Tes
         "target_dkim",
         "target_tls_rpt",
     }
+    dkim_finding = next(
+        finding for finding in data["findings"] if finding["code"] == "dkim_selector_missing"
+    )
+    assert dkim_finding["remediation_steps"]
+    assert "Publish" in " ".join(dkim_finding["remediation_steps"])
 
 
 def test_dns_lint_endpoint_flags_advanced_spf_lookup_findings(

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -99,15 +99,15 @@ async def test_build_dns_guidance_classifies_dmarc_warning_codes():
         spf_record="v=spf1 ?all",
         dkim=True,
         dkim_selectors=["selector1"],
-            dmarc_warnings=[
-                "External rua destination reports.example.net is missing authorization TXT.",
-                "External ruf destination forensics.example.net is missing authorization TXT.",
-                "Unsupported policy value p=monitor.",
-                "DMARC adkim tag should be r or s.",
-                "DMARC fo tag contains unsupported failure options.",
-                "Record contains neither a valid p tag nor a rua tag.",
-                "Unexpected DMARC lint warning.",
-            ],
+        dmarc_warnings=[
+            "External rua destination reports.example.net is missing authorization TXT.",
+            "External ruf destination forensics.example.net is missing authorization TXT.",
+            "Unsupported policy value p=monitor.",
+            "DMARC adkim tag should be r or s.",
+            "DMARC fo tag contains unsupported failure options.",
+            "Record contains neither a valid p tag nor a rua tag.",
+            "Unexpected DMARC lint warning.",
+        ],
         dmarc_suggestions=["Add rua=mailto:... so aggregate reports can reach DMARQ."],
     )
 
@@ -258,3 +258,36 @@ async def test_spf_lint_covers_redirect_void_and_duplicate_free_paths():
     codes = {finding.code for finding in guidance.findings}
     assert "spf_void_lookup" in codes
     assert "spf_duplicate_include" not in codes
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_accepts_valid_dkim_cname_target():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+            "provider._domainkey.vendor.example": ["v=DKIM1; k=rsa; p=VALIDKEY"],
+        }
+    )
+    provider._cnames["mailchimp._domainkey.example.com"] = "provider._domainkey.vendor.example"
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["mailchimp"],
+        selectors_checked=["mailchimp"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        monitored_selectors=["mailchimp"],
+        observed_selectors=["mailchimp"],
+    )
+
+    assert "dkim_selector_cname_broken" not in {finding.code for finding in guidance.findings}

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -99,11 +99,15 @@ async def test_build_dns_guidance_classifies_dmarc_warning_codes():
         spf_record="v=spf1 ?all",
         dkim=True,
         dkim_selectors=["selector1"],
-        dmarc_warnings=[
-            "External rua destination reports.example.net is missing authorization TXT.",
-            "DMARC adkim tag should be r or s.",
-            "DMARC fo tag contains unsupported failure options.",
-        ],
+            dmarc_warnings=[
+                "External rua destination reports.example.net is missing authorization TXT.",
+                "External ruf destination forensics.example.net is missing authorization TXT.",
+                "Unsupported policy value p=monitor.",
+                "DMARC adkim tag should be r or s.",
+                "DMARC fo tag contains unsupported failure options.",
+                "Record contains neither a valid p tag nor a rua tag.",
+                "Unexpected DMARC lint warning.",
+            ],
         dmarc_suggestions=["Add rua=mailto:... so aggregate reports can reach DMARQ."],
     )
 
@@ -117,8 +121,12 @@ async def test_build_dns_guidance_classifies_dmarc_warning_codes():
 
     codes = {finding.code for finding in guidance.findings}
     assert "dmarc_external_rua_unauthorized" in codes
+    assert "dmarc_external_ruf_unauthorized" in codes
+    assert "dmarc_policy_value_invalid" in codes
     assert "dmarc_alignment_value_invalid" in codes
     assert "dmarc_failure_option_invalid" in codes
+    assert "dmarc_policy_or_reporting_missing" in codes
+    assert "dmarc_lint_warning" in codes
     assert "dmarc_suggestion" in codes
     assert "dmarc_monitoring_policy" in codes
     assert "spf_all_neutral" in codes
@@ -220,3 +228,33 @@ async def test_build_dns_guidance_lints_dkim_selector_health():
     assert findings["dkim_selector_missing"].record_name == "old._domainkey.example.com"
     assert findings["dkim_selector_cname_broken"].record_type == "CNAME"
     assert findings["dkim_selector_key_too_short"].remediation_steps
+
+
+@pytest.mark.asyncio
+async def test_spf_lint_covers_redirect_void_and_duplicate_free_paths():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 redirect=missing.example -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 redirect=missing.example a -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+    )
+
+    codes = {finding.code for finding in guidance.findings}
+    assert "spf_void_lookup" in codes
+    assert "spf_duplicate_include" not in codes

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -9,11 +9,15 @@ from app.services.mta_sts import MTAStsResult
 class FakeDNSProvider(BaseDNSProvider):
     def __init__(self, records: dict[str, list[str]]):
         self._records = records
+        self._cnames: dict[str, str] = {}
 
     async def lookup_txt(self, name: str) -> list[str]:
         if name in self._records:
             return self._records[name]
         raise LookupError(f"NXDOMAIN: {name}")
+
+    async def lookup_cname(self, name: str) -> str | None:
+        return self._cnames.get(name)
 
 
 @pytest.mark.asyncio
@@ -171,3 +175,48 @@ async def test_build_dns_guidance_lints_more_spf_tls_mta_and_bimi_states():
     assert "tls_rpt_multiple_records" in codes
     assert "mta_sts_review" in codes
     assert "bimi_review" in codes
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_lints_dkim_selector_health():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+            "google._domainkey.example.com": [
+                "v=DKIM1; k=rsa; p="
+                "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgoodselector"
+                "keymaterialthatislongenoughtolooklikeanormalrsa1024or2048key"
+                "forlintpurposesonly1234567890abcdef"
+            ],
+            "short._domainkey.example.com": ["v=DKIM1; k=rsa; p=SHORT"],
+        }
+    )
+    provider._cnames["mailchimp._domainkey.example.com"] = "missing._domainkey.mcsv.net"
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["google", "short"],
+        selectors_checked=["google", "short", "mailchimp", "old"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        monitored_selectors=["google", "short", "mailchimp", "old"],
+        observed_selectors=["google", "mailchimp"],
+    )
+
+    findings = {finding.code: finding for finding in guidance.findings}
+    assert "dkim_selector_key_too_short" in findings
+    assert "dkim_selector_cname_broken" in findings
+    assert "dkim_selector_missing" in findings
+    assert findings["dkim_selector_missing"].record_name == "old._domainkey.example.com"
+    assert findings["dkim_selector_cname_broken"].record_type == "CNAME"
+    assert findings["dkim_selector_key_too_short"].remediation_steps

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -14,6 +14,7 @@ from app.models.setting import Setting
 from app.services.dns_resolver import (
     BaseDNSProvider,
     CloudflareDNSProvider,
+    DemoDNSProvider,
     DomainDNSResult,
     SystemDNSProvider,
     extract_dmarc_policy,
@@ -810,3 +811,12 @@ async def test_cloudflare_provider_lookup_ptr_returns_none_for_invalid_ip():
     provider = CloudflareDNSProvider()
     result = await provider.lookup_ptr("not-an-ip")
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_demo_provider_lookup_cname_returns_configured_target():
+    provider = DemoDNSProvider()
+
+    target = await provider.lookup_cname("mailchimp._domainkey.dmarq.com")
+
+    assert target == "missing-mcsv._domainkey.mcsv.net"

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -113,9 +113,7 @@ def test_parse_dmarc_record_tags_tracks_active_dmarcbis_tags_only():
 async def test_check_domain_lints_external_report_destination_without_authorization():
     provider = FakeDNSProvider(
         {
-            "_dmarc.example.com": [
-                "v=DMARC1; p=none; rua=mailto:dmarc@reports.example.net!50m"
-            ],
+            "_dmarc.example.com": ["v=DMARC1; p=none; rua=mailto:dmarc@reports.example.net!50m"],
             "example.com": ["v=spf1 include:_spf.example.com -all"],
         }
     )
@@ -132,9 +130,7 @@ async def test_check_domain_lints_external_report_destination_without_authorizat
 async def test_check_domain_accepts_authorized_external_report_destination():
     provider = FakeDNSProvider(
         {
-            "_dmarc.example.com": [
-                "v=DMARC1; p=none; rua=mailto:dmarc@reports.example.net"
-            ],
+            "_dmarc.example.com": ["v=DMARC1; p=none; rua=mailto:dmarc@reports.example.net"],
             "example.com": ["v=spf1 include:_spf.example.com -all"],
             "example.com._report._dmarc.reports.example.net": ["v=DMARC1"],
         }
@@ -452,6 +448,38 @@ async def test_system_provider_raises_lookup_error_on_dns_exception():
             await provider.lookup_txt("nonexistent.example.com")
 
 
+@pytest.mark.asyncio
+async def test_system_provider_lookup_cname_returns_target():
+    """SystemDNSProvider.lookup_cname should strip the trailing target dot."""
+
+    class FakeCnameRdata:
+        target = "selector.provider.example."
+
+    class FakeCnameAnswers:
+        def __iter__(self):
+            return iter([FakeCnameRdata()])
+
+    with patch("dns.asyncresolver.resolve", new=AsyncMock(return_value=FakeCnameAnswers())):
+        provider = SystemDNSProvider()
+        target = await provider.lookup_cname("selector._domainkey.example.com")
+
+    assert target == "selector.provider.example"
+
+
+@pytest.mark.asyncio
+async def test_system_provider_lookup_cname_returns_none_on_dns_exception():
+    import dns.exception  # type: ignore[import]
+
+    with patch(
+        "dns.asyncresolver.resolve",
+        new=AsyncMock(side_effect=dns.exception.DNSException("NXDOMAIN")),
+    ):
+        provider = SystemDNSProvider()
+        target = await provider.lookup_cname("selector._domainkey.example.com")
+
+    assert target is None
+
+
 # ---------------------------------------------------------------------------
 # CloudflareDNSProvider
 # ---------------------------------------------------------------------------
@@ -491,6 +519,43 @@ async def test_cloudflare_provider_raises_on_http_error():
         provider = CloudflareDNSProvider()
         with pytest.raises(LookupError):
             await provider.lookup_txt("_dmarc.example.com")
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_provider_lookup_cname_returns_target():
+    """CloudflareDNSProvider.lookup_cname should parse CNAME answers."""
+    from unittest.mock import MagicMock
+
+    fake_response_data = {
+        "Answer": [
+            {"type": 5, "data": "selector.provider.example."},
+            {"type": 16, "data": '"v=DKIM1; p=ABC"'},
+        ]
+    }
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = lambda: fake_response_data
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        provider = CloudflareDNSProvider()
+        target = await provider.lookup_cname("selector._domainkey.example.com")
+
+    assert target == "selector.provider.example"
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_provider_lookup_cname_returns_none_on_http_error():
+    import httpx
+
+    with patch(
+        "httpx.AsyncClient.get",
+        new=AsyncMock(side_effect=httpx.RequestError("connection refused")),
+    ):
+        provider = CloudflareDNSProvider()
+        target = await provider.lookup_cname("selector._domainkey.example.com")
+
+    assert target is None
 
 
 @pytest.mark.asyncio
@@ -638,6 +703,13 @@ async def test_base_provider_lookup_ptr_returns_none():
     """FakeDNSProvider only implements lookup_txt; lookup_ptr must return None."""
     provider = FakeDNSProvider({})
     result = await provider.lookup_ptr("1.2.3.4")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_base_provider_lookup_cname_returns_none():
+    provider = FakeDNSProvider({})
+    result = await provider.lookup_cname("selector._domainkey.example.com")
     assert result is None
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -30,3 +30,4 @@ jinja2>=3.1.2
 google-auth>=2.0.0
 google-api-python-client>=2.0.0
 google-auth-httplib2>=0.2.0
+litellm>=1.40.0

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -173,6 +173,24 @@ Cloudflare-managed DNS record snapshots and change events are stored in
 `dns_record_snapshots` and `dns_record_changes`. They are updated whenever the
 Cloudflare DNS analysis endpoint is called.
 
+### AI Remediation Plans
+
+DMARQ can generate deterministic remediation plans without a model. To enable
+model-enhanced plans, set `ai.enabled=true`, choose `ai.provider=litellm`
+or another LiteLLM-backed provider mode in Settings, and configure
+`ai.model`. `ai.remote_base_url` can point at an OpenAI-compatible gateway when
+needed.
+
+Provider API keys are not stored in DMARQ settings. Inject `OPENAI_API_KEY`,
+`LITELLM_API_KEY`, or provider-specific environment variables into the backend
+process with your deployment secret manager. In hosted or GitOps deployments,
+prefer 1Password, Kubernetes Secrets, or an equivalent injector so raw keys are
+not copied into application settings.
+
+Remote remediation plans are cached with `ai.remediation_cache_seconds`
+(`86400` by default). Demo mode uses template-backed plans and a longer fixed
+cache window.
+
 ### Advanced Configuration
 
 | Variable | Description | Default | Example |

--- a/docs/reference/ai-mcp-automation.md
+++ b/docs/reference/ai-mcp-automation.md
@@ -10,17 +10,20 @@ Milestone 16 adds optional automation surfaces that are safe by default:
   opaque values, and email local-parts in strict mode.
 - Action tools produce reviewable proposals first. Confirmation is audited, and
   the current implementation does not apply DNS or other external changes.
+- Remediation plans are deterministic by default and can optionally be enhanced
+  through LiteLLM/OpenAI-compatible providers after explicit opt-in.
 
 ## Settings
 
 | Key | Default | Purpose |
 | --- | --- | --- |
 | `ai.enabled` | `false` | Enables AI assistance endpoints |
-| `ai.provider` | `template` | `template`, `local`, or `remote` provider mode |
+| `ai.provider` | `template` | `template`, `local`, `remote`, or `litellm` provider mode |
 | `ai.model` | empty | Optional model name |
 | `ai.remote_base_url` | empty | Optional remote provider URL |
 | `ai.redaction_mode` | `strict` | `strict` or `balanced` safe-context redaction |
 | `ai.action_tools_enabled` | `false` | Allows proposal confirmation records |
+| `ai.remediation_cache_seconds` | `86400` | Cache TTL for AI remediation plans; demo mode uses a longer fixed cache |
 | `mcp.enabled` | `false` | Enables the read-only MCP endpoint |
 
 Use 1Password or another deployment secret injector for provider credentials.
@@ -39,6 +42,26 @@ agent surfaces are allowed to inspect. It includes:
 
 The payload deliberately excludes raw report XML, mailbox credentials, OAuth
 tokens, notification target URLs, and original forensic message content.
+
+## Remediation Plans
+
+`GET /api/v1/ai/domains/{domain}/remediation-plan` builds a step-by-step plan
+from the current DNS lint findings, observed DKIM selectors, configured mail
+sources, DNS provider type, target records, and redacted report summary. Use
+`finding_code=...` to focus the plan on one problem.
+
+Template mode returns deterministic steps and is available without a remote
+model. When `ai.enabled=true` and `ai.provider` is `local`, `remote`, or
+`litellm`, DMARQ uses LiteLLM to request a JSON remediation plan from the
+configured model. `ai.remote_base_url` can point at an OpenAI-compatible local
+or hosted endpoint. Provider credentials must be injected into the process
+environment, for example through 1Password or Kubernetes secrets; DMARQ settings
+do not store API keys.
+
+Remote remediation plans are cached by a hash of the redacted context,
+provider, model, and base-URL state. Demo mode always uses the template plan
+and a long cache window so the public demo does not generate repeated model
+requests.
 
 ## MCP
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -257,6 +257,20 @@ GET /ai/domains/{domain}/summary
 Returns a deterministic evidence-first summary and remediation plan. Each
 recommendation includes evidence links back to the underlying DMARC data.
 
+#### Build Remediation Plan
+
+```text
+GET /ai/domains/{domain}/remediation-plan
+GET /ai/domains/{domain}/remediation-plan?finding_code=dkim_selector_missing
+```
+
+Returns a cached, step-by-step remediation plan built from redacted report,
+DNS, selector, mail-source, and provider context. Template mode is deterministic
+and never calls a remote model. When `ai.enabled=true` and `ai.provider` is
+`local`, `remote`, or `litellm`, DMARQ can ask LiteLLM for an
+OpenAI-compatible JSON plan. Demo mode always uses the template plan and a long
+cache window.
+
 #### Build Action Proposals
 
 ```text
@@ -379,10 +393,12 @@ GET /domains/dns/lint
 GET /domains/dns/lint/export
 ```
 
-Returns typed DNS lint findings with stable `code` values and suggested target
-records for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI readiness. The bulk
-endpoint returns the same payload shape per monitored domain, and the export
-endpoint returns the finding list as CSV for managed-domain reviews.
+Returns typed DNS lint findings with stable `code` values, suggested target
+records, and deterministic `remediation_steps` for DMARC, SPF, DKIM, MTA-STS,
+TLS-RPT, and BIMI readiness. DKIM findings distinguish missing selectors,
+broken CNAME targets, short RSA keys, and stale selectors. The bulk endpoint
+returns the same payload shape per monitored domain, and the export endpoint
+returns the finding list as CSV for managed-domain reviews.
 
 #### Get Posture Dashboard
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -86,6 +86,13 @@ target records. DMARQ checks DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI
 readiness, then exposes the same guidance through the single-domain lint API,
 bulk lint API, and CSV export for managed-domain reviews.
 
+Each lint finding includes a short remediation checklist. DKIM findings now
+distinguish missing observed selectors, broken selector CNAME targets, short
+RSA keys, and selectors that still resolve but have no recent report traffic.
+Optional AI remediation plans can turn the same redacted DNS/report context
+into a longer step-by-step plan through LiteLLM/OpenAI-compatible providers;
+demo mode keeps these plans template-backed and heavily cached.
+
 ### MTA-STS Posture
 
 The domain detail page checks `_mta-sts.<domain>` and fetches the policy from `https://mta-sts.<domain>/.well-known/mta-sts.txt`.


### PR DESCRIPTION
## Summary

- add advanced DKIM selector lint findings for missing observed selectors, broken selector CNAME targets, short RSA keys, and stale selectors
- add deterministic step-by-step remediation steps to DNS lint findings and render them on domain detail pages
- add a cached remediation-plan endpoint under the existing AI surface with optional LiteLLM/OpenAI-compatible enhancement and template fallback for demo/non-configured installs
- enrich demo DNS with DKIM corner cases and document LiteLLM/cache/secret handling

## Validation

- 
- 
- 
- 
- ============================= test session starts ==============================
platform darwin -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /private/tmp/dmarq-238-close
configfile: pyproject.toml (WARNING: ignoring pytest config in setup.cfg!)
plugins: cov-7.1.0, anyio-4.14.1, asyncio-1.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 130 items

backend/app/tests/test_dns_resolver.py ................................. [ 25%]
....................                                                     [ 40%]
backend/app/tests/test_dns_guidance.py .....                             [ 44%]
backend/app/tests/test_dns_endpoints.py ................................ [ 69%]
........................                                                 [ 87%]
backend/app/tests/test_demo_data.py ........                             [ 93%]
backend/app/tests/test_ai_mcp.py ........                                [100%]

=============================== warnings summary ===============================
.venv/lib/python3.13/site-packages/fastapi/testclient.py:1
  /private/tmp/dmarq-238-close/.venv/lib/python3.13/site-packages/fastapi/testclient.py:1: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient as TestClient  # noqa

backend/app/core/config.py:107
  /private/tmp/dmarq-238-close/backend/app/core/config.py:107: PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    @validator("ADMIN_API_KEY", pre=True, always=True)

backend/app/core/config.py:122
  /private/tmp/dmarq-238-close/backend/app/core/config.py:122: PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    @validator("SECRET_KEY", pre=True, always=True)

backend/app/core/config.py:161
  /private/tmp/dmarq-238-close/backend/app/core/config.py:161: PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    @validator("BACKEND_CORS_ORIGINS", pre=True)

backend/app/core/config.py:18
  /private/tmp/dmarq-238-close/backend/app/core/config.py:18: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class Settings(BaseSettings):

backend/app/core/database.py:66
  /private/tmp/dmarq-238-close/backend/app/core/database.py:66: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()

backend/app/api/api_v1/endpoints/mail_sources.py:114
  /private/tmp/dmarq-238-close/backend/app/api/api_v1/endpoints/mail_sources.py:114: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class MailSourceResponse(MailSourceBase):

backend/app/main.py:471: 1 warning
backend/app/tests/test_dns_endpoints.py: 47 warnings
backend/app/tests/test_ai_mcp.py: 8 warnings
  /private/tmp/dmarq-238-close/backend/app/main.py:471: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @application.on_event("startup")

.venv/lib/python3.13/site-packages/fastapi/applications.py:4675: 2 warnings
backend/app/tests/test_dns_endpoints.py: 94 warnings
backend/app/tests/test_ai_mcp.py: 16 warnings
  /private/tmp/dmarq-238-close/.venv/lib/python3.13/site-packages/fastapi/applications.py:4675: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    return self.router.on_event(event_type)  # ty: ignore[deprecated]

backend/app/main.py:536: 1 warning
backend/app/tests/test_dns_endpoints.py: 47 warnings
backend/app/tests/test_ai_mcp.py: 8 warnings
  /private/tmp/dmarq-238-close/backend/app/main.py:536: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @application.on_event("shutdown")

backend/app/tests/test_dns_resolver.py: 3 warnings
backend/app/tests/test_dns_endpoints.py: 342 warnings
backend/app/tests/test_ai_mcp.py: 90 warnings
  /private/tmp/dmarq-238-close/.venv/lib/python3.13/site-packages/sqlalchemy/sql/schema.py:3623: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    return util.wrap_callable(lambda ctx: fn(), fn)  # type: ignore

backend/app/tests/test_dns_endpoints.py: 47 warnings
backend/app/tests/test_ai_mcp.py: 8 warnings
  /private/tmp/dmarq-238-close/backend/app/services/runtime_status.py:23: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

backend/app/tests/test_dns_endpoints.py: 47 warnings
backend/app/tests/test_ai_mcp.py: 8 warnings
  /private/tmp/dmarq-238-close/backend/app/services/runtime_status.py:39: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    _scheduler_state["last_cycle_started_at"] = datetime.utcnow()

backend/app/tests/test_dns_endpoints.py: 47 warnings
backend/app/tests/test_ai_mcp.py: 8 warnings
  /private/tmp/dmarq-238-close/backend/app/services/webhook_events.py:401: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

backend/app/tests/test_dns_endpoints.py: 47 warnings
backend/app/tests/test_ai_mcp.py: 8 warnings
  /private/tmp/dmarq-238-close/backend/app/services/runtime_status.py:43: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    _scheduler_state.update({"last_success_at": datetime.utcnow(), "last_error": None})

backend/app/tests/test_dns_endpoints.py: 94 warnings
backend/app/tests/test_ai_mcp.py: 16 warnings
  /private/tmp/dmarq-238-close/backend/app/services/runtime_status.py:35: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    _scheduler_state.update({"running": False, "stopped_at": datetime.utcnow()})

backend/app/tests/test_dns_endpoints.py: 11 warnings
backend/app/tests/test_ai_mcp.py: 7 warnings
  /private/tmp/dmarq-238-close/backend/app/services/workspace_audit.py:107: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    created_at=created_at or datetime.utcnow(),

backend/app/tests/test_dns_endpoints.py::test_add_selector_invalid_empty
  /private/tmp/dmarq-238-close/.venv/lib/python3.13/site-packages/fastapi/routing.py:344: StarletteDeprecationWarning: 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead.
    return await dependant.call(**values)

backend/app/tests/test_ai_mcp.py::test_ai_summary_is_evidence_first_and_redacted
backend/app/tests/test_ai_mcp.py::test_ai_remediation_plan_uses_template_and_cache
backend/app/tests/test_ai_mcp.py::test_ai_remediation_plan_uses_template_and_cache
backend/app/tests/test_ai_mcp.py::test_action_proposals_are_reviewable_and_not_mutating
backend/app/tests/test_ai_mcp.py::test_action_confirmation_requires_action_tools_enabled
backend/app/tests/test_ai_mcp.py::test_action_confirmation_requires_action_tools_enabled
backend/app/tests/test_ai_mcp.py::test_mcp_requires_enabled_scoped_token
  /private/tmp/dmarq-238-close/backend/app/services/ai_assistance.py:416: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "generated_at": datetime.utcnow().isoformat() + "Z",

backend/app/tests/test_ai_mcp.py::test_ai_remediation_plan_uses_template_and_cache
backend/app/tests/test_ai_mcp.py::test_ai_remediation_plan_uses_template_and_cache
  /private/tmp/dmarq-238-close/backend/app/services/ai_assistance.py:345: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "generated_at": datetime.utcnow().isoformat() + "Z",

backend/app/tests/test_ai_mcp.py::test_ai_remediation_plan_uses_template_and_cache
  /private/tmp/dmarq-238-close/backend/app/services/ai_assistance.py:234: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "generated_at": datetime.utcnow().isoformat() + "Z",

backend/app/tests/test_ai_mcp.py::test_mcp_requires_enabled_scoped_token
backend/app/tests/test_ai_mcp.py::test_mcp_requires_enabled_scoped_token
backend/app/tests/test_ai_mcp.py::test_mcp_requires_enabled_scoped_token
backend/app/tests/test_ai_mcp.py::test_mcp_requires_advanced_integrations_entitlement
  /private/tmp/dmarq-238-close/backend/app/services/api_tokens.py:139: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    token.last_used_at = datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================== 130 passed, 1029 warnings in 4.02s ======================

Refs #308
