### PR TITLE
[codex] Add read-only DNS change plans

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -179,6 +179,39 @@ class DNSLintFindingResponse(BaseModel):
     remediation_steps: List[str] = Field(default_factory=list)
 
 
+class DNSChangePlanItemResponse(BaseModel):
+    """Read-only DNS change plan for operator review."""
+
+    plan_id: str
+    finding_code: str
+    severity: str
+    operation: str
+    record_type: str
+    name: str
+    proposed_value: Optional[str] = None
+    current_values: List[str] = Field(default_factory=list)
+    rationale: str
+    risk: str
+    rollback: str
+    expected_health_impact: str
+    manual_steps: List[str] = Field(default_factory=list)
+    requires_approval: bool = True
+    applies_automatically: bool = False
+    provider_write_available: bool = False
+    provider_value_required: bool = False
+
+
+class DNSChangePlanResponse(BaseModel):
+    """Read-only DNS change plan response for one domain."""
+
+    domain: str
+    status: str
+    read_only: bool = True
+    provider_write_available: bool = False
+    apply_endpoint: Optional[str] = None
+    plans: List[DNSChangePlanItemResponse]
+
+
 class DNSGuidanceResponse(BaseModel):
     """Typed DNS lint and setup guidance for one domain."""
 
@@ -186,6 +219,7 @@ class DNSGuidanceResponse(BaseModel):
     status: str
     findings: List[DNSLintFindingResponse]
     target_records: List[DNSGuidanceRecordResponse]
+    change_plans: List[DNSChangePlanItemResponse] = Field(default_factory=list)
 
 
 class DNSBulkGuidanceItem(BaseModel):
@@ -1697,6 +1731,32 @@ async def get_domain_dns_lint(
         )
 
     return await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
+
+
+@router.get("/{domain_id}/dns/change-plan", response_model=DNSChangePlanResponse)
+async def get_domain_dns_change_plan(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS result"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return read-only DNS change plans for one monitored domain."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store)
+
+    if not _domain_exists(db, store, domain_id, workspace):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Domain not found",
+        )
+
+    guidance = await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
+    return DNSChangePlanResponse(
+        domain=guidance["domain"],
+        status=guidance["status"],
+        plans=guidance["change_plans"],
+    )
 
 
 @router.get("/{domain_id}/dns/health", response_model=DNSHealthResponse)

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -41,6 +41,29 @@ class DNSLintFinding:
 
 
 @dataclass
+class DNSChangePlan:
+    """Read-only DNS change plan derived from a lint finding."""
+
+    plan_id: str
+    finding_code: str
+    severity: str
+    operation: str
+    record_type: str
+    name: str
+    proposed_value: Optional[str]
+    current_values: List[str]
+    rationale: str
+    risk: str
+    rollback: str
+    expected_health_impact: str
+    manual_steps: List[str]
+    requires_approval: bool = True
+    applies_automatically: bool = False
+    provider_write_available: bool = False
+    provider_value_required: bool = False
+
+
+@dataclass
 class DNSGuidanceResult:
     """Complete DNS lint and setup guidance payload for one domain."""
 
@@ -48,6 +71,7 @@ class DNSGuidanceResult:
     status: str
     findings: List[DNSLintFinding]
     target_records: List[DNSGuidanceRecord]
+    change_plans: List[DNSChangePlan] = field(default_factory=list)
 
 
 def _today_id() -> str:
@@ -913,6 +937,156 @@ def _status(findings: List[DNSLintFinding]) -> str:
     return "ready"
 
 
+def _plan_id(finding: DNSLintFinding) -> str:
+    raw = f"{finding.code}-{finding.record_name}-{finding.record_type}".lower()
+    return "".join(character if character.isalnum() else "-" for character in raw).strip("-")
+
+
+def _operation_for_finding(finding: DNSLintFinding) -> str:
+    code = finding.code
+    if code.endswith("_missing") or code in {"dmarc_missing", "spf_missing"}:
+        return "create"
+    if code in {"dkim_selector_stale"}:
+        return "review-remove"
+    if code in {"dkim_selector_key_too_short"}:
+        return "rotate"
+    if code in {"tls_rpt_multiple_records", "spf_multiple_records"}:
+        return "consolidate"
+    if code in {"bimi_dmarc_not_enforced"}:
+        return "defer"
+    return "update"
+
+
+def _provider_value_required(finding: DNSLintFinding) -> bool:
+    if finding.code == "dkim_selector_stale":
+        return False
+    proposed = (finding.target_record.value if finding.target_record else "") or ""
+    return "<" in proposed or finding.code in {
+        "dkim_selector_missing",
+        "dkim_selector_cname_broken",
+        "dkim_selector_key_too_short",
+    }
+
+
+def _proposed_value(finding: DNSLintFinding) -> Optional[str]:
+    if finding.code == "dkim_selector_cname_broken":
+        return "<provider-current-dkim-cname-target>"
+    if finding.code == "dkim_selector_stale":
+        return None
+    if finding.target_record:
+        return finding.target_record.value
+    return None
+
+
+def _risk_for_finding(finding: DNSLintFinding) -> str:
+    risks = {
+        "dmarc_missing": (
+            "Low delivery risk when starting with p=none; incorrect rua values can prevent "
+            "DMARQ from receiving reports."
+        ),
+        "dmarc_monitoring_policy": (
+            "Enforcement changes can reject legitimate mail if sender alignment is not ready."
+        ),
+        "spf_missing": "Medium risk if legitimate senders are omitted from the SPF record.",
+        "spf_multiple_records": (
+            "Medium risk: merging records incorrectly can remove an active sender."
+        ),
+        "spf_all_too_permissive": (
+            "Low immediate delivery risk, but tightening to -all before sender coverage is "
+            "complete can break forwarding or third-party senders."
+        ),
+        "dkim_selector_missing": (
+            "Low DNS risk, but the value must come from the sending provider that owns the selector."
+        ),
+        "dkim_selector_cname_broken": (
+            "Medium risk: replacing a CNAME with the wrong provider target keeps DKIM failing."
+        ),
+        "dkim_selector_key_too_short": (
+            "Medium risk: rotate with a new selector before retiring the old one."
+        ),
+        "dkim_selector_stale": (
+            "Medium risk: removing a selector still used by a sender breaks DKIM for that sender."
+        ),
+        "mta_sts_missing": (
+            "Low risk in testing mode; enforce only after confirming all MX hosts support TLS."
+        ),
+        "tls_rpt_missing": "Low risk: TLS-RPT only controls report delivery.",
+        "bimi_missing": "Low mail-flow risk; BIMI is a brand/readiness feature.",
+    }
+    return risks.get(
+        finding.code,
+        "Review current evidence before changing DNS; publish during a controlled change window.",
+    )
+
+
+def _rollback_for_plan(finding: DNSLintFinding, operation: str) -> str:
+    if operation == "create":
+        return f"Delete the newly created {finding.record_type} record at {finding.record_name}."
+    if operation == "review-remove":
+        return (
+            "Restore the removed record value from DNS provider history if later reports show "
+            "the selector is still active."
+        )
+    if finding.evidence:
+        return "Restore the previous value captured in evidence if authentication regresses."
+    return "Revert to the previous DNS-provider version or zone-file backup."
+
+
+def _expected_health_impact(finding: DNSLintFinding) -> str:
+    if finding.severity == "error":
+        return "Expected to remove a critical DNS-health finding after propagation."
+    if finding.severity == "warning":
+        return "Expected to reduce DNS-health warnings after propagation."
+    return "Expected to improve hygiene and reduce future action-plan noise."
+
+
+def _manual_steps_for_plan(finding: DNSLintFinding, operation: str) -> List[str]:
+    steps = [
+        "Open the authoritative DNS provider for this domain.",
+        f"Find or create the {finding.record_type} record named {finding.record_name}.",
+    ]
+    proposed = _proposed_value(finding)
+    if operation == "review-remove":
+        steps.append("Confirm at least one recent report cycle shows no traffic for this selector.")
+        steps.append("Remove the stale selector only after sender ownership is confirmed.")
+    elif proposed:
+        steps.append(f"Set the record value to: {proposed}")
+    else:
+        steps.append("Follow the finding remediation steps to choose the final DNS value.")
+    steps.extend(finding.remediation_steps)
+    steps.append("Refresh DMARQ DNS lint after DNS propagation.")
+    return list(dict.fromkeys(steps))
+
+
+def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan]:
+    """Create read-only operator change plans from DNS lint findings."""
+    plans: List[DNSChangePlan] = []
+    for finding in findings:
+        operation = _operation_for_finding(finding)
+        proposed_value = _proposed_value(finding)
+        if operation == "defer":
+            continue
+        plans.append(
+            DNSChangePlan(
+                plan_id=_plan_id(finding),
+                finding_code=finding.code,
+                severity=finding.severity,
+                operation=operation,
+                record_type=finding.record_type,
+                name=finding.record_name,
+                proposed_value=proposed_value,
+                current_values=list(finding.evidence),
+                rationale=finding.action,
+                risk=_risk_for_finding(finding),
+                rollback=_rollback_for_plan(finding, operation),
+                expected_health_impact=_expected_health_impact(finding),
+                manual_steps=_manual_steps_for_plan(finding, operation),
+                provider_value_required=_provider_value_required(finding),
+            )
+        )
+    return plans
+
+
 async def build_dns_guidance(
     domain: str,
     provider: BaseDNSProvider,
@@ -947,4 +1121,5 @@ async def build_dns_guidance(
         status=_status(findings),
         findings=findings,
         target_records=targets,
+        change_plans=build_dns_change_plans(findings),
     )

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -485,8 +485,56 @@
                                 </template>
                             </div>
                         </div>
+                        <template x-if="dnsGuidance.change_plans && dnsGuidance.change_plans.length">
+                            <div class="mt-4 border-t border-base-300 pt-4">
+                                <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                                    <div>
+                                        <h4 class="font-semibold">Proposed DNS change plan</h4>
+                                        <p class="text-xs text-base-content/60">Read-only. DMARQ never applies these changes automatically.</p>
+                                    </div>
+                                    <span class="inline-flex w-fit rounded bg-base-200 px-2 py-1 text-xs font-semibold text-base-content/70">
+                                        manual approval required
+                                    </span>
+                                </div>
+                                <div class="mt-3 space-y-2">
+                                    <template x-for="plan in dnsGuidance.change_plans" :key="plan.plan_id">
+                                        <div class="rounded border border-base-300 p-3">
+                                            <div class="flex flex-wrap items-center gap-2">
+                                                <span class="rounded bg-base-200 px-2 py-1 text-xs font-semibold uppercase" x-text="plan.operation"></span>
+                                                <code class="rounded bg-base-200 px-1.5 py-0.5 text-xs" x-text="plan.name"></code>
+                                                <span class="text-xs text-base-content/60" x-text="plan.record_type"></span>
+                                            </div>
+                                            <p class="mt-2 text-sm" x-text="plan.rationale"></p>
+                                            <template x-if="plan.proposed_value">
+                                                <div class="mt-2 rounded bg-base-200 p-2">
+                                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                                                        <code class="flex-1 break-all text-xs" x-text="plan.name + ' ' + plan.record_type + ' ' + plan.proposed_value"></code>
+                                                        <button
+                                                            @click="navigator.clipboard.writeText(plan.name + ' ' + plan.record_type + ' ' + plan.proposed_value)"
+                                                            class="btn btn-xs btn-ghost"
+                                                            title="Copy planned DNS record"
+                                                        >
+                                                            Copy
+                                                        </button>
+                                                    </div>
+                                                    <p x-show="plan.provider_value_required" class="mt-1 text-xs text-base-content/60">
+                                                        Confirm the final value in the sending-provider admin page before publishing.
+                                                    </p>
+                                                </div>
+                                            </template>
+                                            <div class="mt-2 grid gap-2 text-xs text-base-content/70 md:grid-cols-3">
+                                                <p><span class="font-semibold">Risk:</span> <span x-text="plan.risk"></span></p>
+                                                <p><span class="font-semibold">Rollback:</span> <span x-text="plan.rollback"></span></p>
+                                                <p><span class="font-semibold">Impact:</span> <span x-text="plan.expected_health_impact"></span></p>
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
                     </div>
                 </div>
+            </div>
             {% endcall %}
         {% endcall %}
         </section>
@@ -818,7 +866,8 @@ function domainDetailsApp(domainId) {
         dnsGuidance: {
             status: '',
             findings: [],
-            target_records: []
+            target_records: [],
+            change_plans: []
         },
         posture: {
             status: '',

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -348,6 +348,52 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: Tes
     )
     assert dkim_finding["remediation_steps"]
     assert "Publish" in " ".join(dkim_finding["remediation_steps"])
+    change_plan = next(
+        plan for plan in data["change_plans"] if plan["finding_code"] == "dkim_selector_missing"
+    )
+    assert change_plan["operation"] == "create"
+    assert change_plan["record_type"] == "TXT"
+    assert change_plan["requires_approval"] is True
+    assert change_plan["applies_automatically"] is False
+    assert change_plan["provider_write_available"] is False
+    assert change_plan["provider_value_required"] is True
+    assert change_plan["manual_steps"]
+
+
+def test_dns_change_plan_endpoint_returns_read_only_plans(authed_client: TestClient):
+    result = DomainDNSResult(
+        dmarc=False,
+        spf=False,
+        dkim=False,
+        selectors_checked=["selector1"],
+    )
+    mta_sts = MTAStsResult(errors=["No _mta-sts TXT record was found."])
+    bimi = BIMIResult(errors=["No BIMI TXT record was found at the selector."])
+
+    with (
+        _mock_dns(result),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(mta_sts, False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(bimi, False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/change-plan")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["domain"] == DOMAIN
+    assert data["read_only"] is True
+    assert data["provider_write_available"] is False
+    assert data["apply_endpoint"] is None
+    plan = next(plan for plan in data["plans"] if plan["finding_code"] == "dmarc_missing")
+    assert plan["operation"] == "create"
+    assert plan["proposed_value"].startswith("v=DMARC1")
+    assert plan["rollback"]
+    assert plan["expected_health_impact"]
 
 
 def test_dns_lint_endpoint_flags_advanced_spf_lookup_findings(

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -52,6 +52,15 @@ async def test_build_dns_guidance_returns_typed_findings_and_targets():
         "target_tls_rpt",
         "target_bimi",
     }
+    plan = next(plan for plan in guidance.change_plans if plan.finding_code == "dmarc_missing")
+    assert plan.operation == "create"
+    assert plan.record_type == "TXT"
+    assert plan.name == "_dmarc.example.com"
+    assert plan.proposed_value.startswith("v=DMARC1")
+    assert plan.requires_approval is True
+    assert plan.applies_automatically is False
+    assert plan.provider_write_available is False
+    assert plan.rollback.startswith("Delete the newly created")
 
 
 @pytest.mark.asyncio
@@ -228,6 +237,82 @@ async def test_build_dns_guidance_lints_dkim_selector_health():
     assert findings["dkim_selector_missing"].record_name == "old._domainkey.example.com"
     assert findings["dkim_selector_cname_broken"].record_type == "CNAME"
     assert findings["dkim_selector_key_too_short"].remediation_steps
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_creates_operator_plans_for_dkim_review_paths():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+            "stale._domainkey.example.com": [
+                "v=DKIM1; k=rsa; p="
+                "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAstaleselector"
+                "keymaterialthatislongenoughtolooklikeanormalrsa1024or2048key"
+                "forlintpurposesonly1234567890abcdef"
+            ],
+        }
+    )
+    provider._cnames["mailchimp._domainkey.example.com"] = "missing._domainkey.mcsv.net"
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["stale"],
+        selectors_checked=["stale", "mailchimp"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        monitored_selectors=["stale", "mailchimp"],
+        observed_selectors=["google"],
+    )
+
+    plans = {plan.finding_code: plan for plan in guidance.change_plans}
+    assert plans["dkim_selector_stale"].operation == "review-remove"
+    assert plans["dkim_selector_stale"].proposed_value is None
+    assert plans["dkim_selector_stale"].provider_value_required is False
+    assert any("recent report cycle" in step for step in plans["dkim_selector_stale"].manual_steps)
+    assert plans["dkim_selector_cname_broken"].operation == "update"
+    assert plans["dkim_selector_cname_broken"].proposed_value == (
+        "<provider-current-dkim-cname-target>"
+    )
+    assert plans["dkim_selector_cname_broken"].provider_value_required is True
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_defers_bimi_until_dmarc_enforcement():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+    )
+
+    assert "bimi_dmarc_not_enforced" in {finding.code for finding in guidance.findings}
+    assert "bimi_dmarc_not_enforced" not in {plan.finding_code for plan in guidance.change_plans}
 
 
 @pytest.mark.asyncio

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -389,6 +389,7 @@ queried DNS name, record text, logo URL, certificate URL, warnings, and errors.
 
 ```
 GET /domains/{domain_id}/dns/lint
+GET /domains/{domain_id}/dns/change-plan
 GET /domains/dns/lint
 GET /domains/dns/lint/export
 ```
@@ -399,6 +400,13 @@ TLS-RPT, and BIMI readiness. DKIM findings distinguish missing selectors,
 broken CNAME targets, short RSA keys, and stale selectors. The bulk endpoint
 returns the same payload shape per monitored domain, and the export endpoint
 returns the finding list as CSV for managed-domain reviews.
+
+The single-domain lint payload also includes read-only `change_plans`. The
+dedicated `/dns/change-plan` endpoint returns the same operator-facing plans
+with proposed DNS records, captured current values, risk notes, rollback notes,
+expected health impact, and manual approval flags. DMARQ does not expose an
+apply endpoint in the default product path; provider write automation is a
+separate opt-in integration concern.
 
 #### Get Posture Dashboard
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -93,6 +93,12 @@ Optional AI remediation plans can turn the same redacted DNS/report context
 into a longer step-by-step plan through LiteLLM/OpenAI-compatible providers;
 demo mode keeps these plans template-backed and heavily cached.
 
+The same section also shows a read-only proposed DNS change plan when findings
+are actionable. These plans include the record name, type, proposed value,
+captured current values when available, risk notes, rollback guidance, and
+expected health impact. They are copy/paste aids for an operator; DMARQ does
+not apply DNS changes automatically.
+
 ### MTA-STS Posture
 
 The domain detail page checks `_mta-sts.<domain>` and fetches the policy from `https://mta-sts.<domain>/.well-known/mta-sts.txt`.


### PR DESCRIPTION
## Summary
- add read-only DNS change plans derived from existing DNS lint findings
- expose plans in the single-domain lint payload and a dedicated `/dns/change-plan` endpoint
- render proposed manual DNS changes, risk, rollback, and expected health impact on the domain detail page
- document the no-auto-apply boundary and API surface

## Scope boundary
This is the first #314 slice. It deliberately does not add DNS provider writes or an apply endpoint. Every plan is copy/paste oriented, requires operator approval, and reports `provider_write_available=false`.

## Validation
- `python -m black --check backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py`
- `python -m isort --check-only backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py`
- `python -m flake8 backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py`
- `git diff --check`
- `python -m pytest backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py -q` (`64 passed`)

Refs #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only DNS change plan view for actionable domain guidance.
  * Expanded DNS guidance responses to include proposed record changes, rollback notes, risk, and expected health impact.
  * Added a dedicated endpoint to fetch DNS remediation plans for a domain.

* **Documentation**
  * Updated the API reference and user guide to describe the new DNS change plan details and read-only behavior.

* **Bug Fixes**
  * Improved DNS guidance output consistency with additional plan-level details for common DNS issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->