### PR TITLE
[codex] Add mail source backfill progress UI

### DIFF
--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -25,6 +25,10 @@ from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.mail_source_backfill import MailSourceBackfillJob
 from app.models.mail_source_import import MailSourceImport
+from app.services.demo_data import (
+    build_demo_mail_source_backfills,
+    build_demo_mail_sources,
+)
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
@@ -560,6 +564,27 @@ def _backfill_to_response(row: MailSourceBackfillJob) -> MailSourceBackfillRespo
     )
 
 
+def _demo_mail_source_response(row: Dict[str, Any]) -> MailSourceResponse:
+    return MailSourceResponse(**row)
+
+
+def _demo_mail_source_by_id(source_id: int) -> Optional[Dict[str, Any]]:
+    if not get_settings().DEMO_MODE:
+        return None
+    return next((row for row in build_demo_mail_sources() if row["id"] == source_id), None)
+
+
+def _demo_backfill_response(row: Dict[str, Any]) -> MailSourceBackfillResponse:
+    return MailSourceBackfillResponse(**row)
+
+
+def _demo_backfill_job(source_id: int, job_id: int) -> Optional[Dict[str, Any]]:
+    return next(
+        (row for row in build_demo_mail_source_backfills(source_id) if row["id"] == job_id),
+        None,
+    )
+
+
 def _validate_backfill_request(payload: MailSourceBackfillCreate) -> None:
     if payload.max_attempts < 1 or payload.max_attempts > 10:
         raise HTTPException(
@@ -758,6 +783,8 @@ async def list_mail_sources(
         _selected_workspace_id(selected_workspace),
     )
     sources = workspace_mail_source_query(db, workspace).order_by(MailSource.id).all()
+    if not sources and get_settings().DEMO_MODE:
+        return [_demo_mail_source_response(row) for row in build_demo_mail_sources()]
     return [_source_to_response(s) for s in sources]
 
 
@@ -867,6 +894,11 @@ async def list_mail_source_backfills(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> List[MailSourceBackfillResponse]:
     """Return recent resumable mailbox backfill jobs for one mail source."""
+    if _demo_mail_source_by_id(source_id):
+        return [
+            _demo_backfill_response(row)
+            for row in build_demo_mail_source_backfills(source_id)[:limit]
+        ]
     workspace = _authorized_mail_source_workspace(
         _auth,
         db,
@@ -901,6 +933,34 @@ async def create_mail_source_backfill(
 ) -> MailSourceBackfillResponse:
     """Queue a resumable mailbox backfill job without running the connector inline."""
     _validate_backfill_request(payload)
+    demo_source = _demo_mail_source_by_id(source_id)
+    if demo_source:
+        now = datetime.now(timezone.utc)
+        return MailSourceBackfillResponse(
+            id=9900 + source_id,
+            workspace_id=1,
+            mail_source_id=source_id,
+            status="queued",
+            trigger="manual",
+            requested_start=payload.requested_start or now - timedelta(days=30),
+            requested_end=payload.requested_end or now,
+            requested_by="demo-operator@dmarq.org",
+            processed=0,
+            reports_found=0,
+            duplicate_reports=0,
+            error_count=0,
+            attempt_count=0,
+            max_attempts=payload.max_attempts,
+            cursor=None,
+            errors=[],
+            details=[{"status": "queued", "source": str(demo_source["name"])}],
+            started_at=None,
+            finished_at=None,
+            cancelled_at=None,
+            next_retry_at=None,
+            created_at=now,
+            updated_at=now,
+        )
     workspace = _authorized_mail_source_workspace(
         _auth,
         db,
@@ -962,6 +1022,9 @@ async def get_mail_source_backfill(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> MailSourceBackfillResponse:
     """Return one mailbox backfill job for a workspace-scoped mail source."""
+    demo_job = _demo_backfill_job(source_id, job_id)
+    if demo_job:
+        return _demo_backfill_response(demo_job)
     workspace = _authorized_mail_source_workspace(
         _auth,
         db,
@@ -985,6 +1048,22 @@ async def cancel_mail_source_backfill(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> MailSourceBackfillResponse:
     """Mark a queued/running/backoff mailbox backfill job as cancelled."""
+    demo_job = _demo_backfill_job(source_id, job_id)
+    if demo_job:
+        if demo_job["status"] not in BACKFILL_CANCELABLE_STATUSES:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Backfill job in status '{demo_job['status']}' cannot be cancelled.",
+            )
+        now = datetime.now(timezone.utc)
+        cancelled = {
+            **demo_job,
+            "status": "cancelled",
+            "cancelled_at": now,
+            "finished_at": now,
+            "updated_at": now,
+        }
+        return _demo_backfill_response(cancelled)
     workspace = _authorized_mail_source_workspace(
         _auth,
         db,
@@ -1034,6 +1113,25 @@ async def retry_mail_source_backfill(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> MailSourceBackfillResponse:
     """Re-queue a failed, cancelled, or backoff mailbox backfill job."""
+    demo_job = _demo_backfill_job(source_id, job_id)
+    if demo_job:
+        if demo_job["status"] not in BACKFILL_RETRYABLE_STATUSES:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Backfill job in status '{demo_job['status']}' cannot be retried.",
+            )
+        now = datetime.now(timezone.utc)
+        retried = {
+            **demo_job,
+            "status": "queued",
+            "attempt_count": demo_job["attempt_count"] + 1,
+            "started_at": None,
+            "finished_at": None,
+            "cancelled_at": None,
+            "next_retry_at": None,
+            "updated_at": now,
+        }
+        return _demo_backfill_response(retried)
     workspace = _authorized_mail_source_workspace(
         _auth,
         db,

--- a/backend/app/middleware/demo.py
+++ b/backend/app/middleware/demo.py
@@ -11,6 +11,19 @@ from starlette.responses import JSONResponse, Response
 from app.core.config import get_settings
 
 SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+DEMO_BACKFILL_SOURCE_IDS = frozenset({"9001", "9002", "9003"})
+
+
+def _is_demo_backfill_simulation(request: Request) -> bool:
+    if request.method.upper() != "POST":
+        return False
+    parts = request.url.path.strip("/").split("/")
+    return (
+        len(parts) >= 5
+        and parts[:3] == ["api", "v1", "mail-sources"]
+        and parts[3] in DEMO_BACKFILL_SOURCE_IDS
+        and parts[4] == "backfills"
+    )
 
 
 class DemoReadOnlyMiddleware(BaseHTTPMiddleware):
@@ -26,7 +39,11 @@ class DemoReadOnlyMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         settings = self._settings_provider()
-        if settings.DEMO_MODE and request.method.upper() not in SAFE_METHODS:
+        if (
+            settings.DEMO_MODE
+            and request.method.upper() not in SAFE_METHODS
+            and not _is_demo_backfill_simulation(request)
+        ):
             return JSONResponse(
                 status_code=status.HTTP_403_FORBIDDEN,
                 content={

--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -46,6 +46,207 @@ DEMO_TLS_REPORT_PRIVACY_CONTROLS = {
 }
 
 
+def build_demo_mail_sources(today: Optional[date] = None) -> List[Dict[str, Any]]:
+    """Return deterministic demo mail-source rows without real credentials."""
+    anchor = _demo_today(today)
+    checked = datetime.combine(anchor, time(7, 45), tzinfo=timezone.utc)
+    return [
+        {
+            "id": 9001,
+            "name": "dmarq.org aggregate reports",
+            "method": "IMAP",
+            "server": "imap.demo.dmarq.org",
+            "port": 993,
+            "username": "reports@dmarq.org",
+            "password": None,
+            "use_ssl": True,
+            "folder": "INBOX/DMARC",
+            "polling_interval": 60,
+            "enabled": True,
+            "last_checked": checked - timedelta(minutes=18),
+            "created_at": checked - timedelta(days=88),
+            "updated_at": checked - timedelta(minutes=18),
+            "gmail_client_id": None,
+            "gmail_client_secret": None,
+            "gmail_email": None,
+            "gmail_connected": False,
+            "m365_tenant_id": "common",
+            "m365_client_id": None,
+            "m365_client_secret": None,
+            "m365_mailbox": None,
+            "m365_folder_id": None,
+            "m365_email": None,
+            "m365_connected": False,
+        },
+        {
+            "id": 9002,
+            "name": "dmarq.com Google reports",
+            "method": "GMAIL_API",
+            "server": None,
+            "port": 993,
+            "username": None,
+            "password": None,
+            "use_ssl": True,
+            "folder": "DMARC Reports",
+            "polling_interval": 30,
+            "enabled": True,
+            "last_checked": checked - timedelta(hours=2, minutes=7),
+            "created_at": checked - timedelta(days=61),
+            "updated_at": checked - timedelta(hours=2, minutes=7),
+            "gmail_client_id": "demo-google-oauth-client",
+            "gmail_client_secret": None,
+            "gmail_email": "dmarc-reports@dmarq.com",
+            "gmail_connected": True,
+            "m365_tenant_id": "common",
+            "m365_client_id": None,
+            "m365_client_secret": None,
+            "m365_mailbox": None,
+            "m365_folder_id": None,
+            "m365_email": None,
+            "m365_connected": False,
+        },
+        {
+            "id": 9003,
+            "name": "ISP customer shared mailbox",
+            "method": "M365_GRAPH",
+            "server": None,
+            "port": 993,
+            "username": None,
+            "password": None,
+            "use_ssl": True,
+            "folder": "DMARC / Customer Imports",
+            "polling_interval": 120,
+            "enabled": True,
+            "last_checked": checked - timedelta(hours=5, minutes=41),
+            "created_at": checked - timedelta(days=37),
+            "updated_at": checked - timedelta(hours=5, minutes=41),
+            "gmail_client_id": None,
+            "gmail_client_secret": None,
+            "gmail_email": None,
+            "gmail_connected": False,
+            "m365_tenant_id": "northstar-demo",
+            "m365_client_id": "demo-m365-client",
+            "m365_client_secret": None,
+            "m365_mailbox": "dmarc-imports@northstar.example",
+            "m365_folder_id": "demo-folder-dmarc",
+            "m365_email": "dmarc-imports@northstar.example",
+            "m365_connected": True,
+        },
+    ]
+
+
+def build_demo_mail_source_backfills(
+    source_id: int, today: Optional[date] = None
+) -> List[Dict[str, Any]]:
+    """Return rolling demo backfill progress rows for one demo mail source."""
+    anchor = _demo_today(today)
+    now = datetime.combine(anchor, time(8, 15), tzinfo=timezone.utc)
+    common = {
+        "workspace_id": 1,
+        "trigger": "manual",
+        "requested_by": "demo-operator@dmarq.org",
+        "max_attempts": 3,
+        "errors": [],
+    }
+    jobs = {
+        9001: [
+            {
+                **common,
+                "id": 9101,
+                "mail_source_id": 9001,
+                "status": "completed",
+                "requested_start": now - timedelta(days=90),
+                "requested_end": now - timedelta(days=30),
+                "processed": 384,
+                "reports_found": 171,
+                "duplicate_reports": 42,
+                "error_count": 0,
+                "attempt_count": 1,
+                "cursor": "uid:384",
+                "details": [
+                    {"status": "imported", "domain": "dmarq.org"},
+                    {"status": "duplicate", "domain": "dmarq.com"},
+                ],
+                "started_at": now - timedelta(days=1, hours=2),
+                "finished_at": now - timedelta(days=1, hours=1, minutes=34),
+                "cancelled_at": None,
+                "next_retry_at": None,
+                "created_at": now - timedelta(days=1, hours=2, minutes=2),
+                "updated_at": now - timedelta(days=1, hours=1, minutes=34),
+            },
+            {
+                **common,
+                "id": 9102,
+                "mail_source_id": 9001,
+                "status": "running",
+                "requested_start": now - timedelta(days=30),
+                "requested_end": now,
+                "processed": 96,
+                "reports_found": 44,
+                "duplicate_reports": 7,
+                "error_count": 0,
+                "attempt_count": 1,
+                "cursor": "uid:96",
+                "details": [{"status": "imported", "domain": "dmarq.org"}],
+                "started_at": now - timedelta(minutes=22),
+                "finished_at": None,
+                "cancelled_at": None,
+                "next_retry_at": None,
+                "created_at": now - timedelta(minutes=23),
+                "updated_at": now - timedelta(minutes=2),
+            },
+        ],
+        9002: [
+            {
+                **common,
+                "id": 9201,
+                "mail_source_id": 9002,
+                "status": "backoff",
+                "requested_start": now - timedelta(days=60),
+                "requested_end": now - timedelta(days=1),
+                "processed": 58,
+                "reports_found": 25,
+                "duplicate_reports": 11,
+                "error_count": 1,
+                "attempt_count": 2,
+                "cursor": "page:2",
+                "errors": ["Google API rate limit; retry scheduled."],
+                "details": [{"status": "retry_scheduled", "reason": "rate_limit"}],
+                "started_at": now - timedelta(hours=3),
+                "finished_at": None,
+                "cancelled_at": None,
+                "next_retry_at": now + timedelta(minutes=19),
+                "created_at": now - timedelta(hours=3, minutes=4),
+                "updated_at": now - timedelta(minutes=11),
+            }
+        ],
+        9003: [
+            {
+                **common,
+                "id": 9301,
+                "mail_source_id": 9003,
+                "status": "queued",
+                "requested_start": now - timedelta(days=14),
+                "requested_end": now,
+                "processed": 0,
+                "reports_found": 0,
+                "duplicate_reports": 0,
+                "error_count": 0,
+                "attempt_count": 0,
+                "cursor": None,
+                "details": [],
+                "started_at": None,
+                "finished_at": None,
+                "cancelled_at": None,
+                "next_retry_at": None,
+                "created_at": now - timedelta(minutes=6),
+                "updated_at": now - timedelta(minutes=6),
+            }
+        ],
+    }
+    return list(jobs.get(source_id, []))
+
+
 def build_demo_multi_user_deployment() -> Dict[str, Any]:
     """Return a rolling SaaS/ISP demo deployment model without real customers."""
     today = date.today()

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -75,6 +75,7 @@
                                 <th>Server / Account</th>
                                 <th>User / Status</th>
                                 <th>Last Checked</th>
+                                <th>Backfill</th>
                                 <th>Enabled</th>
                                 <th>Actions</th>
                             </tr>
@@ -89,6 +90,63 @@
                                     <td x-text="sourceAccountLabel(source)"></td>
                                     <td x-text="sourceStatusLabel(source)"></td>
                                     <td x-text="source.last_checked ? new Date(source.last_checked).toLocaleString() : 'Never'"></td>
+                                    <td class="min-w-72">
+                                        <template x-if="backfillLoading[source.id]">
+                                            <p class="text-xs text-muted-foreground">Loading backfill status…</p>
+                                        </template>
+                                        <template x-if="!backfillLoading[source.id] && !latestBackfill(source)">
+                                            <div class="space-y-2">
+                                                <p class="text-xs text-muted-foreground">No queued backfills.</p>
+                                                <button class="btn btn-outline btn-xs" x-on:click.stop="openBackfill(source)">
+                                                    Queue backfill
+                                                </button>
+                                            </div>
+                                        </template>
+                                        <template x-if="!backfillLoading[source.id] && latestBackfill(source)">
+                                            <div class="space-y-2" data-backfill-progress>
+                                                <div class="flex items-center justify-between gap-2">
+                                                    <span class="badge badge-sm" :class="backfillBadgeClass(latestBackfill(source).status)"
+                                                        x-text="backfillStatusLabel(latestBackfill(source).status)"></span>
+                                                    <span class="text-[11px] text-muted-foreground"
+                                                        x-text="backfillWindowLabel(latestBackfill(source))"></span>
+                                                </div>
+                                                <progress class="progress progress-primary h-1.5 w-full"
+                                                    :value="backfillProgress(latestBackfill(source))"
+                                                    max="100"></progress>
+                                                <div class="grid grid-cols-3 gap-2 text-[11px] text-muted-foreground">
+                                                    <span><strong class="text-foreground" x-text="latestBackfill(source).processed"></strong> messages</span>
+                                                    <span><strong class="text-foreground" x-text="latestBackfill(source).reports_found"></strong> reports</span>
+                                                    <span><strong class="text-foreground" x-text="latestBackfill(source).duplicate_reports"></strong> duplicates</span>
+                                                </div>
+                                                <p class="text-[11px] text-warning" x-show="latestBackfill(source).next_retry_at"
+                                                    x-text="`Retry ${formatDate(latestBackfill(source).next_retry_at)}`"></p>
+                                                <p class="text-[11px] text-error" x-show="latestBackfill(source).errors && latestBackfill(source).errors.length"
+                                                    x-text="latestBackfill(source).errors[0]"></p>
+                                                <div class="flex flex-wrap gap-1">
+                                                    <button class="btn btn-outline btn-xs"
+                                                        x-on:click.stop="loadBackfills(source)"
+                                                        :disabled="backfillAction[source.id] === 'refresh'">
+                                                        Refresh
+                                                    </button>
+                                                    <button class="btn btn-outline btn-xs"
+                                                        x-show="canCancelBackfill(latestBackfill(source))"
+                                                        x-on:click.stop="cancelBackfill(source, latestBackfill(source))"
+                                                        :disabled="backfillAction[source.id] === 'cancel'">
+                                                        Cancel
+                                                    </button>
+                                                    <button class="btn btn-outline btn-xs"
+                                                        x-show="canRetryBackfill(latestBackfill(source))"
+                                                        x-on:click.stop="retryBackfill(source, latestBackfill(source))"
+                                                        :disabled="backfillAction[source.id] === 'retry'">
+                                                        Retry
+                                                    </button>
+                                                    <button class="btn btn-ghost btn-xs" x-on:click.stop="openBackfill(source)">
+                                                        New
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </td>
                                     <td>
                                         <input
                                             type="checkbox"
@@ -624,6 +682,9 @@
             </div>
             <div class="space-y-3">
                 <p class="text-sm text-muted-foreground" x-text="backfillSource ? backfillSource.name : ''"></p>
+                <p class="text-xs text-muted-foreground">
+                    Queues a resumable mailbox search. Progress appears in the Backfill column.
+                </p>
                 <div class="join w-full">
                     <button type="button" class="btn btn-sm join-item flex-1" x-on:click="backfillDays = 7">7 days</button>
                     <button type="button" class="btn btn-sm join-item flex-1" x-on:click="backfillDays = 30">30 days</button>
@@ -636,8 +697,9 @@
             </div>
             <div class="flex justify-end gap-2">
                 <button class="btn btn-ghost btn-sm" x-on:click="closeBackfill()">Cancel</button>
-                <button class="btn btn-primary btn-sm" x-on:click="runBackfill()" :disabled="!validBackfillDays() || Boolean(fetching[backfillSource && backfillSource.id])">
-                    Run Backfill
+                <button class="btn btn-primary btn-sm" x-on:click="runBackfill()"
+                    :disabled="!validBackfillDays() || Boolean(backfillAction[backfillSource && backfillSource.id])">
+                    Queue Backfill
                 </button>
             </div>
         </div>
@@ -675,6 +737,9 @@ function mailSourcesApp() {
         isSaving: false,
         testing: {},
         fetching: {},
+        backfillJobs: {},
+        backfillLoading: {},
+        backfillAction: {},
         backfillSource: null,
         backfillDays: 30,
         historySource: null,
@@ -719,6 +784,7 @@ function mailSourcesApp() {
                 const resp = await fetch('/api/v1/mail-sources');
                 if (resp.ok) {
                     this.sources = await resp.json();
+                    await this.loadBackfillsForSources();
                 }
             } catch (e) {
                 console.error('Failed to load mail sources', e);
@@ -746,6 +812,7 @@ function mailSourcesApp() {
                     const updated = this.sources.find(s => s.id === source.id) || source;
                     await this.loadImportHistory(updated);
                 }
+                await this.loadBackfills(source, true);
             } catch (e) {
                 this.feedback = { message: `Import error: ${e.message}`, type: 'error' };
             } finally {
@@ -774,7 +841,121 @@ function mailSourcesApp() {
             const source = this.backfillSource;
             const days = Number(this.backfillDays);
             this.closeBackfill();
-            await this.fetchSource(source, days);
+            await this.queueBackfill(source, days);
+        },
+
+        async loadBackfillsForSources() {
+            await Promise.all(this.sources.map(source => this.loadBackfills(source, true)));
+        },
+
+        async loadBackfills(source, silent = false) {
+            if (!source) return;
+            this.backfillLoading = { ...this.backfillLoading, [source.id]: true };
+            this.backfillAction = { ...this.backfillAction, [source.id]: 'refresh' };
+            if (!silent) {
+                this.feedback = this.emptyFeedback();
+            }
+            try {
+                const resp = await fetch(`/api/v1/mail-sources/${source.id}/backfills?limit=5`);
+                const data = await resp.json();
+                if (!resp.ok) {
+                    throw new Error(this.apiErrorMessage(data, 'Failed to load backfill jobs'));
+                }
+                this.backfillJobs = { ...this.backfillJobs, [source.id]: data };
+            } catch (e) {
+                if (!silent) {
+                    this.feedback = { message: `Backfill status error: ${e.message}`, type: 'error' };
+                }
+            } finally {
+                this.backfillLoading = { ...this.backfillLoading, [source.id]: false };
+                this.backfillAction = { ...this.backfillAction, [source.id]: '' };
+            }
+        },
+
+        async queueBackfill(source, days) {
+            if (!source) return;
+            const safeDays = Math.min(365, Math.max(1, Number(days) || 30));
+            const requestedEnd = new Date();
+            const requestedStart = new Date(requestedEnd.getTime() - safeDays * 24 * 60 * 60 * 1000);
+            this.backfillAction = { ...this.backfillAction, [source.id]: 'queue' };
+            this.feedback = this.emptyFeedback();
+            try {
+                const resp = await fetch(`/api/v1/mail-sources/${source.id}/backfills`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        requested_start: requestedStart.toISOString(),
+                        requested_end: requestedEnd.toISOString(),
+                        max_attempts: 3,
+                    }),
+                });
+                const data = await resp.json();
+                if (!resp.ok) {
+                    throw new Error(this.apiErrorMessage(data, 'Failed to queue backfill'));
+                }
+                this.feedback = {
+                    message: `Backfill queued for ${source.name} (${safeDays} day${safeDays === 1 ? '' : 's'}).`,
+                    type: 'success',
+                };
+                const existing = this.backfillJobs[source.id] || [];
+                this.backfillJobs = { ...this.backfillJobs, [source.id]: [data, ...existing].slice(0, 5) };
+                await this.loadBackfills(source, true);
+            } catch (e) {
+                this.feedback = { message: `Backfill error: ${e.message}`, type: 'error' };
+            } finally {
+                this.backfillAction = { ...this.backfillAction, [source.id]: '' };
+            }
+        },
+
+        async cancelBackfill(source, job) {
+            if (!source || !job) return;
+            this.backfillAction = { ...this.backfillAction, [source.id]: 'cancel' };
+            this.feedback = this.emptyFeedback();
+            try {
+                const resp = await fetch(`/api/v1/mail-sources/${source.id}/backfills/${job.id}/cancel`, {
+                    method: 'POST',
+                });
+                const data = await resp.json();
+                if (!resp.ok) {
+                    throw new Error(this.apiErrorMessage(data, 'Failed to cancel backfill'));
+                }
+                this.replaceBackfill(source, data);
+                this.feedback = { message: `Backfill cancelled for ${source.name}.`, type: 'success' };
+            } catch (e) {
+                this.feedback = { message: `Cancel error: ${e.message}`, type: 'error' };
+            } finally {
+                this.backfillAction = { ...this.backfillAction, [source.id]: '' };
+            }
+        },
+
+        async retryBackfill(source, job) {
+            if (!source || !job) return;
+            this.backfillAction = { ...this.backfillAction, [source.id]: 'retry' };
+            this.feedback = this.emptyFeedback();
+            try {
+                const resp = await fetch(`/api/v1/mail-sources/${source.id}/backfills/${job.id}/retry`, {
+                    method: 'POST',
+                });
+                const data = await resp.json();
+                if (!resp.ok) {
+                    throw new Error(this.apiErrorMessage(data, 'Failed to retry backfill'));
+                }
+                this.replaceBackfill(source, data);
+                this.feedback = { message: `Backfill retried for ${source.name}.`, type: 'success' };
+            } catch (e) {
+                this.feedback = { message: `Retry error: ${e.message}`, type: 'error' };
+            } finally {
+                this.backfillAction = { ...this.backfillAction, [source.id]: '' };
+            }
+        },
+
+        replaceBackfill(source, updated) {
+            const rows = this.backfillJobs[source.id] || [];
+            const nextRows = rows.map(row => row.id === updated.id ? updated : row);
+            if (!nextRows.some(row => row.id === updated.id)) {
+                nextRows.unshift(updated);
+            }
+            this.backfillJobs = { ...this.backfillJobs, [source.id]: nextRows.slice(0, 5) };
         },
 
         async loadImportHistory(source) {
@@ -837,6 +1018,68 @@ function mailSourcesApp() {
 
         formatList(value) {
             return value && value.length ? value.join(', ') : '—';
+        },
+
+        apiErrorMessage(data, fallback) {
+            const detail = data && data.detail;
+            if (!detail) return fallback;
+            if (typeof detail === 'string') return detail;
+            if (Array.isArray(detail)) {
+                return detail.map(item => item.msg || item.detail || JSON.stringify(item)).join('; ');
+            }
+            return detail.message || JSON.stringify(detail);
+        },
+
+        latestBackfill(source) {
+            const rows = source ? this.backfillJobs[source.id] || [] : [];
+            return rows.length ? rows[0] : null;
+        },
+
+        backfillStatusLabel(status) {
+            const labels = {
+                queued: 'Queued',
+                running: 'Running',
+                backoff: 'Backoff',
+                failed: 'Failed',
+                cancelled: 'Cancelled',
+                completed: 'Completed',
+            };
+            return labels[status] || status || 'Unknown';
+        },
+
+        backfillBadgeClass(status) {
+            if (status === 'completed') return 'badge-success';
+            if (status === 'running') return 'badge-info';
+            if (status === 'queued') return 'badge-outline';
+            if (status === 'backoff') return 'badge-warning';
+            if (status === 'failed') return 'badge-error';
+            if (status === 'cancelled') return 'badge-neutral';
+            return 'badge-outline';
+        },
+
+        backfillProgress(job) {
+            if (!job) return 0;
+            const processed = Number(job.processed || 0);
+            if (job.status === 'completed') return 100;
+            if (job.status === 'queued') return 5;
+            if (job.status === 'running') return Math.min(95, Math.max(20, 20 + processed / 2));
+            if (job.status === 'backoff') return Math.min(80, Math.max(25, 25 + processed / 2));
+            return Math.min(100, Math.max(10, processed || 10));
+        },
+
+        backfillWindowLabel(job) {
+            if (!job || !job.requested_start || !job.requested_end) return 'Default search window';
+            const start = new Date(job.requested_start).toLocaleDateString();
+            const end = new Date(job.requested_end).toLocaleDateString();
+            return `${start} – ${end}`;
+        },
+
+        canCancelBackfill(job) {
+            return Boolean(job && ['queued', 'running', 'backoff'].includes(job.status));
+        },
+
+        canRetryBackfill(job) {
+            return Boolean(job && ['failed', 'cancelled', 'backoff'].includes(job.status));
         },
 
         formatDetailsSummary(details) {

--- a/backend/app/tests/test_demo_data.py
+++ b/backend/app/tests/test_demo_data.py
@@ -8,6 +8,8 @@ from app.services.demo_data import (
     analyze_demo_forensic_reports,
     build_demo_dashboard_statistics,
     build_demo_forensic_reports,
+    build_demo_mail_source_backfills,
+    build_demo_mail_sources,
     build_demo_reports,
     list_demo_forensic_reports,
     list_demo_tls_reports,
@@ -129,6 +131,23 @@ def test_demo_forensic_reports_fill_list_and_analysis_views():
     assert analysis["groups"]
     assert analysis["samples"]
     assert "redacted headers and metadata only" in analysis["samples"][0]["privacy_note"]
+
+
+def test_demo_mail_sources_include_backfill_lifecycle_examples():
+    sources = build_demo_mail_sources(today=date(2026, 6, 25))
+    source_ids = {source["id"] for source in sources}
+
+    assert {9001, 9002, 9003}.issubset(source_ids)
+    assert all(source["password"] is None for source in sources)
+    assert any(source["method"] == "GMAIL_API" and source["gmail_connected"] for source in sources)
+    assert any(source["method"] == "M365_GRAPH" and source["m365_connected"] for source in sources)
+
+    statuses = {
+        job["status"]
+        for source_id in source_ids
+        for job in build_demo_mail_source_backfills(source_id, today=date(2026, 6, 25))
+    }
+    assert {"completed", "running", "backoff", "queued"}.issubset(statuses)
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_demo_read_only.py
+++ b/backend/app/tests/test_demo_read_only.py
@@ -20,6 +20,14 @@ def _build_demo_guard_client(demo_mode: bool = True) -> TestClient:
     async def resource():
         return {"ok": True}
 
+    @app.post("/api/v1/mail-sources/{source_id}/backfills")
+    async def simulated_backfill(source_id: int):
+        return {"source_id": source_id, "ok": True}
+
+    @app.post("/api/v1/mail-sources/{source_id}/backfills/{job_id}/retry")
+    async def simulated_retry(source_id: int, job_id: int):
+        return {"source_id": source_id, "job_id": job_id, "ok": True}
+
     return TestClient(app)
 
 
@@ -36,6 +44,17 @@ def test_demo_mode_blocks_mutating_methods():
             response = method("/resource")
             assert response.status_code == 403
             assert response.json()["detail"].startswith("This public demo is read-only.")
+
+
+def test_demo_mode_allows_synthetic_backfill_simulation_only():
+    with _build_demo_guard_client() as client:
+        allowed_queue = client.post("/api/v1/mail-sources/9001/backfills")
+        allowed_retry = client.post("/api/v1/mail-sources/9002/backfills/9201/retry")
+        blocked_real_source = client.post("/api/v1/mail-sources/123/backfills")
+
+        assert allowed_queue.status_code == 200
+        assert allowed_retry.status_code == 200
+        assert blocked_real_source.status_code == 403
 
 
 def test_normal_mode_allows_mutating_methods():

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -7,6 +7,7 @@ import json
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Optional
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -523,6 +524,21 @@ def test_mail_source_folder_input_has_no_pattern_validation():
     assert "pattern=" not in folder_input
 
 
+def test_mail_sources_template_exposes_backfill_progress_controls():
+    """The UI should surface queued backfill progress, cancellation, and retry."""
+    template = (Path(__file__).resolve().parents[1] / "templates" / "mail_sources.html").read_text()
+
+    assert "data-backfill-progress" in template
+    assert "/backfills?limit=5" in template
+    assert "/backfills/${job.id}/cancel" in template
+    assert "/backfills/${job.id}/retry" in template
+    assert "Queue Backfill" in template
+    assert "canCancelBackfill" in template
+    assert "canRetryBackfill" in template
+    assert "latestBackfill(source)" in template
+    assert "x-html" not in template
+
+
 class TestImportHistoryDecoding:
     """Unit tests for import-history JSON decoding helpers."""
 
@@ -940,6 +956,42 @@ class TestMailSourcesAPIAuthed:
         assert [item["id"] for item in list_response.json()] == [job["id"]]
         assert get_response.status_code == 200
         assert get_response.json()["id"] == job["id"]
+
+    def test_demo_mode_returns_mail_source_backfill_examples(
+        self,
+        authed_client: TestClient,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            mail_sources_endpoint,
+            "get_settings",
+            lambda: SimpleNamespace(DEMO_MODE=True),
+        )
+
+        sources_response = authed_client.get("/api/v1/mail-sources")
+        assert sources_response.status_code == 200
+        sources = sources_response.json()
+        assert {source["id"] for source in sources} >= {9001, 9002, 9003}
+
+        backfills_response = authed_client.get("/api/v1/mail-sources/9001/backfills?limit=5")
+        assert backfills_response.status_code == 200
+        assert {job["status"] for job in backfills_response.json()} >= {"completed", "running"}
+
+        queue_response = authed_client.post(
+            "/api/v1/mail-sources/9001/backfills",
+            json={"max_attempts": 2},
+        )
+        assert queue_response.status_code == 201
+        assert queue_response.json()["status"] == "queued"
+        assert queue_response.json()["details"][0]["source"] == "dmarq.org aggregate reports"
+
+        cancel_response = authed_client.post("/api/v1/mail-sources/9001/backfills/9102/cancel")
+        assert cancel_response.status_code == 200
+        assert cancel_response.json()["status"] == "cancelled"
+
+        retry_response = authed_client.post("/api/v1/mail-sources/9002/backfills/9201/retry")
+        assert retry_response.status_code == 200
+        assert retry_response.json()["status"] == "queued"
 
     def test_backfill_jobs_respect_selected_workspace_header(
         self,

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -183,6 +183,25 @@ the operator checklist, and writing a sanitized workspace audit event.
 Existing domains and mail sources are not duplicated. Existing notification
 settings are preserved unless `overwrite_existing` is set to `true`.
 
+### Mail Source Backfills
+
+Mailbox backfills are admin endpoints for resumable historical imports. Creating
+a backfill queues a progress row; connector workers can then process the window
+without blocking the UI.
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /mail-sources/{source_id}/backfills?limit=20` | List recent queued, running, completed, failed, cancelled, or backoff jobs |
+| `POST /mail-sources/{source_id}/backfills` | Queue a backfill window with optional `requested_start`, `requested_end`, and `max_attempts` |
+| `GET /mail-sources/{source_id}/backfills/{job_id}` | Inspect one progress row |
+| `POST /mail-sources/{source_id}/backfills/{job_id}/cancel` | Cancel a queued, running, or backoff job |
+| `POST /mail-sources/{source_id}/backfills/{job_id}/retry` | Re-queue a failed, cancelled, or backoff job |
+
+The Mail Sources UI shows the latest backfill status, processed message counts,
+reports found, duplicates, retry timing, and operator controls. In demo mode,
+DMARQ exposes credential-free synthetic mail sources and backfill jobs so the
+workflow is visible without connecting a real mailbox.
+
 ### MSP Operator Views
 
 #### List Workspace Operator Summaries

--- a/docs/user_guide/microsoft365.md
+++ b/docs/user_guide/microsoft365.md
@@ -43,7 +43,7 @@ DMARQ reads messages in the configured search window, filters for messages that 
 
 Imported Graph message IDs are stored on the mail source so scheduled polling does not reprocess the same message. Import history records processed messages, imported reports, duplicates, parse failures, attachment-level details, and the mailbox/folder target used for the attempt.
 
-Manual imports and backfills use the **days** value from the Mail Sources UI or trigger-poll endpoint. DMARQ passes that window to Microsoft Graph as a `receivedDateTime` filter, so large mailboxes can be searched without scanning unrelated older mail. If Graph returns a throttling or temporary service response, DMARQ retries with `Retry-After` or exponential backoff before surfacing the sanitized error in import history.
+Manual imports use the **days** value from the Mail Sources UI or trigger-poll endpoint. Backfills are queued as resumable jobs from the **Backfill** action and show progress, reports found, duplicates, retry timing, cancel, and retry controls in the Mail Sources table. DMARQ passes the selected window to Microsoft Graph as a `receivedDateTime` filter, so large mailboxes can be searched without scanning unrelated older mail. If Graph returns a throttling or temporary service response, DMARQ retries with `Retry-After` or exponential backoff before surfacing the sanitized error in import history or backfill status.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What changed

- Adds a Backfill column to Mail Sources showing the latest queued/running/completed/backoff job, processed messages, reports found, duplicates, retry timing, and inline refresh/cancel/retry controls.
- Changes the Backfill modal to queue resumable backfill jobs instead of running an immediate wider fetch.
- Adds credential-free demo mail sources and synthetic backfill lifecycle examples for dmarq.org, dmarq.com, and an ISP mailbox scenario.
- Allows only those synthetic demo backfill POSTs through the demo read-only guard so the public demo can show queue/cancel/retry without allowing real mutations.
- Documents the backfill job endpoints and updates Microsoft 365 wording to match the queued progress model.

## Scope

Refs #320. This is the UI/demo slice for persisted backfill jobs. It intentionally does not implement connector worker execution or source-specific backfill processing.

## Validation

- `.venv/bin/python -m isort --check-only backend/app/api/api_v1/endpoints/mail_sources.py backend/app/services/demo_data.py backend/app/middleware/demo.py backend/app/tests/test_demo_data.py backend/app/tests/test_mail_sources.py backend/app/tests/test_demo_read_only.py`
- `.venv/bin/python -m black --check backend/app/api/api_v1/endpoints/mail_sources.py backend/app/services/demo_data.py backend/app/middleware/demo.py backend/app/tests/test_demo_data.py backend/app/tests/test_mail_sources.py backend/app/tests/test_demo_read_only.py`
- `.venv/bin/python -m pytest backend/app/tests/test_demo_data.py backend/app/tests/test_mail_sources.py backend/app/tests/test_demo_read_only.py -q`
