### PR TITLE
[codex] Add IMAP backfill worker

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,6 +35,7 @@ from app.models.mail_source import MailSource  # noqa: F401 – ensure table is 
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
+from app.services.mail_source_backfill_worker import run_due_imap_backfill_jobs
 from app.services.microsoft_graph_client import MicrosoftGraphClient
 from app.services.report_persistence import hydrate_report_store_from_db
 from app.services.report_store import ReportStore
@@ -309,6 +310,18 @@ def _deliver_due_webhook_events() -> None:
         db.close()
 
 
+def _run_due_mail_source_backfills() -> int:
+    """Execute a bounded batch of queued mail-source backfill jobs."""
+    db = SessionLocal()
+    try:
+        count = run_due_imap_backfill_jobs(db)
+        if count:
+            logger.info("Processed %d queued IMAP backfill job(s)", count)
+        return count
+    finally:
+        db.close()
+
+
 def _next_sleep_seconds(
     min_sleep: int = 60, enabled_sources: Optional[List[MailSource]] = None
 ) -> int:
@@ -336,6 +349,7 @@ async def scheduled_imap_polling():
             mark_scheduler_cycle_started()
             try:
                 enabled_sources = _poll_all_enabled_sources()
+                _run_due_mail_source_backfills()
                 _send_due_summary_notifications()
                 _deliver_due_webhook_events()
                 mark_scheduler_success()

--- a/backend/app/services/mail_source_backfill_worker.py
+++ b/backend/app/services/mail_source_backfill_worker.py
@@ -1,0 +1,236 @@
+"""Worker helpers for resumable mail-source backfill jobs."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.core.redaction import redact_sensitive_text
+from app.models.mail_source import MailSource
+from app.models.mail_source_backfill import MailSourceBackfillJob
+from app.services.imap_client import IMAPClient
+from app.services.import_history import record_import_attempt
+
+logger = logging.getLogger(__name__)
+
+RUNNABLE_BACKFILL_STATUSES = ("queued", "backoff")
+SUPPORTED_WORKER_METHODS = ("IMAP",)
+MAX_BACKFILL_DAYS = 365
+
+
+def _json_error_list(values: Iterable[object]) -> str:
+    return json.dumps([redact_sensitive_text(value) for value in values])
+
+
+def _naive_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def _backfill_window_days(job: MailSourceBackfillJob, now: Optional[datetime] = None) -> int:
+    """Return the IMAP day window needed for a queued backfill job."""
+    if not job.requested_start:
+        return 30
+
+    anchor = _naive_utc(now or datetime.utcnow())
+    requested_start = _naive_utc(job.requested_start)
+    requested_end = _naive_utc(job.requested_end) if job.requested_end else anchor
+    if requested_end > anchor:
+        requested_end = anchor
+    seconds = max((requested_end - requested_start).total_seconds(), 1)
+    days = int(math.ceil(seconds / 86400))
+    return min(MAX_BACKFILL_DAYS, max(1, days))
+
+
+def _retry_delay(attempt_count: int) -> timedelta:
+    minutes = min(60, max(5, 5 * (2 ** max(attempt_count - 1, 0))))
+    return timedelta(minutes=minutes)
+
+
+def _copy_result_counts(job: MailSourceBackfillJob, results: Dict[str, Any]) -> None:
+    job.processed = int(results.get("processed", 0) or 0)
+    job.reports_found = int(results.get("reports_found", 0) or 0)
+    job.duplicate_reports = int(results.get("duplicate_reports", 0) or 0)
+    job.error_count = len(results.get("errors") or [])
+
+
+def _claim_job(job: MailSourceBackfillJob, now: datetime) -> None:
+    job.status = "running"
+    job.started_at = now
+    job.finished_at = None
+    job.cancelled_at = None
+    job.next_retry_at = None
+    job.attempt_count = int(job.attempt_count or 0) + 1
+    job.updated_at = now
+
+
+def _mark_success(
+    job: MailSourceBackfillJob,
+    results: Dict[str, Any],
+    *,
+    days: int,
+    now: datetime,
+    errors: str,
+    details: str,
+) -> None:
+    _copy_result_counts(job, results)
+    job.status = "completed"
+    job.cursor = f"imap:days={days};processed={job.processed}"
+    job.errors = errors
+    job.details = details
+    job.finished_at = now
+    job.next_retry_at = None
+    job.updated_at = now
+
+
+def _mark_failure(
+    job: MailSourceBackfillJob,
+    message: object,
+    *,
+    now: datetime,
+    results: Optional[Dict[str, Any]] = None,
+    errors: Optional[str] = None,
+    details: Optional[str] = None,
+) -> None:
+    if results:
+        _copy_result_counts(job, results)
+    else:
+        job.error_count = max(1, int(job.error_count or 0))
+
+    job.errors = errors or _json_error_list([message])
+    job.details = details or json.dumps([])
+    if int(job.attempt_count or 0) >= int(job.max_attempts or 1):
+        job.status = "failed"
+        job.finished_at = now
+        job.next_retry_at = None
+    else:
+        job.status = "backoff"
+        job.finished_at = None
+        job.next_retry_at = now + _retry_delay(int(job.attempt_count or 1))
+    job.updated_at = now
+
+
+def run_imap_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
+    """Execute one IMAP backfill job and update its persisted lifecycle state."""
+    source = job.mail_source
+    if source is None or source.method != "IMAP":
+        return False
+    if job.status not in RUNNABLE_BACKFILL_STATUSES:
+        return False
+    if job.next_retry_at and job.next_retry_at > datetime.utcnow():
+        return False
+
+    started_at = datetime.utcnow()
+    days = _backfill_window_days(job, started_at)
+    _claim_job(job, started_at)
+    db.commit()
+
+    try:
+        client = IMAPClient(
+            server=source.server,
+            port=source.port or 993,
+            username=source.username,
+            password=source.password,
+            folder=source.folder,
+            db=db,
+        )
+        results = client.fetch_reports(days=days)
+        source.last_checked = datetime.utcnow()
+        attempt = record_import_attempt(
+            db,
+            source,
+            results,
+            started_at=started_at,
+            trigger="backfill",
+        )
+        db.flush()
+
+        finished_at = datetime.utcnow()
+        if results.get("success"):
+            _mark_success(
+                job,
+                results,
+                days=days,
+                now=finished_at,
+                errors=attempt.errors,
+                details=attempt.details,
+            )
+        else:
+            _mark_failure(
+                job,
+                results.get("error") or "Backfill failed",
+                now=finished_at,
+                results=results,
+                errors=attempt.errors,
+                details=attempt.details,
+            )
+        db.commit()
+        return True
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.exception("IMAP backfill job id=%s failed", job.id)
+        results = {
+            "success": False,
+            "processed": 0,
+            "reports_found": 0,
+            "duplicate_reports": 0,
+            "new_domains": [],
+            "errors": [redact_sensitive_text(exc)],
+            "details": [],
+        }
+        attempt = record_import_attempt(
+            db,
+            source,
+            results,
+            started_at=started_at,
+            trigger="backfill",
+        )
+        db.flush()
+        _mark_failure(
+            job,
+            exc,
+            now=datetime.utcnow(),
+            results=results,
+            errors=attempt.errors,
+            details=attempt.details,
+        )
+        db.commit()
+        return True
+
+
+def due_imap_backfill_jobs(db: Session, limit: int = 1) -> List[MailSourceBackfillJob]:
+    """Return due queued/backoff IMAP jobs, oldest first."""
+    now = datetime.utcnow()
+    safe_limit = max(1, min(limit, 20))
+    return (
+        db.query(MailSourceBackfillJob)
+        .join(MailSource, MailSource.id == MailSourceBackfillJob.mail_source_id)
+        .filter(
+            MailSourceBackfillJob.status.in_(RUNNABLE_BACKFILL_STATUSES),
+            or_(
+                MailSourceBackfillJob.next_retry_at.is_(None),
+                MailSourceBackfillJob.next_retry_at <= now,
+            ),
+            MailSource.method.in_(SUPPORTED_WORKER_METHODS),
+            MailSource.enabled.is_(True),
+        )
+        .order_by(MailSourceBackfillJob.created_at.asc(), MailSourceBackfillJob.id.asc())
+        .with_for_update(skip_locked=True)
+        .limit(safe_limit)
+        .all()
+    )
+
+
+def run_due_imap_backfill_jobs(db: Session, limit: int = 1) -> int:
+    """Execute a bounded batch of due IMAP backfill jobs."""
+    count = 0
+    for job in due_imap_backfill_jobs(db, limit=limit):
+        if run_imap_backfill_job(db, job):
+            count += 1
+    return count

--- a/backend/app/tests/test_mail_source_backfill_worker.py
+++ b/backend/app/tests/test_mail_source_backfill_worker.py
@@ -1,0 +1,215 @@
+from datetime import datetime, timedelta, timezone
+
+from app.models.mail_source import MailSource
+from app.models.mail_source_backfill import MailSourceBackfillJob
+from app.models.mail_source_import import MailSourceImport
+from app.services.mail_source_backfill_worker import (
+    _backfill_window_days,
+    _mark_failure,
+    _retry_delay,
+    run_due_imap_backfill_jobs,
+    run_imap_backfill_job,
+)
+from app.services.workspaces import get_or_create_default_workspace
+
+
+def _source(db_session, *, method="IMAP", enabled=True):
+    workspace = get_or_create_default_workspace(db_session)
+    source = MailSource(
+        workspace_id=workspace.id,
+        name=f"{method} Backfill",
+        method=method,
+        server="imap.example.com",
+        port=993,
+        username="reports@example.com",
+        password="secret",
+        folder="INBOX/DMARC",
+        enabled=enabled,
+    )
+    db_session.add(source)
+    db_session.commit()
+    return workspace, source
+
+
+def _job(db_session, workspace, source, **overrides):
+    values = {
+        "workspace_id": workspace.id,
+        "mail_source_id": source.id,
+        "status": "queued",
+        "requested_start": datetime(2026, 1, 1),
+        "requested_end": datetime(2026, 1, 11),
+        "max_attempts": 3,
+    }
+    values.update(overrides)
+    row = MailSourceBackfillJob(**values)
+    db_session.add(row)
+    db_session.commit()
+    return row
+
+
+def test_run_due_imap_backfill_completes_job_and_records_import(db_session, monkeypatch):
+    workspace, source = _source(db_session)
+    row = _job(db_session, workspace, source)
+    results = {
+        "success": True,
+        "processed": 12,
+        "reports_found": 4,
+        "duplicate_reports": 1,
+        "new_domains": ["example.com"],
+        "errors": [],
+        "details": [{"status": "imported", "domain": "example.com"}],
+    }
+
+    class FakeIMAPClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def fetch_reports(self, days):
+            assert days == 10
+            return results
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.IMAPClient",
+        FakeIMAPClient,
+    )
+
+    assert run_due_imap_backfill_jobs(db_session, limit=1) == 1
+
+    db_session.refresh(row)
+    db_session.refresh(source)
+    attempt = db_session.query(MailSourceImport).filter_by(mail_source_id=source.id).one()
+
+    assert row.status == "completed"
+    assert row.attempt_count == 1
+    assert row.processed == 12
+    assert row.reports_found == 4
+    assert row.duplicate_reports == 1
+    assert row.cursor == "imap:days=10;processed=12"
+    assert row.finished_at is not None
+    assert row.next_retry_at is None
+    assert source.last_checked is not None
+    assert attempt.trigger == "backfill"
+    assert attempt.status == "success"
+
+
+def test_run_imap_backfill_moves_failed_attempt_to_backoff(db_session, monkeypatch):
+    workspace, source = _source(db_session)
+    row = _job(db_session, workspace, source, max_attempts=3)
+
+    class FakeIMAPClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        def fetch_reports(self, days):
+            return {
+                "success": False,
+                "processed": 2,
+                "reports_found": 0,
+                "duplicate_reports": 0,
+                "new_domains": [],
+                "errors": ["temporary provider failure"],
+            }
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.IMAPClient",
+        FakeIMAPClient,
+    )
+
+    assert run_imap_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    assert row.status == "backoff"
+    assert row.attempt_count == 1
+    assert row.error_count == 1
+    assert row.next_retry_at is not None
+    assert row.finished_at is None
+
+
+def test_run_imap_backfill_marks_exhausted_attempt_failed(db_session, monkeypatch):
+    workspace, source = _source(db_session)
+    row = _job(db_session, workspace, source, attempt_count=1, max_attempts=2)
+
+    class FakeIMAPClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        def fetch_reports(self, days):
+            raise RuntimeError("login failed for token=secret-value")
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.IMAPClient",
+        FakeIMAPClient,
+    )
+
+    assert run_imap_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    attempt = db_session.query(MailSourceImport).filter_by(mail_source_id=source.id).one()
+
+    assert row.status == "failed"
+    assert row.attempt_count == 2
+    assert row.finished_at is not None
+    assert row.next_retry_at is None
+    assert "secret-value" not in row.errors
+    assert attempt.trigger == "backfill"
+    assert attempt.status == "failed"
+    assert "secret-value" not in attempt.errors
+
+
+def test_run_due_imap_backfill_skips_unsupported_or_disabled_sources(db_session):
+    workspace, gmail_source = _source(db_session, method="GMAIL_API")
+    disabled_workspace, disabled_source = _source(db_session, enabled=False)
+    _job(db_session, workspace, gmail_source)
+    _job(db_session, disabled_workspace, disabled_source)
+
+    assert run_due_imap_backfill_jobs(db_session) == 0
+
+
+def test_run_imap_backfill_skips_unsupported_status_or_future_retry(db_session):
+    workspace, gmail_source = _source(db_session, method="GMAIL_API")
+    gmail_job = _job(db_session, workspace, gmail_source)
+    assert run_imap_backfill_job(db_session, gmail_job) is False
+
+    workspace, imap_source = _source(db_session)
+    running_job = _job(db_session, workspace, imap_source, status="running")
+    assert run_imap_backfill_job(db_session, running_job) is False
+
+    future_retry_job = _job(
+        db_session,
+        workspace,
+        imap_source,
+        status="backoff",
+        next_retry_at=datetime.utcnow() + timedelta(minutes=5),
+    )
+    assert run_imap_backfill_job(db_session, future_retry_job) is False
+
+
+def test_backfill_window_and_failure_helpers_cover_edge_cases(db_session):
+    workspace, source = _source(db_session)
+    default_window = _job(
+        db_session,
+        workspace,
+        source,
+        requested_start=None,
+        requested_end=None,
+    )
+    assert _backfill_window_days(default_window) == 30
+
+    now = datetime(2026, 1, 11, tzinfo=timezone.utc)
+    future_end = _job(
+        db_session,
+        workspace,
+        source,
+        requested_start=datetime(2026, 1, 10, tzinfo=timezone.utc),
+        requested_end=datetime(2026, 1, 12, tzinfo=timezone.utc),
+    )
+    assert _backfill_window_days(future_end, now=now) == 1
+    assert _retry_delay(20) == timedelta(minutes=60)
+
+    _mark_failure(
+        future_end,
+        "provider returned token=secret-value",
+        now=datetime.utcnow(),
+    )
+    assert future_end.error_count == 1
+    assert "secret-value" not in future_end.errors

--- a/backend/app/tests/test_main_polling.py
+++ b/backend/app/tests/test_main_polling.py
@@ -149,12 +149,29 @@ def test_poll_single_m365_source_skips_without_token():
     mock_session.assert_not_called()
 
 
+def test_run_due_mail_source_backfills_logs_processed_count():
+    from app.main import _run_due_mail_source_backfills
+
+    db = MagicMock()
+    with (
+        patch("app.main.SessionLocal", return_value=db),
+        patch("app.main.run_due_imap_backfill_jobs", return_value=2) as run_due,
+        patch("app.main.logger") as logger,
+    ):
+        assert _run_due_mail_source_backfills() == 2
+
+    run_due.assert_called_once_with(db)
+    logger.info.assert_called_once_with("Processed %d queued IMAP backfill job(s)", 2)
+    db.close.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_scheduled_imap_polling_sleep_exception_falls_back_then_cancels():
     from app.main import scheduled_imap_polling
 
     with (
         patch("app.main._poll_all_enabled_sources", return_value=[]),
+        patch("app.main._run_due_mail_source_backfills", return_value=0),
         patch("app.main._next_sleep_seconds", return_value=60),
         patch(
             "app.main.asyncio.sleep",

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -198,7 +198,10 @@ without blocking the UI.
 | `POST /mail-sources/{source_id}/backfills/{job_id}/retry` | Re-queue a failed, cancelled, or backoff job |
 
 The Mail Sources UI shows the latest backfill status, processed message counts,
-reports found, duplicates, retry timing, and operator controls. In demo mode,
+reports found, duplicates, retry timing, and operator controls. The background
+scheduler currently executes due IMAP backfill jobs in bounded batches and
+records results in import history with trigger `backfill`; Gmail and Microsoft
+365 worker execution remain connector-specific follow-up work. In demo mode,
 DMARQ exposes credential-free synthetic mail sources and backfill jobs so the
 workflow is visible without connecting a real mailbox.
 

--- a/docs/user_guide/microsoft365.md
+++ b/docs/user_guide/microsoft365.md
@@ -43,7 +43,7 @@ DMARQ reads messages in the configured search window, filters for messages that 
 
 Imported Graph message IDs are stored on the mail source so scheduled polling does not reprocess the same message. Import history records processed messages, imported reports, duplicates, parse failures, attachment-level details, and the mailbox/folder target used for the attempt.
 
-Manual imports use the **days** value from the Mail Sources UI or trigger-poll endpoint. Backfills are queued as resumable jobs from the **Backfill** action and show progress, reports found, duplicates, retry timing, cancel, and retry controls in the Mail Sources table. DMARQ passes the selected window to Microsoft Graph as a `receivedDateTime` filter, so large mailboxes can be searched without scanning unrelated older mail. If Graph returns a throttling or temporary service response, DMARQ retries with `Retry-After` or exponential backoff before surfacing the sanitized error in import history or backfill status.
+Manual imports use the **days** value from the Mail Sources UI or trigger-poll endpoint. DMARQ passes that selected window to Microsoft Graph as a `receivedDateTime` filter, so large mailboxes can be searched without scanning unrelated older mail. Backfills are queued as resumable jobs from the **Backfill** action and show progress, reports found, duplicates, retry timing, cancel, and retry controls in the Mail Sources table; Microsoft 365 worker execution is tracked as connector-specific follow-up after the IMAP worker path.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- add a bounded IMAP backfill worker that claims due queued/backoff jobs, executes the selected date window, and records lifecycle state
- wire the worker into the existing scheduler cycle after normal mailbox polling
- persist backfill import-history entries for success, provider-returned failures, and hard exceptions with sanitized errors
- document that Gmail and Microsoft 365 backfill worker execution remain connector-specific follow-up work

Refs #320.

## Validation
- `.venv/bin/python -m isort --check-only backend/app/services/mail_source_backfill_worker.py backend/app/main.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_main_polling.py`
- `.venv/bin/python -m black --check backend/app/services/mail_source_backfill_worker.py backend/app/main.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_main_polling.py`
- `.venv/bin/python -m pytest backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_main_polling.py backend/app/tests/test_mail_sources.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IMAP backfill jobs now run automatically during scheduled mail polling in bounded batches.
  * Backfill progress is now tracked with retry and backoff behavior for failed runs.
  * Successful backfills are recorded in import history with a backfill trigger.

* **Bug Fixes**
  * Improved handling for unsupported or disabled mail sources so they are skipped safely.
  * Error details are sanitized when backfill attempts fail.

* **Documentation**
  * Updated mail source backfill and Microsoft 365 import guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->