### PR TITLE
[codex] Add Gmail backfill worker

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,7 +35,7 @@ from app.models.mail_source import MailSource  # noqa: F401 – ensure table is 
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
-from app.services.mail_source_backfill_worker import run_due_imap_backfill_jobs
+from app.services.mail_source_backfill_worker import run_due_mail_source_backfill_jobs
 from app.services.microsoft_graph_client import MicrosoftGraphClient
 from app.services.report_persistence import hydrate_report_store_from_db
 from app.services.report_store import ReportStore
@@ -314,9 +314,9 @@ def _run_due_mail_source_backfills() -> int:
     """Execute a bounded batch of queued mail-source backfill jobs."""
     db = SessionLocal()
     try:
-        count = run_due_imap_backfill_jobs(db)
+        count = run_due_mail_source_backfill_jobs(db)
         if count:
-            logger.info("Processed %d queued IMAP backfill job(s)", count)
+            logger.info("Processed %d queued mail-source backfill job(s)", count)
         return count
     finally:
         db.close()

--- a/backend/app/services/gmail_client.py
+++ b/backend/app/services/gmail_client.py
@@ -204,7 +204,7 @@ class GmailClient:
     # Core fetching logic
     # ------------------------------------------------------------------
 
-    def fetch_reports(self) -> Dict[str, Any]:
+    def fetch_reports(self, days: Optional[int] = None) -> Dict[str, Any]:
         """
         Search Gmail for DMARC report emails and ingest any new ones.
 
@@ -218,6 +218,8 @@ class GmailClient:
             added in this run so the caller can persist them).
         """
         stats = initial_import_stats()
+        if days is not None:
+            stats["search_window_days"] = int(days)
 
         try:
             service = self._build_service()
@@ -226,7 +228,7 @@ class GmailClient:
             return connector_failure_stats(stats, "Failed to initialize Gmail API.", error=exc)
 
         try:
-            message_ids = self._list_dmarc_message_ids(service)
+            message_ids = self._list_dmarc_message_ids(service, days=days)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error("Gmail API: failed to list messages: %s", exc)
             return connector_failure_stats(stats, "Failed to list Gmail messages.", error=exc)
@@ -270,7 +272,15 @@ class GmailClient:
 
         return build("gmail", "v1", credentials=self.credentials, cache_discovery=False)
 
-    def _list_dmarc_message_ids(self, service) -> List[str]:
+    @staticmethod
+    def _search_query(days: Optional[int] = None) -> str:
+        """Return the Gmail search query, optionally constrained by age."""
+        if days is None:
+            return DMARC_GMAIL_QUERY
+        safe_days = max(1, int(days))
+        return f"newer_than:{safe_days}d {DMARC_GMAIL_QUERY}"
+
+    def _list_dmarc_message_ids(self, service, days: Optional[int] = None) -> List[str]:
         """Return all Gmail message IDs matching the DMARC search query."""
         ids: List[str] = []
         page_token: Optional[str] = None
@@ -278,7 +288,7 @@ class GmailClient:
         while True:
             kwargs: Dict[str, Any] = {
                 "userId": "me",
-                "q": DMARC_GMAIL_QUERY,
+                "q": self._search_query(days),
                 "maxResults": _PAGE_SIZE,
             }
             if page_token:

--- a/backend/app/services/mail_source_backfill_worker.py
+++ b/backend/app/services/mail_source_backfill_worker.py
@@ -14,13 +14,14 @@ from sqlalchemy.orm import Session
 from app.core.redaction import redact_sensitive_text
 from app.models.mail_source import MailSource
 from app.models.mail_source_backfill import MailSourceBackfillJob
+from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
 
 logger = logging.getLogger(__name__)
 
 RUNNABLE_BACKFILL_STATUSES = ("queued", "backoff")
-SUPPORTED_WORKER_METHODS = ("IMAP",)
+SUPPORTED_WORKER_METHODS = ("IMAP", "GMAIL_API")
 MAX_BACKFILL_DAYS = 365
 
 
@@ -76,13 +77,14 @@ def _mark_success(
     results: Dict[str, Any],
     *,
     days: int,
+    cursor_prefix: str,
     now: datetime,
     errors: str,
     details: str,
 ) -> None:
     _copy_result_counts(job, results)
     job.status = "completed"
-    job.cursor = f"imap:days={days};processed={job.processed}"
+    job.cursor = f"{cursor_prefix}:days={days};processed={job.processed}"
     job.errors = errors
     job.details = details
     job.finished_at = now
@@ -158,6 +160,7 @@ def run_imap_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
                 job,
                 results,
                 days=days,
+                cursor_prefix="imap",
                 now=finished_at,
                 errors=attempt.errors,
                 details=attempt.details,
@@ -204,10 +207,164 @@ def run_imap_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
         return True
 
 
-def due_imap_backfill_jobs(db: Session, limit: int = 1) -> List[MailSourceBackfillJob]:
-    """Return due queued/backoff IMAP jobs, oldest first."""
+def _fetch_gmail_backfill_results(
+    db: Session,
+    source: MailSource,
+    *,
+    started_at: datetime,
+    days: int,
+) -> tuple[Dict[str, Any], Any]:
+    if not source.gmail_access_token:
+        raise ValueError("Gmail account not yet authorised. Complete OAuth2 flow first.")
+
+    already = GmailClient.load_ingested_ids(source.gmail_ingested_ids)
+    client = GmailClient(
+        client_id=source.gmail_client_id or "",
+        client_secret=source.gmail_client_secret or "",
+        access_token=source.gmail_access_token,
+        refresh_token=source.gmail_refresh_token or "",
+        already_ingested_ids=already,
+        db=db,
+    )
+    results = client.fetch_reports(days=days)
+    _sync_gmail_backfill_state(source, client, already, results)
+    source.last_checked = datetime.utcnow()
+    attempt = record_import_attempt(
+        db,
+        source,
+        results,
+        started_at=started_at,
+        trigger="backfill",
+    )
+    db.flush()
+    return results, attempt
+
+
+def _sync_gmail_backfill_state(
+    source: MailSource,
+    client: GmailClient,
+    already_ingested: List[str],
+    results: Dict[str, Any],
+) -> None:
+    if results.get("new_ingested_ids"):
+        all_ids = list(dict.fromkeys(already_ingested + results["new_ingested_ids"]))
+        source.gmail_ingested_ids = GmailClient.dump_ingested_ids(all_ids)
+
+    refreshed = client.get_refreshed_tokens()
+    if refreshed:
+        source.gmail_access_token = refreshed["access_token"]
+        if "refresh_token" in refreshed:
+            source.gmail_refresh_token = refreshed["refresh_token"]
+
+
+def _finish_backfill_from_results(
+    job: MailSourceBackfillJob,
+    results: Dict[str, Any],
+    *,
+    days: int,
+    cursor_prefix: str,
+    errors: str,
+    details: str,
+) -> None:
+    finished_at = datetime.utcnow()
+    if results.get("success"):
+        _mark_success(
+            job,
+            results,
+            days=days,
+            cursor_prefix=cursor_prefix,
+            now=finished_at,
+            errors=errors,
+            details=details,
+        )
+    else:
+        _mark_failure(
+            job,
+            results.get("error") or "Backfill failed",
+            now=finished_at,
+            results=results,
+            errors=errors,
+            details=details,
+        )
+
+
+def _backfill_exception_results(exc: Exception) -> Dict[str, Any]:
+    return {
+        "success": False,
+        "processed": 0,
+        "reports_found": 0,
+        "duplicate_reports": 0,
+        "new_domains": [],
+        "errors": [redact_sensitive_text(exc)],
+        "details": [],
+    }
+
+
+def run_gmail_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
+    """Execute one Gmail API backfill job and update its persisted lifecycle state."""
+    source = job.mail_source
+    if source is None or source.method != "GMAIL_API":
+        return False
+    if job.status not in RUNNABLE_BACKFILL_STATUSES:
+        return False
+    if job.next_retry_at and job.next_retry_at > datetime.utcnow():
+        return False
+
+    started_at = datetime.utcnow()
+    days = _backfill_window_days(job, started_at)
+    _claim_job(job, started_at)
+    db.commit()
+
+    try:
+        results, attempt = _fetch_gmail_backfill_results(
+            db,
+            source,
+            started_at=started_at,
+            days=days,
+        )
+        _finish_backfill_from_results(
+            job,
+            results,
+            days=days,
+            cursor_prefix="gmail",
+            errors=attempt.errors,
+            details=attempt.details,
+        )
+        db.commit()
+        return True
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.exception("Gmail backfill job id=%s failed", job.id)
+        results = _backfill_exception_results(exc)
+        attempt = record_import_attempt(
+            db,
+            source,
+            results,
+            started_at=started_at,
+            trigger="backfill",
+        )
+        db.flush()
+        _mark_failure(
+            job,
+            exc,
+            now=datetime.utcnow(),
+            results=results,
+            errors=attempt.errors,
+            details=attempt.details,
+        )
+        db.commit()
+        return True
+
+
+def due_mail_source_backfill_jobs(
+    db: Session,
+    limit: int = 1,
+    *,
+    methods: Iterable[str] = SUPPORTED_WORKER_METHODS,
+) -> List[MailSourceBackfillJob]:
+    """Return due queued/backoff mail-source jobs for supported methods, oldest first."""
     now = datetime.utcnow()
     safe_limit = max(1, min(limit, 20))
+    method_list = tuple(methods)
     return (
         db.query(MailSourceBackfillJob)
         .join(MailSource, MailSource.id == MailSourceBackfillJob.mail_source_id)
@@ -217,7 +374,7 @@ def due_imap_backfill_jobs(db: Session, limit: int = 1) -> List[MailSourceBackfi
                 MailSourceBackfillJob.next_retry_at.is_(None),
                 MailSourceBackfillJob.next_retry_at <= now,
             ),
-            MailSource.method.in_(SUPPORTED_WORKER_METHODS),
+            MailSource.method.in_(method_list),
             MailSource.enabled.is_(True),
         )
         .order_by(MailSourceBackfillJob.created_at.asc(), MailSourceBackfillJob.id.asc())
@@ -227,10 +384,36 @@ def due_imap_backfill_jobs(db: Session, limit: int = 1) -> List[MailSourceBackfi
     )
 
 
+def due_imap_backfill_jobs(db: Session, limit: int = 1) -> List[MailSourceBackfillJob]:
+    """Return due queued/backoff IMAP jobs, oldest first."""
+    return due_mail_source_backfill_jobs(db, limit=limit, methods=("IMAP",))
+
+
+def run_mail_source_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
+    """Execute one supported mail-source backfill job."""
+    source = job.mail_source
+    if source is None:
+        return False
+    if source.method == "IMAP":
+        return run_imap_backfill_job(db, job)
+    if source.method == "GMAIL_API":
+        return run_gmail_backfill_job(db, job)
+    return False
+
+
 def run_due_imap_backfill_jobs(db: Session, limit: int = 1) -> int:
     """Execute a bounded batch of due IMAP backfill jobs."""
     count = 0
     for job in due_imap_backfill_jobs(db, limit=limit):
         if run_imap_backfill_job(db, job):
+            count += 1
+    return count
+
+
+def run_due_mail_source_backfill_jobs(db: Session, limit: int = 1) -> int:
+    """Execute a bounded batch of due supported mail-source backfill jobs."""
+    count = 0
+    for job in due_mail_source_backfill_jobs(db, limit=limit):
+        if run_mail_source_backfill_job(db, job):
             count += 1
     return count

--- a/backend/app/services/mail_source_backfill_worker.py
+++ b/backend/app/services/mail_source_backfill_worker.py
@@ -72,6 +72,17 @@ def _claim_job(job: MailSourceBackfillJob, now: datetime) -> None:
     job.updated_at = now
 
 
+def _job_is_runnable(job: MailSourceBackfillJob, method: str) -> bool:
+    source = job.mail_source
+    if source is None or source.method != method:
+        return False
+    if job.status not in RUNNABLE_BACKFILL_STATUSES:
+        return False
+    if job.next_retry_at and job.next_retry_at > datetime.utcnow():
+        return False
+    return True
+
+
 def _mark_success(
     job: MailSourceBackfillJob,
     results: Dict[str, Any],
@@ -122,11 +133,7 @@ def _mark_failure(
 def run_imap_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
     """Execute one IMAP backfill job and update its persisted lifecycle state."""
     source = job.mail_source
-    if source is None or source.method != "IMAP":
-        return False
-    if job.status not in RUNNABLE_BACKFILL_STATUSES:
-        return False
-    if job.next_retry_at and job.next_retry_at > datetime.utcnow():
+    if not _job_is_runnable(job, "IMAP"):
         return False
 
     started_at = datetime.utcnow()
@@ -303,11 +310,7 @@ def _backfill_exception_results(exc: Exception) -> Dict[str, Any]:
 def run_gmail_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
     """Execute one Gmail API backfill job and update its persisted lifecycle state."""
     source = job.mail_source
-    if source is None or source.method != "GMAIL_API":
-        return False
-    if job.status not in RUNNABLE_BACKFILL_STATUSES:
-        return False
-    if job.next_retry_at and job.next_retry_at > datetime.utcnow():
+    if not _job_is_runnable(job, "GMAIL_API"):
         return False
 
     started_at = datetime.utcnow()

--- a/backend/app/tests/test_gmail_client.py
+++ b/backend/app/tests/test_gmail_client.py
@@ -21,7 +21,7 @@ import pytest
 
 from app.models.report import DMARCReport, ForensicReport
 from app.models.setting import Setting
-from app.services.gmail_client import RETRYABLE_MESSAGE_FAILURE, GmailClient
+from app.services.gmail_client import DMARC_GMAIL_QUERY, RETRYABLE_MESSAGE_FAILURE, GmailClient
 from app.services.report_store import ReportStore
 from app.tests.test_data import SAMPLE_XML
 from app.tests.test_forensic_parser import SAMPLE_FORENSIC_EMAIL
@@ -756,6 +756,24 @@ class TestFetchReports:
 
         assert result["success"] is True
         assert result["processed"] == 0
+
+    def test_fetch_reports_passes_optional_search_window(self):
+        client = _make_client()
+        mock_service = MagicMock()
+        with (
+            patch.object(client, "_build_service", return_value=mock_service),
+            patch.object(client, "_list_dmarc_message_ids", return_value=[]) as list_messages,
+        ):
+            result = client.fetch_reports(days=30)
+
+        list_messages.assert_called_once_with(mock_service, days=30)
+        assert result["search_window_days"] == 30
+
+    def test_search_query_includes_gmail_newer_than_filter(self):
+        query = GmailClient._search_query(days=30)
+
+        assert query.startswith("newer_than:30d ")
+        assert DMARC_GMAIL_QUERY in query
 
     def test_skips_already_ingested_messages(self):
         client = _make_client(already_ingested=["id1"])

--- a/backend/app/tests/test_mail_source_backfill_worker.py
+++ b/backend/app/tests/test_mail_source_backfill_worker.py
@@ -8,7 +8,10 @@ from app.services.mail_source_backfill_worker import (
     _mark_failure,
     _retry_delay,
     run_due_imap_backfill_jobs,
+    run_due_mail_source_backfill_jobs,
+    run_gmail_backfill_job,
     run_imap_backfill_job,
+    run_mail_source_backfill_job,
 )
 from app.services.workspaces import get_or_create_default_workspace
 
@@ -25,6 +28,11 @@ def _source(db_session, *, method="IMAP", enabled=True):
         password="secret",
         folder="INBOX/DMARC",
         enabled=enabled,
+        gmail_client_id="gmail-client",
+        gmail_client_secret="gmail-secret",
+        gmail_access_token="gmail-token" if method == "GMAIL_API" else None,
+        gmail_refresh_token="gmail-refresh" if method == "GMAIL_API" else None,
+        gmail_ingested_ids='["old-id"]' if method == "GMAIL_API" else None,
     )
     db_session.add(source)
     db_session.commit()
@@ -163,6 +171,144 @@ def test_run_due_imap_backfill_skips_unsupported_or_disabled_sources(db_session)
     _job(db_session, disabled_workspace, disabled_source)
 
     assert run_due_imap_backfill_jobs(db_session) == 0
+
+
+def test_run_due_mail_source_backfill_executes_gmail_job(db_session, monkeypatch):
+    workspace, source = _source(db_session, method="GMAIL_API")
+    row = _job(db_session, workspace, source)
+    results = {
+        "success": True,
+        "processed": 5,
+        "reports_found": 3,
+        "duplicate_reports": 1,
+        "new_domains": ["example.com"],
+        "new_ingested_ids": ["new-id", "old-id"],
+        "errors": [],
+        "details": [{"status": "imported", "domain": "example.com"}],
+        "search_window_days": 10,
+    }
+
+    class FakeGmailClient:
+        def __init__(self, **kwargs):
+            assert kwargs["already_ingested_ids"] == ["old-id"]
+
+        def fetch_reports(self, days):
+            assert days == 10
+            return results
+
+        def get_refreshed_tokens(self):
+            return {"access_token": "new-access", "refresh_token": "new-refresh"}
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.GmailClient",
+        FakeGmailClient,
+    )
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.GmailClient.load_ingested_ids",
+        lambda value: ["old-id"],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.GmailClient.dump_ingested_ids",
+        lambda values: ",".join(values),
+        raising=False,
+    )
+
+    assert run_due_mail_source_backfill_jobs(db_session, limit=1) == 1
+
+    db_session.refresh(row)
+    db_session.refresh(source)
+    attempt = db_session.query(MailSourceImport).filter_by(mail_source_id=source.id).one()
+
+    assert row.status == "completed"
+    assert row.cursor == "gmail:days=10;processed=5"
+    assert row.processed == 5
+    assert row.reports_found == 3
+    assert source.gmail_ingested_ids == "old-id,new-id"
+    assert source.gmail_access_token == "new-access"
+    assert source.gmail_refresh_token == "new-refresh"
+    assert source.last_checked is not None
+    assert attempt.trigger == "backfill"
+    assert attempt.status == "success"
+
+
+def test_run_gmail_backfill_without_token_moves_to_backoff(db_session):
+    workspace, source = _source(db_session, method="GMAIL_API")
+    source.gmail_access_token = None
+    db_session.commit()
+    row = _job(db_session, workspace, source, max_attempts=3)
+
+    assert run_gmail_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    attempt = db_session.query(MailSourceImport).filter_by(mail_source_id=source.id).one()
+
+    assert row.status == "backoff"
+    assert row.attempt_count == 1
+    assert row.next_retry_at is not None
+    assert "not yet authorised" in row.errors
+    assert attempt.trigger == "backfill"
+    assert attempt.status == "failed"
+
+
+def test_run_gmail_backfill_provider_failure_moves_to_backoff(db_session, monkeypatch):
+    workspace, source = _source(db_session, method="GMAIL_API")
+    row = _job(db_session, workspace, source, max_attempts=3)
+
+    class FakeGmailClient:
+        load_ingested_ids = staticmethod(lambda _value: [])
+        dump_ingested_ids = staticmethod(lambda values: ",".join(values))
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def fetch_reports(self, days):
+            return {
+                "success": False,
+                "processed": 2,
+                "reports_found": 0,
+                "duplicate_reports": 0,
+                "new_domains": [],
+                "errors": ["temporary Gmail API failure"],
+            }
+
+        def get_refreshed_tokens(self):
+            return None
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.GmailClient",
+        FakeGmailClient,
+    )
+
+    assert run_gmail_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    assert row.status == "backoff"
+    assert row.processed == 2
+    assert row.error_count == 1
+    assert row.next_retry_at is not None
+
+
+def test_run_mail_source_backfill_dispatches_or_skips(db_session, monkeypatch):
+    workspace, imap_source = _source(db_session)
+    imap_job = _job(db_session, workspace, imap_source)
+    workspace, gmail_source = _source(db_session, method="GMAIL_API")
+    gmail_job = _job(db_session, workspace, gmail_source)
+    workspace, m365_source = _source(db_session, method="M365_GRAPH")
+    m365_job = _job(db_session, workspace, m365_source)
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.run_imap_backfill_job",
+        lambda _db, job: job.id == imap_job.id,
+    )
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.run_gmail_backfill_job",
+        lambda _db, job: job.id == gmail_job.id,
+    )
+
+    assert run_mail_source_backfill_job(db_session, imap_job) is True
+    assert run_mail_source_backfill_job(db_session, gmail_job) is True
+    assert run_mail_source_backfill_job(db_session, m365_job) is False
 
 
 def test_run_imap_backfill_skips_unsupported_status_or_future_retry(db_session):

--- a/backend/app/tests/test_main_polling.py
+++ b/backend/app/tests/test_main_polling.py
@@ -155,13 +155,13 @@ def test_run_due_mail_source_backfills_logs_processed_count():
     db = MagicMock()
     with (
         patch("app.main.SessionLocal", return_value=db),
-        patch("app.main.run_due_imap_backfill_jobs", return_value=2) as run_due,
+        patch("app.main.run_due_mail_source_backfill_jobs", return_value=2) as run_due,
         patch("app.main.logger") as logger,
     ):
         assert _run_due_mail_source_backfills() == 2
 
     run_due.assert_called_once_with(db)
-    logger.info.assert_called_once_with("Processed %d queued IMAP backfill job(s)", 2)
+    logger.info.assert_called_once_with("Processed %d queued mail-source backfill job(s)", 2)
     db.close.assert_called_once()
 
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -199,9 +199,9 @@ without blocking the UI.
 
 The Mail Sources UI shows the latest backfill status, processed message counts,
 reports found, duplicates, retry timing, and operator controls. The background
-scheduler currently executes due IMAP backfill jobs in bounded batches and
-records results in import history with trigger `backfill`; Gmail and Microsoft
-365 worker execution remain connector-specific follow-up work. In demo mode,
+scheduler currently executes due IMAP and Gmail backfill jobs in bounded
+batches and records results in import history with trigger `backfill`;
+Microsoft 365 worker execution remains connector-specific follow-up work. In demo mode,
 DMARQ exposes credential-free synthetic mail sources and backfill jobs so the
 workflow is visible without connecting a real mailbox.
 


### PR DESCRIPTION
## What changed
- Adds Gmail API execution to queued mail-source backfill jobs.
- Adds an optional Gmail search window so backfill jobs query `newer_than:{days}d` instead of scanning the entire mailbox.
- Generalizes the scheduler path from IMAP-only to supported mail-source backfills while keeping the existing IMAP wrapper intact.
- Documents that IMAP and Gmail are now worker-backed; Microsoft 365 remains follow-up work for issue #320.

## Why
Issue #320 added the backfill job model and IMAP execution path. Gmail sources could queue jobs through the UI/API, but the background worker did not yet execute them. This makes Gmail backfills operational and records progress/import history in the same lifecycle as IMAP.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_main_polling.py backend/app/tests/test_gmail_client.py backend/app/tests/test_mail_sources.py -q`
- `cd backend && ../.venv/bin/python -m pytest app/tests/test_mail_source_backfill_worker.py app/tests/test_main_polling.py app/tests/test_gmail_client.py app/tests/test_mail_sources.py --cov=app.services.mail_source_backfill_worker --cov=app.services.gmail_client --cov=app.main --cov-report=term-missing -q`
- `.venv/bin/python -m pytest backend/app/tests -q`

Refs #320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing Gmail mail-source backfills alongside existing IMAP backfills.
  * Search can now be limited to recent Gmail messages using a configurable time window.
* **Bug Fixes**
  * Improved backfill job scheduling and logging to reflect mail-source processing more accurately.
  * Added clearer handling for failed Gmail backfills, including retry/backoff behavior.
* **Documentation**
  * Updated scheduler docs to describe IMAP and Gmail backfill processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->