### PR TITLE
[codex] Add Microsoft 365 backfill worker

### DIFF
--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -671,6 +671,7 @@ def _fetch_gmail_source(source: MailSource, db: Session) -> Dict[str, Any]:
         refresh_token=source.gmail_refresh_token or "",
         already_ingested_ids=already,
         db=db,
+        workspace_id=source.workspace_id,
     )
 
     started_at = datetime.utcnow()
@@ -712,6 +713,7 @@ def _fetch_m365_source(source: MailSource, db: Session, days: int = 7) -> Dict[s
         folder_id=_safe_attr(source, "m365_folder_id"),
         already_ingested_ids=already,
         db=db,
+        workspace_id=source.workspace_id,
     )
 
     started_at = datetime.utcnow()
@@ -742,6 +744,7 @@ def _fetch_imap_source(source: MailSource, db: Session, days: int) -> Dict[str, 
         password=source.password,
         folder=source.folder,
         db=db,
+        workspace_id=source.workspace_id,
     )
     started_at = datetime.utcnow()
     results = client.fetch_reports(days=days)
@@ -2090,6 +2093,7 @@ async def gmail_fetch_reports(
         refresh_token=source.gmail_refresh_token or "",
         already_ingested_ids=already,
         db=db,
+        workspace_id=source.workspace_id,
     )
 
     started_at = datetime.utcnow()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -74,6 +74,7 @@ def _poll_single_imap_source(source: MailSource) -> None:
             password=poll_source.password,
             folder=poll_source.folder,
             db=db,
+            workspace_id=getattr(poll_source, "workspace_id", None),
         )
         started_at = datetime.utcnow()
         results = imap_client.fetch_reports(days=9999)
@@ -128,6 +129,7 @@ def _poll_single_gmail_source(source: MailSource) -> None:
             refresh_token=poll_source.gmail_refresh_token or "",
             already_ingested_ids=already,
             db=db,
+            workspace_id=getattr(poll_source, "workspace_id", None),
         )
 
         started_at = datetime.utcnow()
@@ -197,6 +199,7 @@ def _poll_single_m365_source(source: MailSource) -> None:
             folder_id=getattr(poll_source, "m365_folder_id", None),
             already_ingested_ids=already,
             db=db,
+            workspace_id=getattr(poll_source, "workspace_id", None),
         )
 
         started_at = datetime.utcnow()
@@ -759,6 +762,7 @@ def _trigger_poll_imap_source(source: MailSource, db, days: int = 7) -> dict:
         password=source.password,
         folder=source.folder,
         db=db,
+        workspace_id=getattr(source, "workspace_id", None),
     )
     started_at = datetime.utcnow()
     results = imap_client.fetch_reports(days=days)
@@ -790,6 +794,7 @@ def _trigger_poll_gmail_source(source: MailSource, db) -> dict:
         refresh_token=source.gmail_refresh_token or "",
         already_ingested_ids=already,
         db=db,
+        workspace_id=getattr(source, "workspace_id", None),
     )
     started_at = datetime.utcnow()
     results = gmail_client.fetch_reports()
@@ -834,6 +839,7 @@ def _trigger_poll_m365_source(source: MailSource, db, days: int = 7) -> dict:
         folder_id=getattr(source, "m365_folder_id", None),
         already_ingested_ids=already,
         db=db,
+        workspace_id=getattr(source, "workspace_id", None),
     )
     started_at = datetime.utcnow()
     results = graph_client.fetch_reports(days=days)

--- a/backend/app/services/gmail_client.py
+++ b/backend/app/services/gmail_client.py
@@ -87,6 +87,7 @@ class GmailClient:
         refresh_token: str,
         already_ingested_ids: Optional[List[str]] = None,
         db: Any = None,
+        workspace_id: Optional[int] = None,
     ):
         self.client_id = client_id
         self.client_secret = client_secret
@@ -94,6 +95,7 @@ class GmailClient:
         self.already_ingested_ids: List[str] = list(already_ingested_ids or [])
         self.report_store = ReportStore.get_instance()
         self.db = db
+        self.workspace_id = workspace_id
 
         self.credentials = Credentials(
             token=access_token,
@@ -372,13 +374,16 @@ class GmailClient:
         report_id = report.get("report_id", "")
         if report_id and (
             self.report_store.has_report(domain, report_id)
-            or (self.db is not None and report_exists(self.db, domain, report_id))
+            or (
+                self.db is not None
+                and report_exists(self.db, domain, report_id, workspace_id=self.workspace_id)
+            )
         ):
             logger.info("Skipping duplicate DMARC report %s for %s", report_id, domain)
             return False
 
         if self.db is not None:
-            save_parsed_report(self.db, report)
+            save_parsed_report(self.db, report, workspace_id=self.workspace_id)
         self.report_store.add_report(report)
         return True
 

--- a/backend/app/services/imap_client.py
+++ b/backend/app/services/imap_client.py
@@ -36,6 +36,7 @@ class IMAPClient:
         delete_emails: Optional[bool] = None,
         folder: str = None,
         db: Any = None,
+        workspace_id: Optional[int] = None,
     ):
         """
         Initialize the IMAP client with credentials
@@ -49,6 +50,7 @@ class IMAPClient:
                 If omitted, uses DELETE_IMPORTED_EMAILS from settings.
             folder: IMAP mailbox folder to read (if None, uses settings or INBOX)
             db: Optional SQLAlchemy session used to persist imported reports
+            workspace_id: Optional workspace that should own imported domains/reports
         """
         settings = get_settings()
         settings_folder = getattr(settings, "IMAP_FOLDER", None)
@@ -65,6 +67,7 @@ class IMAPClient:
         self.delete_emails = configured_delete if delete_emails is None else delete_emails
         self.folder = folder or settings_folder or "INBOX"
         self.db = db
+        self.workspace_id = workspace_id
 
         self.report_store = ReportStore.get_instance()
 
@@ -459,7 +462,10 @@ class IMAPClient:
         report_id = report.get("report_id", "")
         if report_id and (
             self.report_store.has_report(domain, report_id)
-            or (self.db is not None and report_exists(self.db, domain, report_id))
+            or (
+                self.db is not None
+                and report_exists(self.db, domain, report_id, workspace_id=self.workspace_id)
+            )
         ):
             logger.info("Skipping duplicate DMARC report %s for %s", report_id, domain)
             if stats is not None:
@@ -475,7 +481,7 @@ class IMAPClient:
             return False
 
         if self.db is not None:
-            save_parsed_report(self.db, report)
+            save_parsed_report(self.db, report, workspace_id=self.workspace_id)
         self.report_store.add_report(report)
         self._append_detail(
             stats,

--- a/backend/app/services/mail_source_backfill_worker.py
+++ b/backend/app/services/mail_source_backfill_worker.py
@@ -17,11 +17,12 @@ from app.models.mail_source_backfill import MailSourceBackfillJob
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
+from app.services.microsoft_graph_client import MicrosoftGraphClient
 
 logger = logging.getLogger(__name__)
 
 RUNNABLE_BACKFILL_STATUSES = ("queued", "backoff")
-SUPPORTED_WORKER_METHODS = ("IMAP", "GMAIL_API")
+SUPPORTED_WORKER_METHODS = ("IMAP", "GMAIL_API", "M365_GRAPH")
 MAX_BACKFILL_DAYS = 365
 
 
@@ -149,6 +150,7 @@ def run_imap_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
             password=source.password,
             folder=source.folder,
             db=db,
+            workspace_id=source.workspace_id,
         )
         results = client.fetch_reports(days=days)
         source.last_checked = datetime.utcnow()
@@ -232,6 +234,7 @@ def _fetch_gmail_backfill_results(
         refresh_token=source.gmail_refresh_token or "",
         already_ingested_ids=already,
         db=db,
+        workspace_id=source.workspace_id,
     )
     results = client.fetch_reports(days=days)
     _sync_gmail_backfill_state(source, client, already, results)
@@ -262,6 +265,61 @@ def _sync_gmail_backfill_state(
         source.gmail_access_token = refreshed["access_token"]
         if "refresh_token" in refreshed:
             source.gmail_refresh_token = refreshed["refresh_token"]
+
+
+def _fetch_m365_backfill_results(
+    db: Session,
+    source: MailSource,
+    *,
+    started_at: datetime,
+    days: int,
+) -> tuple[Dict[str, Any], Any]:
+    if not source.m365_access_token:
+        raise ValueError("Microsoft 365 account not yet authorised. Complete OAuth2 flow first.")
+
+    already = MicrosoftGraphClient.load_ingested_ids(source.m365_ingested_ids)
+    client = MicrosoftGraphClient(
+        tenant_id=source.m365_tenant_id or "common",
+        client_id=source.m365_client_id or "",
+        client_secret=source.m365_client_secret or "",
+        access_token=source.m365_access_token,
+        refresh_token=source.m365_refresh_token or "",
+        mailbox=source.m365_mailbox,
+        folder=source.folder or "INBOX",
+        folder_id=getattr(source, "m365_folder_id", None),
+        already_ingested_ids=already,
+        db=db,
+        workspace_id=source.workspace_id,
+    )
+    results = client.fetch_reports(days=days)
+    _sync_m365_backfill_state(source, client, already, results)
+    source.last_checked = datetime.utcnow()
+    attempt = record_import_attempt(
+        db,
+        source,
+        results,
+        started_at=started_at,
+        trigger="backfill",
+    )
+    db.flush()
+    return results, attempt
+
+
+def _sync_m365_backfill_state(
+    source: MailSource,
+    client: MicrosoftGraphClient,
+    already_ingested: List[str],
+    results: Dict[str, Any],
+) -> None:
+    if results.get("new_ingested_ids"):
+        all_ids = list(dict.fromkeys(already_ingested + results["new_ingested_ids"]))
+        source.m365_ingested_ids = MicrosoftGraphClient.dump_ingested_ids(all_ids)
+
+    refreshed = client.get_refreshed_tokens()
+    if refreshed:
+        source.m365_access_token = refreshed["access_token"]
+        if "refresh_token" in refreshed:
+            source.m365_refresh_token = refreshed["refresh_token"]
 
 
 def _finish_backfill_from_results(
@@ -358,6 +416,57 @@ def run_gmail_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
         return True
 
 
+def run_m365_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
+    """Execute one Microsoft 365 Graph backfill job and update persisted state."""
+    source = job.mail_source
+    if not _job_is_runnable(job, "M365_GRAPH"):
+        return False
+
+    started_at = datetime.utcnow()
+    days = _backfill_window_days(job, started_at)
+    _claim_job(job, started_at)
+    db.commit()
+
+    try:
+        results, attempt = _fetch_m365_backfill_results(
+            db,
+            source,
+            started_at=started_at,
+            days=days,
+        )
+        _finish_backfill_from_results(
+            job,
+            results,
+            days=days,
+            cursor_prefix="m365",
+            errors=attempt.errors,
+            details=attempt.details,
+        )
+        db.commit()
+        return True
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.exception("Microsoft 365 backfill job id=%s failed", job.id)
+        results = _backfill_exception_results(exc)
+        attempt = record_import_attempt(
+            db,
+            source,
+            results,
+            started_at=started_at,
+            trigger="backfill",
+        )
+        db.flush()
+        _mark_failure(
+            job,
+            exc,
+            now=datetime.utcnow(),
+            results=results,
+            errors=attempt.errors,
+            details=attempt.details,
+        )
+        db.commit()
+        return True
+
+
 def due_mail_source_backfill_jobs(
     db: Session,
     limit: int = 1,
@@ -401,6 +510,8 @@ def run_mail_source_backfill_job(db: Session, job: MailSourceBackfillJob) -> boo
         return run_imap_backfill_job(db, job)
     if source.method == "GMAIL_API":
         return run_gmail_backfill_job(db, job)
+    if source.method == "M365_GRAPH":
+        return run_m365_backfill_job(db, job)
     return False
 
 

--- a/backend/app/services/microsoft_graph_client.py
+++ b/backend/app/services/microsoft_graph_client.py
@@ -81,6 +81,7 @@ class MicrosoftGraphClient(MailSourceConnector):
         folder_id: Optional[str] = None,
         already_ingested_ids: Optional[List[str]] = None,
         db: Any = None,
+        workspace_id: Optional[int] = None,
         sleep: Optional[Callable[[float], None]] = None,
     ):
         self.tenant_id = tenant_id or "common"
@@ -94,6 +95,7 @@ class MicrosoftGraphClient(MailSourceConnector):
         self.already_ingested_ids: List[str] = list(already_ingested_ids or [])
         self.report_store = ReportStore.get_instance()
         self.db = db
+        self.workspace_id = workspace_id
         self._sleep = sleep or time.sleep
         self._refreshed_tokens: Optional[Dict[str, str]] = None
 
@@ -490,13 +492,16 @@ class MicrosoftGraphClient(MailSourceConnector):
         report_id = report.get("report_id", "")
         if report_id and (
             self.report_store.has_report(domain, report_id)
-            or (self.db is not None and report_exists(self.db, domain, report_id))
+            or (
+                self.db is not None
+                and report_exists(self.db, domain, report_id, workspace_id=self.workspace_id)
+            )
         ):
             logger.info("Skipping duplicate DMARC report %s for %s", report_id, domain)
             return False
 
         if self.db is not None:
-            save_parsed_report(self.db, report)
+            save_parsed_report(self.db, report, workspace_id=self.workspace_id)
         self.report_store.add_report(report)
         return True
 

--- a/backend/app/tests/test_gmail_client.py
+++ b/backend/app/tests/test_gmail_client.py
@@ -19,8 +19,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.models.domain import Domain
 from app.models.report import DMARCReport, ForensicReport
 from app.models.setting import Setting
+from app.models.workspace import Workspace
 from app.services.gmail_client import DMARC_GMAIL_QUERY, RETRYABLE_MESSAGE_FAILURE, GmailClient
 from app.services.report_store import ReportStore
 from app.tests.test_data import SAMPLE_XML
@@ -36,6 +38,7 @@ def _make_client(
     refresh_token: str = "ref",
     already_ingested: Optional[list] = None,
     db=None,
+    workspace_id: Optional[int] = None,
 ) -> GmailClient:
     """Instantiate a GmailClient with real Credentials mocked out."""
     with patch("app.services.gmail_client.Credentials") as mock_creds_class:
@@ -51,6 +54,7 @@ def _make_client(
             refresh_token=refresh_token,
             already_ingested_ids=already_ingested or [],
             db=db,
+            workspace_id=workspace_id,
         )
         # Expose the mock so tests can manipulate it
         client._mock_creds = mock_creds  # type: ignore[attr-defined]
@@ -647,6 +651,30 @@ class TestProcessAttachments:
 
         assert count == 1
         assert db_session.query(DMARCReport).filter_by(report_id="123456789").count() == 1
+
+    def test_google_style_zip_attachment_auto_creates_domain_in_workspace(self, db_session):
+        workspace = Workspace(name="Gmail Auto Domain", slug="gmail-auto-domain")
+        db_session.add(workspace)
+        db_session.commit()
+        client = _make_client(db=db_session, workspace_id=workspace.id)
+        raw = _make_raw_email(
+            [
+                {
+                    "filename": "google.com!example.com!1597449600!1597535999.zip",
+                    "content": _zip_xml(),
+                }
+            ]
+        )
+        msg = email_mod.message_from_bytes(raw)
+        stats = {"reports_found": 0, "errors": []}
+
+        count = client._process_attachments(msg, stats)
+
+        domain = db_session.query(Domain).filter_by(name="example.com").one()
+        assert count == 1
+        assert domain.workspace_id == workspace.id
+        assert domain.dmarc_policy == "none"
+        assert stats["details"][0]["status"] == "imported"
 
     def test_duplicate_report_is_skipped(self):
         """Repeated imports of the same domain/report ID should not inflate totals."""

--- a/backend/app/tests/test_mail_source_backfill_worker.py
+++ b/backend/app/tests/test_mail_source_backfill_worker.py
@@ -11,6 +11,7 @@ from app.services.mail_source_backfill_worker import (
     run_due_mail_source_backfill_jobs,
     run_gmail_backfill_job,
     run_imap_backfill_job,
+    run_m365_backfill_job,
     run_mail_source_backfill_job,
 )
 from app.services.workspaces import get_or_create_default_workspace
@@ -33,6 +34,13 @@ def _source(db_session, *, method="IMAP", enabled=True):
         gmail_access_token="gmail-token" if method == "GMAIL_API" else None,
         gmail_refresh_token="gmail-refresh" if method == "GMAIL_API" else None,
         gmail_ingested_ids='["old-id"]' if method == "GMAIL_API" else None,
+        m365_tenant_id="organizations",
+        m365_client_id="m365-client",
+        m365_client_secret="m365-secret",
+        m365_access_token="m365-token" if method == "M365_GRAPH" else None,
+        m365_refresh_token="m365-refresh" if method == "M365_GRAPH" else None,
+        m365_mailbox="shared@example.com",
+        m365_ingested_ids='["old-m365-id"]' if method == "M365_GRAPH" else None,
     )
     db_session.add(source)
     db_session.commit()
@@ -191,6 +199,7 @@ def test_run_due_mail_source_backfill_executes_gmail_job(db_session, monkeypatch
     class FakeGmailClient:
         def __init__(self, **kwargs):
             assert kwargs["already_ingested_ids"] == ["old-id"]
+            assert kwargs["workspace_id"] == workspace.id
 
         def fetch_reports(self, days):
             assert days == 10
@@ -289,6 +298,124 @@ def test_run_gmail_backfill_provider_failure_moves_to_backoff(db_session, monkey
     assert row.next_retry_at is not None
 
 
+def test_run_due_mail_source_backfill_executes_m365_job(db_session, monkeypatch):
+    workspace, source = _source(db_session, method="M365_GRAPH")
+    row = _job(db_session, workspace, source)
+    results = {
+        "success": True,
+        "processed": 4,
+        "reports_found": 2,
+        "duplicate_reports": 1,
+        "new_domains": ["example.net"],
+        "new_ingested_ids": ["new-m365-id", "old-m365-id"],
+        "errors": [],
+        "details": [{"status": "imported", "domain": "example.net"}],
+        "search_window_days": 10,
+    }
+
+    class FakeMicrosoftGraphClient:
+        def __init__(self, **kwargs):
+            assert kwargs["already_ingested_ids"] == ["old-m365-id"]
+            assert kwargs["workspace_id"] == workspace.id
+            assert kwargs["folder"] == "INBOX/DMARC"
+
+        def fetch_reports(self, days):
+            assert days == 10
+            return results
+
+        def get_refreshed_tokens(self):
+            return {"access_token": "new-m365-access", "refresh_token": "new-m365-refresh"}
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.MicrosoftGraphClient",
+        FakeMicrosoftGraphClient,
+    )
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.MicrosoftGraphClient.load_ingested_ids",
+        lambda value: ["old-m365-id"],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.MicrosoftGraphClient.dump_ingested_ids",
+        lambda values: ",".join(values),
+        raising=False,
+    )
+
+    assert run_due_mail_source_backfill_jobs(db_session, limit=1) == 1
+
+    db_session.refresh(row)
+    db_session.refresh(source)
+    attempt = db_session.query(MailSourceImport).filter_by(mail_source_id=source.id).one()
+
+    assert row.status == "completed"
+    assert row.cursor == "m365:days=10;processed=4"
+    assert row.processed == 4
+    assert row.reports_found == 2
+    assert source.m365_ingested_ids == "old-m365-id,new-m365-id"
+    assert source.m365_access_token == "new-m365-access"
+    assert source.m365_refresh_token == "new-m365-refresh"
+    assert source.last_checked is not None
+    assert attempt.trigger == "backfill"
+    assert attempt.status == "success"
+
+
+def test_run_m365_backfill_without_token_moves_to_backoff(db_session):
+    workspace, source = _source(db_session, method="M365_GRAPH")
+    source.m365_access_token = None
+    db_session.commit()
+    row = _job(db_session, workspace, source, max_attempts=3)
+
+    assert run_m365_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    attempt = db_session.query(MailSourceImport).filter_by(mail_source_id=source.id).one()
+
+    assert row.status == "backoff"
+    assert row.attempt_count == 1
+    assert row.next_retry_at is not None
+    assert "not yet authorised" in row.errors
+    assert attempt.trigger == "backfill"
+    assert attempt.status == "failed"
+
+
+def test_run_m365_backfill_provider_failure_moves_to_backoff(db_session, monkeypatch):
+    workspace, source = _source(db_session, method="M365_GRAPH")
+    row = _job(db_session, workspace, source, max_attempts=3)
+
+    class FakeMicrosoftGraphClient:
+        load_ingested_ids = staticmethod(lambda _value: [])
+        dump_ingested_ids = staticmethod(lambda values: ",".join(values))
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def fetch_reports(self, days):
+            return {
+                "success": False,
+                "processed": 2,
+                "reports_found": 0,
+                "duplicate_reports": 0,
+                "new_domains": [],
+                "errors": ["temporary Microsoft Graph failure"],
+            }
+
+        def get_refreshed_tokens(self):
+            return None
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.MicrosoftGraphClient",
+        FakeMicrosoftGraphClient,
+    )
+
+    assert run_m365_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    assert row.status == "backoff"
+    assert row.processed == 2
+    assert row.error_count == 1
+    assert row.next_retry_at is not None
+
+
 def test_run_mail_source_backfill_dispatches_or_skips(db_session, monkeypatch):
     workspace, imap_source = _source(db_session)
     imap_job = _job(db_session, workspace, imap_source)
@@ -305,10 +432,14 @@ def test_run_mail_source_backfill_dispatches_or_skips(db_session, monkeypatch):
         "app.services.mail_source_backfill_worker.run_gmail_backfill_job",
         lambda _db, job: job.id == gmail_job.id,
     )
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.run_m365_backfill_job",
+        lambda _db, job: job.id == m365_job.id,
+    )
 
     assert run_mail_source_backfill_job(db_session, imap_job) is True
     assert run_mail_source_backfill_job(db_session, gmail_job) is True
-    assert run_mail_source_backfill_job(db_session, m365_job) is False
+    assert run_mail_source_backfill_job(db_session, m365_job) is True
 
 
 def test_run_imap_backfill_skips_unsupported_status_or_future_retry(db_session):

--- a/backend/app/tests/test_main_polling.py
+++ b/backend/app/tests/test_main_polling.py
@@ -81,6 +81,7 @@ def test_poll_single_imap_source_passes_configured_folder():
         password="p",
         folder="Junk Mail",
         db=db,
+        workspace_id=None,
     )
     db.commit.assert_called_once()
     db.close.assert_called_once()

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -199,9 +199,9 @@ without blocking the UI.
 
 The Mail Sources UI shows the latest backfill status, processed message counts,
 reports found, duplicates, retry timing, and operator controls. The background
-scheduler currently executes due IMAP and Gmail backfill jobs in bounded
-batches and records results in import history with trigger `backfill`;
-Microsoft 365 worker execution remains connector-specific follow-up work. In demo mode,
+scheduler currently executes due IMAP, Gmail, and Microsoft 365 backfill jobs in
+bounded batches and records results in import history with trigger `backfill`.
+In demo mode,
 DMARQ exposes credential-free synthetic mail sources and backfill jobs so the
 workflow is visible without connecting a real mailbox.
 


### PR DESCRIPTION
## Summary
- add Microsoft 365 Graph execution to the mail-source backfill worker
- make Gmail, IMAP, and Microsoft 365 report imports persist domains/reports under the source workspace
- cover Gmail auto-created domains and M365 backfill success/backoff paths with tests

Refs #320

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_main_polling.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_gmail_client.py backend/app/tests/test_microsoft_graph_client.py backend/app/tests/test_mail_sources.py -q
- .venv/bin/python -m flake8 backend/app/services/gmail_client.py backend/app/services/imap_client.py backend/app/services/microsoft_graph_client.py backend/app/services/mail_source_backfill_worker.py backend/app/main.py backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_gmail_client.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_main_polling.py
- git diff --check
- .venv/bin/python -m pytest backend/app/tests -q