### PR TITLE
[codex] Expose backfill progress metadata

### DIFF
--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -9,6 +9,7 @@ OAuth2 helper endpoints (authorize-url, callback, fetch).
 
 import json
 import logging
+import math
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
@@ -206,6 +207,12 @@ class MailSourceBackfillResponse(BaseModel):
     attempt_count: int
     max_attempts: int
     cursor: Optional[str] = None
+    requested_window_days: Optional[int] = None
+    elapsed_seconds: Optional[int] = None
+    progress_percent: int
+    status_summary: str
+    can_cancel: bool
+    can_retry: bool
     errors: List[str]
     details: List[Dict[str, str]]
     started_at: Optional[datetime] = None
@@ -535,8 +542,150 @@ def _auth_actor(auth_context: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _utc_naive(value: Optional[datetime]) -> Optional[datetime]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def _backfill_window_days(
+    requested_start: Optional[datetime],
+    requested_end: Optional[datetime],
+    *,
+    now: Optional[datetime] = None,
+) -> Optional[int]:
+    if not requested_start:
+        return 30
+
+    anchor = _utc_naive(now or datetime.utcnow()) or datetime.utcnow()
+    start = _utc_naive(requested_start)
+    end = _utc_naive(requested_end) if requested_end else anchor
+    if start is None or end is None:
+        return None
+    if end > anchor:
+        end = anchor
+    seconds = max((end - start).total_seconds(), 1)
+    return min(365, max(1, int(math.ceil(seconds / 86400))))
+
+
+def _backfill_elapsed_seconds(
+    started_at: Optional[datetime],
+    finished_at: Optional[datetime],
+    *,
+    now: Optional[datetime] = None,
+) -> Optional[int]:
+    start = _utc_naive(started_at)
+    if not start:
+        return None
+    end = _utc_naive(finished_at) or _utc_naive(now or datetime.utcnow())
+    if not end:
+        return None
+    return max(0, int((end - start).total_seconds()))
+
+
+def _backfill_progress_percent(status_value: str, processed: int) -> int:
+    if status_value == "completed":
+        return 100
+    if status_value == "queued":
+        return 0
+    if status_value == "running":
+        return min(95, max(15, 15 + int(processed / 2)))
+    if status_value == "backoff":
+        return min(85, max(20, 20 + int(processed / 2)))
+    if status_value in {"failed", "cancelled"}:
+        return min(100, max(10, int(processed / 2) if processed else 10))
+    return 0
+
+
+def _backfill_status_summary(
+    *,
+    status_value: str,
+    requested_window_days: Optional[int],
+    processed: int,
+    reports_found: int,
+    duplicate_reports: int,
+    error_count: int,
+    attempt_count: int,
+    max_attempts: int,
+) -> str:
+    window = (
+        f"{requested_window_days}-day mailbox window" if requested_window_days else "mailbox window"
+    )
+    if status_value == "queued":
+        return f"Queued to scan a {window}."
+    if status_value == "running":
+        return (
+            f"Scanning a {window}; {processed} messages checked and {reports_found} reports found."
+        )
+    if status_value == "backoff":
+        return (
+            f"Retry scheduled after {error_count or 1} error(s); "
+            f"attempt {attempt_count} of {max_attempts}."
+        )
+    if status_value == "completed":
+        return (
+            f"Completed a {window}; {reports_found} reports imported or confirmed "
+            f"and {duplicate_reports} duplicates skipped."
+        )
+    if status_value == "failed":
+        return f"Failed after attempt {attempt_count} of {max_attempts}."
+    if status_value == "cancelled":
+        return f"Cancelled after checking {processed} messages."
+    return "Backfill status is available."
+
+
+def _backfill_metadata(
+    *,
+    status_value: str,
+    requested_start: Optional[datetime],
+    requested_end: Optional[datetime],
+    started_at: Optional[datetime],
+    finished_at: Optional[datetime],
+    processed: int,
+    reports_found: int,
+    duplicate_reports: int,
+    error_count: int,
+    attempt_count: int,
+    max_attempts: int,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    requested_window_days = _backfill_window_days(requested_start, requested_end, now=now)
+    return {
+        "requested_window_days": requested_window_days,
+        "elapsed_seconds": _backfill_elapsed_seconds(started_at, finished_at, now=now),
+        "progress_percent": _backfill_progress_percent(status_value, processed),
+        "status_summary": _backfill_status_summary(
+            status_value=status_value,
+            requested_window_days=requested_window_days,
+            processed=processed,
+            reports_found=reports_found,
+            duplicate_reports=duplicate_reports,
+            error_count=error_count,
+            attempt_count=attempt_count,
+            max_attempts=max_attempts,
+        ),
+        "can_cancel": status_value in BACKFILL_CANCELABLE_STATUSES,
+        "can_retry": status_value in BACKFILL_RETRYABLE_STATUSES and attempt_count < max_attempts,
+    }
+
+
 def _backfill_to_response(row: MailSourceBackfillJob) -> MailSourceBackfillResponse:
     """Convert a backfill job ORM row to an API response."""
+    metadata = _backfill_metadata(
+        status_value=row.status,
+        requested_start=row.requested_start,
+        requested_end=row.requested_end,
+        started_at=row.started_at,
+        finished_at=row.finished_at,
+        processed=row.processed,
+        reports_found=row.reports_found,
+        duplicate_reports=row.duplicate_reports,
+        error_count=row.error_count,
+        attempt_count=row.attempt_count,
+        max_attempts=row.max_attempts,
+    )
     return MailSourceBackfillResponse(
         id=row.id,
         workspace_id=row.workspace_id,
@@ -553,6 +702,7 @@ def _backfill_to_response(row: MailSourceBackfillJob) -> MailSourceBackfillRespo
         attempt_count=row.attempt_count,
         max_attempts=row.max_attempts,
         cursor=row.cursor,
+        **metadata,
         errors=_decode_json_list(row.errors),
         details=_decode_json_details(row.details),
         started_at=row.started_at,
@@ -575,7 +725,20 @@ def _demo_mail_source_by_id(source_id: int) -> Optional[Dict[str, Any]]:
 
 
 def _demo_backfill_response(row: Dict[str, Any]) -> MailSourceBackfillResponse:
-    return MailSourceBackfillResponse(**row)
+    metadata = _backfill_metadata(
+        status_value=str(row["status"]),
+        requested_start=row.get("requested_start"),
+        requested_end=row.get("requested_end"),
+        started_at=row.get("started_at"),
+        finished_at=row.get("finished_at"),
+        processed=int(row.get("processed") or 0),
+        reports_found=int(row.get("reports_found") or 0),
+        duplicate_reports=int(row.get("duplicate_reports") or 0),
+        error_count=int(row.get("error_count") or 0),
+        attempt_count=int(row.get("attempt_count") or 0),
+        max_attempts=int(row.get("max_attempts") or 1),
+    )
+    return MailSourceBackfillResponse(**{**row, **metadata})
 
 
 def _demo_backfill_job(source_id: int, job_id: int) -> Optional[Dict[str, Any]]:
@@ -939,30 +1102,32 @@ async def create_mail_source_backfill(
     demo_source = _demo_mail_source_by_id(source_id)
     if demo_source:
         now = datetime.now(timezone.utc)
-        return MailSourceBackfillResponse(
-            id=9900 + source_id,
-            workspace_id=1,
-            mail_source_id=source_id,
-            status="queued",
-            trigger="manual",
-            requested_start=payload.requested_start or now - timedelta(days=30),
-            requested_end=payload.requested_end or now,
-            requested_by="demo-operator@dmarq.org",
-            processed=0,
-            reports_found=0,
-            duplicate_reports=0,
-            error_count=0,
-            attempt_count=0,
-            max_attempts=payload.max_attempts,
-            cursor=None,
-            errors=[],
-            details=[{"status": "queued", "source": str(demo_source["name"])}],
-            started_at=None,
-            finished_at=None,
-            cancelled_at=None,
-            next_retry_at=None,
-            created_at=now,
-            updated_at=now,
+        return _demo_backfill_response(
+            {
+                "id": 9900 + source_id,
+                "workspace_id": 1,
+                "mail_source_id": source_id,
+                "status": "queued",
+                "trigger": "manual",
+                "requested_start": payload.requested_start or now - timedelta(days=30),
+                "requested_end": payload.requested_end or now,
+                "requested_by": "demo-operator@dmarq.org",
+                "processed": 0,
+                "reports_found": 0,
+                "duplicate_reports": 0,
+                "error_count": 0,
+                "attempt_count": 0,
+                "max_attempts": payload.max_attempts,
+                "cursor": None,
+                "errors": [],
+                "details": [{"status": "queued", "source": str(demo_source["name"])}],
+                "started_at": None,
+                "finished_at": None,
+                "cancelled_at": None,
+                "next_retry_at": None,
+                "created_at": now,
+                "updated_at": now,
+            }
         )
     workspace = _authorized_mail_source_workspace(
         _auth,

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -113,6 +113,8 @@
                                                 <progress class="progress progress-primary h-1.5 w-full"
                                                     :value="backfillProgress(latestBackfill(source))"
                                                     max="100"></progress>
+                                                <p class="text-[11px] text-muted-foreground"
+                                                    x-text="latestBackfill(source).status_summary || ''"></p>
                                                 <div class="grid grid-cols-3 gap-2 text-[11px] text-muted-foreground">
                                                     <span><strong class="text-foreground" x-text="latestBackfill(source).processed"></strong> messages</span>
                                                     <span><strong class="text-foreground" x-text="latestBackfill(source).reports_found"></strong> reports</span>
@@ -1059,6 +1061,9 @@ function mailSourcesApp() {
 
         backfillProgress(job) {
             if (!job) return 0;
+            if (Number.isFinite(Number(job.progress_percent))) {
+                return Math.max(0, Math.min(100, Number(job.progress_percent)));
+            }
             const processed = Number(job.processed || 0);
             if (job.status === 'completed') return 100;
             if (job.status === 'queued') return 5;
@@ -1068,6 +1073,7 @@ function mailSourcesApp() {
         },
 
         backfillWindowLabel(job) {
+            if (job && job.requested_window_days) return `${job.requested_window_days} days`;
             if (!job || !job.requested_start || !job.requested_end) return 'Default search window';
             const start = new Date(job.requested_start).toLocaleDateString();
             const end = new Date(job.requested_end).toLocaleDateString();
@@ -1075,10 +1081,12 @@ function mailSourcesApp() {
         },
 
         canCancelBackfill(job) {
+            if (job && typeof job.can_cancel === 'boolean') return job.can_cancel;
             return Boolean(job && ['queued', 'running', 'backoff'].includes(job.status));
         },
 
         canRetryBackfill(job) {
+            if (job && typeof job.can_retry === 'boolean') return job.can_retry;
             return Boolean(job && ['failed', 'cancelled', 'backoff'].includes(job.status));
         },
 

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -529,6 +529,10 @@ def test_mail_sources_template_exposes_backfill_progress_controls():
     template = (Path(__file__).resolve().parents[1] / "templates" / "mail_sources.html").read_text()
 
     assert "data-backfill-progress" in template
+    assert "progress_percent" in template
+    assert "status_summary" in template
+    assert "can_cancel" in template
+    assert "can_retry" in template
     assert "/backfills?limit=5" in template
     assert "/backfills/${job.id}/cancel" in template
     assert "/backfills/${job.id}/retry" in template
@@ -948,14 +952,22 @@ class TestMailSourcesAPIAuthed:
         assert job["max_attempts"] == 4
         assert job["errors"] == []
         assert job["details"] == []
+        assert job["requested_window_days"] == 31
+        assert job["elapsed_seconds"] is None
+        assert job["progress_percent"] == 0
+        assert job["can_cancel"] is True
+        assert job["can_retry"] is False
+        assert job["status_summary"] == "Queued to scan a 31-day mailbox window."
 
         list_response = authed_client.get(f"/api/v1/mail-sources/{source_id}/backfills")
         get_response = authed_client.get(f"/api/v1/mail-sources/{source_id}/backfills/{job['id']}")
 
         assert list_response.status_code == 200
         assert [item["id"] for item in list_response.json()] == [job["id"]]
+        assert list_response.json()[0]["requested_window_days"] == 31
         assert get_response.status_code == 200
         assert get_response.json()["id"] == job["id"]
+        assert get_response.json()["can_cancel"] is True
 
     def test_demo_mode_returns_mail_source_backfill_examples(
         self,
@@ -975,7 +987,13 @@ class TestMailSourcesAPIAuthed:
 
         backfills_response = authed_client.get("/api/v1/mail-sources/9001/backfills?limit=5")
         assert backfills_response.status_code == 200
-        assert {job["status"] for job in backfills_response.json()} >= {"completed", "running"}
+        backfills = backfills_response.json()
+        assert {job["status"] for job in backfills} >= {"completed", "running"}
+        running = next(job for job in backfills if job["status"] == "running")
+        assert running["requested_window_days"] == 30
+        assert running["progress_percent"] > 0
+        assert running["can_cancel"] is True
+        assert "Scanning a 30-day mailbox window" in running["status_summary"]
 
         queue_response = authed_client.post(
             "/api/v1/mail-sources/9001/backfills",
@@ -984,6 +1002,8 @@ class TestMailSourcesAPIAuthed:
         assert queue_response.status_code == 201
         assert queue_response.json()["status"] == "queued"
         assert queue_response.json()["details"][0]["source"] == "dmarq.org aggregate reports"
+        assert queue_response.json()["requested_window_days"] == 30
+        assert queue_response.json()["progress_percent"] == 0
 
         cancel_response = authed_client.post("/api/v1/mail-sources/9001/backfills/9102/cancel")
         assert cancel_response.status_code == 200

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -198,12 +198,15 @@ without blocking the UI.
 | `POST /mail-sources/{source_id}/backfills/{job_id}/retry` | Re-queue a failed, cancelled, or backoff job |
 
 The Mail Sources UI shows the latest backfill status, processed message counts,
-reports found, duplicates, retry timing, and operator controls. The background
-scheduler currently executes due IMAP, Gmail, and Microsoft 365 backfill jobs in
-bounded batches and records results in import history with trigger `backfill`.
-In demo mode,
-DMARQ exposes credential-free synthetic mail sources and backfill jobs so the
-workflow is visible without connecting a real mailbox.
+reports found, duplicates, retry timing, progress percentage, and operator
+controls. Backfill responses also include computed fields for
+`requested_window_days`, `elapsed_seconds`, `status_summary`, `can_cancel`, and
+`can_retry` so clients can show actionable progress without parsing cursors. The
+background scheduler currently executes due IMAP, Gmail, and Microsoft 365
+backfill jobs in bounded batches and records results in import history with
+trigger `backfill`. In demo mode, DMARQ exposes credential-free synthetic mail
+sources and backfill jobs so the workflow is visible without connecting a real
+mailbox.
 
 ### MSP Operator Views
 

--- a/docs/user_guide/microsoft365.md
+++ b/docs/user_guide/microsoft365.md
@@ -43,7 +43,7 @@ DMARQ reads messages in the configured search window, filters for messages that 
 
 Imported Graph message IDs are stored on the mail source so scheduled polling does not reprocess the same message. Import history records processed messages, imported reports, duplicates, parse failures, attachment-level details, and the mailbox/folder target used for the attempt.
 
-Manual imports use the **days** value from the Mail Sources UI or trigger-poll endpoint. DMARQ passes that selected window to Microsoft Graph as a `receivedDateTime` filter, so large mailboxes can be searched without scanning unrelated older mail. Backfills are queued as resumable jobs from the **Backfill** action and show progress, reports found, duplicates, retry timing, cancel, and retry controls in the Mail Sources table; Microsoft 365 worker execution is tracked as connector-specific follow-up after the IMAP worker path.
+Manual imports use the **days** value from the Mail Sources UI or trigger-poll endpoint. DMARQ passes that selected window to Microsoft Graph as a `receivedDateTime` filter, so large mailboxes can be searched without scanning unrelated older mail. Backfills are queued as resumable jobs from the **Backfill** action and show progress, reports found, duplicates, retry timing, cancel, and retry controls in the Mail Sources table. The background worker processes due Microsoft 365 backfill jobs alongside IMAP and Gmail jobs.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- add computed progress metadata to mail-source backfill API responses
- let the Mail Sources UI prefer server-provided progress, summary, cancel, and retry fields
- document the backfill response contract and remove stale Microsoft 365 worker follow-up wording

Refs #320

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_mail_sources.py backend/app/tests/test_demo_data.py -q
- .venv/bin/python -m pytest backend/app/tests/test_mail_sources.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_main_polling.py backend/app/tests/test_demo_data.py -q
- .venv/bin/python -m flake8 backend/app
- git diff --check
- .venv/bin/python -m pytest backend/app/tests -q