### PR TITLE
[codex] Fix GitOps manifest push authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,10 +328,13 @@ jobs:
 
       - name: Commit and push manifest update
         if: steps.pat-check.outputs.available == 'true'
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           cd k8s-cluster-state
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${{ env.K8S_STATE_REPO }}.git"
           git add \
             apps/dmarq/preprod/dmarq-stack.yaml \
             apps/dmarq/greenfield-demo/dmarq-stack.yaml


### PR DESCRIPTION
## Summary
- set the k8s-cluster-state remote URL with the configured GH_PAT before pushing manifest updates
- keeps the existing PAT availability/access check, but makes the final push use the same credentials explicitly

## Validation
- git diff --check
- ruby YAML parse for .github/workflows/ci.yml

Follow-up from PR #340: main built and deployed successfully, but the CI GitOps job created the manifest commit and then failed to push it with 'could not read Username'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of automated manifest updates during GitOps runs.
  * Strengthened authentication handling for repository pushes, reducing the chance of update failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->