### PR TITLE
[codex] Add health score history evidence

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -25,6 +25,7 @@ import app.models.alert  # noqa: E402, F401
 import app.models.api_token  # noqa: E402, F401
 import app.models.dns_cache  # noqa: E402, F401
 import app.models.domain  # noqa: E402, F401
+import app.models.health_score_snapshot  # noqa: E402, F401
 import app.models.mail_source  # noqa: E402, F401
 import app.models.mail_source_import  # noqa: E402, F401
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -25,10 +25,10 @@ import app.models.alert  # noqa: E402, F401
 import app.models.api_token  # noqa: E402, F401
 import app.models.dns_cache  # noqa: E402, F401
 import app.models.domain  # noqa: E402, F401
-import app.models.health_score_snapshot  # noqa: E402, F401
 import app.models.mail_source  # noqa: E402, F401
 import app.models.mail_source_import  # noqa: E402, F401
 
+import_module("app.models.health_score_snapshot")
 import_module("app.models.organization")
 import app.models.report  # noqa: E402, F401
 import app.models.setting  # noqa: E402, F401

--- a/backend/alembic/versions/b1c2d3e4f5a6_add_health_score_snapshots.py
+++ b/backend/alembic/versions/b1c2d3e4f5a6_add_health_score_snapshots.py
@@ -1,0 +1,99 @@
+"""add health score snapshots
+
+Revision ID: b1c2d3e4f5a6
+Revises: a0b1c2d3e4f5
+Create Date: 2026-06-29 15:45:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, Sequence[str], None] = "a0b1c2d3e4f5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create persisted domain health score snapshots."""
+    op.create_table(
+        "health_score_snapshots",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("workspace_id", sa.Integer(), nullable=False),
+        sa.Column("domain_name", sa.String(length=255), nullable=False),
+        sa.Column("snapshot_date", sa.Date(), nullable=False),
+        sa.Column("score", sa.Integer(), nullable=False),
+        sa.Column("grade", sa.String(length=4), nullable=False),
+        sa.Column("status", sa.String(length=24), nullable=False),
+        sa.Column("policy", sa.String(length=32), nullable=True),
+        sa.Column("compliance_rate", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_emails", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("failed_emails", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("report_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("dns_posture_score", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("policy_strength_score", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("report_confidence_score", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("top_actions", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "domain_name",
+            "snapshot_date",
+            name="uq_health_score_snapshot_workspace_domain_date",
+        ),
+    )
+    op.create_index(
+        op.f("ix_health_score_snapshots_id"), "health_score_snapshots", ["id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_health_score_snapshots_workspace_id"),
+        "health_score_snapshots",
+        ["workspace_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_health_score_snapshots_domain_name"),
+        "health_score_snapshots",
+        ["domain_name"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_health_score_snapshots_snapshot_date"),
+        "health_score_snapshots",
+        ["snapshot_date"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_health_score_snapshots_created_at"),
+        "health_score_snapshots",
+        ["created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_health_score_snapshots_workspace_domain",
+        "health_score_snapshots",
+        ["workspace_id", "domain_name"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop persisted domain health score snapshots."""
+    op.drop_index("ix_health_score_snapshots_workspace_domain", table_name="health_score_snapshots")
+    op.drop_index(op.f("ix_health_score_snapshots_created_at"), table_name="health_score_snapshots")
+    op.drop_index(
+        op.f("ix_health_score_snapshots_snapshot_date"), table_name="health_score_snapshots"
+    )
+    op.drop_index(
+        op.f("ix_health_score_snapshots_domain_name"), table_name="health_score_snapshots"
+    )
+    op.drop_index(
+        op.f("ix_health_score_snapshots_workspace_id"), table_name="health_score_snapshots"
+    )
+    op.drop_index(op.f("ix_health_score_snapshots_id"), table_name="health_score_snapshots")
+    op.drop_table("health_score_snapshots")

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -26,6 +26,7 @@ from app.services.cloudflare_dns import (
     list_dns_record_changes,
     sync_dns_record_changes,
 )
+from app.services.demo_data import DEMO_DAYS, build_demo_health_score_history
 from app.services.dns_cache import resolve_domain_dns_cached
 from app.services.dns_guidance import build_dns_guidance
 from app.services.dns_resolver import (
@@ -34,6 +35,12 @@ from app.services.dns_resolver import (
     get_default_provider,
 )
 from app.services.health_score import build_health_summary, score_domain_health
+from app.services.health_score_snapshots import (
+    build_health_evidence_export_rows,
+    build_health_score_history,
+    list_health_score_snapshots,
+    upsert_health_score_snapshot,
+)
 from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
 from app.services.organizations import (
     OrganizationPlanLimitError,
@@ -334,6 +341,37 @@ class PostureDashboardResponse(BaseModel):
     recommendations: List[DNSHealthRecommendation]
     changes: List[PostureChangeSummary]
     playbooks: List[OperatorPlaybook]
+
+
+class HealthScoreHistoryPoint(BaseModel):
+    """One persisted health score history point."""
+
+    date: str
+    score: int
+    grade: str
+    status: str
+    policy: Optional[str] = None
+    compliance_rate: int
+    total_emails: int
+    failed_emails: int
+    report_count: int
+    dns_posture_score: int
+    policy_strength_score: int
+    report_confidence_score: int
+    top_actions: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class HealthScoreHistoryResponse(BaseModel):
+    """Score history and trend metadata for one domain."""
+
+    domain: str
+    points: List[HealthScoreHistoryPoint]
+    current_score: Optional[int] = None
+    previous_score: Optional[int] = None
+    score_delta: Optional[int] = None
+    current_grade: Optional[str] = None
+    previous_grade: Optional[str] = None
+    top_drivers: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class MTAStsResponse(BaseModel):
@@ -1280,6 +1318,121 @@ def _build_posture_dashboard(
     )
 
 
+def _history_response_from_points(
+    domain_id: str,
+    points: List[Dict[str, Any]],
+) -> HealthScoreHistoryResponse:
+    """Build a health history response from serialized points."""
+    current = points[-1] if points else None
+    previous = points[-2] if len(points) > 1 else None
+    return HealthScoreHistoryResponse(
+        domain=domain_id,
+        points=points,
+        current_score=current["score"] if current else None,
+        previous_score=previous["score"] if previous else None,
+        score_delta=current["score"] - previous["score"] if current and previous else None,
+        current_grade=current["grade"] if current else None,
+        previous_grade=previous["grade"] if previous else None,
+        top_drivers=current.get("top_actions", []) if current else [],
+    )
+
+
+def _demo_history_points(
+    domain_id: str,
+    *,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    limit: int = 120,
+) -> List[Dict[str, Any]]:
+    points = build_demo_health_score_history(domain_id, days=min(max(limit, 1), DEMO_DAYS))
+    if start_date:
+        points = [point for point in points if date.fromisoformat(point["date"]) >= start_date]
+    if end_date:
+        points = [point for point in points if date.fromisoformat(point["date"]) <= end_date]
+    return points[-limit:]
+
+
+def _write_health_evidence_csv(rows: List[Dict[str, Any]], *, domain_id: str) -> Response:
+    output = io.StringIO()
+    fields = [
+        "domain",
+        "snapshot_date",
+        "score",
+        "grade",
+        "status",
+        "policy",
+        "compliance_rate",
+        "total_emails",
+        "failed_emails",
+        "report_count",
+        "dns_posture_score",
+        "policy_strength_score",
+        "report_confidence_score",
+        "top_actions",
+    ]
+    writer = csv.DictWriter(output, fieldnames=fields)
+    writer.writeheader()
+    writer.writerows(rows)
+    filename = f"{domain_id.replace('/', '_')}-health-evidence.csv"
+    return Response(
+        content=output.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+def _demo_evidence_export_rows(
+    domain_id: str, points: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    rows = []
+    for point in points:
+        rows.append(
+            {
+                "domain": domain_id,
+                "snapshot_date": point["date"],
+                "score": point["score"],
+                "grade": point["grade"],
+                "status": point["status"],
+                "policy": point.get("policy") or "",
+                "compliance_rate": point["compliance_rate"],
+                "total_emails": point["total_emails"],
+                "failed_emails": point["failed_emails"],
+                "report_count": point["report_count"],
+                "dns_posture_score": point["dns_posture_score"],
+                "policy_strength_score": point["policy_strength_score"],
+                "report_confidence_score": point["report_confidence_score"],
+                "top_actions": "; ".join(
+                    f"{action.get('severity')}:{action.get('title')}"
+                    for action in point.get("top_actions", [])
+                    if action.get("title")
+                ),
+            }
+        )
+    return rows
+
+
+def _record_health_snapshot_from_posture(
+    db: Session,
+    *,
+    workspace_id: int,
+    domain_id: str,
+    dns_health: DNSHealthResponse,
+    domain_health: Dict[str, Any],
+    report_count: int,
+) -> None:
+    upsert_health_score_snapshot(
+        db,
+        workspace_id=workspace_id,
+        domain_name=domain_id,
+        health=domain_health,
+        policy=dns_health.policy,
+        compliance_rate=dns_health.compliance_rate,
+        total_emails=dns_health.total_emails,
+        failed_emails=dns_health.failed_emails,
+        report_count=report_count,
+    )
+
+
 @router.get("/summary", response_model=DomainSummaryResponse)
 async def get_domains_summary(
     db: Session = Depends(get_db),
@@ -1803,8 +1956,146 @@ async def get_domain_posture_dashboard(
         store,
         refresh=refresh,
     )
+    summary = store.get_domain_summary(domain_id)
+    if not get_settings().DEMO_MODE:
+        _record_health_snapshot_from_posture(
+            db,
+            workspace_id=workspace.id,
+            domain_id=domain_id,
+            dns_health=health,
+            domain_health=domain_health,
+            report_count=int(summary.get("reports_processed", 0) or 0),
+        )
     changes = list_dns_record_changes(db, domain_id, limit=10)
     return _build_posture_dashboard(domain_id, health, domain_health, changes)
+
+
+@router.get("/{domain_id}/posture/history", response_model=HealthScoreHistoryResponse)
+async def get_domain_health_score_history(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    start_date: Optional[date] = Query(None, title="Start date for score history"),
+    end_date: Optional[date] = Query(None, title="End date for score history"),
+    limit: int = Query(120, ge=1, le=400, title="Maximum history points"),
+    capture_current: bool = Query(True, title="Capture today's current posture first"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return persisted score history for one domain."""
+    if start_date and end_date and start_date > end_date:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="start_date must be on or before end_date",
+        )
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
+    workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    if not _domain_exists(db, store, domain_id, workspace):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Domain not found",
+        )
+
+    if capture_current and not get_settings().DEMO_MODE:
+        health = await _build_domain_dns_health(db, store, domain_id)
+        domain_health = await _build_domain_health_grade(db, domain_id, store)
+        summary = store.get_domain_summary(domain_id)
+        _record_health_snapshot_from_posture(
+            db,
+            workspace_id=workspace.id,
+            domain_id=domain_id,
+            dns_health=health,
+            domain_health=domain_health,
+            report_count=int(summary.get("reports_processed", 0) or 0),
+        )
+
+    snapshots = list_health_score_snapshots(
+        db,
+        workspace_id=workspace.id,
+        domain_name=domain_id,
+        start_date=start_date,
+        end_date=end_date,
+        limit=limit,
+    )
+    if not snapshots and get_settings().DEMO_MODE:
+        return _history_response_from_points(
+            domain_id,
+            _demo_history_points(
+                domain_id,
+                start_date=start_date,
+                end_date=end_date,
+                limit=limit,
+            ),
+        )
+    return HealthScoreHistoryResponse(
+        **build_health_score_history(domain_name=domain_id, snapshots=snapshots)
+    )
+
+
+@router.get("/{domain_id}/posture/evidence/export")
+async def export_domain_health_evidence(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    start_date: Optional[date] = Query(None, title="Start date for evidence export"),
+    end_date: Optional[date] = Query(None, title="End date for evidence export"),
+    limit: int = Query(400, ge=1, le=1000, title="Maximum exported snapshots"),
+    capture_current: bool = Query(True, title="Capture today's current posture first"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Export sanitized health score evidence for one domain as CSV."""
+    if start_date and end_date and start_date > end_date:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="start_date must be on or before end_date",
+        )
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
+    workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    if not _domain_exists(db, store, domain_id, workspace):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Domain not found",
+        )
+
+    if capture_current and not get_settings().DEMO_MODE:
+        health = await _build_domain_dns_health(db, store, domain_id)
+        domain_health = await _build_domain_health_grade(db, domain_id, store)
+        summary = store.get_domain_summary(domain_id)
+        _record_health_snapshot_from_posture(
+            db,
+            workspace_id=workspace.id,
+            domain_id=domain_id,
+            dns_health=health,
+            domain_health=domain_health,
+            report_count=int(summary.get("reports_processed", 0) or 0),
+        )
+
+    snapshots = list_health_score_snapshots(
+        db,
+        workspace_id=workspace.id,
+        domain_name=domain_id,
+        start_date=start_date,
+        end_date=end_date,
+        limit=limit,
+    )
+    if not snapshots and get_settings().DEMO_MODE:
+        points = _demo_history_points(
+            domain_id,
+            start_date=start_date,
+            end_date=end_date,
+            limit=limit,
+        )
+        return _write_health_evidence_csv(
+            _demo_evidence_export_rows(domain_id, points),
+            domain_id=domain_id,
+        )
+    return _write_health_evidence_csv(
+        build_health_evidence_export_rows(snapshots),
+        domain_id=domain_id,
+    )
 
 
 @router.get("/{domain_id}/dns/mta-sts", response_model=MTAStsResponse)

--- a/backend/app/models/health_score_snapshot.py
+++ b/backend/app/models/health_score_snapshot.py
@@ -1,0 +1,53 @@
+from datetime import date, datetime
+
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+
+from app.core.database import Base
+
+
+class HealthScoreSnapshot(Base):
+    """Persisted daily health score evidence for one domain in one workspace."""
+
+    __tablename__ = "health_score_snapshots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    workspace_id = Column(Integer, ForeignKey("workspaces.id"), nullable=False, index=True)
+    domain_name = Column(String(255), nullable=False, index=True)
+    snapshot_date = Column(Date, nullable=False, default=date.today, index=True)
+    score = Column(Integer, nullable=False)
+    grade = Column(String(4), nullable=False)
+    status = Column(String(24), nullable=False)
+    policy = Column(String(32), nullable=True)
+    compliance_rate = Column(Integer, nullable=False, default=0)
+    total_emails = Column(Integer, nullable=False, default=0)
+    failed_emails = Column(Integer, nullable=False, default=0)
+    report_count = Column(Integer, nullable=False, default=0)
+    dns_posture_score = Column(Integer, nullable=False, default=0)
+    policy_strength_score = Column(Integer, nullable=False, default=0)
+    report_confidence_score = Column(Integer, nullable=False, default=0)
+    top_actions = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id",
+            "domain_name",
+            "snapshot_date",
+            name="uq_health_score_snapshot_workspace_domain_date",
+        ),
+        Index("ix_health_score_snapshots_workspace_domain", "workspace_id", "domain_name"),
+    )
+
+    def __repr__(self):
+        return f"<HealthScoreSnapshot {self.domain_name} {self.snapshot_date} {self.score}>"

--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -247,6 +247,68 @@ def build_demo_mail_source_backfills(
     return list(jobs.get(source_id, []))
 
 
+def build_demo_health_score_history(
+    domain: str,
+    today: Optional[date] = None,
+    days: int = DEMO_DAYS,
+) -> List[Dict[str, Any]]:
+    """Return rolling health score history for demo posture trend views."""
+    anchor = _demo_today(today)
+    normalized_domain = (domain or "").lower()
+    points: List[Dict[str, Any]] = []
+    for day_index in range(days):
+        snapshot_date = anchor - timedelta(days=days - day_index - 1)
+        if normalized_domain == "dmarq.com":
+            score = min(76, 58 + round(day_index * 0.18))
+            if day_index % 17 == 0:
+                score -= 4
+            grade = "C" if score >= 70 else "D"
+            status = "attention"
+            policy = "none"
+            action = "Move out of monitoring mode"
+        elif normalized_domain == "dmarq.org":
+            score = min(94, 82 + round(day_index * 0.14))
+            if day_index % 23 == 0:
+                score -= 3
+            grade = "A" if score >= 93 else "B+" if score >= 87 else "B"
+            status = "healthy" if score >= 90 else "attention"
+            policy = "quarantine" if day_index < days - 12 else "reject"
+            action = "Resolve newsletter DKIM drift"
+        else:
+            score = min(88, 68 + round(day_index * 0.12))
+            grade = "B" if score >= 83 else "C" if score >= 70 else "D"
+            status = "attention"
+            policy = "quarantine"
+            action = "Review managed customer sender alignment"
+        points.append(
+            {
+                "date": snapshot_date.isoformat(),
+                "score": score,
+                "grade": grade,
+                "status": status,
+                "policy": policy,
+                "compliance_rate": min(99, score + 5),
+                "total_emails": 1800 + (day_index * 31),
+                "failed_emails": max(2, 210 - day_index * 2),
+                "report_count": day_index + 1,
+                "dns_posture_score": min(100, score + 8),
+                "policy_strength_score": (
+                    100 if policy == "reject" else 88 if policy == "quarantine" else 55
+                ),
+                "report_confidence_score": 100 if day_index > 14 else 78,
+                "top_actions": [
+                    {
+                        "type": "demo_action",
+                        "severity": "medium",
+                        "title": action,
+                        "score_impact": 8,
+                    }
+                ],
+            }
+        )
+    return points
+
+
 def build_demo_multi_user_deployment() -> Dict[str, Any]:
     """Return a rolling SaaS/ISP demo deployment model without real customers."""
     today = date.today()

--- a/backend/app/services/health_score_snapshots.py
+++ b/backend/app/services/health_score_snapshots.py
@@ -1,0 +1,189 @@
+"""Persist and export domain health score snapshots."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.health_score_snapshot import HealthScoreSnapshot
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(round(float(value or 0)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _top_action_rows(actions: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    rows = []
+    for action in list(actions or [])[:5]:
+        rows.append(
+            {
+                "type": str(action.get("type") or ""),
+                "severity": str(action.get("severity") or ""),
+                "title": str(action.get("title") or ""),
+                "score_impact": _as_int(action.get("score_impact")),
+            }
+        )
+    return rows
+
+
+def _snapshot_actions(snapshot: HealthScoreSnapshot) -> List[Dict[str, Any]]:
+    if not snapshot.top_actions:
+        return []
+    try:
+        parsed = json.loads(snapshot.top_actions)
+    except (TypeError, json.JSONDecodeError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [item for item in parsed if isinstance(item, dict)]
+
+
+def upsert_health_score_snapshot(
+    db: Session,
+    *,
+    workspace_id: int,
+    domain_name: str,
+    health: Dict[str, Any],
+    policy: Optional[str] = None,
+    compliance_rate: Any = 0,
+    total_emails: Any = 0,
+    failed_emails: Any = 0,
+    report_count: Any = 0,
+    snapshot_date: Optional[date] = None,
+) -> HealthScoreSnapshot:
+    """Create or update one daily health score snapshot."""
+    captured_date = snapshot_date or date.today()
+    factors = health.get("factors") or {}
+    actions = _top_action_rows(health.get("actions") or [])
+    existing = (
+        db.query(HealthScoreSnapshot)
+        .filter(
+            HealthScoreSnapshot.workspace_id == workspace_id,
+            HealthScoreSnapshot.domain_name == domain_name,
+            HealthScoreSnapshot.snapshot_date == captured_date,
+        )
+        .one_or_none()
+    )
+    snapshot = existing or HealthScoreSnapshot(
+        workspace_id=workspace_id,
+        domain_name=domain_name,
+        snapshot_date=captured_date,
+    )
+    snapshot.score = _as_int(health.get("score"))
+    snapshot.grade = str(health.get("grade") or "F")
+    snapshot.status = str(health.get("status") or "critical")
+    snapshot.policy = policy
+    snapshot.compliance_rate = _as_int(compliance_rate)
+    snapshot.total_emails = _as_int(total_emails)
+    snapshot.failed_emails = _as_int(failed_emails)
+    snapshot.report_count = _as_int(report_count)
+    snapshot.dns_posture_score = _as_int(factors.get("dns_posture"))
+    snapshot.policy_strength_score = _as_int(factors.get("policy_strength"))
+    snapshot.report_confidence_score = _as_int(factors.get("report_confidence"))
+    snapshot.top_actions = json.dumps(actions, sort_keys=True)
+    snapshot.updated_at = datetime.utcnow()
+    if existing is None:
+        db.add(snapshot)
+    db.commit()
+    db.refresh(snapshot)
+    return snapshot
+
+
+def list_health_score_snapshots(
+    db: Session,
+    *,
+    workspace_id: int,
+    domain_name: str,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    limit: int = 120,
+) -> List[HealthScoreSnapshot]:
+    """Return recent health score snapshots in chronological order."""
+    query = db.query(HealthScoreSnapshot).filter(
+        HealthScoreSnapshot.workspace_id == workspace_id,
+        HealthScoreSnapshot.domain_name == domain_name,
+    )
+    if start_date:
+        query = query.filter(HealthScoreSnapshot.snapshot_date >= start_date)
+    if end_date:
+        query = query.filter(HealthScoreSnapshot.snapshot_date <= end_date)
+    rows = query.order_by(HealthScoreSnapshot.snapshot_date.desc()).limit(limit).all()
+    return list(reversed(rows))
+
+
+def snapshot_to_history_point(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
+    """Serialize one snapshot for API responses."""
+    return {
+        "date": snapshot.snapshot_date.isoformat(),
+        "score": snapshot.score,
+        "grade": snapshot.grade,
+        "status": snapshot.status,
+        "policy": snapshot.policy,
+        "compliance_rate": snapshot.compliance_rate,
+        "total_emails": snapshot.total_emails,
+        "failed_emails": snapshot.failed_emails,
+        "report_count": snapshot.report_count,
+        "dns_posture_score": snapshot.dns_posture_score,
+        "policy_strength_score": snapshot.policy_strength_score,
+        "report_confidence_score": snapshot.report_confidence_score,
+        "top_actions": _snapshot_actions(snapshot),
+    }
+
+
+def build_health_score_history(
+    *,
+    domain_name: str,
+    snapshots: List[HealthScoreSnapshot],
+) -> Dict[str, Any]:
+    """Build trend metadata from chronological snapshots."""
+    points = [snapshot_to_history_point(snapshot) for snapshot in snapshots]
+    current = points[-1] if points else None
+    previous = points[-2] if len(points) > 1 else None
+    return {
+        "domain": domain_name,
+        "points": points,
+        "current_score": current["score"] if current else None,
+        "previous_score": previous["score"] if previous else None,
+        "score_delta": (current["score"] - previous["score"] if current and previous else None),
+        "current_grade": current["grade"] if current else None,
+        "previous_grade": previous["grade"] if previous else None,
+        "top_drivers": current["top_actions"] if current else [],
+    }
+
+
+def build_health_evidence_export_rows(
+    snapshots: List[HealthScoreSnapshot],
+) -> List[Dict[str, Any]]:
+    """Return sanitized rows suitable for CSV/JSON evidence exports."""
+    rows = []
+    for snapshot in snapshots:
+        actions = _snapshot_actions(snapshot)
+        rows.append(
+            {
+                "domain": snapshot.domain_name,
+                "snapshot_date": snapshot.snapshot_date.isoformat(),
+                "score": snapshot.score,
+                "grade": snapshot.grade,
+                "status": snapshot.status,
+                "policy": snapshot.policy or "",
+                "compliance_rate": snapshot.compliance_rate,
+                "total_emails": snapshot.total_emails,
+                "failed_emails": snapshot.failed_emails,
+                "report_count": snapshot.report_count,
+                "dns_posture_score": snapshot.dns_posture_score,
+                "policy_strength_score": snapshot.policy_strength_score,
+                "report_confidence_score": snapshot.report_confidence_score,
+                "top_actions": "; ".join(
+                    f"{action.get('severity')}:{action.get('title')}"
+                    for action in actions
+                    if action.get("title")
+                ),
+            }
+        )
+    return rows

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -12,7 +12,6 @@ import app.models.alert  # noqa: F401  # pylint: disable=unused-import
 import app.models.api_token  # noqa: F401  # pylint: disable=unused-import
 import app.models.dns_cache  # noqa: F401  # pylint: disable=unused-import
 import app.models.domain  # noqa: F401  # pylint: disable=unused-import
-import app.models.health_score_snapshot  # noqa: F401  # pylint: disable=unused-import
 import app.models.mail_source as _mail_source_model  # noqa: F401  # pylint: disable=unused-import
 import app.models.mail_source_backfill as _mail_source_backfill_model  # noqa: F401  # pylint: disable=unused-import
 import app.models.mail_source_import  # noqa: F401  # pylint: disable=unused-import
@@ -28,6 +27,7 @@ from app.main import create_app
 from app.services.report_store import ReportStore
 
 import_module("app.models.organization")
+import_module("app.models.health_score_snapshot")
 
 
 @pytest.fixture()

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -12,6 +12,7 @@ import app.models.alert  # noqa: F401  # pylint: disable=unused-import
 import app.models.api_token  # noqa: F401  # pylint: disable=unused-import
 import app.models.dns_cache  # noqa: F401  # pylint: disable=unused-import
 import app.models.domain  # noqa: F401  # pylint: disable=unused-import
+import app.models.health_score_snapshot  # noqa: F401  # pylint: disable=unused-import
 import app.models.mail_source as _mail_source_model  # noqa: F401  # pylint: disable=unused-import
 import app.models.mail_source_backfill as _mail_source_backfill_model  # noqa: F401  # pylint: disable=unused-import
 import app.models.mail_source_import  # noqa: F401  # pylint: disable=unused-import

--- a/backend/app/tests/test_demo_data.py
+++ b/backend/app/tests/test_demo_data.py
@@ -8,6 +8,7 @@ from app.services.demo_data import (
     analyze_demo_forensic_reports,
     build_demo_dashboard_statistics,
     build_demo_forensic_reports,
+    build_demo_health_score_history,
     build_demo_mail_source_backfills,
     build_demo_mail_sources,
     build_demo_reports,
@@ -148,6 +149,20 @@ def test_demo_mail_sources_include_backfill_lifecycle_examples():
         for job in build_demo_mail_source_backfills(source_id, today=date(2026, 6, 25))
     }
     assert {"completed", "running", "backoff", "queued"}.issubset(statuses)
+
+
+def test_demo_health_score_history_covers_core_personas():
+    org = build_demo_health_score_history("dmarq.org", today=date(2026, 6, 25), days=90)
+    com = build_demo_health_score_history("dmarq.com", today=date(2026, 6, 25), days=90)
+    tenant = build_demo_health_score_history("lawfirm.example", today=date(2026, 6, 25), days=10)
+
+    assert org[0]["date"] == "2026-03-28"
+    assert org[-1]["policy"] == "reject"
+    assert org[-1]["score"] > org[0]["score"]
+    assert com[-1]["policy"] == "none"
+    assert com[-1]["grade"] in {"C", "D"}
+    assert tenant[-1]["policy"] == "quarantine"
+    assert tenant[-1]["top_actions"][0]["title"] == "Review managed customer sender alignment"
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -9,13 +9,17 @@ the use of begin_timestamp/end_timestamp integers for date fields.
 """
 
 import csv
+from datetime import date
 from io import StringIO
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.models.domain import Domain
+from app.services import report_persistence
+from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.report_store import ReportStore
 from app.services.workspaces import get_or_create_default_workspace
 
@@ -252,6 +256,292 @@ def test_export_domain_reports_unknown_domain_returns_404(authed_client: TestCli
     """Returns 404 when exporting a domain with no reports."""
     response = authed_client.get("/api/v1/domains/no-such-domain.example.com/reports/export")
     assert response.status_code == 404
+
+
+def test_domain_health_history_returns_persisted_trend(seeded_client: TestClient, db_session):
+    """Health history exposes persisted score movement for the requested domain."""
+    workspace = get_or_create_default_workspace(db_session)
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name=DOMAIN,
+        health={"score": 80, "grade": "B-", "status": "attention", "factors": {}, "actions": []},
+        policy="quarantine",
+        compliance_rate=91,
+        total_emails=100,
+        failed_emails=9,
+        report_count=1,
+        snapshot_date=date(2026, 6, 1),
+    )
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name=DOMAIN,
+        health={
+            "score": 88,
+            "grade": "B+",
+            "status": "attention",
+            "factors": {},
+            "actions": [{"title": "Fix SPF coverage", "severity": "high", "score_impact": 12}],
+        },
+        policy="quarantine",
+        compliance_rate=95,
+        total_emails=200,
+        failed_emails=10,
+        report_count=2,
+        snapshot_date=date(2026, 6, 2),
+    )
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history?capture_current=false")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current_score"] == 88
+    assert data["previous_score"] == 80
+    assert data["score_delta"] == 8
+    assert data["points"][1]["top_actions"][0]["title"] == "Fix SPF coverage"
+
+
+def test_export_domain_health_evidence_returns_sanitized_csv(
+    seeded_client: TestClient,
+    db_session,
+):
+    """Health evidence export contains scores and actions without forensic content."""
+    workspace = get_or_create_default_workspace(db_session)
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name=DOMAIN,
+        health={
+            "score": 72,
+            "grade": "C",
+            "status": "attention",
+            "factors": {"dns_posture": 80, "policy_strength": 55, "report_confidence": 78},
+            "actions": [{"title": "Move out of monitoring mode", "severity": "medium"}],
+        },
+        policy="none",
+        compliance_rate=94,
+        total_emails=500,
+        failed_emails=30,
+        report_count=5,
+        snapshot_date=date(2026, 6, 3),
+    )
+
+    response = seeded_client.get(
+        f"/api/v1/domains/{DOMAIN}/posture/evidence/export?capture_current=false"
+    )
+
+    assert response.status_code == 200
+    rows = list(csv.DictReader(StringIO(response.text)))
+    assert rows[0]["domain"] == DOMAIN
+    assert rows[0]["score"] == "72"
+    assert rows[0]["policy"] == "none"
+    assert rows[0]["top_actions"] == "medium:Move out of monitoring mode"
+    assert "message" not in response.text.lower()
+
+
+def _stub_current_health(monkeypatch):
+    async def fake_dns_health(db, store, domain_id, refresh=False):
+        return domains_endpoint.DNSHealthResponse(
+            status="healthy",
+            policy="reject",
+            compliance_rate=98,
+            total_emails=1000,
+            failed_emails=20,
+            checks=[],
+            recommendations=[],
+        )
+
+    async def fake_domain_grade(db, domain_id, store, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 96,
+            "grade": "A",
+            "status": "healthy",
+            "factors": {
+                "dns_posture": 100,
+                "policy_strength": 100,
+                "report_confidence": 90,
+            },
+            "actions": [
+                {
+                    "type": "monitoring",
+                    "severity": "low",
+                    "title": "Keep monitoring",
+                    "score_impact": 1,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_health", fake_dns_health)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+
+
+def test_domain_health_history_capture_current_snapshot(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Health history can capture today's computed posture before reading history."""
+    _stub_current_health(monkeypatch)
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current_score"] == 96
+    assert data["points"][-1]["policy"] == "reject"
+    assert data["top_drivers"][0]["title"] == "Keep monitoring"
+
+
+def test_domain_health_evidence_export_capture_current_snapshot(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Evidence export can capture the current score before writing CSV."""
+    _stub_current_health(monkeypatch)
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/evidence/export")
+
+    assert response.status_code == 200
+    rows = list(csv.DictReader(StringIO(response.text)))
+    assert rows[0]["score"] == "96"
+    assert rows[0]["policy"] == "reject"
+    assert rows[0]["top_actions"] == "low:Keep monitoring"
+
+
+def test_domain_posture_dashboard_records_current_snapshot(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """The posture dashboard records today's health score outside demo mode."""
+    _stub_current_health(monkeypatch)
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture")
+
+    assert response.status_code == 200
+    assert response.json()["health"]["score"] == 96
+    workspace = get_or_create_default_workspace(db_session)
+    snapshots = domains_endpoint.list_health_score_snapshots(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name=DOMAIN,
+    )
+    assert snapshots[-1].score == 96
+
+
+def test_domain_health_history_rejects_invalid_date_order(seeded_client: TestClient):
+    """Health history validates that the start date is not after the end date."""
+    response = seeded_client.get(
+        f"/api/v1/domains/{DOMAIN}/posture/history"
+        "?start_date=2026-06-03&end_date=2026-06-02&capture_current=false"
+    )
+
+    assert response.status_code == 422
+
+
+def test_domain_health_evidence_export_rejects_invalid_date_order(
+    seeded_client: TestClient,
+):
+    """Health evidence export validates that the start date is not after the end date."""
+    response = seeded_client.get(
+        f"/api/v1/domains/{DOMAIN}/posture/evidence/export"
+        "?start_date=2026-06-03&end_date=2026-06-02&capture_current=false"
+    )
+
+    assert response.status_code == 422
+
+
+def test_domain_health_history_unknown_domain_returns_404(authed_client: TestClient):
+    """Health history returns 404 for domains outside the selected workspace."""
+    response = authed_client.get(
+        "/api/v1/domains/no-such.example/posture/history?capture_current=false"
+    )
+
+    assert response.status_code == 404
+
+
+def test_domain_health_evidence_export_unknown_domain_returns_404(
+    authed_client: TestClient,
+):
+    """Health evidence export returns 404 for domains outside the selected workspace."""
+    response = authed_client.get(
+        "/api/v1/domains/no-such.example/posture/evidence/export?capture_current=false"
+    )
+
+    assert response.status_code == 404
+
+
+def _enable_endpoint_demo_mode(monkeypatch):
+    settings = SimpleNamespace(DEMO_MODE=True)
+    monkeypatch.setattr(domains_endpoint, "get_settings", lambda: settings)
+    monkeypatch.setattr(report_persistence, "get_settings", lambda: settings)
+
+
+def test_domain_health_history_uses_demo_history_fallback(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    """Demo mode serves rolling health history when no snapshots are stored."""
+    _enable_endpoint_demo_mode(monkeypatch)
+
+    response = authed_client.get(
+        "/api/v1/domains/dmarq.org/posture/history"
+        "?capture_current=false&start_date=2026-06-01&limit=3"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["domain"] == "dmarq.org"
+    assert len(data["points"]) <= 3
+    assert data["current_score"] is not None
+
+
+def test_domain_health_evidence_export_uses_demo_history_fallback(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    """Demo mode exports rolling health evidence without persisted snapshots."""
+    _enable_endpoint_demo_mode(monkeypatch)
+
+    response = authed_client.get(
+        "/api/v1/domains/dmarq.com/posture/evidence/export"
+        "?capture_current=false&start_date=2026-06-01&limit=2"
+    )
+
+    assert response.status_code == 200
+    rows = list(csv.DictReader(StringIO(response.text)))
+    assert 0 < len(rows) <= 2
+    assert rows[-1]["domain"] == "dmarq.com"
+    assert rows[-1]["policy"] == "none"
+
+
+def test_health_history_helpers_cover_demo_and_empty_paths():
+    empty = domains_endpoint._history_response_from_points(DOMAIN, [])
+    assert empty.current_score is None
+    assert empty.points == []
+
+    points = domains_endpoint._demo_history_points(
+        "dmarq.org",
+        start_date=date(2026, 6, 1),
+        end_date=date(2099, 12, 31),
+        limit=2,
+    )
+    response = domains_endpoint._history_response_from_points("dmarq.org", points)
+    assert len(response.points) <= 2
+    assert response.current_score is not None
+    assert response.top_drivers
+
+    export_rows = domains_endpoint._demo_evidence_export_rows("dmarq.org", points)
+    assert export_rows[0]["domain"] == "dmarq.org"
+    assert "medium:" in export_rows[0]["top_actions"]
+
+    csv_response = domains_endpoint._write_health_evidence_csv(
+        export_rows,
+        domain_id="dmarq.org",
+    )
+    assert csv_response.media_type == "text/csv"
+    assert "health-evidence.csv" in csv_response.headers["content-disposition"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/test_health_score_snapshots.py
+++ b/backend/app/tests/test_health_score_snapshots.py
@@ -1,0 +1,152 @@
+from datetime import date
+
+from app.services.health_score_snapshots import (
+    build_health_evidence_export_rows,
+    build_health_score_history,
+    list_health_score_snapshots,
+    snapshot_to_history_point,
+    upsert_health_score_snapshot,
+)
+from app.services.workspaces import get_or_create_default_workspace
+
+
+def test_health_score_snapshot_upsert_history_and_export(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    health = {
+        "score": 82,
+        "grade": "B-",
+        "status": "attention",
+        "factors": {
+            "dns_posture": 90,
+            "policy_strength": 88,
+            "report_confidence": 78,
+        },
+        "actions": [
+            {
+                "type": "policy_none",
+                "severity": "medium",
+                "title": "Move out of monitoring mode",
+                "score_impact": 14,
+                "detail": "not exported",
+            }
+        ],
+    }
+
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name="example.com",
+        health=health,
+        policy="quarantine",
+        compliance_rate=91.2,
+        total_emails=1000,
+        failed_emails=88,
+        report_count=7,
+        snapshot_date=date(2026, 6, 1),
+    )
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name="example.com",
+        health={**health, "score": 86, "grade": "B"},
+        policy="quarantine",
+        compliance_rate=94,
+        total_emails=1200,
+        failed_emails=72,
+        report_count=8,
+        snapshot_date=date(2026, 6, 1),
+    )
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name="example.com",
+        health={**health, "score": 90, "grade": "A-"},
+        policy="reject",
+        compliance_rate=97,
+        total_emails=1400,
+        failed_emails=42,
+        report_count=9,
+        snapshot_date=date(2026, 6, 2),
+    )
+
+    snapshots = list_health_score_snapshots(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name="example.com",
+    )
+    assert [snapshot.snapshot_date for snapshot in snapshots] == [
+        date(2026, 6, 1),
+        date(2026, 6, 2),
+    ]
+    assert snapshots[0].score == 86
+
+    history = build_health_score_history(domain_name="example.com", snapshots=snapshots)
+    assert history["current_score"] == 90
+    assert history["previous_score"] == 86
+    assert history["score_delta"] == 4
+    assert history["top_drivers"][0]["title"] == "Move out of monitoring mode"
+
+    export_rows = build_health_evidence_export_rows(snapshots)
+    assert export_rows[0]["domain"] == "example.com"
+    assert export_rows[0]["top_actions"] == "medium:Move out of monitoring mode"
+    assert "not exported" not in str(export_rows)
+
+
+def test_health_score_snapshot_defensive_serialization(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    snapshot = upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name="defensive.example",
+        health={
+            "score": "not-a-number",
+            "grade": "",
+            "status": "",
+            "factors": {"dns_posture": "also-bad"},
+            "actions": [{"title": "Bad input", "score_impact": "bad"}],
+        },
+        compliance_rate="bad",
+        total_emails="bad",
+        failed_emails="bad",
+        report_count="bad",
+        snapshot_date=date(2026, 6, 4),
+    )
+    assert snapshot.score == 0
+    assert snapshot.dns_posture_score == 0
+    assert snapshot_to_history_point(snapshot)["top_actions"][0]["score_impact"] == 0
+
+    snapshot.top_actions = ""
+    assert snapshot_to_history_point(snapshot)["top_actions"] == []
+    assert "HealthScoreSnapshot defensive.example 2026-06-04 0" in repr(snapshot)
+    snapshot.top_actions = "{not-json"
+    assert snapshot_to_history_point(snapshot)["top_actions"] == []
+    snapshot.top_actions = '{"not": "a list"}'
+    assert snapshot_to_history_point(snapshot)["top_actions"] == []
+    snapshot.top_actions = '["not-a-dict", {"title": "kept"}]'
+    assert snapshot_to_history_point(snapshot)["top_actions"] == [{"title": "kept"}]
+
+
+def test_health_score_snapshot_filters_by_date_range(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    for day in range(1, 4):
+        upsert_health_score_snapshot(
+            db_session,
+            workspace_id=workspace.id,
+            domain_name="filtered.example",
+            health={"score": 70 + day, "grade": "C", "status": "attention"},
+            snapshot_date=date(2026, 6, day),
+        )
+
+    snapshots = list_health_score_snapshots(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name="filtered.example",
+        start_date=date(2026, 6, 2),
+        end_date=date(2026, 6, 3),
+        limit=10,
+    )
+
+    assert [snapshot.snapshot_date for snapshot in snapshots] == [
+        date(2026, 6, 2),
+        date(2026, 6, 3),
+    ]

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -445,6 +445,30 @@ actionable recommendations, recent provider-backed DNS drift summaries, and
 short operator playbooks. Recommendation and playbook evidence links point back
 to the page section that triggered the finding.
 
+#### Get Health Score History
+
+```
+GET /domains/{domain_id}/posture/history
+```
+
+Returns persisted daily health score snapshots for one domain, including score,
+grade, policy, aggregate report counts, factor scores, top action drivers,
+previous score, and score delta. Use `start_date`, `end_date`, and `limit` to
+shape audit or dashboard windows. By default the endpoint captures the current
+posture as today's snapshot before reading history; pass `capture_current=false`
+when reading already persisted evidence only.
+
+#### Export Health Evidence
+
+```
+GET /domains/{domain_id}/posture/evidence/export
+```
+
+Exports sanitized score history evidence as CSV. The export includes aggregate
+posture metadata only: score, grade, policy, aggregate message/report counts,
+factor scores, and top action titles. It does not include forensic message
+content, subjects, recipients, or raw uploaded report bodies.
+
 #### Add Domain
 
 ```


### PR DESCRIPTION
## Summary
- add persisted workspace-scoped daily health score snapshots with Alembic migration
- expose domain score history and sanitized health-evidence CSV export endpoints
- record current posture snapshots outside demo mode and provide rolling demo-mode score history for dmarq.org/dmarq.com-style demos
- document the new posture history and evidence export API

## Validation
- .venv/bin/python -m pytest backend/app/tests -q (1200 passed before the final demo-readonly guard tweak)
- .venv/bin/python -m pytest backend/app/tests/test_health_score_snapshots.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_demo_data.py -q (31 passed after final tweak)
- .venv/bin/python -m flake8 backend/app
- .venv/bin/python -m py_compile changed backend modules and migration
- git diff --check

Closes part of #307. Remaining #307 scope after this slice: scheduled/background snapshot creation, UI charts for the history, JSON/PDF audit packets, and broader compliance-specific export bundles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added domain health history endpoints to view past posture scores over time.
  * Added a CSV export for sanitized health evidence and snapshot data.
  * Health posture views now save snapshots automatically for trend tracking.
* **Bug Fixes**
  * Improved handling for missing history by showing demo-based trends when no saved data exists.
  * Added safer input handling for snapshot data and export output.
* **Documentation**
  * Documented the new posture history and evidence export APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->