### PR TITLE
[codex] Add approved DNS provider writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - 🌐 [Live Demo](https://demo.dmarq.org)
 - 🔒 Self-hosted. Secure. Beautifully visual.
-- 🛠️ Docker-deployable. DNS posture checks with optional Cloudflare inspection.
+- 🛠️ Docker-deployable. DNS posture checks with optional, approved DNS remediation.
 - 📬 Aggregate, forensic/failure, and SMTP TLS report support.
 
 ---
@@ -33,7 +33,7 @@ Included:
 - ✅ Import history + backfills for mail sources
 - ✅ Alerts & notifications via Apprise (test send, alert rules, daily/weekly summaries)
 - ✅ DNS checks (DMARC/SPF/DKIM) with DKIM selector discovery from report data
-- ✅ Cloudflare read-only domain discovery, DNS inspection, recommendations, and change tracking
+- ✅ DNS linting, change plans, approved Cloudflare writes, and modular provider write adapters
 - ✅ Forensic/failure report ingestion with redacted metadata and grouped analysis
 - ✅ SMTP TLS report ingestion, trends, and top failure summaries
 - ✅ Public demo mode with rolling synthetic `dmarq.org` and `dmarq.com` data
@@ -55,10 +55,13 @@ Included:
 - Inspect **SPF**, **DKIM**, and **DMARC** records
 - Discover likely **DKIM selectors** from report data
 - Show which records are missing, broken, or invalid
-- 🔒 No automatic changes — all DNS updates require explicit confirmation (when remediation workflows are added)
+- Generate risk-reviewed change plans with rollback notes
+- Apply safe TXT/CNAME remediation through Cloudflare after explicit confirmation
+- Use the modular DNS provider layer for API-backed providers via Lexicon-backed adapters
+- 🔒 No background changes — all DNS updates require explicit operator confirmation
 
 ### 🌐 Cloudflare Integration
-- Optional read-only domain discovery and DNS inspection
+- Optional domain discovery, DNS inspection, and approved DNS record updates
 - Import Cloudflare zones as monitored domains from Settings
 - Suggestions for missing or malformed entries
 - Track configuration changes over time
@@ -67,12 +70,11 @@ Included:
 - `DEMO_MODE=true` seeds deterministic, rolling demo data for `dmarq.org` and `dmarq.com`
 - Demo data fills the dashboard, domain details, DNS posture, aggregate reports,
   forensic reports, TLS reports, exports, and linting views
-- The dashboard starts in a single-user, multi-domain view and can zoom out into
-  SaaS, managed-service, ISP/reseller, and self-hosted deployment examples
-- Demo visitors can switch generated personas to see which accounts, workspaces,
-  billing profiles, and domains different users would experience
+- The public demo presents the self-hosted, single-user, multi-domain experience
+- Account-management, ISP, and multi-tenant demos are intended for a separate
+  admin/provider demo surface
 - A guided dashboard tour walks through the opinionated product flow from domain
-  posture to sender evidence and account drill-down
+  posture to sender evidence and DNS remediation
 - The public demo is read-only so visitors can explore without modifying data
 
 ### ⚙️ Web-Based Setup Wizard

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -29,6 +29,12 @@ from app.services.cloudflare_dns import (
 from app.services.demo_data import DEMO_DAYS, build_demo_health_score_history
 from app.services.dns_cache import resolve_domain_dns_cached
 from app.services.dns_guidance import build_dns_guidance
+from app.services.dns_provider_writes import (
+    DNSProviderWriteError,
+    apply_dns_write,
+    preview_dns_write,
+    provider_capabilities,
+)
 from app.services.dns_resolver import (
     DomainDNSResult,
     extract_dmarc_policy,
@@ -217,6 +223,63 @@ class DNSChangePlanResponse(BaseModel):
     provider_write_available: bool = False
     apply_endpoint: Optional[str] = None
     plans: List[DNSChangePlanItemResponse]
+
+
+class DNSProviderCapabilityResponse(BaseModel):
+    """DNS provider write capability metadata."""
+
+    id: str
+    name: str
+    mode: str
+    record_types: List[str]
+    operations: List[str]
+    credentials: str
+    status: str
+
+
+class DNSProviderCapabilitiesResponse(BaseModel):
+    """Supported DNS provider write capabilities."""
+
+    providers: List[DNSProviderCapabilityResponse]
+
+
+class DNSWriteApplyRequest(BaseModel):
+    """Request to preview or apply one DNS change plan."""
+
+    plan_id: str
+    provider: str = "cloudflare"
+    confirm: bool = False
+    dry_run: bool = True
+    value: Optional[str] = None
+    ttl: int = Field(default=1, ge=1, le=86400)
+
+
+class DNSWriteMutationResponse(BaseModel):
+    """Concrete provider mutation derived from a DNS change plan."""
+
+    operation: str
+    record_type: str
+    name: str
+    content: str
+    ttl: int
+    provider: str
+    zone_id: Optional[str] = None
+    zone_name: Optional[str] = None
+    record_id: Optional[str] = None
+    current_values: List[str] = Field(default_factory=list)
+    applicable: bool
+    blocked_reason: Optional[str] = None
+
+
+class DNSWriteResultResponse(BaseModel):
+    """DNS write preview/apply response."""
+
+    provider: str
+    dry_run: bool
+    applied: bool
+    mutation: DNSWriteMutationResponse
+    provider_result: Optional[Dict[str, Any]] = None
+    changes: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class DNSGuidanceResponse(BaseModel):
@@ -1776,6 +1839,14 @@ async def export_all_domain_dns_lint(
     )
 
 
+@router.get("/dns/providers", response_model=DNSProviderCapabilitiesResponse)
+async def get_dns_provider_capabilities(
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return provider-backed DNS write capabilities."""
+    return DNSProviderCapabilitiesResponse(providers=provider_capabilities())
+
+
 # New endpoints for domain details page
 
 
@@ -1908,8 +1979,110 @@ async def get_domain_dns_change_plan(
     return DNSChangePlanResponse(
         domain=guidance["domain"],
         status=guidance["status"],
-        plans=guidance["change_plans"],
+        read_only=False,
+        provider_write_available=True,
+        apply_endpoint=f"/api/v1/domains/{domain_id}/dns/change-plan/apply",
+        plans=[
+            {
+                **plan,
+                "provider_write_available": (
+                    plan.get("operation") in {"create", "update"}
+                    and plan.get("record_type") in {"TXT", "CNAME"}
+                    and not plan.get("provider_value_required")
+                ),
+            }
+            for plan in guidance["change_plans"]
+        ],
     )
+
+
+def _find_dns_change_plan(guidance: Dict[str, Any], plan_id: str) -> Dict[str, Any]:
+    """Return one DNS change plan by ID or raise a 404."""
+    for plan in guidance.get("change_plans") or []:
+        if plan.get("plan_id") == plan_id:
+            return plan
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"DNS change plan '{plan_id}' was not found",
+    )
+
+
+@router.post("/{domain_id}/dns/change-plan/apply", response_model=DNSWriteResultResponse)
+async def apply_domain_dns_change_plan(
+    request: Request,
+    payload: DNSWriteApplyRequest,
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS result before planning"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Preview or explicitly apply one provider-backed DNS change plan."""
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store)
+
+    if not _domain_exists(db, store, domain_id, workspace):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Domain not found",
+        )
+
+    guidance = await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
+    plan = _find_dns_change_plan(guidance, payload.plan_id)
+    try:
+        if payload.dry_run or not payload.confirm:
+            result = await preview_dns_write(
+                db,
+                domain=domain_id,
+                plan=plan,
+                provider_id=payload.provider,
+                value_override=payload.value,
+                ttl=payload.ttl,
+            )
+            return result.to_dict()
+
+        result = await apply_dns_write(
+            db,
+            workspace=workspace,
+            domain=domain_id,
+            plan=plan,
+            provider_id=payload.provider,
+            value_override=payload.value,
+            ttl=payload.ttl,
+        )
+    except DNSProviderWriteError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    except LookupError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action="domain.dns_change_applied",
+        entity_type="domain",
+        entity_name=domain_id,
+        details={
+            "provider": payload.provider,
+            "plan_id": payload.plan_id,
+            "mutation": result.mutation.to_dict(),
+            "applied": result.applied,
+        },
+        auth_context=_auth,
+        request=request,
+        commit=True,
+    )
+    return result.to_dict()
 
 
 @router.get("/{domain_id}/dns/health", response_model=DNSHealthResponse)

--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -1,0 +1,509 @@
+"""Provider-backed DNS write planning and execution."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol
+
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.models.workspace import Workspace
+from app.services.cloudflare_dns import (
+    build_cloudflare_provider,
+    get_zone_for_domain,
+    sync_dns_record_changes,
+)
+
+SUPPORTED_AUTOMATED_RECORD_TYPES = {"TXT", "CNAME"}
+SUPPORTED_AUTOMATED_OPERATIONS = {"create", "update"}
+NATIVE_PROVIDERS = {"cloudflare"}
+LEXICON_PROVIDERS = {
+    "aliyun",
+    "azure",
+    "cloudns",
+    "digitalocean",
+    "dnsimple",
+    "dnsmadeeasy",
+    "gandi",
+    "godaddy",
+    "googleclouddns",
+    "hetzner",
+    "ionos",
+    "linode",
+    "namecheap",
+    "ovh",
+    "powerdns",
+    "route53",
+    "vultr",
+}
+
+
+class DNSProviderWriteError(ValueError):
+    """Raised when a provider write cannot be safely prepared or applied."""
+
+
+@dataclass
+class DNSWriteMutation:
+    """Concrete provider mutation derived from a DMARQ DNS change plan."""
+
+    # pylint: disable=too-many-instance-attributes
+
+    operation: str
+    record_type: str
+    name: str
+    content: str
+    ttl: int
+    provider: str
+    zone_id: Optional[str] = None
+    zone_name: Optional[str] = None
+    record_id: Optional[str] = None
+    current_values: List[str] = field(default_factory=list)
+    blocked_reason: Optional[str] = None
+
+    @property
+    def applicable(self) -> bool:
+        return self.blocked_reason is None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "operation": self.operation,
+            "record_type": self.record_type,
+            "name": self.name,
+            "content": self.content,
+            "ttl": self.ttl,
+            "provider": self.provider,
+            "zone_id": self.zone_id,
+            "zone_name": self.zone_name,
+            "record_id": self.record_id,
+            "current_values": self.current_values,
+            "applicable": self.applicable,
+            "blocked_reason": self.blocked_reason,
+        }
+
+
+@dataclass
+class DNSWriteResult:
+    """Result of previewing or applying one DNS provider mutation."""
+
+    provider: str
+    dry_run: bool
+    applied: bool
+    mutation: DNSWriteMutation
+    provider_result: Optional[Dict[str, Any]] = None
+    changes: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "dry_run": self.dry_run,
+            "applied": self.applied,
+            "mutation": self.mutation.to_dict(),
+            "provider_result": self.provider_result,
+            "changes": self.changes,
+        }
+
+
+class DNSWriteProvider(Protocol):
+    """Provider-specific DNS write operations."""
+
+    provider_id: str
+
+    async def prepare_mutation(
+        self,
+        db: Session,
+        *,
+        domain: str,
+        plan: Dict[str, Any],
+        value_override: Optional[str],
+        ttl: int,
+    ) -> DNSWriteMutation:
+        """Return the concrete mutation for the supplied plan."""
+
+    async def apply_mutation(
+        self,
+        db: Session,
+        *,
+        domain: str,
+        mutation: DNSWriteMutation,
+    ) -> DNSWriteResult:
+        """Apply the concrete mutation and return provider evidence."""
+
+
+def normalize_provider_id(provider: str) -> str:
+    """Normalize user-facing provider IDs for registry lookups."""
+    return provider.strip().lower().replace("_", "-")
+
+
+def provider_capabilities() -> List[Dict[str, Any]]:
+    """Return available DNS write provider capabilities."""
+    capabilities = [
+        {
+            "id": "cloudflare",
+            "name": "Cloudflare",
+            "mode": "native",
+            "record_types": sorted(SUPPORTED_AUTOMATED_RECORD_TYPES),
+            "operations": sorted(SUPPORTED_AUTOMATED_OPERATIONS),
+            "credentials": "DMARQ Cloudflare settings or environment",
+            "status": "ready",
+        }
+    ]
+    lexicon_available = lexicon_runtime_available()
+    for provider_id in sorted(LEXICON_PROVIDERS):
+        capabilities.append(
+            {
+                "id": provider_id,
+                "name": provider_id,
+                "mode": "lexicon",
+                "record_types": sorted(SUPPORTED_AUTOMATED_RECORD_TYPES),
+                "operations": ["create", "update"],
+                "credentials": "Lexicon provider environment/configuration",
+                "status": "ready" if lexicon_available else "dependency_missing",
+            }
+        )
+    return capabilities
+
+
+def lexicon_runtime_available() -> bool:
+    """Return whether the optional Lexicon runtime can be imported."""
+    return bool(
+        importlib.util.find_spec("lexicon.client") and importlib.util.find_spec("lexicon.config")
+    )
+
+
+def _plan_value(plan: Dict[str, Any], value_override: Optional[str]) -> str:
+    value = (value_override or plan.get("proposed_value") or "").strip()
+    if not value:
+        raise DNSProviderWriteError("This DNS plan does not include an apply-ready record value")
+    if "<" in value or ">" in value:
+        raise DNSProviderWriteError(
+            "This DNS plan needs a provider-specific value before it can be applied"
+        )
+    return value
+
+
+def _validate_plan_for_automation(plan: Dict[str, Any]) -> None:
+    operation = str(plan.get("operation") or "").lower()
+    record_type = str(plan.get("record_type") or "").upper()
+    if operation not in SUPPORTED_AUTOMATED_OPERATIONS:
+        raise DNSProviderWriteError(
+            f"Operation '{operation}' is not safe for automatic DNS writes yet"
+        )
+    if record_type not in SUPPORTED_AUTOMATED_RECORD_TYPES:
+        raise DNSProviderWriteError(
+            f"Record type '{record_type}' is not supported for automatic DNS writes yet"
+        )
+
+
+class CloudflareDNSWriteProvider:
+    """DNS write provider backed by DMARQ's native Cloudflare client."""
+
+    provider_id = "cloudflare"
+
+    async def prepare_mutation(
+        self,
+        db: Session,
+        *,
+        domain: str,
+        plan: Dict[str, Any],
+        value_override: Optional[str],
+        ttl: int,
+    ) -> DNSWriteMutation:
+        _validate_plan_for_automation(plan)
+        value = _plan_value(plan, value_override)
+        record_type = str(plan["record_type"]).upper()
+        record_name = str(plan["name"])
+        zone = await get_zone_for_domain(db, domain)
+        matches = [
+            record
+            for record in zone.get("records", [])
+            if str(record.get("type") or "").upper() == record_type
+            and str(record.get("name") or "").rstrip(".").lower() == record_name.rstrip(".").lower()
+        ]
+        current_values = [str(record.get("content") or "") for record in matches]
+        if len(matches) > 1:
+            return DNSWriteMutation(
+                operation=str(plan["operation"]).lower(),
+                record_type=record_type,
+                name=record_name,
+                content=value,
+                ttl=ttl,
+                provider=self.provider_id,
+                zone_id=zone.get("id"),
+                zone_name=zone.get("name"),
+                current_values=current_values,
+                blocked_reason=(
+                    "Multiple provider records match this name/type; merge them manually first"
+                ),
+            )
+        if matches and current_values[0] == value:
+            operation = "noop"
+        elif matches:
+            operation = "update"
+        else:
+            operation = "create"
+        return DNSWriteMutation(
+            operation=operation,
+            record_type=record_type,
+            name=record_name,
+            content=value,
+            ttl=ttl,
+            provider=self.provider_id,
+            zone_id=zone.get("id"),
+            zone_name=zone.get("name"),
+            record_id=matches[0].get("id") if matches else None,
+            current_values=current_values,
+        )
+
+    async def apply_mutation(
+        self,
+        db: Session,
+        *,
+        domain: str,
+        mutation: DNSWriteMutation,
+    ) -> DNSWriteResult:
+        if not mutation.applicable:
+            raise DNSProviderWriteError(mutation.blocked_reason or "DNS mutation is blocked")
+        if mutation.operation == "noop":
+            return DNSWriteResult(
+                provider=self.provider_id,
+                dry_run=False,
+                applied=False,
+                mutation=mutation,
+                provider_result={"status": "unchanged"},
+            )
+
+        provider = build_cloudflare_provider(db)
+        if not mutation.zone_id:
+            raise DNSProviderWriteError("Cloudflare zone ID could not be resolved")
+        if mutation.operation == "update":
+            if not mutation.record_id:
+                raise DNSProviderWriteError("Cloudflare record ID is required for updates")
+            provider_result = await provider.update_dns_record(
+                zone_id=mutation.zone_id,
+                record_id=mutation.record_id,
+                record_type=mutation.record_type,
+                name=mutation.name,
+                content=mutation.content,
+                ttl=mutation.ttl,
+            )
+        elif mutation.operation == "create":
+            provider_result = await provider.create_dns_record(
+                zone_id=mutation.zone_id,
+                record_type=mutation.record_type,
+                name=mutation.name,
+                content=mutation.content,
+                ttl=mutation.ttl,
+            )
+        else:
+            raise DNSProviderWriteError(f"Unsupported Cloudflare operation: {mutation.operation}")
+
+        records = await provider.list_dns_records(zone_id=mutation.zone_id)
+        changes = sync_dns_record_changes(
+            db,
+            domain=domain,
+            zone_id=mutation.zone_id,
+            records=records,
+        )
+        return DNSWriteResult(
+            provider=self.provider_id,
+            dry_run=False,
+            applied=True,
+            mutation=mutation,
+            provider_result=provider_result,
+            changes=changes,
+        )
+
+
+class LexiconDNSWriteProvider:
+    """DNS write provider backed by dns-lexicon for API-backed providers."""
+
+    def __init__(self, provider_id: str) -> None:
+        self.provider_id = provider_id
+
+    async def prepare_mutation(
+        self,
+        db: Session,  # pylint: disable=unused-argument
+        *,
+        domain: str,
+        plan: Dict[str, Any],
+        value_override: Optional[str],
+        ttl: int,
+    ) -> DNSWriteMutation:
+        if not lexicon_runtime_available():
+            raise DNSProviderWriteError("dns-lexicon is not installed in this DMARQ runtime")
+        _validate_plan_for_automation(plan)
+        value = _plan_value(plan, value_override)
+        record_type = str(plan["record_type"]).upper()
+        record_name = str(plan["name"])
+        current = await asyncio.to_thread(
+            self._list_records,
+            domain,
+            record_type,
+            record_name,
+        )
+        current_values = [str(record.get("content") or "") for record in current]
+        if len(current) > 1:
+            return DNSWriteMutation(
+                operation=str(plan["operation"]).lower(),
+                record_type=record_type,
+                name=record_name,
+                content=value,
+                ttl=ttl,
+                provider=self.provider_id,
+                current_values=current_values,
+                blocked_reason=(
+                    "Multiple provider records match this name/type; merge them manually first"
+                ),
+            )
+        operation = "noop" if current_values == [value] else ("update" if current else "create")
+        return DNSWriteMutation(
+            operation=operation,
+            record_type=record_type,
+            name=record_name,
+            content=value,
+            ttl=ttl,
+            provider=self.provider_id,
+            record_id=str(current[0].get("id") or "") if current else None,
+            current_values=current_values,
+        )
+
+    async def apply_mutation(
+        self,
+        db: Session,  # pylint: disable=unused-argument
+        *,
+        domain: str,
+        mutation: DNSWriteMutation,
+    ) -> DNSWriteResult:
+        if not mutation.applicable:
+            raise DNSProviderWriteError(mutation.blocked_reason or "DNS mutation is blocked")
+        if mutation.operation == "noop":
+            return DNSWriteResult(
+                provider=self.provider_id,
+                dry_run=False,
+                applied=False,
+                mutation=mutation,
+                provider_result={"status": "unchanged"},
+            )
+        provider_result = await asyncio.to_thread(self._apply_record, domain, mutation)
+        return DNSWriteResult(
+            provider=self.provider_id,
+            dry_run=False,
+            applied=True,
+            mutation=mutation,
+            provider_result={"ok": bool(provider_result)},
+        )
+
+    def _client_config(self, domain: str):
+        from lexicon.config import ConfigResolver  # pylint: disable=import-outside-toplevel
+
+        return (
+            ConfigResolver()
+            .with_env()
+            .with_dict(
+                {
+                    "provider_name": self.provider_id,
+                    "domain": domain,
+                }
+            )
+        )
+
+    def _list_records(
+        self,
+        domain: str,
+        record_type: str,
+        record_name: str,
+    ) -> List[Dict[str, Any]]:
+        from lexicon.client import Client  # pylint: disable=import-outside-toplevel
+
+        with Client(self._client_config(domain)) as operations:
+            return operations.list_records(record_type, record_name)
+
+    def _apply_record(self, domain: str, mutation: DNSWriteMutation) -> bool:
+        from lexicon.client import Client  # pylint: disable=import-outside-toplevel
+
+        with Client(self._client_config(domain)) as operations:
+            if mutation.operation == "create":
+                return bool(
+                    operations.create_record(
+                        mutation.record_type,
+                        mutation.name,
+                        mutation.content,
+                    )
+                )
+            if mutation.operation == "update":
+                return bool(
+                    operations.update_record(
+                        mutation.record_id,
+                        mutation.record_type,
+                        mutation.name,
+                        mutation.content,
+                    )
+                )
+        raise DNSProviderWriteError(f"Unsupported Lexicon operation: {mutation.operation}")
+
+
+def build_dns_write_provider(provider_id: str) -> DNSWriteProvider:
+    """Return the configured DNS write provider implementation."""
+    normalized = normalize_provider_id(provider_id)
+    if normalized in NATIVE_PROVIDERS:
+        return CloudflareDNSWriteProvider()
+    if normalized in LEXICON_PROVIDERS:
+        return LexiconDNSWriteProvider(normalized)
+    raise DNSProviderWriteError(f"Unsupported DNS provider: {provider_id}")
+
+
+async def preview_dns_write(
+    db: Session,
+    *,
+    domain: str,
+    plan: Dict[str, Any],
+    provider_id: str,
+    value_override: Optional[str] = None,
+    ttl: int = 1,
+) -> DNSWriteResult:
+    """Return the provider mutation without applying it."""
+    provider = build_dns_write_provider(provider_id)
+    mutation = await provider.prepare_mutation(
+        db,
+        domain=domain,
+        plan=plan,
+        value_override=value_override,
+        ttl=ttl,
+    )
+    return DNSWriteResult(
+        provider=normalize_provider_id(provider_id),
+        dry_run=True,
+        applied=False,
+        mutation=mutation,
+    )
+
+
+async def apply_dns_write(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domain: str,
+    plan: Dict[str, Any],
+    provider_id: str,
+    value_override: Optional[str] = None,
+    ttl: int = 1,
+) -> DNSWriteResult:
+    """Apply one provider-backed DNS mutation after validation."""
+    if get_settings().DEMO_MODE:
+        raise DNSProviderWriteError("Provider DNS writes are disabled in demo mode")
+    provider = build_dns_write_provider(provider_id)
+    mutation = await provider.prepare_mutation(
+        db,
+        domain=domain,
+        plan=plan,
+        value_override=value_override,
+        ttl=ttl,
+    )
+    result = await provider.apply_mutation(db, domain=domain, mutation=mutation)
+    db.flush()
+    if workspace.id is None:
+        raise DNSProviderWriteError("Workspace must be persisted before applying DNS changes")
+    return result

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -585,15 +585,28 @@ class CloudflareDNSProvider(BaseDNSProvider):
         *,
         params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
+        """Call Cloudflare's REST API with GET and return the decoded response."""
+        return await self._api_request("GET", path, params=params)
+
+    async def _api_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_payload: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Call Cloudflare's REST API and return the decoded response."""
         import httpx  # type: ignore[import]
 
         url = f"{self.CLOUDFLARE_API_BASE}{path}"
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.get(
+                response = await client.request(
+                    method,
                     url,
                     params=params,
+                    json=json_payload,
                     headers=self._auth_headers(),
                     timeout=DNS_TIMEOUT,
                 )
@@ -607,6 +620,59 @@ class CloudflareDNSProvider(BaseDNSProvider):
             message = "; ".join(str(error.get("message", error)) for error in errors[:3])
             raise LookupError(message or f"Cloudflare API request failed for {path}")
         return data
+
+    async def create_dns_record(
+        self,
+        *,
+        zone_id: str,
+        record_type: str,
+        name: str,
+        content: str,
+        ttl: int = 1,
+    ) -> Dict[str, Any]:
+        """Create a DNS record through the Cloudflare REST API."""
+        data = await self._api_request(
+            "POST",
+            f"/zones/{zone_id}/dns_records",
+            json_payload={
+                "type": record_type,
+                "name": name,
+                "content": content,
+                "ttl": ttl,
+            },
+        )
+        return data.get("result") or {}
+
+    async def update_dns_record(
+        self,
+        *,
+        zone_id: str,
+        record_id: str,
+        record_type: str,
+        name: str,
+        content: str,
+        ttl: int = 1,
+    ) -> Dict[str, Any]:
+        """Patch a DNS record through the Cloudflare REST API."""
+        data = await self._api_request(
+            "PATCH",
+            f"/zones/{zone_id}/dns_records/{record_id}",
+            json_payload={
+                "type": record_type,
+                "name": name,
+                "content": content,
+                "ttl": ttl,
+            },
+        )
+        return data.get("result") or {}
+
+    async def delete_dns_record(self, *, zone_id: str, record_id: str) -> Dict[str, Any]:
+        """Delete a DNS record through the Cloudflare REST API."""
+        data = await self._api_request(
+            "DELETE",
+            f"/zones/{zone_id}/dns_records/{record_id}",
+        )
+        return data.get("result") or {}
 
     async def list_zones(self) -> List[Dict[str, Any]]:
         """Return all zones visible to the configured Cloudflare API token."""

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -596,12 +596,29 @@
                                 <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                                     <div>
                                         <h4 class="font-semibold">Proposed DNS change plan</h4>
-                                        <p class="text-xs text-base-content/60">Read-only. DMARQ never applies these changes automatically.</p>
+                                        <p class="text-xs text-base-content/60">Provider writes require explicit review and approval.</p>
                                     </div>
-                                    <span class="inline-flex w-fit rounded bg-base-200 px-2 py-1 text-xs font-semibold text-base-content/70">
-                                        manual approval required
-                                    </span>
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <select
+                                            x-model="dnsWrite.provider"
+                                            class="select select-xs select-bordered"
+                                            title="DNS provider"
+                                        >
+                                            <template x-for="provider in dnsProviders" :key="provider.id">
+                                                <option :value="provider.id" x-text="provider.name"></option>
+                                            </template>
+                                        </select>
+                                        <span class="inline-flex w-fit rounded bg-base-200 px-2 py-1 text-xs font-semibold text-base-content/70">
+                                            explicit approval required
+                                        </span>
+                                    </div>
                                 </div>
+                                <p x-show="dnsWrite.message"
+                                   class="mt-2 rounded bg-base-200 px-3 py-2 text-xs text-base-content/75"
+                                   x-text="dnsWrite.message"></p>
+                                <p x-show="dnsWrite.error"
+                                   class="mt-2 rounded bg-red-50 px-3 py-2 text-xs text-red-700"
+                                   x-text="dnsWrite.error"></p>
                                 <div class="mt-3 space-y-2">
                                     <template x-for="plan in dnsGuidance.change_plans" :key="plan.plan_id">
                                         <div class="rounded border border-base-300 p-3">
@@ -633,6 +650,40 @@
                                                 <p><span class="font-semibold">Rollback:</span> <span x-text="plan.rollback"></span></p>
                                                 <p><span class="font-semibold">Impact:</span> <span x-text="plan.expected_health_impact"></span></p>
                                             </div>
+                                            <div class="mt-3 flex flex-col gap-2 border-t border-base-200 pt-3 sm:flex-row sm:items-center sm:justify-between">
+                                                <div class="text-xs text-base-content/60">
+                                                    <span x-show="plan.provider_write_available">Can be previewed and applied with the selected provider.</span>
+                                                    <span x-show="!plan.provider_write_available">Manual-only until the value or operation is safe to automate.</span>
+                                                </div>
+                                                <div class="flex flex-wrap gap-2">
+                                                    <button
+                                                        class="btn btn-xs btn-outline"
+                                                        :disabled="dnsWrite.loading || !plan.provider_write_available"
+                                                        @click="previewDNSChange(plan)"
+                                                    >
+                                                        Preview
+                                                    </button>
+                                                    <button
+                                                        class="btn btn-xs bg-[#2f9da5] text-white hover:bg-[#272a5f]"
+                                                        :disabled="dnsWrite.loading || !plan.provider_write_available"
+                                                        @click="applyDNSChange(plan)"
+                                                    >
+                                                        Apply
+                                                    </button>
+                                                </div>
+                                            </div>
+                                            <template x-if="dnsWrite.preview && dnsWrite.preview.plan_id === plan.plan_id">
+                                                <div class="mt-3 rounded border border-[#2f9da5]/30 bg-[#2f9da5]/10 p-3 text-xs">
+                                                    <div class="font-semibold">Provider preview</div>
+                                                    <div class="mt-1 grid gap-1 sm:grid-cols-2">
+                                                        <p><span class="font-semibold">Operation:</span> <span x-text="dnsWrite.preview.mutation.operation"></span></p>
+                                                        <p><span class="font-semibold">Provider:</span> <span x-text="dnsWrite.preview.provider"></span></p>
+                                                        <p><span class="font-semibold">Zone:</span> <span x-text="dnsWrite.preview.mutation.zone_name || dnsWrite.preview.mutation.zone_id || 'provider resolved'"></span></p>
+                                                        <p><span class="font-semibold">TTL:</span> <span x-text="dnsWrite.preview.mutation.ttl"></span></p>
+                                                    </div>
+                                                    <code class="mt-2 block break-all rounded bg-white/70 p-2" x-text="dnsWrite.preview.mutation.name + ' ' + dnsWrite.preview.mutation.record_type + ' ' + dnsWrite.preview.mutation.content"></code>
+                                                </div>
+                                            </template>
                                         </div>
                                     </template>
                                 </div>
@@ -975,6 +1026,16 @@ function domainDetailsApp(domainId) {
             target_records: [],
             change_plans: []
         },
+        dnsProviders: [
+            { id: 'cloudflare', name: 'Cloudflare' }
+        ],
+        dnsWrite: {
+            provider: 'cloudflare',
+            loading: false,
+            message: '',
+            error: '',
+            preview: null
+        },
         posture: {
             status: '',
             score: 0,
@@ -1041,6 +1102,7 @@ function domainDetailsApp(domainId) {
             this.fetchDNSRecords();
             this.fetchDNSHealth();
             this.fetchDNSGuidance();
+            this.fetchDNSProviders();
             this.fetchPosture();
             this.fetchHealthHistory();
             this.fetchMtaSts();
@@ -1185,6 +1247,73 @@ function domainDetailsApp(domainId) {
             } catch (error) {
                 console.error('Error fetching DNS guidance:', error);
             }
+        },
+
+        async fetchDNSProviders() {
+            try {
+                const response = await fetch('/api/v1/domains/dns/providers');
+                if (response.ok) {
+                    const data = await response.json();
+                    const ready = (data.providers || []).filter(provider => provider.status === 'ready');
+                    this.dnsProviders = ready.length ? ready : this.dnsProviders;
+                    if (!this.dnsProviders.some(provider => provider.id === this.dnsWrite.provider)) {
+                        this.dnsWrite.provider = this.dnsProviders[0].id;
+                    }
+                }
+            } catch (error) {
+                console.error('Error fetching DNS providers:', error);
+            }
+        },
+
+        async submitDNSChange(plan, apply) {
+            this.dnsWrite.loading = true;
+            this.dnsWrite.error = '';
+            this.dnsWrite.message = '';
+            if (apply && !window.confirm(`Apply DNS change for ${plan.name}?`)) {
+                this.dnsWrite.loading = false;
+                return;
+            }
+            try {
+                const response = await fetch(`/api/v1/domains/${this.domainId}/dns/change-plan/apply`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        plan_id: plan.plan_id,
+                        provider: this.dnsWrite.provider,
+                        dry_run: !apply,
+                        confirm: apply
+                    })
+                });
+                const data = await response.json();
+                if (!response.ok) {
+                    this.dnsWrite.error = data.detail || 'DNS change could not be prepared';
+                    return;
+                }
+                data.plan_id = plan.plan_id;
+                this.dnsWrite.preview = data;
+                this.dnsWrite.message = apply
+                    ? 'DNS change submitted. Refreshing DNS evidence now.'
+                    : 'Preview ready. Review the provider mutation before applying.';
+                if (apply) {
+                    await this.fetchDNSRecords();
+                    await this.fetchDNSHealth();
+                    await this.fetchDNSGuidance();
+                    await this.fetchPosture();
+                }
+            } catch (error) {
+                this.dnsWrite.error = 'Network error — DNS change could not be prepared';
+                console.error('Error submitting DNS change:', error);
+            } finally {
+                this.dnsWrite.loading = false;
+            }
+        },
+
+        previewDNSChange(plan) {
+            return this.submitDNSChange(plan, false);
+        },
+
+        applyDNSChange(plan) {
+            return this.submitDNSChange(plan, true);
         },
 
         async fetchPosture() {

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -3,6 +3,7 @@
 import asyncio
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -593,6 +594,17 @@ def test_dns_provider_capabilities_include_cloudflare_and_lexicon(authed_client:
     assert "googleclouddns" in providers
 
 
+def test_dns_provider_capabilities_report_available_lexicon_runtime():
+    with patch("app.services.dns_provider_writes.lexicon_runtime_available", return_value=True):
+        providers = {
+            provider["id"]: provider for provider in dns_provider_writes.provider_capabilities()
+        }
+
+    assert providers["cloudflare"]["status"] == "ready"
+    assert providers["route53"]["status"] == "ready"
+    assert providers["route53"]["mode"] == "lexicon"
+
+
 def test_dns_write_provider_registry_normalizes_supported_provider_ids():
     cloudflare_provider = dns_provider_writes.build_dns_write_provider(" CloudFlare ")
     route53_provider = dns_provider_writes.build_dns_write_provider("ROUTE53")
@@ -870,6 +882,71 @@ def test_cloudflare_write_provider_requires_zone_id_for_apply(db_session):
             raise AssertionError("Expected missing Cloudflare zone ID error")
 
 
+def test_cloudflare_write_provider_creates_record_and_syncs_history(db_session):
+    provider = CloudflareDNSWriteProvider()
+    cloudflare_provider = FakeWriteCloudflareProvider(
+        zones=[{"id": "zone-1", "name": DOMAIN}],
+        records=[],
+    )
+    mutation = DNSWriteMutation(
+        operation="create",
+        record_type="TXT",
+        name=f"_dmarc.{DOMAIN}",
+        content=f"v=DMARC1; p=none; rua=mailto:dmarc@{DOMAIN}",
+        ttl=3600,
+        provider="cloudflare",
+        zone_id="zone-1",
+    )
+
+    with patch(
+        "app.services.dns_provider_writes.build_cloudflare_provider",
+        return_value=cloudflare_provider,
+    ):
+        result = asyncio.run(provider.apply_mutation(db_session, domain=DOMAIN, mutation=mutation))
+
+    assert result.applied is True
+    assert cloudflare_provider.created[0]["ttl"] == 3600
+    assert result.provider_result["id"] == "created-1"
+    assert result.changes[0]["change_type"] == "added"
+    assert db_session.query(DNSRecordChange).count() == 1
+
+
+def test_cloudflare_write_provider_blocks_inapplicable_mutation(db_session):
+    provider = CloudflareDNSWriteProvider()
+    mutation = DNSWriteMutation(
+        operation="update",
+        record_type="TXT",
+        name=f"_dmarc.{DOMAIN}",
+        content=f"v=DMARC1; p=none; rua=mailto:dmarc@{DOMAIN}",
+        ttl=1,
+        provider="cloudflare",
+        blocked_reason="manual merge required",
+    )
+
+    with pytest.raises(DNSProviderWriteError, match="manual merge required"):
+        asyncio.run(provider.apply_mutation(db_session, domain=DOMAIN, mutation=mutation))
+
+
+def test_cloudflare_write_provider_rejects_unsupported_apply_operation(db_session):
+    provider = CloudflareDNSWriteProvider()
+    mutation = DNSWriteMutation(
+        operation="delete",
+        record_type="TXT",
+        name=f"_dmarc.{DOMAIN}",
+        content=f"v=DMARC1; p=none; rua=mailto:dmarc@{DOMAIN}",
+        ttl=1,
+        provider="cloudflare",
+        zone_id="zone-1",
+    )
+
+    with patch(
+        "app.services.dns_provider_writes.build_cloudflare_provider",
+        return_value=FakeWriteCloudflareProvider(),
+    ):
+        with pytest.raises(DNSProviderWriteError, match="Unsupported Cloudflare operation"):
+            asyncio.run(provider.apply_mutation(db_session, domain=DOMAIN, mutation=mutation))
+
+
 def test_lexicon_write_provider_reports_missing_runtime(db_session):
     provider = LexiconDNSWriteProvider("route53")
 
@@ -888,6 +965,86 @@ def test_lexicon_write_provider_reports_missing_runtime(db_session):
             assert "dns-lexicon is not installed" in str(exc)
         else:
             raise AssertionError("Expected missing Lexicon runtime error")
+
+
+def test_lexicon_write_provider_prepares_update_and_applies_record(db_session):
+    provider = LexiconDNSWriteProvider("route53")
+    provider._list_records = lambda domain, record_type, record_name: [  # pylint: disable=protected-access
+        {
+            "id": "record-1",
+            "type": record_type,
+            "name": record_name,
+            "content": "v=DMARC1; p=none",
+        }
+    ]
+    provider._apply_record = (
+        lambda domain, mutation: mutation.record_id == "record-1"
+    )  # pylint: disable=protected-access
+
+    with patch("app.services.dns_provider_writes.lexicon_runtime_available", return_value=True):
+        mutation = asyncio.run(
+            provider.prepare_mutation(
+                db_session,
+                domain=DOMAIN,
+                plan=_dns_plan(operation="update"),
+                value_override="v=DMARC1; p=reject",
+                ttl=300,
+            )
+        )
+        result = asyncio.run(provider.apply_mutation(db_session, domain=DOMAIN, mutation=mutation))
+
+    assert mutation.operation == "update"
+    assert mutation.record_id == "record-1"
+    assert mutation.current_values == ["v=DMARC1; p=none"]
+    assert result.applied is True
+    assert result.provider_result == {"ok": True}
+
+
+def test_lexicon_write_provider_prepares_noop_for_matching_record(db_session):
+    provider = LexiconDNSWriteProvider("route53")
+    expected_value = "v=DMARC1; p=none"
+    provider._list_records = lambda domain, record_type, record_name: [  # pylint: disable=protected-access
+        {"id": "record-1", "content": expected_value}
+    ]
+
+    with patch("app.services.dns_provider_writes.lexicon_runtime_available", return_value=True):
+        mutation = asyncio.run(
+            provider.prepare_mutation(
+                db_session,
+                domain=DOMAIN,
+                plan=_dns_plan(proposed_value=expected_value),
+                value_override=None,
+                ttl=1,
+            )
+        )
+        result = asyncio.run(provider.apply_mutation(db_session, domain=DOMAIN, mutation=mutation))
+
+    assert mutation.operation == "noop"
+    assert result.applied is False
+    assert result.provider_result == {"status": "unchanged"}
+
+
+def test_lexicon_write_provider_blocks_duplicate_records(db_session):
+    provider = LexiconDNSWriteProvider("route53")
+    provider._list_records = lambda domain, record_type, record_name: [  # pylint: disable=protected-access
+        {"id": "record-1", "content": "v=DMARC1; p=none"},
+        {"id": "record-2", "content": "v=DMARC1; p=reject"},
+    ]
+
+    with patch("app.services.dns_provider_writes.lexicon_runtime_available", return_value=True):
+        mutation = asyncio.run(
+            provider.prepare_mutation(
+                db_session,
+                domain=DOMAIN,
+                plan=_dns_plan(),
+                value_override=None,
+                ttl=1,
+            )
+        )
+
+    assert mutation.applicable is False
+    assert mutation.current_values == ["v=DMARC1; p=none", "v=DMARC1; p=reject"]
+    assert "Multiple provider records" in mutation.blocked_reason
 
 
 def test_cloudflare_discover_denies_user_without_workspace_membership(

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -17,8 +17,14 @@ from app.models.setting import Setting
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
-from app.services import cloudflare_dns
+from app.services import cloudflare_dns, dns_provider_writes
 from app.services.cloudflare_dns import analyze_dns_records, sync_dns_record_changes
+from app.services.dns_provider_writes import (
+    CloudflareDNSWriteProvider,
+    DNSProviderWriteError,
+    DNSWriteMutation,
+    LexiconDNSWriteProvider,
+)
 from app.services.organizations import OrganizationPlanLimitError
 from app.services.workspaces import get_or_create_default_workspace
 
@@ -587,6 +593,23 @@ def test_dns_provider_capabilities_include_cloudflare_and_lexicon(authed_client:
     assert "googleclouddns" in providers
 
 
+def test_dns_write_provider_registry_normalizes_supported_provider_ids():
+    cloudflare_provider = dns_provider_writes.build_dns_write_provider(" CloudFlare ")
+    route53_provider = dns_provider_writes.build_dns_write_provider("ROUTE53")
+
+    assert cloudflare_provider.provider_id == "cloudflare"
+    assert route53_provider.provider_id == "route53"
+
+
+def test_dns_write_provider_registry_rejects_unknown_provider():
+    try:
+        dns_provider_writes.build_dns_write_provider("unknown-dns")
+    except DNSProviderWriteError as exc:
+        assert "Unsupported DNS provider" in str(exc)
+    else:
+        raise AssertionError("Expected unsupported DNS provider error")
+
+
 def test_dns_change_plan_marks_apply_ready_records(authed_client: TestClient, db_session):
     db_session.add(Domain(name=DOMAIN))
     db_session.commit()
@@ -637,6 +660,70 @@ def test_dns_change_plan_apply_dry_run_returns_cloudflare_mutation(
     assert data["mutation"]["operation"] == "create"
     assert data["mutation"]["name"] == f"_dmarc.{DOMAIN}"
     assert data["mutation"]["content"] == plan["proposed_value"]
+
+
+def test_dns_change_plan_apply_dry_run_returns_noop_for_unchanged_cloudflare_record(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan()
+    records = [_record("dmarc", "TXT", f"_dmarc.{DOMAIN}", plan["proposed_value"])]
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": records}),
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={"plan_id": plan["plan_id"], "provider": "cloudflare"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dry_run"] is True
+    assert data["mutation"]["operation"] == "noop"
+    assert data["mutation"]["current_values"] == [plan["proposed_value"]]
+
+
+def test_dns_change_plan_apply_blocks_multiple_matching_cloudflare_records(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan()
+    records = [
+        _record("dmarc-1", "TXT", f"_dmarc.{DOMAIN}", "v=DMARC1; p=none"),
+        _record("dmarc-2", "TXT", f"_dmarc.{DOMAIN}", "v=DMARC1; p=reject"),
+    ]
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": records}),
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={"plan_id": plan["plan_id"], "provider": "cloudflare"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mutation"]["applicable"] is False
+    assert "Multiple provider records" in data["mutation"]["blocked_reason"]
 
 
 def test_dns_change_plan_apply_rejects_unconfirmed_real_write(
@@ -734,6 +821,73 @@ def test_dns_change_plan_apply_blocks_provider_value_placeholders(
 
     assert response.status_code == 422
     assert "provider-specific value" in response.json()["detail"]
+
+
+def test_apply_dns_write_rejects_demo_mode(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    plan = _dns_plan()
+
+    class DemoSettings:
+        DEMO_MODE = True
+
+    with patch("app.services.dns_provider_writes.get_settings", return_value=DemoSettings()):
+        try:
+            asyncio.run(
+                dns_provider_writes.apply_dns_write(
+                    db_session,
+                    workspace=workspace,
+                    domain=DOMAIN,
+                    plan=plan,
+                    provider_id="cloudflare",
+                )
+            )
+        except DNSProviderWriteError as exc:
+            assert "disabled in demo mode" in str(exc)
+        else:
+            raise AssertionError("Expected demo mode DNS write block")
+
+
+def test_cloudflare_write_provider_requires_zone_id_for_apply(db_session):
+    provider = CloudflareDNSWriteProvider()
+    mutation = DNSWriteMutation(
+        operation="create",
+        record_type="TXT",
+        name=f"_dmarc.{DOMAIN}",
+        content=f"v=DMARC1; p=none; rua=mailto:dmarc@{DOMAIN}",
+        ttl=1,
+        provider="cloudflare",
+    )
+
+    with patch(
+        "app.services.dns_provider_writes.build_cloudflare_provider",
+        return_value=FakeWriteCloudflareProvider(),
+    ):
+        try:
+            asyncio.run(provider.apply_mutation(db_session, domain=DOMAIN, mutation=mutation))
+        except DNSProviderWriteError as exc:
+            assert "zone ID" in str(exc)
+        else:
+            raise AssertionError("Expected missing Cloudflare zone ID error")
+
+
+def test_lexicon_write_provider_reports_missing_runtime(db_session):
+    provider = LexiconDNSWriteProvider("route53")
+
+    with patch("app.services.dns_provider_writes.lexicon_runtime_available", return_value=False):
+        try:
+            asyncio.run(
+                provider.prepare_mutation(
+                    db_session,
+                    domain=DOMAIN,
+                    plan=_dns_plan(),
+                    value_override=None,
+                    ttl=1,
+                )
+            )
+        except DNSProviderWriteError as exc:
+            assert "dns-lexicon is not installed" in str(exc)
+        else:
+            raise AssertionError("Expected missing Lexicon runtime error")
 
 
 def test_cloudflare_discover_denies_user_without_workspace_membership(

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -16,6 +16,7 @@ from app.models.organization import Entitlement, Organization
 from app.models.setting import Setting
 from app.models.user import User
 from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceAuditLog
 from app.services import cloudflare_dns
 from app.services.cloudflare_dns import analyze_dns_records, sync_dns_record_changes
 from app.services.organizations import OrganizationPlanLimitError
@@ -56,6 +57,37 @@ class FakeCloudflareProvider:
             if domain == zone_name or domain.endswith(f".{zone_name}"):
                 return zone
         return None
+
+
+class FakeWriteCloudflareProvider(FakeCloudflareProvider):
+    def __init__(self, *, zones=None, records=None, fail_zone_lookup=False):
+        super().__init__(zones=zones, records=records, fail_zone_lookup=fail_zone_lookup)
+        self.created = []
+        self.updated = []
+
+    async def create_dns_record(self, *, zone_id, record_type, name, content, ttl=1):
+        record = _record(f"created-{len(self.created) + 1}", record_type, name, content, ttl)
+        self.created.append({"zone_id": zone_id, **record})
+        self.records.append(record)
+        return record
+
+    async def update_dns_record(
+        self,
+        *,
+        zone_id,
+        record_id,
+        record_type,
+        name,
+        content,
+        ttl=1,
+    ):
+        updated = _record(record_id, record_type, name, content, ttl)
+        self.updated.append({"zone_id": zone_id, **updated})
+        for index, record in enumerate(self.records):
+            if record.get("id") == record_id:
+                self.records[index] = updated
+                break
+        return updated
 
 
 def test_analyze_dns_records_reports_healthy_auth_records():
@@ -511,6 +543,197 @@ def test_cloudflare_dns_analysis_endpoint_returns_configuration_errors(authed_cl
 
     assert response.status_code == 400
     assert "Cloudflare API token" in response.json()["detail"]
+
+
+def _dns_plan(plan_id="dmarc-missing-example-com-txt", operation="create", proposed_value=None):
+    return {
+        "plan_id": plan_id,
+        "finding_code": "dmarc_missing",
+        "severity": "error",
+        "operation": operation,
+        "record_type": "TXT",
+        "name": f"_dmarc.{DOMAIN}",
+        "proposed_value": proposed_value or f"v=DMARC1; p=none; rua=mailto:dmarc@{DOMAIN}",
+        "current_values": [],
+        "rationale": "Publish a DMARC TXT record in monitoring mode before tightening policy.",
+        "risk": "Low delivery risk when starting with p=none.",
+        "rollback": f"Delete the newly created TXT record at _dmarc.{DOMAIN}.",
+        "expected_health_impact": "Expected to remove a critical DNS-health finding.",
+        "manual_steps": ["Publish the planned TXT record."],
+        "requires_approval": True,
+        "applies_automatically": False,
+        "provider_write_available": False,
+        "provider_value_required": False,
+    }
+
+
+def _dns_guidance_with_plan(plan):
+    return {
+        "domain": DOMAIN,
+        "status": "critical",
+        "findings": [],
+        "target_records": [],
+        "change_plans": [plan],
+    }
+
+
+def test_dns_provider_capabilities_include_cloudflare_and_lexicon(authed_client: TestClient):
+    response = authed_client.get("/api/v1/domains/dns/providers")
+
+    assert response.status_code == 200
+    providers = {provider["id"]: provider for provider in response.json()["providers"]}
+    assert providers["cloudflare"]["mode"] == "native"
+    assert "route53" in providers
+    assert "googleclouddns" in providers
+
+
+def test_dns_change_plan_marks_apply_ready_records(authed_client: TestClient, db_session):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan()
+
+    with patch(
+        "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+        new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/change-plan")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["read_only"] is False
+    assert data["provider_write_available"] is True
+    assert data["apply_endpoint"].endswith("/dns/change-plan/apply")
+    assert data["plans"][0]["provider_write_available"] is True
+
+
+def test_dns_change_plan_apply_dry_run_returns_cloudflare_mutation(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan()
+    records = [_record("spf", "TXT", DOMAIN, "v=spf1 -all")]
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": records}),
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={"plan_id": plan["plan_id"], "provider": "cloudflare"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dry_run"] is True
+    assert data["applied"] is False
+    assert data["mutation"]["operation"] == "create"
+    assert data["mutation"]["name"] == f"_dmarc.{DOMAIN}"
+    assert data["mutation"]["content"] == plan["proposed_value"]
+
+
+def test_dns_change_plan_apply_rejects_unconfirmed_real_write(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan()
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": []}),
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={"plan_id": plan["plan_id"], "provider": "cloudflare", "dry_run": False},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["dry_run"] is True
+    assert db_session.query(WorkspaceAuditLog).count() == 0
+
+
+def test_dns_change_plan_apply_updates_cloudflare_and_audits(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan(operation="update")
+    provider = FakeWriteCloudflareProvider(
+        zones=[{"id": "zone-1", "name": DOMAIN}],
+        records=[_record("dmarc", "TXT", f"_dmarc.{DOMAIN}", "v=DMARC1; p=none")],
+    )
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(
+                return_value={"id": "zone-1", "name": DOMAIN, "records": list(provider.records)}
+            ),
+        ),
+        patch(
+            "app.services.dns_provider_writes.build_cloudflare_provider",
+            return_value=provider,
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={
+                "plan_id": plan["plan_id"],
+                "provider": "cloudflare",
+                "dry_run": False,
+                "confirm": True,
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["applied"] is True
+    assert provider.updated[0]["content"] == plan["proposed_value"]
+    assert db_session.query(DNSRecordChange).count() == 1
+    audit = db_session.query(WorkspaceAuditLog).one()
+    assert audit.action == "domain.dns_change_applied"
+    assert "cloudflare" in audit.details
+
+
+def test_dns_change_plan_apply_blocks_provider_value_placeholders(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan(proposed_value="v=DKIM1; p=<provider-public-key>")
+
+    with patch(
+        "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+        new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={"plan_id": plan["plan_id"], "provider": "cloudflare"},
+        )
+
+    assert response.status_code == 422
+    assert "provider-specific value" in response.json()["detail"]
 
 
 def test_cloudflare_discover_denies_user_without_workspace_membership(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -360,7 +360,7 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: Tes
     assert change_plan["manual_steps"]
 
 
-def test_dns_change_plan_endpoint_returns_read_only_plans(authed_client: TestClient):
+def test_dns_change_plan_endpoint_returns_apply_gated_plans(authed_client: TestClient):
     result = DomainDNSResult(
         dmarc=False,
         spf=False,
@@ -386,9 +386,9 @@ def test_dns_change_plan_endpoint_returns_read_only_plans(authed_client: TestCli
     assert response.status_code == 200
     data = response.json()
     assert data["domain"] == DOMAIN
-    assert data["read_only"] is True
-    assert data["provider_write_available"] is False
-    assert data["apply_endpoint"] is None
+    assert data["read_only"] is False
+    assert data["provider_write_available"] is True
+    assert data["apply_endpoint"].endswith("/dns/change-plan/apply")
     plan = next(plan for plan in data["plans"] if plan["finding_code"] == "dmarc_missing")
     assert plan["operation"] == "create"
     assert plan["proposed_value"].startswith("v=DMARC1")

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -580,12 +580,15 @@ async def test_cloudflare_provider_lists_zones_from_rest_api():
     mock_response.raise_for_status = MagicMock()
     mock_response.json = lambda: responses.pop(0)
 
-    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)) as mock_get:
+    with patch(
+        "httpx.AsyncClient.request", new=AsyncMock(return_value=mock_response)
+    ) as mock_request:
         provider = CloudflareDNSProvider(api_token="token")
         zones = await provider.list_zones()
 
     assert [zone["name"] for zone in zones] == ["example.com", "example.net"]
-    assert mock_get.await_count == 2
+    assert mock_request.await_count == 2
+    assert mock_request.await_args_list[0].args[0] == "GET"
 
 
 @pytest.mark.asyncio
@@ -602,13 +605,16 @@ async def test_cloudflare_provider_lists_dns_records_from_rest_api():
     mock_response.raise_for_status = MagicMock()
     mock_response.json = lambda: fake_response_data
 
-    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)) as mock_get:
+    with patch(
+        "httpx.AsyncClient.request", new=AsyncMock(return_value=mock_response)
+    ) as mock_request:
         provider = CloudflareDNSProvider(api_token="token", zone_id="zone-1")
         records = await provider.list_dns_records(record_type="TXT")
 
     assert records == fake_response_data["result"]
-    _, kwargs = mock_get.await_args
-    assert "/zones/zone-1/dns_records" in str(mock_get.await_args.args[0])
+    _, url = mock_request.await_args.args
+    _, kwargs = mock_request.await_args
+    assert "/zones/zone-1/dns_records" in str(url)
     assert kwargs["params"]["type"] == "TXT"
 
 
@@ -625,7 +631,7 @@ async def test_cloudflare_provider_raises_when_rest_api_reports_error():
     mock_response.raise_for_status = MagicMock()
     mock_response.json = lambda: fake_response_data
 
-    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+    with patch("httpx.AsyncClient.request", new=AsyncMock(return_value=mock_response)):
         provider = CloudflareDNSProvider(api_token="token")
         with pytest.raises(LookupError, match="invalid token"):
             await provider.list_zones()

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -619,6 +619,49 @@ async def test_cloudflare_provider_lists_dns_records_from_rest_api():
 
 
 @pytest.mark.asyncio
+async def test_cloudflare_provider_creates_updates_and_deletes_dns_records():
+    from unittest.mock import MagicMock
+
+    responses = [
+        {"success": True, "result": {"id": "created", "type": "TXT"}},
+        {"success": True, "result": {"id": "record-1", "type": "TXT"}},
+        {"success": True, "result": {"id": "record-1"}},
+    ]
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = lambda: responses.pop(0)
+
+    with patch(
+        "httpx.AsyncClient.request", new=AsyncMock(return_value=mock_response)
+    ) as mock_request:
+        provider = CloudflareDNSProvider(api_token="token")
+        created = await provider.create_dns_record(
+            zone_id="zone-1",
+            record_type="TXT",
+            name="_dmarc.example.com",
+            content="v=DMARC1; p=none",
+            ttl=120,
+        )
+        updated = await provider.update_dns_record(
+            zone_id="zone-1",
+            record_id="record-1",
+            record_type="TXT",
+            name="_dmarc.example.com",
+            content="v=DMARC1; p=reject",
+            ttl=300,
+        )
+        deleted = await provider.delete_dns_record(zone_id="zone-1", record_id="record-1")
+
+    assert created["id"] == "created"
+    assert updated["id"] == "record-1"
+    assert deleted["id"] == "record-1"
+    assert [call.args[0] for call in mock_request.await_args_list] == ["POST", "PATCH", "DELETE"]
+    assert mock_request.await_args_list[0].kwargs["json"]["ttl"] == 120
+    assert mock_request.await_args_list[1].kwargs["json"]["content"] == "v=DMARC1; p=reject"
+
+
+@pytest.mark.asyncio
 async def test_cloudflare_provider_raises_when_rest_api_reports_error():
     from unittest.mock import MagicMock
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,6 +22,7 @@ python-dotenv>=1.0.0
 tenacity>=8.2.2
 apprise>=1.4.5
 dnspython>=2.3.0
+dns-lexicon>=3.25.2
 email-validator>=2.0.0
 lxml>=4.9.2
 zipfile36>=0.1.3

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -146,7 +146,7 @@ operational policy if long-term storage size matters.
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `CLOUDFLARE_API_TOKEN` | Cloudflare API token for read-only zone discovery and DNS inspection | - | `your_cloudflare_api_token` |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API token for zone discovery, DNS inspection, and optional approved DNS writes | - | `your_cloudflare_api_token` |
 | `CLOUDFLARE_ZONE_ID` | Optional default Cloudflare Zone ID | - | `your_cloudflare_zone_id` |
 | `WEBHOOK_SECRET` | Required secret for inbound email worker webhooks | - | `openssl rand -hex 32` |
 
@@ -154,12 +154,23 @@ Cloudflare credentials can also be stored from **Settings**. The API token is
 encrypted in the settings table and redacted when settings are read back. Leave
 the Zone ID blank to discover every active zone visible to the token.
 
-The read-only integration exposes:
+The integration exposes:
 
 - `GET /api/v1/domains/cloudflare/discover` to list available zones.
 - `POST /api/v1/domains/cloudflare/import` to create monitored domain rows from zones.
 - `GET /api/v1/domains/{domain}/dns/cloudflare` to inspect managed DNS records, return DMARC/SPF/DKIM suggestions, and record detected DNS changes.
 - `GET /api/v1/domains/{domain}/dns/history` to review DNS record additions, modifications, and removals.
+- `GET /api/v1/domains/dns/providers` to list native and Lexicon-backed DNS write providers.
+- `POST /api/v1/domains/{domain}/dns/change-plan/apply` to dry-run or explicitly apply one safe DNS change plan.
+
+Provider writes are opt-in at action time. Requests default to dry-run, and real
+writes require `confirm=true` plus `dry_run=false`. Public demo mode rejects
+provider writes even if credentials are configured.
+
+Cloudflare is implemented natively. Additional API-backed providers use
+DNS-Lexicon where the provider is available in the runtime and its credentials
+are supplied through Lexicon-compatible environment/configuration. Some
+providers require provider-specific Python extras in a custom image.
 
 ### DNS Result Cache
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -35,8 +35,8 @@ The roadmap must continue to honor the public DMARQ promise:
 - Keep self-hosted deployment first-class through Docker and documented
   production operation.
 - Keep Cloudflare and DNS integrations read-only by default: discover, analyze,
-  suggest, and track changes. Any future write automation must be opt-in,
-  previewed, permission-scoped, and audited.
+  suggest, and track changes. DNS write automation must be opt-in per action,
+  previewed, permission-scoped, explicitly confirmed, and audited.
 - Preserve privacy boundaries. Self-hosted deployments do not require a third
   party to see reports. Hosted and ISP modes must state clearly who operates the
   service and must enforce tenant isolation, audit logs, retention controls, and

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -415,6 +415,8 @@ queried DNS name, record text, logo URL, certificate URL, warnings, and errors.
 ```
 GET /domains/{domain_id}/dns/lint
 GET /domains/{domain_id}/dns/change-plan
+POST /domains/{domain_id}/dns/change-plan/apply
+GET /domains/dns/providers
 GET /domains/dns/lint
 GET /domains/dns/lint/export
 ```
@@ -426,12 +428,19 @@ broken CNAME targets, short RSA keys, and stale selectors. The bulk endpoint
 returns the same payload shape per monitored domain, and the export endpoint
 returns the finding list as CSV for managed-domain reviews.
 
-The single-domain lint payload also includes read-only `change_plans`. The
-dedicated `/dns/change-plan` endpoint returns the same operator-facing plans
-with proposed DNS records, captured current values, risk notes, rollback notes,
-expected health impact, and manual approval flags. DMARQ does not expose an
-apply endpoint in the default product path; provider write automation is a
-separate opt-in integration concern.
+The single-domain lint payload also includes `change_plans`. The dedicated
+`/dns/change-plan` endpoint returns the same operator-facing plans with
+proposed DNS records, captured current values, risk notes, rollback notes,
+expected health impact, and manual approval flags.
+
+`GET /domains/dns/providers` returns native and Lexicon-backed provider
+capabilities. `POST /domains/{domain_id}/dns/change-plan/apply` accepts
+`plan_id`, `provider`, `dry_run`, `confirm`, optional `value`, and `ttl`. Calls
+default to dry-run. Real writes require `dry_run=false` and `confirm=true`, are
+blocked in demo mode, and are limited to safe TXT/CNAME create/update plans
+that already have a concrete value. Applied changes are written to the
+workspace audit log and refresh provider-backed DNS change history where the
+provider supports it.
 
 #### Get Posture Dashboard
 

--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -70,7 +70,7 @@ Live DNS checks parse DMARC policy records according to RFC 9989:
 - Subdomain checks fall back to the bounded RFC 9989 DNS Tree Walk, including `psd=n` and `psd=y` stop conditions.
 - Records with a valid aggregate reporting URI but no valid `p` tag are treated as monitoring mode for policy extraction.
 - External `rua` and `ruf` destinations are linted for the required DNS authorization TXT record at `<policy-domain>._report._dmarc.<destination-domain>`.
-- Typed DNS guidance endpoints expose stable finding codes and target records for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI readiness without applying DNS changes automatically.
+- Typed DNS guidance endpoints expose stable finding codes and target records for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI readiness. Provider writes are never automatic; safe TXT/CNAME changes require an explicit apply request.
 
 ## Preserved Metadata
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -93,11 +93,18 @@ Optional AI remediation plans can turn the same redacted DNS/report context
 into a longer step-by-step plan through LiteLLM/OpenAI-compatible providers;
 demo mode keeps these plans template-backed and heavily cached.
 
-The same section also shows a read-only proposed DNS change plan when findings
-are actionable. These plans include the record name, type, proposed value,
-captured current values when available, risk notes, rollback guidance, and
-expected health impact. They are copy/paste aids for an operator; DMARQ does
-not apply DNS changes automatically.
+The same section also shows a proposed DNS change plan when findings are
+actionable. These plans include the record name, type, proposed value, captured
+current values when available, risk notes, rollback guidance, and expected
+health impact. Operators can copy/paste the records manually, preview a
+provider mutation, or apply safe TXT/CNAME changes through a configured DNS
+provider after explicit browser confirmation.
+
+Automatic apply is intentionally limited. DMARQ only applies plans that already
+contain a concrete DNS value and a low-risk operation such as create or update.
+Plans that require provider-specific values, DKIM rotation, record
+consolidation, or stale-selector removal remain manual until an operator
+chooses the exact value and timing.
 
 ### MTA-STS Posture
 

--- a/docs/user_guide/settings.md
+++ b/docs/user_guide/settings.md
@@ -135,10 +135,16 @@ If you use Cloudflare for DNS management:
 3. Use **Discover** to list zones visible to the token.
 4. Use **Import New** to create monitored domain rows for discovered zones that are not already tracked.
 
-The token only needs read access for zone and DNS record inspection. DMARQ uses
-it to fetch managed DNS records, detect missing or malformed DMARC/SPF/DKIM
-entries, and record DNS additions, modifications, or removals over time. DMARQ
-does not automatically change Cloudflare DNS records.
+For inspection only, the token needs zone and DNS read access. To apply DNS
+change plans from a domain detail page, the token also needs Cloudflare DNS
+write permission for the affected zone. DMARQ uses the token to fetch managed
+DNS records, detect missing or malformed DMARC/SPF/DKIM entries, record DNS
+additions, modifications, or removals over time, and apply explicitly approved
+TXT/CNAME remediation plans.
+
+DMARQ never performs background DNS edits. A write-capable token only enables
+operator-approved actions from the DNS change plan UI, and each applied change
+is recorded in the workspace audit log.
 
 ### Other Integrations
 


### PR DESCRIPTION
## Summary
- add an approved DNS provider write service for DMARQ change plans, with native Cloudflare create/update support and a Lexicon-backed provider adapter path
- add provider capability and dry-run/apply APIs, demo-mode write blocking, explicit confirmation requirements, audit logging, and DNS change-history refresh after Cloudflare writes
- add domain-detail UI controls to preview/apply safe TXT/CNAME plans and update docs to reflect the self-hosted single-user demo plus explicit-approval DNS write model

## Scope boundaries
- Cloudflare is the native write provider in this PR
- Lexicon-backed providers are exposed as the modular path for API-backed DNS providers, using provider-specific runtime credentials/configuration
- automatic writes are limited to concrete TXT/CNAME create/update plans; DKIM rotations, consolidation, stale-selector removal, and placeholder provider values remain manual
- PDF evidence reports, ARC/ARF, and the admin/provider demo are intentionally deferred

## Validation
- node --check extracted domain detail script
- git diff --check
- black --check on changed Python files
- isort --check-only on changed Python files
- flake8 on changed Python files
- pylint backend/app/services/dns_provider_writes.py
- .venv/bin/python -m pytest backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_dashboard_template_security.py -q
- .venv/bin/python -m pytest backend/app/tests -q (1220 passed)

Closes part of #314.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-aware DNS change plans with preview and approved apply actions for safe TXT/CNAME updates.
  * Added support for listing DNS providers and applying changes through a guided confirmation flow.
  * Enabled native Cloudflare writes and Lexicon-backed provider support.

* **Bug Fixes**
  * Improved DNS change handling, including safer validation, clearer errors, and audit logging for applied actions.

* **Documentation**
  * Updated product, API, deployment, and user guides to reflect the new DNS remediation workflow and approval requirements.

* **Tests**
  * Expanded coverage for provider capabilities, apply flows, and DNS record write behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->