### PR TITLE
[codex] Fix DNS provider write follow-ups

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2034,11 +2034,12 @@ async def apply_domain_dns_change_plan(
 
     guidance = await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
     plan = _find_dns_change_plan(guidance, payload.plan_id)
+    resolved_domain = guidance["domain"]
     try:
         if payload.dry_run or not payload.confirm:
             result = await preview_dns_write(
                 db,
-                domain=domain_id,
+                domain=resolved_domain,
                 plan=plan,
                 provider_id=payload.provider,
                 value_override=payload.value,
@@ -2049,7 +2050,7 @@ async def apply_domain_dns_change_plan(
         result = await apply_dns_write(
             db,
             workspace=workspace,
-            domain=domain_id,
+            domain=resolved_domain,
             plan=plan,
             provider_id=payload.provider,
             value_override=payload.value,

--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -388,12 +388,16 @@ class LexiconDNSWriteProvider:
                 provider_result={"status": "unchanged"},
             )
         provider_result = await asyncio.to_thread(self._apply_record, domain, mutation)
+        if not provider_result:
+            raise DNSProviderWriteError(
+                f"Lexicon provider '{self.provider_id}' did not apply the DNS mutation"
+            )
         return DNSWriteResult(
             provider=self.provider_id,
             dry_run=False,
             applied=True,
             mutation=mutation,
-            provider_result={"ok": bool(provider_result)},
+            provider_result={"ok": True},
         )
 
     def _client_config(self, domain: str):
@@ -431,6 +435,7 @@ class LexiconDNSWriteProvider:
                         mutation.record_type,
                         mutation.name,
                         mutation.content,
+                        ttl=mutation.ttl,
                     )
                 )
             if mutation.operation == "update":
@@ -440,6 +445,7 @@ class LexiconDNSWriteProvider:
                         mutation.record_type,
                         mutation.name,
                         mutation.content,
+                        ttl=mutation.ttl,
                     )
                 )
         raise DNSProviderWriteError(f"Unsupported Lexicon operation: {mutation.operation}")
@@ -494,6 +500,8 @@ async def apply_dns_write(
     """Apply one provider-backed DNS mutation after validation."""
     if get_settings().DEMO_MODE:
         raise DNSProviderWriteError("Provider DNS writes are disabled in demo mode")
+    if workspace.id is None:
+        raise DNSProviderWriteError("Workspace must be persisted before applying DNS changes")
     provider = build_dns_write_provider(provider_id)
     mutation = await provider.prepare_mutation(
         db,
@@ -504,6 +512,4 @@ async def apply_dns_write(
     )
     result = await provider.apply_mutation(db, domain=domain, mutation=mutation)
     db.flush()
-    if workspace.id is None:
-        raise DNSProviderWriteError("Workspace must be persisted before applying DNS changes")
     return result

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1,6 +1,7 @@
 """Tests for Cloudflare DNS discovery, analysis, and change tracking."""
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -836,7 +837,7 @@ def test_dns_change_plan_apply_updates_cloudflare_and_audits(
     assert db_session.query(DNSRecordChange).count() == 1
     audit = db_session.query(WorkspaceAuditLog).one()
     assert audit.action == "domain.dns_change_applied"
-    assert audit.details["provider"] == "cloudflare"
+    assert json.loads(audit.details)["provider"] == "cloudflare"
 
 
 def test_dns_change_plan_apply_blocks_provider_value_placeholders(

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -674,6 +674,31 @@ def test_dns_change_plan_apply_dry_run_returns_cloudflare_mutation(
     assert data["mutation"]["content"] == plan["proposed_value"]
 
 
+def test_dns_change_plan_apply_uses_resolved_domain_for_provider_calls(
+    authed_client: TestClient,
+    db_session,
+):
+    plan = _dns_plan()
+    records = [_record("spf", "TXT", DOMAIN, "v=spf1 -all")]
+    zone_lookup = AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": records})
+
+    with (
+        patch("app.api.api_v1.endpoints.domains._domain_exists", return_value=True),
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch("app.services.dns_provider_writes.get_zone_for_domain", new=zone_lookup),
+    ):
+        response = authed_client.post(
+            "/api/v1/domains/domain-row-id/dns/change-plan/apply",
+            json={"plan_id": plan["plan_id"], "provider": "cloudflare"},
+        )
+
+    assert response.status_code == 200
+    zone_lookup.assert_awaited_once_with(db_session, DOMAIN)
+
+
 def test_dns_change_plan_apply_dry_run_returns_noop_for_unchanged_cloudflare_record(
     authed_client: TestClient,
     db_session,
@@ -811,7 +836,7 @@ def test_dns_change_plan_apply_updates_cloudflare_and_audits(
     assert db_session.query(DNSRecordChange).count() == 1
     audit = db_session.query(WorkspaceAuditLog).one()
     assert audit.action == "domain.dns_change_applied"
-    assert "cloudflare" in audit.details
+    assert audit.details["provider"] == "cloudflare"
 
 
 def test_dns_change_plan_apply_blocks_provider_value_placeholders(
@@ -857,6 +882,31 @@ def test_apply_dns_write_rejects_demo_mode(db_session):
             assert "disabled in demo mode" in str(exc)
         else:
             raise AssertionError("Expected demo mode DNS write block")
+
+
+def test_apply_dns_write_rejects_unpersisted_workspace_before_provider_call(db_session):
+    workspace = Workspace(slug="pending", name="Pending")
+    plan = _dns_plan()
+
+    class NonDemoSettings:
+        DEMO_MODE = False
+
+    with (
+        patch("app.services.dns_provider_writes.get_settings", return_value=NonDemoSettings()),
+        patch("app.services.dns_provider_writes.build_dns_write_provider") as build_provider,
+    ):
+        with pytest.raises(DNSProviderWriteError, match="Workspace must be persisted"):
+            asyncio.run(
+                dns_provider_writes.apply_dns_write(
+                    db_session,
+                    workspace=workspace,
+                    domain=DOMAIN,
+                    plan=plan,
+                    provider_id="cloudflare",
+                )
+            )
+
+    build_provider.assert_not_called()
 
 
 def test_cloudflare_write_provider_requires_zone_id_for_apply(db_session):
@@ -998,6 +1048,27 @@ def test_lexicon_write_provider_prepares_update_and_applies_record(db_session):
     assert mutation.current_values == ["v=DMARC1; p=none"]
     assert result.applied is True
     assert result.provider_result == {"ok": True}
+
+
+def test_lexicon_write_provider_rejects_failed_apply(db_session):
+    provider = LexiconDNSWriteProvider("route53")
+    provider._list_records = (
+        lambda domain, record_type, record_name: []
+    )  # pylint: disable=protected-access
+    provider._apply_record = lambda domain, mutation: False  # pylint: disable=protected-access
+
+    with patch("app.services.dns_provider_writes.lexicon_runtime_available", return_value=True):
+        mutation = asyncio.run(
+            provider.prepare_mutation(
+                db_session,
+                domain=DOMAIN,
+                plan=_dns_plan(),
+                value_override=None,
+                ttl=300,
+            )
+        )
+        with pytest.raises(DNSProviderWriteError, match="did not apply"):
+            asyncio.run(provider.apply_mutation(db_session, domain=DOMAIN, mutation=mutation))
 
 
 def test_lexicon_write_provider_prepares_noop_for_matching_record(db_session):

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -154,14 +154,16 @@ Cloudflare credentials can also be stored from **Settings**. The API token is
 encrypted in the settings table and redacted when settings are read back. Leave
 the Zone ID blank to discover every active zone visible to the token.
 
-The integration exposes:
+The integration exposes these operational routes:
 
-- `GET /api/v1/domains/cloudflare/discover` to list available zones.
-- `POST /api/v1/domains/cloudflare/import` to create monitored domain rows from zones.
-- `GET /api/v1/domains/{domain}/dns/cloudflare` to inspect managed DNS records, return DMARC/SPF/DKIM suggestions, and record detected DNS changes.
-- `GET /api/v1/domains/{domain}/dns/history` to review DNS record additions, modifications, and removals.
-- `GET /api/v1/domains/dns/providers` to list native and Lexicon-backed DNS write providers.
-- `POST /api/v1/domains/{domain}/dns/change-plan/apply` to dry-run or explicitly apply one safe DNS change plan.
+| Route | Purpose |
+| --- | --- |
+| `GET /api/v1/domains/cloudflare/discover` | List available zones. |
+| `POST /api/v1/domains/cloudflare/import` | Create monitored domain rows from zones. |
+| `GET /api/v1/domains/{domain}/dns/cloudflare` | Inspect managed DNS records, return DMARC/SPF/DKIM suggestions, and record detected DNS changes. |
+| `GET /api/v1/domains/{domain}/dns/history` | Review DNS record additions, modifications, and removals. |
+| `GET /api/v1/domains/dns/providers` | List native and Lexicon-backed DNS write providers. |
+| `POST /api/v1/domains/{domain}/dns/change-plan/apply` | Dry-run or explicitly apply one safe DNS change plan. |
 
 Provider writes are opt-in at action time. Requests default to dry-run, and real
 writes require `confirm=true` plus `dry_run=false`. Public demo mode rejects


### PR DESCRIPTION
## Summary
- use the resolved domain name for DNS write preview/apply calls
- fail Lexicon writes when the provider reports no mutation, pass TTL through Lexicon operations, and validate workspace persistence before external writes
- tighten tests for provider calls, audit details, preflight validation, and Lexicon failures; rework Cloudflare route docs into a table

## Validation
- .venv/bin/python -m black backend/app/api/api_v1/endpoints/domains.py backend/app/services/dns_provider_writes.py backend/app/tests/test_cloudflare_dns.py --check
- .venv/bin/python -m isort backend/app/api/api_v1/endpoints/domains.py backend/app/services/dns_provider_writes.py backend/app/tests/test_cloudflare_dns.py --check-only
- .venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/services/dns_provider_writes.py backend/app/tests/test_cloudflare_dns.py
- .venv/bin/python -m py_compile backend/app/api/api_v1/endpoints/domains.py backend/app/services/dns_provider_writes.py backend/app/tests/test_cloudflare_dns.py
- git diff --check

Follow-up to #344 CodeRabbit review comments.
