### PR TITLE
[codex] Add backfill cursor checkpoints

### DIFF
--- a/backend/alembic/versions/c1d2e3f4a5b6_expand_backfill_cursor_checkpoints.py
+++ b/backend/alembic/versions/c1d2e3f4a5b6_expand_backfill_cursor_checkpoints.py
@@ -1,0 +1,37 @@
+"""expand backfill cursor checkpoints
+
+Revision ID: c1d2e3f4a5b6
+Revises: b1c2d3e4f5a6
+Create Date: 2026-06-29 19:45:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c1d2e3f4a5b6"
+down_revision = "b1c2d3e4f5a6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Allow provider cursor checkpoints to store opaque page tokens safely."""
+    with op.batch_alter_table("mail_source_backfill_jobs") as batch_op:
+        batch_op.alter_column(
+            "cursor",
+            existing_type=sa.String(length=255),
+            type_=sa.Text(),
+            existing_nullable=True,
+        )
+
+
+def downgrade() -> None:
+    """Restore the original short cursor column."""
+    with op.batch_alter_table("mail_source_backfill_jobs") as batch_op:
+        batch_op.alter_column(
+            "cursor",
+            existing_type=sa.Text(),
+            type_=sa.String(length=255),
+            existing_nullable=True,
+        )

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -207,6 +207,7 @@ class MailSourceBackfillResponse(BaseModel):
     attempt_count: int
     max_attempts: int
     cursor: Optional[str] = None
+    cursor_checkpoint: Optional[Dict[str, Any]] = None
     requested_window_days: Optional[int] = None
     elapsed_seconds: Optional[int] = None
     progress_percent: int
@@ -585,6 +586,28 @@ def _backfill_elapsed_seconds(
     return max(0, int((end - start).total_seconds()))
 
 
+def _backfill_cursor_checkpoint(cursor: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Decode a structured backfill cursor while preserving legacy cursor visibility."""
+    if not cursor:
+        return None
+    try:
+        payload = json.loads(cursor)
+    except (TypeError, ValueError):
+        parts: Dict[str, Any] = {"version": 0, "raw": cursor}
+        if ":" in cursor:
+            connector, rest = cursor.split(":", 1)
+            parts["connector"] = connector
+            for segment in rest.split(";"):
+                if "=" not in segment:
+                    continue
+                key, value = segment.split("=", 1)
+                parts[key] = int(value) if value.isdigit() else value
+        return parts
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
 def _backfill_progress_percent(status_value: str, processed: int) -> int:
     if status_value == "completed":
         return 100
@@ -686,6 +709,7 @@ def _backfill_to_response(row: MailSourceBackfillJob) -> MailSourceBackfillRespo
         attempt_count=row.attempt_count,
         max_attempts=row.max_attempts,
     )
+    cursor_checkpoint = _backfill_cursor_checkpoint(row.cursor)
     return MailSourceBackfillResponse(
         id=row.id,
         workspace_id=row.workspace_id,
@@ -702,6 +726,7 @@ def _backfill_to_response(row: MailSourceBackfillJob) -> MailSourceBackfillRespo
         attempt_count=row.attempt_count,
         max_attempts=row.max_attempts,
         cursor=row.cursor,
+        cursor_checkpoint=cursor_checkpoint,
         **metadata,
         errors=_decode_json_list(row.errors),
         details=_decode_json_details(row.details),

--- a/backend/app/models/mail_source_backfill.py
+++ b/backend/app/models/mail_source_backfill.py
@@ -37,7 +37,7 @@ class MailSourceBackfillJob(Base):
     attempt_count = Column(Integer, nullable=False, default=0)
     max_attempts = Column(Integer, nullable=False, default=3)
 
-    cursor = Column(String(length=255), nullable=True)
+    cursor = Column(Text, nullable=True)
     errors = Column(Text, nullable=True)
     details = Column(Text, nullable=True)
 

--- a/backend/app/services/mail_source_backfill_worker.py
+++ b/backend/app/services/mail_source_backfill_worker.py
@@ -63,6 +63,34 @@ def _copy_result_counts(job: MailSourceBackfillJob, results: Dict[str, Any]) -> 
     job.error_count = len(results.get("errors") or [])
 
 
+def _cursor_checkpoint(
+    *,
+    connector: str,
+    state: str,
+    days: int,
+    results: Optional[Dict[str, Any]] = None,
+    page_cursor: Optional[str] = None,
+) -> str:
+    """Return a stable, provider-agnostic cursor checkpoint for one backfill job."""
+    stats = results or {}
+    checkpoint: Dict[str, Any] = {
+        "version": 1,
+        "connector": connector,
+        "state": state,
+        "window_days": days,
+        "processed": int(stats.get("processed", 0) or 0),
+        "reports_found": int(stats.get("reports_found", 0) or 0),
+        "duplicate_reports": int(stats.get("duplicate_reports", 0) or 0),
+        "error_count": len(stats.get("errors") or []),
+    }
+    search_window_days = stats.get("search_window_days")
+    if search_window_days is not None:
+        checkpoint["search_window_days"] = int(search_window_days)
+    if page_cursor:
+        checkpoint["page_cursor"] = redact_sensitive_text(page_cursor)
+    return json.dumps(checkpoint, sort_keys=True, separators=(",", ":"))
+
+
 def _claim_job(job: MailSourceBackfillJob, now: datetime) -> None:
     job.status = "running"
     job.started_at = now
@@ -96,7 +124,12 @@ def _mark_success(
 ) -> None:
     _copy_result_counts(job, results)
     job.status = "completed"
-    job.cursor = f"{cursor_prefix}:days={days};processed={job.processed}"
+    job.cursor = _cursor_checkpoint(
+        connector=cursor_prefix,
+        state="completed",
+        days=days,
+        results=results,
+    )
     job.errors = errors
     job.details = details
     job.finished_at = now
@@ -112,6 +145,8 @@ def _mark_failure(
     results: Optional[Dict[str, Any]] = None,
     errors: Optional[str] = None,
     details: Optional[str] = None,
+    days: Optional[int] = None,
+    cursor_prefix: Optional[str] = None,
 ) -> None:
     if results:
         _copy_result_counts(job, results)
@@ -128,6 +163,13 @@ def _mark_failure(
         job.status = "backoff"
         job.finished_at = None
         job.next_retry_at = now + _retry_delay(int(job.attempt_count or 1))
+    if cursor_prefix and days is not None:
+        job.cursor = _cursor_checkpoint(
+            connector=cursor_prefix,
+            state=job.status,
+            days=days,
+            results=results,
+        )
     job.updated_at = now
 
 
@@ -182,6 +224,8 @@ def run_imap_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
                 results=results,
                 errors=attempt.errors,
                 details=attempt.details,
+                days=days,
+                cursor_prefix="imap",
             )
         db.commit()
         return True
@@ -211,6 +255,8 @@ def run_imap_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
             results=results,
             errors=attempt.errors,
             details=attempt.details,
+            days=days,
+            cursor_prefix="imap",
         )
         db.commit()
         return True
@@ -350,6 +396,8 @@ def _finish_backfill_from_results(
             results=results,
             errors=errors,
             details=details,
+            days=days,
+            cursor_prefix=cursor_prefix,
         )
 
 
@@ -411,6 +459,8 @@ def run_gmail_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
             results=results,
             errors=attempt.errors,
             details=attempt.details,
+            days=days,
+            cursor_prefix="gmail",
         )
         db.commit()
         return True
@@ -462,6 +512,8 @@ def run_m365_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
             results=results,
             errors=attempt.errors,
             details=attempt.details,
+            days=days,
+            cursor_prefix="m365",
         )
         db.commit()
         return True

--- a/backend/app/tests/test_mail_source_backfill_worker.py
+++ b/backend/app/tests/test_mail_source_backfill_worker.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta, timezone
 
 from app.models.mail_source import MailSource
@@ -100,7 +101,11 @@ def test_run_due_imap_backfill_completes_job_and_records_import(db_session, monk
     assert row.processed == 12
     assert row.reports_found == 4
     assert row.duplicate_reports == 1
-    assert row.cursor == "imap:days=10;processed=12"
+    cursor = json.loads(row.cursor)
+    assert cursor["connector"] == "imap"
+    assert cursor["state"] == "completed"
+    assert cursor["window_days"] == 10
+    assert cursor["processed"] == 12
     assert row.finished_at is not None
     assert row.next_retry_at is None
     assert source.last_checked is not None
@@ -137,6 +142,7 @@ def test_run_imap_backfill_moves_failed_attempt_to_backoff(db_session, monkeypat
     assert row.status == "backoff"
     assert row.attempt_count == 1
     assert row.error_count == 1
+    assert json.loads(row.cursor)["state"] == "backoff"
     assert row.next_retry_at is not None
     assert row.finished_at is None
 
@@ -230,7 +236,11 @@ def test_run_due_mail_source_backfill_executes_gmail_job(db_session, monkeypatch
     attempt = db_session.query(MailSourceImport).filter_by(mail_source_id=source.id).one()
 
     assert row.status == "completed"
-    assert row.cursor == "gmail:days=10;processed=5"
+    cursor = json.loads(row.cursor)
+    assert cursor["connector"] == "gmail"
+    assert cursor["state"] == "completed"
+    assert cursor["window_days"] == 10
+    assert cursor["processed"] == 5
     assert row.processed == 5
     assert row.reports_found == 3
     assert source.gmail_ingested_ids == "old-id,new-id"
@@ -295,6 +305,7 @@ def test_run_gmail_backfill_provider_failure_moves_to_backoff(db_session, monkey
     assert row.status == "backoff"
     assert row.processed == 2
     assert row.error_count == 1
+    assert json.loads(row.cursor)["connector"] == "gmail"
     assert row.next_retry_at is not None
 
 
@@ -348,7 +359,11 @@ def test_run_due_mail_source_backfill_executes_m365_job(db_session, monkeypatch)
     attempt = db_session.query(MailSourceImport).filter_by(mail_source_id=source.id).one()
 
     assert row.status == "completed"
-    assert row.cursor == "m365:days=10;processed=4"
+    cursor = json.loads(row.cursor)
+    assert cursor["connector"] == "m365"
+    assert cursor["state"] == "completed"
+    assert cursor["window_days"] == 10
+    assert cursor["processed"] == 4
     assert row.processed == 4
     assert row.reports_found == 2
     assert source.m365_ingested_ids == "old-m365-id,new-m365-id"
@@ -413,6 +428,7 @@ def test_run_m365_backfill_provider_failure_moves_to_backoff(db_session, monkeyp
     assert row.status == "backoff"
     assert row.processed == 2
     assert row.error_count == 1
+    assert json.loads(row.cursor)["connector"] == "m365"
     assert row.next_retry_at is not None
 
 

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -926,7 +926,11 @@ class TestMailSourcesAPIAuthed:
         resp = authed_client.get("/api/v1/mail-sources/99999/imports")
         assert resp.status_code == 404
 
-    def test_create_and_list_backfill_job(self, authed_client: TestClient):
+    def test_create_and_list_backfill_job(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
         create_resp = authed_client.post(
             "/api/v1/mail-sources",
             json={"name": "Backfill API", "method": "IMAP"},
@@ -950,6 +954,7 @@ class TestMailSourcesAPIAuthed:
         assert job["requested_start"] == "2026-05-01T00:00:00"
         assert job["requested_end"] == "2026-05-31T23:59:59"
         assert job["max_attempts"] == 4
+        assert job["cursor_checkpoint"] is None
         assert job["errors"] == []
         assert job["details"] == []
         assert job["requested_window_days"] == 31
@@ -968,6 +973,28 @@ class TestMailSourcesAPIAuthed:
         assert get_response.status_code == 200
         assert get_response.json()["id"] == job["id"]
         assert get_response.json()["can_cancel"] is True
+
+        row = db_session.get(MailSourceBackfillJob, job["id"])
+        row.cursor = json.dumps(
+            {
+                "version": 1,
+                "connector": "gmail",
+                "state": "running",
+                "window_days": 31,
+                "processed": 25,
+                "reports_found": 7,
+                "page_cursor": "next-page-token",
+            }
+        )
+        db_session.commit()
+
+        checkpoint_response = authed_client.get(
+            f"/api/v1/mail-sources/{source_id}/backfills/{job['id']}"
+        )
+
+        assert checkpoint_response.status_code == 200
+        assert checkpoint_response.json()["cursor_checkpoint"]["connector"] == "gmail"
+        assert checkpoint_response.json()["cursor_checkpoint"]["page_cursor"] == "next-page-token"
 
     def test_demo_mode_returns_mail_source_backfill_examples(
         self,

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -201,8 +201,12 @@ The Mail Sources UI shows the latest backfill status, processed message counts,
 reports found, duplicates, retry timing, progress percentage, and operator
 controls. Backfill responses also include computed fields for
 `requested_window_days`, `elapsed_seconds`, `status_summary`, `can_cancel`, and
-`can_retry` so clients can show actionable progress without parsing cursors. The
-background scheduler currently executes due IMAP, Gmail, and Microsoft 365
+`can_retry` so clients can show actionable progress without parsing cursors.
+Workers persist structured provider checkpoints in `cursor_checkpoint`; clients
+can inspect that decoded object for connector, window, processed counts, error
+counts, and future provider page cursors while treating the raw `cursor` as
+diagnostic text. The background scheduler currently executes due IMAP, Gmail,
+and Microsoft 365
 backfill jobs in bounded batches and records results in import history with
 trigger `backfill`. In demo mode, DMARQ exposes credential-free synthetic mail
 sources and backfill jobs so the workflow is visible without connecting a real


### PR DESCRIPTION
## Summary\n- add structured JSON cursor checkpoints for mail-source backfill jobs\n- widen the persisted backfill cursor column to text for provider page tokens\n- expose decoded cursor_checkpoint data in backfill API responses while preserving legacy raw cursor visibility\n- document the new response field and update worker/API tests\n\n## Validation\n- .venv/bin/python -m pytest backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_mail_sources.py -q\n- .venv/bin/python -m pytest backend/app/tests -q\n- .venv/bin/python -m black --check backend/app/models/mail_source_backfill.py backend/app/services/mail_source_backfill_worker.py backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_mail_sources.py backend/alembic/versions/c1d2e3f4a5b6_expand_backfill_cursor_checkpoints.py\n- .venv/bin/python -m isort --check-only backend/app/models/mail_source_backfill.py backend/app/services/mail_source_backfill_worker.py backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_mail_sources.py backend/alembic/versions/c1d2e3f4a5b6_expand_backfill_cursor_checkpoints.py\n- .venv/bin/python -m flake8 backend/app/models/mail_source_backfill.py backend/app/services/mail_source_backfill_worker.py backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_mail_sources.py backend/alembic/versions/c1d2e3f4a5b6_expand_backfill_cursor_checkpoints.py\n\nRefs #320