### PR TITLE
[codex] Cover backfill cursor checkpoint edge cases

### DIFF
--- a/backend/app/tests/test_mail_source_backfill_worker.py
+++ b/backend/app/tests/test_mail_source_backfill_worker.py
@@ -241,6 +241,7 @@ def test_run_due_mail_source_backfill_executes_gmail_job(db_session, monkeypatch
     assert cursor["state"] == "completed"
     assert cursor["window_days"] == 10
     assert cursor["processed"] == 5
+    assert cursor["search_window_days"] == 10
     assert row.processed == 5
     assert row.reports_found == 3
     assert source.gmail_ingested_ids == "old-id,new-id"

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -996,6 +996,24 @@ class TestMailSourcesAPIAuthed:
         assert checkpoint_response.json()["cursor_checkpoint"]["connector"] == "gmail"
         assert checkpoint_response.json()["cursor_checkpoint"]["page_cursor"] == "next-page-token"
 
+    def test_backfill_cursor_checkpoint_preserves_legacy_formats(self):
+        legacy = mail_sources_endpoint._backfill_cursor_checkpoint(
+            "imap:days=10;processed=42;state=backoff;ignored"
+        )
+        plain = mail_sources_endpoint._backfill_cursor_checkpoint("legacy-cursor")
+        list_payload = mail_sources_endpoint._backfill_cursor_checkpoint("[1, 2, 3]")
+
+        assert legacy == {
+            "version": 0,
+            "raw": "imap:days=10;processed=42;state=backoff;ignored",
+            "connector": "imap",
+            "days": 10,
+            "processed": 42,
+            "state": "backoff",
+        }
+        assert plain == {"version": 0, "raw": "legacy-cursor"}
+        assert list_payload is None
+
     def test_demo_mode_returns_mail_source_backfill_examples(
         self,
         authed_client: TestClient,


### PR DESCRIPTION
## Summary
- cover legacy/non-dict backfill cursor checkpoint decoding
- assert Gmail backfill cursor metadata includes the reported search window

## Validation
- python3 -m py_compile backend/app/tests/test_mail_sources.py backend/app/tests/test_mail_source_backfill_worker.py
- git diff --check

Note: pytest/black/isort/flake8 were not available in the temporary checkout's Python environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of mail sync checkpoint data for older formats, helping preserve progress more reliably.
  * Added coverage to ensure completed Gmail backfills store the expected sync window details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->