### PR TITLE
[codex] Add provider backfill page resume

### DIFF
--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -605,6 +605,9 @@ def _backfill_cursor_checkpoint(cursor: Optional[str]) -> Optional[Dict[str, Any
         return parts
     if not isinstance(payload, dict):
         return None
+    if isinstance(payload.get("page_cursor"), str) and payload["page_cursor"]:
+        payload = dict(payload)
+        payload["page_cursor"] = "**redacted**"
     return payload
 
 

--- a/backend/app/services/gmail_client.py
+++ b/backend/app/services/gmail_client.py
@@ -206,7 +206,13 @@ class GmailClient:
     # Core fetching logic
     # ------------------------------------------------------------------
 
-    def fetch_reports(self, days: Optional[int] = None) -> Dict[str, Any]:
+    def fetch_reports(
+        self,
+        days: Optional[int] = None,
+        *,
+        page_cursor: Optional[str] = None,
+        max_pages: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """
         Search Gmail for DMARC report emails and ingest any new ones.
 
@@ -230,10 +236,17 @@ class GmailClient:
             return connector_failure_stats(stats, "Failed to initialize Gmail API.", error=exc)
 
         try:
-            message_ids = self._list_dmarc_message_ids(service, days=days)
+            message_ids, next_page_cursor = self._list_dmarc_message_id_page(
+                service,
+                days=days,
+                page_cursor=page_cursor,
+                max_pages=max_pages,
+            )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error("Gmail API: failed to list messages: %s", exc)
             return connector_failure_stats(stats, "Failed to list Gmail messages.", error=exc)
+        if next_page_cursor:
+            stats["page_cursor"] = next_page_cursor
 
         domains_before = set(self.report_store.get_domains())
 
@@ -284,8 +297,22 @@ class GmailClient:
 
     def _list_dmarc_message_ids(self, service, days: Optional[int] = None) -> List[str]:
         """Return all Gmail message IDs matching the DMARC search query."""
+        ids, _next_page_cursor = self._list_dmarc_message_id_page(service, days=days)
+        return ids
+
+    def _list_dmarc_message_id_page(
+        self,
+        service,
+        days: Optional[int] = None,
+        *,
+        page_cursor: Optional[str] = None,
+        max_pages: Optional[int] = None,
+    ) -> tuple[List[str], Optional[str]]:
+        """Return Gmail message IDs and an optional next-page resume cursor."""
         ids: List[str] = []
-        page_token: Optional[str] = None
+        page_token: Optional[str] = page_cursor
+        pages_read = 0
+        page_limit = max(1, int(max_pages)) if max_pages is not None else None
 
         while True:
             kwargs: Dict[str, Any] = {
@@ -306,10 +333,13 @@ class GmailClient:
                 ids.append(msg["id"])
 
             page_token = result.get("nextPageToken")
+            pages_read += 1
+            if page_limit is not None and pages_read >= page_limit:
+                return ids, page_token
             if not page_token:
                 break
 
-        return ids
+        return ids, None
 
     @staticmethod
     def _append_detail(stats: dict, **detail: str) -> None:

--- a/backend/app/services/mail_source_backfill_worker.py
+++ b/backend/app/services/mail_source_backfill_worker.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 RUNNABLE_BACKFILL_STATUSES = ("queued", "backoff")
 SUPPORTED_WORKER_METHODS = ("IMAP", "GMAIL_API", "M365_GRAPH")
 MAX_BACKFILL_DAYS = 365
+PROVIDER_BACKFILL_PAGE_BATCH_LIMIT = 5
 
 
 def _json_error_list(values: Iterable[object]) -> str:
@@ -60,7 +61,38 @@ def _copy_result_counts(job: MailSourceBackfillJob, results: Dict[str, Any]) -> 
     job.processed = int(results.get("processed", 0) or 0)
     job.reports_found = int(results.get("reports_found", 0) or 0)
     job.duplicate_reports = int(results.get("duplicate_reports", 0) or 0)
-    job.error_count = len(results.get("errors") or [])
+    job.error_count = int(results.get("error_count", len(results.get("errors") or [])) or 0)
+
+
+def _combined_result_counts(
+    job: MailSourceBackfillJob,
+    results: Dict[str, Any],
+) -> Dict[str, Any]:
+    combined = dict(results)
+    combined["processed"] = int(job.processed or 0) + int(results.get("processed", 0) or 0)
+    combined["reports_found"] = int(job.reports_found or 0) + int(
+        results.get("reports_found", 0) or 0
+    )
+    combined["duplicate_reports"] = int(job.duplicate_reports or 0) + int(
+        results.get("duplicate_reports", 0) or 0
+    )
+    combined["error_count"] = int(job.error_count or 0) + len(results.get("errors") or [])
+    return combined
+
+
+def _stored_page_cursor(job: MailSourceBackfillJob, connector: str) -> Optional[str]:
+    if not job.cursor:
+        return None
+    try:
+        payload = json.loads(job.cursor)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("version") != 1 or payload.get("connector") != connector:
+        return None
+    cursor = payload.get("page_cursor")
+    return cursor if isinstance(cursor, str) and cursor else None
 
 
 def _cursor_checkpoint(
@@ -81,13 +113,13 @@ def _cursor_checkpoint(
         "processed": int(stats.get("processed", 0) or 0),
         "reports_found": int(stats.get("reports_found", 0) or 0),
         "duplicate_reports": int(stats.get("duplicate_reports", 0) or 0),
-        "error_count": len(stats.get("errors") or []),
+        "error_count": int(stats.get("error_count", len(stats.get("errors") or [])) or 0),
     }
     search_window_days = stats.get("search_window_days")
     if search_window_days is not None:
         checkpoint["search_window_days"] = int(search_window_days)
     if page_cursor:
-        checkpoint["page_cursor"] = redact_sensitive_text(page_cursor)
+        checkpoint["page_cursor"] = page_cursor
     return json.dumps(checkpoint, sort_keys=True, separators=(",", ":"))
 
 
@@ -129,6 +161,7 @@ def _mark_success(
         state="completed",
         days=days,
         results=results,
+        page_cursor=results.get("page_cursor"),
     )
     job.errors = errors
     job.details = details
@@ -169,7 +202,35 @@ def _mark_failure(
             state=job.status,
             days=days,
             results=results,
+            page_cursor=results.get("page_cursor") if results else None,
         )
+    job.updated_at = now
+
+
+def _mark_queued_for_next_page(
+    job: MailSourceBackfillJob,
+    results: Dict[str, Any],
+    *,
+    days: int,
+    cursor_prefix: str,
+    now: datetime,
+    errors: str,
+    details: str,
+    page_cursor: str,
+) -> None:
+    _copy_result_counts(job, results)
+    job.status = "queued"
+    job.cursor = _cursor_checkpoint(
+        connector=cursor_prefix,
+        state="queued",
+        days=days,
+        results=results,
+        page_cursor=page_cursor,
+    )
+    job.errors = errors
+    job.details = details
+    job.finished_at = None
+    job.next_retry_at = None
     job.updated_at = now
 
 
@@ -268,6 +329,7 @@ def _fetch_gmail_backfill_results(
     *,
     started_at: datetime,
     days: int,
+    page_cursor: Optional[str] = None,
 ) -> tuple[Dict[str, Any], Any]:
     if not source.gmail_access_token:
         raise ValueError("Gmail account not yet authorised. Complete OAuth2 flow first.")
@@ -282,7 +344,11 @@ def _fetch_gmail_backfill_results(
         db=db,
         workspace_id=source.workspace_id,
     )
-    results = client.fetch_reports(days=days)
+    results = client.fetch_reports(
+        days=days,
+        page_cursor=page_cursor,
+        max_pages=PROVIDER_BACKFILL_PAGE_BATCH_LIMIT,
+    )
     _sync_gmail_backfill_state(source, client, already, results)
     source.last_checked = datetime.utcnow()
     attempt = record_import_attempt(
@@ -319,6 +385,7 @@ def _fetch_m365_backfill_results(
     *,
     started_at: datetime,
     days: int,
+    page_cursor: Optional[str] = None,
 ) -> tuple[Dict[str, Any], Any]:
     if not source.m365_access_token:
         raise ValueError("Microsoft 365 account not yet authorised. Complete OAuth2 flow first.")
@@ -337,7 +404,11 @@ def _fetch_m365_backfill_results(
         db=db,
         workspace_id=source.workspace_id,
     )
-    results = client.fetch_reports(days=days)
+    results = client.fetch_reports(
+        days=days,
+        page_cursor=page_cursor,
+        max_pages=PROVIDER_BACKFILL_PAGE_BATCH_LIMIT,
+    )
     _sync_m365_backfill_state(source, client, already, results)
     source.last_checked = datetime.utcnow()
     attempt = record_import_attempt(
@@ -378,10 +449,24 @@ def _finish_backfill_from_results(
     details: str,
 ) -> None:
     finished_at = datetime.utcnow()
+    combined_results = _combined_result_counts(job, results)
     if results.get("success"):
+        page_cursor = results.get("page_cursor")
+        if isinstance(page_cursor, str) and page_cursor:
+            _mark_queued_for_next_page(
+                job,
+                combined_results,
+                days=days,
+                cursor_prefix=cursor_prefix,
+                now=finished_at,
+                errors=errors,
+                details=details,
+                page_cursor=page_cursor,
+            )
+            return
         _mark_success(
             job,
-            results,
+            combined_results,
             days=days,
             cursor_prefix=cursor_prefix,
             now=finished_at,
@@ -393,7 +478,7 @@ def _finish_backfill_from_results(
             job,
             results.get("error") or "Backfill failed",
             now=finished_at,
-            results=results,
+            results=combined_results,
             errors=errors,
             details=details,
             days=days,
@@ -425,11 +510,13 @@ def run_gmail_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
     db.commit()
 
     try:
+        page_cursor = _stored_page_cursor(job, "gmail")
         results, attempt = _fetch_gmail_backfill_results(
             db,
             source,
             started_at=started_at,
             days=days,
+            page_cursor=page_cursor,
         )
         _finish_backfill_from_results(
             job,
@@ -478,11 +565,13 @@ def run_m365_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
     db.commit()
 
     try:
+        page_cursor = _stored_page_cursor(job, "m365")
         results, attempt = _fetch_m365_backfill_results(
             db,
             source,
             started_at=started_at,
             days=days,
+            page_cursor=page_cursor,
         )
         _finish_backfill_from_results(
             job,

--- a/backend/app/services/microsoft_graph_client.py
+++ b/backend/app/services/microsoft_graph_client.py
@@ -250,27 +250,49 @@ class MicrosoftGraphClient(MailSourceConnector):
             search_window_days=days,
         )
 
-    def search_messages(self, days: int) -> Iterable[Dict[str, Any]]:
+    def search_messages(
+        self,
+        days: int,
+        *,
+        page_cursor: Optional[str] = None,
+        max_pages: Optional[int] = None,
+    ) -> tuple[List[Dict[str, Any]], Optional[str]]:
         """Return Microsoft Graph messages that look like DMARC reports."""
-        return self._list_dmarc_messages(days=days)
+        return self._list_dmarc_messages(
+            days=days,
+            page_cursor=page_cursor,
+            max_pages=max_pages,
+        )
 
     def iter_attachments(self, message: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
         """Yield Microsoft Graph attachments for one message."""
         message_id = str(message.get("id") or "")
         return self._list_attachments(message_id)
 
-    def fetch_reports(self, days: int = 7) -> Dict[str, Any]:
+    def fetch_reports(
+        self,
+        days: int = 7,
+        *,
+        page_cursor: Optional[str] = None,
+        max_pages: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """Fetch and ingest DMARC report attachments from Microsoft Graph."""
         safe_days = clamp_search_window(days)
         stats = initial_import_stats(self.import_context(days=safe_days))
 
         try:
-            messages = self.search_messages(days=safe_days)
+            messages, next_page_cursor = self.search_messages(
+                days=safe_days,
+                page_cursor=page_cursor,
+                max_pages=max_pages,
+            )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error("Microsoft Graph: failed to list messages: %s", exc)
             return connector_failure_stats(
                 stats, "Failed to list Microsoft Graph messages.", error=exc
             )
+        if next_page_cursor:
+            stats["page_cursor"] = next_page_cursor
 
         domains_before = set(self.report_store.get_domains())
 
@@ -437,16 +459,26 @@ class MicrosoftGraphClient(MailSourceConnector):
             or lower.endswith(".gzip")
         )
 
-    def _list_dmarc_messages(self, days: int) -> List[Dict[str, Any]]:
+    def _list_dmarc_messages(
+        self,
+        days: int,
+        *,
+        page_cursor: Optional[str] = None,
+        max_pages: Optional[int] = None,
+    ) -> tuple[List[Dict[str, Any]], Optional[str]]:
         messages: List[Dict[str, Any]] = []
-        url = self._messages_path()
+        url = page_cursor or self._messages_path()
         cutoff = datetime.utcnow() - timedelta(days=days)
-        params: Optional[Dict[str, Any]] = {
-            "$top": _PAGE_SIZE,
-            "$select": "id,subject,from,hasAttachments,receivedDateTime",
-            "$orderby": "receivedDateTime desc",
-            "$filter": f"receivedDateTime ge {cutoff.strftime('%Y-%m-%dT%H:%M:%SZ')}",
-        }
+        params: Optional[Dict[str, Any]] = None
+        if not page_cursor:
+            params = {
+                "$top": _PAGE_SIZE,
+                "$select": "id,subject,from,hasAttachments,receivedDateTime",
+                "$orderby": "receivedDateTime desc",
+                "$filter": f"receivedDateTime ge {cutoff.strftime('%Y-%m-%dT%H:%M:%SZ')}",
+            }
+        pages_read = 0
+        page_limit = max(1, int(max_pages)) if max_pages is not None else None
 
         while url:
             data = self._request("GET", url, params=params)
@@ -455,8 +487,11 @@ class MicrosoftGraphClient(MailSourceConnector):
                     messages.append(message)
             url = data.get("@odata.nextLink")
             params = None
+            pages_read += 1
+            if page_limit is not None and pages_read >= page_limit:
+                return messages, url
 
-        return messages
+        return messages, None
 
     def _process_message(self, message: Dict[str, Any], stats: Dict[str, Any]) -> int:
         message_id = str(message.get("id") or "")

--- a/backend/app/tests/test_gmail_client.py
+++ b/backend/app/tests/test_gmail_client.py
@@ -340,6 +340,42 @@ class TestListDmarcMessageIds:
         # list() should have been called twice
         assert service.users.return_value.messages.return_value.list.call_count == 2
 
+    def test_returns_resume_cursor_when_page_limit_is_reached(self):
+        client = _make_client()
+        service = MagicMock()
+        execute = service.users.return_value.messages.return_value.list.return_value.execute
+        execute.side_effect = [
+            {"messages": [{"id": "id1"}], "nextPageToken": "page2"},
+            {"messages": [{"id": "id2"}], "nextPageToken": "page3"},
+        ]
+
+        ids, cursor = client._list_dmarc_message_id_page(
+            service,
+            days=30,
+            page_cursor="page1",
+            max_pages=1,
+        )
+
+        assert ids == ["id1"]
+        assert cursor == "page2"
+        service.users.return_value.messages.return_value.list.assert_called_once()
+        kwargs = service.users.return_value.messages.return_value.list.call_args.kwargs
+        assert kwargs["pageToken"] == "page1"
+
+    def test_fetch_reports_exposes_next_page_cursor(self, monkeypatch):
+        client = _make_client()
+        service = MagicMock()
+        service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [],
+            "nextPageToken": "page2",
+        }
+        monkeypatch.setattr(client, "_build_service", lambda: service)
+
+        result = client.fetch_reports(days=30, page_cursor="page1", max_pages=1)
+
+        assert result["success"] is True
+        assert result["page_cursor"] == "page2"
+
     def test_raises_on_http_error(self):
         from googleapiclient.errors import HttpError
 
@@ -767,7 +803,11 @@ class TestFetchReports:
         mock_service = MagicMock()
         with (
             patch.object(client, "_build_service", return_value=mock_service),
-            patch.object(client, "_list_dmarc_message_ids", side_effect=Exception("list error")),
+            patch.object(
+                client,
+                "_list_dmarc_message_id_page",
+                side_effect=Exception("list error"),
+            ),
         ):
             result = client.fetch_reports()
 
@@ -778,7 +818,7 @@ class TestFetchReports:
         mock_service = MagicMock()
         with (
             patch.object(client, "_build_service", return_value=mock_service),
-            patch.object(client, "_list_dmarc_message_ids", return_value=[]),
+            patch.object(client, "_list_dmarc_message_id_page", return_value=([], None)),
         ):
             result = client.fetch_reports()
 
@@ -790,11 +830,20 @@ class TestFetchReports:
         mock_service = MagicMock()
         with (
             patch.object(client, "_build_service", return_value=mock_service),
-            patch.object(client, "_list_dmarc_message_ids", return_value=[]) as list_messages,
+            patch.object(
+                client,
+                "_list_dmarc_message_id_page",
+                return_value=([], None),
+            ) as list_messages,
         ):
             result = client.fetch_reports(days=30)
 
-        list_messages.assert_called_once_with(mock_service, days=30)
+        list_messages.assert_called_once_with(
+            mock_service,
+            days=30,
+            page_cursor=None,
+            max_pages=None,
+        )
         assert result["search_window_days"] == 30
 
     def test_search_query_includes_gmail_newer_than_filter(self):
@@ -808,7 +857,11 @@ class TestFetchReports:
         mock_service = MagicMock()
         with (
             patch.object(client, "_build_service", return_value=mock_service),
-            patch.object(client, "_list_dmarc_message_ids", return_value=["id1", "id2"]),
+            patch.object(
+                client,
+                "_list_dmarc_message_id_page",
+                return_value=(["id1", "id2"], None),
+            ),
             patch.object(client, "_process_message", return_value=0) as mock_proc,
         ):
             result = client.fetch_reports()
@@ -827,7 +880,11 @@ class TestFetchReports:
         mock_service = MagicMock()
         with (
             patch.object(client, "_build_service", return_value=mock_service),
-            patch.object(client, "_list_dmarc_message_ids", return_value=["id1", "id2"]),
+            patch.object(
+                client,
+                "_list_dmarc_message_id_page",
+                return_value=(["id1", "id2"], None),
+            ),
             patch.object(client, "_process_message", return_value=0),
         ):
             result = client.fetch_reports()
@@ -840,7 +897,11 @@ class TestFetchReports:
         mock_service = MagicMock()
         with (
             patch.object(client, "_build_service", return_value=mock_service),
-            patch.object(client, "_list_dmarc_message_ids", return_value=["id1"]),
+            patch.object(
+                client,
+                "_list_dmarc_message_id_page",
+                return_value=(["id1"], None),
+            ),
             patch.object(client, "_process_message", return_value=RETRYABLE_MESSAGE_FAILURE),
         ):
             result = client.fetch_reports()
@@ -872,7 +933,11 @@ class TestFetchReports:
 
         with (
             patch.object(client, "_build_service", return_value=mock_service),
-            patch.object(client, "_list_dmarc_message_ids", return_value=["id1"]),
+            patch.object(
+                client,
+                "_list_dmarc_message_id_page",
+                return_value=(["id1"], None),
+            ),
             patch.object(client, "_process_message", side_effect=_process_side_effect),
         ):
             result = client.fetch_reports()
@@ -901,7 +966,7 @@ class TestFetchReports:
             patch.object(client, "_build_service", return_value=mock_service),
             patch.object(
                 client,
-                "_list_dmarc_message_ids",
+                "_list_dmarc_message_id_page",
                 side_effect=RuntimeError("refresh_token=1//raw-refresh"),
             ),
         ):

--- a/backend/app/tests/test_mail_source_backfill_worker.py
+++ b/backend/app/tests/test_mail_source_backfill_worker.py
@@ -121,7 +121,7 @@ def test_run_imap_backfill_moves_failed_attempt_to_backoff(db_session, monkeypat
         def __init__(self, **_kwargs):
             pass
 
-        def fetch_reports(self, days):
+        def fetch_reports(self, days, **_kwargs):
             return {
                 "success": False,
                 "processed": 2,
@@ -207,8 +207,10 @@ def test_run_due_mail_source_backfill_executes_gmail_job(db_session, monkeypatch
             assert kwargs["already_ingested_ids"] == ["old-id"]
             assert kwargs["workspace_id"] == workspace.id
 
-        def fetch_reports(self, days):
+        def fetch_reports(self, days, **kwargs):
             assert days == 10
+            assert kwargs["page_cursor"] is None
+            assert kwargs["max_pages"] == 5
             return results
 
         def get_refreshed_tokens(self):
@@ -282,7 +284,7 @@ def test_run_gmail_backfill_provider_failure_moves_to_backoff(db_session, monkey
         def __init__(self, **_kwargs):
             pass
 
-        def fetch_reports(self, days):
+        def fetch_reports(self, days, **_kwargs):
             return {
                 "success": False,
                 "processed": 2,
@@ -331,8 +333,10 @@ def test_run_due_mail_source_backfill_executes_m365_job(db_session, monkeypatch)
             assert kwargs["workspace_id"] == workspace.id
             assert kwargs["folder"] == "INBOX/DMARC"
 
-        def fetch_reports(self, days):
+        def fetch_reports(self, days, **kwargs):
             assert days == 10
+            assert kwargs["page_cursor"] is None
+            assert kwargs["max_pages"] == 5
             return results
 
         def get_refreshed_tokens(self):
@@ -405,7 +409,7 @@ def test_run_m365_backfill_provider_failure_moves_to_backoff(db_session, monkeyp
         def __init__(self, **_kwargs):
             pass
 
-        def fetch_reports(self, days):
+        def fetch_reports(self, days, **_kwargs):
             return {
                 "success": False,
                 "processed": 2,
@@ -431,6 +435,159 @@ def test_run_m365_backfill_provider_failure_moves_to_backoff(db_session, monkeyp
     assert row.error_count == 1
     assert json.loads(row.cursor)["connector"] == "m365"
     assert row.next_retry_at is not None
+
+
+def test_gmail_backfill_queues_next_page_cursor(db_session, monkeypatch):
+    workspace, source = _source(db_session, method="GMAIL_API")
+    row = _job(db_session, workspace, source)
+
+    class FakeGmailClient:
+        load_ingested_ids = staticmethod(lambda _value: ["old-id"])
+        dump_ingested_ids = staticmethod(lambda values: ",".join(values))
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def fetch_reports(self, days, **kwargs):
+            assert days == 10
+            assert kwargs["page_cursor"] is None
+            assert kwargs["max_pages"] == 5
+            return {
+                "success": True,
+                "processed": 2,
+                "reports_found": 1,
+                "duplicate_reports": 0,
+                "new_domains": [],
+                "new_ingested_ids": ["gmail-id-1"],
+                "errors": [],
+                "page_cursor": "gmail-next-page",
+            }
+
+        def get_refreshed_tokens(self):
+            return None
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.GmailClient",
+        FakeGmailClient,
+    )
+
+    assert run_gmail_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    db_session.refresh(source)
+    cursor = json.loads(row.cursor)
+    assert row.status == "queued"
+    assert row.finished_at is None
+    assert row.next_retry_at is None
+    assert row.processed == 2
+    assert cursor["state"] == "queued"
+    assert cursor["page_cursor"] == "gmail-next-page"
+    assert source.gmail_ingested_ids == "old-id,gmail-id-1"
+
+
+def test_gmail_backfill_resumes_from_stored_page_cursor(db_session, monkeypatch):
+    workspace, source = _source(db_session, method="GMAIL_API")
+    row = _job(db_session, workspace, source)
+    row.processed = 2
+    row.reports_found = 1
+    row.cursor = json.dumps(
+        {
+            "version": 1,
+            "connector": "gmail",
+            "state": "queued",
+            "window_days": 10,
+            "processed": 2,
+            "reports_found": 1,
+            "duplicate_reports": 0,
+            "error_count": 0,
+            "page_cursor": "gmail-next-page",
+        }
+    )
+    db_session.commit()
+
+    class FakeGmailClient:
+        load_ingested_ids = staticmethod(lambda _value: ["old-id"])
+        dump_ingested_ids = staticmethod(lambda values: ",".join(values))
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def fetch_reports(self, days, **kwargs):
+            assert days == 10
+            assert kwargs["page_cursor"] == "gmail-next-page"
+            assert kwargs["max_pages"] == 5
+            return {
+                "success": True,
+                "processed": 1,
+                "reports_found": 1,
+                "duplicate_reports": 0,
+                "new_domains": [],
+                "new_ingested_ids": ["gmail-id-2"],
+                "errors": [],
+            }
+
+        def get_refreshed_tokens(self):
+            return None
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.GmailClient",
+        FakeGmailClient,
+    )
+
+    assert run_gmail_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    cursor = json.loads(row.cursor)
+    assert row.status == "completed"
+    assert row.processed == 3
+    assert row.reports_found == 2
+    assert cursor["state"] == "completed"
+    assert "page_cursor" not in cursor
+
+
+def test_m365_backfill_queues_next_link_cursor(db_session, monkeypatch):
+    workspace, source = _source(db_session, method="M365_GRAPH")
+    row = _job(db_session, workspace, source)
+
+    class FakeMicrosoftGraphClient:
+        load_ingested_ids = staticmethod(lambda _value: ["old-m365-id"])
+        dump_ingested_ids = staticmethod(lambda values: ",".join(values))
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def fetch_reports(self, days, **kwargs):
+            assert days == 10
+            assert kwargs["page_cursor"] is None
+            assert kwargs["max_pages"] == 5
+            return {
+                "success": True,
+                "processed": 3,
+                "reports_found": 2,
+                "duplicate_reports": 0,
+                "new_domains": [],
+                "new_ingested_ids": ["m365-id-1"],
+                "errors": [],
+                "page_cursor": "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=abc",
+            }
+
+        def get_refreshed_tokens(self):
+            return None
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.MicrosoftGraphClient",
+        FakeMicrosoftGraphClient,
+    )
+
+    assert run_m365_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    cursor = json.loads(row.cursor)
+    assert row.status == "queued"
+    assert row.processed == 3
+    assert cursor["connector"] == "m365"
+    assert cursor["state"] == "queued"
+    assert cursor["page_cursor"].startswith("https://graph.microsoft.com/")
 
 
 def test_run_mail_source_backfill_dispatches_or_skips(db_session, monkeypatch):

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -994,7 +994,7 @@ class TestMailSourcesAPIAuthed:
 
         assert checkpoint_response.status_code == 200
         assert checkpoint_response.json()["cursor_checkpoint"]["connector"] == "gmail"
-        assert checkpoint_response.json()["cursor_checkpoint"]["page_cursor"] == "next-page-token"
+        assert checkpoint_response.json()["cursor_checkpoint"]["page_cursor"] == "**redacted**"
 
     def test_backfill_cursor_checkpoint_preserves_legacy_formats(self):
         legacy = mail_sources_endpoint._backfill_cursor_checkpoint(

--- a/backend/app/tests/test_microsoft_graph_client.py
+++ b/backend/app/tests/test_microsoft_graph_client.py
@@ -281,6 +281,46 @@ class TestMicrosoftGraphFetchReports:
         assert result["search_window_days"] == 30
         assert result["processed"] == 0
 
+    def test_fetch_reports_resumes_from_graph_next_link_and_returns_next_cursor(self, monkeypatch):
+        seen = []
+
+        def fake_request(method, url, headers=None, params=None, timeout=None):
+            seen.append((url, params))
+            assert method == "GET"
+            assert url == "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=page1"
+            assert params is None
+            return httpx.Response(
+                200,
+                json={
+                    "value": [
+                        {
+                            "id": "message-1",
+                            "subject": "DMARC aggregate report",
+                            "from": {"emailAddress": {"address": "reports@example.net"}},
+                            "hasAttachments": True,
+                        }
+                    ],
+                    "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=page2",
+                },
+            )
+
+        monkeypatch.setattr("app.services.microsoft_graph_client.httpx.request", fake_request)
+        client = _make_client()
+        monkeypatch.setattr(client, "_list_attachments", lambda _message_id: [])
+
+        result = client.fetch_reports(
+            days=30,
+            page_cursor="https://graph.microsoft.com/v1.0/me/messages?$skiptoken=page1",
+            max_pages=1,
+        )
+
+        assert result["success"] is True
+        assert result["processed"] == 1
+        assert (
+            result["page_cursor"] == "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=page2"
+        )
+        assert len(seen) == 1
+
     def test_request_retries_graph_throttling(self, monkeypatch):
         responses = [
             httpx.Response(

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -204,9 +204,12 @@ controls. Backfill responses also include computed fields for
 `can_retry` so clients can show actionable progress without parsing cursors.
 Workers persist structured provider checkpoints in `cursor_checkpoint`; clients
 can inspect that decoded object for connector, window, processed counts, error
-counts, and future provider page cursors while treating the raw `cursor` as
-diagnostic text. The background scheduler currently executes due IMAP, Gmail,
-and Microsoft 365
+counts, and provider page-cursor state while treating the raw `cursor` as
+diagnostic text. Gmail API and Microsoft 365 Graph backfills process provider
+message pages in bounded batches and re-queue the same job with the next
+provider cursor when more pages remain. API responses mask `page_cursor` as
+`**redacted**`; only the worker uses the stored raw cursor to resume. The
+background scheduler currently executes due IMAP, Gmail, and Microsoft 365
 backfill jobs in bounded batches and records results in import history with
 trigger `backfill`. In demo mode, DMARQ exposes credential-free synthetic mail
 sources and backfill jobs so the workflow is visible without connecting a real


### PR DESCRIPTION
## Summary
- let Gmail and Microsoft 365 Graph backfills resume from provider page cursors
- re-queue backfill jobs with raw stored cursors when more provider pages remain
- mask page_cursor in API responses while keeping the stored worker cursor usable
- document bounded provider-page backfill behavior

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_gmail_client.py backend/app/tests/test_microsoft_graph_client.py backend/app/tests/test_mail_sources.py -q
- .venv/bin/python -m black --check backend/app/services/gmail_client.py backend/app/services/microsoft_graph_client.py backend/app/services/mail_source_backfill_worker.py backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_gmail_client.py backend/app/tests/test_microsoft_graph_client.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_mail_sources.py
- .venv/bin/python -m isort --check-only backend/app/services/gmail_client.py backend/app/services/microsoft_graph_client.py backend/app/services/mail_source_backfill_worker.py backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_gmail_client.py backend/app/tests/test_microsoft_graph_client.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_mail_sources.py
- .venv/bin/python -m flake8 backend/app/services/gmail_client.py backend/app/services/microsoft_graph_client.py backend/app/services/mail_source_backfill_worker.py backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_gmail_client.py backend/app/tests/test_microsoft_graph_client.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_mail_sources.py
- git diff --check

Closes part of #320.