### PR TITLE
Add workspace health score history

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -42,9 +42,12 @@ from app.services.dns_resolver import (
 )
 from app.services.health_score import build_health_summary, score_domain_health
 from app.services.health_score_snapshots import (
+    aggregate_workspace_health_points,
     build_health_evidence_export_rows,
     build_health_score_history,
+    build_workspace_health_score_history,
     list_health_score_snapshots,
+    list_workspace_health_score_snapshots,
     upsert_health_score_snapshot,
 )
 from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
@@ -429,6 +432,25 @@ class HealthScoreHistoryResponse(BaseModel):
 
     domain: str
     points: List[HealthScoreHistoryPoint]
+    current_score: Optional[int] = None
+    previous_score: Optional[int] = None
+    score_delta: Optional[int] = None
+    current_grade: Optional[str] = None
+    previous_grade: Optional[str] = None
+    top_drivers: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class WorkspaceHealthScoreHistoryPoint(HealthScoreHistoryPoint):
+    """One workspace-level health score history point."""
+
+    domain_count: int
+
+
+class WorkspaceHealthScoreHistoryResponse(BaseModel):
+    """Score history and trend metadata for the selected workspace."""
+
+    scope: str
+    points: List[WorkspaceHealthScoreHistoryPoint]
     current_score: Optional[int] = None
     previous_score: Optional[int] = None
     score_delta: Optional[int] = None
@@ -1415,6 +1437,45 @@ def _demo_history_points(
     return points[-limit:]
 
 
+def _workspace_history_response_from_points(
+    points: List[Dict[str, Any]],
+) -> WorkspaceHealthScoreHistoryResponse:
+    """Build a workspace health history response from serialized points."""
+    current = points[-1] if points else None
+    previous = points[-2] if len(points) > 1 else None
+    return WorkspaceHealthScoreHistoryResponse(
+        scope="workspace",
+        points=points,
+        current_score=current["score"] if current else None,
+        previous_score=previous["score"] if previous else None,
+        score_delta=current["score"] - previous["score"] if current and previous else None,
+        current_grade=current["grade"] if current else None,
+        previous_grade=previous["grade"] if previous else None,
+        top_drivers=current.get("top_actions", []) if current else [],
+    )
+
+
+def _demo_workspace_history_points(
+    domain_names: List[str],
+    *,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    limit: int = 120,
+) -> List[Dict[str, Any]]:
+    """Return aggregated rolling demo history for the active workspace."""
+    demo_domains = domain_names or ["dmarq.org", "dmarq.com"]
+    points_by_domain = {
+        domain_name: _demo_history_points(
+            domain_name,
+            start_date=start_date,
+            end_date=end_date,
+            limit=limit,
+        )
+        for domain_name in demo_domains
+    }
+    return aggregate_workspace_health_points(points_by_domain)[-limit:]
+
+
 def _write_health_evidence_csv(rows: List[Dict[str, Any]], *, domain_id: str) -> Response:
     output = io.StringIO()
     fields = [
@@ -1611,6 +1672,50 @@ async def get_domains_summary(
         domains=domains_list,
         health_summary=build_health_summary(domains_list, domain_health),
     )
+
+
+@router.get("/summary/health/history", response_model=WorkspaceHealthScoreHistoryResponse)
+async def get_workspace_health_score_history(
+    start_date: Optional[date] = Query(None, title="Start date for score history"),
+    end_date: Optional[date] = Query(None, title="End date for score history"),
+    limit: int = Query(120, ge=1, le=400, title="Maximum history points"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return selected-workspace health score history aggregated across domains."""
+    if start_date and end_date and start_date > end_date:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="start_date must be on or before end_date",
+        )
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
+    workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
+    snapshots = list_workspace_health_score_snapshots(
+        db,
+        workspace_id=workspace.id,
+        start_date=start_date,
+        end_date=end_date,
+        limit=limit,
+    )
+    if not snapshots and get_settings().DEMO_MODE:
+        store = ReportStore()
+        hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+        domains = _domain_names_for_summary(
+            db,
+            store,
+            workspace,
+            include_unscoped_report_domains=True,
+        )
+        return _workspace_history_response_from_points(
+            _demo_workspace_history_points(
+                domains,
+                start_date=start_date,
+                end_date=end_date,
+                limit=limit,
+            )
+        )
+    return WorkspaceHealthScoreHistoryResponse(**build_workspace_health_score_history(snapshots))
 
 
 @router.get("/domains", response_model=List[DomainResponse])

--- a/backend/app/services/health_score_snapshots.py
+++ b/backend/app/services/health_score_snapshots.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+from collections import defaultdict
 from datetime import date, datetime
 from typing import Any, Dict, Iterable, List, Optional
 
 from sqlalchemy.orm import Session
 
 from app.models.health_score_snapshot import HealthScoreSnapshot
+from app.services.health_score import health_grade
 
 
 def _as_int(value: Any) -> int:
@@ -117,6 +119,41 @@ def list_health_score_snapshots(
     return list(reversed(rows))
 
 
+def list_workspace_health_score_snapshots(
+    db: Session,
+    *,
+    workspace_id: int,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    limit: int = 120,
+) -> List[HealthScoreSnapshot]:
+    """Return snapshots for the latest workspace-level history dates."""
+    date_query = db.query(HealthScoreSnapshot.snapshot_date).filter(
+        HealthScoreSnapshot.workspace_id == workspace_id,
+    )
+    if start_date:
+        date_query = date_query.filter(HealthScoreSnapshot.snapshot_date >= start_date)
+    if end_date:
+        date_query = date_query.filter(HealthScoreSnapshot.snapshot_date <= end_date)
+
+    date_rows = (
+        date_query.distinct().order_by(HealthScoreSnapshot.snapshot_date.desc()).limit(limit).all()
+    )
+    history_dates = sorted(row[0] for row in date_rows)
+    if not history_dates:
+        return []
+
+    return (
+        db.query(HealthScoreSnapshot)
+        .filter(
+            HealthScoreSnapshot.workspace_id == workspace_id,
+            HealthScoreSnapshot.snapshot_date.in_(history_dates),
+        )
+        .order_by(HealthScoreSnapshot.snapshot_date.asc(), HealthScoreSnapshot.domain_name.asc())
+        .all()
+    )
+
+
 def snapshot_to_history_point(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
     """Serialize one snapshot for API responses."""
     return {
@@ -136,6 +173,71 @@ def snapshot_to_history_point(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
     }
 
 
+def aggregate_workspace_health_points(
+    points_by_domain: Dict[str, List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Aggregate per-domain history points into workspace-level daily points."""
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for domain_name, points in points_by_domain.items():
+        for point in points:
+            grouped[str(point["date"])].append({**point, "domain": domain_name})
+
+    workspace_points = []
+    for snapshot_date in sorted(grouped):
+        day_points = grouped[snapshot_date]
+        weights = [max(1, _as_int(point.get("total_emails"))) for point in day_points]
+        total_weight = sum(weights) or len(day_points) or 1
+
+        def weighted_average(field: str) -> int:
+            return round(
+                sum(
+                    _as_int(point.get(field)) * weight for point, weight in zip(day_points, weights)
+                )
+                / total_weight
+            )
+
+        score = weighted_average("score")
+        actions: List[Dict[str, Any]] = []
+        for point in day_points:
+            for action in point.get("top_actions", []) or []:
+                action_row = dict(action)
+                action_row.setdefault("domain", point.get("domain"))
+                actions.append(action_row)
+        actions.sort(key=lambda item: _as_int(item.get("score_impact")), reverse=True)
+        critical_actions = sum(1 for action in actions if action.get("severity") == "critical")
+        system_policy = (
+            "reject"
+            if day_points
+            and all((point.get("policy") or "").lower() == "reject" for point in day_points)
+            else None
+        )
+        workspace_points.append(
+            {
+                "date": snapshot_date,
+                "score": score,
+                "grade": health_grade(
+                    score,
+                    policy=system_policy,
+                    critical_actions=critical_actions,
+                ),
+                "status": "healthy" if score >= 90 else "attention" if score >= 70 else "critical",
+                "policy": system_policy,
+                "compliance_rate": weighted_average("compliance_rate"),
+                "total_emails": sum(_as_int(point.get("total_emails")) for point in day_points),
+                "failed_emails": sum(_as_int(point.get("failed_emails")) for point in day_points),
+                "report_count": sum(_as_int(point.get("report_count")) for point in day_points),
+                "dns_posture_score": weighted_average("dns_posture_score"),
+                "policy_strength_score": weighted_average("policy_strength_score"),
+                "report_confidence_score": weighted_average("report_confidence_score"),
+                "domain_count": len(
+                    {point.get("domain") for point in day_points if point.get("domain")}
+                ),
+                "top_actions": actions[:5],
+            }
+        )
+    return workspace_points
+
+
 def build_health_score_history(
     *,
     domain_name: str,
@@ -147,6 +249,28 @@ def build_health_score_history(
     previous = points[-2] if len(points) > 1 else None
     return {
         "domain": domain_name,
+        "points": points,
+        "current_score": current["score"] if current else None,
+        "previous_score": previous["score"] if previous else None,
+        "score_delta": (current["score"] - previous["score"] if current and previous else None),
+        "current_grade": current["grade"] if current else None,
+        "previous_grade": previous["grade"] if previous else None,
+        "top_drivers": current["top_actions"] if current else [],
+    }
+
+
+def build_workspace_health_score_history(
+    snapshots: List[HealthScoreSnapshot],
+) -> Dict[str, Any]:
+    """Build workspace-level score history from domain snapshots."""
+    points_by_domain: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for snapshot in snapshots:
+        points_by_domain[snapshot.domain_name].append(snapshot_to_history_point(snapshot))
+    points = aggregate_workspace_health_points(points_by_domain)
+    current = points[-1] if points else None
+    previous = points[-2] if len(points) > 1 else None
+    return {
+        "scope": "workspace",
         "points": points,
         "current_score": current["score"] if current else None,
         "previous_score": previous["score"] if previous else None,

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -39,7 +39,7 @@
                                    x-model="customEndDate">
                             <button type="button"
                                     class="rounded-md bg-[#272a5f] px-3 py-2 text-sm font-semibold text-white hover:bg-[#171346]"
-                                    @click="fetchDashboardStats()">
+                                    @click="fetchDashboardStats(); fetchWorkspaceHealthHistory()">
                                 Apply
                             </button>
                         </div>
@@ -153,6 +153,18 @@
                     <span x-text="healthSummary?.domain_count || 0"></span>
                     <span> domains need attention.</span>
                 </p>
+                <div class="mt-5 border-t border-[#dfdfdf] pt-4" x-show="healthHistory?.points?.length">
+                    <div class="mb-3 flex items-center justify-between gap-3">
+                        <p class="text-sm font-semibold text-[#120d36]">Score Trend</p>
+                        <p class="text-sm font-semibold"
+                           :class="(healthHistory?.score_delta || 0) >= 0 ? 'text-[#247982]' : 'text-[#b8431d]'">
+                            <span x-text="formatScoreDelta(healthHistory?.score_delta)"></span>
+                        </p>
+                    </div>
+                    <div class="h-24">
+                        <canvas id="health-trend-chart" aria-label="System health score trend"></canvas>
+                    </div>
+                </div>
             </div>
             <div class="grid gap-5 xl:grid-cols-[minmax(0,1fr)_22rem]">
                 <div>
@@ -752,8 +764,10 @@ function dashboardApp() {
         hasDomainData: false,
         volumeTrendChart: null,
         complianceTrendChart: null,
+        healthTrendChart: null,
         domains: [],
         healthSummary: null,
+        healthHistory: null,
         selectedDnsDomain: '',
         demoDeployment: null,
         selectedDemoScenarioId: 'single-user-multiple-domains',
@@ -901,10 +915,12 @@ function dashboardApp() {
                     this.$nextTick(() => {
                         this.updateDnsHealth();
                         this.fetchDashboardStats();
+                        this.fetchWorkspaceHealthHistory();
                     });
                 } else {
                     this.domains = [];
                     this.healthSummary = null;
+                    this.healthHistory = null;
                     this.selectedDnsDomain = '';
                     this.hasDomainData = false;
                     this.clearDashboardCharts();
@@ -915,6 +931,7 @@ function dashboardApp() {
                 console.error('Error fetching domain summary:', error);
                 this.domains = [];
                 this.healthSummary = null;
+                this.healthHistory = null;
                 this.selectedDnsDomain = '';
                 this.hasDomainData = false;
                 this.clearDashboardCharts();
@@ -942,6 +959,21 @@ function dashboardApp() {
             }
         },
 
+        async fetchWorkspaceHealthHistory() {
+            try {
+                const response = await fetch(this.workspaceHealthHistoryUrl());
+                if (!response.ok) {
+                    console.error('Error fetching workspace health history:', response.status);
+                    return;
+                }
+                const data = await response.json();
+                this.healthHistory = data;
+                this.$nextTick(() => this.renderHealthTrend(data.points || []));
+            } catch (error) {
+                console.error('Error fetching workspace health history:', error);
+            }
+        },
+
         dashboardStatsUrl() {
             const params = new URLSearchParams();
             params.set('interval', this.dateInterval);
@@ -952,9 +984,47 @@ function dashboardApp() {
             return `/api/v1/stats/dashboard?${params.toString()}`;
         },
 
+        workspaceHealthHistoryUrl() {
+            const params = new URLSearchParams();
+            params.set('limit', '120');
+            const range = this.healthHistoryDateRange();
+            if (range.start) params.set('start_date', range.start);
+            if (range.end) params.set('end_date', range.end);
+            return `/api/v1/domains/summary/health/history?${params.toString()}`;
+        },
+
+        healthHistoryDateRange() {
+            const today = new Date();
+            const start = new Date(today);
+            if (this.dateInterval === 'custom') {
+                return { start: this.customStartDate || '', end: this.customEndDate || '' };
+            }
+            if (this.dateInterval === 'last_24_hours') {
+                start.setDate(today.getDate() - 1);
+            } else if (this.dateInterval === 'last_48_hours') {
+                start.setDate(today.getDate() - 2);
+            } else if (this.dateInterval === 'last_7_days') {
+                start.setDate(today.getDate() - 6);
+            } else if (this.dateInterval === 'last_90_days') {
+                start.setDate(today.getDate() - 89);
+            } else if (this.dateInterval === 'week_to_date') {
+                const day = today.getDay() || 7;
+                start.setDate(today.getDate() - day + 1);
+            } else if (this.dateInterval === 'month_to_date') {
+                start.setDate(1);
+            } else {
+                start.setDate(today.getDate() - 29);
+            }
+            return {
+                start: start.toISOString().slice(0, 10),
+                end: today.toISOString().slice(0, 10)
+            };
+        },
+
         handleDateIntervalChange() {
             if (this.dateInterval !== 'custom') {
                 this.fetchDashboardStats();
+                this.fetchWorkspaceHealthHistory();
                 return;
             }
             if (!this.customEndDate) {
@@ -1107,6 +1177,66 @@ function dashboardApp() {
 
             this.renderVolumeTrend(trendData);
             this.renderComplianceTrend(trendData);
+        },
+
+        renderHealthTrend(points) {
+            const canvas = document.getElementById('health-trend-chart');
+            if (!canvas || !window.Chart) return;
+            if (!points.length) {
+                if (this.healthTrendChart) {
+                    this.healthTrendChart.destroy();
+                    this.healthTrendChart = null;
+                }
+                return;
+            }
+
+            if (this.healthTrendChart) {
+                this.healthTrendChart.destroy();
+            }
+
+            this.healthTrendChart = new Chart(canvas.getContext('2d'), {
+                type: 'line',
+                data: {
+                    labels: points.map(item => item.date),
+                    datasets: [
+                        {
+                            label: 'Health Score',
+                            data: points.map(item => item.score || 0),
+                            borderColor: '#2f9da5',
+                            backgroundColor: 'rgba(47, 157, 165, 0.14)',
+                            pointRadius: 0,
+                            pointHoverRadius: 4,
+                            borderWidth: 3,
+                            tension: 0.35,
+                            fill: true
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: {
+                        y: {
+                            min: 0,
+                            max: 100,
+                            grid: { color: '#dfdfdf' },
+                            ticks: { display: false }
+                        },
+                        x: {
+                            grid: { display: false },
+                            ticks: { display: false }
+                        }
+                    },
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: context => `Health Score: ${context.parsed.y}/100`
+                            }
+                        }
+                    }
+                }
+            });
         },
 
         renderVolumeTrend(trendData) {
@@ -1268,6 +1398,13 @@ function dashboardApp() {
 
         formatLargeNumber(value) {
             return new Intl.NumberFormat(undefined, { notation: 'compact' }).format(value);
+        },
+
+        formatScoreDelta(value) {
+            if (value === null || value === undefined) return 'No prior score';
+            const number = Number(value) || 0;
+            if (number === 0) return 'No change';
+            return `${number > 0 ? '+' : ''}${number} pts`;
         },
 
         formatMoney(cents, currency = 'EUR') {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -20,6 +20,15 @@ def test_dashboard_domain_details_links_are_encoded():
     assert "encodeURIComponent(domainId)" in template
 
 
+def test_dashboard_exposes_workspace_health_history():
+    template = (Path(__file__).resolve().parents[1] / "templates" / "index.html").read_text()
+
+    assert "Score Trend" in template
+    assert "health-trend-chart" in template
+    assert "/api/v1/domains/summary/health/history" in template
+    assert "fetchWorkspaceHealthHistory" in template
+
+
 def test_domain_details_exposes_health_history_without_html_injection():
     template = (
         Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -302,6 +302,67 @@ def test_domain_health_history_returns_persisted_trend(seeded_client: TestClient
     assert data["points"][1]["top_actions"][0]["title"] == "Fix SPF coverage"
 
 
+def test_workspace_health_history_returns_persisted_trend(
+    seeded_client: TestClient,
+    db_session,
+):
+    """Workspace health history aggregates daily scores across monitored domains."""
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add(
+        Domain(name="example.net", workspace_id=workspace.id, active=True, dmarc_policy="none")
+    )
+    db_session.commit()
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name=DOMAIN,
+        health={"score": 92, "grade": "A-", "status": "healthy", "factors": {}, "actions": []},
+        policy="reject",
+        compliance_rate=97,
+        total_emails=900,
+        failed_emails=27,
+        report_count=10,
+        snapshot_date=date(2026, 6, 1),
+    )
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name="example.net",
+        health={
+            "score": 68,
+            "grade": "D",
+            "status": "critical",
+            "factors": {},
+            "actions": [
+                {
+                    "title": "Move out of monitoring mode",
+                    "severity": "medium",
+                    "score_impact": 14,
+                }
+            ],
+        },
+        policy="none",
+        compliance_rate=72,
+        total_emails=100,
+        failed_emails=28,
+        report_count=3,
+        snapshot_date=date(2026, 6, 1),
+    )
+
+    response = seeded_client.get(
+        "/api/v1/domains/summary/health/history"
+        "?start_date=2026-06-01&end_date=2026-06-30&limit=30"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scope"] == "workspace"
+    assert data["current_score"] == 90
+    assert data["points"][0]["domain_count"] == 2
+    assert data["points"][0]["total_emails"] == 1000
+    assert data["top_drivers"][0]["domain"] == "example.net"
+
+
 def test_export_domain_health_evidence_returns_sanitized_csv(
     seeded_client: TestClient,
     db_session,
@@ -440,6 +501,15 @@ def test_domain_health_history_rejects_invalid_date_order(seeded_client: TestCli
     assert response.status_code == 422
 
 
+def test_workspace_health_history_rejects_invalid_date_order(seeded_client: TestClient):
+    """Workspace health history validates that the start date is not after the end date."""
+    response = seeded_client.get(
+        "/api/v1/domains/summary/health/history" "?start_date=2026-06-03&end_date=2026-06-02"
+    )
+
+    assert response.status_code == 422
+
+
 def test_domain_health_evidence_export_rejects_invalid_date_order(
     seeded_client: TestClient,
 ):
@@ -516,6 +586,25 @@ def test_domain_health_evidence_export_uses_demo_history_fallback(
     assert rows[-1]["policy"] == "none"
 
 
+def test_workspace_health_history_uses_demo_history_fallback(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    """Demo mode serves rolling workspace health history without persisted snapshots."""
+    _enable_endpoint_demo_mode(monkeypatch)
+
+    response = authed_client.get(
+        "/api/v1/domains/summary/health/history" "?start_date=2026-06-01&limit=3"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scope"] == "workspace"
+    assert 0 < len(data["points"]) <= 3
+    assert data["current_score"] is not None
+    assert data["points"][-1]["domain_count"] == 2
+
+
 def test_health_history_helpers_cover_demo_and_empty_paths():
     empty = domains_endpoint._history_response_from_points(DOMAIN, [])
     assert empty.current_score is None
@@ -542,6 +631,15 @@ def test_health_history_helpers_cover_demo_and_empty_paths():
     )
     assert csv_response.media_type == "text/csv"
     assert "health-evidence.csv" in csv_response.headers["content-disposition"]
+
+    workspace_points = domains_endpoint._demo_workspace_history_points(
+        ["dmarq.org", "dmarq.com"],
+        start_date=date(2026, 6, 1),
+        limit=2,
+    )
+    workspace_response = domains_endpoint._workspace_history_response_from_points(workspace_points)
+    assert len(workspace_response.points) <= 2
+    assert workspace_response.current_score is not None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/test_health_score_snapshots.py
+++ b/backend/app/tests/test_health_score_snapshots.py
@@ -1,9 +1,12 @@
 from datetime import date
 
 from app.services.health_score_snapshots import (
+    aggregate_workspace_health_points,
     build_health_evidence_export_rows,
     build_health_score_history,
+    build_workspace_health_score_history,
     list_health_score_snapshots,
+    list_workspace_health_score_snapshots,
     snapshot_to_history_point,
     upsert_health_score_snapshot,
 )
@@ -150,3 +153,101 @@ def test_health_score_snapshot_filters_by_date_range(db_session):
         date(2026, 6, 2),
         date(2026, 6, 3),
     ]
+
+
+def test_workspace_health_score_history_aggregates_domain_snapshots(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    for domain_name, score, total_emails, failed_emails, action_title in [
+        ("example.com", 90, 1000, 20, "Keep reject policy"),
+        ("example.net", 70, 100, 30, "Fix DKIM selector coverage"),
+    ]:
+        upsert_health_score_snapshot(
+            db_session,
+            workspace_id=workspace.id,
+            domain_name=domain_name,
+            health={
+                "score": score,
+                "grade": "A-" if score >= 90 else "C",
+                "status": "healthy" if score >= 90 else "attention",
+                "factors": {
+                    "dns_posture": score,
+                    "policy_strength": 88,
+                    "report_confidence": 90,
+                },
+                "actions": [
+                    {
+                        "type": "demo",
+                        "severity": "high",
+                        "title": action_title,
+                        "score_impact": 12 if score < 90 else 2,
+                    }
+                ],
+            },
+            policy="quarantine",
+            compliance_rate=score,
+            total_emails=total_emails,
+            failed_emails=failed_emails,
+            report_count=4,
+            snapshot_date=date(2026, 6, 5),
+        )
+
+    snapshots = list_workspace_health_score_snapshots(
+        db_session,
+        workspace_id=workspace.id,
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 6, 30),
+    )
+    history = build_workspace_health_score_history(snapshots)
+
+    assert history["scope"] == "workspace"
+    assert history["current_score"] == 88
+    assert history["points"][0]["domain_count"] == 2
+    assert history["points"][0]["total_emails"] == 1100
+    assert history["points"][0]["failed_emails"] == 50
+    assert history["top_drivers"][0]["domain"] == "example.net"
+
+
+def test_aggregate_workspace_health_points_handles_demo_points():
+    points = aggregate_workspace_health_points(
+        {
+            "dmarq.org": [
+                {
+                    "date": "2026-06-01",
+                    "score": 94,
+                    "grade": "A",
+                    "status": "healthy",
+                    "policy": "reject",
+                    "compliance_rate": 98,
+                    "total_emails": 1000,
+                    "failed_emails": 20,
+                    "report_count": 10,
+                    "dns_posture_score": 99,
+                    "policy_strength_score": 100,
+                    "report_confidence_score": 100,
+                    "top_actions": [],
+                }
+            ],
+            "dmarq.com": [
+                {
+                    "date": "2026-06-01",
+                    "score": 70,
+                    "grade": "C",
+                    "status": "attention",
+                    "policy": "none",
+                    "compliance_rate": 75,
+                    "total_emails": 1000,
+                    "failed_emails": 250,
+                    "report_count": 8,
+                    "dns_posture_score": 80,
+                    "policy_strength_score": 55,
+                    "report_confidence_score": 90,
+                    "top_actions": [{"title": "Move out of monitoring mode", "score_impact": 14}],
+                }
+            ],
+        }
+    )
+
+    assert points[0]["score"] == 82
+    assert points[0]["grade"] == "B-"
+    assert points[0]["domain_count"] == 2
+    assert points[0]["top_actions"][0]["domain"] == "dmarq.com"

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -474,6 +474,20 @@ shape audit or dashboard windows. By default the endpoint captures the current
 posture as today's snapshot before reading history; pass `capture_current=false`
 when reading already persisted evidence only.
 
+#### Get Workspace Health Score History
+
+```
+GET /domains/summary/health/history
+```
+
+Returns persisted daily health score snapshots aggregated across the selected
+workspace. The response includes account-level score, grade, domain count,
+aggregate message/report counts, factor scores, top action drivers, previous
+score, and score delta. Use `start_date`, `end_date`, and `limit` to shape the
+same date windows used by the dashboard. In demo mode, the endpoint falls back
+to rolling dmarq.org and dmarq.com demo history when no persisted snapshots are
+available.
+
 #### Export Health Evidence
 
 ```


### PR DESCRIPTION
## Summary
- add selected-workspace health score history aggregation across persisted domain snapshots
- expose GET /api/v1/domains/summary/health/history with date filters and rolling demo fallback for dmarq.org/dmarq.com
- show a System Health score trend on the dashboard using the existing date filters
- document the endpoint and cover aggregation, API, demo fallback, and template wiring

## Validation
- PYTHONPATH=backend .venv/bin/python -m pytest backend/app/tests/test_health_score_snapshots.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py -q
- .venv/bin/python -m flake8 backend/app/services/health_score_snapshots.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_health_score_snapshots.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py
- .venv/bin/python -m black --check backend/app/services/health_score_snapshots.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_health_score_snapshots.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py
- .venv/bin/python -m isort --check-only backend/app/services/health_score_snapshots.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_health_score_snapshots.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py
- git diff --check
- local demo browser check at http://127.0.0.1:8077 confirmed the dashboard renders Score Trend without console errors; only the existing Tailwind CDN warning is present

Part of #307. PDF evidence packets remain parked per product direction.