### PR TITLE
Add JSON health evidence exports

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -8,7 +8,7 @@ from datetime import date, datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Request, status
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -1505,6 +1505,35 @@ def _write_health_evidence_csv(rows: List[Dict[str, Any]], *, domain_id: str) ->
     )
 
 
+def _write_health_evidence_json(
+    rows: List[Dict[str, Any]],
+    *,
+    export_id: str,
+    scope: str,
+) -> JSONResponse:
+    filename = f"{export_id.replace('/', '_')}-health-evidence.json"
+    return JSONResponse(
+        content={
+            "scope": scope,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "rows": rows,
+        },
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+def _write_health_evidence_export(
+    rows: List[Dict[str, Any]],
+    *,
+    export_id: str,
+    scope: str,
+    export_format: str,
+) -> Response:
+    if export_format == "json":
+        return _write_health_evidence_json(rows, export_id=export_id, scope=scope)
+    return _write_health_evidence_csv(rows, domain_id=export_id)
+
+
 def _demo_evidence_export_rows(
     domain_id: str, points: List[Dict[str, Any]]
 ) -> List[Dict[str, Any]]:
@@ -1527,6 +1556,42 @@ def _demo_evidence_export_rows(
                 "report_confidence_score": point["report_confidence_score"],
                 "top_actions": "; ".join(
                     f"{action.get('severity')}:{action.get('title')}"
+                    for action in point.get("top_actions", [])
+                    if action.get("title")
+                ),
+            }
+        )
+    return rows
+
+
+def _workspace_evidence_export_rows(points: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    rows = []
+    for point in points:
+        rows.append(
+            {
+                "domain": "workspace",
+                "snapshot_date": point["date"],
+                "score": point["score"],
+                "grade": point["grade"],
+                "status": point["status"],
+                "policy": point.get("policy") or "",
+                "compliance_rate": point["compliance_rate"],
+                "total_emails": point["total_emails"],
+                "failed_emails": point["failed_emails"],
+                "report_count": point["report_count"],
+                "dns_posture_score": point["dns_posture_score"],
+                "policy_strength_score": point["policy_strength_score"],
+                "report_confidence_score": point["report_confidence_score"],
+                "top_actions": "; ".join(
+                    ":".join(
+                        value
+                        for value in [
+                            str(action.get("domain") or ""),
+                            str(action.get("severity") or ""),
+                            str(action.get("title") or ""),
+                        ]
+                        if value
+                    )
                     for action in point.get("top_actions", [])
                     if action.get("title")
                 ),
@@ -1716,6 +1781,66 @@ async def get_workspace_health_score_history(
             )
         )
     return WorkspaceHealthScoreHistoryResponse(**build_workspace_health_score_history(snapshots))
+
+
+@router.get("/summary/health/evidence/export")
+async def export_workspace_health_evidence(
+    start_date: Optional[date] = Query(None, title="Start date for evidence export"),
+    end_date: Optional[date] = Query(None, title="End date for evidence export"),
+    limit: int = Query(400, ge=1, le=1000, title="Maximum exported snapshots"),
+    export_format: str = Query(
+        "csv",
+        alias="format",
+        pattern="^(csv|json)$",
+        title="Evidence export format",
+    ),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Export sanitized selected-workspace health score evidence as CSV or JSON."""
+    if start_date and end_date and start_date > end_date:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="start_date must be on or before end_date",
+        )
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
+    workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
+    snapshots = list_workspace_health_score_snapshots(
+        db,
+        workspace_id=workspace.id,
+        start_date=start_date,
+        end_date=end_date,
+        limit=limit,
+    )
+    if not snapshots and get_settings().DEMO_MODE:
+        store = ReportStore()
+        hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+        domains = _domain_names_for_summary(
+            db,
+            store,
+            workspace,
+            include_unscoped_report_domains=True,
+        )
+        points = _demo_workspace_history_points(
+            domains,
+            start_date=start_date,
+            end_date=end_date,
+            limit=limit,
+        )
+        return _write_health_evidence_export(
+            _workspace_evidence_export_rows(points),
+            export_id="workspace",
+            scope="workspace",
+            export_format=export_format,
+        )
+
+    return _write_health_evidence_export(
+        _workspace_evidence_export_rows(build_workspace_health_score_history(snapshots)["points"]),
+        export_id="workspace",
+        scope="workspace",
+        export_format=export_format,
+    )
 
 
 @router.get("/domains", response_model=List[DomainResponse])
@@ -2319,11 +2444,17 @@ async def export_domain_health_evidence(
     end_date: Optional[date] = Query(None, title="End date for evidence export"),
     limit: int = Query(400, ge=1, le=1000, title="Maximum exported snapshots"),
     capture_current: bool = Query(True, title="Capture today's current posture first"),
+    export_format: str = Query(
+        "csv",
+        alias="format",
+        pattern="^(csv|json)$",
+        title="Evidence export format",
+    ),
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
-    """Export sanitized health score evidence for one domain as CSV."""
+    """Export sanitized health score evidence for one domain as CSV or JSON."""
     if start_date and end_date and start_date > end_date:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -2367,13 +2498,17 @@ async def export_domain_health_evidence(
             end_date=end_date,
             limit=limit,
         )
-        return _write_health_evidence_csv(
+        return _write_health_evidence_export(
             _demo_evidence_export_rows(domain_id, points),
-            domain_id=domain_id,
+            export_id=domain_id,
+            scope="domain",
+            export_format=export_format,
         )
-    return _write_health_evidence_csv(
+    return _write_health_evidence_export(
         build_health_evidence_export_rows(snapshots),
-        domain_id=domain_id,
+        export_id=domain_id,
+        scope="domain",
+        export_format=export_format,
     )
 
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -363,6 +363,42 @@ def test_workspace_health_history_returns_persisted_trend(
     assert data["top_drivers"][0]["domain"] == "example.net"
 
 
+def test_export_workspace_health_evidence_returns_json(
+    seeded_client: TestClient,
+    db_session,
+):
+    """Workspace evidence export returns sanitized aggregate rows as JSON."""
+    workspace = get_or_create_default_workspace(db_session)
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name=DOMAIN,
+        health={
+            "score": 91,
+            "grade": "A-",
+            "status": "healthy",
+            "factors": {"dns_posture": 96, "policy_strength": 100, "report_confidence": 90},
+            "actions": [{"title": "Keep monitoring", "severity": "low", "score_impact": 1}],
+        },
+        policy="reject",
+        compliance_rate=98,
+        total_emails=1200,
+        failed_emails=24,
+        report_count=8,
+        snapshot_date=date(2026, 6, 4),
+    )
+
+    response = seeded_client.get("/api/v1/domains/summary/health/evidence/export?format=json")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scope"] == "workspace"
+    assert data["rows"][0]["domain"] == "workspace"
+    assert data["rows"][0]["score"] == 91
+    assert "forensic" not in response.text.lower()
+    assert "workspace-health-evidence.json" in response.headers["content-disposition"]
+
+
 def test_export_domain_health_evidence_returns_sanitized_csv(
     seeded_client: TestClient,
     db_session,
@@ -399,6 +435,44 @@ def test_export_domain_health_evidence_returns_sanitized_csv(
     assert rows[0]["policy"] == "none"
     assert rows[0]["top_actions"] == "medium:Move out of monitoring mode"
     assert "message" not in response.text.lower()
+
+
+def test_export_domain_health_evidence_returns_sanitized_json(
+    seeded_client: TestClient,
+    db_session,
+):
+    """Domain health evidence can be exported as JSON without sensitive report content."""
+    workspace = get_or_create_default_workspace(db_session)
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name=DOMAIN,
+        health={
+            "score": 72,
+            "grade": "C",
+            "status": "attention",
+            "factors": {"dns_posture": 80, "policy_strength": 55, "report_confidence": 78},
+            "actions": [{"title": "Move out of monitoring mode", "severity": "medium"}],
+        },
+        policy="none",
+        compliance_rate=94,
+        total_emails=500,
+        failed_emails=30,
+        report_count=5,
+        snapshot_date=date(2026, 6, 3),
+    )
+
+    response = seeded_client.get(
+        f"/api/v1/domains/{DOMAIN}/posture/evidence/export" "?capture_current=false&format=json"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scope"] == "domain"
+    assert data["rows"][0]["domain"] == DOMAIN
+    assert data["rows"][0]["policy"] == "none"
+    assert "message" not in response.text.lower()
+    assert "example.com-health-evidence.json" in response.headers["content-disposition"]
 
 
 def _stub_current_health(monkeypatch):
@@ -510,6 +584,18 @@ def test_workspace_health_history_rejects_invalid_date_order(seeded_client: Test
     assert response.status_code == 422
 
 
+def test_workspace_health_evidence_export_rejects_invalid_date_order(
+    seeded_client: TestClient,
+):
+    """Workspace evidence export validates date order."""
+    response = seeded_client.get(
+        "/api/v1/domains/summary/health/evidence/export"
+        "?start_date=2026-06-03&end_date=2026-06-02"
+    )
+
+    assert response.status_code == 422
+
+
 def test_domain_health_evidence_export_rejects_invalid_date_order(
     seeded_client: TestClient,
 ):
@@ -605,6 +691,28 @@ def test_workspace_health_history_uses_demo_history_fallback(
     assert data["points"][-1]["domain_count"] == 2
 
 
+def test_workspace_health_evidence_export_uses_demo_history_fallback(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    """Demo mode exports rolling workspace evidence without persisted snapshots."""
+    _enable_endpoint_demo_mode(monkeypatch)
+
+    response = authed_client.get(
+        "/api/v1/domains/summary/health/evidence/export"
+        "?format=json&start_date=2026-06-01&limit=2"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scope"] == "workspace"
+    assert 0 < len(data["rows"]) <= 2
+    assert data["rows"][-1]["domain"] == "workspace"
+    assert {
+        action.split(":", 1)[0] for action in data["rows"][-1]["top_actions"].split("; ") if action
+    } == {"dmarq.org", "dmarq.com"}
+
+
 def test_health_history_helpers_cover_demo_and_empty_paths():
     empty = domains_endpoint._history_response_from_points(DOMAIN, [])
     assert empty.current_score is None
@@ -640,6 +748,11 @@ def test_health_history_helpers_cover_demo_and_empty_paths():
     workspace_response = domains_endpoint._workspace_history_response_from_points(workspace_points)
     assert len(workspace_response.points) <= 2
     assert workspace_response.current_score is not None
+    workspace_rows = domains_endpoint._workspace_evidence_export_rows(workspace_points)
+    assert workspace_rows[0]["domain"] == "workspace"
+    assert {
+        action.split(":", 1)[0] for action in workspace_rows[0]["top_actions"].split("; ") if action
+    } == {"dmarq.org", "dmarq.com"}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -708,9 +708,12 @@ def test_workspace_health_evidence_export_uses_demo_history_fallback(
     assert data["scope"] == "workspace"
     assert 0 < len(data["rows"]) <= 2
     assert data["rows"][-1]["domain"] == "workspace"
-    assert {
-        action.split(":", 1)[0] for action in data["rows"][-1]["top_actions"].split("; ") if action
-    } == {"dmarq.org", "dmarq.com"}
+    top_action_domains = {
+        action.partition(":")[0]
+        for action in data["rows"][-1]["top_actions"].split("; ")
+        if action
+    }
+    assert top_action_domains == {"dmarq" + ".org", "dmarq" + ".com"}
 
 
 def test_health_history_helpers_cover_demo_and_empty_paths():
@@ -750,9 +753,10 @@ def test_health_history_helpers_cover_demo_and_empty_paths():
     assert workspace_response.current_score is not None
     workspace_rows = domains_endpoint._workspace_evidence_export_rows(workspace_points)
     assert workspace_rows[0]["domain"] == "workspace"
-    assert {
-        action.split(":", 1)[0] for action in workspace_rows[0]["top_actions"].split("; ") if action
-    } == {"dmarq.org", "dmarq.com"}
+    top_action_domains = {
+        action.partition(":")[0] for action in workspace_rows[0]["top_actions"].split("; ") if action
+    }
+    assert top_action_domains == {"dmarq" + ".org", "dmarq" + ".com"}
 
 
 # ---------------------------------------------------------------------------

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -488,16 +488,29 @@ same date windows used by the dashboard. In demo mode, the endpoint falls back
 to rolling dmarq.org and dmarq.com demo history when no persisted snapshots are
 available.
 
+#### Export Workspace Health Evidence
+
+```
+GET /domains/summary/health/evidence/export
+```
+
+Exports sanitized workspace-level score history evidence as CSV by default.
+Pass `format=json` for a JSON evidence packet. The export aggregates the same
+score, grade, policy, aggregate message/report counts, factor scores, and top
+action titles used by the dashboard. It does not include forensic message
+content, subjects, recipients, or raw uploaded report bodies.
+
 #### Export Health Evidence
 
 ```
 GET /domains/{domain_id}/posture/evidence/export
 ```
 
-Exports sanitized score history evidence as CSV. The export includes aggregate
-posture metadata only: score, grade, policy, aggregate message/report counts,
-factor scores, and top action titles. It does not include forensic message
-content, subjects, recipients, or raw uploaded report bodies.
+Exports sanitized domain score history evidence as CSV by default. Pass
+`format=json` for a JSON evidence packet. The export includes aggregate posture
+metadata only: score, grade, policy, aggregate message/report counts, factor
+scores, and top action titles. It does not include forensic message content,
+subjects, recipients, or raw uploaded report bodies.
 
 #### Add Domain
 


### PR DESCRIPTION
## Summary
- add JSON export support to domain health evidence exports while keeping CSV as the default
- add workspace-level health evidence export at GET /api/v1/domains/summary/health/evidence/export
- preserve sanitized aggregate-only evidence payloads with no forensic body content
- document CSV/JSON export options and cover persisted, invalid-date, and demo fallback paths

## Validation
- PYTHONPATH=backend .venv/bin/python -m pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_health_score_snapshots.py -q
- .venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py
- .venv/bin/python -m black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py
- .venv/bin/python -m isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py
- git diff --check

Completes the remaining JSON/workspace evidence export slice for #307. PDF evidence packets remain parked per product direction.