### PR TITLE
Fix source intelligence review findings

### DIFF
--- a/backend/app/services/demo_data.py
+++ b/backend/app/services/demo_data.py
@@ -1326,6 +1326,7 @@ def build_demo_dashboard_statistics(
             "dmarc_pass_count": 0,
             "dmarc_fail_count": 0,
             "domains": set(),
+            "extensions": {},
         }
     )
 
@@ -1353,6 +1354,9 @@ def build_demo_dashboard_statistics(
             source["dmarc_pass_count"] += count if dmarc_pass else 0
             source["dmarc_fail_count"] += 0 if dmarc_pass else count
             source["domains"].add(report["domain"])
+            for key, value in (record.get("extensions") or {}).items():
+                if key.startswith("demo:") and value and key not in source["extensions"]:
+                    source["extensions"][key] = value
 
     compliance_trend: List[Dict[str, Any]] = []
     for day_key in sorted(daily):
@@ -1394,6 +1398,7 @@ def build_demo_dashboard_statistics(
                 ),
                 "domains": sorted(source["domains"]),
                 "geo": source_geo_for(source["ip"], source),
+                "extensions": dict(source["extensions"]),
             }
         )
     source_rows.sort(key=lambda item: item["count"], reverse=True)
@@ -1406,11 +1411,15 @@ def build_demo_dashboard_statistics(
                 "count": source["count"],
                 "dmarc_fail_count": source["dmarc_fail_count"],
                 "extensions": {
-                    "demo:region": source["geo"]["region"],
-                    "demo:country_code": source["geo"]["country_code"],
-                    "demo:country": source["geo"]["country"],
-                    "demo:asn": source["geo"]["asn"],
-                    "demo:network": source["geo"]["network"],
+                    "demo:region": source["extensions"].get("demo:region")
+                    or source["geo"]["region"],
+                    "demo:country_code": source["extensions"].get("demo:country_code")
+                    or source["geo"]["country_code"],
+                    "demo:country": source["extensions"].get("demo:country")
+                    or source["geo"]["country"],
+                    "demo:asn": source["extensions"].get("demo:asn") or source["geo"]["asn"],
+                    "demo:network": source["extensions"].get("demo:network")
+                    or source["geo"]["network"],
                 },
             }
             for source in source_rows

--- a/backend/app/services/sender_intelligence.py
+++ b/backend/app/services/sender_intelligence.py
@@ -228,6 +228,7 @@ def source_geo_for(ip: str, source: Optional[Dict[str, Any]] = None) -> Dict[str
                     }
                 )
         except ValueError:
+            # Invalid source identifiers have no network metadata to infer.
             pass
 
     return {
@@ -254,9 +255,12 @@ def _report_timestamp(report: Dict[str, Any]) -> int:
                 return int(value)
             except ValueError:
                 try:
-                    return int(
-                        datetime.fromisoformat(value).replace(tzinfo=timezone.utc).timestamp()
-                    )
+                    parsed = datetime.fromisoformat(value)
+                    if parsed.tzinfo is None:
+                        parsed = parsed.replace(tzinfo=timezone.utc)
+                    else:
+                        parsed = parsed.astimezone(timezone.utc)
+                    return int(parsed.timestamp())
                 except ValueError:
                     continue
     return 0
@@ -397,7 +401,8 @@ def _source_anomalies(
         if previous and previous["count"] > 0:
             baseline_rate = previous["count"] / max(1, period_days - recent_days)
             current_rate = count / max(1, recent_days)
-            if current_rate >= baseline_rate * 2.5 and count - previous["count"] >= 50:
+            expected_baseline_count = baseline_rate * recent_days
+            if current_rate >= baseline_rate * 2.5 and count - expected_baseline_count >= 50:
                 add_anomaly(
                     {
                         "type": "volume_spike",
@@ -473,10 +478,13 @@ def build_source_intelligence(
     period_days = max(1, int(period_days or 30))
     recent_days = min(7, max(1, period_days // 2))
     recent_start = latest_ts - recent_days * 86400 if latest_ts else 0
+    period_start = latest_ts - period_days * 86400 if latest_ts else 0
 
     baseline: Dict[str, Dict[str, Any]] = {}
     recent: Dict[str, Dict[str, Any]] = {}
     for row in report_rows:
+        if period_start and int(row.get("_timestamp") or 0) < period_start:
+            continue
         if latest_ts and int(row.get("_timestamp") or 0) >= recent_start:
             _add_rollup(recent, row)
         else:

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -825,7 +825,8 @@
                                             <span class="text-xs text-muted-foreground" x-text="source.geo.region + ' · ' + (source.geo.network || source.geo.country)"></span>
                                         </template>
                                         <template x-if="source.anomalies?.length">
-                                            <span class="mt-1 inline-flex w-fit rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-800"
+                                            <span class="mt-1 inline-flex w-fit rounded-full px-2 py-0.5 text-xs font-semibold"
+                                                  :class="source.anomalies.some(anomaly => anomaly.severity === 'error') ? 'bg-red-100 text-red-800' : 'bg-amber-100 text-amber-800'"
                                                   x-text="source.anomalies.length === 1 ? '1 anomaly' : source.anomalies.length + ' anomalies'"></span>
                                         </template>
                                     </div>

--- a/backend/app/tests/test_demo_data.py
+++ b/backend/app/tests/test_demo_data.py
@@ -97,6 +97,10 @@ def test_build_demo_dashboard_statistics_fills_chart_sources_and_changes():
     assert stats["source_anomalies"]
     assert any(source["dmarc"] in {"mixed", "fail"} for source in stats["top_sources"])
     assert all("geo" in source for source in stats["top_sources"])
+    assert any(
+        source["ip"] == "198.51.100.199" and source["geo"]["network"] == "Unverified Forwarder"
+        for source in stats["top_sources"]
+    )
 
 
 def test_build_demo_domain_statistics_includes_sources():

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -912,9 +912,11 @@ def test_get_domain_source_intelligence_returns_regions_and_anomalies(
     data = response.json()
     assert data["domain"] == DOMAIN
     assert data["summary"]["regions"] >= 1
-    assert data["regions"][0]["message_count"] == 10
-    assert data["anomalies"][0]["type"] == "new_sender"
-    assert data["anomalies"][0]["source_ip"] == "209.85.220.1"
+    assert any(region["message_count"] == 10 for region in data["regions"])
+    assert any(
+        anomaly["type"] == "new_sender" and anomaly["source_ip"] == "209.85.220.1"
+        for anomaly in data["anomalies"]
+    )
 
 
 def test_get_domain_source_intelligence_unknown_domain_returns_404(
@@ -933,9 +935,9 @@ def test_get_domain_sources_includes_geo_and_anomaly_hints(seeded_client: TestCl
     response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=30")
 
     assert response.status_code == 200
-    source = response.json()["sources"][0]
+    source = next(item for item in response.json()["sources"] if item["anomalies"])
     assert source["geo"]["region"]
-    assert source["anomalies"][0]["type"] == "new_sender"
+    assert any(anomaly["type"] == "new_sender" for anomaly in source["anomalies"])
     recommendation_types = {item["type"] for item in source["recommendations"]}
     assert "anomaly_new_sender" in recommendation_types
 

--- a/backend/app/tests/test_sender_intelligence.py
+++ b/backend/app/tests/test_sender_intelligence.py
@@ -220,3 +220,95 @@ def test_build_source_intelligence_accepts_iso_report_dates():
     )
 
     assert intelligence["summary"]["regions"] == 1
+
+
+def test_build_source_intelligence_preserves_aware_iso_offsets():
+    reports = [
+        {
+            "domain": "example.com",
+            "begin_date": "2026-06-24T23:00:00-02:00",
+            "records": [
+                {
+                    "source_ip": "203.0.113.10",
+                    "count": 10,
+                    "spf_result": "pass",
+                    "dkim_result": "pass",
+                }
+            ],
+        },
+        {
+            "domain": "example.com",
+            "begin_date": "2026-06-25T00:30:00+00:00",
+            "records": [
+                {
+                    "source_ip": "198.51.100.199",
+                    "count": 20,
+                    "spf_result": "fail",
+                    "dkim_result": "fail",
+                }
+            ],
+        },
+    ]
+
+    intelligence = build_source_intelligence(
+        "example.com",
+        reports,
+        [
+            {"source_ip": "203.0.113.10", "count": 10, "dmarc_fail_count": 0},
+            {"source_ip": "198.51.100.199", "count": 20, "dmarc_fail_count": 20},
+        ],
+        period_days=30,
+    )
+
+    anomaly_ips = {item["source_ip"] for item in intelligence["anomalies"]}
+    assert "203.0.113.10" in anomaly_ips
+
+
+def test_build_source_intelligence_limits_baseline_to_analysis_window():
+    reports = [
+        {
+            "domain": "example.com",
+            "begin_timestamp": 1_700_000_000,
+            "records": [
+                {
+                    "source_ip": "203.0.113.10",
+                    "count": 1000,
+                    "spf_result": "pass",
+                    "dkim_result": "pass",
+                }
+            ],
+        },
+        {
+            "domain": "example.com",
+            "begin_timestamp": 1_703_500_000,
+            "records": [
+                {
+                    "source_ip": "203.0.113.10",
+                    "count": 10,
+                    "spf_result": "pass",
+                    "dkim_result": "pass",
+                }
+            ],
+        },
+        {
+            "domain": "example.com",
+            "begin_timestamp": 1_704_000_000,
+            "records": [
+                {
+                    "source_ip": "203.0.113.10",
+                    "count": 70,
+                    "spf_result": "pass",
+                    "dkim_result": "pass",
+                }
+            ],
+        },
+    ]
+
+    intelligence = build_source_intelligence(
+        "example.com",
+        reports,
+        [{"source_ip": "203.0.113.10", "count": 1080, "dmarc_fail_count": 0}],
+        period_days=7,
+    )
+
+    assert any(item["type"] == "volume_spike" for item in intelligence["anomalies"])

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -463,7 +463,7 @@ to the page section that triggered the finding.
 
 #### Get Source Intelligence
 
-```
+```http
 GET /domains/{domain_id}/source-intelligence?days=30
 ```
 


### PR DESCRIPTION
## Summary
- preserve demo geo extensions when aggregating source intelligence
- limit source-intelligence baselines to the analysis window and normalize volume-spike detection
- preserve aware ISO offsets, document invalid-IP fallback, and style warning-only anomalies as warnings
- make source-intelligence tests less order-dependent and document the endpoint fence as HTTP

## Validation
- .venv/bin/black --check backend/app/services/sender_intelligence.py backend/app/services/demo_data.py backend/app/tests/test_sender_intelligence.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_demo_data.py
- .venv/bin/flake8 backend/app/services/sender_intelligence.py backend/app/services/demo_data.py backend/app/tests/test_sender_intelligence.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_demo_data.py
- .venv/bin/pytest backend/app/tests/test_sender_intelligence.py backend/app/tests/test_demo_data.py backend/app/tests/test_domain_detail_endpoints.py
- git diff --check