### PR TITLE
Productize source intelligence API tools

### DIFF
--- a/backend/app/api/api_v1/endpoints/mcp.py
+++ b/backend/app/api/api_v1/endpoints/mcp.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from app.api.api_v1.endpoints import domains
 from app.core.database import get_db
 from app.core.security import require_api_token_scope
 from app.services.ai_assistance import (
@@ -47,6 +49,45 @@ READ_ONLY_TOOLS = [
         "inputSchema": {
             "type": "object",
             "properties": {"domain": {"type": "string"}},
+            "required": ["domain"],
+        },
+        "readOnlyHint": True,
+    },
+    {
+        "name": "domain_posture",
+        "description": "Return DNS posture, health score, grade, and action guidance.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "domain": {"type": "string"},
+                "refresh": {"type": "boolean", "default": False},
+            },
+            "required": ["domain"],
+        },
+        "readOnlyHint": True,
+    },
+    {
+        "name": "domain_sources",
+        "description": "Return enriched DMARC sending sources for one domain.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "domain": {"type": "string"},
+                "days": {"type": "integer", "minimum": 1, "maximum": 365, "default": 30},
+            },
+            "required": ["domain"],
+        },
+        "readOnlyHint": True,
+    },
+    {
+        "name": "source_intelligence",
+        "description": "Return source geography summaries and anomaly hints for one domain.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "domain": {"type": "string"},
+                "days": {"type": "integer", "minimum": 1, "maximum": 365, "default": 30},
+            },
             "required": ["domain"],
         },
         "readOnlyHint": True,
@@ -116,6 +157,62 @@ def _list_domains(db: Session, *, workspace_id: Optional[int] = None) -> Dict[st
     }
 
 
+def _tool_domain(arguments: Dict[str, Any]) -> str:
+    domain = str(arguments.get("domain", "")).strip()
+    if not domain:
+        raise ValueError("domain is required")
+    return domain
+
+
+def _tool_days(arguments: Dict[str, Any]) -> int:
+    raw_days = arguments.get("days", 30)
+    try:
+        days = int(raw_days)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("days must be an integer from 1 to 365") from exc
+    if days < 1 or days > 365:
+        raise ValueError("days must be an integer from 1 to 365")
+    return days
+
+
+async def _call_read_only_tool(
+    name: str,
+    arguments: Dict[str, Any],
+    *,
+    db: Session,
+    auth_context: Dict[str, Any],
+    workspace_id: Optional[int],
+) -> Any:
+    if name == "list_domains":
+        return _list_domains(db, workspace_id=workspace_id)
+    if name == "domain_summary":
+        return build_evidence_summary(db, _tool_domain(arguments))
+    if name == "domain_posture":
+        return await domains.get_domain_posture_dashboard(
+            domain_id=_tool_domain(arguments),
+            refresh=bool(arguments.get("refresh", False)),
+            db=db,
+            _auth=auth_context,
+        )
+    if name == "domain_sources":
+        return await domains.get_domain_sources(
+            domain_id=_tool_domain(arguments),
+            days=_tool_days(arguments),
+            db=db,
+            _auth=auth_context,
+        )
+    if name == "source_intelligence":
+        return await domains.get_domain_source_intelligence(
+            domain_id=_tool_domain(arguments),
+            days=_tool_days(arguments),
+            db=db,
+            _auth=auth_context,
+        )
+    if name == "action_proposals":
+        return build_action_proposals(db, _tool_domain(arguments))
+    raise KeyError(name)
+
+
 @router.post("")
 async def mcp_jsonrpc(
     payload: MCPRequest,
@@ -151,17 +248,18 @@ async def mcp_jsonrpc(
     name = payload.params.get("name")
     arguments = payload.params.get("arguments") or {}
     try:
-        if name == "list_domains":
-            result = _list_domains(db, workspace_id=workspace.id)
-        elif name == "domain_summary":
-            result = build_evidence_summary(db, str(arguments.get("domain", "")))
-        elif name == "action_proposals":
-            result = build_action_proposals(db, str(arguments.get("domain", "")))
-        else:
-            return _jsonrpc_response(
-                payload.id,
-                error={"code": -32602, "message": f"Unsupported tool: {name}"},
-            )
+        result = await _call_read_only_tool(
+            str(name),
+            arguments,
+            db=db,
+            auth_context=_auth,
+            workspace_id=workspace.id,
+        )
+    except KeyError:
+        return _jsonrpc_response(
+            payload.id,
+            error={"code": -32602, "message": f"Unsupported tool: {name}"},
+        )
     except ValueError as exc:
         return _jsonrpc_response(payload.id, error={"code": -32004, "message": str(exc)})
 
@@ -180,7 +278,7 @@ async def mcp_jsonrpc(
     return _jsonrpc_response(
         payload.id,
         {
-            "content": [{"type": "json", "json": result}],
+            "content": [{"type": "json", "json": jsonable_encoder(result)}],
             "isError": False,
         },
     )

--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -60,6 +60,44 @@ async def public_domain_reports(
     )
 
 
+@router.get(
+    "/domains/{domain_id}/sources",
+    response_model=domains.DomainSourcesResponse,
+)
+async def public_domain_sources(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_api_token_scope(READ_REPORTS_SCOPE)),
+):
+    """Return enriched DMARC sending sources for one domain."""
+    return await domains.get_domain_sources(
+        domain_id=domain_id,
+        days=days,
+        db=db,
+        _auth=_auth,
+    )
+
+
+@router.get(
+    "/domains/{domain_id}/source-intelligence",
+    response_model=domains.SourceIntelligenceResponse,
+)
+async def public_domain_source_intelligence(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_api_token_scope(READ_REPORTS_SCOPE)),
+):
+    """Return regional source summaries and anomaly hints for one domain."""
+    return await domains.get_domain_source_intelligence(
+        domain_id=domain_id,
+        days=days,
+        db=db,
+        _auth=_auth,
+    )
+
+
 @router.get("/tls-reports/summary", response_model=tls_reports.TLSSummaryResponse)
 async def public_tls_report_summary(
     domain: Optional[str] = Query(default=None),

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -627,7 +627,10 @@ def test_mcp_requires_enabled_scoped_token(client: TestClient, db_session: Sessi
         json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
     )
     assert listed.status_code == 200
-    assert listed.json()["result"]["tools"][0]["readOnlyHint"] is True
+    tools = listed.json()["result"]["tools"]
+    assert tools[0]["readOnlyHint"] is True
+    tool_names = {tool["name"] for tool in tools}
+    assert {"domain_sources", "source_intelligence", "domain_posture"}.issubset(tool_names)
 
     called = client.post(
         "/api/v1/mcp",
@@ -642,6 +645,34 @@ def test_mcp_requires_enabled_scoped_token(client: TestClient, db_session: Sessi
     assert called.status_code == 200
     result = called.json()["result"]["content"][0]["json"]
     assert result["summary"]["domain"] == DOMAIN
+
+    source_intelligence = client.post(
+        "/api/v1/mcp",
+        headers={"X-API-Key": token.secret},
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "source_intelligence", "arguments": {"domain": DOMAIN}},
+        },
+    )
+    assert source_intelligence.status_code == 200
+    source_result = source_intelligence.json()["result"]["content"][0]["json"]
+    assert source_result["domain"] == DOMAIN
+    assert "regions" in source_result
+
+    invalid_window = client.post(
+        "/api/v1/mcp",
+        headers={"X-API-Key": token.secret},
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "source_intelligence", "arguments": {"domain": DOMAIN, "days": 0}},
+        },
+    )
+    assert invalid_window.status_code == 200
+    assert invalid_window.json()["error"]["code"] == -32004
 
 
 def test_mcp_requires_advanced_integrations_entitlement(client: TestClient, db_session: Session):

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock, patch
+
 from fastapi.testclient import TestClient
 
 from app.models.api_token import APIToken
@@ -90,6 +92,36 @@ def test_public_domains_summary_uses_scoped_token_context(client: TestClient, db
 
     assert response.status_code == 200
     assert response.json()["domains"][0]["domain_name"] == DOMAIN
+
+
+def test_public_source_intelligence_endpoints_use_report_scope(client: TestClient, db_session):
+    """Stable public API exposes source evidence without admin-session auth."""
+    _persist_report(db_session)
+    created = create_api_token(db_session, name="source bot", scopes=[READ_REPORTS_SCOPE])
+
+    with patch(
+        "app.api.api_v1.endpoints.domains._safe_ptr_lookup",
+        new=AsyncMock(return_value="mail.example.net"),
+    ):
+        sources = client.get(
+            f"/api/v1/public/domains/{DOMAIN}/sources?days=30",
+            headers={"X-API-Key": created.secret},
+        )
+    intelligence = client.get(
+        f"/api/v1/public/domains/{DOMAIN}/source-intelligence?days=30",
+        headers={"X-API-Key": created.secret},
+    )
+
+    assert sources.status_code == 200
+    source_row = sources.json()["sources"][0]
+    assert source_row["ip"] == "1.2.3.4"
+    assert source_row["hostname"] == "mail.example.net"
+    assert "geo" in source_row
+    assert "anomalies" in source_row
+    assert intelligence.status_code == 200
+    assert intelligence.json()["domain"] == DOMAIN
+    assert "regions" in intelligence.json()
+    assert "summary" in intelligence.json()
 
 
 def test_public_api_rejects_token_without_required_scope(client: TestClient, db_session):

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -59,12 +59,31 @@ through the `/public` path and avoid UI-specific payloads.
 | --- | --- | --- |
 | `GET /public/domains` | `reports:read` | Domain report and DNS summary list |
 | `GET /public/domains/{domain_id}/reports` | `reports:read` | Recent DMARC aggregate report summaries |
+| `GET /public/domains/{domain_id}/sources` | `reports:read` | Enriched sending sources with sender, geo, anomaly, and fix hints |
+| `GET /public/domains/{domain_id}/source-intelligence` | `reports:read` | Regional source summaries and anomaly hints |
 | `GET /public/domains/{domain_id}/posture` | `posture:read` | Evidence-first posture dashboard payload |
 | `GET /public/tls-reports/summary` | `tls-reports:read` | SMTP TLS report trends and failure groups |
 | `POST /mcp` | `mcp:read` | Read-only MCP-style JSON-RPC tool endpoint |
 
 Successful public API calls update the token's last-used timestamp, source IP,
 and usage count for auditing.
+
+Public source responses are intended for SIEM, SOC, ISP, MSP, and AI-agent
+consumers that need evidence-linked DMARC sending-source context without
+screen-scraping the dashboard. Source rows include DNS/PTR enrichment when
+available, sender classification, coarse geography, anomaly badges, SPF hints,
+and safe remediation recommendations.
+
+The MCP endpoint currently exposes these read-only tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `list_domains` | List monitored domains and aggregate counts |
+| `domain_summary` | Return an evidence-first DMARC summary |
+| `domain_posture` | Return posture score, grade, DNS health, and action guidance |
+| `domain_sources` | Return enriched DMARC sending sources |
+| `source_intelligence` | Return source regions and anomaly hints |
+| `action_proposals` | Return reviewable remediation proposals without applying them |
 
 ### Provider API
 


### PR DESCRIPTION
## Summary
- add stable public read-only endpoints for domain sources and source intelligence
- expose source/posture tools through the read-only MCP JSON-RPC surface
- document the public source API and MCP tools

## Scope
This is a bounded #309 slice. It does not add write actions, PDF evidence reports, ARC/ARF, or admin/provider demo changes.

## Validation
- ./.venv/bin/pytest backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py
- ./.venv/bin/flake8 backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py
- ./.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py
- ./.venv/bin/black --check backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py
- git diff --check

Refs #309