### PR TITLE
Productize public action proposals

### DIFF
--- a/backend/app/api/api_v1/endpoints/ai.py
+++ b/backend/app/api/api_v1/endpoints/ai.py
@@ -100,8 +100,9 @@ async def get_domain_safe_context(
 ) -> SafeContextResponse:
     """Return a redacted, evidence-linked context payload for one domain."""
     _require_ai_enabled(db)
+    workspace = _authorized_ai_workspace(_auth, db)
     try:
-        return {"context": build_safe_context(db, domain)}
+        return {"context": build_safe_context(db, domain, workspace_id=workspace.id)}
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
@@ -116,15 +117,15 @@ async def get_domain_evidence_summary(
 ) -> EvidenceSummaryResponse:
     """Return deterministic evidence-first assistance for one domain."""
     _require_ai_enabled(db)
-    try:
-        summary = build_evidence_summary(db, domain)
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     workspace = _authorized_ai_workspace(
         _auth,
         db,
         parse_selected_workspace_id(selected_workspace),
     )
+    try:
+        summary = build_evidence_summary(db, domain, workspace_id=workspace.id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     record_workspace_audit_log(
         db,
         workspace=workspace,
@@ -155,20 +156,21 @@ async def get_domain_remediation_plan(
 ) -> RemediationPlanResponse:  # pylint: disable=too-many-positional-arguments
     """Return a cached step-by-step remediation plan for DNS/posture findings."""
     _require_ai_enabled(db)
+    workspace = _authorized_ai_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
     try:
         plan = await build_remediation_plan(
             db,
             domain,
             finding_code=finding_code,
             refresh=refresh,
+            workspace_id=workspace.id,
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-    workspace = _authorized_ai_workspace(
-        _auth,
-        db,
-        parse_selected_workspace_id(selected_workspace),
-    )
     record_workspace_audit_log(
         db,
         workspace=workspace,
@@ -199,15 +201,15 @@ async def get_domain_action_proposals(
 ) -> ActionProposalResponse:
     """Return reviewable proposals; this endpoint never applies changes."""
     _require_ai_enabled(db)
-    try:
-        payload = build_action_proposals(db, domain)
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     workspace = _authorized_ai_workspace(
         _auth,
         db,
         parse_selected_workspace_id(selected_workspace),
     )
+    try:
+        payload = build_action_proposals(db, domain, workspace_id=workspace.id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     record_workspace_audit_log(
         db,
         workspace=workspace,
@@ -242,7 +244,12 @@ async def confirm_action_proposal(
                 "Action tools are disabled. Enable ai.action_tools_enabled to confirm " "proposals."
             ),
         )
-    proposals = build_action_proposals(db, domain)["proposals"]
+    workspace = _authorized_ai_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    proposals = build_action_proposals(db, domain, workspace_id=workspace.id)["proposals"]
     proposal = next(
         (item for item in proposals if item["proposal_id"] == payload.proposal_id),
         None,
@@ -254,11 +261,6 @@ async def confirm_action_proposal(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="confirmation_text must match proposal_id",
         )
-    workspace = _authorized_ai_workspace(
-        _auth,
-        db,
-        parse_selected_workspace_id(selected_workspace),
-    )
     record_workspace_audit_log(
         db,
         workspace=workspace,

--- a/backend/app/api/api_v1/endpoints/mcp.py
+++ b/backend/app/api/api_v1/endpoints/mcp.py
@@ -186,7 +186,7 @@ async def _call_read_only_tool(
     if name == "list_domains":
         return _list_domains(db, workspace_id=workspace_id)
     if name == "domain_summary":
-        return build_evidence_summary(db, _tool_domain(arguments))
+        return build_evidence_summary(db, _tool_domain(arguments), workspace_id=workspace_id)
     if name == "domain_posture":
         return await domains.get_domain_posture_dashboard(
             domain_id=_tool_domain(arguments),
@@ -209,7 +209,7 @@ async def _call_read_only_tool(
             _auth=auth_context,
         )
     if name == "action_proposals":
-        return build_action_proposals(db, _tool_domain(arguments))
+        return build_action_proposals(db, _tool_domain(arguments), workspace_id=workspace_id)
     raise KeyError(name)
 
 

--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -2,13 +2,15 @@
 
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Path, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from sqlalchemy.orm import Session
 
-from app.api.api_v1.endpoints import domains, tls_reports
+from app.api.api_v1.endpoints import ai, domains, tls_reports
 from app.core.database import get_db
 from app.core.security import require_api_token_scope
+from app.services.ai_assistance import build_action_proposals
 from app.services.api_tokens import READ_POSTURE_SCOPE, READ_REPORTS_SCOPE, READ_TLS_SCOPE
+from app.services.workspace_access import PERMISSION_REPORTS_READ, resolve_authorized_workspace
 
 router = APIRouter()
 
@@ -39,6 +41,23 @@ async def public_domain_posture(
         db=db,
         _auth=_auth,
     )
+
+
+@router.get(
+    "/domains/{domain_id}/action-proposals",
+    response_model=ai.ActionProposalResponse,
+)
+async def public_domain_action_proposals(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_api_token_scope(READ_POSTURE_SCOPE)),
+):
+    """Return stable read-only remediation proposals for one domain."""
+    workspace = resolve_authorized_workspace(db, _auth, PERMISSION_REPORTS_READ)
+    try:
+        return build_action_proposals(db, domain_id, workspace_id=workspace.id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
 
 @router.get(

--- a/backend/app/services/ai_assistance.py
+++ b/backend/app/services/ai_assistance.py
@@ -128,13 +128,19 @@ def redact_safe_value(value: Any, *, mode: str = "strict") -> Any:
     return redacted
 
 
-def _domain_exists(db: Session, store: ReportStore, domain: str) -> bool:
+def _domain_exists(
+    db: Session,
+    store: ReportStore,
+    domain: str,
+    *,
+    workspace_id: Optional[int] = None,
+) -> bool:
     if domain in store.get_domains():
         return True
-    return (
-        db.query(Domain.id).filter(Domain.name == domain, Domain.active.is_(True)).first()
-        is not None
-    )
+    query = db.query(Domain.id).filter(Domain.name == domain, Domain.active.is_(True))
+    if workspace_id is not None:
+        query = query.filter(Domain.workspace_id == workspace_id)
+    return query.first() is not None
 
 
 def _evidence(label: str, value: Any, href: str) -> Dict[str, str]:
@@ -145,8 +151,16 @@ def _evidence(label: str, value: Any, href: str) -> Dict[str, str]:
     }
 
 
-def _domain_selectors_from_db(db: Session, domain: str) -> List[str]:
-    row = db.query(Domain.dkim_selectors).filter(Domain.name == domain).first()
+def _domain_selectors_from_db(
+    db: Session,
+    domain: str,
+    *,
+    workspace_id: Optional[int] = None,
+) -> List[str]:
+    query = db.query(Domain.dkim_selectors).filter(Domain.name == domain)
+    if workspace_id is not None:
+        query = query.filter(Domain.workspace_id == workspace_id)
+    row = query.first()
     if row is None:
         return []
     return [selector.strip() for selector in (row[0] or "").split(",") if selector.strip()]
@@ -165,8 +179,15 @@ def _selectors_from_reports(store: ReportStore, domain: str) -> List[str]:
     return selectors
 
 
-def _mail_source_context(db: Session) -> List[Dict[str, Any]]:
-    rows = db.query(MailSource).filter(MailSource.enabled.is_(True)).order_by(MailSource.name).all()
+def _mail_source_context(
+    db: Session,
+    *,
+    workspace_id: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    query = db.query(MailSource).filter(MailSource.enabled.is_(True))
+    if workspace_id is not None:
+        query = query.filter(MailSource.workspace_id == workspace_id)
+    rows = query.order_by(MailSource.name).all()
     return [
         {
             "name": source.name,
@@ -325,15 +346,16 @@ async def build_remediation_plan(  # pylint: disable=too-many-locals
     *,
     finding_code: Optional[str] = None,
     refresh: bool = False,
+    workspace_id: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Build a step-by-step remediation plan, optionally enhanced through LiteLLM."""
     store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
-    if not _domain_exists(db, store, domain):
+    hydrate_report_store_from_db(db, store, workspace_id=workspace_id)
+    if not _domain_exists(db, store, domain, workspace_id=workspace_id):
         raise ValueError("Domain not found")
 
     config = get_assistance_config(db)
-    manual_selectors = _domain_selectors_from_db(db, domain)
+    manual_selectors = _domain_selectors_from_db(db, domain, workspace_id=workspace_id)
     report_selectors = _selectors_from_reports(store, domain)
     combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
     provider = get_default_provider(db)
@@ -365,14 +387,14 @@ async def build_remediation_plan(  # pylint: disable=too-many-locals
             "generated_at": datetime.utcnow().isoformat() + "Z",
             "demo_mode": get_settings().DEMO_MODE,
             "dns_provider": provider.__class__.__name__,
-            "mail_sources": _mail_source_context(db),
+            "mail_sources": _mail_source_context(db, workspace_id=workspace_id),
             "dkim_selectors": {
                 "manual": manual_selectors,
                 "observed_from_reports": report_selectors,
                 "checked": dns_result.selectors_checked,
                 "resolved": dns_result.dkim_selectors,
             },
-            "safe_summary": build_safe_context(db, domain)["summary"],
+            "safe_summary": build_safe_context(db, domain, workspace_id=workspace_id)["summary"],
             "dns_guidance": {
                 "status": guidance.status,
                 "findings": finding_dicts,
@@ -414,11 +436,16 @@ async def build_remediation_plan(  # pylint: disable=too-many-locals
     return plan
 
 
-def build_safe_context(db: Session, domain: str) -> Dict[str, Any]:
+def build_safe_context(
+    db: Session,
+    domain: str,
+    *,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
     """Build a redacted, evidence-linked context bundle for one domain."""
     store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
-    if not _domain_exists(db, store, domain):
+    hydrate_report_store_from_db(db, store, workspace_id=workspace_id)
+    if not _domain_exists(db, store, domain, workspace_id=workspace_id):
         raise ValueError("Domain not found")
 
     config = get_assistance_config(db)
@@ -497,9 +524,14 @@ def _headline_for_context(context: Dict[str, Any]) -> str:
     return "DMARC posture needs remediation before policy enforcement."
 
 
-def build_evidence_summary(db: Session, domain: str) -> Dict[str, Any]:
+def build_evidence_summary(
+    db: Session,
+    domain: str,
+    *,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
     """Return an evidence-first operator summary and remediation plan."""
-    context = build_safe_context(db, domain)
+    context = build_safe_context(db, domain, workspace_id=workspace_id)
     summary = context["summary"]
     failed = int(summary["failed_messages"])
     total = int(summary["total_messages"])
@@ -573,9 +605,14 @@ def _proposal_id(payload: Dict[str, Any]) -> str:
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
 
-def build_action_proposals(db: Session, domain: str) -> Dict[str, Any]:
+def build_action_proposals(
+    db: Session,
+    domain: str,
+    *,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
     """Generate reviewable, reproducible action proposals without mutating state."""
-    summary = build_evidence_summary(db, domain)
+    summary = build_evidence_summary(db, domain, workspace_id=workspace_id)
     proposals = []
     for index, recommendation in enumerate(summary["recommendations"], start=1):
         payload = {

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -18,6 +18,7 @@ from app.services.api_tokens import MCP_READ_SCOPE, create_api_token
 from app.services.bimi import BIMIResult
 from app.services.dns_resolver import DomainDNSResult
 from app.services.mta_sts import MTAStsResult
+from app.services.report_persistence import save_parsed_report
 from app.services.report_store import ReportStore
 
 DOMAIN = "example.com"
@@ -49,6 +50,11 @@ REPORT = {
 
 def _seed_report_store() -> None:
     ReportStore.get_instance().add_report(REPORT)
+
+
+def _persist_report(db_session: Session) -> None:
+    save_parsed_report(db_session, REPORT)
+    db_session.commit()
 
 
 def _set_setting(db: Session, key: str, value: str, category: str) -> None:
@@ -100,7 +106,7 @@ def test_ai_summary_is_evidence_first_and_redacted(
     authed_client: TestClient,
     db_session: Session,
 ):
-    _seed_report_store()
+    _persist_report(db_session)
     _set_setting(db_session, "ai.enabled", "true", "ai")
     _set_setting(db_session, "ai.redaction_mode", "strict", "ai")
 
@@ -131,7 +137,7 @@ def test_ai_remediation_plan_uses_template_and_cache(
     authed_client: TestClient,
     db_session: Session,
 ):
-    _seed_report_store()
+    _persist_report(db_session)
     _set_setting(db_session, "ai.enabled", "true", "ai")
     _set_setting(db_session, "ai.remediation_cache_seconds", "86400", "ai")
     provider = AsyncMock()
@@ -454,7 +460,7 @@ def test_ai_remediation_plan_can_use_litellm_provider(
     authed_client: TestClient,
     db_session: Session,
 ):
-    _seed_report_store()
+    _persist_report(db_session)
     _set_setting(db_session, "ai.enabled", "true", "ai")
     _set_setting(db_session, "ai.provider", "litellm", "ai")
     provider = AsyncMock()
@@ -562,7 +568,7 @@ def test_action_proposals_are_reviewable_and_not_mutating(
     authed_client: TestClient,
     db_session: Session,
 ):
-    _seed_report_store()
+    _persist_report(db_session)
     _set_setting(db_session, "ai.enabled", "true", "ai")
 
     response = authed_client.get(f"/api/v1/ai/domains/{DOMAIN}/action-proposals")
@@ -581,7 +587,7 @@ def test_action_confirmation_requires_action_tools_enabled(
     authed_client: TestClient,
     db_session: Session,
 ):
-    _seed_report_store()
+    _persist_report(db_session)
     _set_setting(db_session, "ai.enabled", "true", "ai")
     proposal = authed_client.get(f"/api/v1/ai/domains/{DOMAIN}/action-proposals").json()[
         "proposals"
@@ -710,7 +716,7 @@ async def test_mcp_read_only_tool_dispatch_rejects_invalid_tool_arguments(
 
 
 def test_mcp_requires_enabled_scoped_token(client: TestClient, db_session: Session):
-    _seed_report_store()
+    _persist_report(db_session)
     token = create_api_token(db_session, name="mcp client", scopes=[MCP_READ_SCOPE])
 
     disabled = client.post(

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -43,6 +43,23 @@ MINIMAL_REPORT = {
     "summary": {"total_count": 5, "passed_count": 5, "failed_count": 0, "pass_rate": 100.0},
 }
 
+FAILING_REPORT = {
+    **MINIMAL_REPORT,
+    "report_id": "public-api-failing-001",
+    "records": [
+        {
+            "source_ip": "5.6.7.8",
+            "count": 10,
+            "disposition": "none",
+            "dkim_result": "fail",
+            "spf_result": "fail",
+            "dkim": [{"domain": DOMAIN, "result": "fail", "selector": "legacy"}],
+            "spf": [{"domain": DOMAIN, "result": "fail"}],
+        }
+    ],
+    "summary": {"total_count": 10, "passed_count": 0, "failed_count": 10, "pass_rate": 0.0},
+}
+
 
 def _seed_report_store():
     ReportStore.get_instance().add_report(MINIMAL_REPORT)
@@ -50,6 +67,11 @@ def _seed_report_store():
 
 def _persist_report(db_session):
     save_parsed_report(db_session, MINIMAL_REPORT)
+    db_session.commit()
+
+
+def _persist_failing_report(db_session, report=None, *, workspace_id=None):
+    save_parsed_report(db_session, report or FAILING_REPORT, workspace_id=workspace_id)
     db_session.commit()
 
 
@@ -136,6 +158,82 @@ def test_public_api_rejects_token_without_required_scope(client: TestClient, db_
 
     assert response.status_code == 403
     assert response.json()["detail"] == f"API token requires scope: {READ_POSTURE_SCOPE}"
+
+
+def test_public_action_proposals_use_posture_scope(client: TestClient, db_session):
+    """Public action proposals are read-only and scoped to posture tokens."""
+    _persist_failing_report(db_session)
+    posture_token = create_api_token(
+        db_session,
+        name="posture bot",
+        scopes=[READ_POSTURE_SCOPE],
+    )
+    reports_token = create_api_token(
+        db_session,
+        name="reports bot",
+        scopes=[READ_REPORTS_SCOPE],
+    )
+
+    denied = client.get(
+        f"/api/v1/public/domains/{DOMAIN}/action-proposals",
+        headers={"X-API-Key": reports_token.secret},
+    )
+    response = client.get(
+        f"/api/v1/public/domains/{DOMAIN}/action-proposals",
+        headers={"X-API-Key": posture_token.secret},
+    )
+
+    assert denied.status_code == 403
+    assert response.status_code == 200
+    body = response.json()
+    assert body["domain"] == DOMAIN
+    assert body["proposals"]
+    assert body["proposals"][0]["mutates_state"] is False
+    assert body["proposals"][0]["requires_human_confirmation"] is True
+
+
+def test_public_action_proposals_are_workspace_scoped(client: TestClient, db_session):
+    """Public action proposals cannot cross the API token workspace boundary."""
+    get_or_create_default_workspace(db_session)
+    other_workspace = Workspace(
+        slug="public-actions-other",
+        name="Public Actions Other",
+        active=True,
+    )
+    db_session.add(other_workspace)
+    db_session.commit()
+
+    other_domain = "other-workspace.example"
+    other_report = {
+        **FAILING_REPORT,
+        "domain": other_domain,
+        "report_id": "public-api-other-workspace-001",
+    }
+    _persist_failing_report(db_session, other_report, workspace_id=other_workspace.id)
+    default_token = create_api_token(
+        db_session,
+        name="default posture bot",
+        scopes=[READ_POSTURE_SCOPE],
+    )
+    other_token = create_api_token(
+        db_session,
+        name="other posture bot",
+        scopes=[READ_POSTURE_SCOPE],
+        workspace_id=other_workspace.id,
+    )
+
+    denied = client.get(
+        f"/api/v1/public/domains/{other_domain}/action-proposals",
+        headers={"X-API-Key": default_token.secret},
+    )
+    allowed = client.get(
+        f"/api/v1/public/domains/{other_domain}/action-proposals",
+        headers={"X-API-Key": other_token.secret},
+    )
+
+    assert denied.status_code == 404
+    assert allowed.status_code == 200
+    assert allowed.json()["domain"] == other_domain
 
 
 def test_admin_can_create_list_and_revoke_api_tokens(authed_client: TestClient, db_session):

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -62,6 +62,7 @@ through the `/public` path and avoid UI-specific payloads.
 | `GET /public/domains/{domain_id}/sources` | `reports:read` | Enriched sending sources with sender, geo, anomaly, and fix hints |
 | `GET /public/domains/{domain_id}/source-intelligence` | `reports:read` | Regional source summaries and anomaly hints |
 | `GET /public/domains/{domain_id}/posture` | `posture:read` | Evidence-first posture dashboard payload |
+| `GET /public/domains/{domain_id}/action-proposals` | `posture:read` | Reviewable read-only remediation proposals |
 | `GET /public/tls-reports/summary` | `tls-reports:read` | SMTP TLS report trends and failure groups |
 | `POST /mcp` | `mcp:read` | Read-only MCP-style JSON-RPC tool endpoint |
 


### PR DESCRIPTION
## Summary

- add a stable public `GET /public/domains/{domain_id}/action-proposals` endpoint behind `posture:read`
- pass workspace context through AI assistance, admin AI routes, and MCP action/summary helpers
- add scope and workspace-isolation coverage for public action proposals
- document the new public endpoint

## Why

Issue #309 asks for productized public API and MCP access to posture/reporting intelligence. The previous slice exposed sources and source intelligence; this follow-up exposes deterministic read-only action proposals so external operators and automation can retrieve actionable remediation guidance without enabling write actions.

## Validation

- `./.venv/bin/pytest backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q`
- `./.venv/bin/flake8 backend/app/services/ai_assistance.py backend/app/api/api_v1/endpoints/ai.py backend/app/api/api_v1/endpoints/mcp.py backend/app/api/api_v1/endpoints/public.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `./.venv/bin/isort --check-only ... && ./.venv/bin/black --check ... && git diff --check`

Refs #309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public read-only endpoint to view domain action proposals.
  * Action and remediation proposals are now consistently tied to the selected workspace.

* **Bug Fixes**
  * Improved workspace scoping so AI-assisted summaries, evidence, and remediation plans only use data from the authorized workspace.
  * Strengthened access checks for proposal review and confirmation across workspaces.

* **Documentation**
  * Updated API reference to include the new action-proposals endpoint and required access scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->