### PR TITLE
Productize public DNS guidance

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -232,6 +232,29 @@ class DNSChangePlanResponse(BaseModel):
     plans: List[DNSChangePlanItemResponse]
 
 
+def read_only_dns_change_plan_response(payload: Any) -> DNSChangePlanResponse:
+    """Return an automation-safe DNS plan payload without write affordances."""
+    data = payload.model_dump() if hasattr(payload, "model_dump") else dict(payload)
+    plans = []
+    for plan in data.get("plans") or []:
+        plan_data = plan.model_dump() if hasattr(plan, "model_dump") else dict(plan)
+        plans.append(
+            {
+                **plan_data,
+                "provider_write_available": False,
+                "applies_automatically": False,
+            }
+        )
+    return DNSChangePlanResponse(
+        domain=data["domain"],
+        status=data["status"],
+        read_only=True,
+        provider_write_available=False,
+        apply_endpoint=None,
+        plans=plans,
+    )
+
+
 class DNSProviderCapabilityResponse(BaseModel):
     """DNS provider write capability metadata."""
 

--- a/backend/app/api/api_v1/endpoints/mcp.py
+++ b/backend/app/api/api_v1/endpoints/mcp.py
@@ -80,6 +80,32 @@ READ_ONLY_TOOLS = [
         "readOnlyHint": True,
     },
     {
+        "name": "dns_lint",
+        "description": "Return DNS lint findings, evidence, and target records for one domain.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "domain": {"type": "string"},
+                "refresh": {"type": "boolean", "default": False},
+            },
+            "required": ["domain"],
+        },
+        "readOnlyHint": True,
+    },
+    {
+        "name": "dns_change_plan",
+        "description": "Return read-only DNS change plans without apply links.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "domain": {"type": "string"},
+                "refresh": {"type": "boolean", "default": False},
+            },
+            "required": ["domain"],
+        },
+        "readOnlyHint": True,
+    },
+    {
         "name": "source_intelligence",
         "description": "Return source geography summaries and anomaly hints for one domain.",
         "inputSchema": {
@@ -201,6 +227,21 @@ async def _call_read_only_tool(
             db=db,
             _auth=auth_context,
         )
+    if name == "dns_lint":
+        return await domains.get_domain_dns_lint(
+            domain_id=_tool_domain(arguments),
+            refresh=bool(arguments.get("refresh", False)),
+            db=db,
+            _auth=auth_context,
+        )
+    if name == "dns_change_plan":
+        response = await domains.get_domain_dns_change_plan(
+            domain_id=_tool_domain(arguments),
+            refresh=bool(arguments.get("refresh", False)),
+            db=db,
+            _auth=auth_context,
+        )
+        return domains.read_only_dns_change_plan_response(response)
     if name == "source_intelligence":
         return await domains.get_domain_source_intelligence(
             domain_id=_tool_domain(arguments),

--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -44,6 +44,45 @@ async def public_domain_posture(
 
 
 @router.get(
+    "/domains/{domain_id}/dns/lint",
+    response_model=domains.DNSGuidanceResponse,
+)
+async def public_domain_dns_lint(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS result"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_api_token_scope(READ_POSTURE_SCOPE)),
+):
+    """Return stable read-only DNS lint findings for one domain."""
+    return await domains.get_domain_dns_lint(
+        domain_id=domain_id,
+        refresh=refresh,
+        db=db,
+        _auth=_auth,
+    )
+
+
+@router.get(
+    "/domains/{domain_id}/dns/change-plan",
+    response_model=domains.DNSChangePlanResponse,
+)
+async def public_domain_dns_change_plan(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS result"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_api_token_scope(READ_POSTURE_SCOPE)),
+):
+    """Return public read-only DNS change plans without write affordances."""
+    response = await domains.get_domain_dns_change_plan(
+        domain_id=domain_id,
+        refresh=refresh,
+        db=db,
+        _auth=_auth,
+    )
+    return domains.read_only_dns_change_plan_response(response)
+
+
+@router.get(
     "/domains/{domain_id}/action-proposals",
     response_model=ai.ActionProposalResponse,
 )

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -702,6 +702,42 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
             new=AsyncMock(return_value={"domain": DOMAIN, "sources": []}),
         ) as sources,
         patch(
+            "app.api.api_v1.endpoints.mcp.domains.get_domain_dns_lint",
+            new=AsyncMock(return_value={"domain": DOMAIN, "status": "attention"}),
+        ) as dns_lint,
+        patch(
+            "app.api.api_v1.endpoints.mcp.domains.get_domain_dns_change_plan",
+            new=AsyncMock(
+                return_value={
+                    "domain": DOMAIN,
+                    "status": "attention",
+                    "read_only": False,
+                    "provider_write_available": True,
+                    "apply_endpoint": f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+                    "plans": [
+                        {
+                            "plan_id": "dns-plan-1",
+                            "finding_code": "dmarc_missing",
+                            "severity": "error",
+                            "operation": "create",
+                            "record_type": "TXT",
+                            "name": f"_dmarc.{DOMAIN}",
+                            "proposed_value": "v=DMARC1; p=none",
+                            "current_values": [],
+                            "rationale": "Publish DMARC policy discovery.",
+                            "risk": "Low; validates syntax before enforcement.",
+                            "rollback": "Remove the new TXT record.",
+                            "expected_health_impact": ("Expected to remove a DNS-health finding."),
+                            "manual_steps": ["Create the TXT record."],
+                            "requires_approval": True,
+                            "applies_automatically": True,
+                            "provider_write_available": True,
+                        }
+                    ],
+                }
+            ),
+        ) as dns_change_plan,
+        patch(
             "app.api.api_v1.endpoints.mcp.domains.get_domain_source_intelligence",
             new=AsyncMock(return_value={"domain": DOMAIN, "regions": []}),
         ) as intelligence,
@@ -727,6 +763,20 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
             auth_context=auth_context,
             workspace_id=None,
         )
+        dns_lint_result = await mcp_endpoint._call_read_only_tool(
+            "dns_lint",
+            {"domain": DOMAIN, "refresh": True},
+            db=db_session,
+            auth_context=auth_context,
+            workspace_id=None,
+        )
+        dns_plan_result = await mcp_endpoint._call_read_only_tool(
+            "dns_change_plan",
+            {"domain": DOMAIN},
+            db=db_session,
+            auth_context=auth_context,
+            workspace_id=None,
+        )
         intelligence_result = await mcp_endpoint._call_read_only_tool(
             "source_intelligence",
             {"domain": DOMAIN},
@@ -745,10 +795,18 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
     assert listed["domains"][0]["domain"] == DOMAIN
     assert posture_result["grade"] == "A"
     assert source_result["sources"] == []
+    assert dns_lint_result["status"] == "attention"
+    assert dns_plan_result.read_only is True
+    assert dns_plan_result.provider_write_available is False
+    assert dns_plan_result.apply_endpoint is None
+    assert dns_plan_result.plans[0].provider_write_available is False
+    assert dns_plan_result.plans[0].applies_automatically is False
     assert intelligence_result["regions"] == []
     assert proposals["proposals"]
     posture.assert_awaited_once()
     sources.assert_awaited_once()
+    dns_lint.assert_awaited_once()
+    dns_change_plan.assert_awaited_once()
     intelligence.assert_awaited_once()
 
 
@@ -807,7 +865,13 @@ def test_mcp_requires_enabled_scoped_token(client: TestClient, db_session: Sessi
     tools = listed.json()["result"]["tools"]
     assert tools[0]["readOnlyHint"] is True
     tool_names = {tool["name"] for tool in tools}
-    assert {"domain_sources", "source_intelligence", "domain_posture"}.issubset(tool_names)
+    assert {
+        "domain_sources",
+        "source_intelligence",
+        "domain_posture",
+        "dns_lint",
+        "dns_change_plan",
+    }.issubset(tool_names)
 
     initialized = client.post(
         "/api/v1/mcp",

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
+from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.models.api_token import APIToken
 from app.models.organization import BillingAccount, Organization
 from app.models.workspace import Workspace
@@ -234,6 +235,94 @@ def test_public_action_proposals_are_workspace_scoped(client: TestClient, db_ses
     assert denied.status_code == 404
     assert allowed.status_code == 200
     assert allowed.json()["domain"] == other_domain
+
+
+def test_public_dns_guidance_uses_posture_scope_and_read_only_plans(
+    client: TestClient,
+    db_session,
+):
+    """Stable public DNS guidance is posture-scoped and never exposes write affordances."""
+    _persist_report(db_session)
+    posture_token = create_api_token(
+        db_session,
+        name="dns posture bot",
+        scopes=[READ_POSTURE_SCOPE],
+    )
+    reports_token = create_api_token(
+        db_session,
+        name="reports bot",
+        scopes=[READ_REPORTS_SCOPE],
+    )
+    lint_payload = domains_endpoint.DNSGuidanceResponse(
+        domain=DOMAIN,
+        status="attention",
+        findings=[],
+        target_records=[],
+        change_plans=[],
+    )
+    change_payload = domains_endpoint.DNSChangePlanResponse(
+        domain=DOMAIN,
+        status="attention",
+        read_only=False,
+        provider_write_available=True,
+        apply_endpoint=f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+        plans=[
+            domains_endpoint.DNSChangePlanItemResponse(
+                plan_id="dns-plan-1",
+                finding_code="dmarc_missing",
+                severity="error",
+                operation="create",
+                record_type="TXT",
+                name=f"_dmarc.{DOMAIN}",
+                proposed_value="v=DMARC1; p=none",
+                current_values=[],
+                rationale="Publish DMARC policy discovery.",
+                risk="Low; validates syntax before enforcement.",
+                rollback="Remove the new TXT record.",
+                expected_health_impact="Expected to remove a DNS-health finding.",
+                manual_steps=["Create the TXT record."],
+                requires_approval=True,
+                applies_automatically=True,
+                provider_write_available=True,
+            )
+        ],
+    )
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.public.domains.get_domain_dns_lint",
+            new=AsyncMock(return_value=lint_payload),
+        ) as lint,
+        patch(
+            "app.api.api_v1.endpoints.public.domains.get_domain_dns_change_plan",
+            new=AsyncMock(return_value=change_payload),
+        ) as change_plan,
+    ):
+        denied = client.get(
+            f"/api/v1/public/domains/{DOMAIN}/dns/lint",
+            headers={"X-API-Key": reports_token.secret},
+        )
+        lint_response = client.get(
+            f"/api/v1/public/domains/{DOMAIN}/dns/lint?refresh=true",
+            headers={"X-API-Key": posture_token.secret},
+        )
+        plan_response = client.get(
+            f"/api/v1/public/domains/{DOMAIN}/dns/change-plan",
+            headers={"X-API-Key": posture_token.secret},
+        )
+
+    assert denied.status_code == 403
+    assert lint_response.status_code == 200
+    assert lint_response.json()["domain"] == DOMAIN
+    assert plan_response.status_code == 200
+    plan_body = plan_response.json()
+    assert plan_body["read_only"] is True
+    assert plan_body["provider_write_available"] is False
+    assert plan_body["apply_endpoint"] is None
+    assert plan_body["plans"][0]["provider_write_available"] is False
+    assert plan_body["plans"][0]["applies_automatically"] is False
+    lint.assert_awaited_once()
+    change_plan.assert_awaited_once()
 
 
 def test_admin_can_create_list_and_revoke_api_tokens(authed_client: TestClient, db_session):

--- a/docs/reference/ai-mcp-automation.md
+++ b/docs/reference/ai-mcp-automation.md
@@ -75,6 +75,11 @@ The current tools are read-only:
 
 - `list_domains`
 - `domain_summary`
+- `domain_posture`
+- `domain_sources`
+- `dns_lint`
+- `dns_change_plan`
+- `source_intelligence`
 - `action_proposals`
 
 Create a token with the `mcp:read` scope and send it through `X-API-Key`.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -62,6 +62,8 @@ through the `/public` path and avoid UI-specific payloads.
 | `GET /public/domains/{domain_id}/sources` | `reports:read` | Enriched sending sources with sender, geo, anomaly, and fix hints |
 | `GET /public/domains/{domain_id}/source-intelligence` | `reports:read` | Regional source summaries and anomaly hints |
 | `GET /public/domains/{domain_id}/posture` | `posture:read` | Evidence-first posture dashboard payload |
+| `GET /public/domains/{domain_id}/dns/lint` | `posture:read` | DNS lint findings, target records, and evidence |
+| `GET /public/domains/{domain_id}/dns/change-plan` | `posture:read` | Read-only DNS change plans without apply links |
 | `GET /public/domains/{domain_id}/action-proposals` | `posture:read` | Reviewable read-only remediation proposals |
 | `GET /public/tls-reports/summary` | `tls-reports:read` | SMTP TLS report trends and failure groups |
 | `POST /mcp` | `mcp:read` | Read-only MCP-style JSON-RPC tool endpoint |
@@ -83,6 +85,8 @@ The MCP endpoint currently exposes these read-only tools:
 | `domain_summary` | Return an evidence-first DMARC summary |
 | `domain_posture` | Return posture score, grade, DNS health, and action guidance |
 | `domain_sources` | Return enriched DMARC sending sources |
+| `dns_lint` | Return DNS lint findings, evidence, and target records |
+| `dns_change_plan` | Return read-only DNS change plans without apply links |
 | `source_intelligence` | Return source regions and anomaly hints |
 | `action_proposals` | Return reviewable remediation proposals without applying them |
 
@@ -365,6 +369,11 @@ Available tools:
 | --- | --- |
 | `list_domains` | List monitored domains and aggregate counts |
 | `domain_summary` | Return an evidence-first summary for one domain |
+| `domain_posture` | Return posture score, grade, DNS health, and action guidance |
+| `domain_sources` | Return enriched DMARC sending sources |
+| `dns_lint` | Return DNS lint findings, evidence, and target records |
+| `dns_change_plan` | Return read-only DNS change plans without apply links |
+| `source_intelligence` | Return source regions and anomaly hints |
 | `action_proposals` | Return reviewable remediation proposals without applying changes |
 
 Every successful tool call is audited as `mcp.tool_called`.


### PR DESCRIPTION
## Summary
- add stable public read-only DNS lint and DNS change-plan endpoints under `/api/v1/public`
- expose matching read-only MCP tools for DNS guidance automation
- strip provider write/apply affordances from public and MCP DNS change plans
- document the new public API and MCP tool surface

Refs #309

## Validation
- `./.venv/bin/pytest backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q --disable-warnings`
- `./.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `./.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `./.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only DNS lint and DNS change-plan access for domains through the public API.
  * Expanded the read-only tool set with DNS-focused options, including linting and change-planning.
* **Bug Fixes**
  * DNS change-plan responses now consistently return read-only, non-actionable fields to prevent unintended changes.
* **Documentation**
  * Updated API and tool references to reflect the newly available DNS endpoints and read-only tools.
* **Tests**
  * Added coverage for the new DNS endpoints and read-only tool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->