### PR TITLE
Add migration readiness workflow

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -158,6 +158,43 @@ class DomainStatsResponse(BaseModel):
     reportCount: int
 
 
+class MigrationReadinessItem(BaseModel):
+    """One safe migration readiness checklist item."""
+
+    key: str
+    status: str
+    title: str
+    detail: str
+    action: str
+    evidence: List[str] = Field(default_factory=list)
+    href: Optional[str] = None
+
+
+class MigrationExportLink(BaseModel):
+    """Portable export surface available during migration or offboarding."""
+
+    label: str
+    href: str
+    format: str
+    detail: str
+
+
+class MigrationReadinessResponse(BaseModel):
+    """Migration and data-portability readiness for one monitored domain."""
+
+    domain: str
+    status: str
+    readiness_score: int
+    summary: str
+    parallel_reporting_days: int
+    report_count: int
+    source_count: int
+    checklist: List[MigrationReadinessItem]
+    export_links: List[MigrationExportLink]
+    supported_sources: List[str] = Field(default_factory=list)
+    docs_url: str = "https://github.com/christianlouis/dmarq/blob/main/docs/user_guide/migration.md"
+
+
 class DNSRecordResponse(BaseModel):
     """DNS record information for a domain"""
 
@@ -2193,6 +2230,87 @@ async def get_domain_stats(
     )
 
 
+@router.get("/{domain_id}/migration/readiness", response_model=MigrationReadinessResponse)
+async def get_domain_migration_readiness(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS result"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return safe migration and data-portability readiness for one monitored domain."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store)
+
+    if not _domain_exists(db, store, domain_id, workspace):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Domain not found",
+        )
+
+    summary = store.get_domain_summary(domain_id)
+    reports = store.get_domain_reports(domain_id, limit=10000)
+    sources = store.get_domain_sources(domain_id)
+    guidance_payload = await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
+    guidance = DNSGuidanceResponse(**guidance_payload)
+    checklist, parallel_days = _build_migration_checklist(
+        domain_id,
+        summary,
+        reports,
+        sources,
+        guidance,
+    )
+    migration_status, readiness_score = _migration_readiness_status(checklist)
+    report_count = int(summary.get("reports_processed", 0) or len(reports))
+    source_count = len(sources)
+    summary_text = (
+        f"{domain_id} has {parallel_days} distinct report days, "
+        f"{report_count} aggregate reports, and {source_count} observed sending sources."
+    )
+
+    return MigrationReadinessResponse(
+        domain=domain_id,
+        status=migration_status,
+        readiness_score=readiness_score,
+        summary=summary_text,
+        parallel_reporting_days=parallel_days,
+        report_count=report_count,
+        source_count=source_count,
+        checklist=checklist,
+        export_links=[
+            MigrationExportLink(
+                label="Aggregate report CSV",
+                href=f"/api/v1/domains/{domain_id}/reports/export",
+                format="csv",
+                detail="Portable aggregate report summary for parity checks.",
+            ),
+            MigrationExportLink(
+                label="Health evidence CSV",
+                href=f"/api/v1/domains/{domain_id}/posture/evidence/export?capture_current=false",
+                format="csv",
+                detail="Score, policy, report, and DNS posture evidence.",
+            ),
+            MigrationExportLink(
+                label="Health evidence JSON",
+                href=(
+                    f"/api/v1/domains/{domain_id}/posture/evidence/export"
+                    "?capture_current=false&format=json"
+                ),
+                format="json",
+                detail="Machine-readable portability packet for automation.",
+            ),
+        ],
+        supported_sources=[
+            "Valimail",
+            "EasyDMARC",
+            "dmarcian",
+            "PowerDMARC",
+            "DMARCguard",
+            "Manual mailbox exports",
+        ],
+    )
+
+
 @router.get("/{domain_id}/dns", response_model=DNSRecordResponse)
 async def get_domain_dns_records(
     domain_id: str = Path(..., title="The domain ID or name"),
@@ -3005,6 +3123,121 @@ def _report_date(value: Any) -> Optional[date]:
 def _format_report_date(value: Any) -> str:
     report_date = _report_date(value)
     return report_date.isoformat() if report_date else ""
+
+
+def _migration_item(
+    key: str,
+    status_value: str,
+    title: str,
+    detail: str,
+    action: str,
+    evidence: Optional[List[str]] = None,
+    href: Optional[str] = None,
+) -> MigrationReadinessItem:
+    return MigrationReadinessItem(
+        key=key,
+        status=status_value,
+        title=title,
+        detail=detail,
+        action=action,
+        evidence=evidence or [],
+        href=href,
+    )
+
+
+def _migration_readiness_status(items: List[MigrationReadinessItem]) -> tuple[str, int]:
+    if not items:
+        return "blocked", 0
+    complete = sum(1 for item in items if item.status == "complete")
+    score = round((complete / len(items)) * 100)
+    if complete == len(items):
+        return "ready", score
+    if any(item.status == "complete" for item in items):
+        return "in_progress", score
+    return "blocked", score
+
+
+def _parallel_reporting_days(reports: List[Dict[str, Any]]) -> int:
+    dates = {
+        report_date
+        for report in reports
+        if (report_date := _report_date(report.get("begin_timestamp") or report.get("begin_date")))
+    }
+    return len(dates)
+
+
+def _build_migration_checklist(
+    domain_id: str,
+    summary: Dict[str, Any],
+    reports: List[Dict[str, Any]],
+    sources: List[Dict[str, Any]],
+    guidance: DNSGuidanceResponse,
+) -> tuple[List[MigrationReadinessItem], int]:
+    report_count = int(summary.get("reports_processed", 0) or len(reports))
+    total_emails = int(summary.get("total_count", 0) or 0)
+    source_count = len(sources)
+    parallel_days = _parallel_reporting_days(reports)
+    dns_finding_count = len(guidance.findings)
+
+    reporting_status = "complete" if report_count > 0 else "blocked"
+    volume_status = (
+        "complete" if parallel_days >= 14 else ("in_progress" if report_count else "blocked")
+    )
+    source_status = (
+        "complete" if source_count > 0 else ("in_progress" if report_count else "blocked")
+    )
+    dns_status = (
+        "complete" if dns_finding_count == 0 else ("in_progress" if report_count else "blocked")
+    )
+    export_status = "complete" if report_count > 0 else "blocked"
+
+    return [
+        _migration_item(
+            "parallel-reporting",
+            reporting_status,
+            "Run DMARQ alongside the current platform",
+            "Keep the existing DMARC tool in place and add DMARQ as an additional rua target.",
+            "Publish a DMARC record that sends aggregate reports to both systems.",
+            [f"{report_count} reports received", f"{total_emails} messages observed"],
+            "#dns-guidance",
+        ),
+        _migration_item(
+            "volume-parity",
+            volume_status,
+            "Validate 14-30 days of report parity",
+            "Use the overlap window to compare report volume, sender inventory, and policy results.",
+            "Wait for at least 14 distinct report days before removing the old tool.",
+            [f"{parallel_days} distinct report days", f"{report_count} reports processed"],
+            "#compliance-chart-section",
+        ),
+        _migration_item(
+            "sender-parity",
+            source_status,
+            "Review sending-source parity",
+            "Confirmed senders should match what the current platform reports before cutover.",
+            "Investigate unknown or failing sources before tightening policy or removing old routing.",
+            [f"{source_count} sending sources observed"],
+            "#sending-sources",
+        ),
+        _migration_item(
+            "dns-readiness",
+            dns_status,
+            "Clear DNS posture blockers",
+            "DMARC, SPF, DKIM, and reporting authorization findings should be understood before cutover.",
+            "Resolve critical DNS lint findings or document why they are intentionally deferred.",
+            [f"{dns_finding_count} DNS lint findings", f"DNS status: {guidance.status}"],
+            "#dns-guidance",
+        ),
+        _migration_item(
+            "portability-export",
+            export_status,
+            "Confirm export and rollback path",
+            "DMARQ keeps aggregate report and score evidence exportable for audit or offboarding.",
+            "Download report CSV and health evidence before decommissioning the previous platform.",
+            ["CSV reports export", "CSV or JSON health evidence export"],
+            "#recent-reports",
+        ),
+    ], parallel_days
 
 
 def _spf_fix_hint(ip: str, spf_result: str, failed_count: int = 0) -> Optional[str]:

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -378,6 +378,106 @@
         {% endcall %}
         </section>
 
+        <!-- Migration Readiness -->
+        <section id="migration-readiness">
+        {% call card() %}
+            {% call card_header() %}
+                <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                    <div>
+                        {% call card_title() %}Migration Readiness{% endcall %}
+                        {% call card_description() %}
+                            Parallel-reporting checklist and data-portability path for moving from another DMARC platform
+                        {% endcall %}
+                    </div>
+                    <div class="text-right">
+                        <span class="inline-flex items-center rounded px-2 py-1 text-xs font-semibold capitalize"
+                              :class="migrationStatusClass"
+                              x-text="migration.status.replace('_', ' ') || 'checking'"></span>
+                        <div class="mt-1 text-xs text-[#5f5c78]">
+                            <span x-text="migration.readiness_score"></span><span>% ready</span>
+                        </div>
+                    </div>
+                </div>
+            {% endcall %}
+            {% call card_content() %}
+                <div class="grid gap-5 xl:grid-cols-[280px_minmax(0,1fr)]">
+                    <div class="rounded-lg bg-[#f4f3f2] p-4">
+                        <div class="text-sm font-semibold text-[#5f5c78]">Parallel window</div>
+                        <div class="mt-3 grid grid-cols-3 gap-2 text-center">
+                            <div class="rounded bg-white p-3">
+                                <div class="text-2xl font-bold text-[#120d36]" x-text="migration.parallel_reporting_days"></div>
+                                <div class="text-xs text-[#5f5c78]">days</div>
+                            </div>
+                            <div class="rounded bg-white p-3">
+                                <div class="text-2xl font-bold text-[#120d36]" x-text="migration.report_count"></div>
+                                <div class="text-xs text-[#5f5c78]">reports</div>
+                            </div>
+                            <div class="rounded bg-white p-3">
+                                <div class="text-2xl font-bold text-[#120d36]" x-text="migration.source_count"></div>
+                                <div class="text-xs text-[#5f5c78]">sources</div>
+                            </div>
+                        </div>
+                        <p class="mt-3 text-sm text-[#5f5c78]" x-text="migration.summary"></p>
+                        <div class="mt-4 flex flex-wrap gap-2">
+                            <template x-for="source in migration.supported_sources" :key="source">
+                                <span class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#272a5f]" x-text="source"></span>
+                            </template>
+                        </div>
+                    </div>
+
+                    <div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
+                        <div class="space-y-3">
+                            <template x-for="item in migration.checklist" :key="item.key">
+                                <a :href="item.href || '#migration-readiness'"
+                                   class="block rounded-lg border border-[#e6e3e1] p-4 transition hover:border-[#2f9da5] hover:shadow-sm">
+                                    <div class="flex items-start gap-3">
+                                        <span class="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full"
+                                              :class="migrationItemStatusDot(item.status)"></span>
+                                        <div class="min-w-0 flex-1">
+                                            <div class="flex flex-wrap items-center gap-2">
+                                                <h3 class="font-semibold text-[#07071f]" x-text="item.title"></h3>
+                                                <span class="rounded px-2 py-1 text-xs font-semibold capitalize"
+                                                      :class="migrationItemStatusClass(item.status)"
+                                                      x-text="item.status.replace('_', ' ')"></span>
+                                            </div>
+                                            <p class="mt-1 text-sm text-[#5f5c78]" x-text="item.detail"></p>
+                                            <p class="mt-2 text-sm font-semibold text-[#2f9da5]" x-text="item.action"></p>
+                                            <div class="mt-3 flex flex-wrap gap-2">
+                                                <template x-for="evidence in item.evidence" :key="item.key + evidence">
+                                                    <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs text-[#5f5c78]" x-text="evidence"></span>
+                                                </template>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </a>
+                            </template>
+                        </div>
+                        <div class="rounded-lg border border-[#e6e3e1] p-4">
+                            <h3 class="font-semibold text-[#07071f]">Portable data</h3>
+                            <p class="mt-1 text-sm text-[#5f5c78]">Use these exports for parity checks, rollback evidence, or offboarding.</p>
+                            <div class="mt-3 space-y-2">
+                                <template x-for="link in migration.export_links" :key="link.label">
+                                    <a :href="link.href"
+                                       class="block rounded border border-[#e6e3e1] p-3 hover:border-[#2f9da5]"
+                                       download>
+                                        <div class="flex items-center justify-between gap-2">
+                                            <span class="font-semibold text-sm text-[#07071f]" x-text="link.label"></span>
+                                            <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold uppercase text-[#272a5f]" x-text="link.format"></span>
+                                        </div>
+                                        <p class="mt-1 text-xs text-[#5f5c78]" x-text="link.detail"></p>
+                                    </a>
+                                </template>
+                            </div>
+                            <a :href="migration.docs_url" class="mt-4 inline-flex text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">
+                                Migration guide
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            {% endcall %}
+        {% endcall %}
+        </section>
+
         <!-- DNS Records -->
         <section id="dns-records">
         {% call card() %}
@@ -989,6 +1089,7 @@
         </section>
 
         <!-- Recent Reports -->
+        <section id="recent-reports">
         {% call card() %}
             {% call card_header() %}
                 <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -1069,6 +1170,7 @@
                 {% endcall %}
             {% endcall %}
         {% endcall %}
+        </section>
     </div>
 </div>
 {% endblock %}
@@ -1173,6 +1275,18 @@ function domainDetailsApp(domainId) {
             previous_grade: '',
             top_drivers: []
         },
+        migration: {
+            status: '',
+            readiness_score: 0,
+            summary: '',
+            parallel_reporting_days: 0,
+            report_count: 0,
+            source_count: 0,
+            checklist: [],
+            export_links: [],
+            supported_sources: [],
+            docs_url: 'https://github.com/christianlouis/dmarq/blob/main/docs/user_guide/migration.md'
+        },
         filters: {
             dateRange: '30',
             sourceFilter: '',
@@ -1188,6 +1302,7 @@ function domainDetailsApp(domainId) {
             this.fetchDNSProviders();
             this.fetchPosture();
             this.fetchHealthHistory();
+            this.fetchMigrationReadiness();
             this.fetchMtaSts();
             this.fetchBimi();
             this.fetchSelectors();
@@ -1273,6 +1388,25 @@ function domainDetailsApp(domainId) {
             if (this.dnsGuidance.status === 'attention') return 'bg-yellow-100 text-yellow-800';
             if (this.dnsGuidance.status === 'critical') return 'bg-red-100 text-red-700';
             return 'bg-base-200 text-base-content/70';
+        },
+
+        get migrationStatusClass() {
+            if (this.migration.status === 'ready') return 'bg-green-100 text-green-700';
+            if (this.migration.status === 'in_progress') return 'bg-yellow-100 text-yellow-800';
+            if (this.migration.status === 'blocked') return 'bg-red-100 text-red-700';
+            return 'bg-base-200 text-base-content/70';
+        },
+
+        migrationItemStatusClass(status) {
+            if (status === 'complete') return 'bg-green-100 text-green-700';
+            if (status === 'in_progress') return 'bg-yellow-100 text-yellow-800';
+            return 'bg-red-100 text-red-700';
+        },
+
+        migrationItemStatusDot(status) {
+            if (status === 'complete') return 'bg-green-500';
+            if (status === 'in_progress') return 'bg-yellow-500';
+            return 'bg-red-500';
         },
 
         recommendationSeverityClass(severity) {
@@ -1442,6 +1576,17 @@ function domainDetailsApp(domainId) {
                     error: error.message || 'Health score history could not be loaded.'
                 };
                 console.error('Error fetching health score history:', error);
+            }
+        },
+
+        async fetchMigrationReadiness() {
+            try {
+                const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/migration/readiness`);
+                if (response.ok) {
+                    this.migration = await response.json();
+                }
+            } catch (error) {
+                console.error('Error fetching migration readiness:', error);
             }
         },
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -42,6 +42,19 @@ def test_domain_details_exposes_health_history_without_html_injection():
     assert "x-html" not in template
 
 
+def test_domain_details_exposes_migration_readiness_without_html_injection():
+    template = (
+        Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"
+    ).read_text()
+
+    assert "Migration Readiness" in template
+    assert "/migration/readiness" in template
+    assert "parallel_reporting_days" in template
+    assert "migration.export_links" in template
+    assert "migration.checklist" in template
+    assert "x-html" not in template
+
+
 def test_members_template_uses_membership_api_without_html_injection():
     template = (Path(__file__).resolve().parents[1] / "templates" / "members.html").read_text()
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -778,6 +778,83 @@ def test_get_domain_sources_returns_200(seeded_client: TestClient):
     assert source["dmarc"] == "pass"
 
 
+def test_get_domain_migration_readiness_projects_parallel_cutover_state(
+    seeded_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Migration readiness summarizes reports, sources, DNS state, and exports."""
+
+    async def fake_guidance(*_args, **_kwargs):
+        return {
+            "domain": DOMAIN,
+            "status": "ready",
+            "findings": [],
+            "target_records": [],
+            "change_plans": [],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_guidance)
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/migration/readiness")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["domain"] == DOMAIN
+    assert data["report_count"] == 1
+    assert data["source_count"] == 1
+    assert data["parallel_reporting_days"] == 1
+    assert data["status"] == "in_progress"
+    assert data["readiness_score"] == 80
+    statuses = {item["key"]: item["status"] for item in data["checklist"]}
+    assert statuses["parallel-reporting"] == "complete"
+    assert statuses["volume-parity"] == "in_progress"
+    assert statuses["dns-readiness"] == "complete"
+    assert any(link["format"] == "json" for link in data["export_links"])
+    assert "DMARCguard" in data["supported_sources"]
+
+
+def test_get_domain_migration_readiness_blocks_empty_domain(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A pre-created domain remains migration-blocked until reports arrive."""
+    db_session.add(Domain(name="empty.example", active=True))
+    db_session.commit()
+
+    async def fake_guidance(*_args, **_kwargs):
+        return {
+            "domain": "empty.example",
+            "status": "attention",
+            "findings": [
+                {
+                    "code": "dmarc_missing",
+                    "severity": "error",
+                    "title": "Publish DMARC",
+                    "detail": "No DMARC record was found.",
+                    "action": "Publish a DMARC record before cutover.",
+                    "record_type": "TXT",
+                    "record_name": "_dmarc.empty.example",
+                    "evidence": [],
+                    "remediation_steps": [],
+                }
+            ],
+            "target_records": [],
+            "change_plans": [],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_guidance)
+
+    response = authed_client.get("/api/v1/domains/empty.example/migration/readiness")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "blocked"
+    assert data["readiness_score"] == 0
+    assert data["report_count"] == 0
+    assert data["source_count"] == 0
+    assert all(item["status"] == "blocked" for item in data["checklist"])
+
+
 def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
     """Endpoint reports pass/fail totals instead of only the latest IP result."""
     report = {

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,9 @@ For connector implementation boundaries, see the
 
 SMTP TLS reporting imports and privacy controls are covered in [TLS Reports](user_guide/tls_reports.md).
 
+Safe migration from another DMARC platform is covered in
+[Migrating from another DMARC platform](user_guide/migration.md).
+
 Aggregate-report parser support, known edge cases, and fixture guidance are documented in [DMARC Aggregate Format Compatibility](reference/dmarc-compatibility.md).
 
 Opt-in AI summaries and read-only MCP automation are covered in [AI and MCP Automation](reference/ai-mcp-automation.md).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -558,6 +558,18 @@ metadata only: score, grade, policy, aggregate message/report counts, factor
 scores, and top action titles. It does not include forensic message content,
 subjects, recipients, or raw uploaded report bodies.
 
+#### Get Migration Readiness
+
+```
+GET /domains/{domain_id}/migration/readiness
+```
+
+Returns a safe migration and data-portability checklist for moving a domain
+from another DMARC platform to DMARQ. The response uses existing report,
+source, DNS lint, and export evidence to track parallel-reporting progress,
+sender parity, DNS readiness, and export/offboarding availability. It does not
+import third-party vendor files or apply DNS changes.
+
 #### Add Domain
 
 ```

--- a/docs/user_guide/migration.md
+++ b/docs/user_guide/migration.md
@@ -1,0 +1,51 @@
+# Migrating from another DMARC platform
+
+DMARQ supports a safe parallel-reporting migration. Keep the current DMARC
+monitoring platform active, add DMARQ as an additional aggregate-report
+destination, compare the overlap window, and only then remove old routes or
+delegations.
+
+## Parallel-reporting checklist
+
+1. Add DMARQ as an additional `rua` destination in the existing DMARC record.
+2. Keep the current tool active for at least 14 distinct report days.
+3. Compare report volume, sending sources, alignment rates, and policy posture.
+4. Resolve or explicitly defer DNS lint findings before decommissioning the old
+   platform.
+5. Export DMARQ report CSV and health evidence before changing the old tool's
+   DNS routing.
+
+The domain detail page includes a **Migration Readiness** panel. It tracks the
+parallel-reporting window, aggregate report count, observed sending sources,
+DNS lint status, and export availability for each domain.
+
+## Platform-specific notes
+
+For Valimail, EasyDMARC, dmarcian, PowerDMARC, DMARCguard, and manual mailbox
+workflows, prefer adding DMARQ as a second `rua` receiver first. Avoid switching
+MX, mailbox, or delegated reporting DNS in one step unless you already have a
+separate rollback plan.
+
+When the previous platform used hosted reporting addresses or DNS delegation,
+document the old route before removal. Some platforms require removing a
+delegated `_dmarc` or reporting authorization record after the overlap period.
+
+## Data portability
+
+DMARQ currently provides these portable exports for migration and offboarding:
+
+- domain aggregate report CSV from the domain detail page
+- domain health evidence as CSV or JSON
+- workspace health evidence as CSV or JSON
+- DNS lint CSV for managed-domain reviews
+
+These exports intentionally avoid raw message bodies and forensic content.
+They are meant for parity checks, audit evidence, and rollback decisions.
+
+## Import limitations
+
+DMARQ can ingest standard DMARC aggregate reports through upload, IMAP, Gmail,
+and Microsoft 365 mail sources. Vendor-specific historical export imports are
+tracked as follow-up work. Until a vendor importer exists, use the previous
+platform's export as a comparison artifact and let DMARQ build its own evidence
+from newly received aggregate reports.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
     - Dashboard: user_guide/dashboard.md
     - Managing Domains: user_guide/domains.md
     - DMARC Reports: user_guide/reports.md
+    - Migration: user_guide/migration.md
     - TLS Reports: user_guide/tls_reports.md
     - IMAP Integration: user_guide/imap.md
     - Settings: user_guide/settings.md


### PR DESCRIPTION
## Summary
- add a domain migration readiness API that summarizes parallel-reporting status, report/source parity, DNS lint readiness, and export availability
- add a Migration Readiness panel on the domain detail page with checklist links and portable export actions
- document safe parallel-reporting migration from other DMARC platforms and add it to the docs navigation

Refs #311

## Validation
- `./.venv/bin/pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py -q --disable-warnings`
- `./.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `./.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `./.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

Note: `mkdocs` is not installed in this repo virtualenv, so docs navigation was checked by file inspection only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Migration Readiness view for domains, showing readiness score, status, checklist progress, reporting-day counts, source coverage, and export links.
  * Added a new migration readiness API endpoint to power the domain details page.

* **Bug Fixes**
  * Improved domain details loading with safer, structured migration data handling.
  * Added coverage to ensure the migration section renders without unsafe HTML injection.

* **Documentation**
  * Added migration guidance for safe parallel reporting and data portability.
  * Updated API reference and site navigation to include the new migration docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->