### PR TITLE
Fix migration readiness review findings

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -866,6 +866,26 @@ def _domain_exists(db: Session, store: ReportStore, domain_name: str, workspace=
     return domain_name in store.get_domains()
 
 
+def _resolve_domain_name_for_read(
+    db: Session,
+    store: ReportStore,
+    domain_id: str,
+    workspace,
+) -> str:
+    """Resolve a domain path segment to the canonical workspace domain name."""
+    domain = workspace_domain_query(db, workspace).filter(Domain.name == domain_id).first()
+    if domain is None and domain_id.isdigit():
+        domain = workspace_domain_query(db, workspace).filter(Domain.id == int(domain_id)).first()
+    if domain is not None:
+        return str(domain.name)
+    if _domain_exists(db, store, domain_id, workspace):
+        return domain_id
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Domain not found",
+    )
+
+
 def _record_evidence(
     label: str, value: Optional[str], href: str = "#dns-records"
 ) -> DNSHealthEvidence:
@@ -2234,27 +2254,24 @@ async def get_domain_stats(
 async def get_domain_migration_readiness(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached DNS result"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
     """Return safe migration and data-portability readiness for one monitored domain."""
-    workspace = _authorized_domain_read_workspace(_auth, db)
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
+    workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
     store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
 
-    if not _domain_exists(db, store, domain_id, workspace):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Domain not found",
-        )
-
-    summary = store.get_domain_summary(domain_id)
-    reports = store.get_domain_reports(domain_id, limit=10000)
-    sources = store.get_domain_sources(domain_id)
-    guidance_payload = await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
+    summary = store.get_domain_summary(domain_name)
+    reports = store.get_domain_reports(domain_name, limit=10000)
+    sources = store.get_domain_sources(domain_name)
+    guidance_payload = await _build_domain_dns_guidance(db, store, domain_name, refresh=refresh)
     guidance = DNSGuidanceResponse(**guidance_payload)
     checklist, parallel_days = _build_migration_checklist(
-        domain_id,
+        domain_name,
         summary,
         reports,
         sources,
@@ -2264,12 +2281,12 @@ async def get_domain_migration_readiness(
     report_count = int(summary.get("reports_processed", 0) or len(reports))
     source_count = len(sources)
     summary_text = (
-        f"{domain_id} has {parallel_days} distinct report days, "
+        f"{domain_name} has {parallel_days} distinct report days, "
         f"{report_count} aggregate reports, and {source_count} observed sending sources."
     )
 
     return MigrationReadinessResponse(
-        domain=domain_id,
+        domain=domain_name,
         status=migration_status,
         readiness_score=readiness_score,
         summary=summary_text,
@@ -2280,24 +2297,36 @@ async def get_domain_migration_readiness(
         export_links=[
             MigrationExportLink(
                 label="Aggregate report CSV",
-                href=f"/api/v1/domains/{domain_id}/reports/export",
+                href=f"/api/v1/domains/{domain_name}/reports/export",
                 format="csv",
                 detail="Portable aggregate report summary for parity checks.",
             ),
             MigrationExportLink(
                 label="Health evidence CSV",
-                href=f"/api/v1/domains/{domain_id}/posture/evidence/export?capture_current=false",
+                href=f"/api/v1/domains/{domain_name}/posture/evidence/export?capture_current=false",
                 format="csv",
                 detail="Score, policy, report, and DNS posture evidence.",
             ),
             MigrationExportLink(
                 label="Health evidence JSON",
                 href=(
-                    f"/api/v1/domains/{domain_id}/posture/evidence/export"
+                    f"/api/v1/domains/{domain_name}/posture/evidence/export"
                     "?capture_current=false&format=json"
                 ),
                 format="json",
                 detail="Machine-readable portability packet for automation.",
+            ),
+            MigrationExportLink(
+                label="Workspace health evidence",
+                href="/api/v1/domains/summary/health/evidence/export?format=json",
+                format="json",
+                detail="Workspace-level health evidence for portfolio audit checks.",
+            ),
+            MigrationExportLink(
+                label="DNS lint CSV",
+                href="/api/v1/domains/dns/lint/export",
+                format="csv",
+                detail="Managed-domain DNS lint findings for cutover review.",
             ),
         ],
         supported_sources=[
@@ -3204,8 +3233,8 @@ def _build_migration_checklist(
         _migration_item(
             "volume-parity",
             volume_status,
-            "Validate 14-30 days of report parity",
-            "Use the overlap window to compare report volume, sender inventory, and policy results.",
+            "Build 14-30 days of report evidence",
+            "Use the overlap window to observe report volume, sender inventory, and policy results.",
             "Wait for at least 14 distinct report days before removing the old tool.",
             [f"{parallel_days} distinct report days", f"{report_count} reports processed"],
             "#compliance-chart-section",
@@ -3213,8 +3242,8 @@ def _build_migration_checklist(
         _migration_item(
             "sender-parity",
             source_status,
-            "Review sending-source parity",
-            "Confirmed senders should match what the current platform reports before cutover.",
+            "Review observed sending sources",
+            "Observed senders should be reviewed against the current platform before cutover.",
             "Investigate unknown or failing sources before tightening policy or removing old routing.",
             [f"{source_count} sending sources observed"],
             "#sending-sources",

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -392,7 +392,7 @@
                     <div class="text-right">
                         <span class="inline-flex items-center rounded px-2 py-1 text-xs font-semibold capitalize"
                               :class="migrationStatusClass"
-                              x-text="migration.status.replace('_', ' ') || 'checking'"></span>
+                              x-text="migration.loading ? 'checking' : (migration.status.replace('_', ' ') || 'unavailable')"></span>
                         <div class="mt-1 text-xs text-[#5f5c78]">
                             <span x-text="migration.readiness_score"></span><span>% ready</span>
                         </div>
@@ -400,6 +400,7 @@
                 </div>
             {% endcall %}
             {% call card_content() %}
+                <p x-show="migration.error" class="mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700" x-text="migration.error"></p>
                 <div class="grid gap-5 xl:grid-cols-[280px_minmax(0,1fr)]">
                     <div class="rounded-lg bg-[#f4f3f2] p-4">
                         <div class="text-sm font-semibold text-[#5f5c78]">Parallel window</div>
@@ -1276,6 +1277,8 @@ function domainDetailsApp(domainId) {
             top_drivers: []
         },
         migration: {
+            loading: true,
+            error: '',
             status: '',
             readiness_score: 0,
             summary: '',
@@ -1391,6 +1394,7 @@ function domainDetailsApp(domainId) {
         },
 
         get migrationStatusClass() {
+            if (this.migration.error) return 'bg-red-100 text-red-700';
             if (this.migration.status === 'ready') return 'bg-green-100 text-green-700';
             if (this.migration.status === 'in_progress') return 'bg-yellow-100 text-yellow-800';
             if (this.migration.status === 'blocked') return 'bg-red-100 text-red-700';
@@ -1580,12 +1584,24 @@ function domainDetailsApp(domainId) {
         },
 
         async fetchMigrationReadiness() {
+            this.migration.loading = true;
+            this.migration.error = '';
             try {
                 const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/migration/readiness`);
-                if (response.ok) {
-                    this.migration = await response.json();
+                if (!response.ok) {
+                    throw new Error('Migration readiness could not be loaded.');
                 }
+                this.migration = {
+                    loading: false,
+                    error: '',
+                    ...(await response.json())
+                };
             } catch (error) {
+                this.migration = {
+                    ...this.migration,
+                    loading: false,
+                    error: error.message || 'Migration readiness could not be loaded.'
+                };
                 console.error('Error fetching migration readiness:', error);
             }
         },

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -49,6 +49,8 @@ def test_domain_details_exposes_migration_readiness_without_html_injection():
 
     assert "Migration Readiness" in template
     assert "/migration/readiness" in template
+    assert "migration.error" in template
+    assert "Migration readiness could not be loaded." in template
     assert "parallel_reporting_days" in template
     assert "migration.export_links" in template
     assert "migration.checklist" in template

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -87,6 +87,12 @@ def seeded_client(authed_client: TestClient, db_session):
         Domain(name=DOMAIN, workspace_id=workspace.id, active=True, dmarc_policy="reject")
     )
     db_session.commit()
+    report_persistence.save_parsed_report(
+        db_session,
+        REPORT_DICT_POLICY,
+        workspace_id=workspace.id,
+    )
+    db_session.commit()
     ReportStore.get_instance().add_report(REPORT_DICT_POLICY)
     return authed_client
 
@@ -808,8 +814,41 @@ def test_get_domain_migration_readiness_projects_parallel_cutover_state(
     assert statuses["parallel-reporting"] == "complete"
     assert statuses["volume-parity"] == "in_progress"
     assert statuses["dns-readiness"] == "complete"
+    titles = {item["key"]: item["title"] for item in data["checklist"]}
+    assert titles["volume-parity"] == "Build 14-30 days of report evidence"
+    assert titles["sender-parity"] == "Review observed sending sources"
     assert any(link["format"] == "json" for link in data["export_links"])
+    assert {link["label"] for link in data["export_links"]} >= {
+        "Workspace health evidence",
+        "DNS lint CSV",
+    }
     assert "DMARCguard" in data["supported_sources"]
+
+
+def test_get_domain_migration_readiness_accepts_canonical_domain_id(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Path IDs resolve to the canonical domain name before report lookups."""
+    domain = db_session.query(Domain).filter(Domain.name == DOMAIN).one()
+
+    async def fake_guidance(*_args, **_kwargs):
+        assert _args[2] == DOMAIN
+        return {
+            "domain": DOMAIN,
+            "status": "ready",
+            "findings": [],
+            "target_records": [],
+            "change_plans": [],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_guidance)
+
+    response = seeded_client.get(f"/api/v1/domains/{domain.id}/migration/readiness")
+
+    assert response.status_code == 200
+    assert response.json()["domain"] == DOMAIN
 
 
 def test_get_domain_migration_readiness_blocks_empty_domain(


### PR DESCRIPTION
## Summary
- scope migration readiness report hydration to the selected workspace and resolve numeric domain IDs to canonical domain names
- make migration readiness wording avoid claiming legacy parity without an external baseline and expose the documented workspace/DNS exports
- add a frontend fallback state when readiness loading fails, plus regression coverage

Refs #360

## Validation
- `/tmp/dmarq-pr353-coverage/.venv/bin/python -m pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py -q`
- `/tmp/dmarq-pr353-coverage/.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `/tmp/dmarq-pr353-coverage/.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `/tmp/dmarq-pr353-coverage/.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`