### PR TITLE
Add migration parity dashboard

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -195,6 +195,33 @@ class MigrationReadinessResponse(BaseModel):
     docs_url: str = "https://github.com/christianlouis/dmarq/blob/main/docs/user_guide/migration.md"
 
 
+class MigrationParityMetric(BaseModel):
+    """One DMARQ-vs-legacy migration parity comparison."""
+
+    key: str
+    label: str
+    status: str
+    unit: str
+    dmarq_value: Any
+    dmarq_display: str
+    baseline_value: Optional[Any] = None
+    baseline_display: str = "Not provided"
+    delta: Optional[float] = None
+    detail: str
+
+
+class MigrationParityResponse(BaseModel):
+    """Migration parity dashboard for one monitored domain."""
+
+    domain: str
+    status: str
+    summary: str
+    baseline_required: bool
+    tolerance_percent: float
+    metrics: List[MigrationParityMetric]
+    next_steps: List[str] = Field(default_factory=list)
+
+
 class DNSRecordResponse(BaseModel):
     """DNS record information for a domain"""
 
@@ -2340,6 +2367,55 @@ async def get_domain_migration_readiness(
     )
 
 
+@router.get("/{domain_id}/migration/parity", response_model=MigrationParityResponse)
+async def get_domain_migration_parity(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    baseline_report_count: Optional[int] = Query(
+        None, ge=0, title="Aggregate reports seen by the legacy platform"
+    ),
+    baseline_total_emails: Optional[int] = Query(
+        None, ge=0, title="Messages seen by the legacy platform"
+    ),
+    baseline_source_count: Optional[int] = Query(
+        None, ge=0, title="Sending sources seen by the legacy platform"
+    ),
+    baseline_compliance_rate: Optional[float] = Query(
+        None, ge=0, le=100, title="Legacy DMARC alignment or compliance percentage"
+    ),
+    baseline_policy: Optional[str] = Query(
+        None, title="DMARC p= policy reported by the legacy platform"
+    ),
+    tolerance_percent: float = Query(
+        10.0, ge=0, le=100, title="Allowed percent delta before review is required"
+    ),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Compare DMARQ evidence with an optional legacy-platform migration baseline."""
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
+    workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
+
+    summary = store.get_domain_summary(domain_name)
+    reports = store.get_domain_reports(domain_name, limit=10000)
+    sources = store.get_domain_sources(domain_name)
+    return _build_migration_parity_response(
+        domain_name,
+        summary,
+        reports,
+        sources,
+        baseline_report_count=baseline_report_count,
+        baseline_total_emails=baseline_total_emails,
+        baseline_source_count=baseline_source_count,
+        baseline_compliance_rate=baseline_compliance_rate,
+        baseline_policy=baseline_policy,
+        tolerance_percent=tolerance_percent,
+    )
+
+
 @router.get("/{domain_id}/dns", response_model=DNSRecordResponse)
 async def get_domain_dns_records(
     domain_id: str = Path(..., title="The domain ID or name"),
@@ -3267,6 +3343,180 @@ def _build_migration_checklist(
             "#recent-reports",
         ),
     ], parallel_days
+
+
+def _format_parity_value(value: Any, unit: str) -> str:
+    if value is None:
+        return "Not provided"
+    if unit == "percent":
+        return f"{float(value):.1f}%"
+    if unit == "policy":
+        return str(value)
+    return f"{int(value):,}"
+
+
+def _numeric_parity_metric(
+    key: str,
+    label: str,
+    dmarq_value: int | float,
+    baseline_value: Optional[int | float],
+    unit: str,
+    tolerance_percent: float,
+) -> MigrationParityMetric:
+    if baseline_value is None:
+        return MigrationParityMetric(
+            key=key,
+            label=label,
+            status="baseline_needed",
+            unit=unit,
+            dmarq_value=dmarq_value,
+            dmarq_display=_format_parity_value(dmarq_value, unit),
+            detail="Add the legacy-platform value to compare this migration signal.",
+        )
+
+    if unit == "percent":
+        delta = round(float(dmarq_value) - float(baseline_value), 2)
+        matched = abs(delta) <= tolerance_percent
+    elif baseline_value == 0:
+        delta = 0.0 if dmarq_value == 0 else 100.0
+        matched = dmarq_value == 0
+    else:
+        delta = round(
+            ((float(dmarq_value) - float(baseline_value)) / float(baseline_value)) * 100, 2
+        )
+        matched = abs(delta) <= tolerance_percent
+
+    return MigrationParityMetric(
+        key=key,
+        label=label,
+        status="matched" if matched else "attention",
+        unit=unit,
+        dmarq_value=dmarq_value,
+        dmarq_display=_format_parity_value(dmarq_value, unit),
+        baseline_value=baseline_value,
+        baseline_display=_format_parity_value(baseline_value, unit),
+        delta=delta,
+        detail=(
+            "Within the migration tolerance."
+            if matched
+            else "Review the legacy export and DMARQ ingestion before cutover."
+        ),
+    )
+
+
+def _policy_parity_metric(
+    dmarq_policy: Optional[str],
+    baseline_policy: Optional[str],
+) -> MigrationParityMetric:
+    normalized_dmarq = (dmarq_policy or "unknown").lower()
+    normalized_baseline = baseline_policy.lower() if baseline_policy else None
+    if normalized_baseline is None:
+        status_value = "baseline_needed"
+        detail = "Add the legacy-platform DMARC policy to compare policy posture."
+    elif normalized_dmarq == normalized_baseline:
+        status_value = "matched"
+        detail = "DMARQ and the legacy platform report the same DMARC policy."
+    else:
+        status_value = "attention"
+        detail = "Policy differs from the legacy baseline; review DNS and report timing."
+
+    return MigrationParityMetric(
+        key="policy",
+        label="DMARC policy",
+        status=status_value,
+        unit="policy",
+        dmarq_value=normalized_dmarq,
+        dmarq_display=_format_parity_value(normalized_dmarq, "policy"),
+        baseline_value=normalized_baseline,
+        baseline_display=_format_parity_value(normalized_baseline, "policy"),
+        detail=detail,
+    )
+
+
+def _build_migration_parity_response(
+    domain_id: str,
+    summary: Dict[str, Any],
+    reports: List[Dict[str, Any]],
+    sources: List[Dict[str, Any]],
+    *,
+    baseline_report_count: Optional[int],
+    baseline_total_emails: Optional[int],
+    baseline_source_count: Optional[int],
+    baseline_compliance_rate: Optional[float],
+    baseline_policy: Optional[str],
+    tolerance_percent: float,
+) -> MigrationParityResponse:
+    report_count = int(summary.get("reports_processed", 0) or len(reports))
+    total_emails = int(summary.get("total_count", 0) or 0)
+    source_count = len(sources)
+    compliance_rate = float(summary.get("compliance_rate", 0.0) or 0.0)
+    dmarq_policy = _normalize_reported_policy(summary.get("policy"))
+    metrics = [
+        _numeric_parity_metric(
+            "reports",
+            "Aggregate reports",
+            report_count,
+            baseline_report_count,
+            "count",
+            tolerance_percent,
+        ),
+        _numeric_parity_metric(
+            "messages",
+            "Message volume",
+            total_emails,
+            baseline_total_emails,
+            "count",
+            tolerance_percent,
+        ),
+        _numeric_parity_metric(
+            "sources",
+            "Sending sources",
+            source_count,
+            baseline_source_count,
+            "count",
+            tolerance_percent,
+        ),
+        _numeric_parity_metric(
+            "alignment",
+            "Alignment rate",
+            compliance_rate,
+            baseline_compliance_rate,
+            "percent",
+            tolerance_percent,
+        ),
+        _policy_parity_metric(dmarq_policy, baseline_policy),
+    ]
+    baseline_required = any(metric.status == "baseline_needed" for metric in metrics)
+    attention_required = any(metric.status == "attention" for metric in metrics)
+    if baseline_required:
+        status_value = "baseline_needed"
+        summary_text = (
+            "Add baseline values from the current DMARC platform to compare cutover parity."
+        )
+    elif attention_required:
+        status_value = "attention"
+        summary_text = "Some migration parity signals differ from the legacy-platform baseline."
+    else:
+        status_value = "matched"
+        summary_text = "DMARQ evidence is within tolerance of the legacy-platform baseline."
+
+    next_steps = [
+        "Export the same date window from the current DMARC platform.",
+        "Compare aggregate reports, message volume, sending sources, alignment, and policy.",
+        "Keep dual rua reporting active until differences are resolved or documented.",
+    ]
+    if attention_required:
+        next_steps.insert(0, "Review attention metrics before removing legacy reporting routes.")
+
+    return MigrationParityResponse(
+        domain=domain_id,
+        status=status_value,
+        summary=summary_text,
+        baseline_required=baseline_required,
+        tolerance_percent=tolerance_percent,
+        metrics=metrics,
+        next_steps=next_steps,
+    )
 
 
 def _spf_fix_hint(ip: str, spf_result: str, failed_count: int = 0) -> Optional[str]:

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -374,6 +374,85 @@
                         </div>
                     </div>
                 </div>
+                <div class="mt-5 rounded-lg border border-[#e6e3e1] p-4">
+                    <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                        <div>
+                            <h3 class="font-semibold text-[#07071f]">Migration Parity</h3>
+                            <p class="mt-1 text-sm text-[#5f5c78]" x-text="migrationParity.summary"></p>
+                        </div>
+                        <span class="inline-flex w-fit rounded px-2 py-1 text-xs font-semibold capitalize"
+                              :class="migrationParityStatusClass"
+                              x-text="migrationParity.loading ? 'checking' : migrationParity.status.replace('_', ' ')"></span>
+                    </div>
+                    <p x-show="migrationParity.error" class="mt-3 rounded-lg bg-red-50 p-3 text-sm text-red-700" x-text="migrationParity.error"></p>
+                    <div class="mt-4 grid gap-3 lg:grid-cols-5">
+                        <label class="text-xs font-semibold text-[#5f5c78]">
+                            Reports
+                            <input x-model="migrationBaseline.report_count" inputmode="numeric" type="number" min="0" class="mt-1 input input-sm input-bordered w-full" />
+                        </label>
+                        <label class="text-xs font-semibold text-[#5f5c78]">
+                            Messages
+                            <input x-model="migrationBaseline.total_emails" inputmode="numeric" type="number" min="0" class="mt-1 input input-sm input-bordered w-full" />
+                        </label>
+                        <label class="text-xs font-semibold text-[#5f5c78]">
+                            Sources
+                            <input x-model="migrationBaseline.source_count" inputmode="numeric" type="number" min="0" class="mt-1 input input-sm input-bordered w-full" />
+                        </label>
+                        <label class="text-xs font-semibold text-[#5f5c78]">
+                            Alignment %
+                            <input x-model="migrationBaseline.compliance_rate" inputmode="decimal" type="number" min="0" max="100" step="0.1" class="mt-1 input input-sm input-bordered w-full" />
+                        </label>
+                        <label class="text-xs font-semibold text-[#5f5c78]">
+                            Policy
+                            <select x-model="migrationBaseline.policy" class="mt-1 select select-sm select-bordered w-full">
+                                <option value="">Not provided</option>
+                                <option value="none">none</option>
+                                <option value="quarantine">quarantine</option>
+                                <option value="reject">reject</option>
+                            </select>
+                        </label>
+                    </div>
+                    <div class="mt-3 flex flex-wrap items-center gap-2">
+                        <button class="btn btn-sm bg-[#2f9da5] text-white hover:bg-[#272a5f]" @click="compareMigrationBaseline">
+                            Compare baseline
+                        </button>
+                        <span class="text-xs text-[#5f5c78]">Use values from the same legacy-platform export window.</span>
+                    </div>
+                    <div class="mt-4 overflow-x-auto">
+                        <table class="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>Signal</th>
+                                    <th>DMARQ</th>
+                                    <th>Legacy baseline</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <template x-for="metric in migrationParity.metrics" :key="metric.key">
+                                    <tr>
+                                        <td>
+                                            <div class="font-semibold text-[#07071f]" x-text="metric.label"></div>
+                                            <div class="text-xs text-[#5f5c78]" x-text="metric.detail"></div>
+                                        </td>
+                                        <td x-text="metric.dmarq_display"></td>
+                                        <td x-text="metric.baseline_display"></td>
+                                        <td>
+                                            <span class="rounded px-2 py-1 text-xs font-semibold capitalize"
+                                                  :class="migrationParityMetricStatusClass(metric.status)"
+                                                  x-text="metric.status.replace('_', ' ')"></span>
+                                        </td>
+                                    </tr>
+                                </template>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="mt-4 grid gap-2 md:grid-cols-3">
+                        <template x-for="step in migrationParity.next_steps" :key="step">
+                            <div class="rounded bg-[#f4f3f2] px-3 py-2 text-xs text-[#5f5c78]" x-text="step"></div>
+                        </template>
+                    </div>
+                </div>
             {% endcall %}
         {% endcall %}
         </section>
@@ -1290,6 +1369,23 @@ function domainDetailsApp(domainId) {
             supported_sources: [],
             docs_url: 'https://github.com/christianlouis/dmarq/blob/main/docs/user_guide/migration.md'
         },
+        migrationParity: {
+            loading: true,
+            error: '',
+            status: '',
+            summary: '',
+            baseline_required: true,
+            tolerance_percent: 10,
+            metrics: [],
+            next_steps: []
+        },
+        migrationBaseline: {
+            report_count: '',
+            total_emails: '',
+            source_count: '',
+            compliance_rate: '',
+            policy: ''
+        },
         filters: {
             dateRange: '30',
             sourceFilter: '',
@@ -1306,6 +1402,7 @@ function domainDetailsApp(domainId) {
             this.fetchPosture();
             this.fetchHealthHistory();
             this.fetchMigrationReadiness();
+            this.fetchMigrationParity();
             this.fetchMtaSts();
             this.fetchBimi();
             this.fetchSelectors();
@@ -1401,6 +1498,14 @@ function domainDetailsApp(domainId) {
             return 'bg-base-200 text-base-content/70';
         },
 
+        get migrationParityStatusClass() {
+            if (this.migrationParity.error) return 'bg-red-100 text-red-700';
+            if (this.migrationParity.status === 'matched') return 'bg-green-100 text-green-700';
+            if (this.migrationParity.status === 'attention') return 'bg-yellow-100 text-yellow-800';
+            if (this.migrationParity.status === 'baseline_needed') return 'bg-base-200 text-base-content/70';
+            return 'bg-base-200 text-base-content/70';
+        },
+
         migrationItemStatusClass(status) {
             if (status === 'complete') return 'bg-green-100 text-green-700';
             if (status === 'in_progress') return 'bg-yellow-100 text-yellow-800';
@@ -1411,6 +1516,12 @@ function domainDetailsApp(domainId) {
             if (status === 'complete') return 'bg-green-500';
             if (status === 'in_progress') return 'bg-yellow-500';
             return 'bg-red-500';
+        },
+
+        migrationParityMetricStatusClass(status) {
+            if (status === 'matched') return 'bg-green-100 text-green-700';
+            if (status === 'attention') return 'bg-yellow-100 text-yellow-800';
+            return 'bg-base-200 text-base-content/70';
         },
 
         recommendationSeverityClass(severity) {
@@ -1604,6 +1715,44 @@ function domainDetailsApp(domainId) {
                 };
                 console.error('Error fetching migration readiness:', error);
             }
+        },
+
+        migrationParityQueryString() {
+            const params = new URLSearchParams();
+            if (this.migrationBaseline.report_count !== '') params.set('baseline_report_count', this.migrationBaseline.report_count);
+            if (this.migrationBaseline.total_emails !== '') params.set('baseline_total_emails', this.migrationBaseline.total_emails);
+            if (this.migrationBaseline.source_count !== '') params.set('baseline_source_count', this.migrationBaseline.source_count);
+            if (this.migrationBaseline.compliance_rate !== '') params.set('baseline_compliance_rate', this.migrationBaseline.compliance_rate);
+            if (this.migrationBaseline.policy) params.set('baseline_policy', this.migrationBaseline.policy);
+            const query = params.toString();
+            return query ? `?${query}` : '';
+        },
+
+        async fetchMigrationParity() {
+            this.migrationParity.loading = true;
+            this.migrationParity.error = '';
+            try {
+                const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/migration/parity${this.migrationParityQueryString()}`);
+                if (!response.ok) {
+                    throw new Error('Migration parity could not be loaded.');
+                }
+                this.migrationParity = {
+                    loading: false,
+                    error: '',
+                    ...(await response.json())
+                };
+            } catch (error) {
+                this.migrationParity = {
+                    ...this.migrationParity,
+                    loading: false,
+                    error: error.message || 'Migration parity could not be loaded.'
+                };
+                console.error('Error fetching migration parity:', error);
+            }
+        },
+
+        compareMigrationBaseline() {
+            return this.fetchMigrationParity();
         },
 
         async fetchMtaSts() {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -54,6 +54,10 @@ def test_domain_details_exposes_migration_readiness_without_html_injection():
     assert "parallel_reporting_days" in template
     assert "migration.export_links" in template
     assert "migration.checklist" in template
+    assert "Migration Parity" in template
+    assert "/migration/parity" in template
+    assert "migrationParity.metrics" in template
+    assert "migrationBaseline" in template
     assert "x-html" not in template
 
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -889,6 +889,43 @@ def test_get_domain_migration_readiness_returns_404_for_missing_domain(
     assert response.json()["detail"] == "Domain not found"
 
 
+def test_get_domain_migration_parity_requires_legacy_baseline(seeded_client: TestClient):
+    """Parity dashboard is explicit when the old-platform baseline is missing."""
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/migration/parity")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["domain"] == DOMAIN
+    assert data["status"] == "baseline_needed"
+    assert data["baseline_required"] is True
+    metrics = {metric["key"]: metric for metric in data["metrics"]}
+    assert metrics["reports"]["dmarq_display"] == "1"
+    assert metrics["messages"]["dmarq_display"] == "10"
+    assert metrics["sources"]["dmarq_display"] == "1"
+    assert metrics["alignment"]["dmarq_display"] == "100.0%"
+    assert metrics["policy"]["dmarq_display"] == "reject"
+    assert {metric["status"] for metric in data["metrics"]} == {"baseline_needed"}
+
+
+def test_get_domain_migration_parity_matches_legacy_baseline(seeded_client: TestClient):
+    """Matching legacy values mark migration parity as matched."""
+    response = seeded_client.get(
+        f"/api/v1/domains/{DOMAIN}/migration/parity"
+        "?baseline_report_count=1"
+        "&baseline_total_emails=10"
+        "&baseline_source_count=1"
+        "&baseline_compliance_rate=100"
+        "&baseline_policy=reject"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "matched"
+    assert data["baseline_required"] is False
+    assert {metric["status"] for metric in data["metrics"]} == {"matched"}
+    assert data["metrics"][0]["baseline_display"] == "1"
+
+
 def test_get_domain_migration_readiness_blocks_empty_domain(
     authed_client: TestClient,
     db_session,

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -570,6 +570,31 @@ source, DNS lint, and export evidence to track parallel-reporting progress,
 sender parity, DNS readiness, and export/offboarding availability. It does not
 import third-party vendor files or apply DNS changes.
 
+#### Get Migration Parity
+
+```text
+GET /domains/{domain_id}/migration/parity
+```
+
+Returns a read-only parity dashboard for comparing DMARQ evidence with an
+optional legacy-platform baseline. Without baseline query parameters, metrics
+are marked `baseline_needed`.
+
+Optional query parameters:
+
+| Parameter | Purpose |
+| --- | --- |
+| `baseline_report_count` | Aggregate reports seen by the legacy platform |
+| `baseline_total_emails` | Messages seen by the legacy platform |
+| `baseline_source_count` | Sending sources seen by the legacy platform |
+| `baseline_compliance_rate` | Legacy alignment or compliance percentage |
+| `baseline_policy` | Legacy DMARC `p=` policy |
+| `tolerance_percent` | Allowed numeric delta before review is required |
+
+The endpoint compares report count, message volume, sending sources,
+alignment/compliance rate, and policy posture. It does not import vendor files
+or persist the entered baseline values.
+
 #### Add Domain
 
 ```

--- a/docs/user_guide/migration.md
+++ b/docs/user_guide/migration.md
@@ -19,6 +19,20 @@ The domain detail page includes a **Migration Readiness** panel. It tracks the
 parallel-reporting window, aggregate report count, observed sending sources,
 DNS lint status, and export availability for each domain.
 
+The same panel includes **Migration Parity**. Enter values from the same date
+window in the current DMARC platform to compare:
+
+- aggregate report count
+- message volume
+- observed sending sources
+- alignment or compliance rate
+- DMARC policy posture
+
+If no legacy baseline is entered, DMARQ marks the comparison as
+`baseline_needed` rather than claiming parity. Keep dual `rua` reporting active
+until the parity signals are either matched, explained, or intentionally
+accepted.
+
 ## Platform-specific notes
 
 For Valimail, EasyDMARC, dmarcian, PowerDMARC, DMARCguard, and manual mailbox


### PR DESCRIPTION
## Summary
- add a read-only migration parity endpoint for comparing DMARQ evidence against optional legacy-platform baseline values
- show a Migration Parity dashboard on domain details with baseline inputs, metric statuses, and next steps
- document the parity workflow and API parameters

Refs #311

## Validation
- `./.venv/bin/pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py -q --disable-warnings`
- `./.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `./.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `./.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`
