### PR TITLE
Cover migration parity mismatch state

### DIFF
--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -926,6 +926,38 @@ def test_get_domain_migration_parity_matches_legacy_baseline(seeded_client: Test
     assert data["metrics"][0]["baseline_display"] == "1"
 
 
+def test_get_domain_migration_parity_flags_legacy_mismatch(seeded_client: TestClient):
+    """Parity dashboard calls out mismatched legacy baseline values."""
+    response = seeded_client.get(
+        f"/api/v1/domains/{DOMAIN}/migration/parity"
+        "?baseline_report_count=0"
+        "&baseline_total_emails=20"
+        "&baseline_source_count=0"
+        "&baseline_compliance_rate=80"
+        "&baseline_policy=none"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "attention"
+    assert data["baseline_required"] is False
+    assert data["summary"] == (
+        "Some migration parity signals differ from the legacy-platform baseline."
+    )
+    assert data["next_steps"][0] == (
+        "Review attention metrics before removing legacy reporting routes."
+    )
+    metrics = {metric["key"]: metric for metric in data["metrics"]}
+    assert metrics["reports"]["status"] == "attention"
+    assert metrics["reports"]["delta"] == 100.0
+    assert metrics["messages"]["status"] == "attention"
+    assert metrics["messages"]["delta"] == -50.0
+    assert metrics["alignment"]["status"] == "attention"
+    assert metrics["alignment"]["delta"] == 20.0
+    assert metrics["policy"]["status"] == "attention"
+    assert metrics["policy"]["baseline_display"] == "none"
+
+
 def test_get_domain_migration_readiness_blocks_empty_domain(
     authed_client: TestClient,
     db_session,


### PR DESCRIPTION
## Summary
- add regression coverage for migration parity mismatch responses
- cover zero-baseline deltas, percent deltas, policy mismatch, and attention next-step ordering

Refs #311

## Validation
- /tmp/dmarq-pr353-coverage/.venv/bin/pytest backend/app/tests/test_domain_detail_endpoints.py -q --disable-warnings
- /tmp/dmarq-pr353-coverage/.venv/bin/black --check backend/app/tests/test_domain_detail_endpoints.py
- /tmp/dmarq-pr353-coverage/.venv/bin/isort --check-only backend/app/tests/test_domain_detail_endpoints.py
- /tmp/dmarq-pr353-coverage/.venv/bin/flake8 backend/app/tests/test_domain_detail_endpoints.py
- git diff --check