### PR TITLE
Add migration import preview

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2,6 +2,7 @@ import asyncio
 import csv
 import io
 import ipaddress
+import json
 import logging
 from dataclasses import asdict
 from datetime import date, datetime, timezone
@@ -50,6 +51,7 @@ from app.services.health_score_snapshots import (
     list_workspace_health_score_snapshots,
     upsert_health_score_snapshot,
 )
+from app.services.migration_import import preview_migration_import
 from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
 from app.services.organizations import (
     OrganizationPlanLimitError,
@@ -219,6 +221,62 @@ class MigrationParityResponse(BaseModel):
     baseline_required: bool
     tolerance_percent: float
     metrics: List[MigrationParityMetric]
+    next_steps: List[str] = Field(default_factory=list)
+
+
+class MigrationImportPreviewRequest(BaseModel):
+    """Read-only historical export preview request."""
+
+    content: Any
+    format: str = Field(default="auto", pattern="^(auto|csv|json)$")
+    source_platform: Optional[str] = None
+    max_rows: int = Field(default=50, ge=1, le=500)
+
+
+class MigrationImportBaseline(BaseModel):
+    """Suggested legacy baseline values derived from a historical export."""
+
+    report_count: int
+    total_emails: int
+    source_count: int
+    compliance_rate: float
+    policy: Optional[str] = None
+    date_start: Optional[str] = None
+    date_end: Optional[str] = None
+
+
+class MigrationImportPreviewRow(BaseModel):
+    """One normalized read-only export row."""
+
+    domain: Optional[str] = None
+    report_id: Optional[str] = None
+    begin_date: Optional[str] = None
+    end_date: Optional[str] = None
+    source_ip: Optional[str] = None
+    count: int
+    dkim: Optional[str] = None
+    spf: Optional[str] = None
+    disposition: Optional[str] = None
+    policy: Optional[str] = None
+    org_name: Optional[str] = None
+
+
+class MigrationImportPreviewResponse(BaseModel):
+    """Read-only preview of a historical DMARC platform export."""
+
+    domain: str
+    status: str
+    source_platform: Optional[str] = None
+    format: str
+    import_mode: str = "preview_only"
+    row_count: int
+    normalized_count: int
+    ignored_count: int
+    detected_columns: List[str]
+    mapped_columns: Dict[str, str]
+    warnings: List[str] = Field(default_factory=list)
+    baseline: MigrationImportBaseline
+    sample_rows: List[MigrationImportPreviewRow] = Field(default_factory=list)
     next_steps: List[str] = Field(default_factory=list)
 
 
@@ -2413,6 +2471,62 @@ async def get_domain_migration_parity(
         baseline_compliance_rate=baseline_compliance_rate,
         baseline_policy=baseline_policy,
         tolerance_percent=tolerance_percent,
+    )
+
+
+@router.post("/{domain_id}/migration/import/preview", response_model=MigrationImportPreviewResponse)
+async def preview_domain_migration_import(
+    payload: MigrationImportPreviewRequest,
+    domain_id: str = Path(..., title="The domain ID or name"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Preview a historical DMARC export without writing reports or domains."""
+    selected_workspace_id = parse_selected_workspace_id(selected_workspace)
+    workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
+
+    try:
+        content = (
+            payload.content if isinstance(payload.content, str) else json.dumps(payload.content)
+        )
+        preview = preview_migration_import(
+            domain=domain_name,
+            content=content,
+            source_format=payload.format,
+            max_rows=payload.max_rows,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    status_text = "ready" if preview["normalized_count"] else "needs_mapping"
+    next_steps = [
+        "Use the suggested baseline values in Migration Parity for the same date window.",
+        "Keep the old DMARC platform active until mismatches are explained.",
+    ]
+    if preview["warnings"]:
+        next_steps.insert(0, "Review warnings before using this export for parity decisions.")
+
+    return MigrationImportPreviewResponse(
+        domain=domain_name,
+        status=status_text,
+        source_platform=payload.source_platform,
+        format=preview["format"],
+        row_count=preview["row_count"],
+        normalized_count=preview["normalized_count"],
+        ignored_count=preview["ignored_count"],
+        detected_columns=preview["detected_columns"],
+        mapped_columns=preview["mapped_columns"],
+        warnings=preview["warnings"],
+        baseline=MigrationImportBaseline(**preview["baseline"]),
+        sample_rows=[MigrationImportPreviewRow(**row) for row in preview["sample_rows"]],
+        next_steps=next_steps,
     )
 
 

--- a/backend/app/services/migration_import.py
+++ b/backend/app/services/migration_import.py
@@ -1,0 +1,299 @@
+"""Read-only helpers for previewing historical DMARC platform exports."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+COLUMN_ALIASES = {
+    "domain": {
+        "domain",
+        "header_from",
+        "header from",
+        "from domain",
+        "policy_domain",
+        "policy domain",
+    },
+    "report_id": {"report_id", "report id", "reportid", "id"},
+    "begin_date": {"begin_date", "begin date", "date begin", "start", "start date", "period begin"},
+    "end_date": {"end_date", "end date", "date end", "end", "end date", "period end", "date"},
+    "source_ip": {"source_ip", "source ip", "ip", "ip address", "sender ip", "source"},
+    "count": {"count", "messages", "message count", "volume", "total", "total messages"},
+    "dkim": {"dkim", "dkim_result", "dkim result", "dkim aligned", "dkim pass"},
+    "spf": {"spf", "spf_result", "spf result", "spf aligned", "spf pass"},
+    "disposition": {"disposition", "policy disposition", "applied policy"},
+    "policy": {"policy", "dmarc policy", "p", "policy_p"},
+    "org_name": {"org_name", "org name", "reporter", "reporting org", "provider"},
+}
+
+PASS_VALUES = {"pass", "passed", "true", "yes", "1", "aligned", "ok"}
+POLICY_VALUES = {"none", "quarantine", "reject"}
+
+
+@dataclass(frozen=True)
+class MigrationImportRow:
+    """Normalized read-only row from a historical export."""
+
+    domain: Optional[str] = None
+    report_id: Optional[str] = None
+    begin_date: Optional[str] = None
+    end_date: Optional[str] = None
+    source_ip: Optional[str] = None
+    count: int = 0
+    dkim: Optional[str] = None
+    spf: Optional[str] = None
+    disposition: Optional[str] = None
+    policy: Optional[str] = None
+    org_name: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return API-safe row data."""
+        return {
+            "domain": self.domain,
+            "report_id": self.report_id,
+            "begin_date": self.begin_date,
+            "end_date": self.end_date,
+            "source_ip": self.source_ip,
+            "count": self.count,
+            "dkim": self.dkim,
+            "spf": self.spf,
+            "disposition": self.disposition,
+            "policy": self.policy,
+            "org_name": self.org_name,
+        }
+
+
+def preview_migration_import(
+    *,
+    domain: str,
+    content: str,
+    source_format: str = "auto",
+    max_rows: int = 50,
+) -> Dict[str, Any]:
+    """Parse a CSV/JSON vendor export into a read-only migration preview."""
+    rows, detected_format = _load_rows(content, source_format)
+    detected_columns = _detected_columns(rows)
+    aliases = _column_aliases(detected_columns)
+    normalized_rows: List[MigrationImportRow] = []
+    warnings: List[str] = []
+
+    for raw_row in rows[:max_rows]:
+        normalized = _normalize_row(raw_row, aliases)
+        if not normalized.source_ip and normalized.count == 0:
+            warnings.append("Ignored a row without a sending source or message count.")
+            continue
+        normalized_rows.append(normalized)
+
+    ignored_count = max(0, len(rows) - len(normalized_rows))
+    domain_mismatches = sorted(
+        {
+            row.domain
+            for row in normalized_rows
+            if row.domain and row.domain.lower() != domain.lower()
+        }
+    )
+    if domain_mismatches:
+        warnings.append(
+            "Export contains rows for other domains: " + ", ".join(domain_mismatches[:5])
+        )
+    if len(rows) > max_rows:
+        warnings.append(f"Preview limited to the first {max_rows} rows.")
+
+    missing_columns = _missing_recommended_columns(aliases)
+    if missing_columns:
+        warnings.append("Missing recommended columns: " + ", ".join(missing_columns))
+
+    return {
+        "format": detected_format,
+        "row_count": len(rows),
+        "normalized_count": len(normalized_rows),
+        "ignored_count": ignored_count,
+        "detected_columns": detected_columns,
+        "mapped_columns": aliases,
+        "warnings": warnings,
+        "baseline": _build_baseline(normalized_rows),
+        "sample_rows": [row.to_dict() for row in normalized_rows[:10]],
+    }
+
+
+def _load_rows(content: str, source_format: str) -> tuple[List[Dict[str, Any]], str]:
+    normalized_format = (source_format or "auto").strip().lower()
+    if normalized_format not in {"auto", "csv", "json"}:
+        raise ValueError("format must be auto, csv, or json")
+
+    text = content.strip()
+    if not text:
+        raise ValueError("import content is empty")
+
+    if normalized_format == "json" or (normalized_format == "auto" and text[:1] in {"[", "{"}):
+        return _load_json_rows(text), "json"
+    return _load_csv_rows(text), "csv"
+
+
+def _load_csv_rows(text: str) -> List[Dict[str, Any]]:
+    reader = csv.DictReader(io.StringIO(text))
+    if not reader.fieldnames:
+        raise ValueError("CSV content must include a header row")
+    return [dict(row) for row in reader]
+
+
+def _load_json_rows(text: str) -> List[Dict[str, Any]]:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"JSON content could not be parsed: {exc.msg}") from exc
+
+    if isinstance(data, list):
+        rows = data
+    elif isinstance(data, dict):
+        rows = _first_list_value(data, ["rows", "reports", "data", "items", "records"])
+        if rows is None:
+            rows = [data]
+    else:
+        raise ValueError("JSON content must be an object or list")
+
+    if not all(isinstance(row, dict) for row in rows):
+        raise ValueError("JSON rows must be objects")
+    return [dict(row) for row in rows]
+
+
+def _first_list_value(data: Dict[str, Any], keys: Iterable[str]) -> Optional[List[Any]]:
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, list):
+            return value
+    return None
+
+
+def _detected_columns(rows: List[Dict[str, Any]]) -> List[str]:
+    columns: List[str] = []
+    for row in rows:
+        for key in row:
+            key_str = str(key)
+            if key_str not in columns:
+                columns.append(key_str)
+    return columns
+
+
+def _column_aliases(columns: List[str]) -> Dict[str, str]:
+    normalized_columns = {_normalize_column_name(column): column for column in columns}
+    aliases: Dict[str, str] = {}
+    for canonical, candidates in COLUMN_ALIASES.items():
+        for candidate in candidates:
+            column = normalized_columns.get(_normalize_column_name(candidate))
+            if column:
+                aliases[canonical] = column
+                break
+    return aliases
+
+
+def _normalize_column_name(value: str) -> str:
+    return " ".join(value.replace("_", " ").replace("-", " ").strip().lower().split())
+
+
+def _normalize_row(row: Dict[str, Any], aliases: Dict[str, str]) -> MigrationImportRow:
+    return MigrationImportRow(
+        domain=_clean_text(_row_value(row, aliases, "domain")),
+        report_id=_clean_text(_row_value(row, aliases, "report_id")),
+        begin_date=_clean_date(_row_value(row, aliases, "begin_date")),
+        end_date=_clean_date(_row_value(row, aliases, "end_date")),
+        source_ip=_clean_text(_row_value(row, aliases, "source_ip")),
+        count=_clean_int(_row_value(row, aliases, "count")),
+        dkim=_clean_result(_row_value(row, aliases, "dkim")),
+        spf=_clean_result(_row_value(row, aliases, "spf")),
+        disposition=_clean_text(_row_value(row, aliases, "disposition")),
+        policy=_clean_policy(_row_value(row, aliases, "policy")),
+        org_name=_clean_text(_row_value(row, aliases, "org_name")),
+    )
+
+
+def _row_value(row: Dict[str, Any], aliases: Dict[str, str], key: str) -> Any:
+    column = aliases.get(key)
+    if column is None:
+        return None
+    return row.get(column)
+
+
+def _clean_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _clean_date(value: Any) -> Optional[str]:
+    text = _clean_text(value)
+    if text is None:
+        return None
+    if text.isdigit():
+        try:
+            return datetime.fromtimestamp(int(text), tz=timezone.utc).date().isoformat()
+        except (OverflowError, ValueError):
+            return text
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        return text
+
+
+def _clean_int(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return max(0, int(value))
+    text = str(value).strip().replace(",", "")
+    try:
+        return max(0, int(float(text)))
+    except ValueError:
+        return 0
+
+
+def _clean_result(value: Any) -> Optional[str]:
+    text = _clean_text(value)
+    if text is None:
+        return None
+    normalized = text.lower()
+    if normalized in PASS_VALUES:
+        return "pass"
+    if normalized in {"fail", "failed", "false", "no", "0", "unaligned"}:
+        return "fail"
+    return normalized
+
+
+def _clean_policy(value: Any) -> Optional[str]:
+    text = _clean_text(value)
+    if text is None:
+        return None
+    normalized = text.lower().removeprefix("p=").strip()
+    return normalized if normalized in POLICY_VALUES else text
+
+
+def _missing_recommended_columns(aliases: Dict[str, str]) -> List[str]:
+    recommended = ["source_ip", "count", "dkim", "spf", "policy"]
+    return [column for column in recommended if column not in aliases]
+
+
+def _build_baseline(rows: List[MigrationImportRow]) -> Dict[str, Any]:
+    total_emails = sum(row.count for row in rows)
+    aligned_emails = sum(row.count for row in rows if row.dkim == "pass" or row.spf == "pass")
+    source_count = len({row.source_ip for row in rows if row.source_ip})
+    report_ids = {row.report_id for row in rows if row.report_id}
+    policy_counts = Counter(row.policy for row in rows if row.policy)
+    start_dates = [row.begin_date for row in rows if row.begin_date]
+    end_dates = [row.end_date for row in rows if row.end_date]
+    return {
+        "report_count": len(report_ids) if report_ids else len(rows),
+        "total_emails": total_emails,
+        "source_count": source_count,
+        "compliance_rate": round((aligned_emails / total_emails * 100), 2) if total_emails else 0.0,
+        "policy": policy_counts.most_common(1)[0][0] if policy_counts else None,
+        "date_start": min(start_dates) if start_dates else None,
+        "date_end": max(end_dates) if end_dates else None,
+    }

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -958,6 +958,92 @@ def test_get_domain_migration_parity_flags_legacy_mismatch(seeded_client: TestCl
     assert metrics["policy"]["baseline_display"] == "none"
 
 
+def test_preview_domain_migration_import_csv_baseline(seeded_client: TestClient):
+    """Historical CSV exports are normalized without writing reports."""
+    content = "\n".join(
+        [
+            "Domain,Report ID,Date,Source IP,Messages,DKIM,SPF,Policy,Reporter",
+            "example.com,legacy-1,2026-06-01,192.0.2.10,8,pass,fail,reject,Vendor",
+            "example.com,legacy-1,2026-06-01,192.0.2.20,2,fail,pass,reject,Vendor",
+        ]
+    )
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/migration/import/preview",
+        json={
+            "format": "csv",
+            "source_platform": "DMARCguard",
+            "content": content,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["domain"] == DOMAIN
+    assert data["status"] == "ready"
+    assert data["import_mode"] == "preview_only"
+    assert data["row_count"] == 2
+    assert data["normalized_count"] == 2
+    assert data["baseline"] == {
+        "report_count": 1,
+        "total_emails": 10,
+        "source_count": 2,
+        "compliance_rate": 100.0,
+        "policy": "reject",
+        "date_start": None,
+        "date_end": "2026-06-01",
+    }
+    assert data["mapped_columns"]["source_ip"] == "Source IP"
+    assert data["sample_rows"][0]["source_ip"] == "192.0.2.10"
+    assert data["next_steps"][-1] == (
+        "Keep the old DMARC platform active until mismatches are explained."
+    )
+
+
+def test_preview_domain_migration_import_json_warns_on_domain_mismatch(
+    seeded_client: TestClient,
+):
+    """Preview remains domain scoped and warns when export rows include other domains."""
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/migration/import/preview",
+        json={
+            "format": "json",
+            "content": {
+                "rows": [
+                    {
+                        "domain": "other.example",
+                        "report_id": "legacy-2",
+                        "source_ip": "198.51.100.10",
+                        "count": 5,
+                        "dkim_result": "fail",
+                        "spf_result": "pass",
+                        "policy": "p=none",
+                    }
+                ]
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["baseline"]["policy"] == "none"
+    assert data["baseline"]["compliance_rate"] == 100.0
+    assert data["warnings"][0] == "Export contains rows for other domains: other.example"
+
+
+def test_preview_domain_migration_import_rejects_invalid_json(seeded_client: TestClient):
+    """Invalid vendor export payloads return a clear 400 without side effects."""
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/migration/import/preview",
+        json={"format": "json", "content": "{not-json"},
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "JSON content could not be parsed: Expecting property name enclosed in double quotes"
+    )
+
+
 def test_get_domain_migration_readiness_blocks_empty_domain(
     authed_client: TestClient,
     db_session,

--- a/backend/app/tests/test_migration_import.py
+++ b/backend/app/tests/test_migration_import.py
@@ -1,0 +1,102 @@
+"""Tests for read-only historical DMARC export import previews."""
+
+import pytest
+
+from app.services import migration_import
+from app.services.migration_import import preview_migration_import
+
+
+def test_preview_migration_import_auto_json_list_limits_and_warns():
+    """Auto-detected JSON previews cap sample size and surface mapping gaps."""
+    preview = preview_migration_import(
+        domain="example.com",
+        content="""[
+          {"domain": "example.com", "source": "192.0.2.1", "total": "1,200"},
+          {"domain": "example.com", "source": "192.0.2.2", "total": 5}
+        ]""",
+        max_rows=1,
+    )
+
+    assert preview["format"] == "json"
+    assert preview["row_count"] == 2
+    assert preview["normalized_count"] == 1
+    assert preview["ignored_count"] == 1
+    assert preview["baseline"]["total_emails"] == 1200
+    assert preview["sample_rows"][0]["source_ip"] == "192.0.2.1"
+    assert "Preview limited to the first 1 rows." in preview["warnings"]
+    assert "Missing recommended columns: dkim, spf, policy" in preview["warnings"]
+
+
+def test_preview_migration_import_ignores_unmappable_rows():
+    """Rows with neither source nor volume are ignored and flagged."""
+    preview = preview_migration_import(
+        domain="example.com",
+        content="Domain,Reporter\nexample.com,LegacyVendor\n",
+        source_format="csv",
+    )
+
+    assert preview["normalized_count"] == 0
+    assert preview["ignored_count"] == 1
+    assert preview["sample_rows"] == []
+    assert "Ignored a row without a sending source or message count." in preview["warnings"]
+
+
+def test_preview_migration_import_json_object_without_row_collection():
+    """A single JSON object can be previewed as one row."""
+    preview = preview_migration_import(
+        domain="example.com",
+        content="""{
+          "header_from": "example.com",
+          "reportid": "legacy-single",
+          "sender ip": "198.51.100.20",
+          "message count": true,
+          "dkim aligned": "OK",
+          "spf aligned": "unaligned",
+          "dmarc policy": "monitor"
+        }""",
+    )
+
+    assert preview["format"] == "json"
+    assert preview["baseline"]["report_count"] == 1
+    assert preview["baseline"]["total_emails"] == 1
+    assert preview["baseline"]["policy"] == "monitor"
+    assert preview["sample_rows"][0]["dkim"] == "pass"
+    assert preview["sample_rows"][0]["spf"] == "fail"
+
+
+@pytest.mark.parametrize(
+    ("content", "source_format", "message"),
+    [
+        ("{}", "xml", "format must be auto, csv, or json"),
+        ("   ", "auto", "import content is empty"),
+        ("42", "json", "JSON content must be an object or list"),
+        ('["not-a-row"]', "json", "JSON rows must be objects"),
+    ],
+)
+def test_preview_migration_import_rejects_invalid_inputs(content, source_format, message):
+    """Invalid exports fail before any import-side effects can exist."""
+    with pytest.raises(ValueError, match=message):
+        preview_migration_import(
+            domain="example.com",
+            content=content,
+            source_format=source_format,
+        )
+
+
+def test_migration_import_cleaners_cover_edge_values():
+    """Normalizers keep odd vendor values stable and conservative."""
+    assert migration_import._clean_date(None) is None  # pylint: disable=protected-access
+    assert (
+        migration_import._clean_date("999999999999999999999999999999")
+        == "999999999999999999999999999999"
+    )
+    assert migration_import._clean_date("not-a-date") == "not-a-date"
+    assert migration_import._clean_int(None) == 0  # pylint: disable=protected-access
+    assert migration_import._clean_int(-10.5) == 0  # pylint: disable=protected-access
+    assert migration_import._clean_int("unknown") == 0  # pylint: disable=protected-access
+    assert migration_import._clean_result(None) is None  # pylint: disable=protected-access
+    assert (
+        migration_import._clean_result("temperror") == "temperror"
+    )  # pylint: disable=protected-access
+    assert migration_import._clean_policy(None) is None  # pylint: disable=protected-access
+    assert migration_import._clean_policy("custom") == "custom"  # pylint: disable=protected-access

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -239,6 +239,63 @@ trigger `backfill`. In demo mode, DMARQ exposes credential-free synthetic mail
 sources and backfill jobs so the workflow is visible without connecting a real
 mailbox.
 
+### Migration And Portability
+
+Migration endpoints are admin/session endpoints for safe platform cutovers.
+They are scoped to the selected workspace through `X-DMARQ-Workspace-ID` when
+that header is present.
+
+#### Get Migration Readiness
+
+```text
+GET /domains/{domain_id}/migration/readiness
+```
+
+Returns the safe parallel-reporting checklist, portability export links, report
+counts, source counts, and DNS readiness guidance for one monitored domain.
+
+#### Get Migration Parity
+
+```text
+GET /domains/{domain_id}/migration/parity
+```
+
+Optional query parameters:
+
+| Parameter | Purpose |
+| --- | --- |
+| `baseline_report_count` | Aggregate reports seen by the legacy platform |
+| `baseline_total_emails` | Messages seen by the legacy platform |
+| `baseline_source_count` | Sending sources seen by the legacy platform |
+| `baseline_compliance_rate` | Legacy alignment or compliance percentage |
+| `baseline_policy` | DMARC `p=` policy reported by the legacy platform |
+| `tolerance_percent` | Allowed percent delta before review is required |
+
+If no baseline values are provided, the response status is `baseline_needed`
+instead of claiming parity.
+
+#### Preview Historical Export
+
+```text
+POST /domains/{domain_id}/migration/import/preview
+```
+
+Request:
+
+```json
+{
+  "format": "auto",
+  "source_platform": "DMARCguard",
+  "content": "Domain,Report ID,Date,Source IP,Messages,DKIM,SPF,Policy\nexample.com,r1,2026-06-01,192.0.2.10,10,pass,fail,reject",
+  "max_rows": 50
+}
+```
+
+The preview accepts CSV or JSON export content and returns detected columns,
+mapped DMARC fields, warnings, sample normalized rows, and suggested parity
+baseline values. It is read-only: it does not create domains, persist aggregate
+reports, or modify DNS.
+
 ### MSP Operator Views
 
 #### List Workspace Operator Summaries

--- a/docs/user_guide/migration.md
+++ b/docs/user_guide/migration.md
@@ -33,6 +33,25 @@ If no legacy baseline is entered, DMARQ marks the comparison as
 until the parity signals are either matched, explained, or intentionally
 accepted.
 
+## Historical export preview
+
+Use the read-only migration import preview before relying on historical exports
+from another DMARC platform. The preview accepts CSV or JSON content, detects
+common export columns, normalizes a sample of rows, and suggests baseline values
+for the Migration Parity panel:
+
+- aggregate report count
+- message volume
+- observed sending source count
+- compliance or alignment rate
+- most common DMARC policy
+- first and last observed dates where present
+
+The preview does not create domains, write aggregate reports, or modify DNS.
+It is intentionally safe to run against vendor exports while planning a
+cutover. Review warnings for missing columns, rows from other domains, or
+truncated previews before using the suggested baseline values.
+
 ## Platform-specific notes
 
 For Valimail, EasyDMARC, dmarcian, PowerDMARC, DMARCguard, and manual mailbox
@@ -59,7 +78,7 @@ They are meant for parity checks, audit evidence, and rollback decisions.
 ## Import limitations
 
 DMARQ can ingest standard DMARC aggregate reports through upload, IMAP, Gmail,
-and Microsoft 365 mail sources. Vendor-specific historical export imports are
-tracked as follow-up work. Until a vendor importer exists, use the previous
-platform's export as a comparison artifact and let DMARQ build its own evidence
-from newly received aggregate reports.
+and Microsoft 365 mail sources. Vendor-specific historical export persistence is
+tracked as follow-up work. Until a write importer exists, use the migration
+preview and parity dashboard as comparison artifacts while DMARQ builds its own
+evidence from newly received aggregate reports.


### PR DESCRIPTION
## Summary
- add a read-only migration import preview endpoint for historical CSV/JSON exports
- normalize common DMARC export columns into sample rows and suggested parity baseline values
- document the preview workflow and keep the limitations explicit: no persistence, no domain creation, no DNS changes

Refs #311

## Validation
- `./.venv/bin/pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py -q --disable-warnings`
- `./.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/services/migration_import.py backend/app/tests/test_domain_detail_endpoints.py`
- `./.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/services/migration_import.py backend/app/tests/test_domain_detail_endpoints.py`
- `./.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/services/migration_import.py backend/app/tests/test_domain_detail_endpoints.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only historical export preview for migration, supporting CSV and JSON input.
  * Preview results now show detected columns, normalized rows, baseline metrics, warnings, and suggested next steps.
  * Expanded migration-related documentation with API and user guide details for the preview workflow.

* **Bug Fixes**
  * Improved validation and error handling for invalid, empty, or malformed import content.
  * Added safer handling for mixed-domain rows, truncated previews, and missing or unusual field values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->