### PR TITLE
Clarify migration import preview counts

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -272,6 +272,8 @@ class MigrationImportPreviewResponse(BaseModel):
     row_count: int
     normalized_count: int
     ignored_count: int
+    rejected_count: int
+    truncated_count: int
     detected_columns: List[str]
     mapped_columns: Dict[str, str]
     warnings: List[str] = Field(default_factory=list)
@@ -2521,6 +2523,8 @@ async def preview_domain_migration_import(
         row_count=preview["row_count"],
         normalized_count=preview["normalized_count"],
         ignored_count=preview["ignored_count"],
+        rejected_count=preview["rejected_count"],
+        truncated_count=preview["truncated_count"],
         detected_columns=preview["detected_columns"],
         mapped_columns=preview["mapped_columns"],
         warnings=preview["warnings"],

--- a/backend/app/services/migration_import.py
+++ b/backend/app/services/migration_import.py
@@ -33,6 +33,7 @@ COLUMN_ALIASES = {
 
 PASS_VALUES = {"pass", "passed", "true", "yes", "1", "aligned", "ok"}
 POLICY_VALUES = {"none", "quarantine", "reject"}
+MAX_PREVIEW_CONTENT_BYTES = 1_000_000
 
 
 @dataclass(frozen=True)
@@ -77,19 +78,23 @@ def preview_migration_import(
 ) -> Dict[str, Any]:
     """Parse a CSV/JSON vendor export into a read-only migration preview."""
     rows, detected_format = _load_rows(content, source_format)
-    detected_columns = _detected_columns(rows)
+    preview_rows = rows[:max_rows]
+    detected_columns = _detected_columns(preview_rows)
     aliases = _column_aliases(detected_columns)
     normalized_rows: List[MigrationImportRow] = []
     warnings: List[str] = []
+    rejected_count = 0
 
-    for raw_row in rows[:max_rows]:
+    for raw_row in preview_rows:
         normalized = _normalize_row(raw_row, aliases)
         if not normalized.source_ip and normalized.count == 0:
+            rejected_count += 1
             warnings.append("Ignored a row without a sending source or message count.")
             continue
         normalized_rows.append(normalized)
 
-    ignored_count = max(0, len(rows) - len(normalized_rows))
+    truncated_count = max(0, len(rows) - len(preview_rows))
+    ignored_count = rejected_count + truncated_count
     domain_mismatches = sorted(
         {
             row.domain
@@ -113,6 +118,8 @@ def preview_migration_import(
         "row_count": len(rows),
         "normalized_count": len(normalized_rows),
         "ignored_count": ignored_count,
+        "rejected_count": rejected_count,
+        "truncated_count": truncated_count,
         "detected_columns": detected_columns,
         "mapped_columns": aliases,
         "warnings": warnings,
@@ -129,6 +136,8 @@ def _load_rows(content: str, source_format: str) -> tuple[List[Dict[str, Any]], 
     text = content.strip()
     if not text:
         raise ValueError("import content is empty")
+    if len(text.encode("utf-8")) > MAX_PREVIEW_CONTENT_BYTES:
+        raise ValueError("import content is too large for preview")
 
     if normalized_format == "json" or (normalized_format == "auto" and text[:1] in {"[", "{"}):
         return _load_json_rows(text), "json"

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -983,6 +983,9 @@ def test_preview_domain_migration_import_csv_baseline(seeded_client: TestClient)
     assert data["import_mode"] == "preview_only"
     assert data["row_count"] == 2
     assert data["normalized_count"] == 2
+    assert data["ignored_count"] == 0
+    assert data["rejected_count"] == 0
+    assert data["truncated_count"] == 0
     assert data["baseline"] == {
         "report_count": 1,
         "total_emails": 10,
@@ -1038,10 +1041,7 @@ def test_preview_domain_migration_import_rejects_invalid_json(seeded_client: Tes
     )
 
     assert response.status_code == 400
-    assert (
-        response.json()["detail"]
-        == "JSON content could not be parsed: Expecting property name enclosed in double quotes"
-    )
+    assert response.json()["detail"].startswith("JSON content could not be parsed:")
 
 
 def test_get_domain_migration_readiness_blocks_empty_domain(

--- a/backend/app/tests/test_migration_import.py
+++ b/backend/app/tests/test_migration_import.py
@@ -12,7 +12,7 @@ def test_preview_migration_import_auto_json_list_limits_and_warns():
         domain="example.com",
         content="""[
           {"domain": "example.com", "source": "192.0.2.1", "total": "1,200"},
-          {"domain": "example.com", "source": "192.0.2.2", "total": 5}
+          {"domain": "example.com", "source": "192.0.2.2", "total": 5, "unused_after_preview": true}
         ]""",
         max_rows=1,
     )
@@ -21,8 +21,12 @@ def test_preview_migration_import_auto_json_list_limits_and_warns():
     assert preview["row_count"] == 2
     assert preview["normalized_count"] == 1
     assert preview["ignored_count"] == 1
+    assert preview["rejected_count"] == 0
+    assert preview["truncated_count"] == 1
     assert preview["baseline"]["total_emails"] == 1200
     assert preview["sample_rows"][0]["source_ip"] == "192.0.2.1"
+    assert "total" in preview["detected_columns"]
+    assert "unused_after_preview" not in preview["detected_columns"]
     assert "Preview limited to the first 1 rows." in preview["warnings"]
     assert "Missing recommended columns: dkim, spf, policy" in preview["warnings"]
 
@@ -37,8 +41,34 @@ def test_preview_migration_import_ignores_unmappable_rows():
 
     assert preview["normalized_count"] == 0
     assert preview["ignored_count"] == 1
+    assert preview["rejected_count"] == 1
+    assert preview["truncated_count"] == 0
     assert preview["sample_rows"] == []
     assert "Ignored a row without a sending source or message count." in preview["warnings"]
+
+
+def test_preview_migration_import_splits_rejected_and_truncated_counts():
+    """Ignored counts distinguish rejected preview rows from truncated rows."""
+    preview = preview_migration_import(
+        domain="example.com",
+        content="\n".join(
+            [
+                "Domain,Source IP,Messages",
+                "example.com,,0",
+                "example.com,192.0.2.10,3",
+                "example.com,192.0.2.11,7",
+            ]
+        ),
+        source_format="csv",
+        max_rows=2,
+    )
+
+    assert preview["row_count"] == 3
+    assert preview["normalized_count"] == 1
+    assert preview["rejected_count"] == 1
+    assert preview["truncated_count"] == 1
+    assert preview["ignored_count"] == 2
+    assert preview["baseline"]["total_emails"] == 3
 
 
 def test_preview_migration_import_json_object_without_row_collection():
@@ -80,6 +110,18 @@ def test_preview_migration_import_rejects_invalid_inputs(content, source_format,
             domain="example.com",
             content=content,
             source_format=source_format,
+        )
+
+
+def test_preview_migration_import_rejects_oversized_content():
+    """Oversized preview payloads fail without creating a huge parametrized test id."""
+    content = "x" * (migration_import.MAX_PREVIEW_CONTENT_BYTES + 1)
+
+    with pytest.raises(ValueError, match="import content is too large for preview"):
+        preview_migration_import(
+            domain="example.com",
+            content=content,
+            source_format="csv",
         )
 
 


### PR DESCRIPTION
## Summary
- split migration import preview ignored rows into rejected and truncated counts
- limit preview column detection to the sampled preview subset and reject oversized preview payloads before parsing
- make the invalid JSON endpoint test assert a stable error prefix

Follows up on CodeRabbit/Codecov feedback from #365 after it merged.

## Validation
- `/tmp/dmarq-pr353-coverage/.venv/bin/pytest backend/app/tests/test_migration_import.py backend/app/tests/test_domain_detail_endpoints.py -q --disable-warnings`
- `/tmp/dmarq-pr353-coverage/.venv/bin/black --check backend/app/services/migration_import.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_migration_import.py backend/app/tests/test_domain_detail_endpoints.py`
- `/tmp/dmarq-pr353-coverage/.venv/bin/isort --check-only backend/app/services/migration_import.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_migration_import.py backend/app/tests/test_domain_detail_endpoints.py`
- `/tmp/dmarq-pr353-coverage/.venv/bin/flake8 backend/app/services/migration_import.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_migration_import.py backend/app/tests/test_domain_detail_endpoints.py`
- `git diff --check`