### PR TITLE
Add migration import planning metadata

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -18,6 +18,7 @@ from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
+from app.models.report import DMARCReport
 from app.services.bimi import BIMIResult, check_bimi_cached
 from app.services.cloudflare_dns import (
     analyze_dns_records,
@@ -248,6 +249,9 @@ class MigrationImportBaseline(BaseModel):
 class MigrationImportPreviewRow(BaseModel):
     """One normalized read-only export row."""
 
+    row_key: Optional[str] = None
+    report_import_key: Optional[str] = None
+    import_status: Optional[str] = None
     domain: Optional[str] = None
     report_id: Optional[str] = None
     begin_date: Optional[str] = None
@@ -274,6 +278,12 @@ class MigrationImportPreviewResponse(BaseModel):
     ignored_count: int
     rejected_count: int
     truncated_count: int
+    importable_row_count: int
+    planned_report_count: int
+    existing_report_count: int
+    duplicate_row_count: int
+    needs_report_id_count: int
+    batch_fingerprint: str
     detected_columns: List[str]
     mapped_columns: Dict[str, str]
     warnings: List[str] = Field(default_factory=list)
@@ -2490,6 +2500,16 @@ async def preview_domain_migration_import(
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
     domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
+    domain_row = workspace_domain_query(db, workspace).filter(Domain.name == domain_name).first()
+    existing_report_ids: List[str] = []
+    if domain_row is not None:
+        existing_report_ids = [
+            row[0]
+            for row in db.query(DMARCReport.report_id)
+            .filter(DMARCReport.domain_id == domain_row.id)
+            .all()
+            if row[0]
+        ]
 
     try:
         content = (
@@ -2500,6 +2520,7 @@ async def preview_domain_migration_import(
             content=content,
             source_format=payload.format,
             max_rows=payload.max_rows,
+            existing_report_ids=existing_report_ids,
         )
     except ValueError as exc:
         raise HTTPException(
@@ -2525,6 +2546,12 @@ async def preview_domain_migration_import(
         ignored_count=preview["ignored_count"],
         rejected_count=preview["rejected_count"],
         truncated_count=preview["truncated_count"],
+        importable_row_count=preview["importable_row_count"],
+        planned_report_count=preview["planned_report_count"],
+        existing_report_count=preview["existing_report_count"],
+        duplicate_row_count=preview["duplicate_row_count"],
+        needs_report_id_count=preview["needs_report_id_count"],
+        batch_fingerprint=preview["batch_fingerprint"],
         detected_columns=preview["detected_columns"],
         mapped_columns=preview["mapped_columns"],
         warnings=preview["warnings"],

--- a/backend/app/services/migration_import.py
+++ b/backend/app/services/migration_import.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import io
 import json
 from collections import Counter
@@ -51,6 +52,9 @@ class MigrationImportRow:
     disposition: Optional[str] = None
     policy: Optional[str] = None
     org_name: Optional[str] = None
+    row_key: Optional[str] = None
+    report_import_key: Optional[str] = None
+    import_status: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Return API-safe row data."""
@@ -66,6 +70,9 @@ class MigrationImportRow:
             "disposition": self.disposition,
             "policy": self.policy,
             "org_name": self.org_name,
+            "row_key": self.row_key,
+            "report_import_key": self.report_import_key,
+            "import_status": self.import_status,
         }
 
 
@@ -75,6 +82,7 @@ def preview_migration_import(
     content: str,
     source_format: str = "auto",
     max_rows: int = 50,
+    existing_report_ids: Optional[Iterable[str]] = None,
 ) -> Dict[str, Any]:
     """Parse a CSV/JSON vendor export into a read-only migration preview."""
     rows, detected_format = _load_rows(content, source_format)
@@ -84,6 +92,13 @@ def preview_migration_import(
     normalized_rows: List[MigrationImportRow] = []
     warnings: List[str] = []
     rejected_count = 0
+    duplicate_row_count = 0
+    seen_row_keys: set[str] = set()
+    existing_report_id_set = {
+        str(report_id).strip()
+        for report_id in (existing_report_ids or [])
+        if str(report_id).strip()
+    }
 
     for raw_row in preview_rows:
         normalized = _normalize_row(raw_row, aliases)
@@ -91,10 +106,34 @@ def preview_migration_import(
             rejected_count += 1
             warnings.append("Ignored a row without a sending source or message count.")
             continue
-        normalized_rows.append(normalized)
+        row_key = _row_import_key(domain, normalized)
+        if row_key in seen_row_keys:
+            duplicate_row_count += 1
+        seen_row_keys.add(row_key)
+        normalized_rows.append(
+            _annotate_row(
+                normalized,
+                row_key=row_key,
+                report_import_key=_report_import_key(domain, normalized),
+                import_status=_import_status(normalized, existing_report_id_set),
+            )
+        )
 
     truncated_count = max(0, len(rows) - len(preview_rows))
     ignored_count = rejected_count + truncated_count
+    planned_report_keys = {
+        row.report_import_key
+        for row in normalized_rows
+        if row.import_status == "planned" and row.report_import_key
+    }
+    existing_report_keys = {
+        row.report_import_key
+        for row in normalized_rows
+        if row.import_status == "existing_report" and row.report_import_key
+    }
+    needs_report_id_count = sum(
+        1 for row in normalized_rows if row.import_status == "needs_report_id"
+    )
     domain_mismatches = sorted(
         {
             row.domain
@@ -112,6 +151,10 @@ def preview_migration_import(
     missing_columns = _missing_recommended_columns(aliases)
     if missing_columns:
         warnings.append("Missing recommended columns: " + ", ".join(missing_columns))
+    if existing_report_keys:
+        warnings.append("Export contains reports that already exist in DMARQ.")
+    if needs_report_id_count:
+        warnings.append("Some rows need a report ID before they can be safely imported.")
 
     return {
         "format": detected_format,
@@ -120,6 +163,12 @@ def preview_migration_import(
         "ignored_count": ignored_count,
         "rejected_count": rejected_count,
         "truncated_count": truncated_count,
+        "importable_row_count": sum(1 for row in normalized_rows if row.import_status == "planned"),
+        "planned_report_count": len(planned_report_keys),
+        "existing_report_count": len(existing_report_keys),
+        "duplicate_row_count": duplicate_row_count,
+        "needs_report_id_count": needs_report_id_count,
+        "batch_fingerprint": _batch_fingerprint(domain, normalized_rows),
         "detected_columns": detected_columns,
         "mapped_columns": aliases,
         "warnings": warnings,
@@ -221,6 +270,31 @@ def _normalize_row(row: Dict[str, Any], aliases: Dict[str, str]) -> MigrationImp
     )
 
 
+def _annotate_row(
+    row: MigrationImportRow,
+    *,
+    row_key: str,
+    report_import_key: Optional[str],
+    import_status: str,
+) -> MigrationImportRow:
+    return MigrationImportRow(
+        domain=row.domain,
+        report_id=row.report_id,
+        begin_date=row.begin_date,
+        end_date=row.end_date,
+        source_ip=row.source_ip,
+        count=row.count,
+        dkim=row.dkim,
+        spf=row.spf,
+        disposition=row.disposition,
+        policy=row.policy,
+        org_name=row.org_name,
+        row_key=row_key,
+        report_import_key=report_import_key,
+        import_status=import_status,
+    )
+
+
 def _row_value(row: Dict[str, Any], aliases: Dict[str, str], key: str) -> Any:
     column = aliases.get(key)
     if column is None:
@@ -287,6 +361,53 @@ def _clean_policy(value: Any) -> Optional[str]:
 def _missing_recommended_columns(aliases: Dict[str, str]) -> List[str]:
     recommended = ["source_ip", "count", "dkim", "spf", "policy"]
     return [column for column in recommended if column not in aliases]
+
+
+def _stable_hash(payload: Dict[str, Any], prefix: str) -> str:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return f"{prefix}_{hashlib.sha256(body.encode('utf-8')).hexdigest()[:24]}"
+
+
+def _row_import_key(domain: str, row: MigrationImportRow) -> str:
+    payload = {
+        "domain": (row.domain or domain).lower(),
+        "report_id": row.report_id,
+        "begin_date": row.begin_date,
+        "end_date": row.end_date,
+        "source_ip": row.source_ip,
+        "count": row.count,
+        "dkim": row.dkim,
+        "spf": row.spf,
+        "disposition": row.disposition,
+        "policy": row.policy,
+        "org_name": row.org_name,
+    }
+    return _stable_hash(payload, "mir")
+
+
+def _report_import_key(domain: str, row: MigrationImportRow) -> Optional[str]:
+    if not row.report_id:
+        return None
+    return _stable_hash(
+        {
+            "domain": (row.domain or domain).lower(),
+            "report_id": row.report_id,
+        },
+        "mip",
+    )
+
+
+def _import_status(row: MigrationImportRow, existing_report_ids: set[str]) -> str:
+    if not row.report_id:
+        return "needs_report_id"
+    if row.report_id in existing_report_ids:
+        return "existing_report"
+    return "planned"
+
+
+def _batch_fingerprint(domain: str, rows: List[MigrationImportRow]) -> str:
+    row_keys = sorted(row.row_key for row in rows if row.row_key)
+    return _stable_hash({"domain": domain.lower(), "row_keys": row_keys}, "mib")
 
 
 def _build_baseline(rows: List[MigrationImportRow]) -> Dict[str, Any]:

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -986,6 +986,12 @@ def test_preview_domain_migration_import_csv_baseline(seeded_client: TestClient)
     assert data["ignored_count"] == 0
     assert data["rejected_count"] == 0
     assert data["truncated_count"] == 0
+    assert data["importable_row_count"] == 2
+    assert data["planned_report_count"] == 1
+    assert data["existing_report_count"] == 0
+    assert data["duplicate_row_count"] == 0
+    assert data["needs_report_id_count"] == 0
+    assert data["batch_fingerprint"].startswith("mib_")
     assert data["baseline"] == {
         "report_count": 1,
         "total_emails": 10,
@@ -997,9 +1003,42 @@ def test_preview_domain_migration_import_csv_baseline(seeded_client: TestClient)
     }
     assert data["mapped_columns"]["source_ip"] == "Source IP"
     assert data["sample_rows"][0]["source_ip"] == "192.0.2.10"
+    assert data["sample_rows"][0]["row_key"].startswith("mir_")
+    assert data["sample_rows"][0]["report_import_key"].startswith("mip_")
+    assert data["sample_rows"][0]["import_status"] == "planned"
     assert data["next_steps"][-1] == (
         "Keep the old DMARC platform active until mismatches are explained."
     )
+
+
+def test_preview_domain_migration_import_marks_existing_workspace_reports(
+    seeded_client: TestClient,
+):
+    """Import planning checks existing reports only in the authorized workspace."""
+    content = "\n".join(
+        [
+            "Domain,Report ID,Date,Source IP,Messages,DKIM,SPF,Policy",
+            "example.com,rpt-dict-policy,2026-06-01,192.0.2.10,8,pass,fail,reject",
+            "example.com,legacy-new,2026-06-01,192.0.2.20,2,fail,pass,reject",
+        ]
+    )
+
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/migration/import/preview",
+        json={
+            "format": "csv",
+            "content": content,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["existing_report_count"] == 1
+    assert data["planned_report_count"] == 1
+    assert data["importable_row_count"] == 1
+    assert data["sample_rows"][0]["import_status"] == "existing_report"
+    assert data["sample_rows"][1]["import_status"] == "planned"
+    assert "Export contains reports that already exist in DMARQ." in data["warnings"]
 
 
 def test_preview_domain_migration_import_json_warns_on_domain_mismatch(

--- a/backend/app/tests/test_migration_import.py
+++ b/backend/app/tests/test_migration_import.py
@@ -23,6 +23,12 @@ def test_preview_migration_import_auto_json_list_limits_and_warns():
     assert preview["ignored_count"] == 1
     assert preview["rejected_count"] == 0
     assert preview["truncated_count"] == 1
+    assert preview["planned_report_count"] == 0
+    assert preview["importable_row_count"] == 0
+    assert preview["needs_report_id_count"] == 1
+    assert preview["sample_rows"][0]["import_status"] == "needs_report_id"
+    assert preview["sample_rows"][0]["row_key"].startswith("mir_")
+    assert preview["batch_fingerprint"].startswith("mib_")
     assert preview["baseline"]["total_emails"] == 1200
     assert preview["sample_rows"][0]["source_ip"] == "192.0.2.1"
     assert "total" in preview["detected_columns"]
@@ -68,7 +74,36 @@ def test_preview_migration_import_splits_rejected_and_truncated_counts():
     assert preview["rejected_count"] == 1
     assert preview["truncated_count"] == 1
     assert preview["ignored_count"] == 2
+    assert preview["duplicate_row_count"] == 0
     assert preview["baseline"]["total_emails"] == 3
+
+
+def test_preview_migration_import_marks_existing_and_duplicate_reports():
+    """Import planning marks existing reports without removing them from parity baselines."""
+    preview = preview_migration_import(
+        domain="example.com",
+        content="\n".join(
+            [
+                "Domain,Report ID,Date,Source IP,Messages,DKIM,SPF,Policy",
+                "example.com,legacy-1,2026-06-01,192.0.2.10,3,pass,fail,reject",
+                "example.com,legacy-1,2026-06-01,192.0.2.10,3,pass,fail,reject",
+                "example.com,legacy-2,2026-06-01,192.0.2.11,7,fail,pass,reject",
+            ]
+        ),
+        source_format="csv",
+        existing_report_ids={"legacy-1"},
+    )
+
+    assert preview["baseline"]["total_emails"] == 13
+    assert preview["existing_report_count"] == 1
+    assert preview["planned_report_count"] == 1
+    assert preview["importable_row_count"] == 1
+    assert preview["duplicate_row_count"] == 1
+    assert preview["sample_rows"][0]["import_status"] == "existing_report"
+    assert preview["sample_rows"][1]["import_status"] == "existing_report"
+    assert preview["sample_rows"][2]["import_status"] == "planned"
+    assert preview["sample_rows"][2]["report_import_key"].startswith("mip_")
+    assert "Export contains reports that already exist in DMARQ." in preview["warnings"]
 
 
 def test_preview_migration_import_json_object_without_row_collection():

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -296,6 +296,24 @@ mapped DMARC fields, warnings, sample normalized rows, and suggested parity
 baseline values. It is read-only: it does not create domains, persist aggregate
 reports, or modify DNS.
 
+The response also includes import-planning metadata for a future confirmed
+write step:
+
+| Field | Purpose |
+| --- | --- |
+| `batch_fingerprint` | Stable fingerprint for the normalized preview batch |
+| `row_key` | Stable key for each normalized sample row |
+| `report_import_key` | Stable key for the report that row would belong to |
+| `import_status` | `planned`, `existing_report`, or `needs_report_id` |
+| `planned_report_count` | Distinct reports that could be imported later |
+| `existing_report_count` | Distinct reports already present in the workspace |
+| `duplicate_row_count` | Duplicate normalized rows inside the preview sample |
+| `needs_report_id_count` | Rows missing a safe report identifier |
+
+These fields are advisory and read-only. They exist so operators can verify
+idempotency and tenant-scoped duplicate detection before DMARQ adds a confirmed
+historical-import write path.
+
 ### MSP Operator Views
 
 #### List Workspace Operator Summaries

--- a/docs/user_guide/migration.md
+++ b/docs/user_guide/migration.md
@@ -52,6 +52,19 @@ It is intentionally safe to run against vendor exports while planning a
 cutover. Review warnings for missing columns, rows from other domains, or
 truncated previews before using the suggested baseline values.
 
+Preview responses also include an import plan with stable identifiers:
+
+- `batch_fingerprint` identifies the normalized export sample.
+- `row_key` identifies each normalized row.
+- `report_import_key` identifies the aggregate report a row would belong to.
+- `import_status` shows whether a row is `planned`, already covered by an
+  `existing_report`, or blocked as `needs_report_id`.
+
+Use those values to verify that a vendor export can be handled idempotently.
+Rows marked `existing_report` are already present for the selected workspace,
+and rows marked `needs_report_id` should not be used for a confirmed import
+until the source export provides a stable report identifier.
+
 ## Platform-specific notes
 
 For Valimail, EasyDMARC, dmarcian, PowerDMARC, DMARCguard, and manual mailbox


### PR DESCRIPTION
## Summary
- add stable migration import planning metadata to historical CSV/JSON previews
- mark preview rows as `planned`, `existing_report`, or `needs_report_id` using workspace-scoped persisted report IDs
- document the read-only import plan fields for safe idempotency review before a future confirmed write importer

## Boundaries
- read-only only: this does not create domains, persist reports, or modify DNS
- intended as the idempotency/tenant-safety layer before a later confirmed historical import write path for #311

## Validation
- `./.venv/bin/pytest backend/app/tests/test_migration_import.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py -q --disable-warnings`
- `./.venv/bin/black --check backend/app/services/migration_import.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_migration_import.py backend/app/tests/test_domain_detail_endpoints.py`
- `./.venv/bin/isort --check-only backend/app/services/migration_import.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_migration_import.py backend/app/tests/test_domain_detail_endpoints.py`
- `./.venv/bin/flake8 backend/app/services/migration_import.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_migration_import.py backend/app/tests/test_domain_detail_endpoints.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Historical export previews now include import-planning details such as row status, stable identifiers, and batch fingerprints.
  * Preview results now show counts for planned, existing, duplicate, and ID-needed rows.

* **Bug Fixes**
  * Preview output now better distinguishes rows already covered by existing reports from new planned rows.
  * Duplicate rows are now flagged in preview results to help avoid repeat imports.

* **Documentation**
  * Updated migration and API docs to explain the new preview fields and how to use them for safer imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->