### PR TITLE
Address migration import planning review

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2507,6 +2507,7 @@ async def preview_domain_migration_import(
             row[0]
             for row in db.query(DMARCReport.report_id)
             .filter(DMARCReport.domain_id == domain_row.id)
+            .distinct()
             .all()
             if row[0]
         ]

--- a/backend/app/tests/test_migration_import.py
+++ b/backend/app/tests/test_migration_import.py
@@ -8,12 +8,18 @@ from app.services.migration_import import preview_migration_import
 
 def test_preview_migration_import_auto_json_list_limits_and_warns():
     """Auto-detected JSON previews cap sample size and surface mapping gaps."""
-    preview = preview_migration_import(
-        domain="example.com",
-        content="""[
+    content = """[
           {"domain": "example.com", "source": "192.0.2.1", "total": "1,200"},
           {"domain": "example.com", "source": "192.0.2.2", "total": 5, "unused_after_preview": true}
-        ]""",
+        ]"""
+    preview = preview_migration_import(
+        domain="example.com",
+        content=content,
+        max_rows=1,
+    )
+    repeated_preview = preview_migration_import(
+        domain="example.com",
+        content=content,
         max_rows=1,
     )
 
@@ -29,6 +35,8 @@ def test_preview_migration_import_auto_json_list_limits_and_warns():
     assert preview["sample_rows"][0]["import_status"] == "needs_report_id"
     assert preview["sample_rows"][0]["row_key"].startswith("mir_")
     assert preview["batch_fingerprint"].startswith("mib_")
+    assert preview["batch_fingerprint"] == repeated_preview["batch_fingerprint"]
+    assert preview["sample_rows"][0]["row_key"] == repeated_preview["sample_rows"][0]["row_key"]
     assert preview["baseline"]["total_emails"] == 1200
     assert preview["sample_rows"][0]["source_ip"] == "192.0.2.1"
     assert "total" in preview["detected_columns"]
@@ -80,16 +88,23 @@ def test_preview_migration_import_splits_rejected_and_truncated_counts():
 
 def test_preview_migration_import_marks_existing_and_duplicate_reports():
     """Import planning marks existing reports without removing them from parity baselines."""
+    content = "\n".join(
+        [
+            "Domain,Report ID,Date,Source IP,Messages,DKIM,SPF,Policy",
+            "example.com,legacy-1,2026-06-01,192.0.2.10,3,pass,fail,reject",
+            "example.com,legacy-1,2026-06-01,192.0.2.10,3,pass,fail,reject",
+            "example.com,legacy-2,2026-06-01,192.0.2.11,7,fail,pass,reject",
+        ]
+    )
     preview = preview_migration_import(
         domain="example.com",
-        content="\n".join(
-            [
-                "Domain,Report ID,Date,Source IP,Messages,DKIM,SPF,Policy",
-                "example.com,legacy-1,2026-06-01,192.0.2.10,3,pass,fail,reject",
-                "example.com,legacy-1,2026-06-01,192.0.2.10,3,pass,fail,reject",
-                "example.com,legacy-2,2026-06-01,192.0.2.11,7,fail,pass,reject",
-            ]
-        ),
+        content=content,
+        source_format="csv",
+        existing_report_ids={"legacy-1"},
+    )
+    repeated_preview = preview_migration_import(
+        domain="example.com",
+        content=content,
         source_format="csv",
         existing_report_ids={"legacy-1"},
     )
@@ -103,6 +118,12 @@ def test_preview_migration_import_marks_existing_and_duplicate_reports():
     assert preview["sample_rows"][1]["import_status"] == "existing_report"
     assert preview["sample_rows"][2]["import_status"] == "planned"
     assert preview["sample_rows"][2]["report_import_key"].startswith("mip_")
+    assert preview["batch_fingerprint"] == repeated_preview["batch_fingerprint"]
+    assert preview["sample_rows"][2]["row_key"] == repeated_preview["sample_rows"][2]["row_key"]
+    assert (
+        preview["sample_rows"][2]["report_import_key"]
+        == repeated_preview["sample_rows"][2]["report_import_key"]
+    )
     assert "Export contains reports that already exist in DMARQ." in preview["warnings"]
 
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -299,16 +299,22 @@ reports, or modify DNS.
 The response also includes import-planning metadata for a future confirmed
 write step:
 
-| Field | Purpose |
+| Top-level field | Purpose |
 | --- | --- |
 | `batch_fingerprint` | Stable fingerprint for the normalized preview batch |
-| `row_key` | Stable key for each normalized sample row |
+| `importable_row_count` | Normalized rows that are safe to import in a later write step |
+| `planned_report_count` | Distinct planned report keys that could be imported later |
+| `existing_report_count` | Distinct report keys already present in the selected workspace |
+| `duplicate_row_count` | Duplicate normalized rows inside the preview sample |
+| `needs_report_id_count` | Normalized rows missing a safe report identifier |
+
+Each entry in `sample_rows[*]` includes row-level planning fields:
+
+| Row field | Purpose |
+| --- | --- |
+| `row_key` | Stable key for the normalized sample row |
 | `report_import_key` | Stable key for the report that row would belong to |
 | `import_status` | `planned`, `existing_report`, or `needs_report_id` |
-| `planned_report_count` | Distinct reports that could be imported later |
-| `existing_report_count` | Distinct reports already present in the workspace |
-| `duplicate_row_count` | Duplicate normalized rows inside the preview sample |
-| `needs_report_id_count` | Rows missing a safe report identifier |
 
 These fields are advisory and read-only. They exist so operators can verify
 idempotency and tenant-scoped duplicate detection before DMARQ adds a confirmed


### PR DESCRIPTION
## Summary
- document migration import preview planning fields by response scope and add the missing `importable_row_count` reference
- assert stable planning keys and batch fingerprints across repeated preview calls
- avoid duplicate report-id materialization by querying distinct historical report IDs

## Boundaries
- follow-up only for CodeRabbit comments on merged PR #367
- no historical import write path or behavior change beyond duplicate report-id filtering

## Validation
- `/tmp/dmarq-pr353-coverage/.venv/bin/pytest backend/app/tests/test_migration_import.py backend/app/tests/test_domain_detail_endpoints.py -q --disable-warnings`
- `/tmp/dmarq-pr353-coverage/.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_migration_import.py`
- `/tmp/dmarq-pr353-coverage/.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_migration_import.py`
- `/tmp/dmarq-pr353-coverage/.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_migration_import.py`
- `git diff --check`