### PR TITLE
[codex] Add public alert history API

### DIFF
--- a/backend/app/api/api_v1/endpoints/mcp.py
+++ b/backend/app/api/api_v1/endpoints/mcp.py
@@ -18,6 +18,7 @@ from app.services.ai_assistance import (
     build_evidence_summary,
     get_assistance_config,
 )
+from app.services.alert_history import alert_history_summary, list_workspace_alert_history
 from app.services.api_tokens import MCP_READ_SCOPE
 from app.services.organizations import require_organization_feature
 from app.services.report_persistence import hydrate_report_store_from_db
@@ -144,6 +145,19 @@ READ_ONLY_TOOLS = [
         },
         "readOnlyHint": True,
     },
+    {
+        "name": "alert_history",
+        "description": "Return sanitized alert history for monitored workspace domains.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "domain": {"type": "string"},
+                "active": {"type": "boolean"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 200, "default": 50},
+            },
+        },
+        "readOnlyHint": True,
+    },
 ]
 
 
@@ -238,6 +252,67 @@ def _tool_limit(arguments: Dict[str, Any], *, default: int = 400, maximum: int =
     return limit
 
 
+def _tool_optional_bool(arguments: Dict[str, Any], key: str) -> Optional[bool]:
+    raw_value = arguments.get(key)
+    if raw_value in (None, ""):
+        return None
+    if isinstance(raw_value, bool):
+        return raw_value
+    normalized = str(raw_value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{key} must be a boolean")
+
+
+def _tool_optional_domain(arguments: Dict[str, Any]) -> Optional[str]:
+    domain = str(arguments.get("domain", "")).strip()
+    return domain or None
+
+
+def _call_action_proposals_tool(
+    arguments: Dict[str, Any],
+    *,
+    db: Session,
+    workspace_id: Optional[int],
+) -> Any:
+    return build_action_proposals(db, _tool_domain(arguments), workspace_id=workspace_id)
+
+
+def _call_alert_history_tool(
+    arguments: Dict[str, Any],
+    *,
+    db: Session,
+    workspace_id: Optional[int],
+) -> Dict[str, Any]:
+    active_filter = _tool_optional_bool(arguments, "active")
+    domain_filter = _tool_optional_domain(arguments)
+    limit = _tool_limit(arguments, default=50, maximum=200)
+    alerts = list_workspace_alert_history(
+        db,
+        workspace_id=workspace_id or 0,
+        active=active_filter,
+        domain=domain_filter,
+        limit=limit,
+    )
+    return {
+        "alerts": alerts,
+        "summary": alert_history_summary(alerts),
+        "filters": {
+            "active": active_filter,
+            "domain": domain_filter,
+            "limit": limit,
+        },
+    }
+
+
+READ_ONLY_SYNC_HANDLERS = {
+    "action_proposals": _call_action_proposals_tool,
+    "alert_history": _call_alert_history_tool,
+}
+
+
 async def _call_read_only_tool(
     name: str,
     arguments: Dict[str, Any],
@@ -286,8 +361,9 @@ async def _call_read_only_tool(
             db=db,
             _auth=auth_context,
         )
-    if name == "action_proposals":
-        return build_action_proposals(db, _tool_domain(arguments), workspace_id=workspace_id)
+    sync_handler = READ_ONLY_SYNC_HANDLERS.get(name)
+    if sync_handler is not None:
+        return sync_handler(arguments, db=db, workspace_id=workspace_id)
     if name == "health_evidence_export":
         domain = _tool_domain(arguments)
         rows = await domains.build_domain_health_evidence_export_rows(

--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -10,6 +10,7 @@ from app.api.api_v1.endpoints import ai, domains, tls_reports
 from app.core.database import get_db
 from app.core.security import require_api_token_scope
 from app.services.ai_assistance import build_action_proposals
+from app.services.alert_history import alert_history_summary, list_workspace_alert_history
 from app.services.api_tokens import READ_POSTURE_SCOPE, READ_REPORTS_SCOPE, READ_TLS_SCOPE
 from app.services.workspace_access import PERMISSION_REPORTS_READ, resolve_authorized_workspace
 
@@ -98,6 +99,30 @@ async def public_domain_action_proposals(
         return build_action_proposals(db, domain_id, workspace_id=workspace.id)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.get("/alerts")
+async def public_alert_history(
+    active: Optional[bool] = Query(None, title="Filter active or resolved alerts"),
+    domain: Optional[str] = Query(None, title="Limit alerts to one monitored domain"),
+    limit: int = Query(50, ge=1, le=200, title="Maximum alert history rows"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_api_token_scope(READ_POSTURE_SCOPE)),
+):
+    """Return sanitized alert history for the API token workspace."""
+    workspace = resolve_authorized_workspace(db, _auth, PERMISSION_REPORTS_READ)
+    alerts = list_workspace_alert_history(
+        db,
+        workspace_id=workspace.id,
+        active=active,
+        domain=domain,
+        limit=limit,
+    )
+    return {
+        "alerts": alerts,
+        "summary": alert_history_summary(alerts),
+        "filters": {"active": active, "domain": domain, "limit": limit},
+    }
 
 
 @router.get("/domains/{domain_id}/posture/evidence/export")

--- a/backend/app/services/alert_history.py
+++ b/backend/app/services/alert_history.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy.orm import Session
 
 from app.models.alert import AlertConfigurationAudit, AlertHistory
+from app.models.domain import Domain
 
 
 def _json_dumps(value: Dict[str, Any]) -> str:
@@ -48,6 +49,89 @@ def _row_to_dict(row: AlertHistory) -> Dict[str, Any]:
         "first_seen_at": row.first_seen_at.isoformat() if row.first_seen_at else None,
         "last_seen_at": row.last_seen_at.isoformat() if row.last_seen_at else None,
         "resolved_at": row.resolved_at.isoformat() if row.resolved_at else None,
+    }
+
+
+PUBLIC_ALERT_EVIDENCE_KEYS = {
+    "source_ip",
+    "message_count",
+    "failed_messages",
+    "threshold",
+    "missing_days",
+    "last_report_at",
+    "previous_rate",
+    "current_rate",
+    "drop",
+}
+
+
+def _public_alert_row_to_dict(row: AlertHistory) -> Dict[str, Any]:
+    base = _row_to_dict(row)
+    payload = base.pop("payload", {}) or {}
+    evidence = {
+        key: payload[key]
+        for key in sorted(PUBLIC_ALERT_EVIDENCE_KEYS)
+        if key in payload and payload[key] not in (None, "")
+    }
+    if evidence:
+        base["evidence"] = evidence
+    return base
+
+
+def _workspace_domain_names(
+    db: Session,
+    *,
+    workspace_id: int,
+    domain: Optional[str] = None,
+) -> List[str]:
+    query = db.query(Domain.name).filter(Domain.workspace_id == workspace_id)
+    if domain:
+        query = query.filter(Domain.name == domain)
+    return [row[0] for row in query.order_by(Domain.name).all()]
+
+
+def list_workspace_alert_history(
+    db: Session,
+    *,
+    workspace_id: int,
+    active: Optional[bool] = None,
+    domain: Optional[str] = None,
+    limit: int = 50,
+) -> List[Dict[str, Any]]:
+    """Return sanitized alert history for domains in one workspace."""
+    domain_names = _workspace_domain_names(db, workspace_id=workspace_id, domain=domain)
+    if not domain_names:
+        return []
+
+    query = db.query(AlertHistory).filter(AlertHistory.domain.in_(domain_names))
+    if active is not None:
+        query = query.filter(AlertHistory.is_active == active)  # noqa: E712
+    rows = (
+        query.order_by(AlertHistory.last_seen_at.desc(), AlertHistory.id.desc())
+        .limit(max(1, min(limit, 200)))
+        .all()
+    )
+    return [_public_alert_row_to_dict(row) for row in rows]
+
+
+def alert_history_summary(alerts: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Summarize an already-filtered alert history result."""
+    by_severity: Dict[str, int] = {}
+    by_rule: Dict[str, int] = {}
+    active_count = 0
+    for alert in alerts:
+        severity = str(alert.get("severity") or "unknown")
+        rule = str(alert.get("rule") or "unknown")
+        by_severity[severity] = by_severity.get(severity, 0) + 1
+        by_rule[rule] = by_rule.get(rule, 0) + 1
+        if alert.get("is_active"):
+            active_count += 1
+    return {
+        "total": len(alerts),
+        "active": active_count,
+        "resolved": len(alerts) - active_count,
+        "by_severity": by_severity,
+        "by_rule": by_rule,
     }
 
 

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.api.api_v1.endpoints import ai as ai_endpoint
 from app.api.api_v1.endpoints import mcp as mcp_endpoint
+from app.models.alert import AlertHistory
 from app.models.domain import Domain
 from app.models.organization import Entitlement, Organization
 from app.models.setting import Setting
@@ -825,6 +826,55 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
 
 
 @pytest.mark.asyncio
+async def test_mcp_alert_history_returns_sanitized_workspace_alerts(
+    db_session: Session,
+):
+    _persist_report(db_session)
+    domain = db_session.query(Domain).filter(Domain.name == DOMAIN).one()
+    db_session.add_all(
+        [
+            AlertHistory(
+                fingerprint="mcp-alert-active",
+                rule="dmarc_failures_above_threshold",
+                severity="error",
+                domain=DOMAIN,
+                title="DMARC failures",
+                detail="Failures exceeded threshold.",
+                payload='{"failed_messages":42,"threshold":10,"secret":"hidden"}',
+                observed_count=3,
+                is_active=True,
+            ),
+            AlertHistory(
+                fingerprint="mcp-alert-resolved",
+                rule="missing_reports",
+                severity="warning",
+                domain=DOMAIN,
+                title="Missing reports",
+                detail="Resolved.",
+                observed_count=1,
+                is_active=False,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    result = await mcp_endpoint._call_read_only_tool(
+        "alert_history",
+        {"active": "true", "limit": "5"},
+        db=db_session,
+        auth_context={"token_id": "test-token"},
+        workspace_id=domain.workspace_id,
+    )
+
+    assert result["summary"]["active"] == 1
+    assert result["filters"]["active"] is True
+    assert result["alerts"][0]["rule"] == "dmarc_failures_above_threshold"
+    assert result["alerts"][0]["evidence"] == {"failed_messages": 42, "threshold": 10}
+    assert "payload" not in result["alerts"][0]
+    assert "hidden" not in str(result)
+
+
+@pytest.mark.asyncio
 async def test_mcp_read_only_tool_dispatch_rejects_invalid_tool_arguments(
     db_session: Session,
 ):
@@ -875,6 +925,15 @@ async def test_mcp_read_only_tool_dispatch_rejects_invalid_tool_arguments(
             workspace_id=None,
         )
 
+    with pytest.raises(ValueError, match="active must be a boolean"):
+        await mcp_endpoint._call_read_only_tool(
+            "alert_history",
+            {"active": "sometimes"},
+            db=db_session,
+            auth_context=auth_context,
+            workspace_id=None,
+        )
+
     with pytest.raises(KeyError):
         await mcp_endpoint._call_read_only_tool(
             "unknown_tool",
@@ -913,6 +972,7 @@ def test_mcp_requires_enabled_scoped_token(client: TestClient, db_session: Sessi
         "dns_lint",
         "dns_change_plan",
         "health_evidence_export",
+        "alert_history",
     }.issubset(tool_names)
 
     initialized = client.post(

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
+from app.models.alert import AlertHistory
 from app.models.api_token import APIToken
+from app.models.domain import Domain
 from app.models.organization import BillingAccount, Organization
 from app.models.workspace import Workspace
 from app.services.api_tokens import READ_POSTURE_SCOPE, READ_REPORTS_SCOPE, create_api_token
@@ -237,6 +239,98 @@ def test_public_action_proposals_are_workspace_scoped(client: TestClient, db_ses
     assert denied.status_code == 404
     assert allowed.status_code == 200
     assert allowed.json()["domain"] == other_domain
+
+
+def test_public_alert_history_is_posture_scoped_and_sanitized(
+    client: TestClient,
+    db_session,
+):
+    """Public alert history is workspace-scoped and excludes raw alert payloads."""
+    _persist_report(db_session)
+    workspace = get_or_create_default_workspace(db_session)
+    other_workspace = Workspace(slug="public-alerts-other", name="Public Alerts Other")
+    db_session.add(other_workspace)
+    db_session.flush()
+    db_session.add(
+        Domain(
+            workspace_id=other_workspace.id,
+            name="other-alerts.example",
+            active=True,
+            verified=True,
+        )
+    )
+    db_session.add_all(
+        [
+            AlertHistory(
+                fingerprint="public-alert-active",
+                rule="new_sender_source",
+                severity="warning",
+                domain=DOMAIN,
+                title="New sender",
+                detail="192.0.2.1 first appeared.",
+                payload=(
+                    '{"source_ip":"192.0.2.1","message_count":12,' '"secret":"do-not-return"}'
+                ),
+                observed_count=2,
+                is_active=True,
+            ),
+            AlertHistory(
+                fingerprint="public-alert-resolved",
+                rule="missing_reports",
+                severity="warning",
+                domain=DOMAIN,
+                title="Resolved reports",
+                detail="Already fixed.",
+                observed_count=1,
+                is_active=False,
+            ),
+            AlertHistory(
+                fingerprint="public-alert-other-workspace",
+                rule="missing_reports",
+                severity="error",
+                domain="other-alerts.example",
+                title="Other alert",
+                detail="Should not leak.",
+                observed_count=1,
+                is_active=True,
+            ),
+        ]
+    )
+    db_session.commit()
+    posture_token = create_api_token(
+        db_session,
+        name="alert posture bot",
+        scopes=[READ_POSTURE_SCOPE],
+        workspace_id=workspace.id,
+    )
+    reports_token = create_api_token(
+        db_session,
+        name="alert reports bot",
+        scopes=[READ_REPORTS_SCOPE],
+        workspace_id=workspace.id,
+    )
+
+    denied = client.get(
+        "/api/v1/public/alerts?active=true",
+        headers={"X-API-Key": reports_token.secret},
+    )
+    response = client.get(
+        "/api/v1/public/alerts?active=true&limit=10",
+        headers={"X-API-Key": posture_token.secret},
+    )
+
+    assert denied.status_code == 403
+    assert response.status_code == 200
+    body = response.json()
+    assert body["summary"]["active"] == 1
+    assert body["summary"]["by_rule"] == {"new_sender_source": 1}
+    assert [alert["domain"] for alert in body["alerts"]] == [DOMAIN]
+    assert body["alerts"][0]["evidence"] == {
+        "message_count": 12,
+        "source_ip": "192.0.2.1",
+    }
+    assert "payload" not in body["alerts"][0]
+    assert "do-not-return" not in response.text
 
 
 def test_public_health_evidence_export_uses_posture_scope_without_capture(

--- a/docs/reference/ai-mcp-automation.md
+++ b/docs/reference/ai-mcp-automation.md
@@ -77,6 +77,7 @@ The current tools are read-only:
 - `domain_summary`
 - `domain_posture`
 - `health_evidence_export`
+- `alert_history`
 - `domain_sources`
 - `dns_lint`
 - `dns_change_plan`

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -66,6 +66,7 @@ through the `/public` path and avoid UI-specific payloads.
 | `GET /public/domains/{domain_id}/dns/lint` | `posture:read` | DNS lint findings, target records, and evidence |
 | `GET /public/domains/{domain_id}/dns/change-plan` | `posture:read` | Read-only DNS change plans without apply links |
 | `GET /public/domains/{domain_id}/action-proposals` | `posture:read` | Reviewable read-only remediation proposals |
+| `GET /public/alerts` | `posture:read` | Sanitized alert history for monitored workspace domains |
 | `GET /public/tls-reports/summary` | `tls-reports:read` | SMTP TLS report trends and failure groups |
 | `POST /mcp` | `mcp:read` | Read-only MCP-style JSON-RPC tool endpoint |
 
@@ -83,6 +84,12 @@ by default, or CSV with `?format=csv`. Public API calls do not capture a fresh
 DNS snapshot; they return already persisted score evidence, or deterministic
 demo history when demo mode is active.
 
+Public alert history returns already persisted alert lifecycle rows for domains
+in the API token workspace. Use `active=true|false`, `domain=example.com`, and
+`limit=...` to shape the result. The response excludes raw alert payloads and
+only returns allow-listed evidence fields such as sender IP, message counts,
+thresholds, and compliance-drop values.
+
 The MCP endpoint currently exposes these read-only tools:
 
 | Tool | Purpose |
@@ -91,6 +98,7 @@ The MCP endpoint currently exposes these read-only tools:
 | `domain_summary` | Return an evidence-first DMARC summary |
 | `domain_posture` | Return posture score, grade, DNS health, and action guidance |
 | `health_evidence_export` | Return sanitized health score evidence rows |
+| `alert_history` | Return sanitized alert history rows |
 | `domain_sources` | Return enriched DMARC sending sources |
 | `dns_lint` | Return DNS lint findings, evidence, and target records |
 | `dns_change_plan` | Return read-only DNS change plans without apply links |
@@ -460,6 +468,7 @@ Available tools:
 | `domain_summary` | Return an evidence-first summary for one domain |
 | `domain_posture` | Return posture score, grade, DNS health, and action guidance |
 | `health_evidence_export` | Return sanitized health score evidence rows |
+| `alert_history` | Return sanitized alert history rows |
 | `domain_sources` | Return enriched DMARC sending sources |
 | `dns_lint` | Return DNS lint findings, evidence, and target records |
 | `dns_change_plan` | Return read-only DNS change plans without apply links |


### PR DESCRIPTION
## Summary
- add `GET /api/v1/public/alerts` as a posture-scoped read-only automation endpoint
- add the read-only MCP tool `alert_history`
- return only alerts for domains in the current workspace and omit raw alert payloads
- include sanitized evidence fields and alert summary counts for automation clients
- document the new public API and MCP tool

## Validation
- `.venv/bin/black backend/app/services/alert_history.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `.venv/bin/isort backend/app/services/alert_history.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `.venv/bin/pytest backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q`
- `.venv/bin/flake8 backend/app/services/alert_history.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `git diff --check`

## Scope
This is a small #309 read-only slice. It does not evaluate alert rules, send notifications, queue webhooks, modify DNS, add PDF reports, or change the multi-tenant/admin demo.
