### PR TITLE
Add public export catalog

### DIFF
--- a/backend/app/api/api_v1/endpoints/mcp.py
+++ b/backend/app/api/api_v1/endpoints/mcp.py
@@ -20,6 +20,7 @@ from app.services.ai_assistance import (
 )
 from app.services.alert_history import alert_history_summary, list_workspace_alert_history
 from app.services.api_tokens import MCP_READ_SCOPE
+from app.services.export_catalog import build_export_catalog
 from app.services.organizations import require_organization_feature
 from app.services.report_persistence import hydrate_report_store_from_db
 from app.services.report_store import ReportStore
@@ -158,6 +159,12 @@ READ_ONLY_TOOLS = [
         },
         "readOnlyHint": True,
     },
+    {
+        "name": "export_catalog",
+        "description": "Return available public exports, MCP tools, and token usage metadata.",
+        "inputSchema": {"type": "object", "properties": {}},
+        "readOnlyHint": True,
+    },
 ]
 
 
@@ -275,8 +282,10 @@ def _call_action_proposals_tool(
     arguments: Dict[str, Any],
     *,
     db: Session,
+    auth_context: Dict[str, Any],
     workspace_id: Optional[int],
 ) -> Any:
+    del auth_context
     return build_action_proposals(db, _tool_domain(arguments), workspace_id=workspace_id)
 
 
@@ -284,8 +293,10 @@ def _call_alert_history_tool(
     arguments: Dict[str, Any],
     *,
     db: Session,
+    auth_context: Dict[str, Any],
     workspace_id: Optional[int],
 ) -> Dict[str, Any]:
+    del auth_context
     active_filter = _tool_optional_bool(arguments, "active")
     domain_filter = _tool_optional_domain(arguments)
     limit = _tool_limit(arguments, default=50, maximum=200)
@@ -307,9 +318,27 @@ def _call_alert_history_tool(
     }
 
 
+def _call_export_catalog_tool(
+    arguments: Dict[str, Any],
+    *,
+    db: Session,
+    auth_context: Dict[str, Any],
+    workspace_id: Optional[int],
+) -> Dict[str, Any]:
+    del arguments
+    workspace = resolve_authorized_workspace(
+        db,
+        auth_context,
+        PERMISSION_REPORTS_READ,
+        selected_workspace_id=workspace_id,
+    )
+    return build_export_catalog(db, workspace=workspace, auth_context=auth_context)
+
+
 READ_ONLY_SYNC_HANDLERS = {
     "action_proposals": _call_action_proposals_tool,
     "alert_history": _call_alert_history_tool,
+    "export_catalog": _call_export_catalog_tool,
 }
 
 
@@ -363,7 +392,12 @@ async def _call_read_only_tool(
         )
     sync_handler = READ_ONLY_SYNC_HANDLERS.get(name)
     if sync_handler is not None:
-        return sync_handler(arguments, db=db, workspace_id=workspace_id)
+        return sync_handler(
+            arguments,
+            db=db,
+            auth_context=auth_context,
+            workspace_id=workspace_id,
+        )
     if name == "health_evidence_export":
         domain = _tool_domain(arguments)
         rows = await domains.build_domain_health_evidence_export_rows(

--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -8,10 +8,16 @@ from sqlalchemy.orm import Session
 
 from app.api.api_v1.endpoints import ai, domains, tls_reports
 from app.core.database import get_db
-from app.core.security import require_api_token_scope
+from app.core.security import require_api_token_any_scope, require_api_token_scope
 from app.services.ai_assistance import build_action_proposals
 from app.services.alert_history import alert_history_summary, list_workspace_alert_history
-from app.services.api_tokens import READ_POSTURE_SCOPE, READ_REPORTS_SCOPE, READ_TLS_SCOPE
+from app.services.api_tokens import (
+    MCP_READ_SCOPE,
+    READ_POSTURE_SCOPE,
+    READ_REPORTS_SCOPE,
+    READ_TLS_SCOPE,
+)
+from app.services.export_catalog import build_export_catalog
 from app.services.workspace_access import PERMISSION_REPORTS_READ, resolve_authorized_workspace
 
 router = APIRouter()
@@ -24,6 +30,21 @@ async def public_domain_summary(
 ):
     """List monitored domains with report and DNS posture summary fields."""
     return await domains.get_domains_summary(db=db, _auth=_auth)
+
+
+@router.get("/exports")
+async def public_export_catalog(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(
+        require_api_token_any_scope(
+            [READ_REPORTS_SCOPE, READ_POSTURE_SCOPE, READ_TLS_SCOPE, MCP_READ_SCOPE],
+            detail_scope="one of reports:read, posture:read, tls-reports:read, mcp:read",
+        )
+    ),
+):
+    """Return available public export routes, MCP tools, and token usage metadata."""
+    workspace = resolve_authorized_workspace(db, _auth, PERMISSION_REPORTS_READ)
+    return build_export_catalog(db, workspace=workspace, auth_context=_auth)
 
 
 @router.get(

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -2,7 +2,7 @@ import logging
 import os
 import secrets
 from datetime import datetime, timedelta
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Iterable, Optional, Union
 
 from fastapi import Depends, HTTPException, Request, Security, status
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
@@ -224,6 +224,20 @@ async def require_admin_auth(
 
 def require_api_token_scope(required_scope: str) -> Callable:
     """Build a dependency that requires a scoped persistent API token."""
+    return require_api_token_any_scope([required_scope], detail_scope=required_scope)
+
+
+def require_api_token_any_scope(
+    required_scopes: Iterable[str],
+    *,
+    detail_scope: Optional[str] = None,
+) -> Callable:
+    """Build a dependency requiring at least one scoped persistent API token scope."""
+    accepted_scopes = {
+        scope.strip().lower() for scope in required_scopes if scope and scope.strip()
+    }
+    if not accepted_scopes:
+        raise ValueError("At least one API token scope is required")
 
     async def _require_api_token_scope(
         request: Request,
@@ -247,10 +261,11 @@ def require_api_token_scope(required_scope: str) -> Callable:
             )
 
         scopes = parse_scopes(token.scopes)
-        if required_scope not in scopes:
+        if scopes.isdisjoint(accepted_scopes):
+            required_detail = detail_scope or ", ".join(sorted(accepted_scopes))
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"API token requires scope: {required_scope}",
+                detail=f"API token requires scope: {required_detail}",
             )
 
         client_host = request.client.host if request.client else None

--- a/backend/app/services/export_catalog.py
+++ b/backend/app/services/export_catalog.py
@@ -1,0 +1,267 @@
+"""Stable read-only export catalog helpers for public API and MCP clients."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List
+from urllib.parse import quote
+
+from sqlalchemy.orm import Session
+
+from app.models.api_token import APIToken
+from app.models.domain import Domain
+from app.models.workspace import Workspace
+from app.services.api_tokens import (
+    MCP_READ_SCOPE,
+    READ_POSTURE_SCOPE,
+    READ_REPORTS_SCOPE,
+    READ_TLS_SCOPE,
+    parse_scopes,
+)
+
+PUBLIC_EXPORT_ENDPOINTS = [
+    {
+        "key": "domains",
+        "method": "GET",
+        "path": "/api/v1/public/domains",
+        "scope": READ_REPORTS_SCOPE,
+        "description": "Domain report and DNS summary list.",
+    },
+    {
+        "key": "domain_reports",
+        "method": "GET",
+        "path_template": "/api/v1/public/domains/{domain}/reports",
+        "scope": READ_REPORTS_SCOPE,
+        "description": "Recent DMARC aggregate report summaries.",
+    },
+    {
+        "key": "domain_sources",
+        "method": "GET",
+        "path_template": "/api/v1/public/domains/{domain}/sources",
+        "scope": READ_REPORTS_SCOPE,
+        "description": "Enriched DMARC sending sources.",
+    },
+    {
+        "key": "source_intelligence",
+        "method": "GET",
+        "path_template": "/api/v1/public/domains/{domain}/source-intelligence",
+        "scope": READ_REPORTS_SCOPE,
+        "description": "Regional source summaries and anomaly hints.",
+    },
+    {
+        "key": "domain_posture",
+        "method": "GET",
+        "path_template": "/api/v1/public/domains/{domain}/posture",
+        "scope": READ_POSTURE_SCOPE,
+        "description": "Evidence-first posture dashboard payload.",
+    },
+    {
+        "key": "health_evidence_export",
+        "method": "GET",
+        "path_template": "/api/v1/public/domains/{domain}/posture/evidence/export",
+        "scope": READ_POSTURE_SCOPE,
+        "description": "Sanitized health score evidence export.",
+    },
+    {
+        "key": "dns_lint",
+        "method": "GET",
+        "path_template": "/api/v1/public/domains/{domain}/dns/lint",
+        "scope": READ_POSTURE_SCOPE,
+        "description": "DNS lint findings, target records, and evidence.",
+    },
+    {
+        "key": "dns_change_plan",
+        "method": "GET",
+        "path_template": "/api/v1/public/domains/{domain}/dns/change-plan",
+        "scope": READ_POSTURE_SCOPE,
+        "description": "Read-only DNS change plans without apply links.",
+    },
+    {
+        "key": "action_proposals",
+        "method": "GET",
+        "path_template": "/api/v1/public/domains/{domain}/action-proposals",
+        "scope": READ_POSTURE_SCOPE,
+        "description": "Reviewable read-only remediation proposals.",
+    },
+    {
+        "key": "alerts",
+        "method": "GET",
+        "path": "/api/v1/public/alerts",
+        "scope": READ_POSTURE_SCOPE,
+        "description": "Sanitized alert history for monitored workspace domains.",
+    },
+    {
+        "key": "tls_report_summary",
+        "method": "GET",
+        "path": "/api/v1/public/tls-reports/summary",
+        "scope": READ_TLS_SCOPE,
+        "description": "SMTP TLS report trends and failure groups.",
+    },
+]
+
+MCP_EXPORT_TOOLS = [
+    {
+        "name": "list_domains",
+        "description": "List monitored domains and aggregate counts.",
+        "read_only": True,
+    },
+    {
+        "name": "domain_summary",
+        "description": "Return an evidence-first summary for one domain.",
+        "read_only": True,
+    },
+    {
+        "name": "domain_posture",
+        "description": "Return DNS posture, health score, grade, and action guidance.",
+        "read_only": True,
+    },
+    {
+        "name": "domain_sources",
+        "description": "Return enriched DMARC sending sources for one domain.",
+        "read_only": True,
+    },
+    {
+        "name": "dns_lint",
+        "description": "Return DNS lint findings, evidence, and target records for one domain.",
+        "read_only": True,
+    },
+    {
+        "name": "dns_change_plan",
+        "description": "Return read-only DNS change plans without apply links.",
+        "read_only": True,
+    },
+    {
+        "name": "source_intelligence",
+        "description": "Return source geography summaries and anomaly hints for one domain.",
+        "read_only": True,
+    },
+    {
+        "name": "action_proposals",
+        "description": "Return reviewable remediation proposals without applying changes.",
+        "read_only": True,
+    },
+    {
+        "name": "health_evidence_export",
+        "description": "Return sanitized health score evidence rows for one domain.",
+        "read_only": True,
+    },
+    {
+        "name": "alert_history",
+        "description": "Return sanitized alert history for monitored workspace domains.",
+        "read_only": True,
+    },
+    {
+        "name": "export_catalog",
+        "description": "Return available public exports, MCP tools, and token usage metadata.",
+        "read_only": True,
+    },
+]
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _token_summary(db: Session, auth_context: Dict[str, Any]) -> Dict[str, Any]:
+    token = None
+    token_id = auth_context.get("token_id")
+    try:
+        token_id_int = int(token_id) if token_id is not None else None
+    except (TypeError, ValueError):
+        token_id_int = None
+    if token_id_int is not None:
+        token = db.query(APIToken).filter(APIToken.id == token_id_int).first()
+
+    scopes = (
+        sorted(parse_scopes(token.scopes)) if token is not None else auth_context.get("scopes", [])
+    )
+    return {
+        "id": token.id if token is not None else token_id,
+        "name": token.name if token is not None else auth_context.get("token_name"),
+        "workspace_id": (
+            token.workspace_id if token is not None else auth_context.get("workspace_id")
+        ),
+        "scopes": sorted(scopes),
+        "usage_count": int(token.usage_count or 0) if token is not None else None,
+        "last_used_at": token.last_used_at.isoformat() if token and token.last_used_at else None,
+    }
+
+
+def _scope_available(scope: str, token_scopes: Iterable[str]) -> bool:
+    return scope in set(token_scopes)
+
+
+def _public_endpoint_catalog(token_scopes: Iterable[str]) -> List[Dict[str, Any]]:
+    scopes = set(token_scopes)
+    return [
+        {
+            **endpoint,
+            "available": _scope_available(endpoint["scope"], scopes),
+        }
+        for endpoint in PUBLIC_EXPORT_ENDPOINTS
+    ]
+
+
+def _domain_export_links(domain_name: str, token_scopes: Iterable[str]) -> Dict[str, Any]:
+    encoded_domain = quote(domain_name, safe="")
+    links: Dict[str, Any] = {}
+    scopes = set(token_scopes)
+    for endpoint in PUBLIC_EXPORT_ENDPOINTS:
+        path_template = endpoint.get("path_template")
+        if not path_template:
+            continue
+        links[endpoint["key"]] = {
+            "href": path_template.format(domain=encoded_domain),
+            "method": endpoint["method"],
+            "scope": endpoint["scope"],
+            "available": _scope_available(endpoint["scope"], scopes),
+        }
+    return links
+
+
+def build_export_catalog(
+    db: Session,
+    *,
+    workspace: Workspace,
+    auth_context: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return a stable catalog of public and MCP export surfaces for a workspace."""
+    token = _token_summary(db, auth_context)
+    token_scopes = set(token.get("scopes") or [])
+    can_list_domains = not token_scopes.isdisjoint(
+        {READ_REPORTS_SCOPE, READ_POSTURE_SCOPE, MCP_READ_SCOPE}
+    )
+    domains = []
+    if can_list_domains:
+        domains = (
+            db.query(Domain)
+            .filter(Domain.workspace_id == workspace.id)
+            .order_by(Domain.name.asc())
+            .all()
+        )
+    return {
+        "generated_at": _timestamp(),
+        "workspace": {
+            "id": workspace.id,
+            "slug": workspace.slug,
+            "name": workspace.name,
+            "domain_count": len(domains),
+        },
+        "token": token,
+        "public_endpoints": _public_endpoint_catalog(token_scopes),
+        "mcp": {
+            "endpoint": "/api/v1/mcp",
+            "scope": MCP_READ_SCOPE,
+            "available": MCP_READ_SCOPE in token_scopes,
+            "tools": MCP_EXPORT_TOOLS,
+        },
+        "domains": [
+            {
+                "domain": domain.name,
+                "active": bool(domain.active),
+                "verified": bool(domain.verified),
+                "exports": _domain_export_links(domain.name, token_scopes),
+            }
+            for domain in domains
+        ],
+    }

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -909,6 +909,41 @@ async def test_mcp_alert_history_returns_sanitized_workspace_alerts(
 
 
 @pytest.mark.asyncio
+async def test_mcp_export_catalog_returns_workspace_exports(db_session: Session):
+    _persist_report(db_session)
+    domain = db_session.query(Domain).filter(Domain.name == DOMAIN).one()
+    token = create_api_token(
+        db_session,
+        name="mcp catalog",
+        scopes=[MCP_READ_SCOPE],
+        workspace_id=domain.workspace_id,
+    )
+
+    result = await mcp_endpoint._call_read_only_tool(
+        "export_catalog",
+        {},
+        db=db_session,
+        auth_context={
+            "auth_type": "api_token",
+            "token_id": token.token.id,
+            "workspace_id": domain.workspace_id,
+            "scopes": [MCP_READ_SCOPE],
+        },
+        workspace_id=domain.workspace_id,
+    )
+
+    assert result["token"]["name"] == "mcp catalog"
+    assert result["mcp"]["available"] is True
+    assert result["workspace"]["domain_count"] == 1
+    assert result["domains"][0]["domain"] == DOMAIN
+    assert "export_catalog" in {tool["name"] for tool in result["mcp"]["tools"]}
+    assert (
+        result["domains"][0]["exports"]["domain_reports"]["href"]
+        == f"/api/v1/public/domains/{DOMAIN}/reports"
+    )
+
+
+@pytest.mark.asyncio
 async def test_mcp_read_only_tool_dispatch_rejects_invalid_tool_arguments(
     db_session: Session,
 ):
@@ -1007,6 +1042,7 @@ def test_mcp_requires_enabled_scoped_token(client: TestClient, db_session: Sessi
         "dns_change_plan",
         "health_evidence_export",
         "alert_history",
+        "export_catalog",
     }.issubset(tool_names)
 
     initialized = client.post(

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -9,7 +9,13 @@ from app.models.api_token import APIToken
 from app.models.domain import Domain
 from app.models.organization import BillingAccount, Organization
 from app.models.workspace import Workspace
-from app.services.api_tokens import READ_POSTURE_SCOPE, READ_REPORTS_SCOPE, create_api_token
+from app.services.api_tokens import (
+    MCP_READ_SCOPE,
+    READ_POSTURE_SCOPE,
+    READ_REPORTS_SCOPE,
+    READ_TLS_SCOPE,
+    create_api_token,
+)
 from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.organizations import (
     BILLING_MODE_MANUAL_CONTRACT,
@@ -119,6 +125,67 @@ def test_public_domains_summary_uses_scoped_token_context(client: TestClient, db
 
     assert response.status_code == 200
     assert response.json()["domains"][0]["domain_name"] == DOMAIN
+
+
+def test_public_export_catalog_lists_available_exports_and_token_usage(
+    client: TestClient,
+    db_session,
+):
+    """Public export catalog exposes stable routes without leaking token secrets."""
+    _persist_report(db_session)
+    created = create_api_token(
+        db_session,
+        name="catalog bot",
+        scopes=[READ_REPORTS_SCOPE, READ_POSTURE_SCOPE],
+    )
+
+    response = client.get(
+        "/api/v1/public/exports",
+        headers={"X-API-Key": created.secret},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["workspace"]["domain_count"] == 1
+    assert body["token"]["name"] == "catalog bot"
+    assert body["token"]["usage_count"] == 1
+    assert "secret" not in body["token"]
+    endpoint_by_key = {endpoint["key"]: endpoint for endpoint in body["public_endpoints"]}
+    assert endpoint_by_key["domain_reports"]["available"] is True
+    assert endpoint_by_key["health_evidence_export"]["available"] is True
+    assert endpoint_by_key["tls_report_summary"]["available"] is False
+    assert body["domains"][0]["domain"] == DOMAIN
+    assert (
+        body["domains"][0]["exports"]["health_evidence_export"]["href"]
+        == f"/api/v1/public/domains/{DOMAIN}/posture/evidence/export"
+    )
+    assert body["mcp"]["available"] is False
+    assert "export_catalog" in {tool["name"] for tool in body["mcp"]["tools"]}
+
+
+def test_public_export_catalog_accepts_tls_or_mcp_scope_without_domain_leak(
+    client: TestClient,
+    db_session,
+):
+    """Catalog is discoverable to read-only tokens but limits domain-specific links."""
+    _persist_report(db_session)
+    tls_token = create_api_token(db_session, name="tls bot", scopes=[READ_TLS_SCOPE])
+    mcp_token = create_api_token(db_session, name="mcp bot", scopes=[MCP_READ_SCOPE])
+
+    tls_response = client.get(
+        "/api/v1/public/exports",
+        headers={"X-API-Key": tls_token.secret},
+    )
+    mcp_response = client.get(
+        "/api/v1/public/exports",
+        headers={"X-API-Key": mcp_token.secret},
+    )
+
+    assert tls_response.status_code == 200
+    assert tls_response.json()["workspace"]["domain_count"] == 0
+    assert tls_response.json()["domains"] == []
+    assert mcp_response.status_code == 200
+    assert mcp_response.json()["workspace"]["domain_count"] == 1
 
 
 def test_public_source_intelligence_endpoints_use_report_scope(client: TestClient, db_session):

--- a/docs/reference/ai-mcp-automation.md
+++ b/docs/reference/ai-mcp-automation.md
@@ -74,6 +74,7 @@ requests.
 The current tools are read-only:
 
 - `list_domains`
+- `export_catalog`
 - `domain_summary`
 - `domain_posture`
 - `health_evidence_export`

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -57,6 +57,7 @@ through the `/public` path and avoid UI-specific payloads.
 
 | Endpoint | Required scope | Purpose |
 | --- | --- | --- |
+| `GET /public/exports` | any read-only automation scope | Available export routes, MCP tools, domains, and token usage metadata |
 | `GET /public/domains` | `reports:read` | Domain report and DNS summary list |
 | `GET /public/domains/{domain_id}/reports` | `reports:read` | Recent DMARC aggregate report summaries |
 | `GET /public/domains/{domain_id}/sources` | `reports:read` | Enriched sending sources with sender, geo, anomaly, and fix hints |
@@ -72,6 +73,13 @@ through the `/public` path and avoid UI-specific payloads.
 
 Successful public API calls update the token's last-used timestamp, source IP,
 and usage count for auditing.
+
+`GET /public/exports` is the discovery endpoint for automation clients. It
+returns the current workspace, safe token metadata such as scopes and usage
+count, public export routes with their required scopes, MCP tool metadata, and
+domain-specific export links when the current token is allowed to see monitored
+domains. TLS-only tokens can discover the catalog and their own usage state, but
+do not receive the domain-specific export list.
 
 Public source responses are intended for SIEM, SOC, ISP, MSP, and AI-agent
 consumers that need evidence-linked DMARC sending-source context without
@@ -95,6 +103,7 @@ The MCP endpoint currently exposes these read-only tools:
 | Tool | Purpose |
 | --- | --- |
 | `list_domains` | List monitored domains and aggregate counts |
+| `export_catalog` | Return available public exports, MCP tools, and token usage metadata |
 | `domain_summary` | Return an evidence-first DMARC summary |
 | `domain_posture` | Return posture score, grade, DNS health, and action guidance |
 | `health_evidence_export` | Return sanitized health score evidence rows |
@@ -465,6 +474,7 @@ Available tools:
 | Tool | Purpose |
 | --- | --- |
 | `list_domains` | List monitored domains and aggregate counts |
+| `export_catalog` | Return available public exports, MCP tools, and token usage metadata |
 | `domain_summary` | Return an evidence-first summary for one domain |
 | `domain_posture` | Return posture score, grade, DNS health, and action guidance |
 | `health_evidence_export` | Return sanitized health score evidence rows |


### PR DESCRIPTION
## Summary
- add `GET /api/v1/public/exports` as a read-only export and usage catalog for automation clients
- add the read-only MCP tool `export_catalog`
- include safe token metadata, available public endpoints, MCP tool metadata, and domain-specific export links when the token scope allows them
- document the new public endpoint and MCP tool

## Scope
This is a read-only #309 slice. It does not add DNS writes, admin/provider demo behavior, PDF evidence reports, ARC, or ARF.

## Validation
- `./.venv/bin/pytest backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q`
- `./.venv/bin/black --check backend/app/core/security.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `./.venv/bin/isort --check-only backend/app/core/security.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `./.venv/bin/flake8 backend/app/core/security.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new export catalog endpoint for discovering available public exports, tool availability, and workspace-safe token details.
  * Added a new read-only MCP tool that returns the same export catalog information.
  * Expanded access so more read-only API token scopes can view the catalog where permitted.

* **Bug Fixes**
  * Improved scope-based access checks so export links and domain details are only shown when authorized.

* **Documentation**
  * Updated API and MCP references to include the new export catalog endpoint and tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->