### PR TITLE
Address export catalog review follow-up

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -233,6 +233,8 @@ def require_api_token_any_scope(
     detail_scope: Optional[str] = None,
 ) -> Callable:
     """Build a dependency requiring at least one scoped persistent API token scope."""
+    if isinstance(required_scopes, (str, bytes)):
+        raise TypeError("required_scopes must be an iterable of scope strings, not a string")
     accepted_scopes = {
         scope.strip().lower() for scope in required_scopes if scope and scope.strip()
     }

--- a/backend/app/services/export_catalog.py
+++ b/backend/app/services/export_catalog.py
@@ -231,6 +231,7 @@ def build_export_catalog(
     can_list_domains = not token_scopes.isdisjoint(
         {READ_REPORTS_SCOPE, READ_POSTURE_SCOPE, MCP_READ_SCOPE}
     )
+    domain_count = db.query(Domain).filter(Domain.workspace_id == workspace.id).count()
     domains = []
     if can_list_domains:
         domains = (
@@ -245,7 +246,7 @@ def build_export_catalog(
             "id": workspace.id,
             "slug": workspace.slug,
             "name": workspace.name,
-            "domain_count": len(domains),
+            "domain_count": domain_count,
         },
         "token": token,
         "public_endpoints": _public_endpoint_catalog(token_scopes),

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -908,8 +908,10 @@ async def test_mcp_alert_history_returns_sanitized_workspace_alerts(
     assert "hidden" not in str(result)
 
 
-@pytest.mark.asyncio
-async def test_mcp_export_catalog_returns_workspace_exports(db_session: Session):
+def test_mcp_export_catalog_returns_workspace_exports(
+    client: TestClient,
+    db_session: Session,
+):
     _persist_report(db_session)
     domain = db_session.query(Domain).filter(Domain.name == DOMAIN).one()
     token = create_api_token(
@@ -918,19 +920,20 @@ async def test_mcp_export_catalog_returns_workspace_exports(db_session: Session)
         scopes=[MCP_READ_SCOPE],
         workspace_id=domain.workspace_id,
     )
+    _set_setting(db_session, "mcp.enabled", "true", "mcp")
 
-    result = await mcp_endpoint._call_read_only_tool(
-        "export_catalog",
-        {},
-        db=db_session,
-        auth_context={
-            "auth_type": "api_token",
-            "token_id": token.token.id,
-            "workspace_id": domain.workspace_id,
-            "scopes": [MCP_READ_SCOPE],
+    response = client.post(
+        "/api/v1/mcp",
+        headers={"X-API-Key": token.secret},
+        json={
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {"name": "export_catalog", "arguments": {}},
         },
-        workspace_id=domain.workspace_id,
     )
+    assert response.status_code == 200
+    result = response.json()["result"]["content"][0]["json"]
 
     assert result["token"]["name"] == "mcp catalog"
     assert result["mcp"]["available"] is True

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -1,9 +1,11 @@
 from datetime import date
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
+from app.core.security import require_api_token_any_scope
 from app.models.alert import AlertHistory
 from app.models.api_token import APIToken
 from app.models.domain import Domain
@@ -182,10 +184,19 @@ def test_public_export_catalog_accepts_tls_or_mcp_scope_without_domain_leak(
     )
 
     assert tls_response.status_code == 200
-    assert tls_response.json()["workspace"]["domain_count"] == 0
-    assert tls_response.json()["domains"] == []
+    tls_body = tls_response.json()
+    assert tls_body["workspace"]["domain_count"] == 1
+    assert tls_body["domains"] == []
     assert mcp_response.status_code == 200
-    assert mcp_response.json()["workspace"]["domain_count"] == 1
+    mcp_body = mcp_response.json()
+    assert mcp_body["workspace"]["domain_count"] == 1
+    assert mcp_body["domains"][0]["exports"]["domain_reports"]["available"] is False
+    assert mcp_body["domains"][0]["exports"]["health_evidence_export"]["available"] is False
+
+
+def test_require_api_token_any_scope_rejects_bare_string_scope():
+    with pytest.raises(TypeError, match="not a string"):
+        require_api_token_any_scope(READ_REPORTS_SCOPE)
 
 
 def test_public_source_intelligence_endpoints_use_report_scope(client: TestClient, db_session):


### PR DESCRIPTION
## Summary
- make export catalog `workspace.domain_count` reflect the actual workspace domain count even when domain rows are hidden by scope
- reject accidental bare-string calls to `require_api_token_any_scope`
- exercise `export_catalog` through the public MCP JSON-RPC endpoint and tighten MCP-only export availability assertions

## Validation
- `/tmp/dmarq-pr353-coverage/.venv/bin/pytest backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q`
- `/tmp/dmarq-pr353-coverage/.venv/bin/black --check backend/app/core/security.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `/tmp/dmarq-pr353-coverage/.venv/bin/isort --check-only backend/app/core/security.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `/tmp/dmarq-pr353-coverage/.venv/bin/flake8 backend/app/core/security.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `git diff --check`

Follow-up for #373.