### PR TITLE
Add public workspace usage export

### DIFF
--- a/backend/app/api/api_v1/endpoints/mcp.py
+++ b/backend/app/api/api_v1/endpoints/mcp.py
@@ -26,6 +26,7 @@ from app.services.report_persistence import hydrate_report_store_from_db
 from app.services.report_store import ReportStore
 from app.services.workspace_access import PERMISSION_REPORTS_READ, resolve_authorized_workspace
 from app.services.workspace_audit import record_workspace_audit_log
+from app.services.workspace_usage import build_workspace_usage_summary
 
 router = APIRouter()
 
@@ -162,6 +163,12 @@ READ_ONLY_TOOLS = [
     {
         "name": "export_catalog",
         "description": "Return available public exports, MCP tools, and token usage metadata.",
+        "inputSchema": {"type": "object", "properties": {}},
+        "readOnlyHint": True,
+    },
+    {
+        "name": "workspace_usage",
+        "description": "Return workspace-level DMARC usage, source, alert, and import counts.",
         "inputSchema": {"type": "object", "properties": {}},
         "readOnlyHint": True,
     },
@@ -335,10 +342,28 @@ def _call_export_catalog_tool(
     return build_export_catalog(db, workspace=workspace, auth_context=auth_context)
 
 
+def _call_workspace_usage_tool(
+    arguments: Dict[str, Any],
+    *,
+    db: Session,
+    auth_context: Dict[str, Any],
+    workspace_id: Optional[int],
+) -> Dict[str, Any]:
+    del arguments
+    workspace = resolve_authorized_workspace(
+        db,
+        auth_context,
+        PERMISSION_REPORTS_READ,
+        selected_workspace_id=workspace_id,
+    )
+    return build_workspace_usage_summary(db, workspace)
+
+
 READ_ONLY_SYNC_HANDLERS = {
     "action_proposals": _call_action_proposals_tool,
     "alert_history": _call_alert_history_tool,
     "export_catalog": _call_export_catalog_tool,
+    "workspace_usage": _call_workspace_usage_tool,
 }
 
 

--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -19,6 +19,7 @@ from app.services.api_tokens import (
 )
 from app.services.export_catalog import build_export_catalog
 from app.services.workspace_access import PERMISSION_REPORTS_READ, resolve_authorized_workspace
+from app.services.workspace_usage import build_workspace_usage_summary
 
 router = APIRouter()
 
@@ -45,6 +46,21 @@ async def public_export_catalog(
     """Return available public export routes, MCP tools, and token usage metadata."""
     workspace = resolve_authorized_workspace(db, _auth, PERMISSION_REPORTS_READ)
     return build_export_catalog(db, workspace=workspace, auth_context=_auth)
+
+
+@router.get("/usage")
+async def public_workspace_usage(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(
+        require_api_token_any_scope(
+            [READ_REPORTS_SCOPE, READ_POSTURE_SCOPE, MCP_READ_SCOPE],
+            detail_scope="one of reports:read, posture:read, mcp:read",
+        )
+    ),
+):
+    """Return a read-only usage summary for the API token workspace."""
+    workspace = resolve_authorized_workspace(db, _auth, PERMISSION_REPORTS_READ)
+    return build_workspace_usage_summary(db, workspace)
 
 
 @router.get(

--- a/backend/app/services/export_catalog.py
+++ b/backend/app/services/export_catalog.py
@@ -28,6 +28,14 @@ PUBLIC_EXPORT_ENDPOINTS = [
         "description": "Domain report and DNS summary list.",
     },
     {
+        "key": "workspace_usage",
+        "method": "GET",
+        "path": "/api/v1/public/usage",
+        "scope": "reports:read or posture:read or mcp:read",
+        "scopes": [READ_REPORTS_SCOPE, READ_POSTURE_SCOPE, MCP_READ_SCOPE],
+        "description": "Workspace-level DMARC usage, alert, source, and import counts.",
+    },
+    {
         "key": "domain_reports",
         "method": "GET",
         "path_template": "/api/v1/public/domains/{domain}/reports",
@@ -155,6 +163,11 @@ MCP_EXPORT_TOOLS = [
         "description": "Return available public exports, MCP tools, and token usage metadata.",
         "read_only": True,
     },
+    {
+        "name": "workspace_usage",
+        "description": "Return workspace-level DMARC usage, source, alert, and import counts.",
+        "read_only": True,
+    },
 ]
 
 
@@ -187,8 +200,20 @@ def _token_summary(db: Session, auth_context: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _endpoint_scopes(endpoint: Dict[str, Any]) -> List[str]:
+    scopes = endpoint.get("scopes")
+    if scopes:
+        return [str(scope) for scope in scopes]
+    return [str(endpoint["scope"])]
+
+
 def _scope_available(scope: str, token_scopes: Iterable[str]) -> bool:
     return scope in set(token_scopes)
+
+
+def _endpoint_available(endpoint: Dict[str, Any], token_scopes: Iterable[str]) -> bool:
+    scopes = set(token_scopes)
+    return not scopes.isdisjoint(_endpoint_scopes(endpoint))
 
 
 def _public_endpoint_catalog(token_scopes: Iterable[str]) -> List[Dict[str, Any]]:
@@ -196,7 +221,7 @@ def _public_endpoint_catalog(token_scopes: Iterable[str]) -> List[Dict[str, Any]
     return [
         {
             **endpoint,
-            "available": _scope_available(endpoint["scope"], scopes),
+            "available": _endpoint_available(endpoint, scopes),
         }
         for endpoint in PUBLIC_EXPORT_ENDPOINTS
     ]
@@ -214,7 +239,7 @@ def _domain_export_links(domain_name: str, token_scopes: Iterable[str]) -> Dict[
             "href": path_template.format(domain=encoded_domain),
             "method": endpoint["method"],
             "scope": endpoint["scope"],
-            "available": _scope_available(endpoint["scope"], scopes),
+            "available": _endpoint_available(endpoint, scopes),
         }
     return links
 

--- a/backend/app/services/workspace_usage.py
+++ b/backend/app/services/workspace_usage.py
@@ -1,0 +1,273 @@
+"""Read-only workspace usage summaries for public API and MCP clients."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
+
+from app.models.alert import AlertHistory
+from app.models.domain import Domain
+from app.models.mail_source import MailSource
+from app.models.mail_source_import import MailSourceImport
+from app.models.report import DMARCReport, ForensicReport, ReportRecord, TLSReport
+from app.models.workspace import Workspace
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _unix_timestamp(value: Optional[int]) -> Optional[str]:
+    if value is None:
+        return None
+    return datetime.fromtimestamp(int(value), tz=timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round((numerator / denominator) * 100, 1)
+
+
+def _workspace_domains(db: Session, workspace: Workspace) -> List[Domain]:
+    return (
+        db.query(Domain)
+        .filter(Domain.workspace_id == workspace.id)
+        .order_by(Domain.name.asc())
+        .all()
+    )
+
+
+def _message_totals(db: Session, domain_ids: List[int]) -> Dict[str, Any]:
+    if not domain_ids:
+        return {
+            "total_messages": 0,
+            "compliant_messages": 0,
+            "failed_messages": 0,
+            "distinct_source_count": 0,
+        }
+    row = (
+        db.query(
+            func.coalesce(func.sum(ReportRecord.count), 0).label("total_messages"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            (ReportRecord.dkim == "pass") | (ReportRecord.spf == "pass"),
+                            ReportRecord.count,
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("compliant_messages"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            (func.coalesce(ReportRecord.dkim, "fail") != "pass")
+                            & (func.coalesce(ReportRecord.spf, "fail") != "pass"),
+                            ReportRecord.count,
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("failed_messages"),
+            func.count(func.distinct(ReportRecord.source_ip)).label("distinct_source_count"),
+        )
+        .join(DMARCReport, DMARCReport.id == ReportRecord.report_id)
+        .filter(DMARCReport.domain_id.in_(domain_ids))
+        .first()
+    )
+    if row is None:
+        return {
+            "total_messages": 0,
+            "compliant_messages": 0,
+            "failed_messages": 0,
+            "distinct_source_count": 0,
+        }
+    return {
+        "total_messages": int(row.total_messages or 0),
+        "compliant_messages": int(row.compliant_messages or 0),
+        "failed_messages": int(row.failed_messages or 0),
+        "distinct_source_count": int(row.distinct_source_count or 0),
+    }
+
+
+def _domain_usage_rows(db: Session, domains: List[Domain]) -> List[Dict[str, Any]]:
+    if not domains:
+        return []
+    domain_ids = [domain.id for domain in domains]
+    rows = (
+        db.query(
+            Domain.id.label("domain_id"),
+            func.count(func.distinct(DMARCReport.id)).label("report_count"),
+            func.coalesce(func.sum(ReportRecord.count), 0).label("total_messages"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            (func.coalesce(ReportRecord.dkim, "fail") != "pass")
+                            & (func.coalesce(ReportRecord.spf, "fail") != "pass"),
+                            ReportRecord.count,
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("failed_messages"),
+            func.count(func.distinct(ReportRecord.source_ip)).label("source_count"),
+            func.max(DMARCReport.end_date).label("last_report_end"),
+        )
+        .outerjoin(DMARCReport, DMARCReport.domain_id == Domain.id)
+        .outerjoin(ReportRecord, ReportRecord.report_id == DMARCReport.id)
+        .filter(Domain.id.in_(domain_ids))
+        .group_by(Domain.id)
+        .all()
+    )
+    by_domain_id = {int(row.domain_id): row for row in rows}
+    usage_rows = []
+    for domain in domains:
+        row = by_domain_id.get(domain.id)
+        total_messages = int(row.total_messages or 0) if row is not None else 0
+        failed_messages = int(row.failed_messages or 0) if row is not None else 0
+        compliant_messages = max(total_messages - failed_messages, 0)
+        usage_rows.append(
+            {
+                "domain": domain.name,
+                "active": bool(domain.active),
+                "verified": bool(domain.verified),
+                "dmarc_policy": domain.dmarc_policy,
+                "report_count": int(row.report_count or 0) if row is not None else 0,
+                "total_messages": total_messages,
+                "failed_messages": failed_messages,
+                "compliant_messages": compliant_messages,
+                "compliance_rate": _rate(compliant_messages, total_messages),
+                "source_count": int(row.source_count or 0) if row is not None else 0,
+                "last_report_end_at": (
+                    _unix_timestamp(row.last_report_end)
+                    if row is not None and row.last_report_end is not None
+                    else None
+                ),
+            }
+        )
+    return usage_rows
+
+
+def _mail_source_summary(db: Session, workspace: Workspace) -> Dict[str, Any]:
+    sources = db.query(MailSource).filter(MailSource.workspace_id == workspace.id).all()
+    source_ids = [source.id for source in sources]
+    by_method = Counter((source.method or "UNKNOWN").upper() for source in sources)
+    import_rows = (
+        db.query(MailSourceImport.status, func.count(MailSourceImport.id))
+        .filter(MailSourceImport.mail_source_id.in_(source_ids))
+        .group_by(MailSourceImport.status)
+        .all()
+        if source_ids
+        else []
+    )
+    imports_by_status = {str(status): int(count or 0) for status, count in import_rows}
+    return {
+        "total": len(sources),
+        "enabled": sum(1 for source in sources if source.enabled),
+        "disabled": sum(1 for source in sources if not source.enabled),
+        "by_method": dict(sorted(by_method.items())),
+        "imports": {
+            "total": sum(imports_by_status.values()),
+            "by_status": dict(sorted(imports_by_status.items())),
+        },
+    }
+
+
+def _alert_summary(db: Session, domain_names: List[str]) -> Dict[str, Any]:
+    if not domain_names:
+        return {"total": 0, "active": 0, "resolved": 0, "by_rule": {}}
+    rows = (
+        db.query(
+            AlertHistory.rule.label("rule"),
+            AlertHistory.is_active.label("is_active"),
+            func.count(AlertHistory.id).label("count"),
+        )
+        .filter(AlertHistory.domain.in_(domain_names))
+        .group_by(AlertHistory.rule, AlertHistory.is_active)
+        .all()
+    )
+    total = 0
+    active = 0
+    by_rule: Counter[str] = Counter()
+    for row in rows:
+        count = int(row.count or 0)
+        total += count
+        by_rule[str(row.rule)] += count
+        if row.is_active:
+            active += count
+    return {
+        "total": total,
+        "active": active,
+        "resolved": max(total - active, 0),
+        "by_rule": dict(sorted(by_rule.items())),
+    }
+
+
+def build_workspace_usage_summary(db: Session, workspace: Workspace) -> Dict[str, Any]:
+    """Return tenant-safe, read-only usage evidence for one workspace."""
+    domains = _workspace_domains(db, workspace)
+    domain_ids = [domain.id for domain in domains]
+    domain_names = [domain.name for domain in domains]
+    message_totals = _message_totals(db, domain_ids)
+    total_messages = message_totals["total_messages"]
+    compliant_messages = message_totals["compliant_messages"]
+    report_count = (
+        db.query(func.count(DMARCReport.id)).filter(DMARCReport.domain_id.in_(domain_ids)).scalar()
+        if domain_ids
+        else 0
+    )
+    forensic_count = (
+        db.query(func.count(ForensicReport.id))
+        .filter(ForensicReport.domain_id.in_(domain_ids))
+        .scalar()
+        if domain_ids
+        else 0
+    )
+    tls_report_count = (
+        db.query(func.count(TLSReport.id)).filter(TLSReport.domain_id.in_(domain_ids)).scalar()
+        if domain_ids
+        else 0
+    )
+    last_report_end = (
+        db.query(func.max(DMARCReport.end_date))
+        .filter(DMARCReport.domain_id.in_(domain_ids))
+        .scalar()
+        if domain_ids
+        else None
+    )
+    return {
+        "generated_at": _timestamp(),
+        "workspace": {
+            "id": workspace.id,
+            "slug": workspace.slug,
+            "name": workspace.name,
+        },
+        "summary": {
+            "domain_count": len(domains),
+            "active_domain_count": sum(1 for domain in domains if domain.active),
+            "verified_domain_count": sum(1 for domain in domains if domain.verified),
+            "aggregate_report_count": int(report_count or 0),
+            "forensic_report_count": int(forensic_count or 0),
+            "tls_report_count": int(tls_report_count or 0),
+            "total_messages": total_messages,
+            "compliant_messages": compliant_messages,
+            "failed_messages": message_totals["failed_messages"],
+            "compliance_rate": _rate(compliant_messages, total_messages),
+            "distinct_source_count": message_totals["distinct_source_count"],
+            "last_report_end_at": _unix_timestamp(last_report_end),
+        },
+        "mail_sources": _mail_source_summary(db, workspace),
+        "alerts": _alert_summary(db, domain_names),
+        "domains": _domain_usage_rows(db, domains),
+    }

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -691,7 +691,8 @@ def test_action_confirmation_requires_action_tools_enabled(
 @pytest.mark.asyncio
 async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: Session):
     _seed_report_store()
-    auth_context = {"token_id": "test-token"}
+    _persist_report(db_session)
+    auth_context = {"auth_type": "disabled", "token_id": "test-token"}
 
     with (
         patch(
@@ -803,6 +804,13 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
             auth_context=auth_context,
             workspace_id=None,
         )
+        usage_result = await mcp_endpoint._call_read_only_tool(
+            "workspace_usage",
+            {},
+            db=db_session,
+            auth_context=auth_context,
+            workspace_id=None,
+        )
 
     assert listed["domains"][0]["domain"] == DOMAIN
     assert posture_result["grade"] == "A"
@@ -817,6 +825,8 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
     assert proposals["proposals"]
     assert health_evidence_result["scope"] == "domain"
     assert health_evidence_result["rows"][0]["score"] == 72
+    assert usage_result["summary"]["domain_count"] == 1
+    assert usage_result["summary"]["total_messages"] == 10
     posture.assert_awaited_once()
     sources.assert_awaited_once()
     dns_lint.assert_awaited_once()
@@ -939,7 +949,9 @@ def test_mcp_export_catalog_returns_workspace_exports(
     assert result["mcp"]["available"] is True
     assert result["workspace"]["domain_count"] == 1
     assert result["domains"][0]["domain"] == DOMAIN
-    assert "export_catalog" in {tool["name"] for tool in result["mcp"]["tools"]}
+    tool_names = {tool["name"] for tool in result["mcp"]["tools"]}
+    assert "export_catalog" in tool_names
+    assert "workspace_usage" in tool_names
     assert (
         result["domains"][0]["exports"]["domain_reports"]["href"]
         == f"/api/v1/public/domains/{DOMAIN}/reports"
@@ -1046,6 +1058,7 @@ def test_mcp_requires_enabled_scoped_token(client: TestClient, db_session: Sessi
         "health_evidence_export",
         "alert_history",
         "export_catalog",
+        "workspace_usage",
     }.issubset(tool_names)
 
     initialized = client.post(

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -9,6 +9,8 @@ from app.core.security import require_api_token_any_scope
 from app.models.alert import AlertHistory
 from app.models.api_token import APIToken
 from app.models.domain import Domain
+from app.models.mail_source import MailSource
+from app.models.mail_source_import import MailSourceImport
 from app.models.organization import BillingAccount, Organization
 from app.models.workspace import Workspace
 from app.services.api_tokens import (
@@ -163,6 +165,7 @@ def test_public_export_catalog_lists_available_exports_and_token_usage(
     )
     assert body["mcp"]["available"] is False
     assert "export_catalog" in {tool["name"] for tool in body["mcp"]["tools"]}
+    assert "workspace_usage" in {tool["name"] for tool in body["mcp"]["tools"]}
 
 
 def test_public_export_catalog_accepts_tls_or_mcp_scope_without_domain_leak(
@@ -192,11 +195,111 @@ def test_public_export_catalog_accepts_tls_or_mcp_scope_without_domain_leak(
     assert mcp_body["workspace"]["domain_count"] == 1
     assert mcp_body["domains"][0]["exports"]["domain_reports"]["available"] is False
     assert mcp_body["domains"][0]["exports"]["health_evidence_export"]["available"] is False
+    endpoint_by_key = {endpoint["key"]: endpoint for endpoint in mcp_body["public_endpoints"]}
+    assert endpoint_by_key["workspace_usage"]["available"] is True
 
 
 def test_require_api_token_any_scope_rejects_bare_string_scope():
     with pytest.raises(TypeError, match="not a string"):
         require_api_token_any_scope(READ_REPORTS_SCOPE)
+
+
+def test_public_workspace_usage_is_workspace_scoped_and_read_only(
+    client: TestClient,
+    db_session,
+):
+    """Public usage returns aggregate workspace evidence without cross-tenant leakage."""
+    _persist_report(db_session)
+    workspace = get_or_create_default_workspace(db_session)
+    mail_source = MailSource(
+        workspace_id=workspace.id,
+        name="Reports Gmail",
+        method="GMAIL_API",
+        enabled=True,
+    )
+    other_workspace = Workspace(slug="usage-other", name="Usage Other", active=True)
+    db_session.add_all([mail_source, other_workspace])
+    db_session.flush()
+    db_session.add(
+        MailSourceImport(
+            mail_source_id=mail_source.id,
+            trigger="manual",
+            status="completed",
+            processed=3,
+            reports_found=1,
+        )
+    )
+    db_session.add(
+        AlertHistory(
+            fingerprint="public-usage-alert",
+            rule="new_sender_source",
+            severity="warning",
+            domain=DOMAIN,
+            title="New sender",
+            detail="A new sender appeared.",
+            observed_count=1,
+            is_active=True,
+        )
+    )
+    other_domain = "usage-other.example"
+    other_report = {
+        **FAILING_REPORT,
+        "domain": other_domain,
+        "report_id": "public-usage-other-001",
+    }
+    save_parsed_report(db_session, other_report, workspace_id=other_workspace.id)
+    db_session.add(
+        AlertHistory(
+            fingerprint="public-usage-other-alert",
+            rule="missing_reports",
+            severity="error",
+            domain=other_domain,
+            title="Other alert",
+            detail="Should not leak.",
+            observed_count=1,
+            is_active=True,
+        )
+    )
+    db_session.commit()
+    reports_token = create_api_token(
+        db_session,
+        name="usage reports bot",
+        scopes=[READ_REPORTS_SCOPE],
+        workspace_id=workspace.id,
+    )
+    tls_token = create_api_token(
+        db_session,
+        name="usage tls bot",
+        scopes=[READ_TLS_SCOPE],
+        workspace_id=workspace.id,
+    )
+
+    denied = client.get(
+        "/api/v1/public/usage",
+        headers={"X-API-Key": tls_token.secret},
+    )
+    response = client.get(
+        "/api/v1/public/usage",
+        headers={"X-API-Key": reports_token.secret},
+    )
+
+    assert denied.status_code == 403
+    assert response.status_code == 200
+    body = response.json()
+    assert body["workspace"]["id"] == workspace.id
+    assert body["summary"]["domain_count"] == 1
+    assert body["summary"]["aggregate_report_count"] == 1
+    assert body["summary"]["total_messages"] == 5
+    assert body["summary"]["compliant_messages"] == 5
+    assert body["summary"]["failed_messages"] == 0
+    assert body["summary"]["distinct_source_count"] == 1
+    assert body["mail_sources"]["total"] == 1
+    assert body["mail_sources"]["by_method"] == {"GMAIL_API": 1}
+    assert body["mail_sources"]["imports"]["by_status"] == {"completed": 1}
+    assert body["alerts"]["active"] == 1
+    assert body["alerts"]["by_rule"] == {"new_sender_source": 1}
+    assert [row["domain"] for row in body["domains"]] == [DOMAIN]
+    assert other_domain not in response.text
 
 
 def test_public_source_intelligence_endpoints_use_report_scope(client: TestClient, db_session):

--- a/docs/reference/ai-mcp-automation.md
+++ b/docs/reference/ai-mcp-automation.md
@@ -75,6 +75,7 @@ The current tools are read-only:
 
 - `list_domains`
 - `export_catalog`
+- `workspace_usage`
 - `domain_summary`
 - `domain_posture`
 - `health_evidence_export`

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -58,6 +58,7 @@ through the `/public` path and avoid UI-specific payloads.
 | Endpoint | Required scope | Purpose |
 | --- | --- | --- |
 | `GET /public/exports` | any read-only automation scope | Available export routes, MCP tools, domains, and token usage metadata |
+| `GET /public/usage` | `reports:read`, `posture:read`, or `mcp:read` | Workspace-level DMARC usage, source, alert, and import counts |
 | `GET /public/domains` | `reports:read` | Domain report and DNS summary list |
 | `GET /public/domains/{domain_id}/reports` | `reports:read` | Recent DMARC aggregate report summaries |
 | `GET /public/domains/{domain_id}/sources` | `reports:read` | Enriched sending sources with sender, geo, anomaly, and fix hints |
@@ -80,6 +81,13 @@ count, public export routes with their required scopes, MCP tool metadata, and
 domain-specific export links when the current token is allowed to see monitored
 domains. TLS-only tokens can discover the catalog and their own usage state, but
 do not receive the domain-specific export list.
+
+`GET /public/usage` is a compact evidence endpoint for automation dashboards,
+capacity planning, or monthly operational reviews. It returns workspace-scoped
+domain counts, aggregate/forensic/TLS report counts, total and failed DMARC
+messages, distinct sending-source counts, mail-source and import-audit counts,
+active/resolved alert totals, and per-domain usage rows. It is read-only and
+does not expose mailbox credentials, raw report XML, or alert payloads.
 
 Public source responses are intended for SIEM, SOC, ISP, MSP, and AI-agent
 consumers that need evidence-linked DMARC sending-source context without
@@ -104,6 +112,7 @@ The MCP endpoint currently exposes these read-only tools:
 | --- | --- |
 | `list_domains` | List monitored domains and aggregate counts |
 | `export_catalog` | Return available public exports, MCP tools, and token usage metadata |
+| `workspace_usage` | Return workspace-level DMARC usage, source, alert, and import counts |
 | `domain_summary` | Return an evidence-first DMARC summary |
 | `domain_posture` | Return posture score, grade, DNS health, and action guidance |
 | `health_evidence_export` | Return sanitized health score evidence rows |


### PR DESCRIPTION
## Summary
- add `GET /api/v1/public/usage` for workspace-scoped DMARC usage evidence
- add the read-only MCP tool `workspace_usage`
- include the new usage export in `/api/v1/public/exports` and docs

## Scope
This is a read-only #309 slice. It exposes workspace usage, mail-source/import counts, alert counts, and per-domain report/message/source counts. It does not add DNS writes, billing/admin demo UI, ARC/ARF, PDF evidence, or migration write imports.

## Validation
- `./.venv/bin/pytest backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q` (`48 passed`)
- `./.venv/bin/black --check backend/app/services/workspace_usage.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `./.venv/bin/isort --check-only backend/app/services/workspace_usage.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `./.venv/bin/flake8 backend/app/services/workspace_usage.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `./.venv/bin/python -m py_compile backend/app/services/workspace_usage.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/export_catalog.py`
- `git diff --check`
