### PR TITLE
docs: describe mail health roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # DMARQ
 
-**DMARQ** is a modern, privacy-conscious DMARC monitoring and analysis platform built for professionals who want deep visibility into their email authentication posture — without giving up control or relying on third-party SaaS providers.
+**DMARQ** is a modern, privacy-conscious mail health platform built for
+professionals who want to understand and improve domain sending posture without
+giving up control of their reports, DNS, and infrastructure.
 
 - 🌐 [Live Demo](https://demo.dmarq.org)
 - 🔒 Self-hosted. Secure. Beautifully visual.
@@ -11,9 +13,20 @@
 
 ## 💡 What is DMARQ?
 
-DMARQ ingests and visualizes DMARC (Domain-based Message Authentication, Reporting & Conformance) reports — primarily aggregate (RUA) reports today — to help domain owners understand who is sending emails on their behalf and whether those messages are properly authenticated using SPF and DKIM.
+DMARQ ingests and visualizes DMARC (Domain-based Message Authentication,
+Reporting & Conformance) reports — primarily aggregate (RUA) reports today — to
+help domain owners understand who is sending emails on their behalf and whether
+those messages are properly authenticated using SPF and DKIM.
 
-No more guessing. See which services are passing DMARC, which are failing, and how to fix them — all in one clear dashboard.
+The product direction is broader than reporting alone: DMARQ should become a
+human-in-the-loop mail health assistant. It observes DMARC and mail-delivery
+signals, explains what is unhealthy, prepares safe fixes, and tells the operator
+what changed. Automatic detection and guidance are encouraged; hidden DNS or
+mail-server changes are not.
+
+No more guessing. See which services are passing DMARC, which are failing, which
+senders may be risky, and how to fix the underlying issue — all in one clear
+dashboard.
 
 ---
 
@@ -37,6 +50,9 @@ Included:
 - ✅ Forensic/failure report ingestion with redacted metadata and grouped analysis
 - ✅ SMTP TLS report ingestion, trends, and top failure summaries
 - ✅ Public demo mode with rolling synthetic `dmarq.org` and `dmarq.com` data
+- 🔭 Roadmap: domain mail-health scoring, human-approved repair loops, sender IP
+  reputation checks, DNS/mail provider imports, direct report intake workers,
+  ecosystem integrations, and localized remediation guidance
 
 ---
 
@@ -59,6 +75,13 @@ Included:
 - Apply safe TXT/CNAME remediation through Cloudflare after explicit confirmation
 - Use the modular DNS provider layer for API-backed providers via Lexicon-backed adapters
 - 🔒 No background changes — all DNS updates require explicit operator confirmation
+
+### 🧭 Mail Health Direction
+- **Health Score & Grade**: Make domain sending health visible at a glance
+- **Human-in-the-loop Repair**: Detect automatically, explain clearly, apply only after approval
+- **Provider & Self-hosted Guidance**: Work for Google/Microsoft/Postmark/SES-style senders and custom MTAs
+- **Sender Reputation**: Surface blacklist and reputation risks for sending IPs
+- **Localized Advice**: Make remediation guidance understandable to the operator receiving it
 
 ### 🌐 Cloudflare Integration
 - Optional domain discovery, DNS inspection, and approved DNS record updates
@@ -165,10 +188,20 @@ settings.
 
 ## 🧭 Development Roadmap
 
-DMARQ's product scope is deliberately narrow: parse standards-based reports,
-explain the results, and help operators configure and lint DMARC-adjacent DNS
-records. Future work should strengthen that loop rather than turn DMARQ into a
-general-purpose mail gateway or delivery platform.
+DMARQ's product scope is deliberately focused: parse standards-based reports,
+explain the results, and help operators improve DMARC-adjacent DNS and mail
+sending health. Future work should strengthen that loop rather than turn DMARQ
+into a general-purpose mail gateway or a hidden automation platform.
+
+The current roadmap is organized around:
+
+- **Trustworthy report ingestion and DNS linting**
+- **Health score, A-F rating, and prioritized remediation**
+- **Human-approved DNS and provider repair workflows**
+- **Provider discovery, domain imports, and direct report intake**
+- **Sender identity, reputation, and blacklist monitoring**
+- **API/MCP automation for evidence-linked workflows**
+- **Localized guidance, starting with German as the first non-English target**
 
 See the full [Roadmap](docs/development/roadmap.md) and [Milestones](docs/milestones.md).
 
@@ -183,6 +216,10 @@ MIT License — you are free to use, modify, and host DMARQ for any purpose.
 ## 🤝 Contributing
 
 Pull requests are welcome! Please open an issue to discuss major features or design ideas before submitting code. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
+
+Roadmap feedback is especially useful around provider integrations, DNS repair
+safety, reputation data sources, localization, and real-world migration paths
+from commercial DMARC tools.
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/) and
 [python-semantic-release](https://python-semantic-release.readthedocs.io/) for

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -1,6 +1,6 @@
 # DMARQ Product Roadmap
 
-Last updated: 2026-06-29
+Last updated: 2026-06-30
 
 DMARQ has moved beyond its original MVP. The product now parses aggregate and
 forensic DMARC reports, imports from IMAP/Gmail/Microsoft 365, persists report
@@ -19,11 +19,34 @@ The next roadmap turns that foundation into three durable product modes:
 It also grows DMARQ toward competitive parity with commercial DMARC monitoring
 platforms such as Valimail, EasyDMARC, dmarcian, PowerDMARC, and DMARCguard
 while preserving DMARQ's differentiators: self-hosted operation, transparent
-evidence, operator-approved DNS changes, and no forced DNS delegation.
+evidence, human-approved changes, and no forced DNS delegation.
 
 This roadmap is intentionally product-oriented. It should drive implementation
 issues, not replace release notes or the completed milestone history in
 [`milestones.md`](../milestones.md).
+
+## Product North Star
+
+DMARQ should become a domain mail-health assistant, not only a DMARC report
+viewer.
+
+The desired user story is:
+
+> DMARQ observes DMARC and mail-delivery health, detects what is wrong, safely
+> prepares what can be fixed, and tells the operator how healthy each sending
+> domain is - regardless of whether the sender uses commercial providers or
+> self-hosted mail infrastructure.
+
+The human-in-the-loop boundary is non-negotiable:
+
+- DMARQ may automatically ingest, detect, correlate, explain, prioritize, draft
+  repair plans, and notify.
+- DMARQ may apply changes only when the operator has connected a scoped
+  provider, reviewed the exact change, and approved the action.
+- DMARQ must show what it changed, what it could not change, and what still
+  needs manual work.
+- DMARQ should never hide DNS or mail-server modifications behind background
+  automation.
 
 ## Product Commitments
 
@@ -43,6 +66,9 @@ The roadmap must continue to honor the public DMARQ promise:
   secret redaction.
 - Keep normal operation GUI-first: setup, mailbox connection, DNS linting,
   alerts, and report review should not require CLI work.
+- Make remediation understandable. Technical DNS values stay exact, but
+  operator-facing explanations should support localization, with German as the
+  first non-English target language.
 
 ## Current Baseline
 
@@ -75,6 +101,14 @@ The main open strategic issues are:
   score, A-F rating, and remediation action plan.
 - [Issue #305](https://github.com/christianlouis/dmarq/issues/305): competitive
   parity tracker for DMARC monitoring platforms.
+- [Issue #384](https://github.com/christianlouis/dmarq/issues/384): autonomous
+  mail health remediation loop with human approval.
+- [Issue #385](https://github.com/christianlouis/dmarq/issues/385): sender IP
+  reputation and blacklist monitoring.
+- [Issue #386](https://github.com/christianlouis/dmarq/issues/386): ecosystem
+  integration roadmap.
+- [Issue #387](https://github.com/christianlouis/dmarq/issues/387):
+  localization and multilingual remediation guidance.
 
 ## Roadmap Tracks
 
@@ -99,13 +133,53 @@ Deliverables:
   visually consistent.
 - Maintain export and data-access guarantees for a customer's own report data.
 - Add score history and compliance evidence exports for audit workflows.
+- Add sender IP reputation and blacklist signals as visible health-score
+  contributors.
+- Group raw findings into remediation incidents: fixed, approval-ready, manual,
+  or informational.
 
 Exit criteria:
 
 - A domain owner can answer who sends mail, what is failing, what changed, and
   what to do next without leaving the dashboard/detail flow.
+- A domain owner can distinguish observed problems from approved repairs and
+  manual work still waiting on them.
 - Demo mode continues to showcase realistic aggregate, forensic, DNS, TLS-RPT,
   MTA-STS, and BIMI states without touching production paths.
+
+### Track A2: Ecosystem Integrations and Localization
+
+Goal: make DMARQ fit into the places where operators already manage domains,
+DNS, mail delivery, hosting, tickets, and customer accounts.
+
+Integration categories:
+
+| Ecosystem | Why it matters | First useful behavior | Write boundary |
+| --- | --- | --- | --- |
+| DNS providers | DMARC/SPF/DKIM fixes live in DNS | detect provider, import zones, generate change plans | human-approved only |
+| Mail services | sender domains and DKIM records originate there | import verified sender domains and required DNS records | human-approved only |
+| Self-hosted MTAs | many deliverability problems are not SaaS-specific | show IP reputation, DNS, rDNS, and alignment guidance | manual or explicit integration |
+| Hosting panels | SMB users manage DNS/mail in control panels | ISPConfig/cPanel/Plesk/WHMCS integration path | provider-scoped approval |
+| Report intake workers | polling mailboxes is not always ideal | Cloudflare/AWS SES/generic webhook intake | no DNS writes |
+| Ticketing/chatops/SIEM | operators need workflows, not dashboards only | alert and evidence envelopes | read/notify by default |
+| Identity/provider portals | hosted and ISP deployments need lifecycle hooks | OIDC, SCIM, provider SSO, provisioning APIs | audited admin actions |
+
+Localization priorities:
+
+- English remains the source and fallback language.
+- German is the first non-English target because early visible community signals
+  and the project context suggest a strong German-speaking operator audience.
+- Danish, Hebrew, and Estonian are later candidate languages based on a small,
+  aggregate review of public GitHub stargazer profile locations. This is a weak
+  signal, not nationality inference, and should be validated through community
+  feedback before significant translation work.
+
+Exit criteria:
+
+- Remediation guidance can be localized without changing DNS record values,
+  protocol tags, provider names, or evidence.
+- Users can understand what to do next in their preferred language.
+- Community contributors have a documented path to review or add translations.
 
 ### Track B: Auth, RBAC, and Tenant Safety
 
@@ -291,12 +365,18 @@ Deliverables:
 - Add geo/source enrichment and anomaly detection views.
 - Design operator-approved DNS change plans and optional provider write
   integrations without changing the read-only default.
+- Add sender IP reputation and blacklist monitoring as a mail-health signal.
+- Add an autonomous remediation loop that turns findings into human-approved
+  repair plans and notifications.
+- Add multilingual remediation guidance so advice is actionable outside an
+  English-only operations team.
 
 Exit criteria:
 
 - DMARQ can answer the same buyer questions as commercial DMARC monitoring
   platforms: score, grade, sender identity, what changed, what to fix, what the
-  audit evidence is, and how to migrate in or out.
+  audit evidence is, whether sending IPs have reputation risk, and how to
+  migrate in or out.
 - Features remain evidence-linked, tenant-safe, exportable, and usable in
   self-hosted mode.
 
@@ -379,6 +459,21 @@ the features buyers expect.
 - Productize API/MCP surfaces for posture and reporting.
 - Add migration, portability, geo/source intelligence, anomaly detection, and
   optional DNS change-plan workflows.
+- Add reputation/blacklist monitoring for sending IPs and source identities.
+- Add localization support for remediation and notification text.
+
+### Phase 8: Mail Health Autopilot
+
+Outcome: DMARQ can guide operators from observation to safe repair.
+
+- Group DNS, DMARC, sender, provider, and reputation findings into domain health
+  incidents.
+- Classify each incident as informational, manual, approval-ready, or already
+  fixed.
+- Notify operators when important incidents appear, worsen, are fixed, or need
+  approval.
+- Connect one-click repair to the same audited, human-approved change-plan
+  model instead of adding provider-specific shortcuts.
 
 ## GitHub Tracking
 
@@ -408,6 +503,26 @@ the features buyers expect.
   enrichment and anomaly detection views.
 - [Issue #314](https://github.com/christianlouis/dmarq/issues/314):
   operator-approved DNS change plans and optional provider write integrations.
+- [Issue #378](https://github.com/christianlouis/dmarq/issues/378): import
+  domains from verified sender mail services.
+- [Issue #379](https://github.com/christianlouis/dmarq/issues/379): import
+  domains from DNS provider zones.
+- [Issue #380](https://github.com/christianlouis/dmarq/issues/380): safe
+  one-click DNS repair across provider plugins.
+- [Issue #381](https://github.com/christianlouis/dmarq/issues/381): detect DNS
+  provider from NS records and suggest automation path.
+- [Issue #382](https://github.com/christianlouis/dmarq/issues/382): Postmark
+  DNS automation for sender domain setup.
+- [Issue #383](https://github.com/christianlouis/dmarq/issues/383): direct
+  DMARC report intake via hosted mail/webhook workers.
+- [Issue #384](https://github.com/christianlouis/dmarq/issues/384):
+  autonomous mail health remediation loop.
+- [Issue #385](https://github.com/christianlouis/dmarq/issues/385): sender IP
+  reputation and blacklist monitoring.
+- [Issue #386](https://github.com/christianlouis/dmarq/issues/386): ecosystem
+  integration roadmap.
+- [Issue #387](https://github.com/christianlouis/dmarq/issues/387):
+  localization and multilingual remediation guidance.
 
 Completed reference issues:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,27 @@
 # DMARQ Documentation
 
-Welcome to the official documentation for DMARQ - a comprehensive DMARC reporting and analysis tool.
+Welcome to the official documentation for DMARQ - a DMARC reporting and domain
+mail-health tool.
 
-DMARQ helps organizations monitor their email authentication status, analyze DMARC reports, and improve email deliverability and security.
+DMARQ helps organizations monitor email authentication, analyze DMARC reports,
+understand DNS and sender posture, and improve mail-sending health without
+giving up control of their data.
 
 ## What is DMARQ?
 
-DMARQ is a full-stack DMARC monitoring platform designed to help organizations track and improve their email authentication. It processes DMARC reports (aggregate and forensic) and presents compliance insights via a user-friendly dashboard.
+DMARQ is a full-stack DMARC monitoring platform designed to help organizations
+track and improve email authentication. It processes DMARC reports, presents
+compliance insights, and is growing into a human-in-the-loop remediation
+assistant: automatic detection and guidance, operator-approved repair.
+
+The product direction is intentionally practical:
+
+- show which domains and senders are healthy,
+- explain what is broken and why it matters,
+- prepare safe fixes for DNS and provider configuration,
+- support both commercial providers and self-hosted mail infrastructure,
+- surface sender reputation and blacklist risks, and
+- provide guidance in language operators can act on.
 
 ## Key Features
 
@@ -16,6 +31,8 @@ DMARQ is a full-stack DMARC monitoring platform designed to help organizations t
 - **Mailbox Integrations**: Automatically fetch reports from IMAP, Gmail, and Microsoft 365 inboxes
 - **Alerting**: Get notified about important authentication issues
 - **Easy Setup**: Web-based configuration wizard for quick onboarding
+- **Human-in-the-loop Remediation**: Detect automatically, explain clearly, apply only after approval
+- **Roadmap**: Health scoring, sender reputation, provider imports, direct intake workers, and localized guidance
 
 ## Getting Started
 
@@ -37,7 +54,8 @@ Aggregate-report parser support, known edge cases, and fixture guidance are docu
 Opt-in AI summaries and read-only MCP automation are covered in [AI and MCP Automation](reference/ai-mcp-automation.md).
 
 The current product direction across self-hosted, hosted SaaS, ISP/OEM,
-billing, and multi-tenant work is captured in the [Product Roadmap](development/roadmap.md).
+provider integrations, billing, localization, and mail-health automation is
+captured in the [Product Roadmap](development/roadmap.md).
 
 ISP, MSP, and hosting-control-panel lifecycle integrations are documented in
 [Provider Integrations](reference/provider-integrations.md).


### PR DESCRIPTION
## Summary
- Reframe the README and docs landing page around DMARQ as a domain mail-health product, not only a DMARC report viewer.
- Add the human-in-the-loop product boundary to the roadmap: automatic detection/guidance, explicit approval before repair.
- Document ecosystem integration categories, localization priorities, reputation monitoring, and the new roadmap issues #378-#387.

## Why
Users should understand the product direction without reading individual backlog comments: health scoring, safe remediation, provider/self-hosted support, reputation checks, direct intake, and multilingual guidance.

## Validation
- `python3` docs smoke check for edited Markdown files
- `git diff --check -- README.md docs/index.md docs/development/roadmap.md`

Related: #305, #384, #385, #386, #387
