### PR TITLE
[codex] Detect DNS provider from NS records

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -305,6 +305,8 @@ class DNSRecordResponse(BaseModel):
     checkedAt: Optional[str] = None
     dmarcWarnings: List[str] = []
     dmarcSuggestions: List[str] = []
+    nameservers: List[str] = []
+    dnsProvider: Optional[Dict[str, Any]] = None
 
 
 class DNSGuidanceRecordResponse(BaseModel):
@@ -362,6 +364,7 @@ class DNSChangePlanResponse(BaseModel):
     status: str
     read_only: bool = True
     provider_write_available: bool = False
+    dns_provider: Optional[Dict[str, Any]] = None
     apply_endpoint: Optional[str] = None
     plans: List[DNSChangePlanItemResponse]
 
@@ -384,6 +387,7 @@ def read_only_dns_change_plan_response(payload: Any) -> DNSChangePlanResponse:
         status=data["status"],
         read_only=True,
         provider_write_available=False,
+        dns_provider=data.get("dns_provider"),
         apply_endpoint=None,
         plans=plans,
     )
@@ -453,6 +457,7 @@ class DNSGuidanceResponse(BaseModel):
     status: str
     findings: List[DNSLintFindingResponse]
     target_records: List[DNSGuidanceRecordResponse]
+    dns_provider: Optional[Dict[str, Any]] = None
     change_plans: List[DNSChangePlanItemResponse] = Field(default_factory=list)
 
 
@@ -2684,6 +2689,8 @@ async def get_domain_dns_records(
         checkedAt=checked_at.isoformat(),
         dmarcWarnings=result.dmarc_warnings,
         dmarcSuggestions=result.dmarc_suggestions,
+        nameservers=result.nameservers,
+        dnsProvider=asdict(result.dns_provider) if result.dns_provider else None,
     )
 
 
@@ -2732,6 +2739,7 @@ async def get_domain_dns_change_plan(
         status=guidance["status"],
         read_only=False,
         provider_write_available=True,
+        dns_provider=guidance.get("dns_provider"),
         apply_endpoint=f"/api/v1/domains/{domain_id}/dns/change-plan/apply",
         plans=[
             {

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
+from app.services.dns_provider_detection import detection_from_json
 from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult
 
 DEFAULT_DNS_CACHE_TTL_SECONDS = 900
@@ -46,6 +47,8 @@ def _result_from_json(value: str) -> DomainDNSResult:
         dmarc_tags=dict(data.get("dmarc_tags") or {}),
         dmarc_warnings=list(data.get("dmarc_warnings") or []),
         dmarc_suggestions=list(data.get("dmarc_suggestions") or []),
+        nameservers=list(data.get("nameservers") or []),
+        dns_provider=detection_from_json(data.get("dns_provider")),
     )
 
 

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from app.services.bimi import BIMIResult
+from app.services.dns_provider_detection import DNSProviderDetection
 from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult, extract_dmarc_policy
 from app.services.mta_sts import MTAStsResult
 
@@ -71,6 +72,7 @@ class DNSGuidanceResult:
     status: str
     findings: List[DNSLintFinding]
     target_records: List[DNSGuidanceRecord]
+    dns_provider: Optional[DNSProviderDetection] = None
     change_plans: List[DNSChangePlan] = field(default_factory=list)
 
 
@@ -1121,5 +1123,6 @@ async def build_dns_guidance(
         status=_status(findings),
         findings=findings,
         target_records=targets,
+        dns_provider=result.dns_provider,
         change_plans=build_dns_change_plans(findings),
     )

--- a/backend/app/services/dns_provider_detection.py
+++ b/backend/app/services/dns_provider_detection.py
@@ -1,0 +1,132 @@
+"""DNS provider detection from authoritative nameserver evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class DNSProviderDetection:
+    """Likely DNS provider derived from NS records."""
+
+    provider_id: str
+    provider_name: str
+    confidence: str
+    evidence: List[str] = field(default_factory=list)
+    connector_available: bool = False
+    automation_supported: bool = False
+    suggested_action: str = "Use manual DNS instructions until a provider connector is configured."
+
+
+@dataclass(frozen=True)
+class _ProviderPattern:
+    provider_id: str
+    provider_name: str
+    patterns: tuple[str, ...]
+    connector_available: bool = False
+    automation_supported: bool = False
+
+
+_PROVIDER_PATTERNS: tuple[_ProviderPattern, ...] = (
+    _ProviderPattern(
+        "cloudflare",
+        "Cloudflare",
+        ("cloudflare.com",),
+        connector_available=True,
+        automation_supported=True,
+    ),
+    _ProviderPattern("route53", "Amazon Route 53", ("awsdns-", "awsdns.")),
+    _ProviderPattern("googleclouddns", "Google Cloud DNS", ("googledomains.com",)),
+    _ProviderPattern("azure_dns", "Azure DNS", ("azure-dns.",)),
+    _ProviderPattern("digitalocean", "DigitalOcean DNS", ("digitalocean.com",)),
+    _ProviderPattern("hetzner", "Hetzner DNS", ("hetzner.com", "hetzner.de")),
+    _ProviderPattern("namecheap", "Namecheap", ("registrar-servers.com",)),
+    _ProviderPattern("godaddy", "GoDaddy", ("domaincontrol.com",)),
+    _ProviderPattern(
+        "powerdns",
+        "PowerDNS or custom DNS",
+        ("powerdns", "pdns"),
+    ),
+    _ProviderPattern("plesk", "Plesk-hosted DNS", ("plesk",)),
+    _ProviderPattern("cpanel", "cPanel/WHM-hosted DNS", ("cpanel", "webhostbox.net")),
+)
+
+
+def _normalize_nameserver(value: str) -> str:
+    return value.strip().strip(".").lower()
+
+
+def _action_for(pattern: _ProviderPattern) -> str:
+    if pattern.connector_available:
+        return (
+            f"Connect {pattern.provider_name} in Settings to enable provider-aware "
+            "DNS inspection and approved repair plans."
+        )
+    return (
+        f"Use the {pattern.provider_name} DNS console or hosting panel with DMARQ's "
+        "manual change plan until a connector is available."
+    )
+
+
+def detect_dns_provider(nameservers: Iterable[str]) -> DNSProviderDetection:
+    """Return likely DNS provider metadata from authoritative NS names."""
+    normalized = [_normalize_nameserver(item) for item in nameservers if item and item.strip()]
+    if not normalized:
+        return DNSProviderDetection(
+            provider_id="unknown",
+            provider_name="Unknown DNS provider",
+            confidence="unknown",
+            evidence=[],
+            suggested_action=(
+                "No authoritative nameservers were detected. Use manual DNS "
+                "instructions or refresh DNS once delegation is visible."
+            ),
+        )
+
+    for pattern in _PROVIDER_PATTERNS:
+        matches = [
+            nameserver
+            for nameserver in normalized
+            if any(marker in nameserver for marker in pattern.patterns)
+        ]
+        if matches:
+            confidence = "high" if len(matches) >= 2 else "medium"
+            return DNSProviderDetection(
+                provider_id=pattern.provider_id,
+                provider_name=pattern.provider_name,
+                confidence=confidence,
+                evidence=matches,
+                connector_available=pattern.connector_available,
+                automation_supported=pattern.automation_supported,
+                suggested_action=_action_for(pattern),
+            )
+
+    return DNSProviderDetection(
+        provider_id="custom",
+        provider_name="Custom or unrecognized DNS provider",
+        confidence="low",
+        evidence=normalized[:4],
+        suggested_action=(
+            "Use manual DNS instructions, or choose a provider connector once "
+            "DMARQ supports this DNS platform."
+        ),
+    )
+
+
+def detection_from_json(value: Optional[dict]) -> Optional[DNSProviderDetection]:
+    """Rehydrate cached provider detection metadata."""
+    if not value:
+        return None
+    return DNSProviderDetection(
+        provider_id=str(value.get("provider_id") or "unknown"),
+        provider_name=str(value.get("provider_name") or "Unknown DNS provider"),
+        confidence=str(value.get("confidence") or "unknown"),
+        evidence=list(value.get("evidence") or []),
+        connector_available=bool(value.get("connector_available")),
+        automation_supported=bool(value.get("automation_supported")),
+        suggested_action=str(
+            value.get("suggested_action")
+            or "Use manual DNS instructions until a provider connector is configured."
+        ),
+    )

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
+from app.services.dns_provider_detection import DNSProviderDetection, detect_dns_provider
+
 logger = logging.getLogger(__name__)
 
 
@@ -97,6 +99,8 @@ class DomainDNSResult:
     dmarc_tags: Dict[str, str] = field(default_factory=dict)
     dmarc_warnings: List[str] = field(default_factory=list)
     dmarc_suggestions: List[str] = field(default_factory=list)
+    nameservers: List[str] = field(default_factory=list)
+    dns_provider: Optional[DNSProviderDetection] = None
 
 
 def _normalize_dns_name(domain: str) -> str:
@@ -391,6 +395,10 @@ class BaseDNSProvider(ABC):
         """
         return None
 
+    async def lookup_ns(self, domain: str) -> List[str]:
+        """Return authoritative nameservers for *domain* when available."""
+        return []
+
     async def check_dkim(
         self, domain: str, selectors: List[str]
     ) -> Tuple[bool, List[str], Optional[str]]:
@@ -439,12 +447,14 @@ class BaseDNSProvider(ABC):
         dmarc_coro = self.discover_dmarc_policy(domain)
         spf_coro = self.check_spf(domain)
         dkim_coro = self.check_dkim(domain, all_selectors)
+        ns_coro = self.lookup_ns(domain)
 
         (
             (dmarc_ok, dmarc_record, dmarc_policy_domain, dmarc_discovery_method, dmarc_tags),
             (spf_ok, spf_record),
             (dkim_ok, dkim_sels, dkim_record),
-        ) = await asyncio.gather(dmarc_coro, spf_coro, dkim_coro)
+            nameservers,
+        ) = await asyncio.gather(dmarc_coro, spf_coro, dkim_coro, ns_coro)
 
         dmarc_tags = dmarc_tags or {}
         warnings, suggestions = _lint_dmarc_tags(
@@ -478,6 +488,8 @@ class BaseDNSProvider(ABC):
             dmarc_tags=dmarc_tags,
             dmarc_warnings=warnings,
             dmarc_suggestions=suggestions,
+            nameservers=nameservers,
+            dns_provider=detect_dns_provider(nameservers),
         )
 
 
@@ -539,6 +551,21 @@ class SystemDNSProvider(BaseDNSProvider):
         except dns.exception.DNSException as exc:
             logger.debug("CNAME lookup failed for %s: %s", _sanitize_for_log(name), exc)
         return None
+
+    async def lookup_ns(self, domain: str) -> List[str]:
+        """Resolve authoritative NS records for *domain* via the system resolver."""
+        import dns.asyncresolver  # type: ignore[import]
+        import dns.exception  # type: ignore[import]
+
+        try:
+            answers = await dns.asyncresolver.resolve(
+                domain, "NS", lifetime=DNS_TIMEOUT, raise_on_no_answer=False
+            )
+            if answers:
+                return sorted(str(rdata.target).rstrip(".").lower() for rdata in answers)
+        except dns.exception.DNSException as exc:
+            logger.debug("NS lookup failed for %s: %s", _sanitize_for_log(domain), exc)
+        return []
 
 
 class CloudflareDNSProvider(BaseDNSProvider):
@@ -821,6 +848,31 @@ class CloudflareDNSProvider(BaseDNSProvider):
             pass
         return None
 
+    async def lookup_ns(self, domain: str) -> List[str]:
+        """Resolve authoritative NS records via Cloudflare's DoH endpoint."""
+        import httpx  # type: ignore[import]
+
+        params = {"name": domain, "type": "NS"}
+        headers = {"Accept": "application/dns-json"}
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    self.CLOUDFLARE_DOH_URL,
+                    params=params,
+                    headers=headers,
+                    timeout=DNS_TIMEOUT,
+                )
+                response.raise_for_status()
+                data = response.json()
+                return sorted(
+                    answer.get("data", "").rstrip(".").lower()
+                    for answer in data.get("Answer", [])
+                    if answer.get("type") == 2 and answer.get("data")
+                )
+        except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException):
+            pass
+        return []
+
 
 class DemoDNSProvider(BaseDNSProvider):
     """Deterministic DNS provider for the opt-in public demo mode."""
@@ -897,6 +949,14 @@ class DemoDNSProvider(BaseDNSProvider):
     async def lookup_cname(self, name: str) -> Optional[str]:
         normalized = _normalize_dns_name(name)
         return self._cname_records.get(normalized)
+
+    async def lookup_ns(self, domain: str) -> List[str]:
+        normalized = _normalize_dns_name(domain)
+        if normalized == "dmarq.org":
+            return ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
+        if normalized == "dmarq.com":
+            return ["ns1.digitalocean.com", "ns2.digitalocean.com"]
+        return []
 
 
 def _decrypt_setting_value(value: Optional[str]) -> Optional[str]:

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -684,6 +684,24 @@
             {% endcall %}
             {% call card_content() %}
                 <div class="grid gap-4">
+                    <div class="rounded-md border border-[#e6e3e1] bg-[#f9f8f7] p-4">
+                        <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                            <div class="min-w-0">
+                                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Detected DNS provider</p>
+                                <div class="mt-1 flex flex-wrap items-center gap-2">
+                                    <p class="text-lg font-semibold text-[#07071f]" x-text="dnsProviderName"></p>
+                                    <span class="rounded-full px-2 py-1 text-xs font-semibold capitalize"
+                                          :class="dnsProviderConfidenceClass"
+                                          x-text="dnsProviderConfidence"></span>
+                                </div>
+                                <p class="mt-1 text-sm text-[#5f5c78]" x-text="dnsProviderAction"></p>
+                            </div>
+                            <div class="min-w-0 text-sm lg:text-right">
+                                <p class="font-semibold text-[#07071f]">Nameservers</p>
+                                <p class="mt-1 font-mono text-xs text-[#5f5c78] break-all" x-text="dnsNameserverText"></p>
+                            </div>
+                        </div>
+                    </div>
                     <div>
                         <h3 class="font-semibold mb-1 flex items-center">
                             <span class="mr-2">DMARC Record</span>
@@ -812,7 +830,11 @@
                     </div>
                     <div id="dns-guidance" class="border rounded-lg p-4">
                         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                            <h3 class="font-semibold">DNS Guidance</h3>
+                            <div>
+                                <h3 class="font-semibold">DNS Guidance</h3>
+                                <p class="text-xs text-base-content/60"
+                                   x-text="'Automation path: ' + dnsProviderAction"></p>
+                            </div>
                             <span class="inline-flex w-fit rounded px-2 py-1 text-xs font-semibold capitalize"
                                   :class="dnsGuidanceStatusClass"
                                   x-text="dnsGuidance.status || 'checking'"></span>
@@ -1388,7 +1410,9 @@ function domainDetailsApp(domainId) {
             spf: false,
             spfRecord: '',
             dkim: false,
-            dkimSelectors: []
+            dkimSelectors: [],
+            nameservers: [],
+            dnsProvider: null
         },
         dnsHealth: {
             status: '',
@@ -1399,6 +1423,7 @@ function domainDetailsApp(domainId) {
             status: '',
             findings: [],
             target_records: [],
+            dns_provider: null,
             change_plans: []
         },
         dnsProviders: [
@@ -1593,6 +1618,43 @@ function domainDetailsApp(domainId) {
             return 'Verified';
         },
 
+        get detectedDnsProvider() {
+            return this.dnsGuidance.dns_provider || this.dns.dnsProvider || null;
+        },
+
+        get dnsProviderName() {
+            return this.detectedDnsProvider?.provider_name || 'Unknown provider';
+        },
+
+        get dnsProviderConfidence() {
+            return this.detectedDnsProvider?.confidence || 'unknown';
+        },
+
+        get dnsProviderAction() {
+            return this.detectedDnsProvider?.suggested_action || 'Review nameservers and select the DNS provider manually before making changes.';
+        },
+
+        get dnsProviderConfidenceClass() {
+            const confidence = this.dnsProviderConfidence;
+            if (confidence === 'high') return 'bg-green-100 text-green-700';
+            if (confidence === 'medium') return 'bg-yellow-100 text-yellow-800';
+            if (confidence === 'low') return 'bg-red-100 text-red-700';
+            return 'bg-base-200 text-base-content/70';
+        },
+
+        get dnsNameserverText() {
+            const nameservers = this.dns.nameservers || this.detectedDnsProvider?.evidence || [];
+            return nameservers.length ? nameservers.join(', ') : 'No NS evidence available yet';
+        },
+
+        syncDetectedDnsProvider() {
+            const providerId = this.detectedDnsProvider?.provider_id;
+            if (!providerId) return;
+            if (this.dnsProviders.some(provider => provider.id === providerId)) {
+                this.dnsWrite.provider = providerId;
+            }
+        },
+
         get dnsHealthStatusClass() {
             if (this.dnsHealth.status === 'healthy') return 'bg-green-100 text-green-700';
             if (this.dnsHealth.status === 'degraded') return 'bg-yellow-100 text-yellow-800';
@@ -1695,6 +1757,7 @@ function domainDetailsApp(domainId) {
                 if (response.ok) {
                     const data = await response.json();
                     this.dns = data;
+                    this.syncDetectedDnsProvider();
                 }
             } catch (error) {
                 console.error('Error fetching DNS records:', error);
@@ -1717,6 +1780,7 @@ function domainDetailsApp(domainId) {
                 const response = await fetch(`/api/v1/domains/${this.domainId}/dns/lint`);
                 if (response.ok) {
                     this.dnsGuidance = await response.json();
+                    this.syncDetectedDnsProvider();
                 }
             } catch (error) {
                 console.error('Error fetching DNS guidance:', error);
@@ -1733,6 +1797,7 @@ function domainDetailsApp(domainId) {
                     if (!this.dnsProviders.some(provider => provider.id === this.dnsWrite.provider)) {
                         this.dnsWrite.provider = this.dnsProviders[0].id;
                     }
+                    this.syncDetectedDnsProvider();
                 }
             } catch (error) {
                 console.error('Error fetching DNS providers:', error);

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -25,6 +25,7 @@ from app.models.report import DMARCReport, ReportRecord
 from app.models.workspace import Workspace
 from app.services.bimi import BIMIResult
 from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
+from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import DomainDNSResult
 from app.services.mta_sts import MTAStsResult
 from app.services.report_persistence import save_parsed_report
@@ -295,6 +296,8 @@ def test_dns_endpoint_returns_dmarc_lint_findings(authed_client: TestClient):
         dkim=False,
         dmarc_warnings=["External rua destination reports.example.net is missing authorization."],
         dmarc_suggestions=["Policy is monitoring-only."],
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+        dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
     )
 
     with _mock_dns(result):
@@ -304,6 +307,9 @@ def test_dns_endpoint_returns_dmarc_lint_findings(authed_client: TestClient):
     data = response.json()
     assert data["dmarcWarnings"] == result.dmarc_warnings
     assert data["dmarcSuggestions"] == result.dmarc_suggestions
+    assert data["nameservers"] == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
+    assert data["dnsProvider"]["provider_id"] == "cloudflare"
+    assert data["dnsProvider"]["connector_available"] is True
 
 
 def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: TestClient):
@@ -314,6 +320,8 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: Tes
         spf_record="v=spf1 include:_spf.example.com ~all",
         dkim=False,
         selectors_checked=["selector1"],
+        nameservers=["ns1.digitalocean.com", "ns2.digitalocean.com"],
+        dns_provider=detect_dns_provider(["ns1.digitalocean.com", "ns2.digitalocean.com"]),
     )
     mta_sts = MTAStsResult(errors=["No _mta-sts TXT record was found."])
     bimi = BIMIResult(errors=["No BIMI TXT record was found at the selector."])
@@ -335,6 +343,8 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: Tes
     data = response.json()
     assert data["domain"] == DOMAIN
     assert data["status"] == "attention"
+    assert data["dns_provider"]["provider_id"] == "digitalocean"
+    assert data["dns_provider"]["confidence"] == "high"
     codes = {finding["code"] for finding in data["findings"]}
     assert {"dkim_selector_missing", "tls_rpt_missing", "bimi_dmarc_not_enforced"}.issubset(codes)
     assert {record["code"] for record in data["target_records"]} >= {
@@ -366,6 +376,8 @@ def test_dns_change_plan_endpoint_returns_apply_gated_plans(authed_client: TestC
         spf=False,
         dkim=False,
         selectors_checked=["selector1"],
+        nameservers=["ns1.example.net"],
+        dns_provider=detect_dns_provider(["ns1.example.net"]),
     )
     mta_sts = MTAStsResult(errors=["No _mta-sts TXT record was found."])
     bimi = BIMIResult(errors=["No BIMI TXT record was found at the selector."])
@@ -388,6 +400,7 @@ def test_dns_change_plan_endpoint_returns_apply_gated_plans(authed_client: TestC
     assert data["domain"] == DOMAIN
     assert data["read_only"] is False
     assert data["provider_write_available"] is True
+    assert data["dns_provider"]["provider_id"] == "custom"
     assert data["apply_endpoint"].endswith("/dns/change-plan/apply")
     plan = next(plan for plan in data["plans"] if plan["finding_code"] == "dmarc_missing")
     assert plan["operation"] == "create"
@@ -548,6 +561,41 @@ async def test_dns_cache_recovers_from_concurrent_insert(db_session, monkeypatch
     assert result == MOCK_DNS_RESULT
     assert cached is False
     assert db_session.query(DNSCache).count() == 1
+
+
+@pytest.mark.asyncio
+async def test_dns_cache_preserves_provider_detection(db_session):
+    """Cached DNS results should keep nameserver and provider detection evidence."""
+    result_with_provider = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=False,
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+        dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
+    )
+    mock_provider = AsyncMock(check_domain=AsyncMock(return_value=result_with_provider))
+
+    first, cached, _checked = await resolve_domain_dns_cached(
+        db_session,
+        mock_provider,
+        DOMAIN,
+        selectors=[],
+    )
+    second, cached_again, _checked_again = await resolve_domain_dns_cached(
+        db_session,
+        mock_provider,
+        DOMAIN,
+        selectors=[],
+    )
+
+    assert cached is False
+    assert first.dns_provider is not None
+    assert cached_again is True
+    assert second.nameservers == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
+    assert second.dns_provider is not None
+    assert second.dns_provider.provider_id == "cloudflare"
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -11,6 +11,7 @@ import pytest
 
 from app.core.credential_encryption import encrypt_secret
 from app.models.setting import Setting
+from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import (
     BaseDNSProvider,
     CloudflareDNSProvider,
@@ -30,18 +31,42 @@ from app.services.dns_resolver import (
 class FakeDNSProvider(BaseDNSProvider):
     """Concrete provider backed by a simple dict for deterministic tests."""
 
-    def __init__(self, records: dict):
+    def __init__(self, records: dict, nameservers: list[str] | None = None):
         self._records = records
+        self._nameservers = nameservers or []
 
     async def lookup_txt(self, name: str):
         if name in self._records:
             return self._records[name]
         raise LookupError(f"NXDOMAIN: {name}")
 
+    async def lookup_ns(self, domain: str):
+        return list(self._nameservers)
+
 
 # ---------------------------------------------------------------------------
 # extract_dmarc_policy
 # ---------------------------------------------------------------------------
+
+
+def test_detect_dns_provider_matches_cloudflare_with_connector_hint():
+    detection = detect_dns_provider(["ada.ns.cloudflare.com.", "ian.ns.cloudflare.com"])
+
+    assert detection.provider_id == "cloudflare"
+    assert detection.provider_name == "Cloudflare"
+    assert detection.confidence == "high"
+    assert detection.connector_available is True
+    assert detection.automation_supported is True
+    assert "Connect Cloudflare" in detection.suggested_action
+
+
+def test_detect_dns_provider_degrades_for_unknown_nameservers():
+    detection = detect_dns_provider(["ns1.mailhost.example", "ns2.mailhost.example"])
+
+    assert detection.provider_id == "custom"
+    assert detection.confidence == "low"
+    assert detection.connector_available is False
+    assert detection.evidence == ["ns1.mailhost.example", "ns2.mailhost.example"]
 
 
 def test_extract_dmarc_policy_none():
@@ -125,6 +150,24 @@ async def test_check_domain_lints_external_report_destination_without_authorizat
         "External rua destination reports.example.net is missing authorization TXT at "
         "example.com._report._dmarc.reports.example.net."
     ]
+
+
+@pytest.mark.asyncio
+async def test_check_domain_includes_dns_provider_detection():
+    provider = FakeDNSProvider(
+        {
+            "_dmarc.example.com": ["v=DMARC1; p=none; rua=mailto:dmarc@example.com"],
+            "example.com": ["v=spf1 include:_spf.example.com -all"],
+        },
+        nameservers=["ns1.digitalocean.com", "ns2.digitalocean.com"],
+    )
+
+    result = await provider.check_domain("example.com", selectors=[])
+
+    assert result.nameservers == ["ns1.digitalocean.com", "ns2.digitalocean.com"]
+    assert result.dns_provider is not None
+    assert result.dns_provider.provider_id == "digitalocean"
+    assert result.dns_provider.confidence == "high"
 
 
 @pytest.mark.asyncio
@@ -481,6 +524,44 @@ async def test_system_provider_lookup_cname_returns_none_on_dns_exception():
     assert target is None
 
 
+@pytest.mark.asyncio
+async def test_system_provider_lookup_ns_returns_sorted_targets():
+    """SystemDNSProvider.lookup_ns should normalize authoritative NS targets."""
+
+    class FakeNsRdata:
+        def __init__(self, target: str):
+            self.target = target
+
+    class FakeNsAnswers:
+        def __iter__(self):
+            return iter(
+                [
+                    FakeNsRdata("IAN.NS.Cloudflare.com."),
+                    FakeNsRdata("ada.ns.cloudflare.com."),
+                ]
+            )
+
+    with patch("dns.asyncresolver.resolve", new=AsyncMock(return_value=FakeNsAnswers())):
+        provider = SystemDNSProvider()
+        nameservers = await provider.lookup_ns("example.com")
+
+    assert nameservers == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
+
+
+@pytest.mark.asyncio
+async def test_system_provider_lookup_ns_returns_empty_on_dns_exception():
+    import dns.exception  # type: ignore[import]
+
+    with patch(
+        "dns.asyncresolver.resolve",
+        new=AsyncMock(side_effect=dns.exception.DNSException("NXDOMAIN")),
+    ):
+        provider = SystemDNSProvider()
+        nameservers = await provider.lookup_ns("example.com")
+
+    assert nameservers == []
+
+
 # ---------------------------------------------------------------------------
 # CloudflareDNSProvider
 # ---------------------------------------------------------------------------
@@ -557,6 +638,44 @@ async def test_cloudflare_provider_lookup_cname_returns_none_on_http_error():
         target = await provider.lookup_cname("selector._domainkey.example.com")
 
     assert target is None
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_provider_lookup_ns_returns_sorted_targets():
+    """CloudflareDNSProvider.lookup_ns should parse NS answers from DoH JSON."""
+    from unittest.mock import MagicMock
+
+    fake_response_data = {
+        "Answer": [
+            {"type": 2, "data": "IAN.NS.Cloudflare.com."},
+            {"type": 1, "data": "93.184.216.34"},
+            {"type": 2, "data": "ada.ns.cloudflare.com."},
+        ]
+    }
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = lambda: fake_response_data
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        provider = CloudflareDNSProvider()
+        nameservers = await provider.lookup_ns("example.com")
+
+    assert nameservers == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_provider_lookup_ns_returns_empty_on_http_error():
+    import httpx
+
+    with patch(
+        "httpx.AsyncClient.get",
+        new=AsyncMock(side_effect=httpx.RequestError("connection refused")),
+    ):
+        provider = CloudflareDNSProvider()
+        nameservers = await provider.lookup_ns("example.com")
+
+    assert nameservers == []
 
 
 @pytest.mark.asyncio
@@ -869,3 +988,18 @@ async def test_demo_provider_lookup_cname_returns_configured_target():
     target = await provider.lookup_cname("mailchimp._domainkey.dmarq.com")
 
     assert target == "missing-mcsv._domainkey.mcsv.net"
+
+
+@pytest.mark.asyncio
+async def test_demo_provider_lookup_ns_returns_story_providers():
+    provider = DemoDNSProvider()
+
+    assert await provider.lookup_ns("dmarq.org") == [
+        "ada.ns.cloudflare.com",
+        "ian.ns.cloudflare.com",
+    ]
+    assert await provider.lookup_ns("dmarq.com") == [
+        "ns1.digitalocean.com",
+        "ns2.digitalocean.com",
+    ]
+    assert await provider.lookup_ns("unknown.example") == []

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -576,16 +576,22 @@ GET /domains/dns/lint/export
 ```
 
 Returns typed DNS lint findings with stable `code` values, suggested target
-records, and deterministic `remediation_steps` for DMARC, SPF, DKIM, MTA-STS,
-TLS-RPT, and BIMI readiness. DKIM findings distinguish missing selectors,
-broken CNAME targets, short RSA keys, and stale selectors. The bulk endpoint
-returns the same payload shape per monitored domain, and the export endpoint
-returns the finding list as CSV for managed-domain reviews.
+records, detected DNS provider evidence, and deterministic `remediation_steps`
+for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI readiness. DKIM findings
+distinguish missing selectors, broken CNAME targets, short RSA keys, and stale
+selectors. The bulk endpoint returns the same payload shape per monitored
+domain, and the export endpoint returns the finding list as CSV for
+managed-domain reviews.
 
 The single-domain lint payload also includes `change_plans`. The dedicated
 `/dns/change-plan` endpoint returns the same operator-facing plans with
 proposed DNS records, captured current values, risk notes, rollback notes,
-expected health impact, and manual approval flags.
+expected health impact, manual approval flags, and the same `dns_provider`
+advisory object. Provider detection is derived from authoritative NS records
+and includes provider id/name, confidence, evidence, connector availability,
+automation support, and the suggested next setup step. It does not imply write
+access unless credentials are configured and the operator approves an apply
+request.
 
 `GET /domains/dns/providers` returns native and Lexicon-backed provider
 capabilities. `POST /domains/{domain_id}/dns/change-plan/apply` accepts


### PR DESCRIPTION
## Summary

- detect the likely DNS provider from authoritative NS records with confidence, evidence, and automation guidance
- return provider detection through DNS records, DNS lint, and change-plan APIs while preserving cached results
- show detected provider and nameservers on the domain detail page and preselect a matching DNS write provider when available
- document the read-only detection contract and add coverage for known and unknown providers

## Validation

- `./.venv/bin/pytest backend/app/tests/test_dns_resolver.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q`
- `./.venv/bin/python -m py_compile backend/app/services/dns_provider_detection.py backend/app/services/dns_resolver.py backend/app/services/dns_cache.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py`
- `./.venv/bin/python -m black --check backend/app/services/dns_provider_detection.py backend/app/services/dns_resolver.py backend/app/services/dns_cache.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_dns_endpoints.py`
- `./.venv/bin/python -m isort --check-only backend/app/services/dns_provider_detection.py backend/app/services/dns_resolver.py backend/app/services/dns_cache.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_dns_endpoints.py`
- `git diff --check`

Closes #381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNS results now include authoritative nameservers and a detected DNS provider.
  * DNS guidance now shows provider confidence, evidence, and a clearer automation path.
  * DNS change-plan responses now surface provider-aware guidance alongside plan details.

* **Bug Fixes**
  * Cached DNS lookups now preserve provider detection data.
  * DNS provider selection in the UI stays aligned with the latest detected DNS evidence.

* **Documentation**
  * Updated DNS API reference to describe the expanded guidance and change-plan output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->