### PR TITLE
[codex] Add DNS provider zone import API

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -31,6 +31,11 @@ from app.services.cloudflare_dns import (
 from app.services.demo_data import DEMO_DAYS, build_demo_health_score_history
 from app.services.dns_cache import resolve_domain_dns_cached
 from app.services.dns_guidance import build_dns_guidance
+from app.services.dns_provider_imports import (
+    import_dns_provider_domains,
+    preview_dns_provider_import,
+    supported_import_providers,
+)
 from app.services.dns_provider_writes import (
     DNSProviderWriteError,
     apply_dns_write,
@@ -403,6 +408,7 @@ class DNSProviderCapabilityResponse(BaseModel):
     operations: List[str]
     credentials: str
     status: str
+    import_available: bool = False
 
 
 class DNSProviderCapabilitiesResponse(BaseModel):
@@ -676,6 +682,48 @@ class CloudflareImportRequest(BaseModel):
 class CloudflareImportResponse(BaseModel):
     """Cloudflare domain import summary."""
 
+    imported: List[str]
+    existing: List[str]
+    skipped: List[str]
+    total_discovered: int
+
+
+class DNSProviderImportZoneResponse(BaseModel):
+    """DNS provider zone that can be imported as a monitored domain."""
+
+    provider: str
+    provider_name: str
+    zone_id: str
+    domain: str
+    status: Optional[str] = None
+    account_name: Optional[str] = None
+    imported: bool = False
+    importable: bool = True
+    source: str = "dns_zone"
+    next_action: str
+
+
+class DNSProviderImportPreviewResponse(BaseModel):
+    """Read-only DNS provider domain import preview."""
+
+    provider: str
+    provider_name: str
+    zones: List[DNSProviderImportZoneResponse]
+    total_discovered: int
+    importable_count: int
+
+
+class DNSProviderImportRequest(BaseModel):
+    """Optional DNS provider domains to import after preview."""
+
+    domains: Optional[List[str]] = None
+
+
+class DNSProviderImportResponse(BaseModel):
+    """DNS provider domain import summary."""
+
+    provider: str
+    provider_name: str
     imported: List[str]
     existing: List[str]
     skipped: List[str]
@@ -2385,7 +2433,73 @@ async def get_dns_provider_capabilities(
     _auth: dict = Depends(require_admin_auth),
 ):
     """Return provider-backed DNS write capabilities."""
-    return DNSProviderCapabilitiesResponse(providers=provider_capabilities())
+    capabilities = provider_capabilities()
+    import_provider_ids = {provider["id"] for provider in supported_import_providers()}
+    return DNSProviderCapabilitiesResponse(
+        providers=[
+            {
+                **provider,
+                "import_available": provider["id"] in import_provider_ids,
+            }
+            for provider in capabilities
+        ]
+    )
+
+
+@router.get("/dns/import/{provider}/preview", response_model=DNSProviderImportPreviewResponse)
+async def preview_dns_provider_domain_import(
+    provider: str = Path(..., title="DNS provider ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+):
+    """Preview DNS-provider zones that can be imported as monitored domains."""
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    try:
+        return await preview_dns_provider_import(
+            db,
+            provider=provider,
+            workspace_id=workspace.id,
+        )
+    except LookupError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/dns/import/{provider}", response_model=DNSProviderImportResponse)
+async def import_dns_provider_domain_zones(
+    payload: DNSProviderImportRequest,
+    provider: str = Path(..., title="DNS provider ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+):
+    """Import selected, or all new, DNS-provider zones as monitored domains."""
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    try:
+        return await import_dns_provider_domains(
+            db,
+            provider=provider,
+            requested_domains=payload.domains,
+            workspace_id=workspace.id,
+        )
+    except OrganizationPlanLimitError as exc:
+        _raise_plan_limit_error(exc)
+    except LookupError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
 
 # New endpoints for domain details page

--- a/backend/app/services/cloudflare_dns.py
+++ b/backend/app/services/cloudflare_dns.py
@@ -146,7 +146,15 @@ async def import_cloudflare_domains(
         if name in existing_names:
             existing.append(name)
         else:
-            db.add(Domain(name=name, active=True, verified=True, workspace_id=workspace_id))
+            db.add(
+                Domain(
+                    name=name,
+                    description="DNS-discovered from Cloudflare zone import",
+                    active=True,
+                    verified=True,
+                    workspace_id=workspace_id,
+                )
+            )
             imported.append(name)
 
     db.commit()

--- a/backend/app/services/dns_provider_imports.py
+++ b/backend/app/services/dns_provider_imports.py
@@ -1,0 +1,107 @@
+"""Read-only DNS provider zone discovery and domain import helpers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.services.cloudflare_dns import discover_cloudflare_zones, import_cloudflare_domains
+from app.services.dns_provider_writes import normalize_provider_id
+
+
+@dataclass
+class DNSProviderImportZone:
+    """One DNS provider zone that can be imported as a monitored domain."""
+
+    provider: str
+    provider_name: str
+    zone_id: str
+    domain: str
+    status: Optional[str] = None
+    account_name: Optional[str] = None
+    imported: bool = False
+    importable: bool = True
+    source: str = "dns_zone"
+    next_action: str = "Import this DNS zone to monitor DNS posture before reports arrive."
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+PROVIDER_NAMES = {
+    "cloudflare": "Cloudflare",
+}
+
+
+def supported_import_providers() -> List[Dict[str, str]]:
+    """Return DNS providers that support zone import."""
+    return [{"id": provider_id, "name": name} for provider_id, name in PROVIDER_NAMES.items()]
+
+
+def _provider_name(provider_id: str) -> str:
+    return PROVIDER_NAMES.get(provider_id, provider_id)
+
+
+async def preview_dns_provider_import(
+    db: Session,
+    *,
+    provider: str,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return importable zones/domains for a DNS provider without creating rows."""
+    provider_id = normalize_provider_id(provider)
+    if provider_id != "cloudflare":
+        raise LookupError(f"Unsupported DNS provider import: {provider_id}")
+
+    zones = await discover_cloudflare_zones(db, workspace_id=workspace_id)
+    items = [
+        DNSProviderImportZone(
+            provider=provider_id,
+            provider_name=_provider_name(provider_id),
+            zone_id=str(zone["id"]),
+            domain=str(zone["name"]).lower(),
+            status=zone.get("status"),
+            account_name=zone.get("account_name"),
+            imported=bool(zone.get("imported")),
+            importable=not bool(zone.get("imported")),
+            next_action=(
+                "Already monitored in this workspace."
+                if zone.get("imported")
+                else "Import this Cloudflare zone to monitor DNS posture before reports arrive."
+            ),
+        ).to_dict()
+        for zone in zones
+    ]
+    return {
+        "provider": provider_id,
+        "provider_name": _provider_name(provider_id),
+        "zones": items,
+        "total_discovered": len(items),
+        "importable_count": sum(1 for item in items if item["importable"]),
+    }
+
+
+async def import_dns_provider_domains(
+    db: Session,
+    *,
+    provider: str,
+    requested_domains: Optional[List[str]] = None,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Import selected DNS provider zones as monitored domains."""
+    provider_id = normalize_provider_id(provider)
+    if provider_id != "cloudflare":
+        raise LookupError(f"Unsupported DNS provider import: {provider_id}")
+
+    result = await import_cloudflare_domains(
+        db,
+        requested_domains=requested_domains,
+        workspace_id=workspace_id,
+    )
+    return {
+        "provider": provider_id,
+        "provider_name": _provider_name(provider_id),
+        **result,
+    }

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -1183,14 +1183,20 @@ function settingsApp() {
             this.loadingCfZones = true;
             try {
                 await this.saveCategory('cloudflare');
-                const res = await fetch('/api/v1/domains/cloudflare/discover', {
+                const res = await fetch('/api/v1/domains/dns/import/cloudflare/preview', {
                     headers: this.apiHeaders(),
                 });
                 const data = await res.json().catch(() => ({}));
                 if (!res.ok) {
                     this.showFlash('Cloudflare discovery failed: ' + (data.detail || res.statusText), false);
                 } else {
-                    this.cfZones = data || [];
+                    this.cfZones = (data.zones || []).map(zone => ({
+                        id: zone.zone_id,
+                        name: zone.domain,
+                        status: zone.status,
+                        account_name: zone.account_name,
+                        imported: zone.imported,
+                    }));
                     this.showFlash(`${this.cfZones.length} Cloudflare zone${this.cfZones.length === 1 ? '' : 's'} found.`, true);
                 }
             } catch (err) {
@@ -1204,7 +1210,7 @@ function settingsApp() {
             this.importingCfZones = true;
             try {
                 const domains = this.cfZones.filter(z => !z.imported).map(z => z.name);
-                const res = await fetch('/api/v1/domains/cloudflare/import', {
+                const res = await fetch('/api/v1/domains/dns/import/cloudflare', {
                     method: 'POST',
                     headers: this.apiHeaders(),
                     body: JSON.stringify({ domains }),

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -19,7 +19,7 @@ from app.models.setting import Setting
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
-from app.services import cloudflare_dns, dns_provider_writes
+from app.services import cloudflare_dns, dns_provider_imports, dns_provider_writes
 from app.services.cloudflare_dns import analyze_dns_records, sync_dns_record_changes
 from app.services.dns_provider_writes import (
     CloudflareDNSWriteProvider,
@@ -341,7 +341,92 @@ def test_import_cloudflare_domains_imports_requested_and_skips_others(db_session
     assert result["imported"] == ["new.example"]
     assert result["existing"] == []
     assert sorted(result["skipped"]) == [DOMAIN, "skip.example"]
-    assert db_session.query(Domain).filter(Domain.name == "new.example").first() is not None
+    imported = db_session.query(Domain).filter(Domain.name == "new.example").first()
+    assert imported is not None
+    assert imported.description == "DNS-discovered from Cloudflare zone import"
+
+
+def test_dns_provider_import_preview_wraps_cloudflare_zones(db_session):
+    async def fake_discover(_db, workspace_id=None):
+        assert workspace_id == 123
+        return [
+            {
+                "id": "zone-1",
+                "name": DOMAIN,
+                "status": "active",
+                "account_name": "Example",
+                "imported": False,
+            },
+            {
+                "id": "zone-2",
+                "name": "existing.example",
+                "status": "active",
+                "account_name": "Example",
+                "imported": True,
+            },
+        ]
+
+    with patch("app.services.dns_provider_imports.discover_cloudflare_zones", new=fake_discover):
+        result = asyncio.run(
+            dns_provider_imports.preview_dns_provider_import(
+                db_session,
+                provider="cloudflare",
+                workspace_id=123,
+            )
+        )
+
+    assert result["provider"] == "cloudflare"
+    assert result["provider_name"] == "Cloudflare"
+    assert result["total_discovered"] == 2
+    assert result["importable_count"] == 1
+    assert result["zones"][0]["domain"] == DOMAIN
+    assert result["zones"][0]["importable"] is True
+    assert result["zones"][1]["next_action"] == "Already monitored in this workspace."
+
+
+def test_dns_provider_import_rejects_unsupported_provider(db_session):
+    with pytest.raises(LookupError, match="Unsupported DNS provider import"):
+        asyncio.run(
+            dns_provider_imports.preview_dns_provider_import(
+                db_session,
+                provider="unsupported",
+            )
+        )
+
+
+def test_dns_provider_import_apply_rejects_unsupported_provider(db_session):
+    with pytest.raises(LookupError, match="Unsupported DNS provider import"):
+        asyncio.run(
+            dns_provider_imports.import_dns_provider_domains(
+                db_session,
+                provider="unsupported",
+            )
+        )
+
+
+def test_dns_provider_import_creates_empty_report_domain_state(
+    authed_client: TestClient,
+    db_session,
+):
+    async def fake_discover(_db, workspace_id=None):
+        return [{"id": "zone-1", "name": "dns-only.example", "imported": False}]
+
+    with patch("app.services.cloudflare_dns.discover_cloudflare_zones", new=fake_discover):
+        result = asyncio.run(
+            dns_provider_imports.import_dns_provider_domains(
+                db_session,
+                provider="cloudflare",
+                requested_domains=["dns-only.example"],
+            )
+        )
+
+    assert result["imported"] == ["dns-only.example"]
+    response = authed_client.get("/api/v1/domains/domains")
+    assert response.status_code == 200
+    imported = next(item for item in response.json() if item["name"] == "dns-only.example")
+    assert imported["reports_count"] == 0
+    assert imported["emails_count"] == 0
+    assert imported["policy"] == "unknown"
 
 
 def test_import_cloudflare_domains_respects_monitored_domain_plan_limit(db_session):
@@ -490,6 +575,124 @@ def test_cloudflare_discover_endpoint_returns_zones(authed_client: TestClient):
 
     assert response.status_code == 200
     assert response.json()[0]["name"] == DOMAIN
+
+
+def test_dns_provider_import_preview_endpoint_returns_zones(authed_client: TestClient):
+    with patch(
+        "app.api.api_v1.endpoints.domains.preview_dns_provider_import",
+        new=AsyncMock(
+            return_value={
+                "provider": "cloudflare",
+                "provider_name": "Cloudflare",
+                "zones": [
+                    {
+                        "provider": "cloudflare",
+                        "provider_name": "Cloudflare",
+                        "zone_id": "zone-1",
+                        "domain": DOMAIN,
+                        "status": "active",
+                        "account_name": "Example",
+                        "imported": False,
+                        "importable": True,
+                        "source": "dns_zone",
+                        "next_action": "Import this Cloudflare zone.",
+                    }
+                ],
+                "total_discovered": 1,
+                "importable_count": 1,
+            }
+        ),
+    ):
+        response = authed_client.get("/api/v1/domains/dns/import/cloudflare/preview")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["provider"] == "cloudflare"
+    assert data["zones"][0]["domain"] == DOMAIN
+    assert data["zones"][0]["importable"] is True
+
+
+def test_dns_provider_import_endpoint_returns_import_summary(authed_client: TestClient):
+    with patch(
+        "app.api.api_v1.endpoints.domains.import_dns_provider_domains",
+        new=AsyncMock(
+            return_value={
+                "provider": "cloudflare",
+                "provider_name": "Cloudflare",
+                "imported": [DOMAIN],
+                "existing": [],
+                "skipped": [],
+                "total_discovered": 1,
+            }
+        ),
+    ):
+        response = authed_client.post(
+            "/api/v1/domains/dns/import/cloudflare",
+            json={"domains": [DOMAIN]},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["provider"] == "cloudflare"
+    assert data["imported"] == [DOMAIN]
+
+
+def test_dns_provider_import_endpoint_rejects_unknown_provider(authed_client: TestClient):
+    with patch(
+        "app.api.api_v1.endpoints.domains.preview_dns_provider_import",
+        new=AsyncMock(side_effect=LookupError("Unsupported DNS provider import: example")),
+    ):
+        response = authed_client.get("/api/v1/domains/dns/import/example/preview")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported DNS provider import: example"
+
+
+def test_dns_provider_import_endpoint_rejects_unknown_provider_on_apply(
+    authed_client: TestClient,
+):
+    with patch(
+        "app.api.api_v1.endpoints.domains.import_dns_provider_domains",
+        new=AsyncMock(side_effect=LookupError("Unsupported DNS provider import: example")),
+    ):
+        response = authed_client.post("/api/v1/domains/dns/import/example", json={})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported DNS provider import: example"
+
+
+def test_dns_provider_import_endpoint_surfaces_plan_limit(
+    authed_client: TestClient,
+):
+    plan_error = OrganizationPlanLimitError(
+        metric="monitored_domains",
+        current=1,
+        limit=1,
+        attempted=1,
+        unit="domains",
+        entitlement_key="monitored_domains",
+    )
+    with patch(
+        "app.api.api_v1.endpoints.domains.import_dns_provider_domains",
+        new=AsyncMock(side_effect=plan_error),
+    ):
+        response = authed_client.post(
+            "/api/v1/domains/dns/import/cloudflare",
+            json={"domains": [DOMAIN]},
+        )
+
+    assert response.status_code == 402
+    assert response.json()["detail"]["code"] == "plan_limit_exceeded"
+    assert response.json()["detail"]["metric"] == "monitored_domains"
+
+
+def test_dns_provider_capabilities_mark_cloudflare_import_available(authed_client: TestClient):
+    response = authed_client.get("/api/v1/domains/dns/providers")
+
+    assert response.status_code == 200
+    providers = {provider["id"]: provider for provider in response.json()["providers"]}
+    assert providers["cloudflare"]["import_available"] is True
+    assert providers["route53"]["import_available"] is False
 
 
 def test_cloudflare_import_endpoint_returns_import_summary(authed_client: TestClient):

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -158,6 +158,8 @@ The integration exposes these operational routes:
 
 | Route | Purpose |
 | --- | --- |
+| `GET /api/v1/domains/dns/import/cloudflare/preview` | Preview zones visible to the connected Cloudflare token without creating rows. |
+| `POST /api/v1/domains/dns/import/cloudflare` | Import selected Cloudflare zones as monitored domains before reports arrive. |
 | `GET /api/v1/domains/cloudflare/discover` | List available zones. |
 | `POST /api/v1/domains/cloudflare/import` | Create monitored domain rows from zones. |
 | `GET /api/v1/domains/{domain}/dns/cloudflare` | Inspect managed DNS records, return DMARC/SPF/DKIM suggestions, and record detected DNS changes. |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -571,6 +571,8 @@ GET /domains/{domain_id}/dns/lint
 GET /domains/{domain_id}/dns/change-plan
 POST /domains/{domain_id}/dns/change-plan/apply
 GET /domains/dns/providers
+GET /domains/dns/import/{provider}/preview
+POST /domains/dns/import/{provider}
 GET /domains/dns/lint
 GET /domains/dns/lint/export
 ```
@@ -594,7 +596,16 @@ access unless credentials are configured and the operator approves an apply
 request.
 
 `GET /domains/dns/providers` returns native and Lexicon-backed provider
-capabilities. `POST /domains/{domain_id}/dns/change-plan/apply` accepts
+capabilities plus whether a provider supports DNS-zone domain import. Use
+`GET /domains/dns/import/{provider}/preview` to list DNS zones visible to a
+connected provider without creating anything. Use
+`POST /domains/dns/import/{provider}` with an optional `domains` array to import
+selected zones as monitored DMARQ domains before reports have arrived.
+Cloudflare is the first supported provider; the legacy
+`/domains/cloudflare/discover` and `/domains/cloudflare/import` endpoints remain
+available for compatibility.
+
+`POST /domains/{domain_id}/dns/change-plan/apply` accepts
 `plan_id`, `provider`, `dry_run`, `confirm`, optional `value`, and `ttl`. Calls
 default to dry-run. Real writes require `dry_run=false` and `confirm=true`, are
 blocked in demo mode, and are limited to safe TXT/CNAME create/update plans

--- a/docs/user_guide/settings.md
+++ b/docs/user_guide/settings.md
@@ -132,8 +132,9 @@ If you use Cloudflare for DNS management:
 2. Configure:
    - **API Token**: Your Cloudflare API token
    - **Zone ID**: Optional Cloudflare Zone ID for a single domain
-3. Use **Discover** to list zones visible to the token.
-4. Use **Import New** to create monitored domain rows for discovered zones that are not already tracked.
+3. Use **Discover** to preview DNS zones visible to the token.
+4. Use **Import New** to create monitored domain rows for selected/new zones,
+   even before DMARQ has received reports for those domains.
 
 For inspection only, the token needs zone and DNS read access. To apply DNS
 change plans from a domain detail page, the token also needs Cloudflare DNS
@@ -141,6 +142,9 @@ write permission for the affected zone. DMARQ uses the token to fetch managed
 DNS records, detect missing or malformed DMARC/SPF/DKIM entries, record DNS
 additions, modifications, or removals over time, and apply explicitly approved
 TXT/CNAME remediation plans.
+
+The DNS-zone import workflow is provider-shaped. Cloudflare is supported first,
+with the API path designed for additional DNS providers.
 
 DMARQ never performs background DNS edits. A write-capable token only enables
 operator-approved actions from the DNS change plan UI, and each applied change


### PR DESCRIPTION
## Summary

- add a provider-shaped DNS zone import service with Cloudflare as the first adapter
- expose generic `/domains/dns/import/{provider}/preview` and `/domains/dns/import/{provider}` endpoints
- mark DNS provider capabilities with `import_available` so clients know which providers can import zones
- move the Settings Cloudflare discovery/import UI onto the generic API while keeping legacy Cloudflare routes compatible
- mark imported Cloudflare domains as DNS-discovered and document the new provider import flow

## Validation

- `./.venv/bin/pytest backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_api.py -q`
- `./.venv/bin/pytest backend/app/tests/test_public_api.py -q`
- `./.venv/bin/python -m py_compile backend/app/services/dns_provider_imports.py backend/app/services/cloudflare_dns.py backend/app/api/api_v1/endpoints/domains.py`
- `./.venv/bin/python -m black --check backend/app/services/dns_provider_imports.py backend/app/services/cloudflare_dns.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `./.venv/bin/python -m isort --check-only backend/app/services/dns_provider_imports.py backend/app/services/cloudflare_dns.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `./.venv/bin/python -m flake8 backend/app/services/dns_provider_imports.py backend/app/services/cloudflare_dns.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `git diff --check`

Progresses #379
