### PR TITLE
Import Postmark sender domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,6 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # Optional Cloudflare API Integration (for Milestone 8)
 # CLOUDFLARE_API_TOKEN="your_cloudflare_api_token"
 # CLOUDFLARE_ZONE_ID="your_cloudflare_zone_id"
+
+# Optional mail service sender-domain discovery
+# POSTMARK_ACCOUNT_TOKEN="your_postmark_account_token"

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -57,6 +57,13 @@ from app.services.health_score_snapshots import (
     list_workspace_health_score_snapshots,
     upsert_health_score_snapshot,
 )
+from app.services.mail_service_imports import (
+    MailServiceImportError,
+    import_mail_service_domains,
+    mail_service_context_from_domain,
+    preview_mail_service_import,
+    supported_mail_service_import_providers,
+)
 from app.services.migration_import import preview_migration_import
 from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
 from app.services.organizations import (
@@ -147,6 +154,7 @@ class DomainResponse(DomainBase):
     reports_count: int = 0
     emails_count: int = 0
     compliance_rate: float = 0.0
+    mail_service_context: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class DomainCreate(BaseModel):
@@ -721,6 +729,57 @@ class DNSProviderImportRequest(BaseModel):
 
 class DNSProviderImportResponse(BaseModel):
     """DNS provider domain import summary."""
+
+    provider: str
+    provider_name: str
+    imported: List[str]
+    existing: List[str]
+    skipped: List[str]
+    total_discovered: int
+
+
+class RequiredDNSRecordResponse(BaseModel):
+    """DNS record requested by an external service."""
+
+    record_type: str
+    name: str
+    value: str
+    purpose: str
+
+
+class MailServiceImportDomainResponse(BaseModel):
+    """Mail service sender domain that can be imported as a monitored domain."""
+
+    provider: str
+    provider_name: str
+    external_id: str
+    domain: str
+    verification_state: str
+    imported: bool = False
+    importable: bool = True
+    required_dns_records: List[RequiredDNSRecordResponse] = Field(default_factory=list)
+    source: str = "mail_service_sender"
+    next_action: str
+
+
+class MailServiceImportPreviewResponse(BaseModel):
+    """Read-only mail service sender-domain import preview."""
+
+    provider: str
+    provider_name: str
+    domains: List[MailServiceImportDomainResponse]
+    total_discovered: int
+    importable_count: int
+
+
+class MailServiceImportRequest(BaseModel):
+    """Optional sender domains to import after preview."""
+
+    domains: Optional[List[str]] = None
+
+
+class MailServiceImportResponse(BaseModel):
+    """Mail service sender-domain import summary."""
 
     provider: str
     provider_name: str
@@ -2242,6 +2301,7 @@ async def read_domains(
             reports_count=summary.get("reports_processed", 0),
             emails_count=summary.get("total_count", 0),
             compliance_rate=summary.get("compliance_rate", 0.0),
+            mail_service_context=mail_service_context_from_domain(stored_domain),
         )
         result.append(domain_response)
 
@@ -2306,6 +2366,7 @@ async def create_domain(
         name=domain.name,
         description=domain.description,
         policy=domain.dmarc_policy or "unknown",
+        mail_service_context=mail_service_context_from_domain(domain),
     )
 
 
@@ -2340,6 +2401,7 @@ async def read_domain(
         reports_count=summary.get("reports_processed", 0),
         emails_count=summary.get("total_count", 0),
         compliance_rate=summary.get("compliance_rate", 0.0),
+        mail_service_context=mail_service_context_from_domain(stored_domain),
     )
 
 
@@ -2498,6 +2560,86 @@ async def import_dns_provider_domain_zones(
     except LookupError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.get("/mail-services/import/providers")
+async def get_mail_service_import_providers(
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return mail service providers that support sender-domain import."""
+    return {"providers": supported_mail_service_import_providers()}
+
+
+@router.get(
+    "/mail-services/import/{provider}/preview",
+    response_model=MailServiceImportPreviewResponse,
+)
+async def preview_mail_service_domain_import(
+    provider: str = Path(..., title="Mail service provider ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+):
+    """Preview verified sender domains that can be imported as monitored domains."""
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    try:
+        return await preview_mail_service_import(
+            db,
+            provider=provider,
+            workspace_id=workspace.id,
+        )
+    except LookupError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except MailServiceImportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post(
+    "/mail-services/import/{provider}",
+    response_model=MailServiceImportResponse,
+)
+async def import_mail_service_domain_senders(
+    payload: MailServiceImportRequest,
+    provider: str = Path(..., title="Mail service provider ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+):
+    """Import selected, or all new, mail service sender domains as monitored domains."""
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    try:
+        return await import_mail_service_domains(
+            db,
+            provider=provider,
+            requested_domains=payload.domains,
+            workspace_id=workspace.id,
+        )
+    except OrganizationPlanLimitError as exc:
+        _raise_plan_limit_error(exc)
+    except LookupError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except MailServiceImportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
             detail=str(exc),
         ) from exc
 

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -4,12 +4,13 @@ Settings API endpoints.
 Provides endpoints to read and write application-level settings persisted
 in the ``settings`` database table.  Settings are organised into categories:
 
-- ``general``    – App name, base URL, reports-per-page, etc.
-- ``dmarc``      – Default DMARC policy, percentage, etc.
-- ``dns``        – Default DNS resolver, Cloudflare DoH toggle.
-- ``cloudflare`` – Cloudflare API token and Zone ID.
-- ``forensics`` – Forensic report privacy and retention controls.
-- ``notifications`` – Future alerting/notification settings.
+- ``general``    - App name, base URL, reports-per-page, etc.
+- ``dmarc``      - Default DMARC policy, percentage, etc.
+- ``dns``        - Default DNS resolver, Cloudflare DoH toggle.
+- ``cloudflare`` - Cloudflare API token and Zone ID.
+- ``postmark``  - Postmark account token for read-only sender-domain discovery.
+- ``forensics`` - Forensic report privacy and retention controls.
+- ``notifications`` - Future alerting/notification settings.
 """
 
 import logging
@@ -132,6 +133,14 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
         "description": "Cloudflare Zone ID for DNS record management",
         "value_type": "string",
         "category": "cloudflare",
+    },
+    # ── Mail service integrations ───────────────────────────────────────────
+    {
+        "key": "postmark.account_token",
+        "value": "",
+        "description": "Postmark account token for read-only sender-domain discovery",
+        "value_type": "string",
+        "category": "postmark",
     },
     # ── Forensics ────────────────────────────────────────────────────────────
     {
@@ -341,6 +350,7 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
 # Keys whose values should be redacted in GET responses (treated as secrets)
 _SECRET_KEYS = {
     "cloudflare.api_token",
+    "postmark.account_token",
     "notifications.apprise_urls",
     "notifications.smtp_password",
 }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -52,6 +52,7 @@ class Settings(BaseSettings):
     # Optional Cloudflare Integration
     CLOUDFLARE_API_TOKEN: Optional[str] = None
     CLOUDFLARE_ZONE_ID: Optional[str] = None
+    POSTMARK_ACCOUNT_TOKEN: Optional[str] = None
     WEBHOOK_SECRET: Optional[str] = None
 
     # Optional Stripe Billing integration. Self-hosted and provider-billed

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,6 +35,7 @@ from app.models.mail_source import MailSource  # noqa: F401 – ensure table is 
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
+from app.services.mail_service_imports import mail_service_context_from_domain
 from app.services.mail_source_backfill_worker import run_due_mail_source_backfill_jobs
 from app.services.microsoft_graph_client import MicrosoftGraphClient
 from app.services.report_persistence import hydrate_report_store_from_db
@@ -652,6 +653,7 @@ async def domain_details(request: Request, domain_id: str):
             "domain": {
                 "name": domain_id,
                 "description": stored_domain.description if stored_domain else "",
+                "mail_service_context": mail_service_context_from_domain(stored_domain),
                 "policy": (
                     domain_summary.get("policy")
                     or (stored_domain.dmarc_policy if stored_domain else None)

--- a/backend/app/services/mail_service_imports.py
+++ b/backend/app/services/mail_service_imports.py
@@ -1,0 +1,453 @@
+"""Read-only mail service sender-domain discovery and import helpers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional
+
+import httpx
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.core.credential_encryption import decrypt_secret
+from app.models.domain import Domain
+from app.models.setting import Setting
+from app.models.workspace import Workspace
+from app.services.organizations import require_organization_plan_limit
+from app.services.workspaces import assign_default_workspace_to_unscoped_rows
+
+POSTMARK_API_BASE = "https://api.postmarkapp.com"
+MAIL_SERVICE_DESCRIPTION_PREFIX = "Mail-service sender domain imported from "
+
+
+class MailServiceImportError(RuntimeError):
+    """Raised when a mail service API request fails."""
+
+
+@dataclass
+class RequiredDNSRecord:
+    """DNS record requested by a mail delivery service."""
+
+    record_type: str
+    name: str
+    value: str
+    purpose: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return asdict(self)
+
+
+@dataclass
+# pylint: disable=too-many-instance-attributes
+class MailServiceDomain:
+    """One verified or pending sender domain visible in a mail service."""
+
+    provider: str
+    provider_name: str
+    external_id: str
+    domain: str
+    verification_state: str
+    imported: bool = False
+    importable: bool = True
+    required_dns_records: Optional[List[Dict[str, str]]] = None
+    source: str = "mail_service_sender"
+    next_action: str = "Import this sender domain to monitor DNS posture before reports arrive."
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["required_dns_records"] = self.required_dns_records or []
+        return payload
+
+
+PROVIDER_NAMES = {
+    "postmark": "Postmark",
+}
+
+
+def supported_mail_service_import_providers() -> List[Dict[str, str]]:
+    """Return mail service providers that support sender-domain import."""
+    return [{"id": provider_id, "name": name} for provider_id, name in PROVIDER_NAMES.items()]
+
+
+def _provider_name(provider_id: str) -> str:
+    return PROVIDER_NAMES.get(provider_id, provider_id)
+
+
+def _normalize_provider(provider: str) -> str:
+    return (provider or "").strip().lower().replace("_", "-")
+
+
+def _setting_value(db: Session, key: str) -> Optional[str]:
+    row = db.query(Setting).filter(Setting.key == key).first()
+    if row is None or not row.value:
+        return None
+    if key == "postmark.account_token":
+        return decrypt_secret(row.value)
+    return row.value
+
+
+def get_postmark_account_token(db: Session) -> Optional[str]:
+    """Resolve the Postmark account token from settings or environment."""
+    return _setting_value(db, "postmark.account_token") or get_settings().POSTMARK_ACCOUNT_TOKEN
+
+
+def _domain_from_email(value: Any) -> Optional[str]:
+    if not value:
+        return None
+    text = str(value).strip().lower()
+    if "@" not in text:
+        return None
+    domain = text.rsplit("@", 1)[1].strip()
+    return domain or None
+
+
+def _verification_state(*flags: Optional[bool]) -> str:
+    known = [flag for flag in flags if flag is not None]
+    if known and all(known):
+        return "verified"
+    if known and any(known):
+        return "partial"
+    return "pending"
+
+
+def _add_record(
+    records: List[Dict[str, str]],
+    *,
+    record_type: str,
+    name: Any,
+    value: Any,
+    purpose: str,
+) -> None:
+    if not name or not value:
+        return
+    records.append(
+        RequiredDNSRecord(
+            record_type=record_type,
+            name=str(name),
+            value=str(value),
+            purpose=purpose,
+        ).to_dict()
+    )
+
+
+def _postmark_domain_records(item: Dict[str, Any]) -> List[Dict[str, str]]:
+    records: List[Dict[str, str]] = []
+    _add_record(
+        records,
+        record_type="TXT",
+        name=item.get("DKIMPendingHost") or item.get("DKIMHost"),
+        value=item.get("DKIMPendingTextValue") or item.get("DKIMTextValue"),
+        purpose="dkim",
+    )
+    _add_record(
+        records,
+        record_type="CNAME",
+        name=item.get("ReturnPathDomain"),
+        value=item.get("ReturnPathDomainCNAMEValue"),
+        purpose="return_path",
+    )
+    return records
+
+
+def _postmark_sender_records(item: Dict[str, Any]) -> List[Dict[str, str]]:
+    records: List[Dict[str, str]] = []
+    _add_record(
+        records,
+        record_type="TXT",
+        name=item.get("DKIMHost"),
+        value=item.get("DKIMTextValue"),
+        purpose="dkim",
+    )
+    _add_record(
+        records,
+        record_type="CNAME",
+        name=item.get("ReturnPathDomain"),
+        value=item.get("ReturnPathDomainCNAMEValue"),
+        purpose="return_path",
+    )
+    return records
+
+
+async def _postmark_get(path: str, token: str) -> Dict[str, Any]:
+    headers = {
+        "Accept": "application/json",
+        "X-Postmark-Account-Token": token,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.get(f"{POSTMARK_API_BASE}{path}", headers=headers)
+            response.raise_for_status()
+            return response.json()
+    except (httpx.RequestError, httpx.HTTPStatusError, ValueError) as exc:
+        raise MailServiceImportError(f"Postmark discovery failed: {exc}") from exc
+
+
+async def _postmark_get_all(
+    path: str,
+    key: str,
+    token: str,
+    *,
+    count: int = 500,
+) -> List[Dict[str, Any]]:
+    """Return every item from a paginated Postmark account endpoint."""
+    items: List[Dict[str, Any]] = []
+    offset = 0
+    total_count: Optional[int] = None
+    while total_count is None or offset < total_count:
+        separator = "&" if "?" in path else "?"
+        payload = await _postmark_get(f"{path}{separator}count={count}&offset={offset}", token)
+        page_items = payload.get(key) or []
+        items.extend(page_items)
+        total_count = int(payload.get("TotalCount") or len(items))
+        if not page_items:
+            break
+        offset += len(page_items)
+        if offset >= total_count:
+            break
+    return items
+
+
+def _first_present_bool(item: Dict[str, Any], *keys: str) -> Optional[bool]:
+    for key in keys:
+        if key in item:
+            value = item.get(key)
+            return bool(value) if value is not None else None
+    return None
+
+
+async def discover_postmark_sender_domains(
+    db: Session,
+    *,
+    workspace_id: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Return Postmark sender domains and sender signatures with import state."""
+    token = get_postmark_account_token(db)
+    if not token:
+        raise LookupError("Postmark account token is not configured")
+
+    known_query = db.query(Domain.name)
+    if workspace_id is not None:
+        known_query = known_query.filter(Domain.workspace_id == workspace_id)
+    known_domains = {name for (name,) in known_query.all()}
+
+    domain_items = await _postmark_get_all("/domains", "Domains", token)
+    sender_items = await _postmark_get_all("/senders", "SenderSignatures", token)
+    items: Dict[str, Dict[str, Any]] = {}
+
+    for item in domain_items:
+        name = str(item.get("Name") or "").strip().lower()
+        if not name:
+            continue
+        state = _verification_state(
+            item.get("DKIMVerified"),
+            _first_present_bool(item, "ReturnPathDomainVerified", "SPFVerified"),
+        )
+        items[name] = {
+            "provider": "postmark",
+            "provider_name": _provider_name("postmark"),
+            "external_id": str(item.get("ID") or name),
+            "domain": name,
+            "verification_state": state,
+            "required_dns_records": _postmark_domain_records(item),
+            "imported": name in known_domains,
+        }
+
+    for item in sender_items:
+        name = str(item.get("Domain") or "").strip().lower() or _domain_from_email(
+            item.get("EmailAddress")
+        )
+        if not name:
+            continue
+        state = "verified" if item.get("Confirmed") else "pending"
+        if name in items:
+            if items[name]["verification_state"] != "verified" and state == "verified":
+                items[name]["verification_state"] = state
+            items[name]["required_dns_records"].extend(_postmark_sender_records(item))
+            continue
+        items[name] = {
+            "provider": "postmark",
+            "provider_name": _provider_name("postmark"),
+            "external_id": str(item.get("ID") or name),
+            "domain": name,
+            "verification_state": state,
+            "required_dns_records": _postmark_sender_records(item),
+            "imported": name in known_domains,
+        }
+
+    return list(items.values())
+
+
+async def preview_mail_service_import(
+    db: Session,
+    *,
+    provider: str,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return importable sender domains for a mail service without creating rows."""
+    provider_id = _normalize_provider(provider)
+    if provider_id != "postmark":
+        raise LookupError(f"Unsupported mail service import: {provider_id}")
+
+    domains = await discover_postmark_sender_domains(db, workspace_id=workspace_id)
+    items = [
+        MailServiceDomain(
+            provider=provider_id,
+            provider_name=_provider_name(provider_id),
+            external_id=str(item["external_id"]),
+            domain=str(item["domain"]).lower(),
+            verification_state=str(item.get("verification_state") or "pending"),
+            imported=bool(item.get("imported")),
+            importable=not bool(item.get("imported")),
+            required_dns_records=item.get("required_dns_records") or [],
+            next_action=(
+                "Already monitored in this workspace."
+                if item.get("imported")
+                else (
+                    "Import this Postmark sender domain to monitor mail health before "
+                    "reports arrive."
+                )
+            ),
+        ).to_dict()
+        for item in domains
+    ]
+    return {
+        "provider": provider_id,
+        "provider_name": _provider_name(provider_id),
+        "domains": items,
+        "total_discovered": len(items),
+        "importable_count": sum(1 for item in items if item["importable"]),
+    }
+
+
+def mail_service_context_from_domain(domain: Optional[Domain]) -> List[Dict[str, str]]:
+    """Extract displayable mail service context from imported domain descriptions."""
+    if domain is None or not domain.description:
+        return []
+    description = domain.description.strip()
+    if not description.startswith(MAIL_SERVICE_DESCRIPTION_PREFIX):
+        return []
+    remainder = description[len(MAIL_SERVICE_DESCRIPTION_PREFIX) :]
+    provider_name = remainder.split("(", 1)[0].strip().rstrip(".")
+    state = ""
+    if "(" in remainder and ")" in remainder:
+        state = remainder.split("(", 1)[1].split(")", 1)[0].strip()
+    return [
+        {
+            "provider": provider_name.lower(),
+            "provider_name": provider_name,
+            "verification_state": state or "unknown",
+            "source": "mail_service_sender",
+        }
+    ]
+
+
+def _existing_domain_names(db: Session, domain_names: List[str]) -> set[str]:
+    if not domain_names:
+        return set()
+    return {row[0] for row in db.query(Domain.name).filter(Domain.name.in_(domain_names)).all()}
+
+
+def _create_imported_domain(
+    db: Session,
+    *,
+    name: str,
+    provider_name: str,
+    state: str,
+    workspace_id: int,
+) -> str:
+    db.add(
+        Domain(
+            name=name,
+            description=(
+                f"{MAIL_SERVICE_DESCRIPTION_PREFIX}{provider_name} "
+                f"({state}). DNS records are still linted and repaired in DMARQ."
+            ),
+            active=True,
+            verified=(state == "verified"),
+            workspace_id=workspace_id,
+        )
+    )
+    try:
+        db.commit()
+        return "imported"
+    except IntegrityError:
+        db.rollback()
+        return "existing" if _existing_domain_names(db, [name]) else "skipped"
+
+
+async def import_mail_service_domains(
+    db: Session,
+    *,
+    provider: str,
+    requested_domains: Optional[List[str]] = None,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Import selected mail service sender domains as monitored domains."""
+    # pylint: disable=too-many-branches,too-many-locals
+    provider_id = _normalize_provider(provider)
+    if provider_id != "postmark":
+        raise LookupError(f"Unsupported mail service import: {provider_id}")
+
+    if workspace_id is None:
+        workspace = assign_default_workspace_to_unscoped_rows(db)
+        workspace_id = workspace.id
+    else:
+        workspace = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+
+    preview = await preview_mail_service_import(
+        db,
+        provider=provider_id,
+        workspace_id=workspace_id,
+    )
+    requested = {domain.strip().lower() for domain in requested_domains or [] if domain.strip()}
+    imported: List[str] = []
+    existing: List[str] = []
+    skipped: List[str] = []
+    candidate_names: List[str] = []
+    states: Dict[str, str] = {}
+
+    for item in preview["domains"]:
+        name = str(item["domain"]).lower()
+        if requested and name not in requested:
+            skipped.append(name)
+            continue
+        candidate_names.append(name)
+        states[name] = str(item.get("verification_state") or "pending")
+
+    existing_names = _existing_domain_names(db, candidate_names)
+    new_names = [name for name in candidate_names if name not in existing_names]
+    if workspace and workspace.organization and new_names:
+        require_organization_plan_limit(
+            db,
+            workspace.organization,
+            "monitored_domains",
+            increment=len(new_names),
+        )
+
+    provider_name = _provider_name(provider_id)
+    for name in candidate_names:
+        if name in existing_names:
+            existing.append(name)
+        else:
+            result = _create_imported_domain(
+                db,
+                name=name,
+                provider_name=provider_name,
+                state=states.get(name, "pending"),
+                workspace_id=workspace_id,
+            )
+            if result == "imported":
+                imported.append(name)
+            elif result == "existing":
+                existing.append(name)
+            else:
+                skipped.append(name)
+    return {
+        "provider": provider_id,
+        "provider_name": provider_name,
+        "imported": imported,
+        "existing": existing,
+        "skipped": skipped,
+        "total_discovered": preview["total_discovered"],
+    }

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -25,6 +25,17 @@
                     <p class="mb-2 text-sm font-semibold uppercase tracking-wide text-[#2f9da5]">Domain detail</p>
                     <h1 class="text-3xl font-bold tracking-normal text-[#07071f]">{{ domain.name }}</h1>
                     <p class="mt-2 max-w-3xl text-[#5f5c78]">{{ domain.description or "Domain monitored by DMARQ" }}</p>
+                    {% if domain.mail_service_context %}
+                    <div class="mt-4 flex flex-wrap gap-2">
+                        {% for context in domain.mail_service_context %}
+                        <span class="inline-flex items-center gap-2 rounded-md border border-[#d7eef0] bg-[#f1fbfc] px-3 py-1 text-sm font-semibold text-[#176d74]">
+                            <span>{{ context.provider_name }}</span>
+                            <span class="h-1 w-1 rounded-full bg-[#2f9da5]"></span>
+                            <span>{{ context.verification_state|capitalize }} sender domain</span>
+                        </span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
                 </div>
                 <div class="flex flex-wrap gap-2">
                     <a href="/domains" class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]">

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -262,6 +262,124 @@
         {% endcall %}
     {% endcall %}
 
+    <!-- ── Mail Service Imports ───────────────────────────────────────────── -->
+    {% call card() %}
+        {% call card_header() %}
+            {% call card_title() %}Mail Service Imports{% endcall %}
+            {% call card_description() %}
+                Discover verified sender domains from mail delivery services before DMARC reports arrive. Postmark uses an account token with read-only sender-domain discovery in DMARQ.
+            {% endcall %}
+        {% endcall %}
+        {% call card_content() %}
+            <form @submit.prevent="saveCategory('postmark')" class="space-y-4">
+                <div class="form-control w-full">
+                    <label class="label"><span class="label-text font-medium">Postmark Account Token</span></label>
+                    <div class="relative">
+                        <input :type="showPostmarkToken ? 'text' : 'password'"
+                            x-model="s['postmark.account_token']"
+                            class="input input-bordered w-full pr-10"
+                            placeholder="Postmark account token" />
+                        <button type="button"
+                            class="absolute right-2 top-3 text-muted-foreground hover:text-foreground"
+                            @click="showPostmarkToken = !showPostmarkToken">
+                            <svg x-show="!showPostmarkToken" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>
+                            <svg x-show="showPostmarkToken" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line></svg>
+                        </button>
+                    </div>
+                    <label class="label"><span class="label-text-alt text-muted-foreground">Stored securely; leave as-is to keep an existing token</span></label>
+                </div>
+
+                <div class="border-t border-border pt-4 space-y-4">
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold">Verified Sender Domains</h3>
+                            <p class="text-sm text-muted-foreground">Preview Postmark domains and import them into DMARQ for DNS linting and monitoring.</p>
+                        </div>
+                        <div class="flex flex-col gap-2 sm:flex-row">
+                            <button type="button" class="btn btn-outline btn-sm" :disabled="saving || loadingMailServiceDomains" @click="discoverMailServiceDomains()">
+                                <template x-if="!loadingMailServiceDomains">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
+                                        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path>
+                                        <path d="M3 3v5h5"></path>
+                                    </svg>
+                                </template>
+                                <template x-if="loadingMailServiceDomains"><span class="loading loading-spinner loading-xs mr-2"></span></template>
+                                Discover
+                            </button>
+                            <button type="button" class="btn btn-default btn-sm" :disabled="saving || importingMailServiceDomains || mailServiceDomains.length === 0" @click="importMailServiceDomains()">
+                                <template x-if="!importingMailServiceDomains">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
+                                        <path d="M12 5v14"></path>
+                                        <path d="m19 12-7 7-7-7"></path>
+                                    </svg>
+                                </template>
+                                <template x-if="importingMailServiceDomains"><span class="loading loading-spinner loading-xs mr-2"></span></template>
+                                Import New
+                            </button>
+                        </div>
+                    </div>
+                    <template x-if="mailServiceDomains.length > 0">
+                        <div class="overflow-x-auto rounded-md border border-border">
+                            <table class="table table-sm">
+                                <thead>
+                                    <tr>
+                                        <th>Domain</th>
+                                        <th>Provider</th>
+                                        <th>Verification</th>
+                                        <th>DNS Records</th>
+                                        <th>Imported</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <template x-for="domain in mailServiceDomains" :key="domain.provider + ':' + domain.external_id">
+                                        <tr>
+                                            <td class="font-medium" x-text="domain.domain"></td>
+                                            <td x-text="domain.provider_name"></td>
+                                            <td x-text="domain.verification_state"></td>
+                                            <td>
+                                                <template x-if="domain.required_dns_records.length === 0">
+                                                    <span class="text-muted-foreground">None</span>
+                                                </template>
+                                                <div class="space-y-1" x-show="domain.required_dns_records.length > 0">
+                                                    <template x-for="record in domain.required_dns_records" :key="record.record_type + ':' + record.name + ':' + record.value">
+                                                        <div class="rounded border border-border bg-muted/30 px-2 py-1">
+                                                            <div class="flex flex-wrap items-center gap-2 text-xs">
+                                                                <span class="badge badge-outline badge-sm" x-text="record.record_type"></span>
+                                                                <span class="font-medium" x-text="record.name"></span>
+                                                            </div>
+                                                            <code class="mt-1 block max-w-md truncate text-xs text-muted-foreground" x-text="record.value"></code>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <span class="badge" :class="domain.imported ? 'badge-success' : 'badge-outline'" x-text="domain.imported ? 'Yes' : 'No'"></span>
+                                            </td>
+                                        </tr>
+                                    </template>
+                                </tbody>
+                            </table>
+                        </div>
+                    </template>
+                </div>
+                <div class="flex justify-end">
+                    <button type="submit" class="btn btn-default btn-md" :disabled="saving">
+                        <template x-if="!saving">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path><polyline points="17 21 17 13 7 13 7 21"></polyline><polyline points="7 3 7 8 15 8"></polyline></svg>
+                        </template>
+                        <template x-if="saving"><span class="loading loading-spinner loading-xs mr-2"></span></template>
+                        Save Postmark Settings
+                    </button>
+                </div>
+            </form>
+        {% endcall %}
+    {% endcall %}
+
     <!-- ── Forensics ──────────────────────────────────────────────────────── -->
     {% call card() %}
         {% call card_header() %}
@@ -910,6 +1028,10 @@ function settingsApp() {
         importingCfZones: false,
         cfZones: [],
         showCfToken: false,
+        loadingMailServiceDomains: false,
+        importingMailServiceDomains: false,
+        mailServiceDomains: [],
+        showPostmarkToken: false,
         loadingWebhooks: false,
         savingWebhook: false,
         testingWebhookId: null,
@@ -931,6 +1053,15 @@ function settingsApp() {
         // No manual auth header needed for API calls from the UI.
         apiHeaders() {
             return { 'Content-Type': 'application/json' };
+        },
+
+        workspaceHeaders() {
+            const headers = this.apiHeaders();
+            const workspaceId = localStorage.getItem('dmarq.selectedWorkspaceId');
+            if (workspaceId) {
+                headers['X-DMARQ-Workspace-ID'] = workspaceId;
+            }
+            return headers;
         },
 
         async loadSettings() {
@@ -1226,6 +1357,50 @@ function settingsApp() {
                 this.showFlash('Error importing Cloudflare zones: ' + err.message, false);
             } finally {
                 this.importingCfZones = false;
+            }
+        },
+
+        async discoverMailServiceDomains() {
+            this.loadingMailServiceDomains = true;
+            try {
+                await this.saveCategory('postmark');
+                const res = await fetch('/api/v1/domains/mail-services/import/postmark/preview', {
+                    headers: this.workspaceHeaders(),
+                });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok) {
+                    this.showFlash('Postmark discovery failed: ' + (data.detail || res.statusText), false);
+                } else {
+                    this.mailServiceDomains = data.domains || [];
+                    this.showFlash(`${this.mailServiceDomains.length} sender domain${this.mailServiceDomains.length === 1 ? '' : 's'} found.`, true);
+                }
+            } catch (err) {
+                this.showFlash('Error discovering sender domains: ' + err.message, false);
+            } finally {
+                this.loadingMailServiceDomains = false;
+            }
+        },
+
+        async importMailServiceDomains() {
+            this.importingMailServiceDomains = true;
+            try {
+                const domains = this.mailServiceDomains.filter(d => !d.imported).map(d => d.domain);
+                const res = await fetch('/api/v1/domains/mail-services/import/postmark', {
+                    method: 'POST',
+                    headers: this.workspaceHeaders(),
+                    body: JSON.stringify({ domains }),
+                });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok) {
+                    this.showFlash('Postmark import failed: ' + (data.detail || res.statusText), false);
+                } else {
+                    await this.discoverMailServiceDomains();
+                    this.showFlash(`${data.imported.length} domain${data.imported.length === 1 ? '' : 's'} imported.`, true);
+                }
+            } catch (err) {
+                this.showFlash('Error importing sender domains: ' + err.message, false);
+            } finally {
+                this.importingMailServiceDomains = false;
             }
         },
 

--- a/backend/app/tests/test_mail_service_imports.py
+++ b/backend/app/tests/test_mail_service_imports.py
@@ -1,0 +1,578 @@
+"""Tests for mail-service sender-domain discovery and import."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.domain import Domain
+from app.models.setting import Setting
+from app.services import mail_service_imports
+from app.services.mail_service_imports import MailServiceImportError
+from app.services.organizations import OrganizationPlanLimitError
+
+DOMAIN = "example.com"
+
+
+async def _fake_postmark_get(path, _token):
+    if path.startswith("/domains"):
+        return {
+            "Domains": [
+                {
+                    "ID": 123,
+                    "Name": DOMAIN,
+                    "DKIMVerified": True,
+                    "ReturnPathDomainVerified": True,
+                    "DKIMPendingHost": "pm._domainkey.example.com",
+                    "DKIMPendingTextValue": "k=rsa; p=abc",
+                    "ReturnPathDomain": "pm-bounces.example.com",
+                    "ReturnPathDomainCNAMEValue": "pm.mtasv.net",
+                }
+            ]
+        }
+    if path.startswith("/senders"):
+        return {
+            "SenderSignatures": [
+                {
+                    "ID": 456,
+                    "EmailAddress": "billing@pending.example",
+                    "Confirmed": False,
+                    "Domain": "pending.example",
+                    "DKIMHost": "pm._domainkey.pending.example",
+                    "DKIMTextValue": "k=rsa; p=pending",
+                }
+            ]
+        }
+    return {}
+
+
+def test_postmark_token_uses_secret_setting(db_session):
+    db_session.add(
+        Setting(
+            key="postmark.account_token",
+            value="encrypted-token",
+            category="postmark",
+        )
+    )
+    db_session.commit()
+
+    with patch("app.services.mail_service_imports.decrypt_secret", return_value="token"):
+        assert mail_service_imports.get_postmark_account_token(db_session) == "token"
+
+
+def test_postmark_token_falls_back_to_environment(db_session):
+    class FakeSettings:
+        POSTMARK_ACCOUNT_TOKEN = "env-token"
+
+    with patch("app.services.mail_service_imports.get_settings", return_value=FakeSettings()):
+        assert mail_service_imports.get_postmark_account_token(db_session) == "env-token"
+
+
+def test_mail_service_helpers_handle_empty_values(db_session):
+    assert mail_service_imports._domain_from_email(None) is None
+    assert mail_service_imports._domain_from_email("not-an-email") is None
+    assert mail_service_imports._verification_state(False, False) == "pending"
+    assert not mail_service_imports._postmark_domain_records({})
+    assert not mail_service_imports.mail_service_context_from_domain(None)
+    assert not mail_service_imports.mail_service_context_from_domain(
+        Domain(name="plain.example", description="plain domain")
+    )
+    assert mail_service_imports._existing_domain_names(db_session, []) == set()
+
+
+def test_postmark_get_success_and_json_error(monkeypatch):
+    class FakeResponse:
+        def __init__(self, fail_json=False):
+            self.fail_json = fail_json
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            if self.fail_json:
+                raise ValueError("bad json")
+            return {"ok": True}
+
+    class FakeClient:
+        fail_json = False
+
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, url, headers):
+            assert url.endswith("/domains")
+            assert headers["X-Postmark-Account-Token"] == "token"
+            return FakeResponse(fail_json=self.fail_json)
+
+    monkeypatch.setattr(mail_service_imports.httpx, "AsyncClient", FakeClient)
+    assert asyncio.run(mail_service_imports._postmark_get("/domains", "token")) == {"ok": True}
+
+    FakeClient.fail_json = True
+    with pytest.raises(MailServiceImportError, match="Postmark discovery failed"):
+        asyncio.run(mail_service_imports._postmark_get("/domains", "token"))
+
+
+def test_postmark_discovery_requires_token(db_session):
+    with patch("app.services.mail_service_imports.get_postmark_account_token", return_value=None):
+        with pytest.raises(LookupError, match="Postmark account token is not configured"):
+            asyncio.run(mail_service_imports.discover_postmark_sender_domains(db_session))
+
+
+def test_postmark_discovery_skips_empty_items_and_merges_sender_state(db_session):
+    async def fake_postmark_get(path, _token):
+        if path.startswith("/domains"):
+            return {
+                "Domains": [
+                    {"ID": 0, "Name": ""},
+                    {"ID": 1, "Name": "merge.example", "DKIMVerified": False},
+                ]
+            }
+        if path.startswith("/senders"):
+            return {
+                "SenderSignatures": [
+                    {"ID": 0, "Confirmed": True},
+                    {
+                        "ID": 2,
+                        "EmailAddress": "sender@merge.example",
+                        "Confirmed": True,
+                        "DKIMHost": "pm._domainkey.merge.example",
+                        "DKIMTextValue": "k=rsa; p=merge",
+                    },
+                ]
+            }
+        return {}
+
+    with (
+        patch("app.services.mail_service_imports.get_postmark_account_token", return_value="token"),
+        patch("app.services.mail_service_imports._postmark_get", new=fake_postmark_get),
+    ):
+        result = asyncio.run(mail_service_imports.discover_postmark_sender_domains(db_session))
+
+    assert len(result) == 1
+    assert result[0]["domain"] == "merge.example"
+    assert result[0]["verification_state"] == "verified"
+    assert result[0]["required_dns_records"][0]["purpose"] == "dkim"
+
+
+def test_postmark_import_preview_paginates_sender_domains(db_session):
+    async def fake_postmark_get(path, _token):
+        if path == "/domains?count=500&offset=0":
+            return {
+                "TotalCount": 2,
+                "Domains": [
+                    {"ID": 1, "Name": "one.example", "DKIMVerified": True},
+                ],
+            }
+        if path == "/domains?count=500&offset=1":
+            return {
+                "TotalCount": 2,
+                "Domains": [
+                    {"ID": 2, "Name": "two.example", "DKIMVerified": True},
+                ],
+            }
+        if path == "/senders?count=500&offset=0":
+            return {"TotalCount": 0, "SenderSignatures": []}
+        return {}
+
+    with (
+        patch("app.services.mail_service_imports.get_postmark_account_token", return_value="token"),
+        patch("app.services.mail_service_imports._postmark_get", new=fake_postmark_get),
+    ):
+        result = asyncio.run(
+            mail_service_imports.preview_mail_service_import(db_session, provider="postmark")
+        )
+
+    assert [item["domain"] for item in result["domains"]] == ["one.example", "two.example"]
+
+
+def test_postmark_import_preview_preserves_false_verification(db_session):
+    async def fake_postmark_get(path, _token):
+        if path.startswith("/domains"):
+            return {
+                "Domains": [
+                    {
+                        "ID": 1,
+                        "Name": "partial.example",
+                        "DKIMVerified": True,
+                        "ReturnPathDomainVerified": False,
+                        "SPFVerified": True,
+                    }
+                ]
+            }
+        if path.startswith("/senders"):
+            return {"SenderSignatures": []}
+        return {}
+
+    with (
+        patch("app.services.mail_service_imports.get_postmark_account_token", return_value="token"),
+        patch("app.services.mail_service_imports._postmark_get", new=fake_postmark_get),
+    ):
+        result = asyncio.run(
+            mail_service_imports.preview_mail_service_import(db_session, provider="postmark")
+        )
+
+    assert result["domains"][0]["verification_state"] == "partial"
+
+
+def test_postmark_import_preview_returns_sender_domains(db_session):
+    db_session.add(
+        Domain(
+            name=DOMAIN,
+            active=True,
+            verified=True,
+        )
+    )
+    db_session.commit()
+
+    with (
+        patch("app.services.mail_service_imports.get_postmark_account_token", return_value="token"),
+        patch("app.services.mail_service_imports._postmark_get", new=_fake_postmark_get),
+    ):
+        result = asyncio.run(
+            mail_service_imports.preview_mail_service_import(db_session, provider="postmark")
+        )
+
+    assert result["provider"] == "postmark"
+    assert result["provider_name"] == "Postmark"
+    assert result["total_discovered"] == 2
+    assert result["importable_count"] == 1
+    imported = next(item for item in result["domains"] if item["domain"] == DOMAIN)
+    pending = next(item for item in result["domains"] if item["domain"] == "pending.example")
+    assert imported["verification_state"] == "verified"
+    assert imported["imported"] is True
+    assert imported["required_dns_records"][0]["purpose"] == "dkim"
+    assert pending["verification_state"] == "pending"
+    assert pending["required_dns_records"][0]["name"] == "pm._domainkey.pending.example"
+
+
+def test_postmark_import_creates_domain_with_context(db_session):
+    async def fake_discover(_db, **_kwargs):
+        return [
+            {
+                "provider": "postmark",
+                "provider_name": "Postmark",
+                "external_id": "domain-1",
+                "domain": "new.example",
+                "verification_state": "verified",
+                "required_dns_records": [],
+                "imported": False,
+            }
+        ]
+
+    with patch(
+        "app.services.mail_service_imports.discover_postmark_sender_domains",
+        new=fake_discover,
+    ):
+        first = asyncio.run(
+            mail_service_imports.import_mail_service_domains(
+                db_session,
+                provider="postmark",
+                requested_domains=["new.example"],
+            )
+        )
+        second = asyncio.run(
+            mail_service_imports.import_mail_service_domains(
+                db_session,
+                provider="postmark",
+                requested_domains=["new.example"],
+            )
+        )
+
+    domain = db_session.query(Domain).filter(Domain.name == "new.example").one()
+    context = mail_service_imports.mail_service_context_from_domain(domain)
+    assert first["imported"] == ["new.example"]
+    assert second["existing"] == ["new.example"]
+    assert domain.verified is True
+    assert "Postmark (verified)" in domain.description
+    assert context[0]["provider_name"] == "Postmark"
+    assert context[0]["verification_state"] == "verified"
+
+
+def test_mail_service_import_rejects_unsupported_provider(db_session):
+    with pytest.raises(LookupError, match="Unsupported mail service import"):
+        asyncio.run(
+            mail_service_imports.preview_mail_service_import(db_session, provider="sendgrid")
+        )
+
+
+def test_mail_service_import_treats_existing_global_domain_as_existing(db_session):
+    db_session.add(Domain(name="shared.example", active=True, verified=True))
+    db_session.commit()
+
+    async def fake_discover(_db, **_kwargs):
+        return [
+            {
+                "provider": "postmark",
+                "provider_name": "Postmark",
+                "external_id": "domain-1",
+                "domain": "shared.example",
+                "verification_state": "verified",
+                "required_dns_records": [],
+                "imported": False,
+            }
+        ]
+
+    with patch(
+        "app.services.mail_service_imports.discover_postmark_sender_domains",
+        new=fake_discover,
+    ):
+        result = asyncio.run(
+            mail_service_imports.import_mail_service_domains(
+                db_session,
+                provider="postmark",
+                requested_domains=["shared.example"],
+                workspace_id=12345,
+            )
+        )
+
+    assert result["imported"] == []
+    assert result["existing"] == ["shared.example"]
+    assert db_session.query(Domain).filter(Domain.name == "shared.example").count() == 1
+
+
+def test_create_imported_domain_handles_unique_race(db_session):
+    db_session.add(Domain(name="race.example", active=True, verified=True))
+    db_session.commit()
+
+    result = mail_service_imports._create_imported_domain(
+        db_session,
+        name="race.example",
+        provider_name="Postmark",
+        state="verified",
+        workspace_id=1,
+    )
+
+    assert result == "existing"
+
+
+def test_mail_service_import_skips_unrequested_domains(db_session):
+    async def fake_discover(_db, **_kwargs):
+        return [
+            {
+                "provider": "postmark",
+                "provider_name": "Postmark",
+                "external_id": "domain-1",
+                "domain": "wanted.example",
+                "verification_state": "verified",
+                "required_dns_records": [],
+                "imported": False,
+            },
+            {
+                "provider": "postmark",
+                "provider_name": "Postmark",
+                "external_id": "domain-2",
+                "domain": "skipped.example",
+                "verification_state": "verified",
+                "required_dns_records": [],
+                "imported": False,
+            },
+        ]
+
+    with patch(
+        "app.services.mail_service_imports.discover_postmark_sender_domains",
+        new=fake_discover,
+    ):
+        result = asyncio.run(
+            mail_service_imports.import_mail_service_domains(
+                db_session,
+                provider="postmark",
+                requested_domains=["wanted.example"],
+            )
+        )
+
+    assert result["imported"] == ["wanted.example"]
+    assert result["skipped"] == ["skipped.example"]
+
+
+def test_mail_service_import_provider_list_endpoint(authed_client: TestClient):
+    response = authed_client.get("/api/v1/domains/mail-services/import/providers")
+
+    assert response.status_code == 200
+    assert response.json()["providers"] == [{"id": "postmark", "name": "Postmark"}]
+
+
+def test_mail_service_import_endpoint_rejects_unsupported_provider(authed_client: TestClient):
+    with patch(
+        "app.api.api_v1.endpoints.domains.preview_mail_service_import",
+        new=AsyncMock(side_effect=LookupError("Unsupported mail service import: sendgrid")),
+    ):
+        response = authed_client.get("/api/v1/domains/mail-services/import/sendgrid/preview")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported mail service import: sendgrid"
+
+
+def test_mail_service_import_endpoint_returns_preview(authed_client: TestClient):
+    with patch(
+        "app.api.api_v1.endpoints.domains.preview_mail_service_import",
+        new=AsyncMock(
+            return_value={
+                "provider": "postmark",
+                "provider_name": "Postmark",
+                "domains": [
+                    {
+                        "provider": "postmark",
+                        "provider_name": "Postmark",
+                        "external_id": "domain-1",
+                        "domain": DOMAIN,
+                        "verification_state": "verified",
+                        "imported": False,
+                        "importable": True,
+                        "required_dns_records": [
+                            {
+                                "record_type": "TXT",
+                                "name": "pm._domainkey.example.com",
+                                "value": "k=rsa; p=abc",
+                                "purpose": "dkim",
+                            }
+                        ],
+                        "source": "mail_service_sender",
+                        "next_action": "Import this Postmark sender domain.",
+                    }
+                ],
+                "total_discovered": 1,
+                "importable_count": 1,
+            }
+        ),
+    ):
+        response = authed_client.get("/api/v1/domains/mail-services/import/postmark/preview")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["provider"] == "postmark"
+    assert data["domains"][0]["domain"] == DOMAIN
+    assert data["domains"][0]["required_dns_records"][0]["purpose"] == "dkim"
+
+
+def test_mail_service_import_endpoint_returns_import_summary(authed_client: TestClient):
+    with patch(
+        "app.api.api_v1.endpoints.domains.import_mail_service_domains",
+        new=AsyncMock(
+            return_value={
+                "provider": "postmark",
+                "provider_name": "Postmark",
+                "imported": [DOMAIN],
+                "existing": [],
+                "skipped": [],
+                "total_discovered": 1,
+            }
+        ),
+    ):
+        response = authed_client.post(
+            "/api/v1/domains/mail-services/import/postmark",
+            json={"domains": [DOMAIN]},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["imported"] == [DOMAIN]
+
+
+def test_mail_service_import_endpoint_maps_provider_errors(authed_client: TestClient):
+    with patch(
+        "app.api.api_v1.endpoints.domains.preview_mail_service_import",
+        new=AsyncMock(side_effect=MailServiceImportError("Postmark discovery failed: timeout")),
+    ):
+        response = authed_client.get("/api/v1/domains/mail-services/import/postmark/preview")
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Postmark discovery failed: timeout"
+
+
+def test_mail_service_import_endpoint_maps_import_provider_errors(authed_client: TestClient):
+    with patch(
+        "app.api.api_v1.endpoints.domains.import_mail_service_domains",
+        new=AsyncMock(side_effect=MailServiceImportError("Postmark discovery failed: timeout")),
+    ):
+        response = authed_client.post(
+            "/api/v1/domains/mail-services/import/postmark",
+            json={"domains": [DOMAIN]},
+        )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Postmark discovery failed: timeout"
+
+
+def test_mail_service_import_endpoint_rejects_unsupported_import_provider(
+    authed_client: TestClient,
+):
+    with patch(
+        "app.api.api_v1.endpoints.domains.import_mail_service_domains",
+        new=AsyncMock(side_effect=LookupError("Unsupported mail service import: sendgrid")),
+    ):
+        response = authed_client.post(
+            "/api/v1/domains/mail-services/import/sendgrid",
+            json={"domains": [DOMAIN]},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported mail service import: sendgrid"
+
+
+def test_mail_service_import_endpoint_maps_plan_limits(authed_client: TestClient):
+    error = OrganizationPlanLimitError(
+        metric="monitored_domains",
+        current=1,
+        limit=1,
+        attempted=1,
+        unit="domains",
+        entitlement_key="limits.monitored_domains",
+    )
+    with patch(
+        "app.api.api_v1.endpoints.domains.import_mail_service_domains",
+        new=AsyncMock(side_effect=error),
+    ):
+        response = authed_client.post(
+            "/api/v1/domains/mail-services/import/postmark",
+            json={"domains": [DOMAIN]},
+        )
+
+    assert response.status_code == 402
+    assert response.json()["detail"]["code"] == "plan_limit_exceeded"
+
+
+def test_domain_response_includes_mail_service_context(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(
+        Domain(
+            name=DOMAIN,
+            description=(
+                "Mail-service sender domain imported from Postmark (verified). "
+                "DNS records are still linted and repaired in DMARQ."
+            ),
+            active=True,
+            verified=True,
+        )
+    )
+    db_session.commit()
+
+    response = authed_client.get(f"/api/v1/domains/domains/{DOMAIN}")
+
+    assert response.status_code == 200
+    context = response.json()["mail_service_context"]
+    assert context[0]["provider_name"] == "Postmark"
+    assert context[0]["verification_state"] == "verified"
+
+
+def test_postmark_account_token_is_redacted(authed_client: TestClient, db_session):
+    db_session.add(
+        Setting(
+            key="postmark.account_token",
+            value="raw-token",
+            category="postmark",
+        )
+    )
+    db_session.commit()
+
+    response = authed_client.get("/api/v1/settings?category=postmark")
+
+    assert response.status_code == 200
+    assert response.json()[0]["value"] == "**redacted**"

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -148,6 +148,7 @@ operational policy if long-term storage size matters.
 |----------|-------------|---------|---------|
 | `CLOUDFLARE_API_TOKEN` | Cloudflare API token for zone discovery, DNS inspection, and optional approved DNS writes | - | `your_cloudflare_api_token` |
 | `CLOUDFLARE_ZONE_ID` | Optional default Cloudflare Zone ID | - | `your_cloudflare_zone_id` |
+| `POSTMARK_ACCOUNT_TOKEN` | Optional Postmark account token for read-only sender-domain discovery | - | `your_postmark_account_token` |
 | `WEBHOOK_SECRET` | Required secret for inbound email worker webhooks | - | `openssl rand -hex 32` |
 
 Cloudflare credentials can also be stored from **Settings**. The API token is
@@ -166,10 +167,19 @@ The integration exposes these operational routes:
 | `GET /api/v1/domains/{domain}/dns/history` | Review DNS record additions, modifications, and removals. |
 | `GET /api/v1/domains/dns/providers` | List native and Lexicon-backed DNS write providers. |
 | `POST /api/v1/domains/{domain}/dns/change-plan/apply` | Dry-run or explicitly apply one safe DNS change plan. |
+| `GET /api/v1/domains/mail-services/import/providers` | List mail service providers that support sender-domain import. |
+| `GET /api/v1/domains/mail-services/import/postmark/preview` | Preview Postmark sender domains and required DNS records without creating rows. |
+| `POST /api/v1/domains/mail-services/import/postmark` | Import selected Postmark sender domains as monitored domains before reports arrive. |
 
 Provider writes are opt-in at action time. Requests default to dry-run, and real
 writes require `confirm=true` plus `dry_run=false`. Public demo mode rejects
 provider writes even if credentials are configured.
+
+Postmark sender-domain discovery is read-only. DMARQ uses the Postmark account
+token to list domains and sender signatures, then stores imported domains as
+monitored domains so DNS linting, report import, and remediation guidance can
+work before aggregate reports arrive. DMARQ does not modify Postmark or DNS
+records in this workflow.
 
 Cloudflare is implemented natively. Additional API-backed providers use
 DNS-Lexicon where the provider is available in the runtime and its credentials

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -573,6 +573,9 @@ POST /domains/{domain_id}/dns/change-plan/apply
 GET /domains/dns/providers
 GET /domains/dns/import/{provider}/preview
 POST /domains/dns/import/{provider}
+GET /domains/mail-services/import/providers
+GET /domains/mail-services/import/{provider}/preview
+POST /domains/mail-services/import/{provider}
 GET /domains/dns/lint
 GET /domains/dns/lint/export
 ```
@@ -604,6 +607,15 @@ selected zones as monitored DMARQ domains before reports have arrived.
 Cloudflare is the first supported provider; the legacy
 `/domains/cloudflare/discover` and `/domains/cloudflare/import` endpoints remain
 available for compatibility.
+
+`GET /domains/mail-services/import/providers` returns mail delivery services
+that support read-only sender-domain discovery. Postmark is the first supported
+provider. Use `GET /domains/mail-services/import/postmark/preview` to list
+Postmark domains and sender signatures, including verification state and DNS
+records that Postmark exposes. Use
+`POST /domains/mail-services/import/postmark` with an optional `domains` array
+to import selected sender domains as monitored DMARQ domains. This flow does
+not modify Postmark or DNS records.
 
 `POST /domains/{domain_id}/dns/change-plan/apply` accepts
 `plan_id`, `provider`, `dry_run`, `confirm`, optional `value`, and `ttl`. Calls

--- a/docs/user_guide/settings.md
+++ b/docs/user_guide/settings.md
@@ -150,6 +150,21 @@ DMARQ never performs background DNS edits. A write-capable token only enables
 operator-approved actions from the DNS change plan UI, and each applied change
 is recorded in the workspace audit log.
 
+### Mail Service Sender Imports
+
+If you use Postmark to send mail:
+
+1. Navigate to **Settings** > **Mail Service Imports**.
+2. Add a Postmark account token.
+3. Use **Discover** to preview sender domains and their verification state.
+4. Use **Import New** to create monitored domain rows before DMARQ has received
+   reports for those domains.
+
+Imported domains appear in the normal domain list and detail pages. The detail
+page shows that the domain came from Postmark, while DNS linting and
+remediation guidance stay inside DMARQ. This workflow is read-only against
+Postmark and does not change DNS records.
+
 ### Other Integrations
 
 DMARQ supports additional integrations:


### PR DESCRIPTION
## Summary
- add a read-only mail-service sender-domain import service with Postmark as the first end-to-end connector
- expose preview/import API routes and a Settings UI to discover Postmark sender domains before DMARC reports arrive
- show imported mail-service context on domain API/detail pages and document the new configuration/API flow

## Validation
- ./.venv/bin/pytest backend/app/tests/test_mail_service_imports.py -q
- ./.venv/bin/pytest backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_api.py backend/app/tests/test_settings.py backend/app/tests/test_public_api.py -q
- ./.venv/bin/python -m black --check backend/app/services/mail_service_imports.py backend/app/tests/test_mail_service_imports.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/settings.py backend/app/core/config.py backend/app/main.py
- ./.venv/bin/python -m isort --check-only backend/app/services/mail_service_imports.py backend/app/tests/test_mail_service_imports.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/settings.py backend/app/core/config.py backend/app/main.py
- ./.venv/bin/python -m flake8 backend/app/services/mail_service_imports.py backend/app/tests/test_mail_service_imports.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/settings.py backend/app/core/config.py backend/app/main.py
- git diff --check

Closes #378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Postmark sender-domain discovery and import tools in Settings, including token entry, preview, and importing new monitored domains.
  * Domains now show mail service context badges in the domain overview.
  * Import-related API responses now include required DNS record details and verification status.

* **Bug Fixes**
  * Improved handling of secret settings so stored Postmark tokens are redacted in responses.

* **Documentation**
  * Updated setup and API docs with the new mail service import workflow and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->