### PR TITLE
Map Postmark DNS requirements into change plans

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -61,6 +61,7 @@ from app.services.mail_service_imports import (
     MailServiceImportError,
     import_mail_service_domains,
     mail_service_context_from_domain,
+    mail_service_dns_records_for_domain,
     preview_mail_service_import,
     supported_mail_service_import_providers,
 )
@@ -1491,6 +1492,7 @@ async def _build_domain_dns_guidance(
         domain_id,
         refresh=refresh,
     )
+    mail_service_records = await mail_service_dns_records_for_domain(db, domain_id)
     guidance = await build_dns_guidance(
         domain_id,
         provider,
@@ -1499,6 +1501,7 @@ async def _build_domain_dns_guidance(
         bimi_result,
         monitored_selectors=combined_selectors,
         observed_selectors=report_selectors,
+        mail_service_records=mail_service_records,
     )
     return asdict(guidance)
 

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -258,6 +258,16 @@ def _default_remediation_steps(code: str) -> List[str]:
             "Publish a default._bimi TXT record with an HTTPS SVG logo URL.",
             "Add a certificate URL if the mailbox providers you care about require it.",
         ],
+        "mail_service_record_missing": [
+            "Open the sender-domain authentication page in the mail service.",
+            "Copy the required DNS record into the authoritative DNS provider.",
+            "Refresh DMARQ DNS lint and then re-check verification in the mail service.",
+        ],
+        "mail_service_record_conflict": [
+            "Compare the existing DNS value with the value required by the mail service.",
+            "Confirm no other active sender depends on the current value.",
+            "Update the record or split senders onto provider-supported hostnames.",
+        ],
     }
     return steps.get(
         code,
@@ -930,6 +940,92 @@ def _bimi_findings(
     return findings
 
 
+def _normalize_dns_value(value: str) -> str:
+    return " ".join(str(value or "").strip().strip(".").split()).lower()
+
+
+async def _current_mail_service_values(
+    provider: BaseDNSProvider, record_type: str, name: str
+) -> List[str]:
+    if record_type == "TXT":
+        try:
+            return await provider.lookup_txt(name)
+        except LookupError:
+            return []
+    if record_type == "CNAME":
+        cname_lookup = getattr(provider, "lookup_cname", None)
+        if not callable(cname_lookup):
+            return []
+        value = await cname_lookup(name)
+        return [value] if isinstance(value, str) and value else []
+    return []
+
+
+async def _mail_service_dns_findings(
+    provider: BaseDNSProvider,
+    mail_service_records: List[Dict[str, str]],
+) -> List[DNSLintFinding]:
+    findings: List[DNSLintFinding] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in mail_service_records:
+        record_type = str(item.get("record_type") or "").strip().upper()
+        name = str(item.get("name") or "").strip().strip(".")
+        value = str(item.get("value") or "").strip().strip(".")
+        provider_name = str(item.get("provider_name") or item.get("provider") or "Mail service")
+        purpose = str(item.get("purpose") or "sender verification").replace("_", " ")
+        if record_type not in {"TXT", "CNAME"} or not name or not value:
+            continue
+        dedupe_key = (record_type, name.lower(), value)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+
+        current_values = await _current_mail_service_values(provider, record_type, name)
+        normalized_expected = _normalize_dns_value(value)
+        normalized_current = {_normalize_dns_value(current) for current in current_values}
+        if normalized_expected in normalized_current:
+            continue
+
+        target = DNSGuidanceRecord(
+            code=f"target_mail_service_{provider_name.lower()}_{purpose.replace(' ', '_')}",
+            record_type=record_type,
+            name=name,
+            value=value,
+            purpose=f"{provider_name} {purpose} for authenticated sender setup.",
+        )
+        if current_values:
+            findings.append(
+                _finding(
+                    "mail_service_record_conflict",
+                    "warning",
+                    f"{provider_name} DNS record value needs review",
+                    (
+                        f"{provider_name} requires a {record_type} record at {name}, "
+                        "but DNS currently returns a different value."
+                    ),
+                    "Review the sender-domain requirement and update DNS after approval.",
+                    record_type,
+                    name,
+                    target_record=target,
+                    evidence=current_values,
+                )
+            )
+            continue
+        findings.append(
+            _finding(
+                "mail_service_record_missing",
+                "warning",
+                f"{provider_name} DNS record is missing",
+                f"{provider_name} requires a {record_type} record at {name} for {purpose}.",
+                "Publish the required sender-domain DNS record after approval.",
+                record_type,
+                name,
+                target_record=target,
+            )
+        )
+    return findings
+
+
 def _status(findings: List[DNSLintFinding]) -> str:
     severities = {finding.severity for finding in findings}
     if "error" in severities:
@@ -998,7 +1094,8 @@ def _risk_for_finding(finding: DNSLintFinding) -> str:
             "complete can break forwarding or third-party senders."
         ),
         "dkim_selector_missing": (
-            "Low DNS risk, but the value must come from the sending provider that owns the selector."
+            "Low DNS risk, but the value must come from the sending provider that owns "
+            "the selector."
         ),
         "dkim_selector_cname_broken": (
             "Medium risk: replacing a CNAME with the wrong provider target keeps DKIM failing."
@@ -1014,6 +1111,14 @@ def _risk_for_finding(finding: DNSLintFinding) -> str:
         ),
         "tls_rpt_missing": "Low risk: TLS-RPT only controls report delivery.",
         "bimi_missing": "Low mail-flow risk; BIMI is a brand/readiness feature.",
+        "mail_service_record_missing": (
+            "Low DNS risk when copied exactly; mail-service verification remains pending until "
+            "DNS propagates."
+        ),
+        "mail_service_record_conflict": (
+            "Medium risk: replacing a record that another active sender depends on can break "
+            "that sender's authentication."
+        ),
     }
     return risks.get(
         finding.code,
@@ -1098,6 +1203,7 @@ async def build_dns_guidance(
     *,
     monitored_selectors: Optional[List[str]] = None,
     observed_selectors: Optional[List[str]] = None,
+    mail_service_records: Optional[List[Dict[str, str]]] = None,
 ) -> DNSGuidanceResult:
     """Build typed DNS lint findings and target records for a domain."""
     normalized_domain = domain.strip().strip(".").lower()
@@ -1118,6 +1224,7 @@ async def build_dns_guidance(
     findings.extend(_mta_sts_findings(mta_sts, targets))
     findings.extend(await _tls_rpt_findings(normalized_domain, provider, targets))
     findings.extend(_bimi_findings(bimi, extract_dmarc_policy(result.dmarc_record), targets))
+    findings.extend(await _mail_service_dns_findings(provider, mail_service_records or []))
     return DNSGuidanceResult(
         domain=normalized_domain,
         status=_status(findings),

--- a/backend/app/services/mail_service_imports.py
+++ b/backend/app/services/mail_service_imports.py
@@ -320,6 +320,43 @@ async def preview_mail_service_import(
     }
 
 
+async def mail_service_dns_records_for_domain(
+    db: Session,
+    domain: str,
+    *,
+    workspace_id: Optional[int] = None,
+) -> List[Dict[str, str]]:
+    """Return provider-required DNS records for one sender domain."""
+    normalized_domain = domain.strip().strip(".").lower()
+    if not normalized_domain:
+        return []
+    try:
+        domains = await discover_postmark_sender_domains(db, workspace_id=workspace_id)
+    except (LookupError, MailServiceImportError):
+        return []
+    records: List[Dict[str, str]] = []
+    for item in domains:
+        if str(item.get("domain") or "").strip().strip(".").lower() != normalized_domain:
+            continue
+        for record in item.get("required_dns_records") or []:
+            record_type = str(record.get("record_type") or "").strip().upper()
+            name = str(record.get("name") or "").strip().strip(".")
+            value = str(record.get("value") or "").strip().strip(".")
+            if not record_type or not name or not value:
+                continue
+            records.append(
+                {
+                    "provider": "postmark",
+                    "provider_name": _provider_name("postmark"),
+                    "record_type": record_type,
+                    "name": name,
+                    "value": value,
+                    "purpose": str(record.get("purpose") or "sender_verification"),
+                }
+            )
+    return records
+
+
 def mail_service_context_from_domain(domain: Optional[Domain]) -> List[Dict[str, str]]:
     """Extract displayable mail service context from imported domain descriptions."""
     if domain is None or not domain.description:

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -409,6 +409,61 @@ def test_dns_change_plan_endpoint_returns_apply_gated_plans(authed_client: TestC
     assert plan["expected_health_impact"]
 
 
+def test_dns_change_plan_endpoint_includes_postmark_records(authed_client: TestClient):
+    result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+        nameservers=["ns1.example.net"],
+        dns_provider=detect_dns_provider(["ns1.example.net"]),
+    )
+    mta_sts = MTAStsResult(status="pass")
+    bimi = BIMIResult(status="pass")
+
+    with (
+        _mock_dns(result),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(mta_sts, False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(bimi, False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.mail_service_dns_records_for_domain",
+            new=AsyncMock(
+                return_value=[
+                    {
+                        "provider": "postmark",
+                        "provider_name": "Postmark",
+                        "record_type": "CNAME",
+                        "name": "pm-bounces.example.com",
+                        "value": "pm.mtasv.net",
+                        "purpose": "return_path",
+                    }
+                ]
+            ),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/change-plan")
+
+    assert response.status_code == 200
+    plan = next(
+        plan
+        for plan in response.json()["plans"]
+        if plan["finding_code"] == "mail_service_record_missing"
+    )
+    assert plan["operation"] == "create"
+    assert plan["record_type"] == "CNAME"
+    assert plan["name"] == "pm-bounces.example.com"
+    assert plan["proposed_value"] == "pm.mtasv.net"
+    assert plan["provider_write_available"] is True
+
+
 def test_dns_lint_endpoint_flags_advanced_spf_lookup_findings(
     authed_client: TestClient,
 ):

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -376,3 +376,68 @@ async def test_build_dns_guidance_accepts_valid_dkim_cname_target():
     )
 
     assert "dkim_selector_cname_broken" not in {finding.code for finding in guidance.findings}
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_adds_postmark_dns_change_plans():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+            "pm._domainkey.example.com": ["old-dkim-value"],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        mail_service_records=[
+            {
+                "provider": "postmark",
+                "provider_name": "Postmark",
+                "record_type": "TXT",
+                "name": "pm._domainkey.example.com",
+                "value": "new-dkim-value",
+                "purpose": "dkim",
+            },
+            {
+                "provider": "postmark",
+                "provider_name": "Postmark",
+                "record_type": "CNAME",
+                "name": "pm-bounces.example.com",
+                "value": "pm.mtasv.net",
+                "purpose": "return_path",
+            },
+        ],
+    )
+
+    finding_codes = {finding.code for finding in guidance.findings}
+    assert "mail_service_record_conflict" in finding_codes
+    assert "mail_service_record_missing" in finding_codes
+    conflict = next(
+        plan
+        for plan in guidance.change_plans
+        if plan.finding_code == "mail_service_record_conflict"
+    )
+    missing = next(
+        plan for plan in guidance.change_plans if plan.finding_code == "mail_service_record_missing"
+    )
+    assert conflict.operation == "update"
+    assert conflict.record_type == "TXT"
+    assert conflict.proposed_value == "new-dkim-value"
+    assert conflict.provider_value_required is False
+    assert conflict.current_values == ["old-dkim-value"]
+    assert missing.operation == "create"
+    assert missing.record_type == "CNAME"
+    assert missing.proposed_value == "pm.mtasv.net"

--- a/backend/app/tests/test_mail_service_imports.py
+++ b/backend/app/tests/test_mail_service_imports.py
@@ -302,6 +302,64 @@ def test_mail_service_import_rejects_unsupported_provider(db_session):
         )
 
 
+def test_mail_service_dns_records_for_domain_filters_matching_records(db_session):
+    with patch(
+        "app.services.mail_service_imports.discover_postmark_sender_domains",
+        new=AsyncMock(
+            return_value=[
+                {
+                    "domain": "example.com",
+                    "required_dns_records": [
+                        {
+                            "record_type": "txt",
+                            "name": "pm._domainkey.example.com.",
+                            "value": "dkim-value.",
+                            "purpose": "dkim",
+                        },
+                        {"record_type": "", "name": "", "value": ""},
+                    ],
+                },
+                {
+                    "domain": "other.example",
+                    "required_dns_records": [
+                        {
+                            "record_type": "CNAME",
+                            "name": "pm-bounces.other.example",
+                            "value": "pm.mtasv.net",
+                        }
+                    ],
+                },
+            ]
+        ),
+    ):
+        records = asyncio.run(
+            mail_service_imports.mail_service_dns_records_for_domain(db_session, "example.com")
+        )
+
+    assert records == [
+        {
+            "provider": "postmark",
+            "provider_name": "Postmark",
+            "record_type": "TXT",
+            "name": "pm._domainkey.example.com",
+            "value": "dkim-value",
+            "purpose": "dkim",
+        }
+    ]
+
+
+def test_mail_service_dns_records_for_domain_is_optional(db_session):
+    with patch(
+        "app.services.mail_service_imports.discover_postmark_sender_domains",
+        new=AsyncMock(side_effect=LookupError("Postmark account token is not configured")),
+    ):
+        records = asyncio.run(
+            mail_service_imports.mail_service_dns_records_for_domain(db_session, "example.com")
+        )
+
+    assert records == []
+
+
 def test_mail_service_import_treats_existing_global_domain_as_existing(db_session):
     db_session.add(Domain(name="shared.example", active=True, verified=True))
     db_session.commit()

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -178,8 +178,11 @@ provider writes even if credentials are configured.
 Postmark sender-domain discovery is read-only. DMARQ uses the Postmark account
 token to list domains and sender signatures, then stores imported domains as
 monitored domains so DNS linting, report import, and remediation guidance can
-work before aggregate reports arrive. DMARQ does not modify Postmark or DNS
-records in this workflow.
+work before aggregate reports arrive. If Postmark exposes required DKIM or
+return-path DNS records, DMARQ maps missing or conflicting records into the
+normal DNS lint and change-plan responses. DMARQ does not modify Postmark or DNS
+records in this workflow; DNS writes still require an explicit confirmed action
+through a configured DNS provider connector.
 
 Cloudflare is implemented natively. Additional API-backed providers use
 DNS-Lexicon where the provider is available in the runtime and its credentials

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -614,8 +614,11 @@ provider. Use `GET /domains/mail-services/import/postmark/preview` to list
 Postmark domains and sender signatures, including verification state and DNS
 records that Postmark exposes. Use
 `POST /domains/mail-services/import/postmark` with an optional `domains` array
-to import selected sender domains as monitored DMARQ domains. This flow does
-not modify Postmark or DNS records.
+to import selected sender domains as monitored DMARQ domains. When Postmark
+requirements are available for a monitored domain, `GET
+/domains/{domain_id}/dns/lint` and `GET /domains/{domain_id}/dns/change-plan`
+surface missing or conflicting Postmark DNS records as normal DNS findings and
+change plans. This flow does not modify Postmark or DNS records.
 
 `POST /domains/{domain_id}/dns/change-plan/apply` accepts
 `plan_id`, `provider`, `dry_run`, `confirm`, optional `value`, and `ttl`. Calls

--- a/docs/user_guide/settings.md
+++ b/docs/user_guide/settings.md
@@ -162,8 +162,12 @@ If you use Postmark to send mail:
 
 Imported domains appear in the normal domain list and detail pages. The detail
 page shows that the domain came from Postmark, while DNS linting and
-remediation guidance stay inside DMARQ. This workflow is read-only against
-Postmark and does not change DNS records.
+remediation guidance stay inside DMARQ. When the Postmark token is available,
+DMARQ also maps Postmark's required DKIM and return-path records into the
+domain DNS lint and change-plan views. Those plans can be reviewed and, where a
+DNS provider connector is configured, previewed through the normal safe DNS
+write flow. This workflow is read-only against Postmark and does not change DNS
+records without explicit operator approval.
 
 ### Other Integrations
 


### PR DESCRIPTION
## Summary
- map Postmark required DKIM and return-path records into DNS lint findings
- generate normal DNS change plans for missing or conflicting Postmark records
- document the safe read-only Postmark boundary and DNS approval flow

## Validation
- ./.venv/bin/pytest backend/app/tests/test_dns_guidance.py backend/app/tests/test_mail_service_imports.py backend/app/tests/test_dns_endpoints.py -q
- ./.venv/bin/black --check backend/app/services/dns_guidance.py backend/app/services/mail_service_imports.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_mail_service_imports.py backend/app/tests/test_dns_endpoints.py
- ./.venv/bin/isort --check-only backend/app/services/dns_guidance.py backend/app/services/mail_service_imports.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_mail_service_imports.py backend/app/tests/test_dns_endpoints.py
- ./.venv/bin/flake8 backend/app/services/dns_guidance.py backend/app/services/mail_service_imports.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_mail_service_imports.py backend/app/tests/test_dns_endpoints.py
- git diff --check

Closes #382