### PR TITLE
Add DNS repair safety context

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -369,6 +369,7 @@ class DNSChangePlanItemResponse(BaseModel):
     applies_automatically: bool = False
     provider_write_available: bool = False
     provider_value_required: bool = False
+    safety_notes: List[str] = Field(default_factory=list)
 
 
 class DNSChangePlanResponse(BaseModel):
@@ -379,6 +380,9 @@ class DNSChangePlanResponse(BaseModel):
     read_only: bool = True
     provider_write_available: bool = False
     dns_provider: Optional[Dict[str, Any]] = None
+    recommended_provider: Optional[str] = None
+    available_write_providers: List[str] = Field(default_factory=list)
+    safety_notes: List[str] = Field(default_factory=list)
     apply_endpoint: Optional[str] = None
     plans: List[DNSChangePlanItemResponse]
 
@@ -402,9 +406,94 @@ def read_only_dns_change_plan_response(payload: Any) -> DNSChangePlanResponse:
         read_only=True,
         provider_write_available=False,
         dns_provider=data.get("dns_provider"),
+        recommended_provider=None,
+        available_write_providers=[],
+        safety_notes=[
+            "Public automation responses are read-only and never expose DNS write affordances."
+        ],
         apply_endpoint=None,
         plans=plans,
     )
+
+
+DNS_AUTOMATION_OPERATIONS = {"create", "update"}
+DNS_AUTOMATION_RECORD_TYPES = {"TXT", "CNAME"}
+DNS_PROVIDER_ID_ALIASES = {
+    "azure_dns": "azure",
+}
+
+
+def _ready_dns_write_provider_ids() -> List[str]:
+    """Return configured provider IDs that can be used for DNS write previews."""
+    return [
+        provider["id"] for provider in provider_capabilities() if provider.get("status") == "ready"
+    ]
+
+
+def _recommended_dns_write_provider(
+    dns_provider: Optional[Dict[str, Any]], available_providers: List[str]
+) -> Optional[str]:
+    """Map detected DNS provider metadata to an available writer implementation."""
+    if not dns_provider:
+        return available_providers[0] if available_providers else None
+    detected = str(dns_provider.get("provider_id") or "").strip().lower()
+    provider_id = DNS_PROVIDER_ID_ALIASES.get(detected, detected)
+    if provider_id in available_providers:
+        return provider_id
+    return None
+
+
+def _dns_plan_provider_write_available(plan: Dict[str, Any]) -> bool:
+    """Return whether a change plan is safe enough to preview through a provider."""
+    return (
+        plan.get("operation") in DNS_AUTOMATION_OPERATIONS
+        and plan.get("record_type") in DNS_AUTOMATION_RECORD_TYPES
+        and not plan.get("provider_value_required")
+        and bool(plan.get("proposed_value"))
+        and "<" not in str(plan.get("proposed_value") or "")
+    )
+
+
+def _dns_plan_safety_notes(plan: Dict[str, Any], *, provider_write_available: bool) -> List[str]:
+    """Explain why a plan is apply-ready or intentionally manual-only."""
+    notes: List[str] = []
+    if provider_write_available:
+        notes.append("Preview the provider mutation before applying this DNS change.")
+        if plan.get("current_values"):
+            notes.append("Existing provider values will be shown in the preview before approval.")
+        return notes
+    if plan.get("operation") not in DNS_AUTOMATION_OPERATIONS:
+        notes.append("This operation is review-only and is not safe for automatic DNS writes.")
+    if plan.get("record_type") not in DNS_AUTOMATION_RECORD_TYPES:
+        notes.append("Only TXT and CNAME records are provider-write enabled right now.")
+    if plan.get("provider_value_required"):
+        notes.append("A provider-specific final value is required before automation is safe.")
+    proposed_value = str(plan.get("proposed_value") or "")
+    if not proposed_value:
+        notes.append("No concrete target value is available for an automated write.")
+    elif "<" in proposed_value:
+        notes.append("Placeholder values must be replaced with provider-confirmed values first.")
+    return notes or ["Manual review is required before this DNS change can be automated."]
+
+
+def _dns_change_plan_safety_notes(
+    *, recommended_provider: Optional[str], available_providers: List[str]
+) -> List[str]:
+    """Return response-level safety guidance for operator-controlled DNS writes."""
+    notes = [
+        "DNS writes are never automatic; every provider change requires explicit approval.",
+        "Use preview first to confirm zone, record, old value, new value, and TTL.",
+    ]
+    if recommended_provider:
+        notes.append(f"Recommended provider for this domain: {recommended_provider}.")
+    elif not available_providers:
+        notes.append("No ready DNS write provider is configured; use the manual steps.")
+    else:
+        notes.append(
+            "Detected DNS provider does not match a ready write connector; "
+            "choose a provider manually only if it manages this zone."
+        )
+    return notes
 
 
 class DNSProviderCapabilityResponse(BaseModel):
@@ -2993,24 +3082,38 @@ async def get_domain_dns_change_plan(
         )
 
     guidance = await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
+    available_providers = _ready_dns_write_provider_ids()
+    recommended_provider = _recommended_dns_write_provider(
+        guidance.get("dns_provider"),
+        available_providers,
+    )
+    plans = []
+    for plan in guidance["change_plans"]:
+        provider_write_available = _dns_plan_provider_write_available(plan)
+        plans.append(
+            {
+                **plan,
+                "provider_write_available": provider_write_available,
+                "safety_notes": _dns_plan_safety_notes(
+                    plan,
+                    provider_write_available=provider_write_available,
+                ),
+            }
+        )
     return DNSChangePlanResponse(
         domain=guidance["domain"],
         status=guidance["status"],
         read_only=False,
-        provider_write_available=True,
+        provider_write_available=bool(available_providers),
         dns_provider=guidance.get("dns_provider"),
+        recommended_provider=recommended_provider,
+        available_write_providers=available_providers,
+        safety_notes=_dns_change_plan_safety_notes(
+            recommended_provider=recommended_provider,
+            available_providers=available_providers,
+        ),
         apply_endpoint=f"/api/v1/domains/{domain_id}/dns/change-plan/apply",
-        plans=[
-            {
-                **plan,
-                "provider_write_available": (
-                    plan.get("operation") in {"create", "update"}
-                    and plan.get("record_type") in {"TXT", "CNAME"}
-                    and not plan.get("provider_value_required")
-                ),
-            }
-            for plan in guidance["change_plans"]
-        ],
+        plans=plans,
     )
 
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -925,6 +925,11 @@
                                     <div>
                                         <h4 class="font-semibold">Proposed DNS change plan</h4>
                                         <p class="text-xs text-base-content/60">Provider writes require explicit review and approval.</p>
+                                        <p x-show="dnsGuidance.recommended_provider"
+                                           class="mt-1 text-xs text-base-content/60">
+                                            Recommended provider:
+                                            <span class="font-semibold" x-text="providerName(dnsGuidance.recommended_provider)"></span>
+                                        </p>
                                     </div>
                                     <div class="flex flex-wrap items-center gap-2">
                                         <select
@@ -941,6 +946,13 @@
                                         </span>
                                     </div>
                                 </div>
+                                <template x-if="dnsGuidance.safety_notes && dnsGuidance.safety_notes.length">
+                                    <ul class="mt-2 list-disc space-y-1 pl-5 text-xs text-base-content/65">
+                                        <template x-for="note in dnsGuidance.safety_notes" :key="note">
+                                            <li x-text="note"></li>
+                                        </template>
+                                    </ul>
+                                </template>
                                 <p x-show="dnsWrite.message"
                                    class="mt-2 rounded bg-base-200 px-3 py-2 text-xs text-base-content/75"
                                    x-text="dnsWrite.message"></p>
@@ -982,6 +994,12 @@
                                                 <div class="text-xs text-base-content/60">
                                                     <span x-show="plan.provider_write_available">Can be previewed and applied with the selected provider.</span>
                                                     <span x-show="!plan.provider_write_available">Manual-only until the value or operation is safe to automate.</span>
+                                                    <ul x-show="plan.safety_notes && plan.safety_notes.length"
+                                                        class="mt-1 list-disc space-y-0.5 pl-4">
+                                                        <template x-for="note in plan.safety_notes" :key="note">
+                                                            <li x-text="note"></li>
+                                                        </template>
+                                                    </ul>
                                                 </div>
                                                 <div class="flex flex-wrap gap-2">
                                                     <button
@@ -1435,7 +1453,10 @@ function domainDetailsApp(domainId) {
             findings: [],
             target_records: [],
             dns_provider: null,
-            change_plans: []
+            change_plans: [],
+            recommended_provider: null,
+            available_write_providers: [],
+            safety_notes: []
         },
         dnsProviders: [
             { id: 'cloudflare', name: 'Cloudflare' }
@@ -1659,11 +1680,16 @@ function domainDetailsApp(domainId) {
         },
 
         syncDetectedDnsProvider() {
-            const providerId = this.detectedDnsProvider?.provider_id;
+            const providerId = this.dnsGuidance.recommended_provider || this.detectedDnsProvider?.provider_id;
             if (!providerId) return;
             if (this.dnsProviders.some(provider => provider.id === providerId)) {
                 this.dnsWrite.provider = providerId;
             }
+        },
+
+        providerName(providerId) {
+            const provider = this.dnsProviders.find(item => item.id === providerId);
+            return provider ? provider.name : providerId;
         },
 
         get dnsHealthStatusClass() {

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -784,6 +784,7 @@ def _dns_guidance_with_plan(plan):
         "status": "critical",
         "findings": [],
         "target_records": [],
+        "dns_provider": None,
         "change_plans": [plan],
     }
 
@@ -830,6 +831,7 @@ def test_dns_change_plan_marks_apply_ready_records(authed_client: TestClient, db
     db_session.add(Domain(name=DOMAIN))
     db_session.commit()
     plan = _dns_plan()
+    plan["current_values"] = ["v=DMARC1; p=none"]
 
     with patch(
         "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
@@ -842,7 +844,125 @@ def test_dns_change_plan_marks_apply_ready_records(authed_client: TestClient, db
     assert data["read_only"] is False
     assert data["provider_write_available"] is True
     assert data["apply_endpoint"].endswith("/dns/change-plan/apply")
+    assert "cloudflare" in data["available_write_providers"]
+    assert data["recommended_provider"] == "cloudflare"
+    assert data["safety_notes"]
     assert data["plans"][0]["provider_write_available"] is True
+    assert data["plans"][0]["safety_notes"] == [
+        "Preview the provider mutation before applying this DNS change.",
+        "Existing provider values will be shown in the preview before approval.",
+    ]
+
+
+def test_dns_change_plan_recommends_detected_provider(authed_client: TestClient, db_session):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan(operation="update")
+    guidance = _dns_guidance_with_plan(plan)
+    guidance["dns_provider"] = {
+        "provider_id": "digitalocean",
+        "provider_name": "DigitalOcean DNS",
+        "confidence": "high",
+        "evidence": ["ns1.digitalocean.com"],
+    }
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=guidance),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.provider_capabilities",
+            return_value=[
+                {
+                    "id": "cloudflare",
+                    "name": "Cloudflare",
+                    "mode": "native",
+                    "record_types": ["CNAME", "TXT"],
+                    "operations": ["create", "update"],
+                    "credentials": "settings",
+                    "status": "ready",
+                },
+                {
+                    "id": "digitalocean",
+                    "name": "digitalocean",
+                    "mode": "lexicon",
+                    "record_types": ["CNAME", "TXT"],
+                    "operations": ["create", "update"],
+                    "credentials": "environment",
+                    "status": "ready",
+                },
+            ],
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/change-plan")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["recommended_provider"] == "digitalocean"
+    assert data["available_write_providers"] == ["cloudflare", "digitalocean"]
+    assert "Recommended provider for this domain: digitalocean." in data["safety_notes"]
+
+
+def test_dns_change_plan_avoids_wrong_provider_recommendation(
+    authed_client: TestClient, db_session
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    guidance = _dns_guidance_with_plan(_dns_plan(operation="update"))
+    guidance["dns_provider"] = {
+        "provider_id": "exampledns",
+        "provider_name": "ExampleDNS",
+        "confidence": "medium",
+        "evidence": ["ns1.exampledns.test"],
+    }
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=guidance),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.provider_capabilities",
+            return_value=[
+                {
+                    "id": "cloudflare",
+                    "name": "Cloudflare",
+                    "mode": "native",
+                    "record_types": ["CNAME", "TXT"],
+                    "operations": ["create", "update"],
+                    "credentials": "settings",
+                    "status": "ready",
+                },
+            ],
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/change-plan")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["recommended_provider"] is None
+    assert data["available_write_providers"] == ["cloudflare"]
+    assert "does not match a ready write connector" in " ".join(data["safety_notes"])
+
+
+def test_dns_change_plan_explains_manual_only_plans(authed_client: TestClient, db_session):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan(operation="rotate", proposed_value="<provider-current-dkim-key>")
+    plan["provider_value_required"] = True
+
+    with patch(
+        "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+        new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/change-plan")
+
+    assert response.status_code == 200
+    plan_response = response.json()["plans"][0]
+    assert plan_response["provider_write_available"] is False
+    assert "This operation is review-only" in " ".join(plan_response["safety_notes"])
+    assert "provider-specific final value" in " ".join(plan_response["safety_notes"])
 
 
 def test_dns_change_plan_apply_dry_run_returns_cloudflare_mutation(

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -173,7 +173,10 @@ The integration exposes these operational routes:
 
 Provider writes are opt-in at action time. Requests default to dry-run, and real
 writes require `confirm=true` plus `dry_run=false`. Public demo mode rejects
-provider writes even if credentials are configured.
+provider writes even if credentials are configured. DNS change-plan responses
+include the currently ready write providers, the provider DMARQ recommends from
+nameserver detection when possible, and safety notes for apply-ready versus
+manual-only changes.
 
 Postmark sender-domain discovery is read-only. DMARQ uses the Postmark account
 token to list domains and sender signatures, then stores imported domains as

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -628,6 +628,11 @@ that already have a concrete value. Applied changes are written to the
 workspace audit log and refresh provider-backed DNS change history where the
 provider supports it.
 
+`GET /domains/{domain_id}/dns/change-plan` also returns
+`available_write_providers`, `recommended_provider`, and response-level
+`safety_notes`. Each plan contains its own `safety_notes` explaining whether it
+can be previewed through a provider connector or why it remains manual-only.
+
 #### Get Posture Dashboard
 
 ```

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -111,6 +111,11 @@ health impact. Operators can copy/paste the records manually, preview a
 provider mutation, or apply safe TXT/CNAME changes through a configured DNS
 provider after explicit browser confirmation.
 
+When DMARQ can detect the authoritative DNS provider from nameservers and a
+matching connector is available, the change-plan section highlights the
+recommended provider. Each plan also includes safety notes that explain why the
+plan is apply-ready or why it remains manual-only.
+
 Automatic apply is intentionally limited. DMARQ only applies plans that already
 contain a concrete DNS value and a low-risk operation such as create or update.
 Plans that require provider-specific values, DKIM rotation, record


### PR DESCRIPTION
## Summary
- add available/recommended DNS write provider metadata to the domain DNS change-plan API
- add response-level and per-plan safety notes so operators can see why a plan is apply-ready or manual-only
- show recommended provider and safety notes on the domain detail DNS repair UI
- document the new safety metadata in user, deployment, and API docs

## Boundaries
- Refs #380
- This does not relax live DNS write controls: provider writes remain preview/approval gated, and demo-mode protections are unchanged.
- This is a partial #380 slice; broader one-click repair coverage, provider verification depth, and rollback/audit work remain follow-up slices.

## Validation
- `./.venv/bin/pytest backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q`
- `./.venv/bin/python -m py_compile backend/app/api/api_v1/endpoints/domains.py`
- `./.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `./.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `./.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `git diff --check`