### PR TITLE
Guard DNS provider mismatches

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -39,6 +39,7 @@ from app.services.dns_provider_imports import (
 from app.services.dns_provider_writes import (
     DNSProviderWriteError,
     apply_dns_write,
+    normalize_provider_id,
     preview_dns_write,
     provider_capabilities,
 )
@@ -419,8 +420,20 @@ def read_only_dns_change_plan_response(payload: Any) -> DNSChangePlanResponse:
 DNS_AUTOMATION_OPERATIONS = {"create", "update"}
 DNS_AUTOMATION_RECORD_TYPES = {"TXT", "CNAME"}
 DNS_PROVIDER_ID_ALIASES = {
+    "azure-dns": "azure",
     "azure_dns": "azure",
 }
+
+
+def _canonical_dns_provider_id(provider: Optional[str]) -> str:
+    """Normalize detected and requested DNS provider IDs for comparisons."""
+    raw_provider = str(provider or "").strip().lower()
+    normalized_provider = normalize_provider_id(raw_provider)
+    return (
+        DNS_PROVIDER_ID_ALIASES.get(raw_provider)
+        or DNS_PROVIDER_ID_ALIASES.get(normalized_provider)
+        or normalized_provider
+    )
 
 
 def _ready_dns_write_provider_ids() -> List[str]:
@@ -436,11 +449,82 @@ def _recommended_dns_write_provider(
     """Map detected DNS provider metadata to an available writer implementation."""
     if not dns_provider:
         return available_providers[0] if available_providers else None
-    detected = str(dns_provider.get("provider_id") or "").strip().lower()
-    provider_id = DNS_PROVIDER_ID_ALIASES.get(detected, detected)
+    provider_id = _detected_dns_provider_id(dns_provider)
     if provider_id in available_providers:
         return provider_id
     return None
+
+
+def _detected_dns_provider_id(dns_provider: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Return a known detected provider ID, ignoring custom/unknown detections."""
+    if not dns_provider:
+        return None
+    provider_id = _canonical_dns_provider_id(dns_provider.get("provider_id"))
+    if provider_id in {"", "custom", "unknown"}:
+        return None
+    return provider_id
+
+
+def _ensure_dns_provider_selection_is_safe(
+    *, requested_provider: str, provider_match_target: Optional[str], allow_mismatch: bool
+) -> None:
+    """Block accidental writes through a connector that does not match NS detection."""
+    if not provider_match_target:
+        return
+    selected_provider = _canonical_dns_provider_id(requested_provider)
+    if selected_provider == provider_match_target:
+        return
+    if allow_mismatch:
+        return
+    raise DNSProviderWriteError(
+        "Selected DNS provider does not match the detected provider for this domain. "
+        "Preview with the recommended provider or explicitly allow a provider mismatch."
+    )
+
+
+def _dns_provider_mismatch_audit_details(
+    *,
+    requested_provider: str,
+    recommended_provider: Optional[str],
+    detected_provider: Optional[str],
+    allow_mismatch: bool,
+) -> Dict[str, Any]:
+    """Return non-secret provider mismatch details for DNS write audit logs."""
+    selected_provider = _canonical_dns_provider_id(requested_provider)
+    provider_match_target = recommended_provider or detected_provider
+    return {
+        "detected_provider": detected_provider,
+        "recommended_provider": recommended_provider,
+        "provider_match_target": provider_match_target,
+        "selected_provider": selected_provider,
+        "provider_mismatch": bool(
+            provider_match_target and selected_provider != provider_match_target
+        ),
+        "provider_mismatch_override": bool(
+            provider_match_target and selected_provider != provider_match_target and allow_mismatch
+        ),
+    }
+
+
+def _provider_mismatch_safety_note(
+    *,
+    requested_provider: str,
+    recommended_provider: Optional[str],
+    detected_provider: Optional[str],
+    allow_mismatch: bool,
+) -> Optional[str]:
+    """Return a UI/API safety note for intentional provider mismatches."""
+    details = _dns_provider_mismatch_audit_details(
+        requested_provider=requested_provider,
+        recommended_provider=recommended_provider,
+        detected_provider=detected_provider,
+        allow_mismatch=allow_mismatch,
+    )
+    if not details["provider_mismatch"]:
+        return None
+    if allow_mismatch:
+        return "Provider mismatch override was explicitly requested for this DNS change."
+    return "Selected provider does not match the detected provider for this domain."
 
 
 def _dns_plan_provider_write_available(plan: Dict[str, Any]) -> bool:
@@ -522,6 +606,7 @@ class DNSWriteApplyRequest(BaseModel):
     provider: str = "cloudflare"
     confirm: bool = False
     dry_run: bool = True
+    allow_provider_mismatch: bool = False
     value: Optional[str] = None
     ttl: int = Field(default=1, ge=1, le=86400)
 
@@ -3156,7 +3241,25 @@ async def apply_domain_dns_change_plan(
     guidance = await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
     plan = _find_dns_change_plan(guidance, payload.plan_id)
     resolved_domain = guidance["domain"]
+    available_providers = _ready_dns_write_provider_ids()
+    detected_provider = _detected_dns_provider_id(guidance.get("dns_provider"))
+    recommended_provider = _recommended_dns_write_provider(
+        guidance.get("dns_provider"),
+        available_providers,
+    )
+    provider_match_target = recommended_provider or detected_provider
+    provider_mismatch_details = _dns_provider_mismatch_audit_details(
+        requested_provider=payload.provider,
+        recommended_provider=recommended_provider,
+        detected_provider=detected_provider,
+        allow_mismatch=payload.allow_provider_mismatch,
+    )
     try:
+        _ensure_dns_provider_selection_is_safe(
+            requested_provider=payload.provider,
+            provider_match_target=provider_match_target,
+            allow_mismatch=payload.allow_provider_mismatch,
+        )
         if payload.dry_run or not payload.confirm:
             result = await preview_dns_write(
                 db,
@@ -3166,7 +3269,21 @@ async def apply_domain_dns_change_plan(
                 value_override=payload.value,
                 ttl=payload.ttl,
             )
-            return result.to_dict()
+            result_payload = result.to_dict()
+            safety_note = _provider_mismatch_safety_note(
+                requested_provider=payload.provider,
+                recommended_provider=recommended_provider,
+                detected_provider=detected_provider,
+                allow_mismatch=payload.allow_provider_mismatch,
+            )
+            if safety_note:
+                result_payload["changes"].append(
+                    {
+                        "type": "safety_note",
+                        "message": safety_note,
+                    }
+                )
+            return result_payload
 
         result = await apply_dns_write(
             db,
@@ -3199,6 +3316,7 @@ async def apply_domain_dns_change_plan(
             "plan_id": payload.plan_id,
             "mutation": result.mutation.to_dict(),
             "applied": result.applied,
+            **provider_mismatch_details,
         },
         auth_context=_auth,
         request=request,

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -946,6 +946,16 @@
                                         </span>
                                     </div>
                                 </div>
+                                <div x-show="dnsProviderMismatch"
+                                     class="mt-2 rounded border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-900">
+                                    <p class="font-semibold">Selected DNS provider differs from the detected provider.</p>
+                                    <label class="mt-2 flex items-start gap-2">
+                                        <input type="checkbox"
+                                               class="checkbox checkbox-xs mt-0.5"
+                                               x-model="dnsWrite.allowProviderMismatch">
+                                        <span>I confirm this provider manages the zone and want to override the provider match guard.</span>
+                                    </label>
+                                </div>
                                 <template x-if="dnsGuidance.safety_notes && dnsGuidance.safety_notes.length">
                                     <ul class="mt-2 list-disc space-y-1 pl-5 text-xs text-base-content/65">
                                         <template x-for="note in dnsGuidance.safety_notes" :key="note">
@@ -1463,6 +1473,7 @@ function domainDetailsApp(domainId) {
         ],
         dnsWrite: {
             provider: 'cloudflare',
+            allowProviderMismatch: false,
             loading: false,
             message: '',
             error: '',
@@ -1684,12 +1695,36 @@ function domainDetailsApp(domainId) {
             if (!providerId) return;
             if (this.dnsProviders.some(provider => provider.id === providerId)) {
                 this.dnsWrite.provider = providerId;
+                this.dnsWrite.allowProviderMismatch = false;
             }
         },
 
         providerName(providerId) {
             const provider = this.dnsProviders.find(item => item.id === providerId);
             return provider ? provider.name : providerId;
+        },
+
+        canonicalProviderId(providerId) {
+            const normalized = String(providerId || '').trim().toLowerCase().replace(/_/g, '-');
+            return { 'azure-dns': 'azure' }[normalized] || normalized;
+        },
+
+        get detectedDnsProviderId() {
+            const detectedProvider = this.canonicalProviderId(this.detectedDnsProvider?.provider_id);
+            return ['custom', 'unknown', ''].includes(detectedProvider) ? null : detectedProvider;
+        },
+
+        get dnsProviderMatchTarget() {
+            return this.canonicalProviderId(this.dnsGuidance.recommended_provider) || this.detectedDnsProviderId;
+        },
+
+        get dnsProviderMismatch() {
+            const targetProvider = this.dnsProviderMatchTarget;
+            return Boolean(
+                targetProvider &&
+                this.dnsWrite.provider &&
+                this.canonicalProviderId(this.dnsWrite.provider) !== targetProvider
+            );
         },
 
         get dnsHealthStatusClass() {
@@ -1856,6 +1891,7 @@ function domainDetailsApp(domainId) {
                     body: JSON.stringify({
                         plan_id: plan.plan_id,
                         provider: this.dnsWrite.provider,
+                        allow_provider_mismatch: this.dnsWrite.allowProviderMismatch,
                         dry_run: !apply,
                         confirm: apply
                     })

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1054,6 +1054,53 @@ def test_dns_change_plan_apply_dry_run_returns_noop_for_unchanged_cloudflare_rec
     assert data["mutation"]["current_values"] == [plan["proposed_value"]]
 
 
+def test_dns_change_plan_apply_blocks_detected_provider_mismatch(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan()
+    guidance = _dns_guidance_with_plan(plan)
+    guidance["dns_provider"] = {
+        "provider_id": "digitalocean",
+        "provider_name": "DigitalOcean DNS",
+        "confidence": "high",
+        "evidence": ["ns1.digitalocean.com"],
+    }
+    zone_lookup = AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": []})
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=guidance),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.provider_capabilities",
+            return_value=[
+                {
+                    "id": "cloudflare",
+                    "name": "Cloudflare",
+                    "mode": "native",
+                    "record_types": ["CNAME", "TXT"],
+                    "operations": ["create", "update"],
+                    "credentials": "settings",
+                    "status": "ready",
+                },
+            ],
+        ),
+        patch("app.services.dns_provider_writes.get_zone_for_domain", new=zone_lookup),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={"plan_id": plan["plan_id"], "provider": "cloudflare"},
+        )
+
+    assert response.status_code == 422
+    assert "does not match the detected provider" in response.json()["detail"]
+    zone_lookup.assert_not_awaited()
+
+
 def test_dns_change_plan_apply_blocks_multiple_matching_cloudflare_records(
     authed_client: TestClient,
     db_session,
@@ -1160,7 +1207,89 @@ def test_dns_change_plan_apply_updates_cloudflare_and_audits(
     assert db_session.query(DNSRecordChange).count() == 1
     audit = db_session.query(WorkspaceAuditLog).one()
     assert audit.action == "domain.dns_change_applied"
-    assert json.loads(audit.details)["provider"] == "cloudflare"
+    audit_details = json.loads(audit.details)
+    assert audit_details["provider"] == "cloudflare"
+    assert audit_details["provider_mismatch"] is False
+
+
+def test_dns_change_plan_apply_allows_explicit_provider_mismatch_override_and_audits(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan(operation="update")
+    guidance = _dns_guidance_with_plan(plan)
+    guidance["dns_provider"] = {
+        "provider_id": "digitalocean",
+        "provider_name": "DigitalOcean DNS",
+        "confidence": "high",
+        "evidence": ["ns1.digitalocean.com"],
+    }
+    provider = FakeWriteCloudflareProvider(
+        zones=[{"id": "zone-1", "name": DOMAIN}],
+        records=[_record("dmarc", "TXT", f"_dmarc.{DOMAIN}", "v=DMARC1; p=none")],
+    )
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=guidance),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.provider_capabilities",
+            return_value=[
+                {
+                    "id": "cloudflare",
+                    "name": "Cloudflare",
+                    "mode": "native",
+                    "record_types": ["CNAME", "TXT"],
+                    "operations": ["create", "update"],
+                    "credentials": "settings",
+                    "status": "ready",
+                },
+                {
+                    "id": "digitalocean",
+                    "name": "digitalocean",
+                    "mode": "lexicon",
+                    "record_types": ["CNAME", "TXT"],
+                    "operations": ["create", "update"],
+                    "credentials": "environment",
+                    "status": "ready",
+                },
+            ],
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(
+                return_value={"id": "zone-1", "name": DOMAIN, "records": list(provider.records)}
+            ),
+        ),
+        patch(
+            "app.services.dns_provider_writes.build_cloudflare_provider",
+            return_value=provider,
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={
+                "plan_id": plan["plan_id"],
+                "provider": "cloudflare",
+                "dry_run": False,
+                "confirm": True,
+                "allow_provider_mismatch": True,
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["applied"] is True
+    audit = db_session.query(WorkspaceAuditLog).one()
+    audit_details = json.loads(audit.details)
+    assert audit_details["recommended_provider"] == "digitalocean"
+    assert audit_details["selected_provider"] == "cloudflare"
+    assert audit_details["provider_mismatch"] is True
+    assert audit_details["provider_mismatch_override"] is True
 
 
 def test_dns_change_plan_apply_blocks_provider_value_placeholders(

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -176,7 +176,10 @@ writes require `confirm=true` plus `dry_run=false`. Public demo mode rejects
 provider writes even if credentials are configured. DNS change-plan responses
 include the currently ready write providers, the provider DMARQ recommends from
 nameserver detection when possible, and safety notes for apply-ready versus
-manual-only changes.
+manual-only changes. If a write request selects a provider that does not match
+the detected provider, DMARQ rejects it unless the request explicitly sets
+`allow_provider_mismatch=true`; applied overrides are captured in the workspace
+audit log.
 
 Postmark sender-domain discovery is read-only. DMARQ uses the Postmark account
 token to list domains and sender signatures, then stores imported domains as

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -621,12 +621,15 @@ surface missing or conflicting Postmark DNS records as normal DNS findings and
 change plans. This flow does not modify Postmark or DNS records.
 
 `POST /domains/{domain_id}/dns/change-plan/apply` accepts
-`plan_id`, `provider`, `dry_run`, `confirm`, optional `value`, and `ttl`. Calls
-default to dry-run. Real writes require `dry_run=false` and `confirm=true`, are
-blocked in demo mode, and are limited to safe TXT/CNAME create/update plans
-that already have a concrete value. Applied changes are written to the
-workspace audit log and refresh provider-backed DNS change history where the
-provider supports it.
+`plan_id`, `provider`, `dry_run`, `confirm`, optional `value`, `ttl`, and
+`allow_provider_mismatch`. Calls default to dry-run. Real writes require
+`dry_run=false` and `confirm=true`, are blocked in demo mode, and are limited to
+safe TXT/CNAME create/update plans that already have a concrete value. If
+nameserver detection recommends a different provider than the selected provider,
+the request is rejected unless `allow_provider_mismatch=true` is supplied.
+Applied changes are written to the workspace audit log, including provider
+mismatch override details when present, and refresh provider-backed DNS change
+history where the provider supports it.
 
 `GET /domains/{domain_id}/dns/change-plan` also returns
 `available_write_providers`, `recommended_provider`, and response-level

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -116,6 +116,12 @@ matching connector is available, the change-plan section highlights the
 recommended provider. Each plan also includes safety notes that explain why the
 plan is apply-ready or why it remains manual-only.
 
+If an operator selects a different provider than the nameserver-detected
+provider, DMARQ blocks the preview/apply request by default. The mismatch can be
+overridden only with an explicit confirmation that the selected provider
+actually manages the zone; that override is captured in the workspace audit log
+when a write is applied.
+
 Automatic apply is intentionally limited. DMARQ only applies plans that already
 contain a concrete DNS value and a low-risk operation such as create or update.
 Plans that require provider-specific values, DKIM rotation, record


### PR DESCRIPTION
## Summary
- block DNS change preview/apply requests when the selected provider differs from nameserver-detected provider context
- allow an explicit `allow_provider_mismatch` override for operator-confirmed edge cases
- record provider mismatch and override details in DNS write audit logs
- show the override confirmation in the domain DNS repair UI and document the API behavior

## Boundaries
- Refs #380
- This tightens DNS write safety and does not add new automatic write behavior.
- The broader #380 work remains open for deeper provider verification, rollback flows, and end-to-end repair completion semantics.

## Validation
- `./.venv/bin/pytest backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q`
- `./.venv/bin/python -m py_compile backend/app/api/api_v1/endpoints/domains.py`
- `./.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `./.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `./.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `git diff --check`