### PR TITLE
feat: verify dns repair applies

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -628,6 +628,15 @@ class DNSWriteMutationResponse(BaseModel):
     blocked_reason: Optional[str] = None
 
 
+class DNSWriteVerificationResponse(BaseModel):
+    """Provider-side verification evidence after a DNS apply."""
+
+    status: str
+    verified: bool
+    checked_values: List[str] = Field(default_factory=list)
+    message: str = ""
+
+
 class DNSWriteResultResponse(BaseModel):
     """DNS write preview/apply response."""
 
@@ -637,6 +646,7 @@ class DNSWriteResultResponse(BaseModel):
     mutation: DNSWriteMutationResponse
     provider_result: Optional[Dict[str, Any]] = None
     changes: List[Dict[str, Any]] = Field(default_factory=list)
+    verification: DNSWriteVerificationResponse
 
 
 class DNSGuidanceResponse(BaseModel):
@@ -3316,6 +3326,7 @@ async def apply_domain_dns_change_plan(
             "plan_id": payload.plan_id,
             "mutation": result.mutation.to_dict(),
             "applied": result.applied,
+            "verification": result.verification.to_dict(),
             **provider_mismatch_details,
         },
         auth_context=_auth,

--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -85,6 +85,24 @@ class DNSWriteMutation:
 
 
 @dataclass
+class DNSWriteVerification:
+    """Provider-side verification evidence for an applied DNS mutation."""
+
+    status: str
+    verified: bool
+    checked_values: List[str] = field(default_factory=list)
+    message: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "verified": self.verified,
+            "checked_values": self.checked_values,
+            "message": self.message,
+        }
+
+
+@dataclass
 class DNSWriteResult:
     """Result of previewing or applying one DNS provider mutation."""
 
@@ -94,6 +112,13 @@ class DNSWriteResult:
     mutation: DNSWriteMutation
     provider_result: Optional[Dict[str, Any]] = None
     changes: List[Dict[str, Any]] = field(default_factory=list)
+    verification: DNSWriteVerification = field(
+        default_factory=lambda: DNSWriteVerification(
+            status="not_run",
+            verified=False,
+            message="Verification only runs after a confirmed provider apply.",
+        )
+    )
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -103,6 +128,7 @@ class DNSWriteResult:
             "mutation": self.mutation.to_dict(),
             "provider_result": self.provider_result,
             "changes": self.changes,
+            "verification": self.verification.to_dict(),
         }
 
 
@@ -197,6 +223,56 @@ def _validate_plan_for_automation(plan: Dict[str, Any]) -> None:
         )
 
 
+def _verification_from_records(
+    *,
+    mutation: DNSWriteMutation,
+    records: List[Dict[str, Any]],
+) -> DNSWriteVerification:
+    """Return provider-side evidence that the expected record is now visible."""
+    checked_values = [
+        str(record.get("content") or "")
+        for record in records
+        if (not record.get("type") or str(record.get("type") or "").upper() == mutation.record_type)
+        and (
+            not record.get("name")
+            or str(record.get("name") or "").rstrip(".").lower()
+            == mutation.name.rstrip(".").lower()
+        )
+    ]
+    verified = mutation.content in checked_values
+    if verified:
+        return DNSWriteVerification(
+            status="verified",
+            verified=True,
+            checked_values=checked_values,
+            message="Provider API returned the expected DNS record after apply.",
+        )
+    return DNSWriteVerification(
+        status="failed",
+        verified=False,
+        checked_values=checked_values,
+        message=(
+            "Provider API did not return the expected DNS record after apply; "
+            "verify propagation and provider state before treating this as repaired."
+        ),
+    )
+
+
+def _noop_verification(mutation: DNSWriteMutation) -> DNSWriteVerification:
+    """Return verification evidence for an unchanged record."""
+    verified = mutation.content in mutation.current_values
+    return DNSWriteVerification(
+        status="already_current" if verified else "failed",
+        verified=verified,
+        checked_values=mutation.current_values,
+        message=(
+            "Provider already has the expected DNS value."
+            if verified
+            else "Provider preview marked this record unchanged, but the expected value was not present."
+        ),
+    )
+
+
 class CloudflareDNSWriteProvider:
     """DNS write provider backed by DMARQ's native Cloudflare client."""
 
@@ -273,6 +349,7 @@ class CloudflareDNSWriteProvider:
                 applied=False,
                 mutation=mutation,
                 provider_result={"status": "unchanged"},
+                verification=_noop_verification(mutation),
             )
 
         provider = build_cloudflare_provider(db)
@@ -307,6 +384,7 @@ class CloudflareDNSWriteProvider:
             zone_id=mutation.zone_id,
             records=records,
         )
+        verification = _verification_from_records(mutation=mutation, records=records)
         return DNSWriteResult(
             provider=self.provider_id,
             dry_run=False,
@@ -314,6 +392,7 @@ class CloudflareDNSWriteProvider:
             mutation=mutation,
             provider_result=provider_result,
             changes=changes,
+            verification=verification,
         )
 
 
@@ -386,18 +465,26 @@ class LexiconDNSWriteProvider:
                 applied=False,
                 mutation=mutation,
                 provider_result={"status": "unchanged"},
+                verification=_noop_verification(mutation),
             )
         provider_result = await asyncio.to_thread(self._apply_record, domain, mutation)
         if not provider_result:
             raise DNSProviderWriteError(
                 f"Lexicon provider '{self.provider_id}' did not apply the DNS mutation"
             )
+        records = await asyncio.to_thread(
+            self._list_records,
+            domain,
+            mutation.record_type,
+            mutation.name,
+        )
         return DNSWriteResult(
             provider=self.provider_id,
             dry_run=False,
             applied=True,
             mutation=mutation,
             provider_result={"ok": True},
+            verification=_verification_from_records(mutation=mutation, records=records),
         )
 
     def _client_config(self, domain: str):

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1038,6 +1038,16 @@
                                                         <p><span class="font-semibold">TTL:</span> <span x-text="dnsWrite.preview.mutation.ttl"></span></p>
                                                     </div>
                                                     <code class="mt-2 block break-all rounded bg-white/70 p-2" x-text="dnsWrite.preview.mutation.name + ' ' + dnsWrite.preview.mutation.record_type + ' ' + dnsWrite.preview.mutation.content"></code>
+                                                    <template x-if="dnsWrite.preview.verification && dnsWrite.preview.verification.status !== 'not_run'">
+                                                        <div class="mt-2 rounded bg-white/70 p-2">
+                                                            <p>
+                                                                <span class="font-semibold">Verification:</span>
+                                                                <span x-text="dnsWrite.preview.verification.status"></span>
+                                                            </p>
+                                                            <p class="mt-1 text-base-content/70"
+                                                               x-text="dnsWrite.preview.verification.message"></p>
+                                                        </div>
+                                                    </template>
                                                 </div>
                                             </template>
                                         </div>
@@ -1904,7 +1914,9 @@ function domainDetailsApp(domainId) {
                 data.plan_id = plan.plan_id;
                 this.dnsWrite.preview = data;
                 this.dnsWrite.message = apply
-                    ? 'DNS change submitted. Refreshing DNS evidence now.'
+                    ? (data.verification?.verified
+                        ? 'DNS change verified by the provider. Refreshing DNS evidence now.'
+                        : 'DNS change submitted, but provider verification is not complete. Review the verification details before treating it as repaired.')
                     : 'Preview ready. Review the provider mutation before applying.';
                 if (apply) {
                     await this.fetchDNSRecords();

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -98,6 +98,11 @@ class FakeWriteCloudflareProvider(FakeCloudflareProvider):
         return updated
 
 
+class FakeUnverifiedWriteCloudflareProvider(FakeWriteCloudflareProvider):
+    async def list_dns_records(self, *, zone_id=None, name=None, record_type=None):
+        return []
+
+
 def test_analyze_dns_records_reports_healthy_auth_records():
     records = [
         _record("spf", "TXT", DOMAIN, "v=spf1 include:_spf.google.com ~all"),
@@ -996,6 +1001,8 @@ def test_dns_change_plan_apply_dry_run_returns_cloudflare_mutation(
     assert data["mutation"]["operation"] == "create"
     assert data["mutation"]["name"] == f"_dmarc.{DOMAIN}"
     assert data["mutation"]["content"] == plan["proposed_value"]
+    assert data["verification"]["status"] == "not_run"
+    assert data["verification"]["verified"] is False
 
 
 def test_dns_change_plan_apply_uses_resolved_domain_for_provider_calls(
@@ -1203,6 +1210,9 @@ def test_dns_change_plan_apply_updates_cloudflare_and_audits(
     assert response.status_code == 200
     data = response.json()
     assert data["applied"] is True
+    assert data["verification"]["status"] == "verified"
+    assert data["verification"]["verified"] is True
+    assert data["verification"]["checked_values"] == [plan["proposed_value"]]
     assert provider.updated[0]["content"] == plan["proposed_value"]
     assert db_session.query(DNSRecordChange).count() == 1
     audit = db_session.query(WorkspaceAuditLog).one()
@@ -1210,6 +1220,57 @@ def test_dns_change_plan_apply_updates_cloudflare_and_audits(
     audit_details = json.loads(audit.details)
     assert audit_details["provider"] == "cloudflare"
     assert audit_details["provider_mismatch"] is False
+    assert audit_details["verification"]["status"] == "verified"
+    assert audit_details["verification"]["verified"] is True
+
+
+def test_dns_change_plan_apply_reports_unverified_provider_readback(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan(operation="update")
+    provider = FakeUnverifiedWriteCloudflareProvider(
+        zones=[{"id": "zone-1", "name": DOMAIN}],
+        records=[_record("dmarc", "TXT", f"_dmarc.{DOMAIN}", "v=DMARC1; p=none")],
+    )
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(
+                return_value={"id": "zone-1", "name": DOMAIN, "records": list(provider.records)}
+            ),
+        ),
+        patch(
+            "app.services.dns_provider_writes.build_cloudflare_provider",
+            return_value=provider,
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={
+                "plan_id": plan["plan_id"],
+                "provider": "cloudflare",
+                "dry_run": False,
+                "confirm": True,
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["applied"] is True
+    assert data["verification"]["status"] == "failed"
+    assert data["verification"]["verified"] is False
+    assert "did not return the expected DNS record" in data["verification"]["message"]
+    audit_details = json.loads(db_session.query(WorkspaceAuditLog).one().details)
+    assert audit_details["verification"]["status"] == "failed"
+    assert audit_details["verification"]["verified"] is False
 
 
 def test_dns_change_plan_apply_allows_explicit_provider_mismatch_override_and_audits(
@@ -1410,6 +1471,8 @@ def test_cloudflare_write_provider_creates_record_and_syncs_history(db_session):
     assert result.applied is True
     assert cloudflare_provider.created[0]["ttl"] == 3600
     assert result.provider_result["id"] == "created-1"
+    assert result.verification.status == "verified"
+    assert result.verification.verified is True
     assert result.changes[0]["change_type"] == "added"
     assert db_session.query(DNSRecordChange).count() == 1
 
@@ -1472,17 +1535,22 @@ def test_lexicon_write_provider_reports_missing_runtime(db_session):
 
 def test_lexicon_write_provider_prepares_update_and_applies_record(db_session):
     provider = LexiconDNSWriteProvider("route53")
-    provider._list_records = lambda domain, record_type, record_name: [  # pylint: disable=protected-access
-        {
+    records = [{"id": "record-1", "content": "v=DMARC1; p=none"}]
+
+    def list_records(domain, record_type, record_name):
+        return records
+
+    def apply_record(domain, mutation):
+        records[0] = {
             "id": "record-1",
-            "type": record_type,
-            "name": record_name,
-            "content": "v=DMARC1; p=none",
+            "type": mutation.record_type,
+            "name": mutation.name,
+            "content": mutation.content,
         }
-    ]
-    provider._apply_record = (
-        lambda domain, mutation: mutation.record_id == "record-1"
-    )  # pylint: disable=protected-access
+        return mutation.record_id == "record-1"
+
+    provider._list_records = list_records  # pylint: disable=protected-access
+    provider._apply_record = apply_record  # pylint: disable=protected-access
 
     with patch("app.services.dns_provider_writes.lexicon_runtime_available", return_value=True):
         mutation = asyncio.run(
@@ -1501,6 +1569,8 @@ def test_lexicon_write_provider_prepares_update_and_applies_record(db_session):
     assert mutation.current_values == ["v=DMARC1; p=none"]
     assert result.applied is True
     assert result.provider_result == {"ok": True}
+    assert result.verification.status == "verified"
+    assert result.verification.verified is True
 
 
 def test_lexicon_write_provider_rejects_failed_apply(db_session):

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -629,7 +629,11 @@ nameserver detection recommends a different provider than the selected provider,
 the request is rejected unless `allow_provider_mismatch=true` is supplied.
 Applied changes are written to the workspace audit log, including provider
 mismatch override details when present, and refresh provider-backed DNS change
-history where the provider supports it.
+history where the provider supports it. Apply responses also include a
+`verification` object with `status`, `verified`, `checked_values`, and
+`message`. Treat a repair as complete only when `verification.verified=true`;
+otherwise the mutation was submitted but the provider readback did not yet show
+the expected DNS value.
 
 `GET /domains/{domain_id}/dns/change-plan` also returns
 `available_write_providers`, `recommended_provider`, and response-level

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -122,6 +122,12 @@ overridden only with an explicit confirmation that the selected provider
 actually manages the zone; that override is captured in the workspace audit log
 when a write is applied.
 
+After a confirmed provider write, DMARQ reads the record back from the provider
+API and shows the verification result. Do not treat the issue as repaired until
+the response says the expected value was verified. If verification fails, keep
+the change under review and check provider state, propagation, and whether a
+different authoritative DNS provider manages the zone.
+
 Automatic apply is intentionally limited. DMARQ only applies plans that already
 contain a concrete DNS value and a low-risk operation such as create or update.
 Plans that require provider-specific values, DKIM rotation, record


### PR DESCRIPTION
Refs #380

## Summary
- add provider-side verification evidence to DNS write apply responses
- verify Cloudflare and Lexicon writes by reading the expected record back from the provider
- surface verification status in the domain detail UI and workspace audit log
- document that repairs are complete only after provider verification passes

## Validation
- ./.venv/bin/pytest backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q
- ./.venv/bin/python -m py_compile backend/app/services/dns_provider_writes.py backend/app/api/api_v1/endpoints/domains.py
- ./.venv/bin/black --check backend/app/services/dns_provider_writes.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py
- ./.venv/bin/isort --check-only backend/app/services/dns_provider_writes.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py
- ./.venv/bin/flake8 backend/app/services/dns_provider_writes.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNS changes now include provider verification details, such as status, checked values, and a verification message.
  * The DNS change apply flow now shows whether the provider confirmed the update or whether verification is still pending.

* **Bug Fixes**
  * Improved post-submit messaging so users get a clearer outcome when DNS records are not yet confirmed by the provider.

* **Documentation**
  * Updated DNS API and domain guidance to explain the new verification response and when a change should be considered complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->