### PR TITLE
feat: add dns repair rollback guidance

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -637,6 +637,18 @@ class DNSWriteVerificationResponse(BaseModel):
     message: str = ""
 
 
+class DNSWriteRollbackResponse(BaseModel):
+    """Human-reviewed rollback guidance for a provider DNS mutation."""
+
+    summary: str
+    steps: List[str] = Field(default_factory=list)
+    previous_values: List[str] = Field(default_factory=list)
+    record_type: str
+    name: str
+    provider: str
+    requires_manual_review: bool = True
+
+
 class DNSWriteResultResponse(BaseModel):
     """DNS write preview/apply response."""
 
@@ -647,6 +659,7 @@ class DNSWriteResultResponse(BaseModel):
     provider_result: Optional[Dict[str, Any]] = None
     changes: List[Dict[str, Any]] = Field(default_factory=list)
     verification: DNSWriteVerificationResponse
+    rollback: DNSWriteRollbackResponse
 
 
 class DNSGuidanceResponse(BaseModel):
@@ -3223,6 +3236,59 @@ def _find_dns_change_plan(guidance: Dict[str, Any], plan_id: str) -> Dict[str, A
     )
 
 
+def _dns_write_rollback_guidance(plan: Dict[str, Any], result: Any) -> Dict[str, Any]:
+    """Return manual rollback guidance for a prepared or applied DNS mutation."""
+    mutation = result.mutation
+    previous_values = list(mutation.current_values or [])
+    summary = str(plan.get("rollback") or "").strip()
+    if not summary:
+        summary = "Review provider history and restore the previous DNS value if needed."
+
+    if mutation.operation == "create":
+        steps = [
+            f"Open {mutation.provider} DNS for the zone that contains {mutation.name}.",
+            f"Find the {mutation.record_type} record named {mutation.name}.",
+            "Delete the created record only after confirming no legitimate sender depends on it.",
+            "Refresh DMARQ DNS evidence and confirm the domain returns to the intended state.",
+        ]
+    elif mutation.operation == "update":
+        if previous_values:
+            steps = [
+                f"Open {mutation.provider} DNS for the zone that contains {mutation.name}.",
+                f"Edit the {mutation.record_type} record named {mutation.name}.",
+                "Restore the previous value shown in DMARQ's rollback evidence.",
+                "Refresh DMARQ DNS evidence and confirm the restored record is visible.",
+            ]
+        else:
+            steps = [
+                f"Open {mutation.provider} DNS for the zone that contains {mutation.name}.",
+                f"Review provider history for the {mutation.record_type} record named {mutation.name}.",
+                "Restore the last known-good value before this DMARQ repair.",
+                "Refresh DMARQ DNS evidence and confirm the restored record is visible.",
+            ]
+    elif mutation.operation == "noop":
+        summary = "No provider rollback is needed because no DNS mutation was applied."
+        steps = [
+            "No DNS record was created or updated by this operation.",
+            "Keep the finding under observation and refresh DNS evidence if the provider changes.",
+        ]
+    else:
+        steps = [
+            "Review the provider change history before reverting this DNS record.",
+            "Refresh DMARQ DNS evidence after any manual rollback.",
+        ]
+
+    return {
+        "summary": summary,
+        "steps": steps,
+        "previous_values": previous_values,
+        "record_type": mutation.record_type,
+        "name": mutation.name,
+        "provider": mutation.provider,
+        "requires_manual_review": True,
+    }
+
+
 @router.post("/{domain_id}/dns/change-plan/apply", response_model=DNSWriteResultResponse)
 async def apply_domain_dns_change_plan(
     request: Request,
@@ -3280,6 +3346,7 @@ async def apply_domain_dns_change_plan(
                 ttl=payload.ttl,
             )
             result_payload = result.to_dict()
+            result_payload["rollback"] = _dns_write_rollback_guidance(plan, result)
             safety_note = _provider_mismatch_safety_note(
                 requested_provider=payload.provider,
                 recommended_provider=recommended_provider,
@@ -3315,6 +3382,7 @@ async def apply_domain_dns_change_plan(
             detail=str(exc),
         ) from exc
 
+    rollback = _dns_write_rollback_guidance(plan, result)
     record_workspace_audit_log(
         db,
         workspace=workspace,
@@ -3327,13 +3395,16 @@ async def apply_domain_dns_change_plan(
             "mutation": result.mutation.to_dict(),
             "applied": result.applied,
             "verification": result.verification.to_dict(),
+            "rollback": rollback,
             **provider_mismatch_details,
         },
         auth_context=_auth,
         request=request,
         commit=True,
     )
-    return result.to_dict()
+    result_payload = result.to_dict()
+    result_payload["rollback"] = rollback
+    return result_payload
 
 
 @router.get("/{domain_id}/dns/health", response_model=DNSHealthResponse)

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1048,6 +1048,27 @@
                                                                x-text="dnsWrite.preview.verification.message"></p>
                                                         </div>
                                                     </template>
+                                                    <template x-if="dnsWrite.preview.rollback">
+                                                        <div class="mt-2 rounded bg-white/70 p-2">
+                                                            <p>
+                                                                <span class="font-semibold">Rollback:</span>
+                                                                <span x-text="dnsWrite.preview.rollback.summary"></span>
+                                                            </p>
+                                                            <template x-if="dnsWrite.preview.rollback.previous_values && dnsWrite.preview.rollback.previous_values.length">
+                                                                <div class="mt-2">
+                                                                    <p class="font-semibold">Previous value</p>
+                                                                    <template x-for="value in dnsWrite.preview.rollback.previous_values" :key="value">
+                                                                        <code class="mt-1 block break-all rounded bg-base-200 p-2" x-text="value"></code>
+                                                                    </template>
+                                                                </div>
+                                                            </template>
+                                                            <ol class="mt-2 list-decimal space-y-1 pl-5 text-base-content/70">
+                                                                <template x-for="(step, stepIndex) in dnsWrite.preview.rollback.steps" :key="'rollback-' + stepIndex">
+                                                                    <li x-text="step"></li>
+                                                                </template>
+                                                            </ol>
+                                                        </div>
+                                                    </template>
                                                 </div>
                                             </template>
                                         </div>

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1003,6 +1003,12 @@ def test_dns_change_plan_apply_dry_run_returns_cloudflare_mutation(
     assert data["mutation"]["content"] == plan["proposed_value"]
     assert data["verification"]["status"] == "not_run"
     assert data["verification"]["verified"] is False
+    assert data["rollback"]["summary"] == plan["rollback"]
+    assert data["rollback"]["provider"] == "cloudflare"
+    assert data["rollback"]["record_type"] == "TXT"
+    assert data["rollback"]["name"] == f"_dmarc.{DOMAIN}"
+    assert data["rollback"]["requires_manual_review"] is True
+    assert "Delete the created record" in " ".join(data["rollback"]["steps"])
 
 
 def test_dns_change_plan_apply_uses_resolved_domain_for_provider_calls(
@@ -1059,6 +1065,8 @@ def test_dns_change_plan_apply_dry_run_returns_noop_for_unchanged_cloudflare_rec
     assert data["dry_run"] is True
     assert data["mutation"]["operation"] == "noop"
     assert data["mutation"]["current_values"] == [plan["proposed_value"]]
+    assert "No provider rollback is needed" in data["rollback"]["summary"]
+    assert data["rollback"]["previous_values"] == [plan["proposed_value"]]
 
 
 def test_dns_change_plan_apply_blocks_detected_provider_mismatch(
@@ -1213,6 +1221,8 @@ def test_dns_change_plan_apply_updates_cloudflare_and_audits(
     assert data["verification"]["status"] == "verified"
     assert data["verification"]["verified"] is True
     assert data["verification"]["checked_values"] == [plan["proposed_value"]]
+    assert data["rollback"]["previous_values"] == ["v=DMARC1; p=none"]
+    assert "Restore the previous value" in " ".join(data["rollback"]["steps"])
     assert provider.updated[0]["content"] == plan["proposed_value"]
     assert db_session.query(DNSRecordChange).count() == 1
     audit = db_session.query(WorkspaceAuditLog).one()
@@ -1222,6 +1232,7 @@ def test_dns_change_plan_apply_updates_cloudflare_and_audits(
     assert audit_details["provider_mismatch"] is False
     assert audit_details["verification"]["status"] == "verified"
     assert audit_details["verification"]["verified"] is True
+    assert audit_details["rollback"]["previous_values"] == ["v=DMARC1; p=none"]
 
 
 def test_dns_change_plan_apply_reports_unverified_provider_readback(

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -633,7 +633,11 @@ history where the provider supports it. Apply responses also include a
 `verification` object with `status`, `verified`, `checked_values`, and
 `message`. Treat a repair as complete only when `verification.verified=true`;
 otherwise the mutation was submitted but the provider readback did not yet show
-the expected DNS value.
+the expected DNS value. The same response includes a `rollback` object with a
+summary, manual steps, captured `previous_values` when available, and
+`requires_manual_review=true`. DMARQ does not automatically roll back provider
+writes; operators should use this evidence to restore the prior value only
+after confirming the rollback is still safe.
 
 `GET /domains/{domain_id}/dns/change-plan` also returns
 `available_write_providers`, `recommended_provider`, and response-level

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -128,6 +128,12 @@ the response says the expected value was verified. If verification fails, keep
 the change under review and check provider state, propagation, and whether a
 different authoritative DNS provider manages the zone.
 
+Provider previews and apply responses also include rollback guidance. For
+updates, DMARQ shows the previous provider value when it was captured; for
+creates, it explains how to remove the created record. Rollback is deliberately
+manual-review only so an operator can confirm no current sender depends on the
+record before reverting it.
+
 Automatic apply is intentionally limited. DMARQ only applies plans that already
 contain a concrete DNS value and a low-risk operation such as create or update.
 Plans that require provider-specific values, DKIM rotation, record


### PR DESCRIPTION
Refs #380

## Summary
- add structured rollback guidance to DNS repair preview/apply responses
- store rollback evidence with DNS repair audit logs
- show rollback steps and previous values in the domain detail provider preview
- document manual-review rollback behavior

## Validation
- pytest backend/app/tests/test_cloudflare_dns.py -q
- black backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py
- isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py
- python -m py_compile backend/app/api/api_v1/endpoints/domains.py
- flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py
- git diff --check