### PR TITLE
feat: require dns apply preview confirmation

### DIFF
--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1907,14 +1907,38 @@ function domainDetailsApp(domainId) {
             }
         },
 
+        dnsApplyConfirmationText(preview) {
+            const mutation = preview?.mutation || {};
+            const previousValues = mutation.current_values || [];
+            const previousText = previousValues.length ? previousValues.join('\n') : 'None captured by the provider preview.';
+            const proposedText = mutation.content || 'No proposed value available.';
+            const rollbackText = preview?.rollback?.summary || 'Review provider history before reverting this DNS record.';
+            const provider = this.providerName(preview?.provider || mutation.provider || this.dnsWrite.provider);
+            return [
+                'Apply this live DNS change?',
+                '',
+                `Provider: ${provider}`,
+                `Operation: ${mutation.operation || 'unknown'}`,
+                `Record: ${mutation.name || 'unknown'}`,
+                `Type: ${mutation.record_type || 'unknown'}`,
+                `TTL: ${mutation.ttl || 'provider default'}`,
+                '',
+                'Previous value:',
+                previousText,
+                '',
+                'Proposed value:',
+                proposedText,
+                '',
+                `Rollback: ${rollbackText}`,
+                '',
+                'DMARQ will verify the provider readback after apply, but DNS propagation may still take time.'
+            ].join('\n');
+        },
+
         async submitDNSChange(plan, apply) {
             this.dnsWrite.loading = true;
             this.dnsWrite.error = '';
             this.dnsWrite.message = '';
-            if (apply && !window.confirm(`Apply DNS change for ${plan.name}?`)) {
-                this.dnsWrite.loading = false;
-                return;
-            }
             try {
                 const response = await fetch(`/api/v1/domains/${this.domainId}/dns/change-plan/apply`, {
                     method: 'POST',
@@ -1945,9 +1969,11 @@ function domainDetailsApp(domainId) {
                     await this.fetchDNSGuidance();
                     await this.fetchPosture();
                 }
+                return data;
             } catch (error) {
                 this.dnsWrite.error = 'Network error — DNS change could not be prepared';
                 console.error('Error submitting DNS change:', error);
+                return null;
             } finally {
                 this.dnsWrite.loading = false;
             }
@@ -1957,7 +1983,23 @@ function domainDetailsApp(domainId) {
             return this.submitDNSChange(plan, false);
         },
 
-        applyDNSChange(plan) {
+        async applyDNSChange(plan) {
+            const previewProvider = this.canonicalProviderId(this.dnsWrite.preview?.provider);
+            const selectedProvider = this.canonicalProviderId(this.dnsWrite.provider);
+            let preview = this.dnsWrite.preview &&
+                this.dnsWrite.preview.plan_id === plan.plan_id &&
+                previewProvider === selectedProvider
+                ? this.dnsWrite.preview
+                : null;
+            if (!preview) {
+                preview = await this.submitDNSChange(plan, false);
+            }
+            if (!preview?.mutation) {
+                return null;
+            }
+            if (!window.confirm(this.dnsApplyConfirmationText(preview))) {
+                return null;
+            }
             return this.submitDNSChange(plan, true);
         },
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -627,6 +627,9 @@ change plans. This flow does not modify Postmark or DNS records.
 safe TXT/CNAME create/update plans that already have a concrete value. If
 nameserver detection recommends a different provider than the selected provider,
 the request is rejected unless `allow_provider_mismatch=true` is supplied.
+The web UI prepares a provider preview before live apply confirmation and shows
+the exact provider, operation, record name/type, TTL, previous value, proposed
+value, and rollback summary in the final browser confirmation.
 Applied changes are written to the workspace audit log, including provider
 mismatch override details when present, and refresh provider-backed DNS change
 history where the provider supports it. Apply responses also include a

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -116,6 +116,12 @@ matching connector is available, the change-plan section highlights the
 recommended provider. Each plan also includes safety notes that explain why the
 plan is apply-ready or why it remains manual-only.
 
+The Apply button uses the provider preview as the final confirmation source. If
+there is no current preview for the selected plan, DMARQ prepares one first and
+then asks the operator to confirm the exact provider, operation, record name,
+record type, TTL, previous value, proposed value, and rollback summary before a
+live provider write is submitted.
+
 If an operator selects a different provider than the nameserver-detected
 provider, DMARQ blocks the preview/apply request by default. The mismatch can be
 overridden only with an explicit confirmation that the selected provider


### PR DESCRIPTION
Refs #380

## Summary
- require the domain-detail Apply button to use a current provider preview before live DNS writes
- show provider, operation, record, type, TTL, previous value, proposed value, and rollback summary in the final confirmation
- regenerate the preview when the selected provider changes before apply
- document the preview-backed confirmation flow

## Validation
- pytest backend/app/tests/test_cloudflare_dns.py -q
- git diff --check