### PR TITLE
feat: simulate dns repair apply in demo mode

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -42,6 +42,7 @@ from app.services.dns_provider_writes import (
     normalize_provider_id,
     preview_dns_write,
     provider_capabilities,
+    simulate_demo_dns_write,
 )
 from app.services.dns_resolver import (
     DomainDNSResult,
@@ -3362,15 +3363,24 @@ async def apply_domain_dns_change_plan(
                 )
             return result_payload
 
-        result = await apply_dns_write(
-            db,
-            workspace=workspace,
-            domain=resolved_domain,
-            plan=plan,
-            provider_id=payload.provider,
-            value_override=payload.value,
-            ttl=payload.ttl,
-        )
+        if get_settings().DEMO_MODE:
+            result = simulate_demo_dns_write(
+                domain=resolved_domain,
+                plan=plan,
+                provider_id=payload.provider,
+                value_override=payload.value,
+                ttl=payload.ttl,
+            )
+        else:
+            result = await apply_dns_write(
+                db,
+                workspace=workspace,
+                domain=resolved_domain,
+                plan=plan,
+                provider_id=payload.provider,
+                value_override=payload.value,
+                ttl=payload.ttl,
+            )
     except DNSProviderWriteError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -42,6 +42,7 @@ from app.services.dns_provider_writes import (
     normalize_provider_id,
     preview_dns_write,
     provider_capabilities,
+    simulate_demo_dns_preview,
     simulate_demo_dns_write,
 )
 from app.services.dns_resolver import (
@@ -3338,14 +3339,23 @@ async def apply_domain_dns_change_plan(
             allow_mismatch=payload.allow_provider_mismatch,
         )
         if payload.dry_run or not payload.confirm:
-            result = await preview_dns_write(
-                db,
-                domain=resolved_domain,
-                plan=plan,
-                provider_id=payload.provider,
-                value_override=payload.value,
-                ttl=payload.ttl,
-            )
+            if get_settings().DEMO_MODE:
+                result = simulate_demo_dns_preview(
+                    domain=resolved_domain,
+                    plan=plan,
+                    provider_id=payload.provider,
+                    value_override=payload.value,
+                    ttl=payload.ttl,
+                )
+            else:
+                result = await preview_dns_write(
+                    db,
+                    domain=resolved_domain,
+                    plan=plan,
+                    provider_id=payload.provider,
+                    value_override=payload.value,
+                    ttl=payload.ttl,
+                )
             result_payload = result.to_dict()
             result_payload["rollback"] = _dns_write_rollback_guidance(plan, result)
             safety_note = _provider_mismatch_safety_note(

--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -548,6 +548,61 @@ def build_dns_write_provider(provider_id: str) -> DNSWriteProvider:
     raise DNSProviderWriteError(f"Unsupported DNS provider: {provider_id}")
 
 
+def simulate_demo_dns_write(
+    *,
+    domain: str,
+    plan: Dict[str, Any],
+    provider_id: str,
+    value_override: Optional[str] = None,
+    ttl: int = 1,
+) -> DNSWriteResult:
+    """Return a confirmed demo apply result without touching a DNS provider."""
+    _validate_plan_for_automation(plan)
+    content = _plan_value(plan, value_override)
+    provider = normalize_provider_id(provider_id)
+    record_type = str(plan.get("record_type") or "").upper()
+    name = str(plan.get("name") or "").strip()
+    operation = str(plan.get("operation") or "").lower()
+    mutation = DNSWriteMutation(
+        operation=operation,
+        record_type=record_type,
+        name=name,
+        content=content,
+        ttl=ttl,
+        provider=provider,
+        zone_id="demo-zone",
+        zone_name=domain,
+        record_id=f"demo-{record_type.lower()}-{name}" if operation == "update" else None,
+        current_values=list(plan.get("current_values") or []),
+    )
+    return DNSWriteResult(
+        provider=provider,
+        dry_run=False,
+        applied=True,
+        mutation=mutation,
+        provider_result={
+            "id": mutation.record_id or f"demo-created-{record_type.lower()}-{name}",
+            "mode": "demo",
+            "message": "Demo mode simulated the provider apply; no live DNS was changed.",
+        },
+        changes=[
+            {
+                "type": "demo_apply",
+                "message": "Demo mode simulated the DNS repair and did not contact a provider.",
+            }
+        ],
+        verification=DNSWriteVerification(
+            status="verified",
+            verified=True,
+            checked_values=[content],
+            message=(
+                "Demo mode simulated provider readback for the proposed DNS value. "
+                "No live DNS was changed."
+            ),
+        ),
+    )
+
+
 async def preview_dns_write(
     db: Session,
     *,

--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -644,7 +644,7 @@ def simulate_demo_dns_write(
         verification=DNSWriteVerification(
             status="verified",
             verified=True,
-            checked_values=[content],
+            checked_values=[mutation.content],
             message=(
                 "Demo mode simulated provider readback for the proposed DNS value. "
                 "No live DNS was changed."

--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -548,6 +548,66 @@ def build_dns_write_provider(provider_id: str) -> DNSWriteProvider:
     raise DNSProviderWriteError(f"Unsupported DNS provider: {provider_id}")
 
 
+def _demo_dns_mutation(
+    *,
+    domain: str,
+    plan: Dict[str, Any],
+    provider_id: str,
+    value_override: Optional[str] = None,
+    ttl: int = 1,
+) -> DNSWriteMutation:
+    """Return a provider-like mutation for demo flows without provider access."""
+    _validate_plan_for_automation(plan)
+    content = _plan_value(plan, value_override)
+    provider = normalize_provider_id(provider_id)
+    record_type = str(plan.get("record_type") or "").upper()
+    name = str(plan.get("name") or "").strip()
+    operation = str(plan.get("operation") or "").lower()
+    demo_record_id = f"demo-{domain}-{record_type.lower()}-{name}"
+    return DNSWriteMutation(
+        operation=operation,
+        record_type=record_type,
+        name=name,
+        content=content,
+        ttl=ttl,
+        provider=provider,
+        zone_id="demo-zone",
+        zone_name=domain,
+        record_id=demo_record_id if operation == "update" else None,
+        current_values=list(plan.get("current_values") or []),
+    )
+
+
+def simulate_demo_dns_preview(
+    *,
+    domain: str,
+    plan: Dict[str, Any],
+    provider_id: str,
+    value_override: Optional[str] = None,
+    ttl: int = 1,
+) -> DNSWriteResult:
+    """Return a demo preview result without touching a DNS provider."""
+    mutation = _demo_dns_mutation(
+        domain=domain,
+        plan=plan,
+        provider_id=provider_id,
+        value_override=value_override,
+        ttl=ttl,
+    )
+    return DNSWriteResult(
+        provider=normalize_provider_id(provider_id),
+        dry_run=True,
+        applied=False,
+        mutation=mutation,
+        changes=[
+            {
+                "type": "demo_preview",
+                "message": "Demo mode simulated the DNS provider preview.",
+            }
+        ],
+    )
+
+
 def simulate_demo_dns_write(
     *,
     domain: str,
@@ -557,31 +617,21 @@ def simulate_demo_dns_write(
     ttl: int = 1,
 ) -> DNSWriteResult:
     """Return a confirmed demo apply result without touching a DNS provider."""
-    _validate_plan_for_automation(plan)
-    content = _plan_value(plan, value_override)
-    provider = normalize_provider_id(provider_id)
-    record_type = str(plan.get("record_type") or "").upper()
-    name = str(plan.get("name") or "").strip()
-    operation = str(plan.get("operation") or "").lower()
-    mutation = DNSWriteMutation(
-        operation=operation,
-        record_type=record_type,
-        name=name,
-        content=content,
+    mutation = _demo_dns_mutation(
+        domain=domain,
+        plan=plan,
+        provider_id=provider_id,
+        value_override=value_override,
         ttl=ttl,
-        provider=provider,
-        zone_id="demo-zone",
-        zone_name=domain,
-        record_id=f"demo-{record_type.lower()}-{name}" if operation == "update" else None,
-        current_values=list(plan.get("current_values") or []),
     )
     return DNSWriteResult(
-        provider=provider,
+        provider=normalize_provider_id(provider_id),
         dry_run=False,
         applied=True,
         mutation=mutation,
         provider_result={
-            "id": mutation.record_id or f"demo-created-{record_type.lower()}-{name}",
+            "id": mutation.record_id
+            or f"demo-created-{domain}-{mutation.record_type.lower()}-{mutation.name}",
             "mode": "demo",
             "message": "Demo mode simulated the provider apply; no live DNS was changed.",
         },

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1284,6 +1284,54 @@ def test_dns_change_plan_apply_reports_unverified_provider_readback(
     assert audit_details["verification"]["verified"] is False
 
 
+def test_dns_change_plan_apply_simulates_confirmed_write_in_demo_mode(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan(operation="update")
+    plan["current_values"] = ["v=DMARC1; p=none"]
+
+    class DemoSettings:
+        DEMO_MODE = True
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch("app.api.api_v1.endpoints.domains.get_settings", return_value=DemoSettings()),
+        patch("app.services.dns_provider_writes.build_dns_write_provider") as build_provider,
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={
+                "plan_id": plan["plan_id"],
+                "provider": "cloudflare",
+                "dry_run": False,
+                "confirm": True,
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["applied"] is True
+    assert data["dry_run"] is False
+    assert data["provider_result"]["mode"] == "demo"
+    assert data["mutation"]["zone_id"] == "demo-zone"
+    assert data["mutation"]["current_values"] == ["v=DMARC1; p=none"]
+    assert data["verification"]["status"] == "verified"
+    assert data["verification"]["verified"] is True
+    assert "No live DNS was changed" in data["verification"]["message"]
+    assert data["rollback"]["previous_values"] == ["v=DMARC1; p=none"]
+    build_provider.assert_not_called()
+    audit_details = json.loads(db_session.query(WorkspaceAuditLog).one().details)
+    assert audit_details["applied"] is True
+    assert audit_details["verification"]["status"] == "verified"
+    assert audit_details["rollback"]["previous_values"] == ["v=DMARC1; p=none"]
+
+
 def test_dns_change_plan_apply_allows_explicit_provider_mismatch_override_and_audits(
     authed_client: TestClient,
     db_session,

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1304,6 +1304,15 @@ def test_dns_change_plan_apply_simulates_confirmed_write_in_demo_mode(
         patch("app.api.api_v1.endpoints.domains.get_settings", return_value=DemoSettings()),
         patch("app.services.dns_provider_writes.build_dns_write_provider") as build_provider,
     ):
+        preview_response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={
+                "plan_id": plan["plan_id"],
+                "provider": "cloudflare",
+                "dry_run": True,
+                "confirm": False,
+            },
+        )
         response = authed_client.post(
             f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
             json={
@@ -1314,6 +1323,13 @@ def test_dns_change_plan_apply_simulates_confirmed_write_in_demo_mode(
             },
         )
 
+    assert preview_response.status_code == 200
+    preview_data = preview_response.json()
+    assert preview_data["applied"] is False
+    assert preview_data["dry_run"] is True
+    assert preview_data["mutation"]["zone_id"] == "demo-zone"
+    assert preview_data["mutation"]["current_values"] == ["v=DMARC1; p=none"]
+    assert preview_data["verification"]["status"] == "not_run"
     assert response.status_code == 200
     data = response.json()
     assert data["applied"] is True

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -623,8 +623,10 @@ change plans. This flow does not modify Postmark or DNS records.
 `POST /domains/{domain_id}/dns/change-plan/apply` accepts
 `plan_id`, `provider`, `dry_run`, `confirm`, optional `value`, `ttl`, and
 `allow_provider_mismatch`. Calls default to dry-run. Real writes require
-`dry_run=false` and `confirm=true`, are blocked in demo mode, and are limited to
-safe TXT/CNAME create/update plans that already have a concrete value. If
+`dry_run=false` and `confirm=true`, and are limited to safe TXT/CNAME
+create/update plans that already have a concrete value. In demo mode, confirmed
+applies return a simulated provider result and verification evidence without
+contacting a DNS provider or changing live DNS. If
 nameserver detection recommends a different provider than the selected provider,
 the request is rejected unless `allow_provider_mismatch=true` is supplied.
 The web UI prepares a provider preview before live apply confirmation and shows

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -134,6 +134,10 @@ the response says the expected value was verified. If verification fails, keep
 the change under review and check provider state, propagation, and whether a
 different authoritative DNS provider manages the zone.
 
+On the public demo, the same flow is simulated. The confirmation, apply result,
+verification message, audit evidence, and rollback guidance are shown, but
+DMARQ does not contact a DNS provider or modify live DNS records.
+
 Provider previews and apply responses also include rollback guidance. For
 updates, DMARQ shows the previous provider value when it was captured; for
 creates, it explains how to remove the created record. Rollback is deliberately


### PR DESCRIPTION
Refs #380

## Summary
- add a demo-mode DNS apply simulator that returns confirmed provider apply, verification, and audit-ready evidence without contacting a DNS provider
- route confirmed change-plan applies through the simulator only when demo mode is enabled, while the live provider service still rejects demo writes directly
- document how the public demo shows the apply/verify/rollback flow without changing live DNS

## Validation
- ./.venv/bin/pytest backend/app/tests/test_cloudflare_dns.py -q
- ./.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/services/dns_provider_writes.py backend/app/tests/test_cloudflare_dns.py
- ./.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/services/dns_provider_writes.py backend/app/tests/test_cloudflare_dns.py
- ./.venv/bin/python -m py_compile backend/app/api/api_v1/endpoints/domains.py backend/app/services/dns_provider_writes.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo-mode DNS apply now completes as a simulated confirmed action, returning provider-like results and verification details without making live DNS changes.

* **Bug Fixes**
  * Confirmed DNS change plans in demo environments no longer stop at apply; they now follow the expected apply/verify/rollback flow with simulated results.

* **Documentation**
  * Updated DNS guidance and API docs to explain how confirmed applies behave in demo mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->