### PR TITLE
feat: add domain remediation queue

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -74,6 +74,7 @@ from app.services.organizations import (
     OrganizationPlanLimitError,
     require_organization_plan_limit,
 )
+from app.services.remediation_queue import build_remediation_queue
 from app.services.report_persistence import (
     hydrate_report_store_from_db,
 )
@@ -787,6 +788,51 @@ class PostureDashboardResponse(BaseModel):
     recommendations: List[DNSHealthRecommendation]
     changes: List[PostureChangeSummary]
     playbooks: List[OperatorPlaybook]
+
+
+class RemediationAutomation(BaseModel):
+    """Automation eligibility for one remediation item."""
+
+    eligible: bool = False
+    requires_approval: bool = True
+    provider: Optional[str] = None
+    plan_id: Optional[str] = None
+    apply_endpoint: Optional[str] = None
+    reason: str = ""
+
+
+class RemediationEvidence(BaseModel):
+    """Evidence attached to one remediation queue item."""
+
+    label: str
+    value: str
+
+
+class RemediationQueueItem(BaseModel):
+    """One prioritized operator action for a domain."""
+
+    id: str
+    source: str
+    state: str
+    severity: str
+    confidence: str
+    title: str
+    detail: str
+    next_steps: List[str] = Field(default_factory=list)
+    evidence: List[RemediationEvidence] = Field(default_factory=list)
+    blast_radius: str
+    prerequisites: List[str] = Field(default_factory=list)
+    expected_health_score_impact: str
+    automation: RemediationAutomation
+
+
+class RemediationQueueResponse(BaseModel):
+    """Prioritized remediation queue for a domain."""
+
+    domain: str
+    status: str
+    summary: Dict[str, int]
+    items: List[RemediationQueueItem]
 
 
 class HealthScoreHistoryPoint(BaseModel):
@@ -3483,6 +3529,44 @@ async def get_domain_posture_dashboard(
         )
     changes = list_dns_record_changes(db, domain_id, limit=10)
     return _build_posture_dashboard(domain_id, health, domain_health, changes)
+
+
+@router.get("/{domain_id}/remediation", response_model=RemediationQueueResponse)
+async def get_domain_remediation_queue(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS posture"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return a prioritized, human-reviewed remediation queue for one domain."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    if not _domain_exists(db, store, domain_id, workspace):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Domain not found",
+        )
+
+    domain_health = await _build_domain_health_grade(
+        db,
+        domain_id,
+        store,
+        refresh=refresh,
+    )
+    guidance = await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
+    available_providers = _ready_dns_write_provider_ids()
+    recommended_provider = _recommended_dns_write_provider(
+        guidance.get("dns_provider"),
+        available_providers,
+    )
+    return build_remediation_queue(
+        domain=domain_id,
+        health=domain_health,
+        dns_guidance=guidance,
+        available_write_providers=available_providers,
+        recommended_provider=recommended_provider,
+    )
 
 
 @router.get("/{domain_id}/posture/history", response_model=HealthScoreHistoryResponse)

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -1,0 +1,199 @@
+"""Build prioritized, human-reviewed remediation queues for domains."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+DNS_AUTOMATION_OPERATIONS = {"create", "update"}
+DNS_AUTOMATION_RECORD_TYPES = {"TXT", "CNAME"}
+SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
+DNS_SEVERITY = {"error": "critical", "warning": "medium", "info": "low"}
+HEALTH_DNS_EQUIVALENTS = {
+    "missing_dmarc": {"dmarc_missing"},
+    "missing_spf": {"spf_missing"},
+    "missing_dkim": {"dkim_selector_missing", "dkim_selector_broken"},
+    "dmarc_lint": {
+        "dmarc_external_rua_unauthorized",
+        "dmarc_external_ruf_unauthorized",
+        "dmarc_policy_value_invalid",
+        "dmarc_alignment_value_invalid",
+        "dmarc_failure_option_invalid",
+        "dmarc_policy_or_reporting_missing",
+        "dmarc_lint_warning",
+    },
+}
+
+
+def _evidence_from_pairs(evidence: Iterable[Dict[str, Any]]) -> List[Dict[str, str]]:
+    rows: List[Dict[str, str]] = []
+    for item in evidence:
+        label = str(item.get("label") or item.get("name") or "evidence")
+        value = str(item.get("value") or item.get("detail") or "")
+        if value:
+            rows.append({"label": label, "value": value})
+    return rows
+
+
+def _evidence_from_values(values: Iterable[Any], *, label: str) -> List[Dict[str, str]]:
+    return [{"label": label, "value": str(value)} for value in values if str(value)]
+
+
+def _automation_eligible(plan: Dict[str, Any], available_write_providers: List[str]) -> bool:
+    proposed_value = str(plan.get("proposed_value") or "")
+    return (
+        bool(available_write_providers)
+        and plan.get("operation") in DNS_AUTOMATION_OPERATIONS
+        and plan.get("record_type") in DNS_AUTOMATION_RECORD_TYPES
+        and bool(proposed_value)
+        and "<" not in proposed_value
+        and not plan.get("provider_value_required")
+    )
+
+
+def _queue_status(items: List[Dict[str, Any]]) -> str:
+    if any(item["state"] == "approval_ready" for item in items):
+        return "needs_approval"
+    if any(item["state"] == "manual_action" for item in items):
+        return "needs_manual_action"
+    if any(item["state"] == "investigate" for item in items):
+        return "needs_investigation"
+    return "healthy"
+
+
+def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
+    return {
+        "total": len(items),
+        "approval_ready": sum(1 for item in items if item["state"] == "approval_ready"),
+        "manual_action": sum(1 for item in items if item["state"] == "manual_action"),
+        "investigate": sum(1 for item in items if item["state"] == "investigate"),
+        "informational": sum(1 for item in items if item["state"] == "informational"),
+    }
+
+
+def _dns_item(
+    *,
+    domain: str,
+    plan: Dict[str, Any],
+    finding: Optional[Dict[str, Any]],
+    available_write_providers: List[str],
+    recommended_provider: Optional[str],
+) -> Dict[str, Any]:
+    automation_ready = _automation_eligible(plan, available_write_providers)
+    severity = DNS_SEVERITY.get(str(plan.get("severity") or "info"), "low")
+    steps = list(plan.get("manual_steps") or [])
+    evidence = _evidence_from_values(plan.get("current_values") or [], label="current_value")
+    if finding:
+        evidence.extend(_evidence_from_values(finding.get("evidence") or [], label="finding"))
+    prerequisites = [
+        "Review the exact DNS diff in DMARQ.",
+        "Confirm the record belongs to this sending domain.",
+    ]
+    if automation_ready:
+        prerequisites.append("Preview the provider mutation before approving the write.")
+    else:
+        prerequisites.append("Use the manual DNS-provider steps; provider write is not ready.")
+    if recommended_provider:
+        prerequisites.append(f"Use the detected provider path for {recommended_provider}.")
+
+    return {
+        "id": f"dns:{plan.get('plan_id') or plan.get('finding_code')}",
+        "source": "dns_lint",
+        "state": "approval_ready" if automation_ready else "manual_action",
+        "severity": severity,
+        "confidence": "high" if finding else "medium",
+        "title": finding.get("title") if finding else f"Review {plan.get('finding_code')}",
+        "detail": finding.get("detail") if finding else str(plan.get("rationale") or ""),
+        "next_steps": steps or [str(plan.get("rationale") or "Review the DNS finding.")],
+        "evidence": evidence,
+        "blast_radius": f"DNS record {plan.get('name')} ({plan.get('record_type')})",
+        "prerequisites": prerequisites,
+        "expected_health_score_impact": str(plan.get("expected_health_impact") or ""),
+        "automation": {
+            "eligible": automation_ready,
+            "requires_approval": True,
+            "provider": recommended_provider,
+            "plan_id": plan.get("plan_id"),
+            "apply_endpoint": (
+                f"/api/v1/domains/{domain}/dns/change-plan/apply" if automation_ready else None
+            ),
+            "reason": (
+                "Safe provider-backed DNS preview is available."
+                if automation_ready
+                else "Manual review is required before provider automation is safe."
+            ),
+        },
+    }
+
+
+def _health_item(domain: str, action: Dict[str, Any]) -> Dict[str, Any]:
+    state = "investigate" if action.get("type") == "low_compliance" else "manual_action"
+    return {
+        "id": f"health:{action.get('type')}",
+        "source": "health_score",
+        "state": state,
+        "severity": str(action.get("severity") or "medium"),
+        "confidence": "medium",
+        "title": str(action.get("title") or "Review domain health"),
+        "detail": str(action.get("detail") or ""),
+        "next_steps": [str(action.get("next_step") or "Review the domain evidence.")],
+        "evidence": _evidence_from_pairs(action.get("evidence") or []),
+        "blast_radius": f"Observed DMARC traffic for {domain}",
+        "prerequisites": [
+            "Confirm the sender or DNS owner before making changes.",
+            "Use report evidence to avoid trusting unknown senders by mistake.",
+        ],
+        "expected_health_score_impact": str(action.get("score_impact") or 0),
+        "automation": {
+            "eligible": False,
+            "requires_approval": True,
+            "provider": None,
+            "plan_id": None,
+            "apply_endpoint": None,
+            "reason": "This item needs investigation before a provider change is safe.",
+        },
+    }
+
+
+def build_remediation_queue(
+    *,
+    domain: str,
+    health: Dict[str, Any],
+    dns_guidance: Dict[str, Any],
+    available_write_providers: Optional[List[str]] = None,
+    recommended_provider: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Group health and DNS findings into a prioritized remediation queue."""
+    providers = list(available_write_providers or [])
+    findings = {str(finding.get("code")): finding for finding in dns_guidance.get("findings") or []}
+    plans = list(dns_guidance.get("change_plans") or [])
+    planned_findings: Set[str] = {str(plan.get("finding_code")) for plan in plans}
+    items = [
+        _dns_item(
+            domain=domain,
+            plan=plan,
+            finding=findings.get(str(plan.get("finding_code"))),
+            available_write_providers=providers,
+            recommended_provider=recommended_provider,
+        )
+        for plan in plans
+    ]
+
+    for action in health.get("actions") or []:
+        action_type = str(action.get("type") or "")
+        if HEALTH_DNS_EQUIVALENTS.get(action_type, set()) & planned_findings:
+            continue
+        items.append(_health_item(domain, action))
+
+    items.sort(
+        key=lambda item: (
+            item["state"] != "approval_ready",
+            -SEVERITY_RANK.get(item["severity"], 0),
+            item["id"],
+        )
+    )
+    return {
+        "domain": domain,
+        "status": _queue_status(items),
+        "summary": _summary(items),
+        "items": items,
+    }

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -202,6 +202,78 @@
                     </div>
                 </div>
 
+                <div class="mt-5 rounded-lg border border-[#e6e3e1] bg-[#f8f7f6] p-4">
+                    <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div>
+                            <h3 class="font-semibold text-[#07071f]">Remediation Queue</h3>
+                            <p class="mt-1 text-sm text-[#5f5c78]">Prioritized fixes with evidence, prerequisites, and approval status.</p>
+                        </div>
+                        <div class="flex flex-wrap gap-2 text-xs">
+                            <span class="rounded bg-white px-2 py-1 font-semibold text-[#272a5f]">
+                                <span x-text="remediationQueue.summary.total"></span><span> open</span>
+                            </span>
+                            <span class="rounded bg-green-100 px-2 py-1 font-semibold text-green-700">
+                                <span x-text="remediationQueue.summary.approval_ready"></span><span> approval-ready</span>
+                            </span>
+                            <span class="rounded bg-yellow-100 px-2 py-1 font-semibold text-yellow-800">
+                                <span x-text="remediationQueue.summary.manual_action"></span><span> manual</span>
+                            </span>
+                            <span class="rounded bg-blue-100 px-2 py-1 font-semibold text-blue-700">
+                                <span x-text="remediationQueue.summary.investigate"></span><span> investigate</span>
+                            </span>
+                        </div>
+                    </div>
+                    <template x-if="remediationQueue.items.length === 0">
+                        <p class="mt-4 text-sm text-[#5f5c78]">No remediation items are queued for this domain.</p>
+                    </template>
+                    <div class="mt-4 grid gap-3 xl:grid-cols-2">
+                        <template x-for="item in remediationQueue.items.slice(0, 6)" :key="item.id">
+                            <div class="rounded-lg border border-[#e6e3e1] bg-white p-4">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div class="min-w-0">
+                                        <div class="flex flex-wrap items-center gap-2">
+                                            <span class="rounded px-2 py-1 text-xs font-semibold capitalize"
+                                                  :class="remediationStateClass(item.state)"
+                                                  x-text="item.state.replace('_', ' ')"></span>
+                                            <span class="inline-flex items-center gap-1 text-xs font-semibold uppercase text-[#5f5c78]">
+                                                <span class="h-2 w-2 rounded-full"
+                                                      :class="remediationSeverityDotClass(item.severity)"></span>
+                                                <span x-text="item.severity"></span>
+                                            </span>
+                                            <span class="text-xs text-[#5f5c78]" x-text="item.source.replace('_', ' ')"></span>
+                                        </div>
+                                        <h4 class="mt-3 font-semibold text-[#07071f]" x-text="item.title"></h4>
+                                        <p class="mt-1 text-sm text-[#5f5c78]" x-text="item.detail"></p>
+                                    </div>
+                                </div>
+                                <div class="mt-3 rounded bg-[#f4f3f2] p-3">
+                                    <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next step</p>
+                                    <p class="mt-1 text-sm text-[#120d36]" x-text="item.next_steps[0] || 'Review the evidence.'"></p>
+                                </div>
+                                <div class="mt-3 flex flex-wrap items-center gap-2 text-xs">
+                                    <span class="rounded bg-[#f4f3f2] px-2 py-1 text-[#5f5c78]" x-text="item.blast_radius"></span>
+                                    <span class="rounded bg-[#f4f3f2] px-2 py-1 text-[#5f5c78]">
+                                        <span>Impact </span><span x-text="item.expected_health_score_impact || 'n/a'"></span>
+                                    </span>
+                                    <a x-show="item.automation && item.automation.plan_id"
+                                       href="#dns-guidance"
+                                       class="rounded bg-[#2f9da5]/10 px-2 py-1 font-semibold text-[#1f7c83]">
+                                        Review DNS plan
+                                    </a>
+                                </div>
+                                <div class="mt-3 flex flex-wrap gap-2">
+                                    <template x-for="evidence in item.evidence.slice(0, 3)" :key="item.id + evidence.label + evidence.value">
+                                        <span class="badge badge-outline gap-1">
+                                            <span x-text="evidence.label"></span>
+                                            <span class="max-w-[14rem] truncate font-mono" x-text="evidence.value"></span>
+                                        </span>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+
                 <div class="mt-5 grid gap-5 xl:grid-cols-2">
                     <div class="space-y-3">
                         <h3 class="font-semibold">Recommendations</h3>
@@ -1526,6 +1598,17 @@ function domainDetailsApp(domainId) {
             changes: [],
             playbooks: []
         },
+        remediationQueue: {
+            status: '',
+            summary: {
+                total: 0,
+                approval_ready: 0,
+                manual_action: 0,
+                investigate: 0,
+                informational: 0
+            },
+            items: []
+        },
         mtaSts: {
             status: '',
             dns_record: '',
@@ -1623,6 +1706,7 @@ function domainDetailsApp(domainId) {
             this.fetchDNSGuidance();
             this.fetchDNSProviders();
             this.fetchPosture();
+            this.fetchRemediationQueue();
             this.fetchHealthHistory();
             this.fetchMigrationReadiness();
             this.fetchMigrationParity();
@@ -1826,6 +1910,20 @@ function domainDetailsApp(domainId) {
             return 'bg-blue-500';
         },
 
+        remediationSeverityDotClass(severity) {
+            if (['critical', 'high', 'error'].includes(severity)) return 'bg-red-500';
+            if (['medium', 'warning'].includes(severity)) return 'bg-yellow-500';
+            if (severity === 'low') return 'bg-blue-500';
+            return 'bg-base-300';
+        },
+
+        remediationStateClass(state) {
+            if (state === 'approval_ready') return 'bg-green-100 text-green-700';
+            if (state === 'manual_action') return 'bg-yellow-100 text-yellow-800';
+            if (state === 'investigate') return 'bg-blue-100 text-blue-700';
+            return 'bg-base-200 text-base-content/70';
+        },
+
         senderStatusClass(status) {
             if (status === 'known') return 'bg-green-100 text-green-800';
             if (status === 'ambiguous') return 'bg-yellow-100 text-yellow-800';
@@ -1968,6 +2066,7 @@ function domainDetailsApp(domainId) {
                     await this.fetchDNSHealth();
                     await this.fetchDNSGuidance();
                     await this.fetchPosture();
+                    await this.fetchRemediationQueue();
                 }
                 return data;
             } catch (error) {
@@ -2011,6 +2110,17 @@ function domainDetailsApp(domainId) {
                 }
             } catch (error) {
                 console.error('Error fetching posture dashboard:', error);
+            }
+        },
+
+        async fetchRemediationQueue() {
+            try {
+                const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation`);
+                if (response.ok) {
+                    this.remediationQueue = await response.json();
+                }
+            } catch (error) {
+                console.error('Error fetching remediation queue:', error);
             }
         },
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -571,6 +571,100 @@ def test_domain_posture_dashboard_records_current_snapshot(
     assert snapshots[-1].score == 96
 
 
+def test_domain_remediation_queue_groups_dns_and_health_actions(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Domain remediation returns a prioritized, human-reviewed action queue."""
+
+    async def fake_domain_grade(db, domain_id, store, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 72,
+            "grade": "C",
+            "status": "attention",
+            "factors": {
+                "dns_posture": 60,
+                "policy_strength": 40,
+                "report_confidence": 90,
+            },
+            "actions": [
+                {
+                    "type": "missing_dmarc",
+                    "severity": "high",
+                    "title": "Publish DMARC",
+                    "detail": "No DMARC policy was found.",
+                    "next_step": "Publish a DMARC TXT record.",
+                    "score_impact": 30,
+                },
+                {
+                    "type": "low_compliance",
+                    "severity": "medium",
+                    "title": "Review failing senders",
+                    "detail": "Some senders fail DMARC.",
+                    "next_step": "Investigate the top failing source.",
+                    "score_impact": 12,
+                },
+            ],
+        }
+
+    async def fake_dns_guidance(db, store, domain_id, refresh=False):
+        return {
+            "domain": domain_id,
+            "status": "critical",
+            "dns_provider": {"provider_id": "cloudflare"},
+            "findings": [
+                {
+                    "code": "dmarc_missing",
+                    "severity": "error",
+                    "title": "Publish DMARC",
+                    "detail": "No DMARC TXT record was found.",
+                    "evidence": ["_dmarc.example.com"],
+                }
+            ],
+            "change_plans": [
+                {
+                    "plan_id": "dmarc-missing",
+                    "finding_code": "dmarc_missing",
+                    "severity": "error",
+                    "operation": "create",
+                    "record_type": "TXT",
+                    "name": "_dmarc.example.com",
+                    "proposed_value": "v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+                    "current_values": [],
+                    "rationale": "Publish a monitoring DMARC record.",
+                    "expected_health_impact": "High",
+                    "manual_steps": ["Create the TXT record."],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
+    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: ["cloudflare"])
+    monkeypatch.setattr(
+        domains_endpoint,
+        "_recommended_dns_write_provider",
+        lambda dns_provider, available_providers: "cloudflare",
+    )
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "needs_approval"
+    assert data["summary"]["total"] == 2
+    assert data["summary"]["approval_ready"] == 1
+    assert data["summary"]["investigate"] == 1
+    assert data["items"][0]["id"] == "dns:dmarc-missing"
+    assert data["items"][0]["automation"]["eligible"] is True
+    assert data["items"][0]["automation"]["provider"] == "cloudflare"
+    assert [item["id"] for item in data["items"]] == [
+        "dns:dmarc-missing",
+        "health:low_compliance",
+    ]
+
+
 def test_domain_health_history_rejects_invalid_date_order(seeded_client: TestClient):
     """Health history validates that the start date is not after the end date."""
     response = seeded_client.get(

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -1,0 +1,117 @@
+from app.services.remediation_queue import build_remediation_queue
+
+
+def test_remediation_queue_prioritizes_provider_ready_dns_plan():
+    health = {
+        "actions": [
+            {
+                "type": "missing_dmarc",
+                "severity": "high",
+                "title": "Publish DMARC",
+                "detail": "No DMARC policy was found.",
+                "next_step": "Publish a DMARC TXT record.",
+                "score_impact": 30,
+                "evidence": [{"label": "record", "value": "_dmarc.example.com"}],
+            },
+            {
+                "type": "low_compliance",
+                "severity": "medium",
+                "title": "Review failing senders",
+                "detail": "Some senders fail DMARC.",
+                "next_step": "Investigate the top failing source.",
+                "score_impact": 12,
+            },
+        ]
+    }
+    dns_guidance = {
+        "findings": [
+            {
+                "code": "dmarc_missing",
+                "severity": "error",
+                "title": "Publish DMARC",
+                "detail": "No DMARC TXT record was found.",
+                "evidence": ["_dmarc.example.com"],
+            }
+        ],
+        "change_plans": [
+            {
+                "plan_id": "dmarc-missing",
+                "finding_code": "dmarc_missing",
+                "severity": "error",
+                "operation": "create",
+                "record_type": "TXT",
+                "name": "_dmarc.example.com",
+                "proposed_value": "v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+                "current_values": [],
+                "rationale": "Publish a monitoring DMARC record.",
+                "expected_health_impact": "High",
+                "manual_steps": ["Create the TXT record."],
+            }
+        ],
+    }
+
+    queue = build_remediation_queue(
+        domain="example.com",
+        health=health,
+        dns_guidance=dns_guidance,
+        available_write_providers=["cloudflare"],
+        recommended_provider="cloudflare",
+    )
+
+    assert queue["status"] == "needs_approval"
+    assert queue["summary"] == {
+        "total": 2,
+        "approval_ready": 1,
+        "manual_action": 0,
+        "investigate": 1,
+        "informational": 0,
+    }
+    assert queue["items"][0]["id"] == "dns:dmarc-missing"
+    assert queue["items"][0]["state"] == "approval_ready"
+    assert queue["items"][0]["automation"]["eligible"] is True
+    assert queue["items"][0]["automation"]["apply_endpoint"] == (
+        "/api/v1/domains/example.com/dns/change-plan/apply"
+    )
+    assert [item["id"] for item in queue["items"]] == [
+        "dns:dmarc-missing",
+        "health:low_compliance",
+    ]
+
+
+def test_remediation_queue_keeps_placeholder_plan_manual():
+    queue = build_remediation_queue(
+        domain="example.com",
+        health={"actions": []},
+        dns_guidance={
+            "findings": [
+                {
+                    "code": "dkim_selector_missing",
+                    "severity": "warning",
+                    "title": "Publish DKIM",
+                    "detail": "The selector target is not configured.",
+                }
+            ],
+            "change_plans": [
+                {
+                    "plan_id": "dkim-selector",
+                    "finding_code": "dkim_selector_missing",
+                    "severity": "warning",
+                    "operation": "create",
+                    "record_type": "CNAME",
+                    "name": "pm._domainkey.example.com",
+                    "proposed_value": "<selector target from mail provider>",
+                    "provider_value_required": True,
+                    "rationale": "Provider-specific DKIM target is required.",
+                    "expected_health_impact": "Medium",
+                }
+            ],
+        },
+        available_write_providers=["cloudflare"],
+        recommended_provider="cloudflare",
+    )
+
+    assert queue["status"] == "needs_manual_action"
+    assert queue["summary"]["manual_action"] == 1
+    assert queue["items"][0]["state"] == "manual_action"
+    assert queue["items"][0]["automation"]["eligible"] is False
+    assert queue["items"][0]["automation"]["apply_endpoint"] is None

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -570,6 +570,7 @@ queried DNS name, record text, logo URL, certificate URL, warnings, and errors.
 GET /domains/{domain_id}/dns/lint
 GET /domains/{domain_id}/dns/change-plan
 POST /domains/{domain_id}/dns/change-plan/apply
+GET /domains/{domain_id}/remediation
 GET /domains/dns/providers
 GET /domains/dns/import/{provider}/preview
 POST /domains/dns/import/{provider}
@@ -648,6 +649,14 @@ after confirming the rollback is still safe.
 `available_write_providers`, `recommended_provider`, and response-level
 `safety_notes`. Each plan contains its own `safety_notes` explaining whether it
 can be previewed through a provider connector or why it remains manual-only.
+
+`GET /domains/{domain_id}/remediation` returns the human-reviewed remediation
+queue for a domain. It groups DNS change plans and health-score actions into
+prioritized items with state, severity, next steps, evidence, blast radius,
+prerequisites, expected health-score impact, and automation eligibility. DNS
+items that have a concrete safe TXT/CNAME provider write are marked
+`approval_ready` and point to the same explicit preview/apply endpoint used by
+the DNS change-plan UI. The endpoint does not perform DNS writes.
 
 #### Get Posture Dashboard
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -79,6 +79,13 @@ Operator playbooks sit beside the recommendations. They are short remediation
 checklists for common gaps such as missing SPF, missing DKIM, policy enforcement
 readiness, MTA-STS setup, or BIMI prerequisites.
 
+The dashboard also includes a **Remediation Queue** that merges health-score
+actions and DNS lint change plans into one prioritized list. Items are marked
+as approval-ready, manual, or investigate-only, and include the evidence,
+blast radius, prerequisites, and expected health-score impact. Approval-ready
+DNS items link back to the DNS change-plan review area; they still require an
+operator preview and explicit approval before any provider write is sent.
+
 ### Source Intelligence
 
 The domain detail page groups sending sources into coarse regions and networks


### PR DESCRIPTION
## Summary
- add a domain remediation queue API that groups DNS lint change plans and health-score actions into prioritized human-reviewed items
- surface the queue on the domain detail posture dashboard with approval/manual/investigation state and DNS-plan links
- document the new endpoint and operator workflow

Refs #384

## Validation
- ./.venv/bin/pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py -q
- ./.venv/bin/black --check backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/isort --check-only backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/flake8 backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/python -m py_compile backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py
- git diff --check
- ./.venv/bin/mkdocs build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Remediation Queue view for domains, showing prioritized actions with status, severity, evidence, next steps, and automation readiness.
  * Introduced a domain remediation endpoint that returns the queue data used by the dashboard.
  * Queue items now refresh after DNS changes are applied, keeping the dashboard current.

* **Documentation**
  * Updated the domain user guide and API reference with the new remediation queue endpoint and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->