### PR TITLE
fix: harden remediation queue follow-ups

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3541,7 +3541,7 @@ async def get_domain_remediation_queue(
     """Return a prioritized, human-reviewed remediation queue for one domain."""
     workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    hydrate_report_store_from_db(db, store)
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3541,7 +3541,7 @@ async def get_domain_remediation_queue(
     """Return a prioritized, human-reviewed remediation queue for one domain."""
     workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -78,7 +78,10 @@ def _dns_item(
     available_write_providers: List[str],
     recommended_provider: Optional[str],
 ) -> Dict[str, Any]:
-    automation_ready = _automation_eligible(plan, available_write_providers)
+    automation_ready = bool(recommended_provider) and _automation_eligible(
+        plan,
+        available_write_providers,
+    )
     severity = DNS_SEVERITY.get(str(plan.get("severity") or "info"), "low")
     steps = list(plan.get("manual_steps") or [])
     evidence = _evidence_from_values(plan.get("current_values") or [], label="current_value")

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -272,6 +272,11 @@
                             </div>
                         </template>
                     </div>
+                    <template x-if="remediationQueue.items.length > 6">
+                        <p class="mt-3 text-xs font-semibold text-[#5f5c78]">
+                            <span>+</span><span x-text="remediationQueue.items.length - 6"></span><span> more remediation items</span>
+                        </p>
+                    </template>
                 </div>
 
                 <div class="mt-5 grid gap-5 xl:grid-cols-2">
@@ -2116,9 +2121,26 @@ function domainDetailsApp(domainId) {
         async fetchRemediationQueue() {
             try {
                 const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation`);
-                if (response.ok) {
-                    this.remediationQueue = await response.json();
+                if (!response.ok) {
+                    console.error('Error fetching remediation queue:', {
+                        domainId: this.domainId,
+                        status: response.status,
+                        statusText: response.statusText
+                    });
+                    this.remediationQueue = {
+                        status: 'unavailable',
+                        summary: {
+                            total: 0,
+                            approval_ready: 0,
+                            manual_action: 0,
+                            investigate: 0,
+                            informational: 0
+                        },
+                        items: []
+                    };
+                    return;
                 }
+                this.remediationQueue = await response.json();
             } catch (error) {
                 console.error('Error fetching remediation queue:', error);
             }

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -665,13 +665,13 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
     ]
 
 
-def test_domain_remediation_queue_hydrates_legacy_report_domains_without_workspace_filter(
-    authed_client: TestClient,
+def test_domain_remediation_queue_hydrates_report_store_with_workspace_filter(
+    seeded_client: TestClient,
+    db_session,
     monkeypatch,
 ):
-    """Legacy report-only domains remain readable through the remediation endpoint."""
-    store = ReportStore.get_instance()
-    store.add_report(REPORT_DICT_POLICY)
+    """Domain remediation only hydrates reports scoped to the authorized workspace."""
+    workspace = get_or_create_default_workspace(db_session)
     captured = {}
 
     def fake_hydrate(db, store_arg, workspace_id=None):
@@ -702,10 +702,10 @@ def test_domain_remediation_queue_hydrates_legacy_report_domains_without_workspa
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
     monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: [])
 
-    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
 
     assert response.status_code == 200
-    assert captured["workspace_id"] is None
+    assert captured["workspace_id"] == workspace.id
     assert response.json()["domain"] == DOMAIN
 
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -665,6 +665,50 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
     ]
 
 
+def test_domain_remediation_queue_hydrates_legacy_report_domains_without_workspace_filter(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    """Legacy report-only domains remain readable through the remediation endpoint."""
+    store = ReportStore.get_instance()
+    store.add_report(REPORT_DICT_POLICY)
+    captured = {}
+
+    def fake_hydrate(db, store_arg, workspace_id=None):
+        captured["workspace_id"] = workspace_id
+        return 1
+
+    async def fake_domain_grade(db, domain_id, store_arg, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 100,
+            "grade": "A",
+            "status": "healthy",
+            "factors": {},
+            "actions": [],
+        }
+
+    async def fake_dns_guidance(db, store_arg, domain_id, refresh=False):
+        return {
+            "domain": domain_id,
+            "status": "healthy",
+            "dns_provider": None,
+            "findings": [],
+            "change_plans": [],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
+    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: [])
+
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+
+    assert response.status_code == 200
+    assert captured["workspace_id"] is None
+    assert response.json()["domain"] == DOMAIN
+
+
 def test_domain_health_history_rejects_invalid_date_order(seeded_client: TestClient):
     """Health history validates that the start date is not after the end date."""
     response = seeded_client.get(

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -115,3 +115,42 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
     assert queue["items"][0]["state"] == "manual_action"
     assert queue["items"][0]["automation"]["eligible"] is False
     assert queue["items"][0]["automation"]["apply_endpoint"] is None
+
+
+def test_remediation_queue_requires_recommended_provider_for_automation():
+    queue = build_remediation_queue(
+        domain="example.com",
+        health={"actions": []},
+        dns_guidance={
+            "findings": [
+                {
+                    "code": "dmarc_missing",
+                    "severity": "error",
+                    "title": "Publish DMARC",
+                    "detail": "No DMARC TXT record was found.",
+                }
+            ],
+            "change_plans": [
+                {
+                    "plan_id": "dmarc-missing",
+                    "finding_code": "dmarc_missing",
+                    "severity": "error",
+                    "operation": "create",
+                    "record_type": "TXT",
+                    "name": "_dmarc.example.com",
+                    "proposed_value": "v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+                    "rationale": "Publish a monitoring DMARC record.",
+                }
+            ],
+        },
+        available_write_providers=["cloudflare"],
+        recommended_provider=None,
+    )
+
+    assert queue["status"] == "needs_manual_action"
+    assert queue["summary"]["approval_ready"] == 0
+    assert queue["summary"]["manual_action"] == 1
+    assert queue["items"][0]["state"] == "manual_action"
+    assert queue["items"][0]["automation"]["eligible"] is False
+    assert queue["items"][0]["automation"]["provider"] is None
+    assert queue["items"][0]["automation"]["apply_endpoint"] is None


### PR DESCRIPTION
## Summary
- require a detected/recommended provider before marking remediation queue DNS items approval-ready
- keep remediation queue report hydration scoped to the authorized workspace
- log non-OK remediation queue fetches and surface hidden queue overflow in the domain UI
- add targeted coverage for provider gating and workspace-scoped remediation hydration

Refs #380
Refs #384

## Tests
- ./.venv/bin/pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py -q
- ./.venv/bin/black --check backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/isort --check-only backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/flake8 backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/python -m py_compile backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py
- git diff --check