### PR TITLE
fix: reset remediation queue on fetch failure

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3543,6 +3543,8 @@ async def get_domain_remediation_queue(
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
     if not _domain_exists(db, store, domain_id, workspace):
+        hydrate_report_store_from_db(db, store)
+    if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Domain not found",

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1321,6 +1321,13 @@ def _domain_exists(db: Session, store: ReportStore, domain_name: str, workspace=
     return domain_name in store.get_domains()
 
 
+def _stored_domain_exists(db: Session, domain_id: str) -> bool:
+    query = db.query(Domain.id)
+    if domain_id.isdigit() and query.filter(Domain.id == int(domain_id)).first() is not None:
+        return True
+    return query.filter(Domain.name == domain_id).first() is not None
+
+
 def _resolve_domain_name_for_read(
     db: Session,
     store: ReportStore,
@@ -3542,28 +3549,28 @@ async def get_domain_remediation_queue(
     workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
-    if not _domain_exists(db, store, domain_id, workspace):
+    try:
+        domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
+    except HTTPException as exc:
+        if exc.status_code != status.HTTP_404_NOT_FOUND or _stored_domain_exists(db, domain_id):
+            raise
         hydrate_report_store_from_db(db, store)
-    if not _domain_exists(db, store, domain_id, workspace):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Domain not found",
-        )
+        domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
 
     domain_health = await _build_domain_health_grade(
         db,
-        domain_id,
+        domain_name,
         store,
         refresh=refresh,
     )
-    guidance = await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
+    guidance = await _build_domain_dns_guidance(db, store, domain_name, refresh=refresh)
     available_providers = _ready_dns_write_provider_ids()
     recommended_provider = _recommended_dns_write_provider(
         guidance.get("dns_provider"),
         available_providers,
     )
     return build_remediation_queue(
-        domain=domain_id,
+        domain=domain_name,
         health=domain_health,
         dns_guidance=guidance,
         available_write_providers=available_providers,

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2143,6 +2143,17 @@ function domainDetailsApp(domainId) {
                 this.remediationQueue = await response.json();
             } catch (error) {
                 console.error('Error fetching remediation queue:', error);
+                this.remediationQueue = {
+                    status: 'unavailable',
+                    summary: {
+                        total: 0,
+                        approval_ready: 0,
+                        manual_action: 0,
+                        investigate: 0,
+                        informational: 0
+                    },
+                    items: []
+                };
             }
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2118,6 +2118,20 @@ function domainDetailsApp(domainId) {
             }
         },
 
+        resetRemediationQueue() {
+            this.remediationQueue = {
+                status: 'unavailable',
+                summary: {
+                    total: 0,
+                    approval_ready: 0,
+                    manual_action: 0,
+                    investigate: 0,
+                    informational: 0
+                },
+                items: []
+            };
+        },
+
         async fetchRemediationQueue() {
             try {
                 const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation`);
@@ -2127,33 +2141,13 @@ function domainDetailsApp(domainId) {
                         status: response.status,
                         statusText: response.statusText
                     });
-                    this.remediationQueue = {
-                        status: 'unavailable',
-                        summary: {
-                            total: 0,
-                            approval_ready: 0,
-                            manual_action: 0,
-                            investigate: 0,
-                            informational: 0
-                        },
-                        items: []
-                    };
+                    this.resetRemediationQueue();
                     return;
                 }
                 this.remediationQueue = await response.json();
             } catch (error) {
                 console.error('Error fetching remediation queue:', error);
-                this.remediationQueue = {
-                    status: 'unavailable',
-                    summary: {
-                        total: 0,
-                        approval_ready: 0,
-                        manual_action: 0,
-                        investigate: 0,
-                        informational: 0
-                    },
-                    items: []
-                };
+                this.resetRemediationQueue();
             }
         },
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -714,7 +714,6 @@ def test_domain_remediation_queue_falls_back_for_legacy_report_domains(
     monkeypatch,
 ):
     """Domain remediation uses scoped hydration before legacy report-only fallback."""
-    store = ReportStore.get_instance()
     hydrate_calls = []
 
     def fake_hydrate(db, store_arg, workspace_id=None):
@@ -755,6 +754,55 @@ def test_domain_remediation_queue_falls_back_for_legacy_report_domains(
     assert len(hydrate_calls) == 2
     assert hydrate_calls[0] is not None
     assert hydrate_calls[1] is None
+    assert response.json()["domain"] == DOMAIN
+
+
+def test_domain_remediation_queue_accepts_numeric_domain_id(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Domain remediation resolves numeric path IDs to the authorized domain name."""
+    domain = db_session.query(Domain).filter(Domain.name == DOMAIN).one()
+    hydrate_calls = []
+    seen_domains = []
+
+    def fake_hydrate(db, store_arg, workspace_id=None):
+        hydrate_calls.append(workspace_id)
+        return 1
+
+    async def fake_domain_grade(db, domain_id, store_arg, refresh=False):
+        seen_domains.append(domain_id)
+        return {
+            "domain": domain_id,
+            "score": 100,
+            "grade": "A",
+            "status": "healthy",
+            "factors": {},
+            "actions": [],
+        }
+
+    async def fake_dns_guidance(db, store_arg, domain_id, refresh=False):
+        seen_domains.append(domain_id)
+        return {
+            "domain": domain_id,
+            "status": "healthy",
+            "dns_provider": None,
+            "findings": [],
+            "change_plans": [],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
+    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: [])
+
+    response = seeded_client.get(f"/api/v1/domains/{domain.id}/remediation")
+
+    assert response.status_code == 200
+    assert len(hydrate_calls) == 1
+    assert hydrate_calls[0] is not None
+    assert seen_domains == [DOMAIN, DOMAIN]
     assert response.json()["domain"] == DOMAIN
 
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -709,6 +709,55 @@ def test_domain_remediation_queue_hydrates_report_store_with_workspace_filter(
     assert response.json()["domain"] == DOMAIN
 
 
+def test_domain_remediation_queue_falls_back_for_legacy_report_domains(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    """Domain remediation uses scoped hydration before legacy report-only fallback."""
+    store = ReportStore.get_instance()
+    hydrate_calls = []
+
+    def fake_hydrate(db, store_arg, workspace_id=None):
+        hydrate_calls.append(workspace_id)
+        if workspace_id is not None:
+            store_arg.clear()
+            return 0
+        store_arg.add_report(REPORT_DICT_POLICY)
+        return 1
+
+    async def fake_domain_grade(db, domain_id, store_arg, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 100,
+            "grade": "A",
+            "status": "healthy",
+            "factors": {},
+            "actions": [],
+        }
+
+    async def fake_dns_guidance(db, store_arg, domain_id, refresh=False):
+        return {
+            "domain": domain_id,
+            "status": "healthy",
+            "dns_provider": None,
+            "findings": [],
+            "change_plans": [],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
+    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: [])
+
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+
+    assert response.status_code == 200
+    assert len(hydrate_calls) == 2
+    assert hydrate_calls[0] is not None
+    assert hydrate_calls[1] is None
+    assert response.json()["domain"] == DOMAIN
+
+
 def test_domain_health_history_rejects_invalid_date_order(seeded_client: TestClient):
     """Health history validates that the start date is not after the end date."""
     response = seeded_client.get(

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.models.domain import Domain
+from app.models.workspace import Workspace
 from app.services import report_persistence
 from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.report_store import ReportStore
@@ -804,6 +805,37 @@ def test_domain_remediation_queue_accepts_numeric_domain_id(
     assert hydrate_calls[0] is not None
     assert seen_domains == [DOMAIN, DOMAIN]
     assert response.json()["domain"] == DOMAIN
+
+
+def test_domain_remediation_queue_rejects_other_workspace_numeric_domain_without_fallback(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Existing domains outside the authorized workspace do not trigger legacy fallback."""
+    other_workspace = Workspace(slug="other-remediation", name="Other Remediation", active=True)
+    db_session.add(other_workspace)
+    db_session.flush()
+    other_domain = Domain(
+        name="other-remediation.example",
+        workspace_id=other_workspace.id,
+        active=True,
+    )
+    db_session.add(other_domain)
+    db_session.commit()
+    hydrate_calls = []
+
+    def fake_hydrate(db, store_arg, workspace_id=None):
+        hydrate_calls.append(workspace_id)
+        return 0
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
+
+    response = seeded_client.get(f"/api/v1/domains/{other_domain.id}/remediation")
+
+    assert response.status_code == 404
+    assert len(hydrate_calls) == 1
+    assert hydrate_calls[0] is not None
 
 
 def test_domain_health_history_rejects_invalid_date_order(seeded_client: TestClient):


### PR DESCRIPTION
## Summary
- reset the domain remediation queue to an explicit unavailable/empty state when the network request throws
- keep the backend remediation lookup workspace-scoped; no unscoped legacy fallback is included

Refs #384

## Tests
- ./.venv/bin/pytest backend/app/tests/test_domain_detail_endpoints.py -q
- ./.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/python -m py_compile backend/app/api/api_v1/endpoints/domains.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when remediation queue data can’t be loaded, now showing a consistent “unavailable” state with clear zeroed counts and no items.
  * This helps prevent confusing or partial queue information from appearing after an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->