### PR TITLE
test: cover invalid TLS report zip

### DIFF
--- a/backend/app/services/tls_report_parser.py
+++ b/backend/app/services/tls_report_parser.py
@@ -63,6 +63,7 @@ def _extract_json_content(file_content: bytes, filename: str) -> bytes:
         extracted = _extract_json_from_zip(file_content)
         if extracted is not None:
             return extracted
+        raise ValueError("Could not extract JSON content from ZIP TLS report")
     if lower.endswith((".gz", ".gzip")):
         try:
             return gzip.decompress(file_content)

--- a/backend/app/tests/test_tls_report_parser.py
+++ b/backend/app/tests/test_tls_report_parser.py
@@ -79,6 +79,15 @@ def test_parse_tls_report_zip():
     assert parsed["policies"][0]["policy_domain"] == "example.com"
 
 
+def test_parse_tls_report_rejects_zip_without_json_file():
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("nested/readme.txt", "not a TLS report")
+
+    with pytest.raises(ValueError, match="Could not extract JSON content"):
+        TLSReportParser.parse_file(archive.getvalue(), "tls-report.zip")
+
+
 def test_parse_tls_report_rejects_bad_zip_file():
     with pytest.raises(ValueError, match="Could not extract JSON content"):
         TLSReportParser.parse_file(b"not a zip file", "tls-report.zip")

--- a/backend/app/tests/test_tls_report_parser.py
+++ b/backend/app/tests/test_tls_report_parser.py
@@ -79,6 +79,11 @@ def test_parse_tls_report_zip():
     assert parsed["policies"][0]["policy_domain"] == "example.com"
 
 
+def test_parse_tls_report_rejects_bad_zip_file():
+    with pytest.raises(ValueError, match="Could not extract JSON content"):
+        TLSReportParser.parse_file(b"not a zip file", "tls-report.zip")
+
+
 def test_parse_tls_report_generates_stable_id_when_missing():
     report = dict(SAMPLE_TLS_REPORT)
     report.pop("report-id")

--- a/backend/app/tests/test_tls_report_parser.py
+++ b/backend/app/tests/test_tls_report_parser.py
@@ -7,7 +7,6 @@ import pytest
 
 from app.services.tls_report_parser import TLSReportParser
 
-
 SAMPLE_TLS_REPORT = {
     "organization-name": "Example Reporter",
     "date-range": {


### PR DESCRIPTION
## Summary
- raise a clear error when a .zip TLS report has no extractable JSON content
- add regression coverage for corrupt TLS report ZIP uploads

## Tests
- .venv/bin/python -m pytest backend/app/tests/test_tls_report_parser.py -q
- .venv/bin/python -m flake8 backend/app/services/tls_report_parser.py backend/app/tests/test_tls_report_parser.py
- git diff --check