### PR TITLE
fix: gate legacy remediation fallback

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -19,6 +19,7 @@ from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.report import DMARCReport
+from app.models.workspace import Workspace
 from app.services.bimi import BIMIResult, check_bimi_cached
 from app.services.cloudflare_dns import (
     analyze_dns_records,
@@ -1326,6 +1327,10 @@ def _stored_domain_exists(db: Session, domain_id: str) -> bool:
     if domain_id.isdigit() and query.filter(Domain.id == int(domain_id)).first() is not None:
         return True
     return query.filter(Domain.name == domain_id).first() is not None
+
+
+def _allows_legacy_report_only_fallback(db: Session) -> bool:
+    return db.query(Workspace.id).filter(Workspace.active.is_(True)).limit(2).count() <= 1
 
 
 def _resolve_domain_name_for_read(
@@ -3552,7 +3557,11 @@ async def get_domain_remediation_queue(
     try:
         domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
     except HTTPException as exc:
-        if exc.status_code != status.HTTP_404_NOT_FOUND or _stored_domain_exists(db, domain_id):
+        if (
+            exc.status_code != status.HTTP_404_NOT_FOUND
+            or _stored_domain_exists(db, domain_id)
+            or not _allows_legacy_report_only_fallback(db)
+        ):
             raise
         hydrate_report_store_from_db(db, store)
         domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1330,7 +1330,7 @@ def _stored_domain_exists(db: Session, domain_id: str) -> bool:
 
 
 def _allows_legacy_report_only_fallback(db: Session) -> bool:
-    return db.query(Workspace.id).filter(Workspace.active.is_(True)).limit(2).count() <= 1
+    return db.query(Workspace.id).limit(2).count() <= 1
 
 
 def _resolve_domain_name_for_read(

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -838,16 +838,18 @@ def test_domain_remediation_queue_rejects_other_workspace_numeric_domain_without
     assert hydrate_calls[0] is not None
 
 
+@pytest.mark.parametrize("other_workspace_active", [True, False])
 def test_domain_remediation_queue_rejects_report_only_fallback_with_multiple_workspaces(
     authed_client: TestClient,
     db_session,
     monkeypatch,
+    other_workspace_active,
 ):
     """Legacy report-only fallback is only safe for single-workspace deployments."""
     other_workspace = Workspace(
         slug="second-remediation",
         name="Second Remediation",
-        active=True,
+        active=other_workspace_active,
     )
     db_session.add(other_workspace)
     db_session.commit()

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -838,6 +838,38 @@ def test_domain_remediation_queue_rejects_other_workspace_numeric_domain_without
     assert hydrate_calls[0] is not None
 
 
+def test_domain_remediation_queue_rejects_report_only_fallback_with_multiple_workspaces(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Legacy report-only fallback is only safe for single-workspace deployments."""
+    other_workspace = Workspace(
+        slug="second-remediation",
+        name="Second Remediation",
+        active=True,
+    )
+    db_session.add(other_workspace)
+    db_session.commit()
+    hydrate_calls = []
+
+    def fake_hydrate(db, store_arg, workspace_id=None):
+        hydrate_calls.append(workspace_id)
+        if workspace_id is None:
+            store_arg.add_report(REPORT_DICT_POLICY)
+            return 1
+        store_arg.clear()
+        return 0
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
+
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+
+    assert response.status_code == 404
+    assert len(hydrate_calls) == 1
+    assert hydrate_calls[0] is not None
+
+
 def test_domain_health_history_rejects_invalid_date_order(seeded_client: TestClient):
     """Health history validates that the start date is not after the end date."""
     response = seeded_client.get(


### PR DESCRIPTION
## Summary
- gate legacy report-only remediation queue fallback to single-workspace deployments
- keep existing stored-domain workspace checks intact for numeric and named domain paths
- add regression coverage proving a second active workspace blocks unscoped report-only fallback

Refs #384

## Tests
- ./.venv/bin/pytest backend/app/tests/test_domain_detail_endpoints.py -q
- ./.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py
- ./.venv/bin/python -m py_compile backend/app/api/api_v1/endpoints/domains.py
- git diff --check
