### PR TITLE
fix: surface lexicon dns provider hints

### DIFF
--- a/backend/app/services/dns_provider_detection.py
+++ b/backend/app/services/dns_provider_detection.py
@@ -36,17 +36,61 @@ _PROVIDER_PATTERNS: tuple[_ProviderPattern, ...] = (
         connector_available=True,
         automation_supported=True,
     ),
-    _ProviderPattern("route53", "Amazon Route 53", ("awsdns-", "awsdns.")),
-    _ProviderPattern("googleclouddns", "Google Cloud DNS", ("googledomains.com",)),
-    _ProviderPattern("azure_dns", "Azure DNS", ("azure-dns.",)),
-    _ProviderPattern("digitalocean", "DigitalOcean DNS", ("digitalocean.com",)),
-    _ProviderPattern("hetzner", "Hetzner DNS", ("hetzner.com", "hetzner.de")),
-    _ProviderPattern("namecheap", "Namecheap", ("registrar-servers.com",)),
-    _ProviderPattern("godaddy", "GoDaddy", ("domaincontrol.com",)),
+    _ProviderPattern(
+        "route53",
+        "Amazon Route 53",
+        ("awsdns-", "awsdns."),
+        connector_available=True,
+        automation_supported=True,
+    ),
+    _ProviderPattern(
+        "googleclouddns",
+        "Google Cloud DNS",
+        ("googledomains.com",),
+        connector_available=True,
+        automation_supported=True,
+    ),
+    _ProviderPattern(
+        "azure_dns",
+        "Azure DNS",
+        ("azure-dns.",),
+        connector_available=True,
+        automation_supported=True,
+    ),
+    _ProviderPattern(
+        "digitalocean",
+        "DigitalOcean DNS",
+        ("digitalocean.com",),
+        connector_available=True,
+        automation_supported=True,
+    ),
+    _ProviderPattern(
+        "hetzner",
+        "Hetzner DNS",
+        ("hetzner.com", "hetzner.de"),
+        connector_available=True,
+        automation_supported=True,
+    ),
+    _ProviderPattern(
+        "namecheap",
+        "Namecheap",
+        ("registrar-servers.com",),
+        connector_available=True,
+        automation_supported=True,
+    ),
+    _ProviderPattern(
+        "godaddy",
+        "GoDaddy",
+        ("domaincontrol.com",),
+        connector_available=True,
+        automation_supported=True,
+    ),
     _ProviderPattern(
         "powerdns",
         "PowerDNS or custom DNS",
         ("powerdns", "pdns"),
+        connector_available=True,
+        automation_supported=True,
     ),
     _ProviderPattern("plesk", "Plesk-hosted DNS", ("plesk",)),
     _ProviderPattern("cpanel", "cPanel/WHM-hosted DNS", ("cpanel", "webhostbox.net")),
@@ -61,7 +105,7 @@ def _action_for(pattern: _ProviderPattern) -> str:
     if pattern.connector_available:
         return (
             f"Connect {pattern.provider_name} in Settings to enable provider-aware "
-            "DNS inspection and approved repair plans."
+            "DNS inspection, preview, and explicitly approved repair plans."
         )
     return (
         f"Use the {pattern.provider_name} DNS console or hosting panel with DMARQ's "

--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -39,6 +39,26 @@ LEXICON_PROVIDERS = {
     "route53",
     "vultr",
 }
+PROVIDER_DISPLAY_NAMES = {
+    "aliyun": "Alibaba Cloud DNS",
+    "azure": "Azure DNS",
+    "cloudflare": "Cloudflare",
+    "cloudns": "ClouDNS",
+    "digitalocean": "DigitalOcean DNS",
+    "dnsimple": "DNSimple",
+    "dnsmadeeasy": "DNS Made Easy",
+    "gandi": "Gandi",
+    "godaddy": "GoDaddy",
+    "googleclouddns": "Google Cloud DNS",
+    "hetzner": "Hetzner DNS",
+    "ionos": "IONOS",
+    "linode": "Linode DNS",
+    "namecheap": "Namecheap",
+    "ovh": "OVHcloud",
+    "powerdns": "PowerDNS",
+    "route53": "Amazon Route 53",
+    "vultr": "Vultr DNS",
+}
 
 
 class DNSProviderWriteError(ValueError):
@@ -168,7 +188,7 @@ def provider_capabilities() -> List[Dict[str, Any]]:
     capabilities = [
         {
             "id": "cloudflare",
-            "name": "Cloudflare",
+            "name": PROVIDER_DISPLAY_NAMES["cloudflare"],
             "mode": "native",
             "record_types": sorted(SUPPORTED_AUTOMATED_RECORD_TYPES),
             "operations": sorted(SUPPORTED_AUTOMATED_OPERATIONS),
@@ -181,7 +201,7 @@ def provider_capabilities() -> List[Dict[str, Any]]:
         capabilities.append(
             {
                 "id": provider_id,
-                "name": provider_id,
+                "name": PROVIDER_DISPLAY_NAMES.get(provider_id, provider_id),
                 "mode": "lexicon",
                 "record_types": sorted(SUPPORTED_AUTOMATED_RECORD_TYPES),
                 "operations": ["create", "update"],

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -813,6 +813,8 @@ def test_dns_provider_capabilities_report_available_lexicon_runtime():
     assert providers["cloudflare"]["status"] == "ready"
     assert providers["route53"]["status"] == "ready"
     assert providers["route53"]["mode"] == "lexicon"
+    assert providers["route53"]["name"] == "Amazon Route 53"
+    assert providers["digitalocean"]["name"] == "DigitalOcean DNS"
 
 
 def test_dns_write_provider_registry_normalizes_supported_provider_ids():

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -60,6 +60,27 @@ def test_detect_dns_provider_matches_cloudflare_with_connector_hint():
     assert "Connect Cloudflare" in detection.suggested_action
 
 
+def test_detect_dns_provider_matches_lexicon_provider_with_connector_hint():
+    detection = detect_dns_provider(["ns1.digitalocean.com", "ns2.digitalocean.com"])
+
+    assert detection.provider_id == "digitalocean"
+    assert detection.provider_name == "DigitalOcean DNS"
+    assert detection.confidence == "high"
+    assert detection.connector_available is True
+    assert detection.automation_supported is True
+    assert "Connect DigitalOcean DNS" in detection.suggested_action
+    assert "explicitly approved repair plans" in detection.suggested_action
+
+
+def test_detect_dns_provider_maps_azure_nameservers_to_aliasable_provider():
+    detection = detect_dns_provider(["ns1-01.azure-dns.com", "ns2-01.azure-dns.net"])
+
+    assert detection.provider_id == "azure_dns"
+    assert detection.provider_name == "Azure DNS"
+    assert detection.connector_available is True
+    assert detection.automation_supported is True
+
+
 def test_detect_dns_provider_degrades_for_unknown_nameservers():
     detection = detect_dns_provider(["ns1.mailhost.example", "ns2.mailhost.example"])
 


### PR DESCRIPTION
## Summary
- mark DNS providers already covered by the Lexicon write registry as connector/automation-capable in NS-based provider detection
- expose clearer provider display names for Lexicon-backed write capabilities
- cover DigitalOcean and Azure provider detection plus provider capability names with focused tests

Refs #380

## Safety boundary
- no new DNS write operation was added
- no automatic DNS write path was added
- existing preview/confirm/provider-mismatch safeguards remain unchanged

## Tests
- ./.venv/bin/pytest backend/app/tests/test_dns_resolver.py backend/app/tests/test_cloudflare_dns.py::test_dns_provider_capabilities_include_cloudflare_and_lexicon backend/app/tests/test_cloudflare_dns.py::test_dns_provider_capabilities_report_available_lexicon_runtime backend/app/tests/test_cloudflare_dns.py::test_dns_change_plan_recommends_detected_provider backend/app/tests/test_cloudflare_dns.py::test_dns_change_plan_avoids_wrong_provider_recommendation -q
- ./.venv/bin/black --check backend/app/services/dns_provider_detection.py backend/app/services/dns_provider_writes.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_cloudflare_dns.py
- ./.venv/bin/isort --check-only backend/app/services/dns_provider_detection.py backend/app/services/dns_provider_writes.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_cloudflare_dns.py
- ./.venv/bin/flake8 backend/app/services/dns_provider_detection.py backend/app/services/dns_provider_writes.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_cloudflare_dns.py
- ./.venv/bin/python -m py_compile backend/app/services/dns_provider_detection.py backend/app/services/dns_provider_writes.py
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNS provider detection now returns clearer provider availability and automation details for several major providers.
  * Provider names in DNS capability results are now shown in a more human-readable format.

* **Bug Fixes**
  * Improved detection and guidance for common DNS setups, including DigitalOcean and Azure-style nameservers.
  * Updated suggested repair guidance to include DNS inspection, preview, and approved repair plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->