### PR TITLE
feat: add remediation notification routing metadata

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -809,6 +809,17 @@ class RemediationEvidence(BaseModel):
     value: str
 
 
+class RemediationNotification(BaseModel):
+    """Read-only notification routing metadata for one remediation item."""
+
+    state: str
+    event: str
+    channel: str
+    dedupe_key: str
+    reason: str
+    next_transition: str
+
+
 class RemediationQueueItem(BaseModel):
     """One prioritized operator action for a domain."""
 
@@ -825,6 +836,7 @@ class RemediationQueueItem(BaseModel):
     prerequisites: List[str] = Field(default_factory=list)
     expected_health_score_impact: str
     automation: RemediationAutomation
+    notification: RemediationNotification
 
 
 class RemediationQueueResponse(BaseModel):

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -67,7 +67,71 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
         "manual_action": sum(1 for item in items if item["state"] == "manual_action"),
         "investigate": sum(1 for item in items if item["state"] == "investigate"),
         "informational": sum(1 for item in items if item["state"] == "informational"),
+        "notify_approval_required": sum(
+            1 for item in items if item.get("notification", {}).get("state") == "approval_required"
+        ),
+        "notify_action_required": sum(
+            1 for item in items if item.get("notification", {}).get("state") == "action_required"
+        ),
+        "notify_investigation_required": sum(
+            1
+            for item in items
+            if item.get("notification", {}).get("state") == "investigation_required"
+        ),
+        "notify_summary_only": sum(
+            1 for item in items if item.get("notification", {}).get("state") == "summary_only"
+        ),
     }
+
+
+def _notification_profile(domain: str, item: Dict[str, Any]) -> Dict[str, str]:
+    """Return read-only notification routing metadata for a remediation item."""
+    state = str(item.get("state") or "")
+    severity = str(item.get("severity") or "info")
+    source = str(item.get("source") or "remediation")
+    item_id = str(item.get("id") or "unknown")
+    dedupe_key = f"dmarq:remediation:{domain}:{item_id}"
+
+    if state == "approval_ready":
+        return {
+            "state": "approval_required",
+            "event": "dmarq.remediation.approval_required",
+            "channel": "email_security",
+            "dedupe_key": dedupe_key,
+            "reason": "Notify an operator that a safe DNS repair is ready for preview.",
+            "next_transition": "verified_after_apply",
+        }
+    if state == "manual_action" and SEVERITY_RANK.get(severity, 0) >= SEVERITY_RANK["high"]:
+        return {
+            "state": "action_required",
+            "event": "dmarq.remediation.manual_action_required",
+            "channel": "email_security",
+            "dedupe_key": dedupe_key,
+            "reason": "Escalate high-impact manual remediation work.",
+            "next_transition": "resolved_by_operator",
+        }
+    if state == "investigate":
+        return {
+            "state": "investigation_required",
+            "event": "dmarq.remediation.investigation_required",
+            "channel": "email_security",
+            "dedupe_key": dedupe_key,
+            "reason": "Ask an operator to confirm whether the sender or finding is legitimate.",
+            "next_transition": "manual_action_or_resolved",
+        }
+    return {
+        "state": "summary_only",
+        "event": "dmarq.remediation.summary",
+        "channel": "daily_summary" if source == "dns_lint" else "email_security",
+        "dedupe_key": dedupe_key,
+        "reason": "Include this lower-risk remediation item in summary reporting.",
+        "next_transition": "resolved_or_escalated",
+    }
+
+
+def _attach_notification_profiles(domain: str, items: List[Dict[str, Any]]) -> None:
+    for item in items:
+        item["notification"] = _notification_profile(domain, item)
 
 
 def _dns_item(
@@ -187,6 +251,7 @@ def build_remediation_queue(
             continue
         items.append(_health_item(domain, action))
 
+    _attach_notification_profiles(domain, items)
     items.sort(
         key=lambda item: (
             item["state"] != "approval_ready",

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -241,6 +241,10 @@
                                                 <span x-text="item.severity"></span>
                                             </span>
                                             <span class="text-xs text-[#5f5c78]" x-text="item.source.replace('_', ' ')"></span>
+                                            <span x-show="item.notification"
+                                                  class="rounded px-2 py-1 text-xs font-semibold"
+                                                  :class="remediationNotificationClass(item.notification.state)"
+                                                  x-text="item.notification.state.replaceAll('_', ' ')"></span>
                                         </div>
                                         <h4 class="mt-3 font-semibold text-[#07071f]" x-text="item.title"></h4>
                                         <p class="mt-1 text-sm text-[#5f5c78]" x-text="item.detail"></p>
@@ -255,6 +259,9 @@
                                     <span class="rounded bg-[#f4f3f2] px-2 py-1 text-[#5f5c78]">
                                         <span>Impact </span><span x-text="item.expected_health_score_impact || 'n/a'"></span>
                                     </span>
+                                    <span x-show="item.notification"
+                                          class="rounded bg-[#f4f3f2] px-2 py-1 text-[#5f5c78]"
+                                          x-text="item.notification.event"></span>
                                     <a x-show="item.automation && item.automation.plan_id"
                                        href="#dns-guidance"
                                        class="rounded bg-[#2f9da5]/10 px-2 py-1 font-semibold text-[#1f7c83]">
@@ -1929,6 +1936,13 @@ function domainDetailsApp(domainId) {
             return 'bg-base-200 text-base-content/70';
         },
 
+        remediationNotificationClass(state) {
+            if (state === 'approval_required') return 'bg-green-100 text-green-700';
+            if (state === 'action_required') return 'bg-red-100 text-red-700';
+            if (state === 'investigation_required') return 'bg-blue-100 text-blue-700';
+            return 'bg-base-200 text-base-content/70';
+        },
+
         senderStatusClass(status) {
             if (status === 'known') return 'bg-green-100 text-green-800';
             if (status === 'ambiguous') return 'bg-yellow-100 text-yellow-800';
@@ -2126,7 +2140,11 @@ function domainDetailsApp(domainId) {
                     approval_ready: 0,
                     manual_action: 0,
                     investigate: 0,
-                    informational: 0
+                    informational: 0,
+                    notify_approval_required: 0,
+                    notify_action_required: 0,
+                    notify_investigation_required: 0,
+                    notify_summary_only: 0
                 },
                 items: []
             };

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -65,12 +65,28 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "manual_action": 0,
         "investigate": 1,
         "informational": 0,
+        "notify_approval_required": 1,
+        "notify_action_required": 0,
+        "notify_investigation_required": 1,
+        "notify_summary_only": 0,
     }
     assert queue["items"][0]["id"] == "dns:dmarc-missing"
     assert queue["items"][0]["state"] == "approval_ready"
     assert queue["items"][0]["automation"]["eligible"] is True
     assert queue["items"][0]["automation"]["apply_endpoint"] == (
         "/api/v1/domains/example.com/dns/change-plan/apply"
+    )
+    assert queue["items"][0]["notification"] == {
+        "state": "approval_required",
+        "event": "dmarq.remediation.approval_required",
+        "channel": "email_security",
+        "dedupe_key": "dmarq:remediation:example.com:dns:dmarc-missing",
+        "reason": "Notify an operator that a safe DNS repair is ready for preview.",
+        "next_transition": "verified_after_apply",
+    }
+    assert queue["items"][1]["notification"]["state"] == "investigation_required"
+    assert queue["items"][1]["notification"]["event"] == (
+        "dmarq.remediation.investigation_required"
     )
     assert [item["id"] for item in queue["items"]] == [
         "dns:dmarc-missing",
@@ -112,9 +128,12 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
 
     assert queue["status"] == "needs_manual_action"
     assert queue["summary"]["manual_action"] == 1
+    assert queue["summary"]["notify_summary_only"] == 1
     assert queue["items"][0]["state"] == "manual_action"
     assert queue["items"][0]["automation"]["eligible"] is False
     assert queue["items"][0]["automation"]["apply_endpoint"] is None
+    assert queue["items"][0]["notification"]["state"] == "summary_only"
+    assert queue["items"][0]["notification"]["event"] == "dmarq.remediation.summary"
 
 
 def test_remediation_queue_requires_recommended_provider_for_automation():
@@ -154,3 +173,7 @@ def test_remediation_queue_requires_recommended_provider_for_automation():
     assert queue["items"][0]["automation"]["eligible"] is False
     assert queue["items"][0]["automation"]["provider"] is None
     assert queue["items"][0]["automation"]["apply_endpoint"] is None
+    assert queue["items"][0]["notification"]["state"] == "action_required"
+    assert queue["items"][0]["notification"]["event"] == (
+        "dmarq.remediation.manual_action_required"
+    )

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -653,10 +653,13 @@ can be previewed through a provider connector or why it remains manual-only.
 `GET /domains/{domain_id}/remediation` returns the human-reviewed remediation
 queue for a domain. It groups DNS change plans and health-score actions into
 prioritized items with state, severity, next steps, evidence, blast radius,
-prerequisites, expected health-score impact, and automation eligibility. DNS
-items that have a concrete safe TXT/CNAME provider write are marked
-`approval_ready` and point to the same explicit preview/apply endpoint used by
-the DNS change-plan UI. The endpoint does not perform DNS writes.
+prerequisites, expected health-score impact, automation eligibility, and
+read-only notification routing metadata. DNS items that have a concrete safe
+TXT/CNAME provider write are marked `approval_ready` and point to the same
+explicit preview/apply endpoint used by the DNS change-plan UI. Notification
+metadata includes the event name, channel, dedupe key, reason, and next state
+transition that an operator workflow can use. The endpoint does not perform DNS
+writes or send notifications.
 
 #### Get Posture Dashboard
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -85,6 +85,10 @@ as approval-ready, manual, or investigate-only, and include the evidence,
 blast radius, prerequisites, and expected health-score impact. Approval-ready
 DNS items link back to the DNS change-plan review area; they still require an
 operator preview and explicit approval before any provider write is sent.
+Each item also shows a notification profile such as approval required, action
+required, investigation required, or summary only. These labels explain how
+DMARQ would route the item into alerting or ticketing workflows; viewing the
+queue does not send a notification.
 
 ### Source Intelligence
 


### PR DESCRIPTION
## Summary
- add read-only notification routing metadata to remediation queue items
- classify queue items into approval-required, action-required, investigation-required, or summary-only notification states
- surface the notification state/event on the domain detail remediation queue
- document that the endpoint exposes routing metadata but does not send notifications

Refs #384

## Safety boundary
- no Apprise, webhook, ticketing, or email notification is sent by this change
- no DNS write behavior changes
- no new live provider action is added

## Tests
- ./.venv/bin/pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py -q
- ./.venv/bin/black --check backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py
- ./.venv/bin/isort --check-only backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py
- ./.venv/bin/flake8 backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py
- ./.venv/bin/python -m py_compile backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py
- git diff --check
