### PR TITLE
fix: address remediation preview review feedback

### DIFF
--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Optional, Set
 
+from app.services.webhook_events import (
+    EVENT_REMEDIATION_APPROVAL_REQUIRED,
+    EVENT_REMEDIATION_INVESTIGATION_REQUIRED,
+    EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED,
+    EVENT_REMEDIATION_SUMMARY,
+)
+
 DNS_AUTOMATION_OPERATIONS = {"create", "update"}
 DNS_AUTOMATION_RECORD_TYPES = {"TXT", "CNAME"}
 SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
@@ -95,7 +102,7 @@ def _notification_profile(domain: str, item: Dict[str, Any]) -> Dict[str, Any]:
     if state == "approval_ready":
         return {
             "state": "approval_required",
-            "event": "dmarq.remediation.approval_required",
+            "event": EVENT_REMEDIATION_APPROVAL_REQUIRED,
             "channel": "email_security",
             "dedupe_key": dedupe_key,
             "reason": "Notify an operator that a safe DNS repair is ready for preview.",
@@ -104,7 +111,7 @@ def _notification_profile(domain: str, item: Dict[str, Any]) -> Dict[str, Any]:
     if state == "manual_action" and SEVERITY_RANK.get(severity, 0) >= SEVERITY_RANK["high"]:
         return {
             "state": "action_required",
-            "event": "dmarq.remediation.manual_action_required",
+            "event": EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED,
             "channel": "email_security",
             "dedupe_key": dedupe_key,
             "reason": "Escalate high-impact manual remediation work.",
@@ -113,7 +120,7 @@ def _notification_profile(domain: str, item: Dict[str, Any]) -> Dict[str, Any]:
     if state == "investigate":
         return {
             "state": "investigation_required",
-            "event": "dmarq.remediation.investigation_required",
+            "event": EVENT_REMEDIATION_INVESTIGATION_REQUIRED,
             "channel": "email_security",
             "dedupe_key": dedupe_key,
             "reason": "Ask an operator to confirm whether the sender or finding is legitimate.",
@@ -121,7 +128,7 @@ def _notification_profile(domain: str, item: Dict[str, Any]) -> Dict[str, Any]:
         }
     return {
         "state": "summary_only",
-        "event": "dmarq.remediation.summary",
+        "event": EVENT_REMEDIATION_SUMMARY,
         "channel": "daily_summary" if source == "dns_lint" else "email_security",
         "dedupe_key": dedupe_key,
         "reason": "Include this lower-risk remediation item in summary reporting.",
@@ -144,7 +151,7 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
         "title": str(item.get("title") or ""),
         "detail": str(item.get("detail") or ""),
         "notification_state": str(notification.get("state") or "summary_only"),
-        "event_type": str(notification.get("event") or "dmarq.remediation.summary"),
+        "event_type": str(notification.get("event") or EVENT_REMEDIATION_SUMMARY),
         "channel": str(notification.get("channel") or "email_security"),
         "dedupe_key": str(notification.get("dedupe_key") or ""),
         "reason": str(notification.get("reason") or ""),
@@ -158,9 +165,9 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
         },
         "evidence": [
             {"label": str(row.get("label") or "evidence"), "value": str(row.get("value") or "")}
-            for row in item.get("evidence", [])[:5]
+            for row in item.get("evidence", [])
             if str(row.get("value") or "")
-        ],
+        ][:5],
     }
 
 

--- a/backend/app/services/ticketing_chatops_templates.py
+++ b/backend/app/services/ticketing_chatops_templates.py
@@ -10,8 +10,8 @@ from app.services.webhook_events import (
     EVENT_ALERT_RESOLVED,
     EVENT_COMPLIANCE_DROP,
     EVENT_REMEDIATION_APPROVAL_REQUIRED,
-    EVENT_REMEDIATION_INVESTIGATION_REQUIRED,
     EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED,
+    EVENT_REMEDIATION_INVESTIGATION_REQUIRED,
     EVENT_REMEDIATION_SUMMARY,
     EVENT_REPORTS_MISSING,
     EVENT_SENDER_NEW,
@@ -112,7 +112,7 @@ EVENT_WORKFLOW_MAPPINGS: Dict[str, Dict[str, Any]] = {
         "chat_action": "include_in_summary",
         "dedupe_key_template": "{dedupe_key}",
         "summary_template": "DMARQ remediation summary item for {domain}: {title}",
-        "noise_control": "Do not create standalone tickets for summary-only items unless the severity escalates.",
+        "noise_control": "Do not create standalone tickets for summary-only info items; create tickets only when a later remediation event transitions to approval, manual action, or investigation.",
     },
 }
 

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -1,4 +1,4 @@
-from app.services.remediation_queue import build_remediation_queue
+from app.services.remediation_queue import _remediation_notification_payload, build_remediation_queue
 
 
 def test_remediation_queue_prioritizes_provider_ready_dns_plan():
@@ -167,6 +167,40 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
     assert queue["items"][0]["notification"]["payload_preview"]["event_type"] == (
         "dmarq.remediation.summary"
     )
+
+
+def test_remediation_notification_payload_uses_first_non_empty_evidence_rows():
+    """Payload previews keep the first five evidence rows after removing blanks."""
+    payload = _remediation_notification_payload(
+        "example.com",
+        {
+            "id": "health:review",
+            "source": "health_score",
+            "state": "manual_action",
+            "severity": "medium",
+            "title": "Review evidence",
+            "notification": {"event": "dmarq.remediation.summary"},
+            "automation": {},
+            "evidence": [
+                {"label": "empty", "value": ""},
+                {"label": "first", "value": "one"},
+                {"label": "empty_again", "value": None},
+                {"label": "second", "value": "two"},
+                {"label": "third", "value": "three"},
+                {"label": "fourth", "value": "four"},
+                {"label": "fifth", "value": "five"},
+                {"label": "sixth", "value": "six"},
+            ],
+        },
+    )
+
+    assert payload["evidence"] == [
+        {"label": "first", "value": "one"},
+        {"label": "second", "value": "two"},
+        {"label": "third", "value": "three"},
+        {"label": "fourth", "value": "four"},
+        {"label": "fifth", "value": "five"},
+    ]
 
 
 def test_remediation_queue_requires_recommended_provider_for_automation():

--- a/backend/app/tests/test_ticketing_chatops_templates.py
+++ b/backend/app/tests/test_ticketing_chatops_templates.py
@@ -16,6 +16,8 @@ from app.services.webhook_events import (
     EVENT_ALERT_RESOLVED,
     EVENT_COMPLIANCE_DROP,
     EVENT_REMEDIATION_APPROVAL_REQUIRED,
+    EVENT_REMEDIATION_INVESTIGATION_REQUIRED,
+    EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED,
     EVENT_REMEDIATION_SUMMARY,
 )
 
@@ -46,6 +48,20 @@ def test_ticketing_chatops_bundle_is_versioned_and_complete():
     assert (
         bundle["event_workflow_mappings"][EVENT_REMEDIATION_APPROVAL_REQUIRED]["ticket_action"]
         == "create_or_update"
+    )
+    assert (
+        bundle["event_workflow_mappings"][EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED]["severity"]
+        == "high"
+    )
+    assert (
+        bundle["event_workflow_mappings"][EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED]["chat_action"]
+        == "notify_channel_and_thread"
+    )
+    assert (
+        bundle["event_workflow_mappings"][EVENT_REMEDIATION_INVESTIGATION_REQUIRED][
+            "summary_template"
+        ]
+        == "Investigate DMARQ remediation item for {domain}: {title}"
     )
     assert (
         bundle["event_workflow_mappings"][EVENT_REMEDIATION_SUMMARY]["chat_action"]


### PR DESCRIPTION
## Summary
- reuse remediation webhook event constants in queue notification metadata
- filter payload preview evidence before applying the five-row limit
- clarify summary-only remediation workflow noise-control guidance
- add spot-checks for manual-action and investigation remediation mappings

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_ticketing_chatops_templates.py backend/app/tests/test_webhooks.py -q
- .venv/bin/python -m flake8 backend/app/services/remediation_queue.py backend/app/services/ticketing_chatops_templates.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_ticketing_chatops_templates.py
- git diff --check