### PR TITLE
[codex] Audit remediation notification lifecycle

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -91,7 +91,7 @@ from app.services.workspace_access import (
     parse_selected_workspace_id,
     resolve_authorized_workspace,
 )
-from app.services.workspace_audit import record_workspace_audit_log
+from app.services.workspace_audit import audit_log_to_dict, record_workspace_audit_log
 from app.services.workspaces import (
     workspace_domain_query,
 )
@@ -101,6 +101,13 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 DOMAIN_SELECTOR_LOOKUP_CHUNK_SIZE = 500
+REMEDIATION_NOTIFICATION_LIFECYCLE_STATES = {
+    "previewed",
+    "acknowledged",
+    "snoozed",
+    "resolved",
+    "rejected",
+}
 
 
 def _authorized_domain_workspace(
@@ -847,6 +854,27 @@ class RemediationQueueResponse(BaseModel):
     status: str
     summary: Dict[str, int]
     items: List[RemediationQueueItem]
+
+
+class RemediationNotificationAuditRequest(BaseModel):
+    """Operator lifecycle marker for one remediation notification preview."""
+
+    item_id: str
+    lifecycle_state: str
+    event: Optional[str] = None
+    dedupe_key: Optional[str] = None
+    note: Optional[str] = None
+
+
+class RemediationNotificationAuditResponse(BaseModel):
+    """Persisted audit marker for one remediation notification lifecycle step."""
+
+    domain: str
+    item_id: str
+    event: str
+    dedupe_key: str
+    lifecycle_state: str
+    audit: Dict[str, Any]
 
 
 class HealthScoreHistoryPoint(BaseModel):
@@ -3556,15 +3584,14 @@ async def get_domain_posture_dashboard(
     return _build_posture_dashboard(domain_id, health, domain_health, changes)
 
 
-@router.get("/{domain_id}/remediation", response_model=RemediationQueueResponse)
-async def get_domain_remediation_queue(
-    domain_id: str = Path(..., title="The domain ID or name"),
-    refresh: bool = Query(False, title="Refresh cached DNS posture"),
-    db: Session = Depends(get_db),
-    _auth: dict = Depends(require_admin_auth),
-):
-    """Return a prioritized, human-reviewed remediation queue for one domain."""
-    workspace = _authorized_domain_read_workspace(_auth, db)
+async def _build_domain_remediation_queue_for_workspace(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domain_id: str,
+    refresh: bool = False,
+) -> Dict[str, Any]:
+    """Build the current remediation queue for an authorized workspace."""
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
     try:
@@ -3598,6 +3625,134 @@ async def get_domain_remediation_queue(
         available_write_providers=available_providers,
         recommended_provider=recommended_provider,
     )
+
+
+@router.get("/{domain_id}/remediation", response_model=RemediationQueueResponse)
+async def get_domain_remediation_queue(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS posture"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return a prioritized, human-reviewed remediation queue for one domain."""
+    workspace = _authorized_domain_read_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    return await _build_domain_remediation_queue_for_workspace(
+        db,
+        workspace=workspace,
+        domain_id=domain_id,
+        refresh=refresh,
+    )
+
+
+@router.post(
+    "/{domain_id}/remediation/notifications/audit",
+    response_model=RemediationNotificationAuditResponse,
+)
+async def audit_domain_remediation_notification(
+    request: Request,
+    payload: RemediationNotificationAuditRequest,
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS posture"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Record a sanitized operator lifecycle marker without dispatching notifications."""
+    lifecycle_state = payload.lifecycle_state.strip().lower()
+    if lifecycle_state not in REMEDIATION_NOTIFICATION_LIFECYCLE_STATES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "Unsupported lifecycle_state. Use one of: "
+                + ", ".join(sorted(REMEDIATION_NOTIFICATION_LIFECYCLE_STATES))
+            ),
+        )
+
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    queue = await _build_domain_remediation_queue_for_workspace(
+        db,
+        workspace=workspace,
+        domain_id=domain_id,
+        refresh=refresh,
+    )
+    item = next(
+        (
+            candidate
+            for candidate in queue.get("items", [])
+            if candidate.get("id") == payload.item_id
+        ),
+        None,
+    )
+    if item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Remediation item not found",
+        )
+
+    notification = item.get("notification") or {}
+    event = str(notification.get("event") or "")
+    dedupe_key = str(notification.get("dedupe_key") or "")
+    if payload.event and payload.event != event:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Notification event does not match the current remediation item",
+        )
+    if payload.dedupe_key and payload.dedupe_key != dedupe_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Notification dedupe_key does not match the current remediation item",
+        )
+
+    automation = item.get("automation") or {}
+    audit_row = record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action="remediation.notification_lifecycle_recorded",
+        entity_type="remediation_notification",
+        entity_id=item.get("id"),
+        entity_name=queue.get("domain"),
+        details={
+            "item_id": item.get("id"),
+            "domain": queue.get("domain"),
+            "event": event,
+            "dedupe_key": dedupe_key,
+            "lifecycle_state": lifecycle_state,
+            "notification_state": notification.get("state"),
+            "notification_channel": notification.get("channel"),
+            "notification_next_transition": notification.get("next_transition"),
+            "source": item.get("source"),
+            "severity": item.get("severity"),
+            "confidence": item.get("confidence"),
+            "automation_eligible": automation.get("eligible"),
+            "automation_provider": automation.get("provider"),
+            "automation_plan_id": automation.get("plan_id"),
+            "payload_preview": notification.get("payload_preview") or {},
+            "operator_note": payload.note,
+            "sent": False,
+            "delivery_enqueued": False,
+            "dns_write_attempted": False,
+        },
+        auth_context=_auth,
+        request=request,
+        commit=True,
+    )
+    return {
+        "domain": str(queue.get("domain") or domain_id),
+        "item_id": str(item.get("id") or payload.item_id),
+        "event": event,
+        "dedupe_key": dedupe_key,
+        "lifecycle_state": lifecycle_state,
+        "audit": audit_log_to_dict(audit_row),
+    }
 
 
 @router.get("/{domain_id}/posture/history", response_model=HealthScoreHistoryResponse)

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -9,6 +9,7 @@ the use of begin_timestamp/end_timestamp integers for date fields.
 """
 
 import csv
+import json
 from datetime import date
 from io import StringIO
 from types import SimpleNamespace
@@ -19,6 +20,7 @@ from fastapi.testclient import TestClient
 from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.models.domain import Domain
 from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceAuditLog
 from app.services import report_persistence
 from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.report_store import ReportStore
@@ -664,6 +666,268 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
         "dns:dmarc-missing",
         "health:low_compliance",
     ]
+
+
+def test_domain_remediation_notification_lifecycle_audit_records_sanitized_marker(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Operators can audit notification lifecycle steps without dispatching work."""
+
+    async def fake_domain_grade(db, domain_id, store, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 72,
+            "grade": "C",
+            "status": "attention",
+            "factors": {"dns_posture": 60},
+            "actions": [],
+        }
+
+    async def fake_dns_guidance(db, store, domain_id, refresh=False):
+        return {
+            "domain": domain_id,
+            "status": "critical",
+            "dns_provider": {"provider_id": "cloudflare"},
+            "findings": [],
+            "change_plans": [
+                {
+                    "plan_id": "dmarc-missing",
+                    "finding_code": "dmarc_missing",
+                    "severity": "error",
+                    "operation": "create",
+                    "record_type": "TXT",
+                    "name": "_dmarc.example.com",
+                    "proposed_value": "v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+                    "current_values": [],
+                    "rationale": "Publish a monitoring DMARC record.",
+                    "expected_health_impact": "High",
+                    "manual_steps": ["Create the TXT record."],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
+    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: ["cloudflare"])
+    monkeypatch.setattr(
+        domains_endpoint,
+        "_recommended_dns_write_provider",
+        lambda dns_provider, available_providers: "cloudflare",
+    )
+
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "event": "dmarq.remediation.approval_required",
+            "lifecycle_state": "acknowledged",
+            "note": "Reviewed with DNS owner",
+        },
+        headers={"X-Forwarded-For": "203.0.113.44"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["domain"] == DOMAIN
+    assert data["item_id"] == "dns:dmarc-missing"
+    assert data["lifecycle_state"] == "acknowledged"
+    assert data["audit"]["action"] == "remediation.notification_lifecycle_recorded"
+    assert data["audit"]["ip_address"] == "203.0.113.44"
+    details = data["audit"]["details"]
+    assert details["sent"] is False
+    assert details["delivery_enqueued"] is False
+    assert details["dns_write_attempted"] is False
+    assert details["payload_preview"]["event_type"] == "dmarq.remediation.approval_required"
+
+    audit_row = (
+        db_session.query(WorkspaceAuditLog)
+        .filter(WorkspaceAuditLog.action == "remediation.notification_lifecycle_recorded")
+        .one()
+    )
+    persisted_details = json.loads(audit_row.details)
+    assert persisted_details["operator_note"] == "Reviewed with DNS owner"
+    assert persisted_details["automation_provider"] == "cloudflare"
+
+
+def test_domain_remediation_notification_lifecycle_audit_rejects_mismatched_event(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Lifecycle markers must match the current remediation notification metadata."""
+
+    async def fake_domain_grade(db, domain_id, store, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 72,
+            "grade": "C",
+            "status": "attention",
+            "factors": {"dns_posture": 60},
+            "actions": [],
+        }
+
+    async def fake_dns_guidance(db, store, domain_id, refresh=False):
+        return {
+            "domain": domain_id,
+            "status": "critical",
+            "dns_provider": {"provider_id": "cloudflare"},
+            "findings": [],
+            "change_plans": [
+                {
+                    "plan_id": "dmarc-missing",
+                    "finding_code": "dmarc_missing",
+                    "severity": "error",
+                    "operation": "create",
+                    "record_type": "TXT",
+                    "name": "_dmarc.example.com",
+                    "proposed_value": "v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+                    "current_values": [],
+                    "rationale": "Publish a monitoring DMARC record.",
+                    "expected_health_impact": "High",
+                    "manual_steps": ["Create the TXT record."],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
+    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: ["cloudflare"])
+    monkeypatch.setattr(
+        domains_endpoint,
+        "_recommended_dns_write_provider",
+        lambda dns_provider, available_providers: "cloudflare",
+    )
+
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "event": "dmarq.remediation.summary",
+            "lifecycle_state": "acknowledged",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "does not match" in response.json()["detail"]
+
+
+def test_domain_remediation_notification_lifecycle_audit_rejects_invalid_state(
+    seeded_client: TestClient,
+):
+    """Lifecycle markers only accept the explicit operator states."""
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "lifecycle_state": "sent",
+        },
+    )
+
+    assert response.status_code == 422
+    assert "Unsupported lifecycle_state" in response.json()["detail"]
+
+
+def test_domain_remediation_notification_lifecycle_audit_rejects_unknown_item(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Lifecycle markers must target a current remediation queue item."""
+
+    async def fake_domain_grade(db, domain_id, store, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 100,
+            "grade": "A",
+            "status": "healthy",
+            "factors": {},
+            "actions": [],
+        }
+
+    async def fake_dns_guidance(db, store, domain_id, refresh=False):
+        return {
+            "domain": domain_id,
+            "status": "healthy",
+            "dns_provider": None,
+            "findings": [],
+            "change_plans": [],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
+    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: [])
+
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "lifecycle_state": "previewed",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Remediation item not found"
+
+
+def test_domain_remediation_notification_lifecycle_audit_rejects_mismatched_dedupe_key(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Lifecycle markers can optionally guard against stale dedupe keys."""
+
+    async def fake_domain_grade(db, domain_id, store, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 72,
+            "grade": "C",
+            "status": "attention",
+            "factors": {"dns_posture": 60},
+            "actions": [],
+        }
+
+    async def fake_dns_guidance(db, store, domain_id, refresh=False):
+        return {
+            "domain": domain_id,
+            "status": "critical",
+            "dns_provider": {"provider_id": "cloudflare"},
+            "findings": [],
+            "change_plans": [
+                {
+                    "plan_id": "dmarc-missing",
+                    "finding_code": "dmarc_missing",
+                    "severity": "error",
+                    "operation": "create",
+                    "record_type": "TXT",
+                    "name": "_dmarc.example.com",
+                    "proposed_value": "v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+                    "current_values": [],
+                    "rationale": "Publish a monitoring DMARC record.",
+                    "expected_health_impact": "High",
+                    "manual_steps": ["Create the TXT record."],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
+    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: ["cloudflare"])
+    monkeypatch.setattr(
+        domains_endpoint,
+        "_recommended_dns_write_provider",
+        lambda dns_provider, available_providers: "cloudflare",
+    )
+
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "dedupe_key": "stale-key",
+            "lifecycle_state": "previewed",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "dedupe_key does not match" in response.json()["detail"]
 
 
 def test_domain_remediation_queue_hydrates_report_store_with_workspace_filter(

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -571,6 +571,7 @@ GET /domains/{domain_id}/dns/lint
 GET /domains/{domain_id}/dns/change-plan
 POST /domains/{domain_id}/dns/change-plan/apply
 GET /domains/{domain_id}/remediation
+POST /domains/{domain_id}/remediation/notifications/audit
 GET /domains/dns/providers
 GET /domains/dns/import/{provider}/preview
 POST /domains/dns/import/{provider}
@@ -663,6 +664,15 @@ sanitized `payload_preview` using schema
 `dmarq.remediation.notification.v1`; it is the deterministic data shape a
 future webhook, ticketing, or chatops delivery would receive. The endpoint does
 not perform DNS writes, enqueue webhook deliveries, or send notifications.
+
+`POST /domains/{domain_id}/remediation/notifications/audit` records an
+operator lifecycle marker for one current remediation item. The request accepts
+`item_id`, `lifecycle_state`, and optional `event`, `dedupe_key`, and `note`.
+Supported lifecycle states are `previewed`, `acknowledged`, `snoozed`,
+`resolved`, and `rejected`. If `event` or `dedupe_key` is supplied, it must
+match the current queue item's notification metadata. The response includes the
+sanitized workspace audit row. This endpoint is deliberately audit-only: it
+does not enqueue webhook deliveries, send notifications, or attempt DNS writes.
 
 #### Get Posture Dashboard
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -135,6 +135,13 @@ then asks the operator to confirm the exact provider, operation, record name,
 record type, TTL, previous value, proposed value, and rollback summary before a
 live provider write is submitted.
 
+Remediation notification previews can also be marked as previewed,
+acknowledged, snoozed, resolved, or rejected through the API. These markers are
+written to the workspace audit log with the sanitized notification preview, but
+they do not send notifications, enqueue webhooks, or touch DNS. This gives
+operators an auditable lifecycle before any automated remediation loop is
+enabled.
+
 If an operator selects a different provider than the nameserver-detected
 provider, DMARQ blocks the preview/apply request by default. The mismatch can be
 overridden only with an explicit confirmation that the selected provider


### PR DESCRIPTION
## What changed
- Added `POST /domains/{domain_id}/remediation/notifications/audit` to record operator lifecycle markers for current remediation notification previews.
- Validates lifecycle state and optionally verifies supplied event/dedupe key against the current queue item.
- Writes a sanitized workspace audit entry that explicitly records no notification send, webhook enqueue, or DNS write happened.
- Reuses the remediation queue builder for read and audit flows, including selected workspace support.
- Documented the new audit-only endpoint in the API reference and domain user guide.

## Why
This is the next safe slice for #384: it gives DMARQ an auditable lifecycle for remediation notifications before real autonomous dispatch or repair loops are enabled.

## Validation
- `python -m black backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py`
- `python -m isort backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py`
- `git diff --check`
- `python -m py_compile backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/services/remediation_queue.py`
- `pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_remediation_queue.py -q`

## Safety boundary
This PR is intentionally audit-only. It does not send notifications, enqueue webhooks, call LLMs, or attempt DNS/provider writes.

Refs #384
