### PR TITLE
fix: validate empty remediation audit metadata

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3701,12 +3701,12 @@ async def audit_domain_remediation_notification(
     notification = item.get("notification") or {}
     event = str(notification.get("event") or "")
     dedupe_key = str(notification.get("dedupe_key") or "")
-    if payload.event and payload.event != event:
+    if payload.event is not None and payload.event != event:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Notification event does not match the current remediation item",
         )
-    if payload.dedupe_key and payload.dedupe_key != dedupe_key:
+    if payload.dedupe_key is not None and payload.dedupe_key != dedupe_key:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Notification dedupe_key does not match the current remediation item",

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -811,6 +811,18 @@ def test_domain_remediation_notification_lifecycle_audit_rejects_mismatched_even
     assert response.status_code == 400
     assert "does not match" in response.json()["detail"]
 
+    empty_event_response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "event": "",
+            "lifecycle_state": "acknowledged",
+        },
+    )
+
+    assert empty_event_response.status_code == 400
+    assert "does not match" in empty_event_response.json()["detail"]
+
 
 def test_domain_remediation_notification_lifecycle_audit_rejects_invalid_state(
     seeded_client: TestClient,
@@ -928,6 +940,18 @@ def test_domain_remediation_notification_lifecycle_audit_rejects_mismatched_dedu
 
     assert response.status_code == 400
     assert "dedupe_key does not match" in response.json()["detail"]
+
+    empty_dedupe_response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "dedupe_key": "",
+            "lifecycle_state": "previewed",
+        },
+    )
+
+    assert empty_dedupe_response.status_code == 400
+    assert "dedupe_key does not match" in empty_dedupe_response.json()["detail"]
 
 
 def test_domain_remediation_queue_hydrates_report_store_with_workspace_filter(


### PR DESCRIPTION
## What changed
- Treat supplied empty remediation audit `event` values as mismatches instead of skipping validation.
- Treat supplied empty remediation audit `dedupe_key` values as mismatches instead of skipping validation.
- Added regression coverage for both empty-string cases.

## Why
Copilot flagged that truthiness checks allowed clients to bypass the documented supplied-value validation on PR #409.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_domain_detail_endpoints.py -q`
- `.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py`
- `git diff --check`

Refs #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for remediation notification audit requests so empty values are handled consistently and mismatched values return clear 400 errors.
  * Empty `event` and `dedupe_key` inputs now correctly trigger validation failures when they do not match the current remediation item.

* **Tests**
  * Added coverage for negative audit request cases to verify empty `event` and `dedupe_key` values are rejected as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->