### PR TITLE
[codex] Preview remediation dispatch readiness

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -75,6 +75,7 @@ from app.services.organizations import (
     OrganizationPlanLimitError,
     require_organization_plan_limit,
 )
+from app.services.remediation_dispatch import attach_remediation_dispatch_previews
 from app.services.remediation_queue import build_remediation_queue
 from app.services.report_persistence import (
     hydrate_report_store_from_db,
@@ -826,6 +827,7 @@ class RemediationNotification(BaseModel):
     reason: str
     next_transition: str
     payload_preview: Dict[str, Any] = Field(default_factory=dict)
+    dispatch: Dict[str, Any] = Field(default_factory=dict)
 
 
 class RemediationQueueItem(BaseModel):
@@ -3641,12 +3643,13 @@ async def get_domain_remediation_queue(
         db,
         selected_workspace_id=parse_selected_workspace_id(selected_workspace),
     )
-    return await _build_domain_remediation_queue_for_workspace(
+    queue = await _build_domain_remediation_queue_for_workspace(
         db,
         workspace=workspace,
         domain_id=domain_id,
         refresh=refresh,
     )
+    return attach_remediation_dispatch_previews(db, workspace=workspace, queue=queue)
 
 
 @router.post(
@@ -3684,6 +3687,7 @@ async def audit_domain_remediation_notification(
         domain_id=domain_id,
         refresh=refresh,
     )
+    attach_remediation_dispatch_previews(db, workspace=workspace, queue=queue)
     item = next(
         (
             candidate

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -286,6 +286,38 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
         "value_type": "string",
         "category": "notifications",
     },
+    {
+        "key": "notifications.remediation_dispatch_enabled",
+        "value": "false",
+        "description": "Allow human-reviewed remediation notifications to become dispatch-eligible",
+        "value_type": "boolean",
+        "category": "notifications",
+    },
+    {
+        "key": "notifications.remediation_dispatch_channel",
+        "value": "webhook",
+        "description": "Remediation notification dispatch channel; webhook is currently supported",
+        "value_type": "string",
+        "category": "notifications",
+    },
+    {
+        "key": "notifications.remediation_dispatch_require_acknowledgement",
+        "value": "true",
+        "description": "Require previewed or acknowledged audit state before remediation dispatch",
+        "value_type": "boolean",
+        "category": "notifications",
+    },
+    {
+        "key": "notifications.remediation_dispatch_events",
+        "value": (
+            "dmarq.remediation.approval_required,"
+            "dmarq.remediation.manual_action_required,"
+            "dmarq.remediation.investigation_required"
+        ),
+        "description": "Comma-separated remediation events eligible for future dispatch",
+        "value_type": "string",
+        "category": "notifications",
+    },
     # ── Optional AI / MCP ───────────────────────────────────────────────────
     {
         "key": "ai.enabled",

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -1,0 +1,186 @@
+"""Read-only dispatch readiness for remediation notification previews."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set
+
+from sqlalchemy.orm import Session
+
+from app.models.setting import Setting
+from app.models.webhook import WebhookEndpoint
+from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceAuditLog
+from app.services.webhook_events import SUPPORTED_EVENT_TYPES, endpoint_matches_event
+
+DISPATCH_ENABLED_KEY = "notifications.remediation_dispatch_enabled"
+DISPATCH_CHANNEL_KEY = "notifications.remediation_dispatch_channel"
+DISPATCH_REQUIRE_ACK_KEY = "notifications.remediation_dispatch_require_acknowledgement"
+DISPATCH_EVENTS_KEY = "notifications.remediation_dispatch_events"
+
+DEFAULT_DISPATCH_EVENTS = {
+    "dmarq.remediation.approval_required",
+    "dmarq.remediation.manual_action_required",
+    "dmarq.remediation.investigation_required",
+}
+ACKNOWLEDGED_LIFECYCLE_STATES = {"previewed", "acknowledged"}
+
+
+def _truthy(value: Optional[str], *, default: bool = False) -> bool:
+    if value is None or value == "":
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _settings(db: Session) -> Dict[str, str]:
+    rows = (
+        db.query(Setting)
+        .filter(
+            Setting.key.in_(
+                [
+                    DISPATCH_ENABLED_KEY,
+                    DISPATCH_CHANNEL_KEY,
+                    DISPATCH_REQUIRE_ACK_KEY,
+                    DISPATCH_EVENTS_KEY,
+                ]
+            )
+        )
+        .all()
+    )
+    return {row.key: row.value or "" for row in rows}
+
+
+def _configured_events(value: str) -> Set[str]:
+    if not value.strip():
+        return set(DEFAULT_DISPATCH_EVENTS)
+    configured = {item.strip() for item in value.split(",") if item.strip()}
+    return {event for event in configured if event in SUPPORTED_EVENT_TYPES}
+
+
+def _latest_lifecycle_marker(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domain: str,
+    item_id: str,
+) -> Dict[str, Optional[str]]:
+    row = (
+        db.query(WorkspaceAuditLog)
+        .filter(
+            WorkspaceAuditLog.workspace_id == workspace.id,
+            WorkspaceAuditLog.action == "remediation.notification_lifecycle_recorded",
+            WorkspaceAuditLog.entity_type == "remediation_notification",
+            WorkspaceAuditLog.entity_id == item_id,
+            WorkspaceAuditLog.entity_name == domain,
+        )
+        .order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
+        .first()
+    )
+    if row is None:
+        return {"state": None, "recorded_at": None}
+    try:
+        details = json.loads(row.details or "{}")
+    except (json.JSONDecodeError, TypeError):
+        details = {}
+    recorded_at = row.created_at.isoformat() if isinstance(row.created_at, datetime) else None
+    return {"state": details.get("lifecycle_state"), "recorded_at": recorded_at}
+
+
+def _matching_webhook_count(db: Session, *, workspace: Workspace, event_type: str) -> int:
+    endpoints = (
+        db.query(WebhookEndpoint)
+        .filter(
+            WebhookEndpoint.workspace_id == workspace.id,
+            WebhookEndpoint.enabled.is_(True),
+        )
+        .all()
+    )
+    return sum(1 for endpoint in endpoints if endpoint_matches_event(endpoint, event_type))
+
+
+def build_remediation_dispatch_preview(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domain: str,
+    item: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return a read-only dispatch readiness summary for one remediation item."""
+    settings = _settings(db)
+    enabled = _truthy(settings.get(DISPATCH_ENABLED_KEY), default=False)
+    channel = (settings.get(DISPATCH_CHANNEL_KEY) or "webhook").strip().lower() or "webhook"
+    require_ack = _truthy(settings.get(DISPATCH_REQUIRE_ACK_KEY), default=True)
+    configured_events = _configured_events(settings.get(DISPATCH_EVENTS_KEY, ""))
+    notification = item.get("notification") or {}
+    event_type = str(notification.get("event") or "")
+    item_id = str(item.get("id") or "")
+    lifecycle = _latest_lifecycle_marker(db, workspace=workspace, domain=domain, item_id=item_id)
+    lifecycle_state = lifecycle.get("state")
+    webhook_count = _matching_webhook_count(db, workspace=workspace, event_type=event_type)
+    blocked_reasons: List[str] = []
+
+    if not enabled:
+        blocked_reasons.append("Remediation dispatch is disabled in notification settings.")
+    if event_type not in configured_events:
+        blocked_reasons.append("This remediation event is not enabled for dispatch.")
+    if channel != "webhook":
+        blocked_reasons.append("Only webhook dispatch is supported in this release slice.")
+    if require_ack and lifecycle_state not in ACKNOWLEDGED_LIFECYCLE_STATES:
+        blocked_reasons.append("Record a previewed or acknowledged lifecycle marker first.")
+    if channel == "webhook" and webhook_count == 0:
+        blocked_reasons.append("No enabled webhook endpoint is subscribed to this event.")
+
+    return {
+        "enabled": enabled,
+        "eligible": enabled and not blocked_reasons,
+        "channel": channel,
+        "event_enabled": event_type in configured_events,
+        "requires_lifecycle_acknowledgement": require_ack,
+        "lifecycle_state": lifecycle_state,
+        "lifecycle_recorded_at": lifecycle.get("recorded_at"),
+        "webhook_endpoint_count": webhook_count,
+        "blocked_reasons": blocked_reasons,
+        "would_enqueue": enabled and not blocked_reasons,
+        "delivery_enqueued": False,
+        "next_steps": _next_steps(blocked_reasons),
+    }
+
+
+def _next_steps(blocked_reasons: List[str]) -> List[str]:
+    if not blocked_reasons:
+        return ["Review the payload preview, then use the future dispatch endpoint to enqueue it."]
+    steps = []
+    for reason in blocked_reasons:
+        if reason.startswith("Remediation dispatch is disabled"):
+            steps.append(f"Enable {DISPATCH_ENABLED_KEY} after testing routing.")
+        elif reason.startswith("This remediation event"):
+            steps.append(f"Add the event to {DISPATCH_EVENTS_KEY}.")
+        elif reason.startswith("Only webhook"):
+            steps.append(f"Set {DISPATCH_CHANNEL_KEY}=webhook.")
+        elif reason.startswith("Record a previewed"):
+            steps.append(
+                "Record a previewed or acknowledged remediation notification audit marker."
+            )
+        elif reason.startswith("No enabled webhook"):
+            steps.append("Create or enable a webhook endpoint subscribed to the remediation event.")
+    return steps
+
+
+def attach_remediation_dispatch_previews(
+    db: Session,
+    *,
+    workspace: Workspace,
+    queue: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Attach read-only dispatch readiness to every queue item notification."""
+    domain = str(queue.get("domain") or "")
+    for item in queue.get("items", []):
+        notification = item.setdefault("notification", {})
+        notification["dispatch"] = build_remediation_dispatch_preview(
+            db,
+            workspace=workspace,
+            domain=domain,
+            item=item,
+        )
+    return queue

--- a/backend/app/services/workspace_onboarding.py
+++ b/backend/app/services/workspace_onboarding.py
@@ -45,6 +45,10 @@ SAFE_NOTIFICATION_DEFAULTS = {
     "notifications.summary_weekly_enabled",
     "notifications.summary_send_hour_utc",
     "notifications.summary_weekday_utc",
+    "notifications.remediation_dispatch_enabled",
+    "notifications.remediation_dispatch_channel",
+    "notifications.remediation_dispatch_require_acknowledgement",
+    "notifications.remediation_dispatch_events",
 }
 
 NOTIFICATION_SETTING_META = {
@@ -62,6 +66,13 @@ NOTIFICATION_SETTING_META = {
     "notifications.summary_weekly_enabled": ("Send weekly DMARC summaries", "boolean"),
     "notifications.summary_send_hour_utc": ("UTC hour for scheduled summaries", "integer"),
     "notifications.summary_weekday_utc": ("UTC weekday for weekly summaries", "integer"),
+    "notifications.remediation_dispatch_enabled": ("Enable remediation dispatch", "boolean"),
+    "notifications.remediation_dispatch_channel": ("Remediation dispatch channel", "string"),
+    "notifications.remediation_dispatch_require_acknowledgement": (
+        "Require remediation lifecycle acknowledgement",
+        "boolean",
+    ),
+    "notifications.remediation_dispatch_events": ("Eligible remediation events", "string"),
 }
 
 WORKSPACE_ONBOARDING_TEMPLATES: List[Dict[str, Any]] = [

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -19,11 +19,17 @@ from fastapi.testclient import TestClient
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.models.domain import Domain
+from app.models.setting import Setting
+from app.models.webhook import WebhookDelivery
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services import report_persistence
 from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.report_store import ReportStore
+from app.services.webhook_events import (
+    EVENT_REMEDIATION_APPROVAL_REQUIRED,
+    create_webhook_endpoint,
+)
 from app.services.workspaces import get_or_create_default_workspace
 
 # ---------------------------------------------------------------------------
@@ -75,6 +81,52 @@ REPORT_STR_POLICY = {
     "report_id": "rpt-str-policy",
     "policy": "quarantine",
 }
+
+
+def _stub_approval_ready_remediation(monkeypatch):
+    """Stub a deterministic approval-ready remediation queue for example.com."""
+
+    async def fake_domain_grade(db, domain_id, store, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 72,
+            "grade": "C",
+            "status": "attention",
+            "factors": {"dns_posture": 60},
+            "actions": [],
+        }
+
+    async def fake_dns_guidance(db, store, domain_id, refresh=False):
+        return {
+            "domain": domain_id,
+            "status": "critical",
+            "dns_provider": {"provider_id": "cloudflare"},
+            "findings": [],
+            "change_plans": [
+                {
+                    "plan_id": "dmarc-missing",
+                    "finding_code": "dmarc_missing",
+                    "severity": "error",
+                    "operation": "create",
+                    "record_type": "TXT",
+                    "name": "_dmarc.example.com",
+                    "proposed_value": "v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+                    "current_values": [],
+                    "rationale": "Publish a monitoring DMARC record.",
+                    "expected_health_impact": "High",
+                    "manual_steps": ["Create the TXT record."],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
+    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: ["cloudflare"])
+    monkeypatch.setattr(
+        domains_endpoint,
+        "_recommended_dns_write_provider",
+        lambda dns_provider, available_providers: "cloudflare",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -662,10 +714,145 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
     assert data["items"][0]["id"] == "dns:dmarc-missing"
     assert data["items"][0]["automation"]["eligible"] is True
     assert data["items"][0]["automation"]["provider"] == "cloudflare"
+    dispatch = data["items"][0]["notification"]["dispatch"]
+    assert dispatch["enabled"] is False
+    assert dispatch["eligible"] is False
+    assert dispatch["delivery_enqueued"] is False
+    assert "Remediation dispatch is disabled" in dispatch["blocked_reasons"][0]
     assert [item["id"] for item in data["items"]] == [
         "dns:dmarc-missing",
         "health:low_compliance",
     ]
+
+
+def test_domain_remediation_dispatch_preview_becomes_eligible_without_enqueuing(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Opt-in remediation dispatch readiness is visible but still read-only."""
+    _stub_approval_ready_remediation(monkeypatch)
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add_all(
+        [
+            Setting(
+                key="notifications.remediation_dispatch_enabled",
+                value="true",
+                description="Enable remediation dispatch",
+                value_type="boolean",
+                category="notifications",
+            ),
+            Setting(
+                key="notifications.remediation_dispatch_require_acknowledgement",
+                value="true",
+                description="Require remediation acknowledgement",
+                value_type="boolean",
+                category="notifications",
+            ),
+        ]
+    )
+    create_webhook_endpoint(
+        db_session,
+        workspace_id=workspace.id,
+        name="remediation receiver",
+        url="https://receiver.example/remediation",
+        event_types=[EVENT_REMEDIATION_APPROVAL_REQUIRED],
+    )
+    db_session.commit()
+
+    audit_response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "event": EVENT_REMEDIATION_APPROVAL_REQUIRED,
+            "lifecycle_state": "acknowledged",
+        },
+    )
+    assert audit_response.status_code == 200
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+
+    assert response.status_code == 200
+    dispatch = response.json()["items"][0]["notification"]["dispatch"]
+    assert dispatch["enabled"] is True
+    assert dispatch["eligible"] is True
+    assert dispatch["would_enqueue"] is True
+    assert dispatch["delivery_enqueued"] is False
+    assert dispatch["lifecycle_state"] == "acknowledged"
+    assert dispatch["webhook_endpoint_count"] == 1
+    assert dispatch["blocked_reasons"] == []
+    assert db_session.query(WebhookDelivery).count() == 0
+
+
+def test_domain_remediation_dispatch_preview_reports_blockers_for_unsupported_routes(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Dispatch previews stay blocked for unsupported channels and event routing."""
+    _stub_approval_ready_remediation(monkeypatch)
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add_all(
+        [
+            Setting(
+                key="notifications.remediation_dispatch_enabled",
+                value="true",
+                description="Enable remediation dispatch",
+                value_type="boolean",
+                category="notifications",
+            ),
+            Setting(
+                key="notifications.remediation_dispatch_channel",
+                value="email",
+                description="Route remediation dispatch through email",
+                value_type="string",
+                category="notifications",
+            ),
+            Setting(
+                key="notifications.remediation_dispatch_events",
+                value="dmarq.domain.health.degraded, not-a-real-event",
+                description="Eligible remediation events",
+                value_type="string",
+                category="notifications",
+            ),
+            Setting(
+                key="notifications.remediation_dispatch_require_acknowledgement",
+                value="true",
+                description="Require remediation acknowledgement",
+                value_type="boolean",
+                category="notifications",
+            ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="system",
+                actor_id="test-suite",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:dmarc-missing",
+                entity_name=DOMAIN,
+                details="{broken-json",
+            ),
+        ]
+    )
+    db_session.commit()
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+
+    assert response.status_code == 200
+    dispatch = response.json()["items"][0]["notification"]["dispatch"]
+    assert dispatch["enabled"] is True
+    assert dispatch["eligible"] is False
+    assert dispatch["event_enabled"] is False
+    assert dispatch["channel"] == "email"
+    assert dispatch["lifecycle_state"] is None
+    assert dispatch["delivery_enqueued"] is False
+    assert dispatch["blocked_reasons"] == [
+        "This remediation event is not enabled for dispatch.",
+        "Only webhook dispatch is supported in this release slice.",
+        "Record a previewed or acknowledged lifecycle marker first.",
+    ]
+    assert "Add the event to notifications.remediation_dispatch_events." in dispatch["next_steps"]
+    assert "Set notifications.remediation_dispatch_channel=webhook." in dispatch["next_steps"]
 
 
 def test_domain_remediation_notification_lifecycle_audit_records_sanitized_marker(

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -659,8 +659,12 @@ read-only notification routing metadata. DNS items that have a concrete safe
 TXT/CNAME provider write are marked `approval_ready` and point to the same
 explicit preview/apply endpoint used by the DNS change-plan UI. Notification
 metadata includes the event name, channel, dedupe key, reason, and next state
-transition that an operator workflow can use. Each item also includes a
-sanitized `payload_preview` using schema
+transition that an operator workflow can use. Each notification also includes a
+read-only `dispatch` preview showing whether the item would be eligible for a
+future dispatch step, which channel would be used, whether a previewed or
+acknowledged lifecycle marker is still required, how many enabled webhook
+endpoints match the event, and why dispatch is currently blocked. Each item
+also includes a sanitized `payload_preview` using schema
 `dmarq.remediation.notification.v1`; it is the deterministic data shape a
 future webhook, ticketing, or chatops delivery would receive. The endpoint does
 not perform DNS writes, enqueue webhook deliveries, or send notifications.
@@ -673,6 +677,18 @@ Supported lifecycle states are `previewed`, `acknowledged`, `snoozed`,
 match the current queue item's notification metadata. The response includes the
 sanitized workspace audit row. This endpoint is deliberately audit-only: it
 does not enqueue webhook deliveries, send notifications, or attempt DNS writes.
+
+The remediation dispatch preview is controlled by notification settings and is
+disabled by default:
+
+- `notifications.remediation_dispatch_enabled`
+- `notifications.remediation_dispatch_channel`
+- `notifications.remediation_dispatch_require_acknowledgement`
+- `notifications.remediation_dispatch_events`
+
+In this release slice, `webhook` is the only supported dispatch channel. Even
+when the preview reports `eligible=true`, DMARQ only reports readiness and does
+not enqueue delivery rows until a future explicit dispatch endpoint is added.
 
 #### Get Posture Dashboard
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -92,6 +92,13 @@ queue does not send a notification. API clients also receive a sanitized
 `payload_preview` for each item so ticketing, webhook, and chatops routes can
 be tested before delivery automation is enabled.
 
+The same notification block includes a dispatch readiness preview. It explains
+whether remediation dispatch is enabled, whether the event is configured, if a
+previewed or acknowledged audit marker is still required, and whether an
+enabled webhook endpoint is subscribed to the event. This is a readiness check
+only; DMARQ does not enqueue webhook deliveries or send notifications from the
+queue view.
+
 ### Source Intelligence
 
 The domain detail page groups sending sources into coarse regions and networks
@@ -141,6 +148,14 @@ written to the workspace audit log with the sanitized notification preview, but
 they do not send notifications, enqueue webhooks, or touch DNS. This gives
 operators an auditable lifecycle before any automated remediation loop is
 enabled.
+
+Dispatch remains opt-in through notification settings:
+`notifications.remediation_dispatch_enabled`,
+`notifications.remediation_dispatch_channel`,
+`notifications.remediation_dispatch_require_acknowledgement`, and
+`notifications.remediation_dispatch_events`. The current supported channel is
+`webhook`; enabling the settings only makes queue items dispatch-eligible for a
+future explicit dispatch step.
 
 If an operator selects a different provider than the nameserver-detected
 provider, DMARQ blocks the preview/apply request by default. The mismatch can be


### PR DESCRIPTION
## What changed
- Added a read-only remediation dispatch readiness service.
- `GET /domains/{domain_id}/remediation` now includes `notification.dispatch` for each queue item.
- Dispatch readiness reports whether remediation dispatch is enabled, whether the event is configured, whether a previewed/acknowledged audit marker exists, whether a matching webhook endpoint is enabled, and which blockers remain.
- Added safe notification settings for future opt-in remediation dispatch.
- Allowed those settings in workspace onboarding defaults.
- Documented the dispatch preview and its safety boundary.

## Why
This is the next bounded #384 slice after audit lifecycle markers. It gives operators and UI/API clients a deterministic readiness state before we add any explicit dispatch endpoint.

## Safety boundary
This PR does not enqueue webhook deliveries, send Apprise/email/chat notifications, call LLMs, or modify DNS/provider records. Even when `eligible=true`, the response is still a preview only.

## Validation
- `python -m black backend/app/services/remediation_dispatch.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/settings.py backend/app/services/workspace_onboarding.py backend/app/tests/test_domain_detail_endpoints.py`
- `python -m isort backend/app/services/remediation_dispatch.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/settings.py backend/app/services/workspace_onboarding.py backend/app/tests/test_domain_detail_endpoints.py`
- `git diff --check`
- `python -m py_compile backend/app/services/remediation_dispatch.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/settings.py backend/app/services/workspace_onboarding.py backend/app/tests/test_domain_detail_endpoints.py`
- `pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_settings.py::TestSettingsAPI::test_list_settings_seeds_defaults backend/app/tests/test_workspace_onboarding.py -q`

Refs #384
