### PR TITLE
fix: reuse remediation dispatch preview context

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3687,7 +3687,7 @@ async def audit_domain_remediation_notification(
         domain_id=domain_id,
         refresh=refresh,
     )
-    attach_remediation_dispatch_previews(db, workspace=workspace, queue=queue)
+    queue = attach_remediation_dispatch_previews(db, workspace=workspace, queue=queue)
     item = next(
         (
             candidate

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
 from sqlalchemy.orm import Session
 
@@ -87,8 +87,8 @@ def _latest_lifecycle_marker(
     return {"state": details.get("lifecycle_state"), "recorded_at": recorded_at}
 
 
-def _matching_webhook_count(db: Session, *, workspace: Workspace, event_type: str) -> int:
-    endpoints = (
+def _enabled_webhook_endpoints(db: Session, *, workspace: Workspace) -> List[WebhookEndpoint]:
+    return (
         db.query(WebhookEndpoint)
         .filter(
             WebhookEndpoint.workspace_id == workspace.id,
@@ -96,7 +96,21 @@ def _matching_webhook_count(db: Session, *, workspace: Workspace, event_type: st
         )
         .all()
     )
+
+
+def _matching_webhook_count(
+    endpoints: Sequence[WebhookEndpoint], *, event_type: str
+) -> int:
     return sum(1 for endpoint in endpoints if endpoint_matches_event(endpoint, event_type))
+
+
+def _webhook_event_counts(
+    endpoints: Sequence[WebhookEndpoint], event_types: Iterable[str]
+) -> Dict[str, int]:
+    return {
+        event_type: _matching_webhook_count(endpoints, event_type=event_type)
+        for event_type in set(event_types)
+    }
 
 
 def build_remediation_dispatch_preview(
@@ -105,9 +119,11 @@ def build_remediation_dispatch_preview(
     workspace: Workspace,
     domain: str,
     item: Dict[str, Any],
+    settings: Optional[Dict[str, str]] = None,
+    webhook_event_counts: Optional[Dict[str, int]] = None,
 ) -> Dict[str, Any]:
     """Return a read-only dispatch readiness summary for one remediation item."""
-    settings = _settings(db)
+    settings = settings if settings is not None else _settings(db)
     enabled = _truthy(settings.get(DISPATCH_ENABLED_KEY), default=False)
     channel = (settings.get(DISPATCH_CHANNEL_KEY) or "webhook").strip().lower() or "webhook"
     require_ack = _truthy(settings.get(DISPATCH_REQUIRE_ACK_KEY), default=True)
@@ -117,7 +133,11 @@ def build_remediation_dispatch_preview(
     item_id = str(item.get("id") or "")
     lifecycle = _latest_lifecycle_marker(db, workspace=workspace, domain=domain, item_id=item_id)
     lifecycle_state = lifecycle.get("state")
-    webhook_count = _matching_webhook_count(db, workspace=workspace, event_type=event_type)
+    if webhook_event_counts is None:
+        endpoints = _enabled_webhook_endpoints(db, workspace=workspace)
+        webhook_count = _matching_webhook_count(endpoints, event_type=event_type)
+    else:
+        webhook_count = webhook_event_counts.get(event_type, 0)
     blocked_reasons: List[str] = []
 
     if not enabled:
@@ -175,12 +195,26 @@ def attach_remediation_dispatch_previews(
 ) -> Dict[str, Any]:
     """Attach read-only dispatch readiness to every queue item notification."""
     domain = str(queue.get("domain") or "")
-    for item in queue.get("items", []):
+    items = list(queue.get("items", []))
+    settings = _settings(db)
+    configured_events = _configured_events(settings.get(DISPATCH_EVENTS_KEY, ""))
+    event_types = {
+        str((item.get("notification") or {}).get("event") or "")
+        for item in items
+    }
+    endpoints = _enabled_webhook_endpoints(db, workspace=workspace)
+    webhook_event_counts = _webhook_event_counts(
+        endpoints,
+        configured_events | event_types,
+    )
+    for item in items:
         notification = item.setdefault("notification", {})
         notification["dispatch"] = build_remediation_dispatch_preview(
             db,
             workspace=workspace,
             domain=domain,
             item=item,
+            settings=settings,
+            webhook_event_counts=webhook_event_counts,
         )
     return queue

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -196,6 +196,8 @@ def attach_remediation_dispatch_previews(
     """Attach read-only dispatch readiness to every queue item notification."""
     domain = str(queue.get("domain") or "")
     items = list(queue.get("items", []))
+    if not items:
+        return queue
     settings = _settings(db)
     configured_events = _configured_events(settings.get(DISPATCH_EVENTS_KEY, ""))
     event_types = {

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -57,3 +57,21 @@ def test_attach_remediation_dispatch_previews_reuses_request_context(monkeypatch
     dispatches = [item["notification"]["dispatch"] for item in result["items"]]
     assert [dispatch["webhook_endpoint_count"] for dispatch in dispatches] == [1, 1]
     assert [dispatch["eligible"] for dispatch in dispatches] == [True, True]
+
+
+def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("empty queues should not fetch dispatch context")
+
+    monkeypatch.setattr(remediation_dispatch, "_settings", fail_if_called)
+    monkeypatch.setattr(remediation_dispatch, "_enabled_webhook_endpoints", fail_if_called)
+
+    queue = {"domain": "example.com", "items": []}
+
+    result = remediation_dispatch.attach_remediation_dispatch_previews(
+        object(),
+        workspace=SimpleNamespace(id=42),
+        queue=queue,
+    )
+
+    assert result is queue

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+from app.services import remediation_dispatch
+from app.services.webhook_events import EVENT_REMEDIATION_APPROVAL_REQUIRED
+
+
+def test_attach_remediation_dispatch_previews_reuses_request_context(monkeypatch):
+    calls = {"settings": 0, "webhooks": 0}
+
+    def fake_settings(_db):
+        calls["settings"] += 1
+        return {
+            remediation_dispatch.DISPATCH_ENABLED_KEY: "true",
+            remediation_dispatch.DISPATCH_REQUIRE_ACK_KEY: "false",
+            remediation_dispatch.DISPATCH_CHANNEL_KEY: "webhook",
+            remediation_dispatch.DISPATCH_EVENTS_KEY: EVENT_REMEDIATION_APPROVAL_REQUIRED,
+        }
+
+    def fake_enabled_webhook_endpoints(_db, *, workspace):
+        calls["webhooks"] += 1
+        assert workspace.id == 42
+        return [SimpleNamespace(event_types="*")]
+
+    monkeypatch.setattr(remediation_dispatch, "_settings", fake_settings)
+    monkeypatch.setattr(
+        remediation_dispatch,
+        "_enabled_webhook_endpoints",
+        fake_enabled_webhook_endpoints,
+    )
+    monkeypatch.setattr(
+        remediation_dispatch,
+        "_latest_lifecycle_marker",
+        lambda *_args, **_kwargs: {"state": None, "recorded_at": None},
+    )
+
+    queue = {
+        "domain": "example.com",
+        "items": [
+            {
+                "id": "dns:dmarc-missing",
+                "notification": {"event": EVENT_REMEDIATION_APPROVAL_REQUIRED},
+            },
+            {
+                "id": "health:low_compliance",
+                "notification": {"event": EVENT_REMEDIATION_APPROVAL_REQUIRED},
+            },
+        ],
+    }
+
+    result = remediation_dispatch.attach_remediation_dispatch_previews(
+        object(),
+        workspace=SimpleNamespace(id=42),
+        queue=queue,
+    )
+
+    assert calls == {"settings": 1, "webhooks": 1}
+    dispatches = [item["notification"]["dispatch"] for item in result["items"]]
+    assert [dispatch["webhook_endpoint_count"] for dispatch in dispatches] == [1, 1]
+    assert [dispatch["eligible"] for dispatch in dispatches] == [True, True]


### PR DESCRIPTION
## Summary
- reuse remediation dispatch settings and webhook endpoint lookups while attaching queue previews
- assign the audit preview return value explicitly before reading the mutated queue
- add regression coverage for one settings/webhook lookup across multiple queue items

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_domain_detail_endpoints.py -q
- .venv/bin/python -m flake8 backend/app/services/remediation_dispatch.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_dispatch.py
- git diff --check

Follow-up for Copilot comments on #411.