### PR TITLE
test: cover remediation dispatch fallback context

### DIFF
--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -75,3 +75,47 @@ def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):
     )
 
     assert result is queue
+
+
+def test_build_remediation_dispatch_preview_fetches_context_when_not_preloaded(monkeypatch):
+    calls = {"settings": 0, "webhooks": 0}
+
+    def fake_settings(_db):
+        calls["settings"] += 1
+        return {
+            remediation_dispatch.DISPATCH_ENABLED_KEY: "true",
+            remediation_dispatch.DISPATCH_REQUIRE_ACK_KEY: "false",
+            remediation_dispatch.DISPATCH_CHANNEL_KEY: "webhook",
+            remediation_dispatch.DISPATCH_EVENTS_KEY: EVENT_REMEDIATION_APPROVAL_REQUIRED,
+        }
+
+    def fake_enabled_webhook_endpoints(_db, *, workspace):
+        calls["webhooks"] += 1
+        assert workspace.id == 42
+        return [SimpleNamespace(event_types=EVENT_REMEDIATION_APPROVAL_REQUIRED)]
+
+    monkeypatch.setattr(remediation_dispatch, "_settings", fake_settings)
+    monkeypatch.setattr(
+        remediation_dispatch,
+        "_enabled_webhook_endpoints",
+        fake_enabled_webhook_endpoints,
+    )
+    monkeypatch.setattr(
+        remediation_dispatch,
+        "_latest_lifecycle_marker",
+        lambda *_args, **_kwargs: {"state": None, "recorded_at": None},
+    )
+
+    preview = remediation_dispatch.build_remediation_dispatch_preview(
+        object(),
+        workspace=SimpleNamespace(id=42),
+        domain="example.com",
+        item={
+            "id": "dns:dmarc-missing",
+            "notification": {"event": EVENT_REMEDIATION_APPROVAL_REQUIRED},
+        },
+    )
+
+    assert calls == {"settings": 1, "webhooks": 1}
+    assert preview["webhook_endpoint_count"] == 1
+    assert preview["eligible"] is True


### PR DESCRIPTION
## Summary
- add regression coverage for building remediation dispatch preview context when settings and webhook counts are not preloaded
- preserve the already-merged PR #412 behavior while covering the fallback fetch path Codecov flagged

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_domain_detail_endpoints.py -q` (71 passed)
- `.venv/bin/python -m flake8 backend/app/services/remediation_dispatch.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_dispatch.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for remediation dispatch preview handling when required context is not already available.
  * Improved confidence that preview data is populated correctly, including webhook endpoint counts and eligibility status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->