### PR TITLE
feat: add remediation notification dispatch endpoint

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1,5 +1,6 @@
 import asyncio
 import csv
+import hashlib
 import io
 import ipaddress
 import json
@@ -86,6 +87,7 @@ from app.services.sender_intelligence import (
     identify_sender,
     source_geo_for,
 )
+from app.services.webhook_events import delivery_to_dict, enqueue_webhook_event
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
     PERMISSION_REPORTS_READ,
@@ -876,6 +878,30 @@ class RemediationNotificationAuditResponse(BaseModel):
     event: str
     dedupe_key: str
     lifecycle_state: str
+    audit: Dict[str, Any]
+
+
+class RemediationNotificationDispatchRequest(BaseModel):
+    """Explicit operator request to enqueue one remediation notification."""
+
+    item_id: str
+    confirm: bool = False
+    event: Optional[str] = None
+    dedupe_key: Optional[str] = None
+    note: Optional[str] = None
+
+
+class RemediationNotificationDispatchResponse(BaseModel):
+    """Persisted webhook delivery state for one approved remediation dispatch."""
+
+    domain: str
+    item_id: str
+    event: str
+    dedupe_key: str
+    delivery_enqueued: bool
+    delivery_count: int
+    deliveries: List[Dict[str, Any]] = Field(default_factory=list)
+    dispatch: Dict[str, Any] = Field(default_factory=dict)
     audit: Dict[str, Any]
 
 
@@ -3755,6 +3781,145 @@ async def audit_domain_remediation_notification(
         "event": event,
         "dedupe_key": dedupe_key,
         "lifecycle_state": lifecycle_state,
+        "audit": audit_log_to_dict(audit_row),
+    }
+
+
+def _remediation_dispatch_idempotency_key(event: str, dedupe_key: str) -> str:
+    """Return a bounded idempotency key for explicit remediation dispatch."""
+    digest = hashlib.sha256(f"{event}:{dedupe_key}".encode("utf-8")).hexdigest()[:32]
+    return f"remediation-dispatch:{digest}"
+
+
+@router.post(
+    "/{domain_id}/remediation/notifications/dispatch",
+    response_model=RemediationNotificationDispatchResponse,
+)
+async def dispatch_domain_remediation_notification(
+    request: Request,
+    payload: RemediationNotificationDispatchRequest,
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS posture"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Enqueue an explicitly approved remediation notification for webhook delivery."""
+    if not payload.confirm:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Set confirm=true to enqueue remediation notification delivery.",
+        )
+
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    queue = await _build_domain_remediation_queue_for_workspace(
+        db,
+        workspace=workspace,
+        domain_id=domain_id,
+        refresh=refresh,
+    )
+    queue = attach_remediation_dispatch_previews(db, workspace=workspace, queue=queue)
+    item = next(
+        (
+            candidate
+            for candidate in queue.get("items", [])
+            if candidate.get("id") == payload.item_id
+        ),
+        None,
+    )
+    if item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Remediation item not found",
+        )
+
+    notification = item.get("notification") or {}
+    event = str(notification.get("event") or "")
+    dedupe_key = str(notification.get("dedupe_key") or "")
+    if payload.event is not None and payload.event != event:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Notification event does not match the current remediation item",
+        )
+    if payload.dedupe_key is not None and payload.dedupe_key != dedupe_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Notification dedupe_key does not match the current remediation item",
+        )
+
+    dispatch_preview = notification.get("dispatch") or {}
+    if not dispatch_preview.get("eligible"):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Remediation notification is not dispatch-ready.",
+                "blocked_reasons": dispatch_preview.get("blocked_reasons") or [],
+                "next_steps": dispatch_preview.get("next_steps") or [],
+            },
+        )
+
+    notification_payload = notification.get("payload_preview") or {}
+    deliveries = enqueue_webhook_event(
+        db,
+        event_type=event,
+        payload=notification_payload,
+        idempotency_key=_remediation_dispatch_idempotency_key(event, dedupe_key),
+        workspace_id=workspace.id,
+    )
+    delivery_rows = [delivery_to_dict(delivery) for delivery in deliveries]
+    automation = item.get("automation") or {}
+    audit_row = record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action="remediation.notification_dispatch_enqueued",
+        entity_type="remediation_notification",
+        entity_id=item.get("id"),
+        entity_name=queue.get("domain"),
+        details={
+            "item_id": item.get("id"),
+            "domain": queue.get("domain"),
+            "event": event,
+            "dedupe_key": dedupe_key,
+            "notification_state": notification.get("state"),
+            "notification_channel": notification.get("channel"),
+            "notification_next_transition": notification.get("next_transition"),
+            "source": item.get("source"),
+            "severity": item.get("severity"),
+            "confidence": item.get("confidence"),
+            "automation_eligible": automation.get("eligible"),
+            "automation_provider": automation.get("provider"),
+            "automation_plan_id": automation.get("plan_id"),
+            "payload_preview": notification_payload,
+            "operator_note": payload.note,
+            "sent": False,
+            "delivery_enqueued": bool(delivery_rows),
+            "delivery_count": len(delivery_rows),
+            "deliveries": delivery_rows,
+            "dns_write_attempted": False,
+        },
+        auth_context=_auth,
+        request=request,
+        commit=True,
+    )
+
+    dispatch_response = {
+        **dispatch_preview,
+        "delivery_enqueued": bool(delivery_rows),
+        "delivery_count": len(delivery_rows),
+    }
+    return {
+        "domain": str(queue.get("domain") or domain_id),
+        "item_id": str(item.get("id") or payload.item_id),
+        "event": event,
+        "dedupe_key": dedupe_key,
+        "delivery_enqueued": bool(delivery_rows),
+        "delivery_count": len(delivery_rows),
+        "deliveries": delivery_rows,
+        "dispatch": dispatch_response,
         "audit": audit_log_to_dict(audit_row),
     }
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -855,6 +855,185 @@ def test_domain_remediation_dispatch_preview_reports_blockers_for_unsupported_ro
     assert "Set notifications.remediation_dispatch_channel=webhook." in dispatch["next_steps"]
 
 
+def test_domain_remediation_notification_dispatch_enqueues_webhook_delivery(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Explicit dispatch approval queues webhook delivery state without DNS writes."""
+    _stub_approval_ready_remediation(monkeypatch)
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add_all(
+        [
+            Setting(
+                key="notifications.remediation_dispatch_enabled",
+                value="true",
+                description="Enable remediation dispatch",
+                value_type="boolean",
+                category="notifications",
+            ),
+            Setting(
+                key="notifications.remediation_dispatch_channel",
+                value="webhook",
+                description="Route remediation dispatch through webhooks",
+                value_type="string",
+                category="notifications",
+            ),
+            Setting(
+                key="notifications.remediation_dispatch_events",
+                value=EVENT_REMEDIATION_APPROVAL_REQUIRED,
+                description="Eligible remediation events",
+                value_type="string",
+                category="notifications",
+            ),
+            Setting(
+                key="notifications.remediation_dispatch_require_acknowledgement",
+                value="true",
+                description="Require remediation acknowledgement",
+                value_type="boolean",
+                category="notifications",
+            ),
+        ]
+    )
+    db_session.commit()
+    create_webhook_endpoint(
+        db_session,
+        workspace_id=workspace.id,
+        name="Security operations",
+        url="https://hooks.example.test/remediation",
+        secret="remediation-secret-value",
+        event_types=[EVENT_REMEDIATION_APPROVAL_REQUIRED],
+    )
+
+    audit_response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "event": EVENT_REMEDIATION_APPROVAL_REQUIRED,
+            "lifecycle_state": "acknowledged",
+        },
+    )
+    assert audit_response.status_code == 200
+
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "confirm": True,
+            "event": EVENT_REMEDIATION_APPROVAL_REQUIRED,
+            "dedupe_key": f"dmarq:remediation:{DOMAIN}:dns:dmarc-missing",
+            "note": "Route this to the webhook queue",
+        },
+        headers={"X-Forwarded-For": "203.0.113.45"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["domain"] == DOMAIN
+    assert data["item_id"] == "dns:dmarc-missing"
+    assert data["delivery_enqueued"] is True
+    assert data["delivery_count"] == 1
+    assert data["dispatch"]["eligible"] is True
+    assert data["dispatch"]["delivery_enqueued"] is True
+    assert data["deliveries"][0]["event_type"] == EVENT_REMEDIATION_APPROVAL_REQUIRED
+    assert data["deliveries"][0]["status"] == "pending"
+    assert data["audit"]["action"] == "remediation.notification_dispatch_enqueued"
+    assert data["audit"]["ip_address"] == "203.0.113.45"
+    details = data["audit"]["details"]
+    assert details["sent"] is False
+    assert details["delivery_enqueued"] is True
+    assert details["delivery_count"] == 1
+    assert details["dns_write_attempted"] is False
+    assert details["operator_note"] == "Route this to the webhook queue"
+    assert db_session.query(WebhookDelivery).count() == 1
+
+    duplicate_response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "confirm": True,
+            "event": EVENT_REMEDIATION_APPROVAL_REQUIRED,
+        },
+    )
+    assert duplicate_response.status_code == 200
+    assert duplicate_response.json()["delivery_count"] == 1
+    assert db_session.query(WebhookDelivery).count() == 1
+
+
+def test_domain_remediation_notification_dispatch_requires_confirmed_readiness(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Dispatch stays blocked until an operator confirms and readiness is green."""
+    _stub_approval_ready_remediation(monkeypatch)
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add_all(
+        [
+            Setting(
+                key="notifications.remediation_dispatch_enabled",
+                value="true",
+                description="Enable remediation dispatch",
+                value_type="boolean",
+                category="notifications",
+            ),
+            Setting(
+                key="notifications.remediation_dispatch_channel",
+                value="webhook",
+                description="Route remediation dispatch through webhooks",
+                value_type="string",
+                category="notifications",
+            ),
+            Setting(
+                key="notifications.remediation_dispatch_events",
+                value=EVENT_REMEDIATION_APPROVAL_REQUIRED,
+                description="Eligible remediation events",
+                value_type="string",
+                category="notifications",
+            ),
+            Setting(
+                key="notifications.remediation_dispatch_require_acknowledgement",
+                value="true",
+                description="Require remediation acknowledgement",
+                value_type="boolean",
+                category="notifications",
+            ),
+        ]
+    )
+    db_session.commit()
+    create_webhook_endpoint(
+        db_session,
+        workspace_id=workspace.id,
+        name="Security operations",
+        url="https://hooks.example.test/remediation",
+        secret="remediation-secret-value",
+        event_types=[EVENT_REMEDIATION_APPROVAL_REQUIRED],
+    )
+
+    unconfirmed_response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "confirm": False,
+        },
+    )
+    assert unconfirmed_response.status_code == 400
+    assert "confirm=true" in unconfirmed_response.json()["detail"]
+
+    blocked_response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "confirm": True,
+        },
+    )
+    assert blocked_response.status_code == 409
+    detail = blocked_response.json()["detail"]
+    assert detail["message"] == "Remediation notification is not dispatch-ready."
+    assert "Record a previewed or acknowledged lifecycle marker first." in detail["blocked_reasons"]
+    assert db_session.query(WebhookDelivery).count() == 0
+
+
 def test_domain_remediation_notification_lifecycle_audit_records_sanitized_marker(
     seeded_client: TestClient,
     db_session,

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -678,8 +678,8 @@ match the current queue item's notification metadata. The response includes the
 sanitized workspace audit row. This endpoint is deliberately audit-only: it
 does not enqueue webhook deliveries, send notifications, or attempt DNS writes.
 
-`POST /domains/{domain_id}/remediation/notifications/dispatch` enqueues a
-webhook delivery for one current remediation item after explicit operator
+`POST /domains/{domain_id}/remediation/notifications/dispatch` enqueues
+webhook deliveries for one current remediation item after explicit operator
 approval. The request accepts `item_id`, `confirm=true`, and optional `event`,
 `dedupe_key`, and `note`. If `event` or `dedupe_key` is supplied, it must match
 the current queue item. The item's `dispatch.eligible` preview must already be

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -678,6 +678,18 @@ match the current queue item's notification metadata. The response includes the
 sanitized workspace audit row. This endpoint is deliberately audit-only: it
 does not enqueue webhook deliveries, send notifications, or attempt DNS writes.
 
+`POST /domains/{domain_id}/remediation/notifications/dispatch` enqueues a
+webhook delivery for one current remediation item after explicit operator
+approval. The request accepts `item_id`, `confirm=true`, and optional `event`,
+`dedupe_key`, and `note`. If `event` or `dedupe_key` is supplied, it must match
+the current queue item. The item's `dispatch.eligible` preview must already be
+true, which means dispatch is enabled, the event is configured, the channel is
+`webhook`, required lifecycle acknowledgement has been recorded, and at least
+one enabled webhook endpoint matches the event. The response includes persisted
+webhook delivery rows and a sanitized workspace audit row. The endpoint only
+queues notification delivery state; it does not send synchronously and never
+attempts DNS/provider writes.
+
 The remediation dispatch preview is controlled by notification settings and is
 disabled by default:
 
@@ -686,9 +698,10 @@ disabled by default:
 - `notifications.remediation_dispatch_require_acknowledgement`
 - `notifications.remediation_dispatch_events`
 
-In this release slice, `webhook` is the only supported dispatch channel. Even
-when the preview reports `eligible=true`, DMARQ only reports readiness and does
-not enqueue delivery rows until a future explicit dispatch endpoint is added.
+In this release slice, `webhook` is the only supported dispatch channel. The
+queue endpoint remains read-only. Delivery rows are created only by the explicit
+dispatch endpoint with `confirm=true`; DNS/provider writes remain a separate
+operator-approved flow.
 
 #### Get Posture Dashboard
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -99,6 +99,13 @@ enabled webhook endpoint is subscribed to the event. This is a readiness check
 only; DMARQ does not enqueue webhook deliveries or send notifications from the
 queue view.
 
+After a remediation notification is previewed or acknowledged, an operator can
+explicitly enqueue the notification through the dispatch API with
+`confirm=true`. Dispatch currently means "create persisted webhook delivery
+rows for configured endpoints"; it does not send from the queue view and does
+not apply DNS changes. The delivery history can then be inspected through the
+webhook delivery state.
+
 ### Source Intelligence
 
 The domain detail page groups sending sources into coarse regions and networks
@@ -154,8 +161,9 @@ Dispatch remains opt-in through notification settings:
 `notifications.remediation_dispatch_channel`,
 `notifications.remediation_dispatch_require_acknowledgement`, and
 `notifications.remediation_dispatch_events`. The current supported channel is
-`webhook`; enabling the settings only makes queue items dispatch-eligible for a
-future explicit dispatch step.
+`webhook`; enabling the settings only makes queue items dispatch-eligible. A
+separate dispatch request with `confirm=true` is still required to create
+delivery rows.
 
 If an operator selects a different provider than the nameserver-detected
 provider, DMARQ blocks the preview/apply request by default. The mismatch can be


### PR DESCRIPTION
## Summary
- add an explicit `POST /api/v1/domains/{domain_id}/remediation/notifications/dispatch` approval endpoint
- require `confirm=true`, current queue metadata, dispatch readiness, lifecycle acknowledgement, and a matching enabled webhook endpoint before enqueueing
- persist webhook delivery rows and a sanitized workspace audit event while keeping DNS/provider writes out of scope
- document the dispatch flow in the API reference and domain user guide

## Safety boundary
- No DNS/provider writes are attempted.
- The queue view remains read-only.
- Dispatch only creates webhook delivery state after explicit operator confirmation; it does not bypass the existing delivery worker state machine.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_remediation_dispatch.py -q`
- `.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_remediation_dispatch.py`
- `.venv/bin/python -m compileall -q backend/app`
- `.venv/bin/python -m mkdocs build`
- `git diff --check`

`mkdocs build --strict` still fails on pre-existing documentation link warnings outside this change.

Refs #384