### PR TITLE
test: cover remediation dispatch validation errors

### DIFF
--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -1051,6 +1051,7 @@ def test_domain_remediation_notification_dispatch_rejects_stale_identifiers(
     )
     assert missing_item_response.status_code == 404
     assert missing_item_response.json()["detail"] == "Remediation item not found"
+    assert db_session.query(WebhookDelivery).count() == 0
 
     event_mismatch_response = seeded_client.post(
         f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",
@@ -1062,6 +1063,7 @@ def test_domain_remediation_notification_dispatch_rejects_stale_identifiers(
     )
     assert event_mismatch_response.status_code == 400
     assert "event does not match" in event_mismatch_response.json()["detail"]
+    assert db_session.query(WebhookDelivery).count() == 0
 
     dedupe_mismatch_response = seeded_client.post(
         f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -1034,6 +1034,48 @@ def test_domain_remediation_notification_dispatch_requires_confirmed_readiness(
     assert db_session.query(WebhookDelivery).count() == 0
 
 
+def test_domain_remediation_notification_dispatch_rejects_stale_identifiers(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Dispatch requests must target the current queue item metadata."""
+    _stub_approval_ready_remediation(monkeypatch)
+
+    missing_item_response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",
+        json={
+            "item_id": "dns:spf-missing",
+            "confirm": True,
+        },
+    )
+    assert missing_item_response.status_code == 404
+    assert missing_item_response.json()["detail"] == "Remediation item not found"
+
+    event_mismatch_response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "confirm": True,
+            "event": "remediation.invalid",
+        },
+    )
+    assert event_mismatch_response.status_code == 400
+    assert "event does not match" in event_mismatch_response.json()["detail"]
+
+    dedupe_mismatch_response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",
+        json={
+            "item_id": "dns:dmarc-missing",
+            "confirm": True,
+            "dedupe_key": "dmarq:remediation:wrong",
+        },
+    )
+    assert dedupe_mismatch_response.status_code == 400
+    assert "dedupe_key does not match" in dedupe_mismatch_response.json()["detail"]
+    assert db_session.query(WebhookDelivery).count() == 0
+
+
 def test_domain_remediation_notification_lifecycle_audit_records_sanitized_marker(
     seeded_client: TestClient,
     db_session,


### PR DESCRIPTION
## Summary
- cover missing remediation dispatch validation error branches from PR #414
- assert stale item IDs, event mismatches, and dedupe key mismatches do not enqueue deliveries

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_domain_detail_endpoints.py -q
- .venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py
- git diff --check
- .venv/bin/python -m coverage run -m pytest backend/app/tests/test_domain_detail_endpoints.py -q