### PR TITLE
test: use stable missing remediation dispatch id

### DIFF
--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -1045,7 +1045,7 @@ def test_domain_remediation_notification_dispatch_rejects_stale_identifiers(
     missing_item_response = seeded_client.post(
         f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",
         json={
-            "item_id": "dns:spf-missing",
+            "item_id": "__missing-remediation-item__",
             "confirm": True,
         },
     )


### PR DESCRIPTION
## Summary
- replace the missing-item dispatch test fixture with an obviously nonexistent sentinel ID
- addresses the stale-item-id stability feedback from PR #415

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_domain_detail_endpoints.py -q
- .venv/bin/python -m flake8 backend/app/tests/test_domain_detail_endpoints.py
- git diff --check