### PR TITLE
[codex] summarize remediation dispatch readiness

### DIFF
--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -113,6 +113,23 @@ def _webhook_event_counts(
     }
 
 
+def _endpoint_route_key(endpoint: WebhookEndpoint) -> str:
+    return str(getattr(endpoint, "id", None) or getattr(endpoint, "url", None) or id(endpoint))
+
+
+def _webhook_event_route_keys(
+    endpoints: Sequence[WebhookEndpoint], event_types: Iterable[str]
+) -> Dict[str, Set[str]]:
+    return {
+        event_type: {
+            _endpoint_route_key(endpoint)
+            for endpoint in endpoints
+            if endpoint_matches_event(endpoint, event_type)
+        }
+        for event_type in set(event_types)
+    }
+
+
 def build_remediation_dispatch_preview(
     db: Session,
     *,
@@ -197,6 +214,7 @@ def attach_remediation_dispatch_previews(
     domain = str(queue.get("domain") or "")
     items = list(queue.get("items", []))
     if not items:
+        _attach_dispatch_summary(queue, items)
         return queue
     settings = _settings(db)
     configured_events = _configured_events(settings.get(DISPATCH_EVENTS_KEY, ""))
@@ -206,6 +224,10 @@ def attach_remediation_dispatch_previews(
     }
     endpoints = _enabled_webhook_endpoints(db, workspace=workspace)
     webhook_event_counts = _webhook_event_counts(
+        endpoints,
+        configured_events | event_types,
+    )
+    webhook_event_route_keys = _webhook_event_route_keys(
         endpoints,
         configured_events | event_types,
     )
@@ -219,18 +241,28 @@ def attach_remediation_dispatch_previews(
             settings=settings,
             webhook_event_counts=webhook_event_counts,
         )
-    _attach_dispatch_summary(queue, items)
+    _attach_dispatch_summary(
+        queue,
+        items,
+        webhook_event_route_keys=webhook_event_route_keys,
+    )
     return queue
 
 
-def _attach_dispatch_summary(queue: Dict[str, Any], items: Sequence[Dict[str, Any]]) -> None:
+def _attach_dispatch_summary(
+    queue: Dict[str, Any],
+    items: Sequence[Dict[str, Any]],
+    *,
+    webhook_event_route_keys: Optional[Dict[str, Set[str]]] = None,
+) -> None:
     """Expose queue-level dispatch readiness counters for dashboards."""
     summary = dict(queue.get("summary") or {})
-    dispatches = [
-        (item.get("notification") or {}).get("dispatch") or {}
+    notifications = [
+        item.get("notification") or {}
         for item in items
         if (item.get("notification") or {}).get("dispatch") is not None
     ]
+    dispatches = [notification.get("dispatch") or {} for notification in notifications]
     blocked = [dispatch for dispatch in dispatches if dispatch.get("blocked_reasons")]
     awaiting_ack = [
         dispatch
@@ -238,18 +270,18 @@ def _attach_dispatch_summary(queue: Dict[str, Any], items: Sequence[Dict[str, An
         if dispatch.get("requires_lifecycle_acknowledgement")
         and dispatch.get("lifecycle_state") not in ACKNOWLEDGED_LIFECYCLE_STATES
     ]
+    route_keys: Set[str] = set()
+    if webhook_event_route_keys:
+        for notification in notifications:
+            event_type = str(notification.get("event") or "")
+            route_keys.update(webhook_event_route_keys.get(event_type, set()))
     summary.update(
         {
             "dispatch_ready": sum(1 for dispatch in dispatches if dispatch.get("eligible")),
             "dispatch_blocked": len(blocked),
             "dispatch_disabled": sum(1 for dispatch in dispatches if not dispatch.get("enabled")),
             "dispatch_awaiting_acknowledgement": len(awaiting_ack),
-            "dispatch_webhook_routes": sum(
-                int(dispatch.get("webhook_endpoint_count") or 0) for dispatch in dispatches
-            ),
-            "dispatch_delivery_enqueued": sum(
-                1 for dispatch in dispatches if dispatch.get("delivery_enqueued")
-            ),
+            "dispatch_webhook_routes": len(route_keys),
         }
     )
     queue["summary"] = summary

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -219,4 +219,37 @@ def attach_remediation_dispatch_previews(
             settings=settings,
             webhook_event_counts=webhook_event_counts,
         )
+    _attach_dispatch_summary(queue, items)
     return queue
+
+
+def _attach_dispatch_summary(queue: Dict[str, Any], items: Sequence[Dict[str, Any]]) -> None:
+    """Expose queue-level dispatch readiness counters for dashboards."""
+    summary = dict(queue.get("summary") or {})
+    dispatches = [
+        (item.get("notification") or {}).get("dispatch") or {}
+        for item in items
+        if (item.get("notification") or {}).get("dispatch") is not None
+    ]
+    blocked = [dispatch for dispatch in dispatches if dispatch.get("blocked_reasons")]
+    awaiting_ack = [
+        dispatch
+        for dispatch in blocked
+        if dispatch.get("requires_lifecycle_acknowledgement")
+        and dispatch.get("lifecycle_state") not in ACKNOWLEDGED_LIFECYCLE_STATES
+    ]
+    summary.update(
+        {
+            "dispatch_ready": sum(1 for dispatch in dispatches if dispatch.get("eligible")),
+            "dispatch_blocked": len(blocked),
+            "dispatch_disabled": sum(1 for dispatch in dispatches if not dispatch.get("enabled")),
+            "dispatch_awaiting_acknowledgement": len(awaiting_ack),
+            "dispatch_webhook_routes": sum(
+                int(dispatch.get("webhook_endpoint_count") or 0) for dispatch in dispatches
+            ),
+            "dispatch_delivery_enqueued": sum(
+                1 for dispatch in dispatches if dispatch.get("delivery_enqueued")
+            ),
+        }
+    )
+    queue["summary"] = summary

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -221,8 +221,36 @@
                             <span class="rounded bg-blue-100 px-2 py-1 font-semibold text-blue-700">
                                 <span x-text="remediationQueue.summary.investigate"></span><span> investigate</span>
                             </span>
+                            <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700">
+                                <span x-text="remediationQueue.summary.dispatch_ready || 0"></span><span> ready to notify</span>
+                            </span>
+                            <span class="rounded bg-red-100 px-2 py-1 font-semibold text-red-700">
+                                <span x-text="remediationQueue.summary.dispatch_blocked || 0"></span><span> blocked</span>
+                            </span>
                         </div>
                     </div>
+                    <template x-if="remediationQueue.items.length > 0">
+                        <div class="mt-4 grid gap-3 md:grid-cols-3">
+                            <div class="rounded-lg bg-white p-3">
+                                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Notification readiness</p>
+                                <p class="mt-1 text-sm text-[#120d36]" x-text="remediationReadinessText"></p>
+                            </div>
+                            <div class="rounded-lg bg-white p-3">
+                                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Awaiting operator</p>
+                                <p class="mt-1 text-sm text-[#120d36]">
+                                    <span x-text="remediationQueue.summary.dispatch_awaiting_acknowledgement || 0"></span>
+                                    <span> need preview or acknowledgement</span>
+                                </p>
+                            </div>
+                            <div class="rounded-lg bg-white p-3">
+                                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Webhook routes</p>
+                                <p class="mt-1 text-sm text-[#120d36]">
+                                    <span x-text="remediationQueue.summary.dispatch_webhook_routes || 0"></span>
+                                    <span> matching endpoint routes</span>
+                                </p>
+                            </div>
+                        </div>
+                    </template>
                     <template x-if="remediationQueue.items.length === 0">
                         <p class="mt-4 text-sm text-[#5f5c78]">No remediation items are queued for this domain.</p>
                     </template>
@@ -254,6 +282,20 @@
                                     <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next step</p>
                                     <p class="mt-1 text-sm text-[#120d36]" x-text="item.next_steps[0] || 'Review the evidence.'"></p>
                                 </div>
+                                <template x-if="item.notification && item.notification.dispatch">
+                                    <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3">
+                                        <div class="flex flex-wrap items-center justify-between gap-2">
+                                            <p class="text-xs font-semibold uppercase text-[#5f5c78]">Notification dispatch</p>
+                                            <span class="rounded px-2 py-1 text-xs font-semibold"
+                                                  :class="remediationDispatchClass(item.notification.dispatch)"
+                                                  x-text="remediationDispatchLabel(item.notification.dispatch)"></span>
+                                        </div>
+                                        <p class="mt-2 text-sm text-[#120d36]" x-text="remediationDispatchNextStep(item.notification.dispatch)"></p>
+                                        <template x-if="(item.notification.dispatch.blocked_reasons || []).length">
+                                            <p class="mt-1 text-xs text-[#5f5c78]" x-text="item.notification.dispatch.blocked_reasons[0]"></p>
+                                        </template>
+                                    </div>
+                                </template>
                                 <div class="mt-3 flex flex-wrap items-center gap-2 text-xs">
                                     <span class="rounded bg-[#f4f3f2] px-2 py-1 text-[#5f5c78]" x-text="item.blast_radius"></span>
                                     <span class="rounded bg-[#f4f3f2] px-2 py-1 text-[#5f5c78]">
@@ -1617,7 +1659,13 @@ function domainDetailsApp(domainId) {
                 approval_ready: 0,
                 manual_action: 0,
                 investigate: 0,
-                informational: 0
+                informational: 0,
+                dispatch_ready: 0,
+                dispatch_blocked: 0,
+                dispatch_disabled: 0,
+                dispatch_awaiting_acknowledgement: 0,
+                dispatch_webhook_routes: 0,
+                dispatch_delivery_enqueued: 0
             },
             items: []
         },
@@ -1758,6 +1806,19 @@ function domainDetailsApp(domainId) {
             const query = params.toString();
             const baseUrl = `/api/v1/domains/${encodeURIComponent(this.domainId)}/reports/export`;
             return query ? `${baseUrl}?${query}` : baseUrl;
+        },
+
+        get remediationReadinessText() {
+            const summary = this.remediationQueue.summary || {};
+            const ready = summary.dispatch_ready || 0;
+            const blocked = summary.dispatch_blocked || 0;
+            if (ready > 0) {
+                return `${ready} remediation notification${ready === 1 ? '' : 's'} can be dispatched after review.`;
+            }
+            if (blocked > 0) {
+                return `${blocked} remediation notification${blocked === 1 ? '' : 's'} need settings, acknowledgement, or routing first.`;
+            }
+            return 'No remediation notifications need operator dispatch.';
         },
 
         get healthEvidenceExportUrl() {
@@ -1941,6 +2002,27 @@ function domainDetailsApp(domainId) {
             if (state === 'action_required') return 'bg-red-100 text-red-700';
             if (state === 'investigation_required') return 'bg-blue-100 text-blue-700';
             return 'bg-base-200 text-base-content/70';
+        },
+
+        remediationDispatchClass(dispatch) {
+            if (dispatch?.delivery_enqueued) return 'bg-teal-100 text-teal-700';
+            if (dispatch?.eligible) return 'bg-green-100 text-green-700';
+            if (dispatch?.enabled) return 'bg-yellow-100 text-yellow-800';
+            return 'bg-base-200 text-base-content/70';
+        },
+
+        remediationDispatchLabel(dispatch) {
+            if (dispatch?.delivery_enqueued) return 'delivery queued';
+            if (dispatch?.eligible) return 'ready';
+            if (dispatch?.enabled) return 'blocked';
+            return 'disabled';
+        },
+
+        remediationDispatchNextStep(dispatch) {
+            if (dispatch?.delivery_enqueued) return 'Delivery has been queued for the configured webhook route.';
+            if (dispatch?.eligible) return 'Review the payload preview and explicitly dispatch when the operator is ready.';
+            const nextStep = (dispatch?.next_steps || [])[0];
+            return nextStep || 'Review notification settings before dispatching this remediation item.';
         },
 
         senderStatusClass(status) {
@@ -2144,7 +2226,13 @@ function domainDetailsApp(domainId) {
                     notify_approval_required: 0,
                     notify_action_required: 0,
                     notify_investigation_required: 0,
-                    notify_summary_only: 0
+                    notify_summary_only: 0,
+                    dispatch_ready: 0,
+                    dispatch_blocked: 0,
+                    dispatch_disabled: 0,
+                    dispatch_awaiting_acknowledgement: 0,
+                    dispatch_webhook_routes: 0,
+                    dispatch_delivery_enqueued: 0
                 },
                 items: []
             };

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1664,8 +1664,7 @@ function domainDetailsApp(domainId) {
                 dispatch_blocked: 0,
                 dispatch_disabled: 0,
                 dispatch_awaiting_acknowledgement: 0,
-                dispatch_webhook_routes: 0,
-                dispatch_delivery_enqueued: 0
+                dispatch_webhook_routes: 0
             },
             items: []
         },
@@ -1816,7 +1815,7 @@ function domainDetailsApp(domainId) {
                 return `${ready} remediation notification${ready === 1 ? '' : 's'} can be dispatched after review.`;
             }
             if (blocked > 0) {
-                return `${blocked} remediation notification${blocked === 1 ? '' : 's'} need settings, acknowledgement, or routing first.`;
+                return `${blocked} remediation notification${blocked === 1 ? '' : 's'} ${blocked === 1 ? 'needs' : 'need'} settings, acknowledgement, or routing first.`;
             }
             return 'No remediation notifications need operator dispatch.';
         },
@@ -2004,23 +2003,35 @@ function domainDetailsApp(domainId) {
             return 'bg-base-200 text-base-content/70';
         },
 
-        remediationDispatchClass(dispatch) {
-            if (dispatch?.delivery_enqueued) return 'bg-teal-100 text-teal-700';
-            if (dispatch?.eligible) return 'bg-green-100 text-green-700';
-            if (dispatch?.enabled) return 'bg-yellow-100 text-yellow-800';
-            return 'bg-base-200 text-base-content/70';
-        },
-
-        remediationDispatchLabel(dispatch) {
-            if (dispatch?.delivery_enqueued) return 'delivery queued';
+        remediationDispatchStatus(dispatch) {
+            if (dispatch?.delivery_enqueued) return 'delivery_enqueued';
             if (dispatch?.eligible) return 'ready';
             if (dispatch?.enabled) return 'blocked';
             return 'disabled';
         },
 
+        remediationDispatchClass(dispatch) {
+            return {
+                delivery_enqueued: 'bg-teal-100 text-teal-700',
+                ready: 'bg-green-100 text-green-700',
+                blocked: 'bg-yellow-100 text-yellow-800',
+                disabled: 'bg-base-200 text-base-content/70'
+            }[this.remediationDispatchStatus(dispatch)];
+        },
+
+        remediationDispatchLabel(dispatch) {
+            return {
+                delivery_enqueued: 'delivery queued',
+                ready: 'ready',
+                blocked: 'blocked',
+                disabled: 'disabled'
+            }[this.remediationDispatchStatus(dispatch)];
+        },
+
         remediationDispatchNextStep(dispatch) {
-            if (dispatch?.delivery_enqueued) return 'Delivery has been queued for the configured webhook route.';
-            if (dispatch?.eligible) return 'Review the payload preview and explicitly dispatch when the operator is ready.';
+            const status = this.remediationDispatchStatus(dispatch);
+            if (status === 'delivery_enqueued') return 'Delivery has been queued for the configured webhook route.';
+            if (status === 'ready') return 'Review the payload preview and explicitly dispatch when the operator is ready.';
             const nextStep = (dispatch?.next_steps || [])[0];
             return nextStep || 'Review notification settings before dispatching this remediation item.';
         },
@@ -2231,8 +2242,7 @@ function domainDetailsApp(domainId) {
                     dispatch_blocked: 0,
                     dispatch_disabled: 0,
                     dispatch_awaiting_acknowledgement: 0,
-                    dispatch_webhook_routes: 0,
-                    dispatch_delivery_enqueued: 0
+                    dispatch_webhook_routes: 0
                 },
                 items: []
             };

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -60,6 +60,8 @@ def test_attach_remediation_dispatch_previews_reuses_request_context(monkeypatch
     dispatches = [item["notification"]["dispatch"] for item in result["items"]]
     assert [dispatch["webhook_endpoint_count"] for dispatch in dispatches] == [1, 1]
     assert [dispatch["eligible"] for dispatch in dispatches] == [True, True]
+    assert result["summary"]["dispatch_ready"] == 2
+    assert result["summary"]["dispatch_webhook_routes"] == 1
 
 
 def test_attach_remediation_dispatch_previews_adds_dashboard_summary(monkeypatch):
@@ -118,7 +120,6 @@ def test_attach_remediation_dispatch_previews_adds_dashboard_summary(monkeypatch
     assert summary["dispatch_disabled"] == 0
     assert summary["dispatch_awaiting_acknowledgement"] == 1
     assert summary["dispatch_webhook_routes"] == 1
-    assert summary["dispatch_delivery_enqueued"] == 0
 
 
 def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):
@@ -137,6 +138,13 @@ def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):
     )
 
     assert result is queue
+    assert result["summary"] == {
+        "dispatch_ready": 0,
+        "dispatch_blocked": 0,
+        "dispatch_disabled": 0,
+        "dispatch_awaiting_acknowledgement": 0,
+        "dispatch_webhook_routes": 0,
+    }
 
 
 def test_build_remediation_dispatch_preview_fetches_context_when_not_preloaded(monkeypatch):

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -1,7 +1,10 @@
 from types import SimpleNamespace
 
 from app.services import remediation_dispatch
-from app.services.webhook_events import EVENT_REMEDIATION_APPROVAL_REQUIRED
+from app.services.webhook_events import (
+    EVENT_REMEDIATION_APPROVAL_REQUIRED,
+    EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED,
+)
 
 
 def test_attach_remediation_dispatch_previews_reuses_request_context(monkeypatch):
@@ -57,6 +60,65 @@ def test_attach_remediation_dispatch_previews_reuses_request_context(monkeypatch
     dispatches = [item["notification"]["dispatch"] for item in result["items"]]
     assert [dispatch["webhook_endpoint_count"] for dispatch in dispatches] == [1, 1]
     assert [dispatch["eligible"] for dispatch in dispatches] == [True, True]
+
+
+def test_attach_remediation_dispatch_previews_adds_dashboard_summary(monkeypatch):
+    def fake_settings(_db):
+        return {
+            remediation_dispatch.DISPATCH_ENABLED_KEY: "true",
+            remediation_dispatch.DISPATCH_REQUIRE_ACK_KEY: "true",
+            remediation_dispatch.DISPATCH_CHANNEL_KEY: "webhook",
+            remediation_dispatch.DISPATCH_EVENTS_KEY: EVENT_REMEDIATION_APPROVAL_REQUIRED,
+        }
+
+    def fake_enabled_webhook_endpoints(_db, *, workspace):
+        assert workspace.id == 42
+        return [SimpleNamespace(event_types=EVENT_REMEDIATION_APPROVAL_REQUIRED)]
+
+    def fake_lifecycle(_db, *, workspace, domain, item_id):
+        assert workspace.id == 42
+        assert domain == "example.com"
+        if item_id == "dns:dmarc-missing":
+            return {"state": "acknowledged", "recorded_at": "2026-07-01T08:00:00"}
+        return {"state": None, "recorded_at": None}
+
+    monkeypatch.setattr(remediation_dispatch, "_settings", fake_settings)
+    monkeypatch.setattr(
+        remediation_dispatch,
+        "_enabled_webhook_endpoints",
+        fake_enabled_webhook_endpoints,
+    )
+    monkeypatch.setattr(remediation_dispatch, "_latest_lifecycle_marker", fake_lifecycle)
+
+    queue = {
+        "domain": "example.com",
+        "summary": {"total": 2, "approval_ready": 1, "manual_action": 1},
+        "items": [
+            {
+                "id": "dns:dmarc-missing",
+                "notification": {"event": EVENT_REMEDIATION_APPROVAL_REQUIRED},
+            },
+            {
+                "id": "health:spf-hardening",
+                "notification": {"event": EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED},
+            },
+        ],
+    }
+
+    result = remediation_dispatch.attach_remediation_dispatch_previews(
+        object(),
+        workspace=SimpleNamespace(id=42),
+        queue=queue,
+    )
+
+    summary = result["summary"]
+    assert summary["total"] == 2
+    assert summary["dispatch_ready"] == 1
+    assert summary["dispatch_blocked"] == 1
+    assert summary["dispatch_disabled"] == 0
+    assert summary["dispatch_awaiting_acknowledgement"] == 1
+    assert summary["dispatch_webhook_routes"] == 1
+    assert summary["dispatch_delivery_enqueued"] == 0
 
 
 def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -670,10 +670,9 @@ future webhook, ticketing, or chatops delivery would receive. The endpoint does
 not perform DNS writes, enqueue webhook deliveries, or send notifications.
 The queue `summary` also exposes dispatch readiness counters, including
 `dispatch_ready`, `dispatch_blocked`, `dispatch_disabled`,
-`dispatch_awaiting_acknowledgement`, `dispatch_webhook_routes`, and
-`dispatch_delivery_enqueued`, so dashboards can separate immediately
-actionable notifications from items blocked by settings, routing, or operator
-acknowledgement.
+`dispatch_awaiting_acknowledgement`, and `dispatch_webhook_routes`, so
+dashboards can separate immediately actionable notifications from items blocked
+by settings, routing, or operator acknowledgement.
 
 `POST /domains/{domain_id}/remediation/notifications/audit` records an
 operator lifecycle marker for one current remediation item. The request accepts

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -668,6 +668,12 @@ also includes a sanitized `payload_preview` using schema
 `dmarq.remediation.notification.v1`; it is the deterministic data shape a
 future webhook, ticketing, or chatops delivery would receive. The endpoint does
 not perform DNS writes, enqueue webhook deliveries, or send notifications.
+The queue `summary` also exposes dispatch readiness counters, including
+`dispatch_ready`, `dispatch_blocked`, `dispatch_disabled`,
+`dispatch_awaiting_acknowledgement`, `dispatch_webhook_routes`, and
+`dispatch_delivery_enqueued`, so dashboards can separate immediately
+actionable notifications from items blocked by settings, routing, or operator
+acknowledgement.
 
 `POST /domains/{domain_id}/remediation/notifications/audit` records an
 operator lifecycle marker for one current remediation item. The request accepts

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -97,7 +97,9 @@ whether remediation dispatch is enabled, whether the event is configured, if a
 previewed or acknowledged audit marker is still required, and whether an
 enabled webhook endpoint is subscribed to the event. This is a readiness check
 only; DMARQ does not enqueue webhook deliveries or send notifications from the
-queue view.
+queue view. The queue header summarizes how many items are ready to notify,
+blocked, awaiting acknowledgement, or covered by webhook routes so operators can
+see the next action without opening every item.
 
 After a remediation notification is previewed or acknowledged, an operator can
 explicitly enqueue the notification through the dispatch API with


### PR DESCRIPTION
## What changed

- Adds queue-level remediation dispatch readiness counters for the domain remediation API response.
- Shows ready/blocked/awaiting-acknowledgement/webhook-route status in the domain detail remediation queue.
- Adds per-item dispatch status and next-step guidance without sending notifications or touching DNS.
- Documents the new summary fields and user-facing readiness summary.

## Why

Issue #384 needs the remediation loop to become actionable for operators. The previous queue exposed per-item dispatch previews, but the dashboard did not summarize what can be acted on now versus what is blocked by settings, acknowledgement, or webhook routing.

## Validation

- `.venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_domain_detail_endpoints.py -q`
- `.venv/bin/python -m flake8 backend/app/services/remediation_dispatch.py backend/app/tests/test_remediation_dispatch.py`
- `.venv/bin/python -m compileall -q backend/app`
- `.venv/bin/python -m mkdocs build`
- `git diff --check`

`mkdocs build` still reports the existing non-strict documentation link warnings unrelated to this slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Remediation Queue now shows richer dispatch status summaries, including items ready to notify, blocked, disabled, awaiting acknowledgement, and covered by webhook routes.
  * Individual remediation items can display a new notification dispatch section with status, next-step guidance, and blocked-reason details.

* **Bug Fixes**
  * Queue dashboard counts now update correctly with dispatch readiness data instead of showing only per-item status.

* **Documentation**
  * Updated API and user guide content to describe the new dispatch-related queue counters and dashboard indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->