### PR TITLE
[codex] Add remediation notification history

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -829,6 +829,7 @@ class RemediationNotification(BaseModel):
     reason: str
     next_transition: str
     payload_preview: Dict[str, Any] = Field(default_factory=dict)
+    history: List[Dict[str, Any]] = Field(default_factory=list)
     dispatch: Dict[str, Any] = Field(default_factory=dict)
 
 

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -25,6 +25,10 @@ DEFAULT_DISPATCH_EVENTS = {
     "dmarq.remediation.investigation_required",
 }
 ACKNOWLEDGED_LIFECYCLE_STATES = {"previewed", "acknowledged"}
+HISTORY_ACTIONS = {
+    "remediation.notification_lifecycle_recorded",
+    "remediation.notification_dispatch_enqueued",
+}
 
 
 def _truthy(value: Optional[str], *, default: bool = False) -> bool:
@@ -87,6 +91,94 @@ def _latest_lifecycle_marker(
     return {"state": details.get("lifecycle_state"), "recorded_at": recorded_at}
 
 
+def _audit_details(row: WorkspaceAuditLog) -> Dict[str, Any]:
+    try:
+        details = json.loads(row.details or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return details if isinstance(details, dict) else {}
+
+
+def _history_entry(row: WorkspaceAuditLog) -> Optional[Dict[str, Any]]:
+    details = _audit_details(row)
+    created_at = row.created_at.isoformat() if isinstance(row.created_at, datetime) else None
+    action = str(row.action or "")
+    if action == "remediation.notification_dispatch_enqueued":
+        state = "delivery_enqueued" if details.get("delivery_enqueued") else "dispatch_requested"
+        label = "Dispatch enqueued" if details.get("delivery_enqueued") else "Dispatch requested"
+    else:
+        lifecycle_state = str(details.get("lifecycle_state") or "")
+        if not lifecycle_state:
+            return None
+        state = lifecycle_state
+        label = f"Lifecycle {lifecycle_state.replace('_', ' ')}"
+
+    return {
+        "action": action,
+        "state": state,
+        "label": label,
+        "created_at": created_at,
+        "actor_type": row.actor_type,
+        "actor_id": row.actor_id,
+        "operator_note": details.get("operator_note"),
+        "delivery_enqueued": bool(details.get("delivery_enqueued")),
+        "delivery_count": int(details.get("delivery_count") or 0),
+        "dns_write_attempted": bool(details.get("dns_write_attempted")),
+        "sent": bool(details.get("sent")),
+    }
+
+
+def _notification_histories(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domain: str,
+    item_ids: Iterable[str],
+    limit_per_item: int = 5,
+) -> Dict[str, List[Dict[str, Any]]]:
+    ids = [item_id for item_id in {str(item_id or "") for item_id in item_ids} if item_id]
+    if not ids:
+        return {}
+    rows = (
+        db.query(WorkspaceAuditLog)
+        .filter(
+            WorkspaceAuditLog.workspace_id == workspace.id,
+            WorkspaceAuditLog.entity_type == "remediation_notification",
+            WorkspaceAuditLog.entity_id.in_(ids),
+            WorkspaceAuditLog.entity_name == domain,
+            WorkspaceAuditLog.action.in_(HISTORY_ACTIONS),
+        )
+        .order_by(
+            WorkspaceAuditLog.entity_id.asc(),
+            WorkspaceAuditLog.created_at.desc(),
+            WorkspaceAuditLog.id.desc(),
+        )
+        .all()
+    )
+    histories: Dict[str, List[Dict[str, Any]]] = {item_id: [] for item_id in ids}
+    for row in rows:
+        item_id = str(row.entity_id or "")
+        if len(histories.setdefault(item_id, [])) >= limit_per_item:
+            continue
+        entry = _history_entry(row)
+        if entry is None:
+            continue
+        histories[item_id].append(entry)
+    return histories
+
+
+def _latest_lifecycle_marker_from_history(
+    history: Sequence[Dict[str, Any]],
+) -> Dict[str, Optional[str]]:
+    for entry in history:
+        if entry.get("action") == "remediation.notification_lifecycle_recorded":
+            return {
+                "state": entry.get("state"),
+                "recorded_at": entry.get("created_at"),
+            }
+    return {"state": None, "recorded_at": None}
+
+
 def _enabled_webhook_endpoints(db: Session, *, workspace: Workspace) -> List[WebhookEndpoint]:
     return (
         db.query(WebhookEndpoint)
@@ -138,6 +230,7 @@ def build_remediation_dispatch_preview(
     item: Dict[str, Any],
     settings: Optional[Dict[str, str]] = None,
     webhook_event_counts: Optional[Dict[str, int]] = None,
+    history: Optional[Sequence[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Return a read-only dispatch readiness summary for one remediation item."""
     settings = settings if settings is not None else _settings(db)
@@ -148,7 +241,11 @@ def build_remediation_dispatch_preview(
     notification = item.get("notification") or {}
     event_type = str(notification.get("event") or "")
     item_id = str(item.get("id") or "")
-    lifecycle = _latest_lifecycle_marker(db, workspace=workspace, domain=domain, item_id=item_id)
+    lifecycle = (
+        _latest_lifecycle_marker_from_history(history)
+        if history is not None
+        else _latest_lifecycle_marker(db, workspace=workspace, domain=domain, item_id=item_id)
+    )
     lifecycle_state = lifecycle.get("state")
     if webhook_event_counts is None:
         endpoints = _enabled_webhook_endpoints(db, workspace=workspace)
@@ -223,6 +320,12 @@ def attach_remediation_dispatch_previews(
         for item in items
     }
     endpoints = _enabled_webhook_endpoints(db, workspace=workspace)
+    histories = _notification_histories(
+        db,
+        workspace=workspace,
+        domain=domain,
+        item_ids=[str(item.get("id") or "") for item in items],
+    )
     webhook_event_counts = _webhook_event_counts(
         endpoints,
         configured_events | event_types,
@@ -233,6 +336,8 @@ def attach_remediation_dispatch_previews(
     )
     for item in items:
         notification = item.setdefault("notification", {})
+        item_history = histories.get(str(item.get("id") or ""), [])
+        notification["history"] = item_history
         notification["dispatch"] = build_remediation_dispatch_preview(
             db,
             workspace=workspace,
@@ -240,6 +345,7 @@ def attach_remediation_dispatch_previews(
             item=item,
             settings=settings,
             webhook_event_counts=webhook_event_counts,
+            history=item_history,
         )
     _attach_dispatch_summary(
         queue,

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -99,6 +99,13 @@ def _audit_details(row: WorkspaceAuditLog) -> Dict[str, Any]:
     return details if isinstance(details, dict) else {}
 
 
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _history_entry(row: WorkspaceAuditLog) -> Optional[Dict[str, Any]]:
     details = _audit_details(row)
     created_at = row.created_at.isoformat() if isinstance(row.created_at, datetime) else None
@@ -119,10 +126,9 @@ def _history_entry(row: WorkspaceAuditLog) -> Optional[Dict[str, Any]]:
         "label": label,
         "created_at": created_at,
         "actor_type": row.actor_type,
-        "actor_id": row.actor_id,
         "operator_note": details.get("operator_note"),
         "delivery_enqueued": bool(details.get("delivery_enqueued")),
-        "delivery_count": int(details.get("delivery_count") or 0),
+        "delivery_count": _safe_int(details.get("delivery_count")),
         "dns_write_attempted": bool(details.get("dns_write_attempted")),
         "sent": bool(details.get("sent")),
     }
@@ -139,6 +145,7 @@ def _notification_histories(
     ids = [item_id for item_id in {str(item_id or "") for item_id in item_ids} if item_id]
     if not ids:
         return {}
+    row_cap = max(len(ids) * limit_per_item * 3, limit_per_item)
     rows = (
         db.query(WorkspaceAuditLog)
         .filter(
@@ -153,6 +160,7 @@ def _notification_histories(
             WorkspaceAuditLog.created_at.desc(),
             WorkspaceAuditLog.id.desc(),
         )
+        .limit(row_cap)
         .all()
     )
     histories: Dict[str, List[Dict[str, Any]]] = {item_id: [] for item_id in ids}

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -294,6 +294,38 @@
                                         <template x-if="(item.notification.dispatch.blocked_reasons || []).length">
                                             <p class="mt-1 text-xs text-[#5f5c78]" x-text="item.notification.dispatch.blocked_reasons[0]"></p>
                                         </template>
+                                        <template x-if="(item.notification.history || []).length">
+                                            <div class="mt-3 border-t border-[#e6e3e1] pt-3">
+                                                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Recent operator history</p>
+                                                <div class="mt-2 space-y-2">
+                                                    <template x-for="entry in item.notification.history.slice(0, 3)"
+                                                              :key="item.id + '-' + entry.action + '-' + entry.created_at">
+                                                        <div class="flex items-start gap-2 text-xs">
+                                                            <span class="mt-1 h-2 w-2 shrink-0 rounded-full"
+                                                                  :class="remediationHistoryDotClass(entry)"></span>
+                                                            <div class="min-w-0">
+                                                                <p class="font-semibold text-[#120d36]">
+                                                                    <span x-text="entry.label"></span>
+                                                                    <span x-show="entry.delivery_count"
+                                                                          class="font-normal text-[#5f5c78]">
+                                                                        · <span x-text="entry.delivery_count"></span> delivery
+                                                                    </span>
+                                                                </p>
+                                                                <p class="text-[#5f5c78]">
+                                                                    <span x-text="formatDate(entry.created_at)"></span>
+                                                                    <span x-show="entry.actor_type"> · </span>
+                                                                    <span x-show="entry.actor_type" x-text="entry.actor_type"></span>
+                                                                    <span x-show="entry.dns_write_attempted === false"> · no DNS write</span>
+                                                                </p>
+                                                                <p x-show="entry.operator_note"
+                                                                   class="truncate text-[#5f5c78]"
+                                                                   x-text="entry.operator_note"></p>
+                                                            </div>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                            </div>
+                                        </template>
                                     </div>
                                 </template>
                                 <div class="mt-3 flex flex-wrap items-center gap-2 text-xs">
@@ -2034,6 +2066,14 @@ function domainDetailsApp(domainId) {
             if (status === 'ready') return 'Review the payload preview and explicitly dispatch when the operator is ready.';
             const nextStep = (dispatch?.next_steps || [])[0];
             return nextStep || 'Review notification settings before dispatching this remediation item.';
+        },
+
+        remediationHistoryDotClass(entry) {
+            if (entry?.delivery_enqueued) return 'bg-teal-500';
+            if (['acknowledged', 'resolved'].includes(entry?.state)) return 'bg-green-500';
+            if (entry?.state === 'rejected') return 'bg-red-500';
+            if (entry?.state === 'snoozed') return 'bg-yellow-500';
+            return 'bg-blue-500';
         },
 
         senderStatusClass(status) {

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -947,6 +947,21 @@ def test_domain_remediation_notification_dispatch_enqueues_webhook_delivery(
     assert details["operator_note"] == "Route this to the webhook queue"
     assert db_session.query(WebhookDelivery).count() == 1
 
+    queue_response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+    assert queue_response.status_code == 200
+    history = queue_response.json()["items"][0]["notification"]["history"]
+    assert [entry["action"] for entry in history[:2]] == [
+        "remediation.notification_dispatch_enqueued",
+        "remediation.notification_lifecycle_recorded",
+    ]
+    assert history[0]["state"] == "delivery_enqueued"
+    assert history[0]["delivery_enqueued"] is True
+    assert history[0]["delivery_count"] == 1
+    assert history[0]["dns_write_attempted"] is False
+    assert history[0]["operator_note"] == "Route this to the webhook queue"
+    assert history[1]["state"] == "acknowledged"
+    assert "deliveries" not in history[0]
+
     duplicate_response = seeded_client.post(
         f"/api/v1/domains/{DOMAIN}/remediation/notifications/dispatch",
         json={

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -1,10 +1,14 @@
+import json
+from datetime import datetime
 from types import SimpleNamespace
 
+from app.models.workspace_access import WorkspaceAuditLog
 from app.services import remediation_dispatch
 from app.services.webhook_events import (
     EVENT_REMEDIATION_APPROVAL_REQUIRED,
     EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED,
 )
+from app.services.workspaces import get_or_create_default_workspace
 
 
 def test_attach_remediation_dispatch_previews_reuses_request_context(monkeypatch):
@@ -164,6 +168,86 @@ def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):
         "dispatch_awaiting_acknowledgement": 0,
         "dispatch_webhook_routes": 0,
     }
+
+
+def test_notification_histories_return_sanitized_recent_audit_events(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add_all(
+        [
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="user",
+                actor_id="operator-1",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:dmarc-missing",
+                entity_name="example.com",
+                details=json.dumps(
+                    {
+                        "lifecycle_state": "acknowledged",
+                        "operator_note": "Reviewed with DNS owner",
+                        "delivery_enqueued": False,
+                        "dns_write_attempted": False,
+                    }
+                ),
+                created_at=datetime(2026, 7, 1, 8, 0, 0),
+            ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="user",
+                actor_id="operator-1",
+                action="remediation.notification_dispatch_enqueued",
+                entity_type="remediation_notification",
+                entity_id="dns:dmarc-missing",
+                entity_name="example.com",
+                details=json.dumps(
+                    {
+                        "operator_note": "Route this to security",
+                        "delivery_enqueued": True,
+                        "delivery_count": 1,
+                        "deliveries": [{"secret": "do-not-return"}],
+                        "dns_write_attempted": False,
+                        "sent": False,
+                    }
+                ),
+                created_at=datetime(2026, 7, 1, 9, 0, 0),
+            ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="system",
+                actor_id="legacy",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:dmarc-missing",
+                entity_name="example.com",
+                details="{broken-json",
+                created_at=datetime(2026, 7, 1, 10, 0, 0),
+            ),
+        ]
+    )
+    db_session.commit()
+
+    histories = remediation_dispatch._notification_histories(
+        db_session,
+        workspace=workspace,
+        domain="example.com",
+        item_ids=["dns:dmarc-missing"],
+    )
+
+    history = histories["dns:dmarc-missing"]
+    assert [entry["action"] for entry in history] == [
+        "remediation.notification_dispatch_enqueued",
+        "remediation.notification_lifecycle_recorded",
+    ]
+    assert history[0]["label"] == "Dispatch enqueued"
+    assert history[0]["state"] == "delivery_enqueued"
+    assert history[0]["delivery_count"] == 1
+    assert history[0]["operator_note"] == "Route this to security"
+    assert history[0]["sent"] is False
+    assert history[0]["dns_write_attempted"] is False
+    assert "deliveries" not in history[0]
+    assert history[1]["state"] == "acknowledged"
+    assert history[1]["operator_note"] == "Reviewed with DNS owner"
 
 
 def test_build_remediation_dispatch_preview_fetches_context_when_not_preloaded(monkeypatch):

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -204,7 +204,7 @@ def test_notification_histories_return_sanitized_recent_audit_events(db_session)
                     {
                         "operator_note": "Route this to security",
                         "delivery_enqueued": True,
-                        "delivery_count": 1,
+                        "delivery_count": "not-a-number",
                         "deliveries": [{"secret": "do-not-return"}],
                         "dns_write_attempted": False,
                         "sent": False,
@@ -241,11 +241,12 @@ def test_notification_histories_return_sanitized_recent_audit_events(db_session)
     ]
     assert history[0]["label"] == "Dispatch enqueued"
     assert history[0]["state"] == "delivery_enqueued"
-    assert history[0]["delivery_count"] == 1
+    assert history[0]["delivery_count"] == 0
     assert history[0]["operator_note"] == "Route this to security"
     assert history[0]["sent"] is False
     assert history[0]["dns_write_attempted"] is False
     assert "deliveries" not in history[0]
+    assert "actor_id" not in history[0]
     assert history[1]["state"] == "acknowledged"
     assert history[1]["operator_note"] == "Reviewed with DNS owner"
 

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -35,6 +35,11 @@ def test_attach_remediation_dispatch_previews_reuses_request_context(monkeypatch
         "_latest_lifecycle_marker",
         lambda *_args, **_kwargs: {"state": None, "recorded_at": None},
     )
+    monkeypatch.setattr(
+        remediation_dispatch,
+        "_notification_histories",
+        lambda *_args, **_kwargs: {},
+    )
 
     queue = {
         "domain": "example.com",
@@ -91,6 +96,20 @@ def test_attach_remediation_dispatch_previews_adds_dashboard_summary(monkeypatch
         fake_enabled_webhook_endpoints,
     )
     monkeypatch.setattr(remediation_dispatch, "_latest_lifecycle_marker", fake_lifecycle)
+    monkeypatch.setattr(
+        remediation_dispatch,
+        "_notification_histories",
+        lambda *_args, **_kwargs: {
+            "dns:dmarc-missing": [
+                {
+                    "action": "remediation.notification_lifecycle_recorded",
+                    "state": "acknowledged",
+                    "created_at": "2026-07-01T08:00:00",
+                }
+            ],
+            "health:spf-hardening": [],
+        },
+    )
 
     queue = {
         "domain": "example.com",

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -674,6 +674,14 @@ The queue `summary` also exposes dispatch readiness counters, including
 dashboards can separate immediately actionable notifications from items blocked
 by settings, routing, or operator acknowledgement.
 
+Each notification also includes a compact `history` array derived from
+workspace audit events for the current queue item. The history lists recent
+lifecycle markers and explicit dispatch enqueue events with timestamp, actor
+type, operator note, delivery count, and safety flags such as `sent`,
+`delivery_enqueued`, and `dns_write_attempted`. It omits webhook secrets and
+full delivery payloads; use the webhook delivery APIs for transport-level
+troubleshooting.
+
 `POST /domains/{domain_id}/remediation/notifications/audit` records an
 operator lifecycle marker for one current remediation item. The request accepts
 `item_id`, `lifecycle_state`, and optional `event`, `dedupe_key`, and `note`.

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -167,6 +167,14 @@ Dispatch remains opt-in through notification settings:
 separate dispatch request with `confirm=true` is still required to create
 delivery rows.
 
+The domain detail page shows recent operator history on each remediation
+notification, including preview/acknowledgement markers, snoozes or rejections,
+and confirmed dispatch enqueue events. This keeps the recommended next action
+next to the evidence: an operator can see whether a recommendation is still
+waiting for review, already acknowledged, or already queued for the configured
+webhook route. The timeline is read-only and highlights that remediation
+notification handling does not perform DNS writes.
+
 If an operator selects a different provider than the nameserver-detected
 provider, DMARQ blocks the preview/apply request by default. The mismatch can be
 overridden only with an explicit confirmation that the selected provider


### PR DESCRIPTION
## Summary

Adds a compact remediation notification history to the domain remediation queue so operators can see the recent human-in-the-loop lifecycle directly next to each queued recommendation.

## What changed

- Hydrates recent workspace audit events for each remediation queue item.
- Adds `notification.history` entries for lifecycle markers and explicit dispatch enqueue events.
- Keeps the history intentionally compact and sanitized: timestamp, actor type, operator note, delivery count, and safety flags, without webhook secrets or full delivery payloads.
- Shows the recent operator history on the domain detail remediation cards.
- Documents the queue history in API and domain user docs.

## Safety boundary

This is read-only queue/UI context. It does not send notifications, enqueue deliveries from queue views, call LLMs, or perform DNS/provider writes.

## Validation

- `.venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_domain_detail_endpoints.py -q`
- `.venv/bin/python -m flake8 backend/app/services/remediation_dispatch.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_remediation_dispatch.py`
- `.venv/bin/python -m compileall -q backend/app`
- `.venv/bin/python -m mkdocs build` (passes with existing non-strict doc link warnings)
- `git diff --check`

Part of #384.
