### PR TITLE
Add passive DANE TLSA posture checks

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -30,6 +30,7 @@ from app.services.cloudflare_dns import (
     list_dns_record_changes,
     sync_dns_record_changes,
 )
+from app.services.dane import check_dane_cached
 from app.services.demo_data import DEMO_DAYS, build_demo_health_score_history
 from app.services.dns_cache import resolve_domain_dns_cached
 from app.services.dns_guidance import build_dns_guidance
@@ -988,6 +989,34 @@ class BIMIResponse(BaseModel):
     checked_at: Optional[str] = None
 
 
+class TLSARecordResponse(BaseModel):
+    """One observed TLSA record for an MX host."""
+
+    query_name: str
+    mx_host: str
+    record: str
+    certificate_usage: Optional[int] = None
+    selector: Optional[int] = None
+    matching_type: Optional[int] = None
+    association_data: Optional[str] = None
+    valid: bool = False
+    errors: List[str] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+
+
+class DANEResponse(BaseModel):
+    """DANE/TLSA posture result for a domain."""
+
+    status: str
+    port: int = 25
+    mx_hosts: List[str] = Field(default_factory=list)
+    records: List[TLSARecordResponse] = Field(default_factory=list)
+    errors: List[str] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+    cached: bool = False
+    checked_at: Optional[str] = None
+
+
 class CloudflareZoneResponse(BaseModel):
     """Cloudflare zone available for import."""
 
@@ -1819,6 +1848,12 @@ async def _build_domain_dns_guidance(
         domain_id,
         refresh=refresh,
     )
+    dane_result, _, _ = await check_dane_cached(
+        db,
+        provider,
+        domain_id,
+        refresh=refresh,
+    )
     mail_service_records = await mail_service_dns_records_for_domain(db, domain_id)
     guidance = await build_dns_guidance(
         domain_id,
@@ -1826,6 +1861,7 @@ async def _build_domain_dns_guidance(
         dns_result,
         mta_sts_result,
         bimi_result,
+        dane_result,
         monitored_selectors=combined_selectors,
         observed_selectors=report_selectors,
         mail_service_records=mail_service_records,
@@ -4094,6 +4130,42 @@ async def get_domain_bimi(
         logo_url=result.logo_url,
         certificate_url=result.certificate_url,
         evidence_url=result.evidence_url,
+        errors=result.errors,
+        warnings=result.warnings,
+        cached=cached,
+        checked_at=checked_at.isoformat(),
+    )
+
+
+@router.get("/{domain_id}/dns/dane", response_model=DANEResponse)
+async def get_domain_dane(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    port: int = Query(25, ge=1, le=65535, title="SMTP service port for TLSA lookup"),
+    refresh: bool = Query(False, title="Refresh cached DANE result"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return cached DANE/TLSA posture for a domain's MX hosts."""
+    workspace = _authorized_domain_read_workspace(_auth, db)
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store)
+    if not _domain_exists(db, store, domain_id, workspace):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Domain not found",
+        )
+    result, cached, checked_at = await check_dane_cached(
+        db,
+        get_default_provider(db),
+        domain_id,
+        port=port,
+        refresh=refresh,
+    )
+    return DANEResponse(
+        status=result.status,
+        port=result.port,
+        mx_hosts=result.mx_hosts,
+        records=[TLSARecordResponse(**asdict(record)) for record in result.records],
         errors=result.errors,
         warnings=result.warnings,
         cached=cached,

--- a/backend/app/services/ai_assistance.py
+++ b/backend/app/services/ai_assistance.py
@@ -18,6 +18,7 @@ from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.setting import Setting
 from app.services.bimi import check_bimi_cached
+from app.services.dane import check_dane_cached
 from app.services.dns_cache import resolve_domain_dns_cached
 from app.services.dns_guidance import build_dns_guidance
 from app.services.dns_resolver import get_default_provider
@@ -368,12 +369,14 @@ async def build_remediation_plan(  # pylint: disable=too-many-locals
     )
     mta_sts_result, _, _ = await check_mta_sts_cached(db, provider, domain, refresh=refresh)
     bimi_result, _, _ = await check_bimi_cached(db, provider, domain, refresh=refresh)
+    dane_result, _, _ = await check_dane_cached(db, provider, domain, refresh=refresh)
     guidance = await build_dns_guidance(
         domain,
         provider,
         dns_result,
         mta_sts_result,
         bimi_result,
+        dane_result,
         monitored_selectors=combined_selectors,
         observed_selectors=report_selectors,
     )

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -1,0 +1,249 @@
+"""Read-only DANE/TLSA posture checks for monitored mail domains."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional, Tuple
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.dns_cache import DNSCache
+from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS
+from app.services.dns_resolver import BaseDNSProvider
+
+_CACHE_KEY = "dane-v1"
+_HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
+_VALID_CERTIFICATE_USAGES = {0, 1, 2, 3}
+_VALID_SELECTORS = {0, 1}
+_VALID_MATCHING_TYPES = {0, 1, 2}
+
+
+@dataclass
+class TLSARecord:
+    """One TLSA record observed for an MX host."""
+
+    query_name: str
+    mx_host: str
+    record: str
+    certificate_usage: Optional[int] = None
+    selector: Optional[int] = None
+    matching_type: Optional[int] = None
+    association_data: Optional[str] = None
+    valid: bool = False
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+
+@dataclass
+class DANEResult:
+    """Operator-facing DANE/TLSA posture evidence."""
+
+    status: str = "fail"
+    port: int = 25
+    mx_hosts: List[str] = field(default_factory=list)
+    records: List[TLSARecord] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _is_fresh(row: DNSCache, ttl_seconds: int, now: datetime) -> bool:
+    return row.checked_at >= now - timedelta(seconds=ttl_seconds)
+
+
+def _record_from_json(value: dict) -> TLSARecord:
+    return TLSARecord(
+        query_name=str(value.get("query_name") or ""),
+        mx_host=str(value.get("mx_host") or ""),
+        record=str(value.get("record") or ""),
+        certificate_usage=value.get("certificate_usage"),
+        selector=value.get("selector"),
+        matching_type=value.get("matching_type"),
+        association_data=value.get("association_data"),
+        valid=bool(value.get("valid")),
+        errors=list(value.get("errors") or []),
+        warnings=list(value.get("warnings") or []),
+    )
+
+
+def _result_from_json(value: str) -> DANEResult:
+    data = json.loads(value)
+    return DANEResult(
+        status=str(data.get("status") or "fail"),
+        port=int(data.get("port") or 25),
+        mx_hosts=list(data.get("mx_hosts") or []),
+        records=[_record_from_json(row) for row in data.get("records") or []],
+        errors=list(data.get("errors") or []),
+        warnings=list(data.get("warnings") or []),
+    )
+
+
+def _safe_int(value: str) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_tlsa_record(record: str, *, query_name: str, mx_host: str) -> TLSARecord:
+    """Parse a TLSA record and return normalized lint evidence."""
+    result = TLSARecord(query_name=query_name, mx_host=mx_host, record=record)
+    parts = record.split()
+    if len(parts) < 4:
+        result.errors.append(
+            "TLSA records must contain certificate usage, selector, matching type, and data."
+        )
+        return result
+
+    usage = _safe_int(parts[0])
+    selector = _safe_int(parts[1])
+    matching_type = _safe_int(parts[2])
+    association_data = "".join(parts[3:]).strip()
+    result.certificate_usage = usage
+    result.selector = selector
+    result.matching_type = matching_type
+    result.association_data = association_data
+
+    if usage not in _VALID_CERTIFICATE_USAGES:
+        result.errors.append("TLSA certificate usage must be 0, 1, 2, or 3.")
+    if selector not in _VALID_SELECTORS:
+        result.errors.append("TLSA selector must be 0 for full certificate or 1 for SPKI.")
+    if matching_type not in _VALID_MATCHING_TYPES:
+        result.errors.append("TLSA matching type must be 0, 1, or 2.")
+    if not association_data:
+        result.errors.append("TLSA association data is empty.")
+    elif not _HEX_RE.match(association_data):
+        result.errors.append("TLSA association data must be hexadecimal.")
+    elif len(association_data) % 2:
+        result.errors.append("TLSA association data must contain complete bytes.")
+
+    if usage in {0, 1}:
+        result.warnings.append(
+            "PKIX TLSA usages still depend on public CA validation; usage 3 is common for DANE-EE."
+        )
+    if matching_type == 0:
+        result.warnings.append(
+            "Full-certificate TLSA values are bulky and rotate whenever the certificate changes."
+        )
+
+    result.valid = not result.errors
+    return result
+
+
+async def check_dane(domain: str, provider: BaseDNSProvider, *, port: int = 25) -> DANEResult:
+    """Resolve MX hosts and lint their SMTP DANE TLSA records."""
+    normalized_domain = domain.strip().strip(".").lower()
+    result = DANEResult(port=port)
+    raw_mx_hosts = await provider.lookup_mx(normalized_domain)
+    mx_hosts = raw_mx_hosts if isinstance(raw_mx_hosts, (list, tuple)) else []
+    result.mx_hosts = list(dict.fromkeys(str(host).strip(".").lower() for host in mx_hosts if host))
+    if not result.mx_hosts:
+        result.errors.append("No MX hosts were found for DANE/TLSA evaluation.")
+        return result
+
+    missing_hosts: List[str] = []
+    invalid_hosts: List[str] = []
+    for mx_host in result.mx_hosts:
+        query_name = f"_{port}._tcp.{mx_host}"
+        raw_records = await provider.lookup_tlsa(query_name)
+        records = raw_records if isinstance(raw_records, (list, tuple)) else []
+        if not records:
+            missing_hosts.append(mx_host)
+            continue
+        parsed_records = [
+            parse_tlsa_record(record, query_name=query_name, mx_host=mx_host) for record in records
+        ]
+        result.records.extend(parsed_records)
+        if not any(record.valid for record in parsed_records):
+            invalid_hosts.append(mx_host)
+
+    if missing_hosts:
+        result.errors.append(
+            "No TLSA records were found for MX host(s): " + ", ".join(missing_hosts)
+        )
+    if invalid_hosts:
+        result.errors.append(
+            "TLSA records need syntax review for MX host(s): " + ", ".join(invalid_hosts)
+        )
+    if result.records:
+        result.warnings.append(
+            "DMARQ validates TLSA syntax and MX coverage, but does not yet validate DNSSEC chains "
+            "or compare TLSA hashes with live SMTP certificates."
+        )
+
+    if not result.errors:
+        result.status = "pass"
+    elif result.records:
+        result.status = "partial"
+    return result
+
+
+async def check_dane_cached(
+    db: Session,
+    provider: BaseDNSProvider,
+    domain: str,
+    *,
+    port: int = 25,
+    ttl_seconds: int = DEFAULT_DNS_CACHE_TTL_SECONDS,
+    refresh: bool = False,
+) -> Tuple[DANEResult, bool, datetime]:
+    """Resolve DANE posture, reusing the shared DNS cache semantics."""
+    now = _utcnow_naive()
+    normalized_domain = domain.strip().strip(".").lower()
+    provider_name = f"{provider.__class__.__name__}:dane"
+    cache_key = f"{_CACHE_KEY}:{port}"
+    row = (
+        db.query(DNSCache)
+        .filter(
+            DNSCache.domain == normalized_domain,
+            DNSCache.provider == provider_name,
+            DNSCache.selectors_key == cache_key,
+        )
+        .first()
+    )
+    if row and not refresh and _is_fresh(row, ttl_seconds, now):
+        return _result_from_json(row.result_json), True, row.checked_at
+
+    result = await check_dane(normalized_domain, provider, port=port)
+    payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
+    if row is None:
+        row = DNSCache(
+            domain=normalized_domain,
+            provider=provider_name,
+            selectors_key=cache_key,
+            result_json=payload,
+            checked_at=now,
+        )
+        db.add(row)
+    else:
+        row.result_json = payload
+        row.checked_at = now
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        row = (
+            db.query(DNSCache)
+            .filter(
+                DNSCache.domain == normalized_domain,
+                DNSCache.provider == provider_name,
+                DNSCache.selectors_key == cache_key,
+            )
+            .first()
+        )
+        if row is None:
+            raise
+        row.result_json = payload
+        row.checked_at = now
+        db.commit()
+
+    db.refresh(row)
+    return result, False, row.checked_at

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -143,7 +143,8 @@ async def check_dane(domain: str, provider: BaseDNSProvider, *, port: int = 25) 
     result = DANEResult(port=port)
     raw_mx_hosts = await provider.lookup_mx(normalized_domain)
     mx_hosts = raw_mx_hosts if isinstance(raw_mx_hosts, (list, tuple)) else []
-    result.mx_hosts = list(dict.fromkeys(str(host).strip(".").lower() for host in mx_hosts if host))
+    normalized_hosts = (str(host).strip(".").lower() for host in mx_hosts)
+    result.mx_hosts = list(dict.fromkeys(host for host in normalized_hosts if host))
     if not result.mx_hosts:
         result.errors.append("No MX hosts were found for DANE/TLSA evaluation.")
         return result
@@ -178,9 +179,10 @@ async def check_dane(domain: str, provider: BaseDNSProvider, *, port: int = 25) 
             "or compare TLSA hashes with live SMTP certificates."
         )
 
+    valid_hosts = {record.mx_host for record in result.records if record.valid}
     if not result.errors:
         result.status = "pass"
-    elif result.records:
+    elif valid_hosts:
         result.status = "partial"
     return result
 

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -152,8 +152,9 @@ def _dane_target_record(domain: str, result: DANEResult) -> DNSGuidanceRecord:
         name=f"_{result.port}._tcp.{mx_host}",
         value="3 1 1 <sha256-of-current-mx-certificate-spki>",
         purpose=(
-            "DANE SMTP TLSA certificate pinning for the MX host. Publish only after "
-            "DNSSEC is correctly signed and the TLSA value matches the live MX certificate."
+            "DANE SMTP TLSA certificate pinning for one MX host. Publish one matching TLSA "
+            "record for every MX host, and only after DNSSEC is correctly signed and the TLSA "
+            "value matches the live MX certificate."
         ),
         priority="optional",
     )

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from app.services.bimi import BIMIResult
+from app.services.dane import DANEResult
 from app.services.dns_provider_detection import DNSProviderDetection
 from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult, extract_dmarc_policy
 from app.services.mta_sts import MTAStsResult
@@ -143,6 +144,21 @@ def _target_by_code(records: List[DNSGuidanceRecord], code: str) -> DNSGuidanceR
     return next(record for record in records if record.code == code)
 
 
+def _dane_target_record(domain: str, result: DANEResult) -> DNSGuidanceRecord:
+    mx_host = result.mx_hosts[0] if result.mx_hosts else f"<mx-host>.{domain}"
+    return DNSGuidanceRecord(
+        code="target_dane",
+        record_type="TLSA",
+        name=f"_{result.port}._tcp.{mx_host}",
+        value="3 1 1 <sha256-of-current-mx-certificate-spki>",
+        purpose=(
+            "DANE SMTP TLSA certificate pinning for the MX host. Publish only after "
+            "DNSSEC is correctly signed and the TLSA value matches the live MX certificate."
+        ),
+        priority="optional",
+    )
+
+
 def _finding(
     code: str,
     severity: str,
@@ -257,6 +273,16 @@ def _default_remediation_steps(code: str) -> List[str]:
             "Complete DMARC enforcement first.",
             "Publish a default._bimi TXT record with an HTTPS SVG logo URL.",
             "Add a certificate URL if the mailbox providers you care about require it.",
+        ],
+        "dane_missing": [
+            "Confirm that the domain's DNS zone is signed and validating with DNSSEC.",
+            "For each MX host, derive the intended TLSA value from the live SMTP certificate.",
+            "Publish TLSA records under _25._tcp.<mx-host> and refresh DMARQ DNS lint.",
+        ],
+        "dane_review": [
+            "Review every TLSA record shown in evidence for the affected MX hosts.",
+            "Compare the TLSA selector and hash with the current SMTP TLS certificate.",
+            "Rotate TLSA values in the same change window as certificate changes.",
         ],
         "mail_service_record_missing": [
             "Open the sender-domain authentication page in the mail service.",
@@ -940,6 +966,41 @@ def _bimi_findings(
     return findings
 
 
+def _dane_findings(result: DANEResult, targets: List[DNSGuidanceRecord]) -> List[DNSLintFinding]:
+    target = _target_by_code(targets, "target_dane")
+    if result.status == "pass" and not result.warnings:
+        return []
+    detail = "; ".join(result.warnings or result.errors or ["No DANE/TLSA records were found."])
+    evidence = [record.record for record in result.records] or result.mx_hosts
+    if result.status == "fail":
+        return [
+            _finding(
+                "dane_missing",
+                "info",
+                "DANE TLSA records are not ready",
+                detail,
+                "Treat DANE as optional unless you operate DNSSEC-signed MX infrastructure.",
+                "TLSA",
+                target.name,
+                target_record=target,
+                evidence=evidence,
+            )
+        ]
+    return [
+        _finding(
+            "dane_review",
+            "warning",
+            "DANE TLSA setup needs review",
+            detail,
+            "Review TLSA syntax, MX coverage, DNSSEC validation, and certificate rotation handling.",
+            "TLSA",
+            target.name,
+            target_record=target,
+            evidence=evidence,
+        )
+    ]
+
+
 def _normalize_dns_value(value: str) -> str:
     return " ".join(str(value or "").strip().strip(".").split()).lower()
 
@@ -1111,6 +1172,14 @@ def _risk_for_finding(finding: DNSLintFinding) -> str:
         ),
         "tls_rpt_missing": "Low risk: TLS-RPT only controls report delivery.",
         "bimi_missing": "Low mail-flow risk; BIMI is a brand/readiness feature.",
+        "dane_missing": (
+            "Medium operational risk if enabled incorrectly; DANE depends on DNSSEC and exact "
+            "TLSA/certificate lifecycle management."
+        ),
+        "dane_review": (
+            "Medium operational risk: stale or malformed TLSA records can cause strict receivers "
+            "to reject SMTP TLS delivery."
+        ),
         "mail_service_record_missing": (
             "Low DNS risk when copied exactly; mail-service verification remains pending until "
             "DNS propagates."
@@ -1200,6 +1269,7 @@ async def build_dns_guidance(
     result: DomainDNSResult,
     mta_sts: MTAStsResult,
     bimi: BIMIResult,
+    dane: Optional[DANEResult] = None,
     *,
     monitored_selectors: Optional[List[str]] = None,
     observed_selectors: Optional[List[str]] = None,
@@ -1207,7 +1277,9 @@ async def build_dns_guidance(
 ) -> DNSGuidanceResult:
     """Build typed DNS lint findings and target records for a domain."""
     normalized_domain = domain.strip().strip(".").lower()
+    dane_result = dane or DANEResult(errors=["No DANE/TLSA context was evaluated."])
     targets = _target_records(normalized_domain, result)
+    targets.append(_dane_target_record(normalized_domain, dane_result))
     findings: List[DNSLintFinding] = []
     findings.extend(_dmarc_findings(normalized_domain, result, targets))
     findings.extend(await _spf_findings(normalized_domain, provider, result, targets))
@@ -1224,6 +1296,7 @@ async def build_dns_guidance(
     findings.extend(_mta_sts_findings(mta_sts, targets))
     findings.extend(await _tls_rpt_findings(normalized_domain, provider, targets))
     findings.extend(_bimi_findings(bimi, extract_dmarc_policy(result.dmarc_record), targets))
+    findings.extend(_dane_findings(dane_result, targets))
     findings.extend(await _mail_service_dns_findings(provider, mail_service_records or []))
     return DNSGuidanceResult(
         domain=normalized_domain,

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -966,11 +966,22 @@ def _bimi_findings(
     return findings
 
 
+def _actionable_dane_warnings(result: DANEResult) -> List[str]:
+    return [
+        warning
+        for warning in result.warnings
+        if not warning.startswith(
+            "DMARQ validates TLSA syntax and MX coverage, but does not yet validate DNSSEC chains"
+        )
+    ]
+
+
 def _dane_findings(result: DANEResult, targets: List[DNSGuidanceRecord]) -> List[DNSLintFinding]:
     target = _target_by_code(targets, "target_dane")
-    if result.status == "pass" and not result.warnings:
+    warnings = _actionable_dane_warnings(result)
+    if result.status == "pass" and not warnings:
         return []
-    detail = "; ".join(result.warnings or result.errors or ["No DANE/TLSA records were found."])
+    detail = "; ".join(warnings or result.errors or ["No DANE/TLSA records were found."])
     evidence = [record.record for record in result.records] or result.mx_hosts
     if result.status == "fail":
         return [

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -940,7 +940,7 @@ class CloudflareDNSProvider(BaseDNSProvider):
                     try:
                         preference = int(parts[0])
                     except ValueError:
-                        preference = 0
+                        continue
                     rows.append((preference, parts[1].rstrip(".").lower()))
                 return [host for _preference, host in sorted(rows)]
         except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException):

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -395,8 +395,16 @@ class BaseDNSProvider(ABC):
         """
         return None
 
+    async def lookup_mx(self, domain: str) -> List[str]:
+        """Return MX hostnames for *domain* when available."""
+        return []
+
     async def lookup_ns(self, domain: str) -> List[str]:
         """Return authoritative nameservers for *domain* when available."""
+        return []
+
+    async def lookup_tlsa(self, name: str) -> List[str]:
+        """Return TLSA record strings for *name* when available."""
         return []
 
     async def check_dkim(
@@ -565,6 +573,39 @@ class SystemDNSProvider(BaseDNSProvider):
                 return sorted(str(rdata.target).rstrip(".").lower() for rdata in answers)
         except dns.exception.DNSException as exc:
             logger.debug("NS lookup failed for %s: %s", _sanitize_for_log(domain), exc)
+        return []
+
+    async def lookup_mx(self, domain: str) -> List[str]:
+        """Resolve MX hostnames for *domain* via the system resolver."""
+        import dns.asyncresolver  # type: ignore[import]
+        import dns.exception  # type: ignore[import]
+
+        try:
+            answers = await dns.asyncresolver.resolve(
+                domain, "MX", lifetime=DNS_TIMEOUT, raise_on_no_answer=False
+            )
+            if answers:
+                return [
+                    str(rdata.exchange).rstrip(".").lower()
+                    for rdata in sorted(answers, key=lambda item: int(item.preference))
+                ]
+        except dns.exception.DNSException as exc:
+            logger.debug("MX lookup failed for %s: %s", _sanitize_for_log(domain), exc)
+        return []
+
+    async def lookup_tlsa(self, name: str) -> List[str]:
+        """Resolve TLSA records for *name* via the system resolver."""
+        import dns.asyncresolver  # type: ignore[import]
+        import dns.exception  # type: ignore[import]
+
+        try:
+            answers = await dns.asyncresolver.resolve(
+                name, "TLSA", lifetime=DNS_TIMEOUT, raise_on_no_answer=False
+            )
+            if answers:
+                return [str(rdata).strip() for rdata in answers]
+        except dns.exception.DNSException as exc:
+            logger.debug("TLSA lookup failed for %s: %s", _sanitize_for_log(name), exc)
         return []
 
 
@@ -873,6 +914,64 @@ class CloudflareDNSProvider(BaseDNSProvider):
             pass
         return []
 
+    async def lookup_mx(self, domain: str) -> List[str]:
+        """Resolve MX hostnames via Cloudflare's DoH endpoint."""
+        import httpx  # type: ignore[import]
+
+        params = {"name": domain, "type": "MX"}
+        headers = {"Accept": "application/dns-json"}
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    self.CLOUDFLARE_DOH_URL,
+                    params=params,
+                    headers=headers,
+                    timeout=DNS_TIMEOUT,
+                )
+                response.raise_for_status()
+                data = response.json()
+                rows = []
+                for answer in data.get("Answer", []):
+                    if answer.get("type") != 15 or not answer.get("data"):
+                        continue
+                    parts = str(answer["data"]).split()
+                    if len(parts) < 2:
+                        continue
+                    try:
+                        preference = int(parts[0])
+                    except ValueError:
+                        preference = 0
+                    rows.append((preference, parts[1].rstrip(".").lower()))
+                return [host for _preference, host in sorted(rows)]
+        except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException):
+            pass
+        return []
+
+    async def lookup_tlsa(self, name: str) -> List[str]:
+        """Resolve TLSA records via Cloudflare's DoH endpoint."""
+        import httpx  # type: ignore[import]
+
+        params = {"name": name, "type": "TLSA"}
+        headers = {"Accept": "application/dns-json"}
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    self.CLOUDFLARE_DOH_URL,
+                    params=params,
+                    headers=headers,
+                    timeout=DNS_TIMEOUT,
+                )
+                response.raise_for_status()
+                data = response.json()
+                return [
+                    str(answer.get("data", "")).strip()
+                    for answer in data.get("Answer", [])
+                    if answer.get("type") == 52 and answer.get("data")
+                ]
+        except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException):
+            pass
+        return []
+
 
 class DemoDNSProvider(BaseDNSProvider):
     """Deterministic DNS provider for the opt-in public demo mode."""
@@ -950,6 +1049,14 @@ class DemoDNSProvider(BaseDNSProvider):
         normalized = _normalize_dns_name(name)
         return self._cname_records.get(normalized)
 
+    async def lookup_mx(self, domain: str) -> List[str]:
+        normalized = _normalize_dns_name(domain)
+        if normalized == "dmarq.org":
+            return ["mx1.dmarq.org", "mx2.dmarq.org"]
+        if normalized == "dmarq.com":
+            return ["mail.dmarq.com"]
+        return []
+
     async def lookup_ns(self, domain: str) -> List[str]:
         normalized = _normalize_dns_name(domain)
         if normalized == "dmarq.org":
@@ -957,6 +1064,18 @@ class DemoDNSProvider(BaseDNSProvider):
         if normalized == "dmarq.com":
             return ["ns1.digitalocean.com", "ns2.digitalocean.com"]
         return []
+
+    async def lookup_tlsa(self, name: str) -> List[str]:
+        records = {
+            "_25._tcp.mx1.dmarq.org": [
+                "3 1 1 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            ],
+            "_25._tcp.mx2.dmarq.org": [
+                "3 1 1 abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+            ],
+            "_25._tcp.mail.dmarq.com": ["3 1 1 not-hex-demo-value"],
+        }
+        return list(records.get(_normalize_dns_name(name), []))
 
 
 def _decrypt_setting_value(value: Optional[str]) -> Optional[str]:

--- a/backend/app/tests/test_dane.py
+++ b/backend/app/tests/test_dane.py
@@ -60,7 +60,7 @@ async def test_check_dane_requires_mx_hosts():
 
 
 @pytest.mark.asyncio
-async def test_check_dane_reports_partial_mx_coverage_and_invalid_records():
+async def test_check_dane_reports_fail_when_all_records_are_invalid_or_missing():
     provider = FakeDANEDNSProvider(
         mx_hosts=["mx1.example.com", "mx2.example.com"],
         tlsa_records={
@@ -70,11 +70,42 @@ async def test_check_dane_reports_partial_mx_coverage_and_invalid_records():
 
     result = await check_dane("example.com", provider)
 
-    assert result.status == "partial"
+    assert result.status == "fail"
     assert result.mx_hosts == ["mx1.example.com", "mx2.example.com"]
     assert result.records[0].valid is False
     assert "No TLSA records were found for MX host(s): mx2.example.com" in result.errors
     assert "TLSA records need syntax review for MX host(s): mx1.example.com" in result.errors
+
+
+@pytest.mark.asyncio
+async def test_check_dane_reports_partial_mx_coverage_with_one_valid_host():
+    provider = FakeDANEDNSProvider(
+        mx_hosts=["mx1.example.com", "mx2.example.com"],
+        tlsa_records={
+            "_25._tcp.mx1.example.com": [
+                "3 1 1 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            ],
+        },
+    )
+
+    result = await check_dane("example.com", provider)
+
+    assert result.status == "partial"
+    assert result.mx_hosts == ["mx1.example.com", "mx2.example.com"]
+    assert result.records[0].valid is True
+    assert "No TLSA records were found for MX host(s): mx2.example.com" in result.errors
+
+
+@pytest.mark.asyncio
+async def test_check_dane_filters_null_mx_marker():
+    provider = FakeDANEDNSProvider(mx_hosts=["."])
+
+    result = await check_dane("example.com", provider)
+
+    assert result.status == "fail"
+    assert result.mx_hosts == []
+    assert result.errors == ["No MX hosts were found for DANE/TLSA evaluation."]
+    provider.lookup_tlsa.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -105,3 +136,4 @@ async def test_check_dane_cached_reuses_fresh_result(db_session):
     assert second_cached is True
     assert second_checked == first_checked
     provider.lookup_mx.assert_awaited_once()
+    provider.lookup_tlsa.assert_awaited_once()

--- a/backend/app/tests/test_dane.py
+++ b/backend/app/tests/test_dane.py
@@ -1,0 +1,107 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.dane import check_dane, check_dane_cached, parse_tlsa_record
+from app.services.dns_resolver import BaseDNSProvider
+
+
+class FakeDANEDNSProvider(BaseDNSProvider):
+    def __init__(self, mx_hosts=None, tlsa_records=None):
+        self.mx_hosts = mx_hosts or []
+        self.tlsa_records = tlsa_records or {}
+        self.lookup_mx = AsyncMock(return_value=self.mx_hosts)
+        self.lookup_tlsa = AsyncMock(side_effect=self._lookup_tlsa)
+
+    async def lookup_txt(self, name: str):  # pragma: no cover - unused protocol method
+        raise LookupError(name)
+
+    async def _lookup_tlsa(self, name: str):
+        return list(self.tlsa_records.get(name, []))
+
+
+def test_parse_tlsa_record_accepts_valid_dane_ee_spki_hash():
+    record = parse_tlsa_record(
+        "3 1 1 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        query_name="_25._tcp.mx.example.com",
+        mx_host="mx.example.com",
+    )
+
+    assert record.valid is True
+    assert record.certificate_usage == 3
+    assert record.selector == 1
+    assert record.matching_type == 1
+    assert record.errors == []
+
+
+def test_parse_tlsa_record_rejects_bad_fields():
+    record = parse_tlsa_record(
+        "9 4 8 not-hex",
+        query_name="_25._tcp.mx.example.com",
+        mx_host="mx.example.com",
+    )
+
+    assert record.valid is False
+    assert "TLSA certificate usage must be 0, 1, 2, or 3." in record.errors
+    assert "TLSA selector must be 0 for full certificate or 1 for SPKI." in record.errors
+    assert "TLSA matching type must be 0, 1, or 2." in record.errors
+    assert "TLSA association data must be hexadecimal." in record.errors
+
+
+@pytest.mark.asyncio
+async def test_check_dane_requires_mx_hosts():
+    provider = FakeDANEDNSProvider(mx_hosts=[])
+
+    result = await check_dane("example.com", provider)
+
+    assert result.status == "fail"
+    assert result.records == []
+    assert result.errors == ["No MX hosts were found for DANE/TLSA evaluation."]
+
+
+@pytest.mark.asyncio
+async def test_check_dane_reports_partial_mx_coverage_and_invalid_records():
+    provider = FakeDANEDNSProvider(
+        mx_hosts=["mx1.example.com", "mx2.example.com"],
+        tlsa_records={
+            "_25._tcp.mx1.example.com": ["3 1 1 not-hex"],
+        },
+    )
+
+    result = await check_dane("example.com", provider)
+
+    assert result.status == "partial"
+    assert result.mx_hosts == ["mx1.example.com", "mx2.example.com"]
+    assert result.records[0].valid is False
+    assert "No TLSA records were found for MX host(s): mx2.example.com" in result.errors
+    assert "TLSA records need syntax review for MX host(s): mx1.example.com" in result.errors
+
+
+@pytest.mark.asyncio
+async def test_check_dane_cached_reuses_fresh_result(db_session):
+    provider = FakeDANEDNSProvider(
+        mx_hosts=["mx.example.com"],
+        tlsa_records={
+            "_25._tcp.mx.example.com": [
+                "3 1 1 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            ],
+        },
+    )
+
+    first, first_cached, first_checked = await check_dane_cached(
+        db_session,
+        provider,
+        "example.com",
+    )
+    second, second_cached, second_checked = await check_dane_cached(
+        db_session,
+        provider,
+        "example.com",
+    )
+
+    assert first.status == "pass"
+    assert first_cached is False
+    assert second.status == "pass"
+    assert second_cached is True
+    assert second_checked == first_checked
+    provider.lookup_mx.assert_awaited_once()

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -24,6 +24,7 @@ from app.models.organization import Entitlement, Organization
 from app.models.report import DMARCReport, ReportRecord
 from app.models.workspace import Workspace
 from app.services.bimi import BIMIResult
+from app.services.dane import DANEResult, TLSARecord
 from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
 from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import DomainDNSResult
@@ -896,6 +897,54 @@ def test_bimi_endpoint_returns_cached_posture(authed_client: TestClient):
 
 def test_bimi_endpoint_returns_404_for_unknown_domain(authed_client: TestClient):
     response = authed_client.get("/api/v1/domains/unknown.example.com/dns/bimi")
+
+    assert response.status_code == 404
+
+
+def test_dane_endpoint_returns_cached_posture(authed_client: TestClient):
+    """The domain detail page can fetch DANE/TLSA posture with cache metadata."""
+    checked_at = datetime(2026, 5, 23, 12, 0, 0)
+    result = DANEResult(
+        status="pass",
+        port=25,
+        mx_hosts=["mx.example.com"],
+        records=[
+            TLSARecord(
+                query_name="_25._tcp.mx.example.com",
+                mx_host="mx.example.com",
+                record=(
+                    "3 1 1 " "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                ),
+                certificate_usage=3,
+                selector=1,
+                matching_type=1,
+                association_data=(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                ),
+                valid=True,
+            )
+        ],
+    )
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.check_dane_cached",
+        new=AsyncMock(return_value=(result, True, checked_at)),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/dane")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "pass"
+    assert data["mx_hosts"] == ["mx.example.com"]
+    assert data["records"][0]["query_name"] == "_25._tcp.mx.example.com"
+    assert data["records"][0]["certificate_usage"] == 3
+    assert data["records"][0]["valid"] is True
+    assert data["cached"] is True
+    assert data["checked_at"] == checked_at.isoformat()
+
+
+def test_dane_endpoint_returns_404_for_unknown_domain(authed_client: TestClient):
+    response = authed_client.get("/api/v1/domains/unknown.example.com/dns/dane")
 
     assert response.status_code == 404
 

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.services.bimi import BIMIResult
+from app.services.dane import DANEResult
 from app.services.dns_guidance import build_dns_guidance
 from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult
 from app.services.mta_sts import MTAStsResult
@@ -92,6 +93,43 @@ async def test_build_dns_guidance_lints_spf_and_tls_rpt_records():
     assert "spf_multiple_records" in codes
     assert "spf_all_too_permissive" in codes
     assert "tls_rpt_rua_missing" in codes
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_ignores_dane_limitation_notice_for_pass_status():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+    dane = DANEResult(
+        status="pass",
+        mx_hosts=["mx.example.com"],
+        warnings=[
+            "DMARQ validates TLSA syntax and MX coverage, but does not yet validate DNSSEC chains "
+            "or compare TLSA hashes with live SMTP certificates."
+        ],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        dane=dane,
+    )
+
+    assert "dane_review" not in {finding.code for finding in guidance.findings}
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -51,6 +51,7 @@ async def test_build_dns_guidance_returns_typed_findings_and_targets():
         "target_mta_sts",
         "target_tls_rpt",
         "target_bimi",
+        "target_dane",
     }
     plan = next(plan for plan in guidance.change_plans if plan.finding_code == "dmarc_missing")
     assert plan.operation == "create"

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -700,6 +700,30 @@ async def test_cloudflare_provider_lookup_ns_returns_empty_on_http_error():
 
 
 @pytest.mark.asyncio
+async def test_cloudflare_provider_lookup_mx_skips_malformed_answers():
+    from unittest.mock import MagicMock
+
+    fake_response_data = {
+        "Answer": [
+            {"type": 15, "data": "bad mail.bad.example."},
+            {"type": 15, "data": "20 mail2.example."},
+            {"type": 15, "data": "10 mail1.example."},
+            {"type": 1, "data": "93.184.216.34"},
+        ]
+    }
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = lambda: fake_response_data
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        provider = CloudflareDNSProvider()
+        mx_hosts = await provider.lookup_mx("example.com")
+
+    assert mx_hosts == ["mail1.example", "mail2.example"]
+
+
+@pytest.mark.asyncio
 async def test_cloudflare_provider_lists_zones_from_rest_api():
     from unittest.mock import MagicMock
 

--- a/docs/development/protocol-coverage.md
+++ b/docs/development/protocol-coverage.md
@@ -1,0 +1,68 @@
+# Protocol Coverage Plan
+
+DMARQ's core scope remains DMARC report ingestion, DNS posture guidance, and
+human-approved remediation. Adjacent protocols are useful when they improve mail
+health evidence for domain owners, but they should not turn DMARQ into a hosted
+mail-transfer service.
+
+## In Scope Now
+
+### DANE/TLSA
+
+DMARQ supports passive DANE posture checks for SMTP delivery:
+
+- discover MX hosts for a monitored domain.
+- query `_25._tcp.<mx-host>` TLSA records.
+- lint TLSA syntax for certificate usage, selector, matching type, and
+  hexadecimal association data.
+- show missing, partial, invalid, and syntactically valid coverage in DNS lint.
+- expose a read-only API endpoint at `GET /domains/{domain_id}/dns/dane`.
+- generate manual remediation steps and target-record shape without applying
+  DNS writes.
+
+Boundaries:
+
+- DMARQ does not yet validate DNSSEC chains.
+- DMARQ does not yet connect to live SMTP hosts to compare TLSA hashes with the
+  presented certificate.
+- DMARQ does not automatically publish TLSA records.
+
+DANE is therefore a hygiene and readiness signal, not a delivery guarantee.
+
+### ARF for DMARC Failure Reports
+
+DMARQ already consumes DMARC forensic/RUF failure reports that arrive as
+`multipart/report` messages with `message/feedback-report` parts. It stores
+redacted metadata needed for DMARC operations and avoids raw message-body
+storage.
+
+Boundaries:
+
+- DMARQ consumes inbound reports; it does not generate outbound ARF reports for
+  other receivers.
+- Generic abuse-desk ARF processing is out of scope unless the report contains
+  DMARC/RUF-relevant evidence.
+
+## Next Design Slices
+
+### ARC
+
+ARC support should start as message/report metadata analysis, not DNS
+automation. Useful first slices:
+
+- detect ARC-related headers in forensic/RUF evidence when present.
+- explain when ARC may affect forwarded mail interpretation.
+- keep ARC separate from DMARC pass/fail scoring unless DMARQ has explicit
+  receiver-side evidence.
+
+### Deeper DANE Validation
+
+Future DANE work can add:
+
+- DNSSEC validation evidence.
+- live SMTP STARTTLS certificate retrieval.
+- TLSA hash comparison against the presented certificate or SPKI.
+- certificate rotation warnings.
+
+Those features require network-safety controls and should remain read-only until
+operators explicitly approve any DNS changes.

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -82,7 +82,7 @@ Completed or substantially delivered:
 - Dashboard, domain reports, source reports, trend charts, exports, and
   recommendations.
 - DNS health checks for DMARC/SPF/DKIM plus posture checks for MTA-STS, TLS-RPT,
-  and BIMI.
+  BIMI, and passive DANE/TLSA readiness.
 - Cloudflare read-only inspection, DNS snapshots, and DNS change history.
 - Notifications, alert rules, alert history, and Apprise delivery.
 - API tokens, webhooks, SIEM templates, and ticketing/chatops templates.
@@ -101,6 +101,9 @@ The main open strategic issues are:
   score, A-F rating, and remediation action plan.
 - [Issue #305](https://github.com/christianlouis/dmarq/issues/305): competitive
   parity tracker for DMARC monitoring platforms.
+- [Issue #310](https://github.com/christianlouis/dmarq/issues/310): DANE, ARC,
+  and ARF competitive protocol coverage. The first shipped slice is passive
+  DANE/TLSA posture; ARC and deeper ARF work remain separate design slices.
 - [Issue #384](https://github.com/christianlouis/dmarq/issues/384): autonomous
   mail health remediation loop with human approval.
 - [Issue #385](https://github.com/christianlouis/dmarq/issues/385): sender IP
@@ -145,7 +148,7 @@ Exit criteria:
 - A domain owner can distinguish observed problems from approved repairs and
   manual work still waiting on them.
 - Demo mode continues to showcase realistic aggregate, forensic, DNS, TLS-RPT,
-  MTA-STS, and BIMI states without touching production paths.
+  MTA-STS, BIMI, and DANE/TLSA states without touching production paths.
 
 ### Track A2: Ecosystem Integrations and Localization
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -564,6 +564,18 @@ GET /domains/{domain_id}/dns/bimi
 Returns the cached BIMI TXT posture for the default selector, including the
 queried DNS name, record text, logo URL, certificate URL, warnings, and errors.
 
+#### Get DANE/TLSA Posture
+
+```
+GET /domains/{domain_id}/dns/dane
+```
+
+Returns cached read-only SMTP DANE evidence for the domain's MX hosts. The
+response lists discovered MX hosts, queried TLSA owner names, parsed TLSA
+fields, syntax errors, warnings, cache state, and the check timestamp. DMARQ
+currently validates MX coverage and TLSA syntax only; it does not yet validate
+DNSSEC chains or compare TLSA hashes with live SMTP certificates.
+
 #### Get DNS Lint Guidance
 
 ```
@@ -584,7 +596,7 @@ GET /domains/dns/lint/export
 
 Returns typed DNS lint findings with stable `code` values, suggested target
 records, detected DNS provider evidence, and deterministic `remediation_steps`
-for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI readiness. DKIM findings
+for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, BIMI, and DANE/TLSA readiness. DKIM findings
 distinguish missing selectors, broken CNAME targets, short RSA keys, and stale
 selectors. The bulk endpoint returns the same payload shape per monitored
 domain, and the export endpoint returns the finding list as CSV for

--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -70,7 +70,12 @@ Live DNS checks parse DMARC policy records according to RFC 9989:
 - Subdomain checks fall back to the bounded RFC 9989 DNS Tree Walk, including `psd=n` and `psd=y` stop conditions.
 - Records with a valid aggregate reporting URI but no valid `p` tag are treated as monitoring mode for policy extraction.
 - External `rua` and `ruf` destinations are linted for the required DNS authorization TXT record at `<policy-domain>._report._dmarc.<destination-domain>`.
-- Typed DNS guidance endpoints expose stable finding codes and target records for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, and BIMI readiness. Provider writes are never automatic; safe TXT/CNAME changes require an explicit apply request.
+- Typed DNS guidance endpoints expose stable finding codes and target records
+  for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, BIMI, and passive DANE/TLSA
+  readiness. Provider writes are never automatic; safe TXT/CNAME changes
+  require an explicit apply request. DANE/TLSA support is currently read-only
+  MX/TLSA syntax and coverage guidance, not DNSSEC chain validation or live SMTP
+  certificate pinning verification.
 
 ## Preserved Metadata
 
@@ -97,6 +102,8 @@ CSV exports include the most useful aggregate metadata for operators:
 - Unsupported attachments are skipped by IMAP and Gmail import paths and recorded in import details when stats are available.
 - For duplicate detection, DMARQ uses the domain and `report_id` pair. Fixture report IDs must remain unique within a single test import run.
 - RFC 9991 describes report generation duties such as outbound rate limiting and external `ruf` destination verification for Mail Receivers. DMARQ currently implements report-consumer parsing and analysis, not report generation.
+- ARC is tracked as a future message-analysis feature. DMARQ does not currently
+  score ARC chains or treat ARC as a replacement for DMARC alignment evidence.
 - The product-scope backlog for parser, analyzer, DNS guidance, and DNS linting work is tracked in `docs/development/dmarc-scope-open-items.md`.
 
 ## Fixture Pack

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
     - Testing: development/testing.md
     - CI/CD Pipeline: development/ci-cd.md
     - Roadmap: development/roadmap.md
+    - Protocol Coverage: development/protocol-coverage.md
     - Agentic Coding: development/agents.md
     - Issue Generation: development/issue_generation.md
   - FAQ: faq.md


### PR DESCRIPTION
## Summary\n- add read-only DANE/TLSA posture checks for monitored domains by resolving MX hosts and linting _25._tcp.<mx-host> TLSA records\n- surface DANE findings in DNS guidance, remediation context, and a new /domains/{domain_id}/dns/dane API response\n- document the #310 protocol boundary: DANE/TLSA is supported passively now; ARC and deeper ARF/DANE validation remain follow-up design slices\n\n## Validation\n- .venv/bin/python -m pytest backend/app/tests/test_dane.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py -q\n- .venv/bin/python -m pytest backend/app/tests/test_ai_mcp.py -q\n- .venv/bin/python -m flake8 backend/app/services/dane.py backend/app/services/dns_resolver.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/services/ai_assistance.py backend/app/tests/test_dane.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py\n- .venv/bin/python -m black --check backend/app/services/dane.py backend/app/services/dns_resolver.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/services/ai_assistance.py backend/app/tests/test_dane.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py\n- .venv/bin/python -m isort --check-only backend/app/services/dane.py backend/app/services/dns_resolver.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/services/ai_assistance.py backend/app/tests/test_dane.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py\n- .venv/bin/python -m compileall -q backend/app\n- .venv/bin/python -m mkdocs build\n- git diff --check\n\nCloses a first implementation slice of #310.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only DANE/TLSA posture checks for domains, including MX discovery, TLSA parsing, and cached results.
  * Introduced a new API endpoint to view DANE/TLSA posture details and cache status.
  * DNS guidance now includes DANE/TLSA findings and target records.

* **Bug Fixes**
  * Improved handling of missing or malformed TLSA data with clearer status and warnings.

* **Documentation**
  * Updated API and development docs to cover DANE/TLSA support and current limitations.

* **Tests**
  * Added coverage for DANE parsing, evaluation, caching, and the new endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->