### PR TITLE
Fix source reputation workspace scope

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2111,11 +2111,21 @@ async def _build_domain_health_grade(
         sources,
         period_days=30,
     )
+    sender_by_ip = {
+        str(source.get("source_ip") or "unknown"): identify_sender(
+            str(source.get("source_ip") or "unknown"),
+            source,
+            hostname=None,
+            domain=domain_id,
+        )
+        for source in sources
+    }
     reputation_result, _, _ = await build_source_reputation_cached(
         db,
         domain_id,
         reports,
         sources,
+        senders_by_ip=sender_by_ip,
         anomalies_by_ip=intelligence.get("anomalies_by_ip", {}),
         days=30,
         refresh=refresh,
@@ -5241,7 +5251,7 @@ async def get_domain_source_reputation(
     """Return passive reputation evidence for observed sender IPs."""
     workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
 
     if not _domain_exists(db, store, domain_id, workspace):
         raise HTTPException(
@@ -5257,11 +5267,21 @@ async def get_domain_source_reputation(
         sources,
         period_days=days,
     )
+    sender_by_ip = {
+        str(source.get("source_ip") or "unknown"): identify_sender(
+            str(source.get("source_ip") or "unknown"),
+            source,
+            hostname=None,
+            domain=domain_id,
+        )
+        for source in sources
+    }
     result, cached, _ = await build_source_reputation_cached(
         db,
         domain_id,
         reports,
         sources,
+        senders_by_ip=sender_by_ip,
         anomalies_by_ip=intelligence.get("anomalies_by_ip", {}),
         days=days,
         refresh=refresh,

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -261,30 +261,30 @@ def test_get_selectors_report_selector_moves_to_manual_when_added(authed_client:
     assert "google" not in data["report_selectors"]
 
 
-def test_get_source_reputation_returns_listed_source(authed_client: TestClient):
+def test_get_source_reputation_returns_listed_source(authed_client: TestClient, db_session):
     """Source reputation exposes listed sender IP evidence for domain detail views."""
-    ReportStore.get_instance().add_report(
-        {
-            **MINIMAL_REPORT,
-            "report_id": "listed-source-reputation",
-            "records": [
-                {
-                    "source_ip": "198.51.100.199",
-                    "count": 12,
-                    "disposition": "none",
-                    "dkim_result": "fail",
-                    "spf_result": "fail",
-                    "dkim": [{"domain": DOMAIN, "result": "fail", "selector": "legacy"}],
-                    "spf": [{"domain": DOMAIN, "result": "fail"}],
-                    "extensions": {
-                        "demo:source": "unknown-forwarder",
-                        "demo:reputation": "listed",
-                        "demo:blacklists": "Demo RBL",
-                    },
-                }
-            ],
-        }
-    )
+    report = {
+        **MINIMAL_REPORT,
+        "report_id": "listed-source-reputation",
+        "records": [
+            {
+                "source_ip": "198.51.100.199",
+                "count": 12,
+                "disposition": "none",
+                "dkim_result": "fail",
+                "spf_result": "fail",
+                "dkim": [{"domain": DOMAIN, "result": "fail", "selector": "legacy"}],
+                "spf": [{"domain": DOMAIN, "result": "fail"}],
+                "extensions": {
+                    "demo:source": "unknown-forwarder",
+                    "demo:reputation": "listed",
+                    "demo:blacklists": "Demo RBL",
+                },
+            }
+        ],
+    }
+    save_parsed_report(db_session, report)
+    db_session.commit()
 
     response = authed_client.get(f"/api/v1/domains/{DOMAIN}/source-reputation")
 

--- a/backend/app/tests/test_source_reputation.py
+++ b/backend/app/tests/test_source_reputation.py
@@ -121,6 +121,24 @@ def test_build_source_reputation_reports_warning_anomalies():
     assert any(item.label == "Source anomalies" and item.value == "1" for item in source.evidence)
 
 
+def test_build_source_reputation_flags_non_global_source_ip():
+    sources = [
+        {
+            "source_ip": "10.0.0.25",
+            "count": 8,
+            "dmarc_fail_count": 0,
+            "extensions": {},
+        }
+    ]
+
+    result = build_source_reputation("example.com", [], sources)
+
+    source = source_reputation_by_ip(result)["10.0.0.25"]
+    assert source.status == "unknown"
+    assert source.risk_score == 18
+    assert any(item.label == "Network scope" for item in source.evidence)
+
+
 def test_build_source_reputation_marks_clean_known_source():
     sources = [
         {


### PR DESCRIPTION
## Summary
- pass sender identity context through source reputation health and endpoint builds
- hydrate source reputation reports within the authorized workspace scope
- cover non-global source IP scoring and scoped source-reputation endpoint data

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_source_reputation.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_health_score.py -q`
- `.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_source_reputation.py backend/app/tests/test_dns_endpoints.py`
- `git diff --check`