### PR TITLE
Add opt-in sender reputation feed providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,14 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 
 # Optional mail service sender-domain discovery
 # POSTMARK_ACCOUNT_TOKEN="your_postmark_account_token"
+
+# Optional sender IP reputation feeds
+# Disabled by default. Enable only after reviewing provider terms, credentials,
+# query limits, and privacy implications for sending observed source IPs to
+# external reputation providers.
+# SOURCE_REPUTATION_FEEDS_ENABLED=false
+# SOURCE_REPUTATION_FEEDS="spamhaus_dqs,spamcop_scbl,barracuda_brbl"
+# SOURCE_REPUTATION_SPAMHAUS_DQS_ZONE="your-dqs-zone.example"
+# SOURCE_REPUTATION_FEED_TIMEOUT_SECONDS=2
+# SOURCE_REPUTATION_FEED_CACHE_SECONDS=86400
+# SOURCE_REPUTATION_FEED_MAX_IPS=100

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -93,6 +93,7 @@ from app.services.source_reputation import (
     build_source_reputation_cached,
     source_reputation_by_ip,
 )
+from app.services.source_reputation_feeds import feed_registry
 from app.services.webhook_events import delivery_to_dict, enqueue_webhook_event
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
@@ -1324,6 +1325,7 @@ class DomainSourceReputationResponse(BaseModel):
     checked_at: str
     sources: List[SourceReputationResponse] = Field(default_factory=list)
     summary: Dict[str, int] = Field(default_factory=dict)
+    feeds: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     cached: bool = False
 
 
@@ -5272,6 +5274,7 @@ async def get_domain_source_reputation(
         checked_at=result.checked_at,
         sources=[_source_reputation_response(item) for item in result.sources],
         summary=result.summary,
+        feeds=feed_registry(),
         cached=cached,
     )
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -55,6 +55,15 @@ class Settings(BaseSettings):
     POSTMARK_ACCOUNT_TOKEN: Optional[str] = None
     WEBHOOK_SECRET: Optional[str] = None
 
+    # Optional sender reputation feed lookups. Disabled by default because many
+    # reputation providers require explicit terms, credentials, and volume limits.
+    SOURCE_REPUTATION_FEEDS_ENABLED: bool = False
+    SOURCE_REPUTATION_FEEDS: Optional[str] = None
+    SOURCE_REPUTATION_SPAMHAUS_DQS_ZONE: Optional[str] = None
+    SOURCE_REPUTATION_FEED_TIMEOUT_SECONDS: float = 2.0
+    SOURCE_REPUTATION_FEED_CACHE_SECONDS: int = 86_400
+    SOURCE_REPUTATION_FEED_MAX_IPS: int = 100
+
     # Optional Stripe Billing integration. Self-hosted and provider-billed
     # deployments work without these values.
     STRIPE_SECRET_KEY: Optional[str] = None

--- a/backend/app/services/source_reputation.py
+++ b/backend/app/services/source_reputation.py
@@ -12,8 +12,14 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.models.dns_cache import DNSCache
 from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS
+from app.services.source_reputation_feeds import (
+    IPFeedReputation,
+    lookup_sources_reputation_cached,
+    providers_from_settings,
+)
 
 _CACHE_PROVIDER = "source-reputation-v1"
 
@@ -247,6 +253,7 @@ def _source_reputation(
     sender: Optional[Dict[str, Any]],
     anomalies: List[Dict[str, Any]],
     seen: Dict[str, Optional[int]],
+    feed_result: Optional[IPFeedReputation],
     *,
     checked_at: str,
 ) -> SourceReputation:
@@ -277,6 +284,20 @@ def _source_reputation(
         evidence.append(ReputationEvidence("Reputation status", reported, "metadata"))
     elif reported == "clean":
         evidence.append(ReputationEvidence("Reputation status", "clean", "metadata"))
+
+    external_listings = _external_listings(feed_result)
+    if external_listings:
+        risk_score += 45
+        listings.extend(item for item in external_listings if item not in listings)
+        evidence.append(
+            ReputationEvidence(
+                "External reputation feeds",
+                ", ".join(external_listings),
+                "external",
+            )
+        )
+    for item in _external_feed_notes(feed_result):
+        evidence.append(item)
 
     if sender and sender.get("status") in {"unknown", "suspicious"}:
         risk_score += 18 if sender.get("status") == "unknown" else 25
@@ -322,6 +343,32 @@ def _summary_for(status: str, risk_score: int, failed: int) -> str:
     return "No reputation listing evidence is available for this source."
 
 
+def _external_listings(feed_result: Optional[IPFeedReputation]) -> List[str]:
+    if feed_result is None:
+        return []
+    listings: List[str] = []
+    for item in feed_result.evidence:
+        if item.status == "listed":
+            listings.append(item.listing or item.provider_name or item.provider_id)
+    return listings
+
+
+def _external_feed_notes(feed_result: Optional[IPFeedReputation]) -> List[ReputationEvidence]:
+    if feed_result is None:
+        return []
+    notes: List[ReputationEvidence] = []
+    for item in feed_result.evidence:
+        if item.status in {"error", "not_configured"}:
+            notes.append(
+                ReputationEvidence(
+                    f"{item.provider_name} lookup",
+                    item.detail or item.status,
+                    "external",
+                )
+            )
+    return notes
+
+
 def _recommendations(
     status: str,
     listings: List[str],
@@ -355,11 +402,13 @@ def build_source_reputation(
     *,
     senders_by_ip: Optional[Dict[str, Dict[str, Any]]] = None,
     anomalies_by_ip: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+    feed_results_by_ip: Optional[Dict[str, IPFeedReputation]] = None,
 ) -> DomainReputation:
     """Build passive reputation evidence for observed sources."""
     checked_at = _utcnow_iso()
     sender_map = senders_by_ip or {}
     anomaly_map = anomalies_by_ip or {}
+    feed_map = feed_results_by_ip or {}
     seen_windows = _source_seen_windows(reports)
     source_rows = list(sources)
     reputations = [
@@ -368,6 +417,7 @@ def build_source_reputation(
             sender_map.get(str(source.get("source_ip") or source.get("ip") or "unknown")),
             anomaly_map.get(str(source.get("source_ip") or source.get("ip") or "unknown"), []),
             seen_windows.get(str(source.get("source_ip") or source.get("ip") or "unknown"), {}),
+            feed_map.get(str(source.get("source_ip") or source.get("ip") or "unknown")),
             checked_at=checked_at,
         )
         for source in source_rows
@@ -415,6 +465,7 @@ def source_reputation_cache_key(
     *,
     senders_by_ip: Optional[Dict[str, Dict[str, Any]]] = None,
     anomalies_by_ip: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+    feed_results_by_ip: Optional[Dict[str, IPFeedReputation]] = None,
     days: int = 30,
 ) -> str:
     """Return a stable cache key for a domain reputation input set."""
@@ -422,8 +473,17 @@ def source_reputation_cache_key(
         f"source-reputation:{int(days)}:"
         f"{_source_fingerprint(sources)}:"
         f"{_report_fingerprint(reports)}:"
-        f"{_context_fingerprint(senders_by_ip, anomalies_by_ip)}"
+        f"{_context_fingerprint(senders_by_ip, anomalies_by_ip)}:"
+        f"{_feed_fingerprint(feed_results_by_ip)}"
     )
+
+
+def _feed_fingerprint(feed_results_by_ip: Optional[Dict[str, IPFeedReputation]]) -> str:
+    payload = json.dumps(
+        {ip: asdict(result) for ip, result in sorted((feed_results_by_ip or {}).items())},
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
 
 
 async def build_source_reputation_cached(
@@ -442,11 +502,21 @@ async def build_source_reputation_cached(
     now = _utcnow_naive()
     source_rows = list(sources)
     report_rows = list(reports)
+    settings = get_settings()
+    feed_results_by_ip = await lookup_sources_reputation_cached(
+        db,
+        [str(source.get("source_ip") or source.get("ip") or "unknown") for source in source_rows],
+        providers_from_settings(settings),
+        ttl_seconds=settings.SOURCE_REPUTATION_FEED_CACHE_SECONDS,
+        max_ips=settings.SOURCE_REPUTATION_FEED_MAX_IPS,
+        refresh=refresh,
+    )
     cache_key = source_reputation_cache_key(
         source_rows,
         report_rows,
         senders_by_ip=senders_by_ip,
         anomalies_by_ip=anomalies_by_ip,
+        feed_results_by_ip=feed_results_by_ip,
         days=days,
     )
     row = (
@@ -467,6 +537,7 @@ async def build_source_reputation_cached(
         source_rows,
         senders_by_ip=senders_by_ip,
         anomalies_by_ip=anomalies_by_ip,
+        feed_results_by_ip=feed_results_by_ip,
     )
     payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
     if row is None:

--- a/backend/app/services/source_reputation.py
+++ b/backend/app/services/source_reputation.py
@@ -17,6 +17,7 @@ from app.models.dns_cache import DNSCache
 from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS
 from app.services.source_reputation_feeds import (
     IPFeedReputation,
+    ReputationFeedProvider,
     lookup_sources_reputation_cached,
     providers_from_settings,
 )
@@ -466,21 +467,52 @@ def source_reputation_cache_key(
     senders_by_ip: Optional[Dict[str, Dict[str, Any]]] = None,
     anomalies_by_ip: Optional[Dict[str, List[Dict[str, Any]]]] = None,
     feed_results_by_ip: Optional[Dict[str, IPFeedReputation]] = None,
+    feed_providers: Optional[Iterable[ReputationFeedProvider]] = None,
+    feed_max_ips: Optional[int] = None,
     days: int = 30,
 ) -> str:
     """Return a stable cache key for a domain reputation input set."""
+    feed_fingerprint = (
+        _feed_provider_fingerprint(feed_providers, feed_max_ips=feed_max_ips)
+        if feed_providers is not None
+        else _feed_fingerprint(feed_results_by_ip)
+    )
     return (
         f"source-reputation:{int(days)}:"
         f"{_source_fingerprint(sources)}:"
         f"{_report_fingerprint(reports)}:"
         f"{_context_fingerprint(senders_by_ip, anomalies_by_ip)}:"
-        f"{_feed_fingerprint(feed_results_by_ip)}"
+        f"{feed_fingerprint}"
     )
 
 
 def _feed_fingerprint(feed_results_by_ip: Optional[Dict[str, IPFeedReputation]]) -> str:
     payload = json.dumps(
         {ip: asdict(result) for ip, result in sorted((feed_results_by_ip or {}).items())},
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+
+def _feed_provider_fingerprint(
+    feed_providers: Iterable[ReputationFeedProvider],
+    *,
+    feed_max_ips: Optional[int],
+) -> str:
+    payload = json.dumps(
+        {
+            "max_ips": feed_max_ips,
+            "providers": [
+                {
+                    "provider_id": provider.config.provider_id,
+                    "enabled": provider.config.enabled,
+                    "kind": provider.config.kind,
+                    "query_zone": provider.config.query_zone,
+                    "listing_name": provider.config.listing_name,
+                }
+                for provider in feed_providers
+            ],
+        },
         sort_keys=True,
     )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
@@ -503,20 +535,14 @@ async def build_source_reputation_cached(
     source_rows = list(sources)
     report_rows = list(reports)
     settings = get_settings()
-    feed_results_by_ip = await lookup_sources_reputation_cached(
-        db,
-        [str(source.get("source_ip") or source.get("ip") or "unknown") for source in source_rows],
-        providers_from_settings(settings),
-        ttl_seconds=settings.SOURCE_REPUTATION_FEED_CACHE_SECONDS,
-        max_ips=settings.SOURCE_REPUTATION_FEED_MAX_IPS,
-        refresh=refresh,
-    )
+    feed_providers = providers_from_settings(settings)
     cache_key = source_reputation_cache_key(
         source_rows,
         report_rows,
         senders_by_ip=senders_by_ip,
         anomalies_by_ip=anomalies_by_ip,
-        feed_results_by_ip=feed_results_by_ip,
+        feed_providers=feed_providers,
+        feed_max_ips=settings.SOURCE_REPUTATION_FEED_MAX_IPS,
         days=days,
     )
     row = (
@@ -530,6 +556,15 @@ async def build_source_reputation_cached(
     )
     if row and not refresh and _is_fresh(row, ttl_seconds, now):
         return _result_from_json(row.result_json), True, row.checked_at
+
+    feed_results_by_ip = await lookup_sources_reputation_cached(
+        db,
+        [str(source.get("source_ip") or source.get("ip") or "unknown") for source in source_rows],
+        feed_providers,
+        ttl_seconds=settings.SOURCE_REPUTATION_FEED_CACHE_SECONDS,
+        max_ips=settings.SOURCE_REPUTATION_FEED_MAX_IPS,
+        refresh=refresh,
+    )
 
     result = build_source_reputation(
         domain,

--- a/backend/app/services/source_reputation_feeds.py
+++ b/backend/app/services/source_reputation_feeds.py
@@ -1,0 +1,394 @@
+"""Optional external sender reputation feed lookups.
+
+External reputation feeds are disabled by default. They are intended to enrich
+DMARC evidence when an operator explicitly opts in to provider terms, API
+credentials, and lookup volume.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import ipaddress
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List, Optional, Protocol, Tuple
+
+import dns.exception
+import dns.resolver
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings, get_settings
+from app.models.dns_cache import DNSCache
+
+_CACHE_PROVIDER = "source-reputation-feed-v1"
+
+
+@dataclass(frozen=True)
+class FeedProviderConfig:
+    """Runtime configuration for one external reputation provider."""
+
+    provider_id: str
+    display_name: str
+    kind: str = "dnsbl"
+    enabled: bool = False
+    query_zone: Optional[str] = None
+    listing_name: Optional[str] = None
+    requires_terms: bool = True
+    default_enabled: bool = False
+
+
+@dataclass
+class FeedLookupEvidence:
+    """One external feed observation."""
+
+    provider_id: str
+    provider_name: str
+    status: str
+    listing: Optional[str] = None
+    detail: Optional[str] = None
+    checked_at: str = ""
+
+
+@dataclass
+class IPFeedReputation:
+    """External feed result set for one IP."""
+
+    ip: str
+    listed: bool = False
+    evidence: List[FeedLookupEvidence] = field(default_factory=list)
+
+
+class ReputationFeedProvider(Protocol):
+    """Provider interface for sender reputation feed lookups."""
+
+    config: FeedProviderConfig
+
+    async def lookup_ip(self, ip: str) -> FeedLookupEvidence:
+        """Return reputation evidence for one IP."""
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _reverse_ip(ip: str) -> str:
+    address = ipaddress.ip_address(ip)
+    if address.version != 4:
+        raise ValueError("DNSBL providers in this registry currently support IPv4 sources only.")
+    return ".".join(reversed(ip.split(".")))
+
+
+class DNSBLFeedProvider:
+    """DNSBL-backed reputation provider."""
+
+    def __init__(
+        self,
+        config: FeedProviderConfig,
+        *,
+        timeout_seconds: float = 2.0,
+        resolver: Optional[dns.resolver.Resolver] = None,
+    ) -> None:
+        self.config = config
+        self.timeout_seconds = timeout_seconds
+        self._resolver = resolver or dns.resolver.Resolver()
+        self._resolver.lifetime = timeout_seconds
+        self._resolver.timeout = timeout_seconds
+
+    async def lookup_ip(self, ip: str) -> FeedLookupEvidence:
+        checked_at = _utcnow_iso()
+        if not self.config.query_zone:
+            return self._evidence(
+                "not_configured",
+                checked_at=checked_at,
+                detail="Provider query zone is not configured.",
+            )
+
+        skipped = self._skip_reason(ip)
+        if skipped:
+            return self._evidence("skipped", checked_at=checked_at, detail=skipped)
+
+        query_name = f"{_reverse_ip(ip)}.{self.config.query_zone.strip('.')}"
+        try:
+            answers = await asyncio.to_thread(self._resolver.resolve, query_name, "A")
+        except dns.exception.DNSException as exc:
+            return self._dns_error_evidence(exc, checked_at)
+
+        values = [answer.to_text() for answer in answers]
+        return self._evidence(
+            "listed",
+            checked_at=checked_at,
+            listing=self.config.listing_name or self.config.display_name,
+            detail=", ".join(values),
+        )
+
+    def _evidence(
+        self,
+        status: str,
+        *,
+        checked_at: str,
+        listing: Optional[str] = None,
+        detail: Optional[str] = None,
+    ) -> FeedLookupEvidence:
+        return FeedLookupEvidence(
+            provider_id=self.config.provider_id,
+            provider_name=self.config.display_name,
+            status=status,
+            listing=listing,
+            detail=detail,
+            checked_at=checked_at,
+        )
+
+    @staticmethod
+    def _skip_reason(ip: str) -> Optional[str]:
+        try:
+            address = ipaddress.ip_address(ip)
+        except ValueError:
+            return "Invalid IP address."
+        if not address.is_global:
+            return "Non-global IPs are not sent to external reputation feeds."
+        return None
+
+    def _dns_error_evidence(
+        self,
+        exc: dns.exception.DNSException,
+        checked_at: str,
+    ) -> FeedLookupEvidence:
+        if isinstance(exc, dns.resolver.NXDOMAIN):
+            return self._evidence("clean", checked_at=checked_at)
+        if isinstance(exc, (dns.resolver.NoAnswer, dns.resolver.NoNameservers)):
+            return self._evidence(
+                "clean",
+                checked_at=checked_at,
+                detail="No listing response returned.",
+            )
+        if isinstance(exc, dns.exception.Timeout):
+            return self._evidence("error", checked_at=checked_at, detail="Lookup timed out.")
+        return self._evidence("error", checked_at=checked_at, detail=str(exc))
+
+
+class StaticFeedProvider:
+    """Deterministic provider for tests and demo fixtures."""
+
+    def __init__(self, config: FeedProviderConfig, listings_by_ip: Dict[str, str]) -> None:
+        self.config = config
+        self._listings_by_ip = listings_by_ip
+
+    async def lookup_ip(self, ip: str) -> FeedLookupEvidence:
+        listing = self._listings_by_ip.get(ip)
+        return FeedLookupEvidence(
+            provider_id=self.config.provider_id,
+            provider_name=self.config.display_name,
+            status="listed" if listing else "clean",
+            listing=listing,
+            checked_at=_utcnow_iso(),
+        )
+
+
+def _split_csv(value: Optional[str]) -> List[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def provider_configs_from_settings(settings: Optional[Settings] = None) -> List[FeedProviderConfig]:
+    """Return configured external reputation feed providers."""
+    settings = settings or get_settings()
+    enabled_ids = set(_split_csv(settings.SOURCE_REPUTATION_FEEDS))
+    globally_enabled = bool(settings.SOURCE_REPUTATION_FEEDS_ENABLED)
+    spamhaus_zone = settings.SOURCE_REPUTATION_SPAMHAUS_DQS_ZONE
+    provider_rows = [
+        FeedProviderConfig(
+            provider_id="spamhaus_dqs",
+            display_name="Spamhaus DQS",
+            enabled=globally_enabled and "spamhaus_dqs" in enabled_ids and bool(spamhaus_zone),
+            query_zone=spamhaus_zone,
+            listing_name="Spamhaus DQS",
+            requires_terms=True,
+        ),
+        FeedProviderConfig(
+            provider_id="spamcop_scbl",
+            display_name="SpamCop SCBL",
+            enabled=globally_enabled and "spamcop_scbl" in enabled_ids,
+            query_zone="bl.spamcop.net",
+            listing_name="SpamCop SCBL",
+            requires_terms=True,
+        ),
+        FeedProviderConfig(
+            provider_id="barracuda_brbl",
+            display_name="Barracuda BRBL",
+            enabled=globally_enabled and "barracuda_brbl" in enabled_ids,
+            query_zone="b.barracudacentral.org",
+            listing_name="Barracuda BRBL",
+            requires_terms=True,
+        ),
+    ]
+    return provider_rows
+
+
+def providers_from_settings(settings: Optional[Settings] = None) -> List[ReputationFeedProvider]:
+    """Build enabled reputation feed provider instances from runtime settings."""
+    settings = settings or get_settings()
+    if settings.DEMO_MODE:
+        return []
+    return [
+        DNSBLFeedProvider(config, timeout_seconds=settings.SOURCE_REPUTATION_FEED_TIMEOUT_SECONDS)
+        for config in provider_configs_from_settings(settings)
+        if config.enabled
+    ]
+
+
+def feed_registry(settings: Optional[Settings] = None) -> Dict[str, Dict[str, object]]:
+    """Return safe metadata for available external reputation providers."""
+    return {
+        config.provider_id: asdict(config) for config in provider_configs_from_settings(settings)
+    }
+
+
+def _cache_key(ip: str, providers: Iterable[ReputationFeedProvider]) -> str:
+    payload = {
+        "ip": ip,
+        "providers": [
+            {
+                "provider_id": provider.config.provider_id,
+                "query_zone": provider.config.query_zone,
+            }
+            for provider in providers
+        ],
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()[:32]
+
+
+def _is_fresh(row: DNSCache, ttl_seconds: int, now: datetime) -> bool:
+    return row.checked_at >= now - timedelta(seconds=ttl_seconds)
+
+
+def _evidence_from_json(value: Dict[str, object]) -> FeedLookupEvidence:
+    return FeedLookupEvidence(
+        provider_id=str(value.get("provider_id") or ""),
+        provider_name=str(value.get("provider_name") or ""),
+        status=str(value.get("status") or "unknown"),
+        listing=value.get("listing") if value.get("listing") is not None else None,
+        detail=value.get("detail") if value.get("detail") is not None else None,
+        checked_at=str(value.get("checked_at") or ""),
+    )
+
+
+def _result_from_json(value: str) -> IPFeedReputation:
+    data = json.loads(value)
+    return IPFeedReputation(
+        ip=str(data.get("ip") or ""),
+        listed=bool(data.get("listed")),
+        evidence=[_evidence_from_json(item) for item in data.get("evidence") or []],
+    )
+
+
+async def lookup_ip_reputation(
+    ip: str,
+    providers: Iterable[ReputationFeedProvider],
+) -> IPFeedReputation:
+    """Lookup one IP across configured external reputation providers."""
+    provider_rows = list(providers)
+    evidence = [await provider.lookup_ip(ip) for provider in provider_rows]
+    return IPFeedReputation(
+        ip=ip,
+        listed=any(item.status == "listed" for item in evidence),
+        evidence=evidence,
+    )
+
+
+async def lookup_ip_reputation_cached(
+    db: Session,
+    ip: str,
+    providers: Iterable[ReputationFeedProvider],
+    *,
+    ttl_seconds: int = 86_400,
+    refresh: bool = False,
+) -> Tuple[IPFeedReputation, bool, datetime]:
+    """Lookup one IP across feeds using a persistent cache."""
+    now = _utcnow_naive()
+    provider_rows = list(providers)
+    if not provider_rows:
+        return IPFeedReputation(ip=ip), False, now
+    selectors_key = _cache_key(ip, provider_rows)
+    row = (
+        db.query(DNSCache)
+        .filter(
+            DNSCache.domain == ip,
+            DNSCache.provider == _CACHE_PROVIDER,
+            DNSCache.selectors_key == selectors_key,
+        )
+        .first()
+    )
+    if row and not refresh and _is_fresh(row, ttl_seconds, now):
+        return _result_from_json(row.result_json), True, row.checked_at
+
+    result = await lookup_ip_reputation(ip, provider_rows)
+    payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
+    if row is None:
+        row = DNSCache(
+            domain=ip,
+            provider=_CACHE_PROVIDER,
+            selectors_key=selectors_key,
+            result_json=payload,
+            checked_at=now,
+        )
+        db.add(row)
+    else:
+        row.result_json = payload
+        row.checked_at = now
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        row = (
+            db.query(DNSCache)
+            .filter(
+                DNSCache.domain == ip,
+                DNSCache.provider == _CACHE_PROVIDER,
+                DNSCache.selectors_key == selectors_key,
+            )
+            .first()
+        )
+        if row is None:
+            raise
+        row.result_json = payload
+        row.checked_at = now
+        db.commit()
+
+    db.refresh(row)
+    return result, False, row.checked_at
+
+
+async def lookup_sources_reputation_cached(
+    db: Session,
+    source_ips: Iterable[str],
+    providers: Iterable[ReputationFeedProvider],
+    *,
+    ttl_seconds: int = 86_400,
+    max_ips: int = 100,
+    refresh: bool = False,
+) -> Dict[str, IPFeedReputation]:
+    """Lookup a bounded set of source IPs across configured reputation feeds."""
+    provider_rows = list(providers)
+    if not provider_rows:
+        return {}
+    unique_ips = list(dict.fromkeys(str(ip) for ip in source_ips if str(ip).strip()))[:max_ips]
+    results: Dict[str, IPFeedReputation] = {}
+    for ip in unique_ips:
+        result, _, _ = await lookup_ip_reputation_cached(
+            db,
+            ip,
+            provider_rows,
+            ttl_seconds=ttl_seconds,
+            refresh=refresh,
+        )
+        results[ip] = result
+    return results

--- a/backend/app/services/source_reputation_feeds.py
+++ b/backend/app/services/source_reputation_feeds.py
@@ -162,11 +162,17 @@ class DNSBLFeedProvider:
     ) -> FeedLookupEvidence:
         if isinstance(exc, dns.resolver.NXDOMAIN):
             return self._evidence("clean", checked_at=checked_at)
-        if isinstance(exc, (dns.resolver.NoAnswer, dns.resolver.NoNameservers)):
+        if isinstance(exc, dns.resolver.NoAnswer):
             return self._evidence(
                 "clean",
                 checked_at=checked_at,
                 detail="No listing response returned.",
+            )
+        if isinstance(exc, dns.resolver.NoNameservers):
+            return self._evidence(
+                "error",
+                checked_at=checked_at,
+                detail="Provider nameservers are unavailable.",
             )
         if isinstance(exc, dns.exception.Timeout):
             return self._evidence("error", checked_at=checked_at, detail="Lookup timed out.")
@@ -247,7 +253,16 @@ def providers_from_settings(settings: Optional[Settings] = None) -> List[Reputat
 def feed_registry(settings: Optional[Settings] = None) -> Dict[str, Dict[str, object]]:
     """Return safe metadata for available external reputation providers."""
     return {
-        config.provider_id: asdict(config) for config in provider_configs_from_settings(settings)
+        config.provider_id: {
+            "provider_id": config.provider_id,
+            "display_name": config.display_name,
+            "kind": config.kind,
+            "enabled": config.enabled,
+            "requires_terms": config.requires_terms,
+            "default_enabled": config.default_enabled,
+            "configured": bool(config.query_zone),
+        }
+        for config in provider_configs_from_settings(settings)
     }
 
 
@@ -380,7 +395,22 @@ async def lookup_sources_reputation_cached(
     provider_rows = list(providers)
     if not provider_rows:
         return {}
-    unique_ips = list(dict.fromkeys(str(ip) for ip in source_ips if str(ip).strip()))[:max_ips]
+    unique_ips: List[str] = []
+    seen: set[str] = set()
+    for raw_ip in source_ips:
+        ip = str(raw_ip).strip()
+        if not ip or ip in seen:
+            continue
+        try:
+            address = ipaddress.ip_address(ip)
+        except ValueError:
+            continue
+        if not address.is_global:
+            continue
+        seen.add(ip)
+        unique_ips.append(ip)
+        if len(unique_ips) >= max_ips:
+            break
     results: Dict[str, IPFeedReputation] = {}
     for ip in unique_ips:
         result, _, _ = await lookup_ip_reputation_cached(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -292,6 +292,8 @@ def test_get_source_reputation_returns_listed_source(authed_client: TestClient):
     data = response.json()
     assert data["status"] == "listed"
     assert data["summary"]["listed"] == 1
+    assert data["feeds"]["spamhaus_dqs"]["enabled"] is False
+    assert data["feeds"]["spamcop_scbl"]["default_enabled"] is False
     listed = next(source for source in data["sources"] if source["ip"] == "198.51.100.199")
     assert listed["status"] == "listed"
     assert listed["listings"] == ["Demo RBL"]

--- a/backend/app/tests/test_source_reputation.py
+++ b/backend/app/tests/test_source_reputation.py
@@ -5,6 +5,7 @@ from app.services.source_reputation import (
     build_source_reputation_cached,
     source_reputation_by_ip,
 )
+from app.services.source_reputation_feeds import FeedLookupEvidence, IPFeedReputation
 
 
 def _report(records):
@@ -66,7 +67,9 @@ def test_build_source_reputation_flags_reported_listed_without_listing_names():
     assert result.summary["highest_risk_score"] >= 45
     assert source.status == "listed"
     assert source.risk_score >= 45
-    assert any(item.label == "Reputation status" and item.value == "listed" for item in source.evidence)
+    assert any(
+        item.label == "Reputation status" and item.value == "listed" for item in source.evidence
+    )
 
 
 def test_build_source_reputation_reports_suspicious_sender_context():
@@ -140,6 +143,44 @@ def test_build_source_reputation_marks_clean_known_source():
     assert result.summary["clean"] == 1
     assert result.sources[0].status == "clean"
     assert result.sources[0].risk_score <= 10
+
+
+def test_build_source_reputation_merges_external_feed_listing():
+    sources = [
+        {
+            "source_ip": "8.8.8.8",
+            "count": 100,
+            "dmarc_fail_count": 0,
+        }
+    ]
+
+    result = build_source_reputation(
+        "example.com",
+        [],
+        sources,
+        feed_results_by_ip={
+            "8.8.8.8": IPFeedReputation(
+                ip="8.8.8.8",
+                listed=True,
+                evidence=[
+                    FeedLookupEvidence(
+                        provider_id="demo_feed",
+                        provider_name="Demo Reputation Feed",
+                        status="listed",
+                        listing="Demo RBL",
+                    )
+                ],
+            )
+        },
+    )
+
+    source = result.sources[0]
+    assert result.status == "listed"
+    assert source.status == "listed"
+    assert "Demo RBL" in source.listings
+    assert source.risk_score >= 45
+    assert any(item.label == "External reputation feeds" for item in source.evidence)
+    assert any("delisting" in item for item in source.recommendations)
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_source_reputation.py
+++ b/backend/app/tests/test_source_reputation.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from app.services.source_reputation import (
@@ -250,3 +252,61 @@ async def test_build_source_reputation_cached_includes_reports_in_cache_key(db_s
     assert second_cached is False
     assert source_reputation_by_ip(first)["203.0.113.10"].first_seen == 1_700_000_000
     assert source_reputation_by_ip(second)["203.0.113.10"].first_seen == 1_800_000_000
+
+
+@pytest.mark.asyncio
+async def test_build_source_reputation_cached_skips_feed_lookup_on_fresh_domain_cache(
+    db_session,
+    monkeypatch,
+):
+    calls = 0
+    provider = SimpleNamespace(
+        config=SimpleNamespace(
+            provider_id="demo_feed",
+            enabled=True,
+            kind="dnsbl",
+            query_zone="example.test",
+            listing_name="Demo RBL",
+        )
+    )
+
+    async def fake_lookup_sources(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return {}
+
+    monkeypatch.setattr(
+        "app.services.source_reputation.providers_from_settings",
+        lambda _settings: [provider],
+    )
+    monkeypatch.setattr(
+        "app.services.source_reputation.lookup_sources_reputation_cached",
+        fake_lookup_sources,
+    )
+    sources = [
+        {
+            "source_ip": "8.8.8.8",
+            "count": 100,
+            "dmarc_fail_count": 0,
+            "extensions": {"demo:reputation": "clean", "demo:source": "workspace-mail"},
+        }
+    ]
+
+    first, first_cached, _ = await build_source_reputation_cached(
+        db_session,
+        "example.com",
+        [],
+        sources,
+    )
+    second, second_cached, _ = await build_source_reputation_cached(
+        db_session,
+        "example.com",
+        [],
+        sources,
+    )
+
+    assert first.status == "clean"
+    assert second.status == "clean"
+    assert first_cached is False
+    assert second_cached is True
+    assert calls == 1

--- a/backend/app/tests/test_source_reputation_feeds.py
+++ b/backend/app/tests/test_source_reputation_feeds.py
@@ -1,12 +1,15 @@
 from types import SimpleNamespace
 
+import dns.resolver
 import pytest
 
 from app.services.source_reputation_feeds import (
+    DNSBLFeedProvider,
     FeedProviderConfig,
     StaticFeedProvider,
     feed_registry,
     lookup_ip_reputation_cached,
+    lookup_sources_reputation_cached,
     provider_configs_from_settings,
 )
 
@@ -65,7 +68,36 @@ def test_feed_registry_exposes_safe_metadata_only():
     assert registry["spamcop_scbl"]["enabled"] is True
     assert registry["barracuda_brbl"]["enabled"] is True
     assert registry["spamhaus_dqs"]["enabled"] is False
+    assert registry["spamcop_scbl"]["configured"] is True
+    assert registry["spamhaus_dqs"]["configured"] is False
+    assert "query_zone" not in registry["spamcop_scbl"]
     assert "secret" not in registry["spamcop_scbl"]
+
+
+class NoNameserversResolver:
+    lifetime = 0.0
+    timeout = 0.0
+
+    def resolve(self, *_args, **_kwargs):
+        raise dns.resolver.NoNameservers()
+
+
+@pytest.mark.asyncio
+async def test_dnsbl_no_nameservers_reports_provider_error():
+    provider = DNSBLFeedProvider(
+        FeedProviderConfig(
+            provider_id="demo_feed",
+            display_name="Demo Reputation Feed",
+            enabled=True,
+            query_zone="example.test",
+        ),
+        resolver=NoNameserversResolver(),
+    )
+
+    evidence = await provider.lookup_ip("8.8.8.8")
+
+    assert evidence.status == "error"
+    assert "nameserver" in evidence.detail.lower()
 
 
 @pytest.mark.asyncio
@@ -97,3 +129,26 @@ async def test_lookup_ip_reputation_cached_reuses_provider_result(db_session):
     assert first_cached is False
     assert second_cached is True
     assert second.listed is True
+
+
+@pytest.mark.asyncio
+async def test_lookup_sources_reputation_filters_ineligible_ips_before_max_limit(db_session):
+    provider = StaticFeedProvider(
+        FeedProviderConfig(
+            provider_id="demo_feed",
+            display_name="Demo Reputation Feed",
+            enabled=True,
+            listing_name="Demo RBL",
+        ),
+        {"8.8.8.8": "Demo RBL"},
+    )
+
+    results = await lookup_sources_reputation_cached(
+        db_session,
+        ["10.0.0.1", "not-an-ip", "8.8.8.8"],
+        [provider],
+        max_ips=1,
+    )
+
+    assert list(results) == ["8.8.8.8"]
+    assert results["8.8.8.8"].listed is True

--- a/backend/app/tests/test_source_reputation_feeds.py
+++ b/backend/app/tests/test_source_reputation_feeds.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.source_reputation_feeds import (
+    FeedProviderConfig,
+    StaticFeedProvider,
+    feed_registry,
+    lookup_ip_reputation_cached,
+    provider_configs_from_settings,
+)
+
+
+def _settings(**overrides):
+    values = {
+        "SOURCE_REPUTATION_FEEDS_ENABLED": False,
+        "SOURCE_REPUTATION_FEEDS": None,
+        "SOURCE_REPUTATION_SPAMHAUS_DQS_ZONE": None,
+        "SOURCE_REPUTATION_FEED_TIMEOUT_SECONDS": 2.0,
+        "SOURCE_REPUTATION_FEED_CACHE_SECONDS": 86_400,
+        "SOURCE_REPUTATION_FEED_MAX_IPS": 100,
+        "DEMO_MODE": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_provider_configs_are_disabled_by_default():
+    configs = provider_configs_from_settings(_settings())
+
+    assert {item.provider_id for item in configs} == {
+        "spamhaus_dqs",
+        "spamcop_scbl",
+        "barracuda_brbl",
+    }
+    assert all(item.enabled is False for item in configs)
+    assert all(item.requires_terms is True for item in configs)
+
+
+def test_spamhaus_dqs_requires_configured_query_zone():
+    without_zone = provider_configs_from_settings(
+        _settings(SOURCE_REPUTATION_FEEDS_ENABLED=True, SOURCE_REPUTATION_FEEDS="spamhaus_dqs")
+    )
+    with_zone = provider_configs_from_settings(
+        _settings(
+            SOURCE_REPUTATION_FEEDS_ENABLED=True,
+            SOURCE_REPUTATION_FEEDS="spamhaus_dqs",
+            SOURCE_REPUTATION_SPAMHAUS_DQS_ZONE="example.dq.spamhaus.net",
+        )
+    )
+
+    assert without_zone[0].enabled is False
+    assert with_zone[0].enabled is True
+    assert with_zone[0].query_zone == "example.dq.spamhaus.net"
+
+
+def test_feed_registry_exposes_safe_metadata_only():
+    registry = feed_registry(
+        _settings(
+            SOURCE_REPUTATION_FEEDS_ENABLED=True,
+            SOURCE_REPUTATION_FEEDS="spamcop_scbl,barracuda_brbl",
+        )
+    )
+
+    assert registry["spamcop_scbl"]["enabled"] is True
+    assert registry["barracuda_brbl"]["enabled"] is True
+    assert registry["spamhaus_dqs"]["enabled"] is False
+    assert "secret" not in registry["spamcop_scbl"]
+
+
+@pytest.mark.asyncio
+async def test_lookup_ip_reputation_cached_reuses_provider_result(db_session):
+    provider = StaticFeedProvider(
+        FeedProviderConfig(
+            provider_id="demo_feed",
+            display_name="Demo Reputation Feed",
+            enabled=True,
+            listing_name="Demo RBL",
+        ),
+        {"8.8.8.8": "Demo RBL"},
+    )
+
+    first, first_cached, _ = await lookup_ip_reputation_cached(
+        db_session,
+        "8.8.8.8",
+        [provider],
+    )
+    second, second_cached, _ = await lookup_ip_reputation_cached(
+        db_session,
+        "8.8.8.8",
+        [provider],
+    )
+
+    assert first.listed is True
+    assert first.evidence[0].status == "listed"
+    assert first.evidence[0].listing == "Demo RBL"
+    assert first_cached is False
+    assert second_cached is True
+    assert second.listed is True

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -77,6 +77,27 @@ For deployment verification, upgrades, rollback, and routine checks, use the [Op
 | `SESSION_LIFETIME` | Session lifetime in minutes | `1440` (24h) | `60`, `720` |
 | `DEMO_MODE` | Force generated demo reports and demo DNS records for public demo instances. Do not enable on production customer data. | `false` | `true` |
 
+### Sender Reputation Feeds
+
+External sender-IP reputation feeds are disabled by default. Enable them only
+after reviewing each provider's terms, credential model, rate limits, and
+privacy implications. DMARQ never needs these feeds to parse DMARC reports; they
+only enrich observed sending-source evidence.
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `SOURCE_REPUTATION_FEEDS_ENABLED` | Enable external reputation feed lookups. Demo mode still disables live external lookups. | `false` | `true` |
+| `SOURCE_REPUTATION_FEEDS` | Comma-separated enabled feed IDs. Supported first IDs are `spamhaus_dqs`, `spamcop_scbl`, and `barracuda_brbl`. | - | `spamhaus_dqs,spamcop_scbl` |
+| `SOURCE_REPUTATION_SPAMHAUS_DQS_ZONE` | Spamhaus DQS query zone assigned to your account. Required before the `spamhaus_dqs` provider becomes active. | - | `example.dq.spamhaus.net` |
+| `SOURCE_REPUTATION_FEED_TIMEOUT_SECONDS` | Per-provider DNSBL lookup timeout. | `2` | `2` |
+| `SOURCE_REPUTATION_FEED_CACHE_SECONDS` | Persistent cache TTL for per-IP feed results. | `86400` | `86400` |
+| `SOURCE_REPUTATION_FEED_MAX_IPS` | Maximum source IPs checked per reputation refresh. | `100` | `250` |
+
+Feed lookups are skipped for private, reserved, loopback, and otherwise
+non-global IP addresses. Feed failures are shown as evidence, but they do not
+create blacklist findings by themselves. A source is treated as listed only when
+a configured provider returns a positive listing response.
+
 ### Demo Mode
 
 Set `DEMO_MODE=true` only for public demo environments such as `demo.dmarq.org`.

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -84,9 +84,11 @@ Completed or substantially delivered:
 - DNS health checks for DMARC/SPF/DKIM plus posture checks for MTA-STS, TLS-RPT,
   BIMI, and passive DANE/TLSA readiness.
 - Passive sender IP reputation scoring from observed report evidence, known
-  sender context, local/demo metadata, reserved-address detection, and source
-  anomalies. External DNSBL and commercial reputation feeds remain modular
-  follow-up work.
+  sender context, local/demo metadata, reserved-address detection, source
+  anomalies, and an opt-in external DNSBL feed registry. Feed lookups are
+  disabled by default, cached, and currently cover Spamhaus DQS, SpamCop SCBL,
+  and Barracuda BRBL as the first provider set. Deeper commercial reputation
+  feed contracts and UI configuration remain follow-up work.
 - Cloudflare read-only inspection, DNS snapshots, and DNS change history.
 - Notifications, alert rules, alert history, and Apprise delivery.
 - API tokens, webhooks, SIEM templates, and ticketing/chatops templates.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -764,13 +764,20 @@ GET /domains/{domain_id}/source-reputation?days=30
 ```
 
 Returns cached, passive sender-IP reputation evidence for observed DMARC
-sources. This first slice does not query external DNSBL services directly; it
-scores existing DMARC evidence, known sender context, demo/provider metadata,
-reserved or malformed IPs, and source-intelligence anomalies. Rows include a
-bounded `risk_score`, `status`, optional listing names, first/last seen
-timestamps when report windows are available, evidence, and safe remediation
-steps. `GET /domains/{domain_id}/sources` embeds the same per-source
-`reputation` object next to sender, geo, anomaly, and SPF/DKIM context.
+sources. By default it scores existing DMARC evidence, known sender context,
+demo/provider metadata, reserved or malformed IPs, and source-intelligence
+anomalies without contacting third-party reputation services.
+
+When explicitly enabled by configuration, DMARQ can enrich this result with
+cached external reputation feed lookups. The first provider registry supports
+Spamhaus DQS, SpamCop SCBL, and Barracuda BRBL. External lookups are opt-in,
+bounded, cached, skipped for non-global IPs, and disabled in demo mode. Rows
+include a bounded `risk_score`, `status`, optional listing names, first/last
+seen timestamps when report windows are available, evidence, and safe
+remediation steps. The response also includes a `feeds` metadata map so UIs can
+show which external providers are available and whether they are active.
+`GET /domains/{domain_id}/sources` embeds the same per-source `reputation`
+object next to sender, geo, anomaly, and SPF/DKIM context.
 
 #### Get Health Score History
 


### PR DESCRIPTION
## Summary

- add an opt-in sender reputation feed registry for Spamhaus DQS, SpamCop SCBL, and Barracuda BRBL
- add cached DNSBL lookup plumbing with non-global IP skipping, timeout/error evidence, and demo-mode live-lookup disablement
- merge external feed listings into existing source reputation scoring, recommendations, and `/source-reputation` responses
- document env configuration, API response metadata, and roadmap state

## Safety / scope

- External feeds remain disabled by default.
- Spamhaus DQS is not active unless an operator configures the assigned DQS query zone.
- Demo mode does not perform live external feed lookups.
- Non-global IPs are never sent to external reputation feeds.
- Feed failures are evidence only; they do not create listings by themselves.

## Validation

- `.venv/bin/python -m pytest backend/app/tests/test_source_reputation.py backend/app/tests/test_source_reputation_feeds.py backend/app/tests/test_dns_endpoints.py -q` — 74 passed
- `.venv/bin/python -m pytest backend/app/tests -q` — 1419 passed
- `.venv/bin/flake8 backend/app` — passed
- targeted Black/isort checks for changed backend files — passed
- `.venv/bin/python -m compileall -q backend/app` — passed
- `.venv/bin/mkdocs build` — passed with existing documentation warnings

Notes:
- `mkdocs build --strict` still fails on pre-existing broken doc links unrelated to this change.
- Full `black backend/app --check` still reports pre-existing unformatted files unrelated to this change; changed files pass targeted Black/isort.

Closes #421.
