### PR TITLE
feat: add modular Authentik and OIDC auth modes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ SECRET_KEY="CHANGE_THIS_TO_A_RANDOM_SECRET_IN_PRODUCTION"
 # Affects HSTS and other security settings
 ENVIRONMENT="development"
 
+# Public URL used for OAuth callbacks when DMARQ is behind a proxy/ingress.
+# PUBLIC_BASE_URL="https://app.example.com"
+
 # Database
 DATABASE_URL="sqlite:///./dmarq.db"
 # For production, use PostgreSQL:
@@ -45,6 +48,30 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # Optional Cloudflare API Integration (for Milestone 8)
 # CLOUDFLARE_API_TOKEN="your_cloudflare_api_token"
 # CLOUDFLARE_ZONE_ID="your_cloudflare_zone_id"
+
+# Authentication
+# AUTH_MODE options: auto, disabled, logto, authentik, oidc, trusted_proxy
+# AUTH_MODE="auto"
+# AUTH_DISABLED=false
+
+# Logto OIDC
+# LOGTO_ENDPOINT="https://your-tenant.logto.app"
+# LOGTO_APP_ID="your_logto_app_id"
+# LOGTO_APP_SECRET="your_logto_app_secret"
+# LOGTO_REDIRECT_URI="https://app.example.com/api/v1/auth/callback"
+
+# Authentik direct OIDC
+# AUTH_MODE="authentik"
+# AUTHENTIK_ISSUER_URL="https://idp.example.com/application/o/dmarq"
+# AUTHENTIK_CLIENT_ID="your_authentik_client_id"
+# AUTHENTIK_CLIENT_SECRET="your_authentik_client_secret"
+# AUTHENTIK_REDIRECT_URI="https://app.example.com/api/v1/auth/callback"
+# AUTHENTIK_ALLOWED_DOMAINS="example.com"
+
+# Authentik Outpost / trusted proxy mode.
+# Only enable when DMARQ is reachable exclusively through that proxy.
+# AUTH_MODE="trusted_proxy"
+# AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS="example.com"
 
 # Optional mail service sender-domain discovery
 # POSTMARK_ACCOUNT_TOKEN="your_postmark_account_token"

--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -1,11 +1,11 @@
 """
-Authentication endpoints (Logto OIDC).
+Authentication endpoints (Logto, Authentik/OIDC, and trusted proxy).
 
 Routes
 ------
-GET  /sign-in          – Initiate the Logto sign-in flow.
-GET  /callback         – Handle the Logto authorization-code callback.
-GET  /sign-out         – Sign the user out (clears session + redirects to Logto).
+GET  /sign-in          – Initiate the configured sign-in flow.
+GET  /callback         – Handle the configured authorization-code callback.
+GET  /sign-out         – Sign the user out.
 GET  /me               – Return the currently authenticated user's profile.
 GET  /forgot-password  – Redirect to Logto's forgot-password screen (unauthenticated).
 GET  /change-password  – Redirect to Logto Account Center password page (authenticated).
@@ -24,6 +24,16 @@ from fastapi.responses import RedirectResponse
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
+from app.core.auth_providers import (
+    OIDC_STATE_COOKIE,
+    OIDC_STATE_MAX_AGE,
+    build_oidc_authorization_url,
+    configured_oidc_provider,
+    decode_oidc_state,
+    exchange_oidc_callback,
+    sync_external_user,
+    trusted_proxy_claims_from_request,
+)
 from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.logto import (
@@ -88,6 +98,23 @@ def _logto_not_configured() -> HTTPException:
     )
 
 
+def _auth_not_configured() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail=(
+            "Authentication is not configured. Configure Logto, Authentik/OIDC, "
+            "trusted proxy authentication, or AUTH_DISABLED=true for local use."
+        ),
+    )
+
+
+def _active_auth_provider() -> str:
+    provider = getattr(settings, "active_auth_provider", None)
+    if isinstance(provider, str):
+        return provider
+    return "logto" if getattr(settings, "logto_configured", False) else "unconfigured"
+
+
 def _get_redirect_uri(request: Request) -> str:
     """Build the callback redirect URI, preferring the configured override."""
     if settings.LOGTO_REDIRECT_URI:
@@ -105,14 +132,43 @@ async def sign_in(
     next: Optional[str] = None,
 ) -> RedirectResponse:
     """
-    Initiate the Logto OIDC sign-in flow.
+    Initiate the configured sign-in flow.
 
-    Stores the PKCE sign-in session in a short-lived cookie and redirects the
-    browser to Logto's authorization endpoint.  The optional ``next`` query
-    parameter is persisted in a separate cookie and used to redirect the user
-    to their original page after a successful login.
+    Logto keeps its SDK-backed PKCE storage.  Generic OIDC/AuthentiK uses a
+    signed state cookie.  Trusted proxy mode does not own the upstream sign-in
+    flow, so this route simply returns to the requested page.
     """
-    if not settings.logto_configured:
+    provider_name = _active_auth_provider()
+    if provider_name == "trusted_proxy":
+        return RedirectResponse(url=_safe_next(next), status_code=302)
+
+    if provider_name in {"oidc", "authentik"}:
+        provider = configured_oidc_provider(settings)
+        if provider is None:
+            raise _auth_not_configured()
+        safe = _safe_next(next)
+        try:
+            sign_in_url, state_token = await build_oidc_authorization_url(
+                request,
+                provider,
+                next_url=safe,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning("%s sign-in initialization failed: %s", provider.label, exc)
+            return RedirectResponse(url="/login?error=callback_failed", status_code=302)
+        response = RedirectResponse(url=sign_in_url, status_code=302)
+        response.set_cookie(
+            key=OIDC_STATE_COOKIE,
+            value=state_token,
+            httponly=True,
+            samesite="lax",
+            max_age=OIDC_STATE_MAX_AGE,
+        )
+        return response
+
+    if _active_auth_provider() != "logto" or not settings.logto_configured:
         raise _logto_not_configured()
 
     storage = CookieStorage(request)
@@ -137,19 +193,64 @@ async def sign_in(
     return response
 
 
+async def _handle_external_oidc_callback(
+    request: Request,
+    db: Session,
+) -> RedirectResponse:
+    """Handle the generic OIDC/AuthentiK authorization-code callback."""
+    provider = configured_oidc_provider(settings)
+    if provider is None:
+        raise _auth_not_configured()
+
+    query_state = request.query_params.get("state")
+    cookie_state = request.cookies.get(OIDC_STATE_COOKIE)
+    state_payload = decode_oidc_state(query_state or "", settings)
+    if not query_state or query_state != cookie_state or state_payload is None:
+        return RedirectResponse(url="/login?error=callback_failed", status_code=302)
+
+    code = request.query_params.get("code")
+    if not code:
+        return RedirectResponse(url="/login?error=callback_failed", status_code=302)
+
+    try:
+        claims = await exchange_oidc_callback(request, provider, code=code)
+        user = sync_external_user(claims, db)
+    except HTTPException as exc:
+        logger.warning("%s callback rejected: %s", provider.label, exc.detail)
+        return RedirectResponse(url="/login?error=callback_failed", status_code=302)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning("%s callback error: %s", provider.label, exc)
+        return RedirectResponse(url="/login?error=token_error", status_code=302)
+
+    response = RedirectResponse(url=_safe_next(state_payload.get("next")), status_code=302)
+    response.set_cookie(
+        key=SESSION_COOKIE,
+        value=create_session_token(user.id),
+        httponly=True,
+        samesite="lax",
+        max_age=86_400,
+    )
+    response.delete_cookie(key=OIDC_STATE_COOKIE, httponly=True, samesite="lax")
+    logger.info("User id=%d logged in via %s.", user.id, provider.label)
+    return response
+
+
 @router.get("/callback")
 async def callback(
     request: Request,
     db: Session = Depends(get_db),
 ) -> RedirectResponse:
     """
-    Handle the Logto authorization-code callback.
+    Handle the configured authorization-code callback.
 
-    Exchanges the code for tokens, validates the ID token, upserts the local
-    user shadow record, issues the app-level session cookie, and clears the
-    temporary Logto cookies.
+    Exchanges the code for tokens, upserts the local user shadow record, issues
+    the app-level session cookie, and clears temporary provider cookies.
     """
-    if not settings.logto_configured:
+    provider_name = _active_auth_provider()
+    if provider_name in {"oidc", "authentik"}:
+        return await _handle_external_oidc_callback(request, db)
+
+    if provider_name != "logto" or not settings.logto_configured:
         raise _logto_not_configured()
 
     storage = CookieStorage(request)
@@ -199,17 +300,18 @@ async def sign_out(request: Request) -> RedirectResponse:
 
     When ``AUTH_DISABLED=true`` there is nothing to sign out of; redirects to ``/``.
 
-    Otherwise clears the app session cookie and redirects to Logto's end-session
-    endpoint (if available) so that the Logto session is terminated too.
+    Logto deployments use Logto's end-session endpoint when available.  Generic
+    OIDC/AuthentiK and trusted-proxy deployments clear DMARQ's session and
+    return to the login page.
     """
-    if settings.AUTH_DISABLED:
+    if settings.AUTH_DISABLED or _active_auth_provider() == "disabled":
         return RedirectResponse(url="/", status_code=302)
 
     post_logout_url = str(request.base_url).rstrip("/")
 
     # Best-effort: obtain Logto's end-session URL from OIDC metadata.
     end_session_url: Optional[str] = None
-    if settings.logto_configured:
+    if _active_auth_provider() == "logto" and settings.logto_configured:
         try:
             storage = CookieStorage(request)
             client = make_logto_client(storage)
@@ -238,7 +340,7 @@ async def change_password(request: Request) -> RedirectResponse:
     query parameter is appended so that Logto returns the user to the Profile &
     Security page after a successful update.
     """
-    if not settings.logto_configured:
+    if _active_auth_provider() != "logto" or not settings.logto_configured:
         raise _logto_not_configured()
 
     base = str(request.base_url).rstrip("/")
@@ -260,7 +362,7 @@ async def forgot_password(request: Request) -> RedirectResponse:
     This endpoint is kept for unauthenticated / "I forgot my password" use
     cases.  Authenticated users should use ``/change-password`` instead.
     """
-    if not settings.logto_configured:
+    if _active_auth_provider() != "logto" or not settings.logto_configured:
         raise _logto_not_configured()
 
     storage = CookieStorage(request)
@@ -290,7 +392,7 @@ async def manage_mfa(request: Request) -> RedirectResponse:
     query parameter is appended so that Logto returns the user to the Profile &
     Security page after a successful update.
     """
-    if not settings.logto_configured:
+    if _active_auth_provider() != "logto" or not settings.logto_configured:
         raise _logto_not_configured()
 
     base = str(request.base_url).rstrip("/")
@@ -312,7 +414,7 @@ async def account_portal(request: Request) -> RedirectResponse:
     appended so that Logto returns the user to the Profile & Security page
     after a successful update.
     """
-    if not settings.logto_configured:
+    if _active_auth_provider() != "logto" or not settings.logto_configured:
         raise _logto_not_configured()
 
     base = str(request.base_url).rstrip("/")
@@ -334,8 +436,10 @@ async def get_current_user(
     Otherwise reads the ``dmarq_session`` cookie (issued at callback time) and
     looks up the corresponding local ``User`` record.
     """
+    provider_name = _active_auth_provider()
+
     # Auth-disabled: return a synthetic profile so the UI renders correctly.
-    if settings.AUTH_DISABLED:
+    if settings.AUTH_DISABLED or provider_name == "disabled":
         return {
             "id": 0,
             "email": "admin@localhost",
@@ -345,6 +449,23 @@ async def get_current_user(
             "is_superuser": True,
             "logto_id": None,
             "auth_disabled": True,
+            "auth_provider": "disabled",
+            "auth_provider_label": "No authentication",
+        }
+
+    trusted_claims = trusted_proxy_claims_from_request(request, settings)
+    if trusted_claims is not None:
+        return {
+            "id": 0,
+            "email": trusted_claims.email,
+            "full_name": trusted_claims.name,
+            "username": trusted_claims.username,
+            "picture": trusted_claims.picture,
+            "is_superuser": True,
+            "logto_id": f"{trusted_claims.provider}:{trusted_claims.subject}",
+            "auth_disabled": False,
+            "auth_provider": trusted_claims.provider,
+            "auth_provider_label": getattr(settings, "auth_provider_label", "Trusted proxy"),
         }
 
     token = request.cookies.get(SESSION_COOKIE)
@@ -378,4 +499,6 @@ async def get_current_user(
         "picture": user.picture,
         "is_superuser": user.is_superuser,
         "logto_id": user.logto_id,
+        "auth_provider": provider_name,
+        "auth_provider_label": getattr(settings, "auth_provider_label", "Authentication"),
     }

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -26,6 +26,7 @@ from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.mail_source_backfill import MailSourceBackfillJob
 from app.models.mail_source_import import MailSourceImport
+from app.models.setting import Setting
 from app.services.demo_data import (
     build_demo_mail_source_backfills,
     build_demo_mail_sources,
@@ -59,6 +60,7 @@ _OAUTH_STATE_TTL = timedelta(minutes=10)
 BACKFILL_RETRYABLE_STATUSES = {"failed", "cancelled", "backoff"}
 BACKFILL_CANCELABLE_STATUSES = {"queued", "running", "backoff"}
 BACKFILL_SUPPORTED_METHODS = {"IMAP", "GMAIL_API", "M365_GRAPH"}
+GENERAL_BASE_URL_KEY = "general.base_url"
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +239,27 @@ def _sanitize_for_log(value: object) -> str:
 def _redact_sensitive_text(value: object) -> str:
     """Remove log-injection characters and redact secret-like diagnostic text."""
     return redact_recovery_text(value)
+
+
+def _setting_value(db: Session, key: str) -> Optional[str]:
+    row = db.query(Setting).filter(Setting.key == key).first()
+    return row.value if row and row.value else None
+
+
+def _public_base_url(request: Request, db: Session) -> str:
+    """Return the externally visible base URL for OAuth redirect URIs."""
+    configured = get_settings().PUBLIC_BASE_URL or _setting_value(db, GENERAL_BASE_URL_KEY)
+    if configured:
+        return configured.rstrip("/")
+
+    base_url = str(request.base_url).rstrip("/")
+    forwarded_proto = (
+        (request.headers.get("x-forwarded-proto") or "").split(",", maxsplit=1)[0].strip()
+    )
+    if forwarded_proto in {"http", "https"} and "://" in base_url:
+        _, rest = base_url.split("://", maxsplit=1)
+        return f"{forwarded_proto}://{rest}".rstrip("/")
+    return base_url
 
 
 def _diagnostic_category(message: str, details: Optional[object] = None) -> str:
@@ -1686,7 +1709,7 @@ async def m365_authorize_url(
             detail="m365_client_id is not configured for this source.",
         )
 
-    base_url = str(request.base_url).rstrip("/")
+    base_url = _public_base_url(request, db)
     redirect_uri = f"{base_url}/api/v1/mail-sources/{source_id}/m365/callback"
     auth_url = MicrosoftGraphClient.build_authorization_url(
         tenant_id=source.m365_tenant_id or "common",
@@ -1801,7 +1824,7 @@ async def m365_oauth_callback(
             status_code=404,
         )
 
-    base_url = str(request.base_url).rstrip("/")
+    base_url = _public_base_url(request, db)
     redirect_uri = f"{base_url}/api/v1/mail-sources/{source_id}/m365/callback"
 
     try:
@@ -2047,7 +2070,7 @@ async def gmail_authorize_url(
         )
 
     # Build a redirect_uri that points back to this server's callback endpoint
-    base_url = str(request.base_url).rstrip("/")
+    base_url = _public_base_url(request, db)
     redirect_uri = f"{base_url}/api/v1/mail-sources/{source_id}/gmail/callback"
 
     auth_url = GmailClient.build_authorization_url(
@@ -2105,7 +2128,7 @@ async def gmail_oauth_callback(
             status_code=404,
         )
 
-    base_url = str(request.base_url).rstrip("/")
+    base_url = _public_base_url(request, db)
     redirect_uri = f"{base_url}/api/v1/mail-sources/{source_id}/gmail/callback"
 
     try:

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -1,0 +1,340 @@
+"""Provider-neutral authentication helpers for external identity providers."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Optional
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import HTTPException, Request, status
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings, get_settings
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+OIDC_STATE_COOKIE = "dmarq_oidc_state"
+OIDC_STATE_MAX_AGE = 600
+
+
+@dataclass(frozen=True)
+class OIDCProviderConfig:
+    """Runtime OIDC provider configuration."""
+
+    provider: str
+    label: str
+    issuer_url: str
+    client_id: str
+    client_secret: str
+    redirect_uri: Optional[str]
+    scopes: str
+    skip_ssl_verify: bool
+    allowed_emails: Optional[str] = None
+    allowed_domains: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ExternalIdentityClaims:
+    """Normalized user claims from an external IdP or trusted proxy."""
+
+    provider: str
+    subject: str
+    email: str
+    name: Optional[str] = None
+    username: Optional[str] = None
+    picture: Optional[str] = None
+    email_verified: bool = False
+
+
+def _split_csv(value: Optional[str]) -> set[str]:
+    if not value:
+        return set()
+    return {item.strip().lower() for item in value.split(",") if item.strip()}
+
+
+def email_allowed(
+    email: str,
+    *,
+    allowed_emails: Optional[str] = None,
+    allowed_domains: Optional[str] = None,
+) -> bool:
+    """Return True when *email* is allowed by optional comma-separated allow lists."""
+    normalized = (email or "").strip().lower()
+    if not normalized or "@" not in normalized:
+        return False
+    explicit_emails = _split_csv(allowed_emails)
+    explicit_domains = _split_csv(allowed_domains)
+    if not explicit_emails and not explicit_domains:
+        return True
+    domain = normalized.rsplit("@", 1)[1]
+    return normalized in explicit_emails or domain in explicit_domains
+
+
+def configured_oidc_provider(settings: Settings | None = None) -> Optional[OIDCProviderConfig]:
+    """Return the active direct-OIDC provider config, if direct OIDC is selected."""
+    cfg = settings or get_settings()
+    provider = getattr(cfg, "active_auth_provider", "unconfigured")
+    if provider == "authentik":
+        issuer = cfg.AUTHENTIK_ISSUER_URL or cfg.OIDC_ISSUER_URL
+        client_id = cfg.AUTHENTIK_CLIENT_ID or cfg.OIDC_CLIENT_ID
+        client_secret = cfg.AUTHENTIK_CLIENT_SECRET or cfg.OIDC_CLIENT_SECRET
+        if not issuer or not client_id or not client_secret:
+            return None
+        return OIDCProviderConfig(
+            provider="authentik",
+            label="Authentik",
+            issuer_url=issuer.rstrip("/"),
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uri=cfg.AUTHENTIK_REDIRECT_URI or cfg.OIDC_REDIRECT_URI,
+            scopes=cfg.AUTHENTIK_SCOPES or cfg.OIDC_SCOPES,
+            skip_ssl_verify=cfg.OIDC_SKIP_SSL_VERIFY,
+            allowed_emails=cfg.AUTHENTIK_ALLOWED_EMAILS or cfg.OIDC_ALLOWED_EMAILS,
+            allowed_domains=cfg.AUTHENTIK_ALLOWED_DOMAINS or cfg.OIDC_ALLOWED_DOMAINS,
+        )
+    if provider == "oidc":
+        if not cfg.OIDC_ISSUER_URL or not cfg.OIDC_CLIENT_ID or not cfg.OIDC_CLIENT_SECRET:
+            return None
+        return OIDCProviderConfig(
+            provider="oidc",
+            label=cfg.OIDC_PROVIDER_LABEL or "OpenID Connect",
+            issuer_url=cfg.OIDC_ISSUER_URL.rstrip("/"),
+            client_id=cfg.OIDC_CLIENT_ID,
+            client_secret=cfg.OIDC_CLIENT_SECRET,
+            redirect_uri=cfg.OIDC_REDIRECT_URI,
+            scopes=cfg.OIDC_SCOPES,
+            skip_ssl_verify=cfg.OIDC_SKIP_SSL_VERIFY,
+            allowed_emails=cfg.OIDC_ALLOWED_EMAILS,
+            allowed_domains=cfg.OIDC_ALLOWED_DOMAINS,
+        )
+    return None
+
+
+def default_redirect_uri(request: Request) -> str:
+    """Build the default OIDC callback URL for this request."""
+    base = str(request.base_url).rstrip("/")
+    return f"{base}/api/v1/auth/callback"
+
+
+def create_oidc_state(next_url: str, settings: Settings | None = None) -> str:
+    """Create a signed, short-lived OIDC state token."""
+    cfg = settings or get_settings()
+    payload = {
+        "type": OIDC_STATE_COOKIE,
+        "next": next_url,
+        "exp": datetime.utcnow() + timedelta(seconds=OIDC_STATE_MAX_AGE),
+    }
+    return jwt.encode(payload, cfg.SECRET_KEY, algorithm=cfg.ALGORITHM)
+
+
+def decode_oidc_state(value: str, settings: Settings | None = None) -> Optional[dict[str, Any]]:
+    """Validate a signed OIDC state token and return its payload."""
+    cfg = settings or get_settings()
+    try:
+        payload = jwt.decode(value, cfg.SECRET_KEY, algorithms=[cfg.ALGORITHM])
+        if payload.get("type") != OIDC_STATE_COOKIE:
+            return None
+        return payload
+    except (JWTError, TypeError, ValueError):
+        return None
+
+
+async def fetch_oidc_discovery(provider: OIDCProviderConfig) -> dict[str, Any]:
+    """Fetch the provider's OIDC discovery document."""
+    url = f"{provider.issuer_url}/.well-known/openid-configuration"
+    async with httpx.AsyncClient(
+        timeout=10,
+        verify=not provider.skip_ssl_verify,
+        follow_redirects=True,
+    ) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        metadata = response.json()
+    if not metadata.get("authorization_endpoint") or not metadata.get("token_endpoint"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="OIDC discovery document is missing required endpoints.",
+        )
+    return metadata
+
+
+async def build_oidc_authorization_url(
+    request: Request,
+    provider: OIDCProviderConfig,
+    *,
+    next_url: str,
+) -> tuple[str, str]:
+    """Return the provider authorization URL and signed state token."""
+    metadata = await fetch_oidc_discovery(provider)
+    redirect_uri = provider.redirect_uri or default_redirect_uri(request)
+    state = create_oidc_state(next_url)
+    params = {
+        "client_id": provider.client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": provider.scopes,
+        "state": state,
+    }
+    return f"{metadata['authorization_endpoint']}?{urlencode(params)}", state
+
+
+async def exchange_oidc_callback(
+    request: Request,
+    provider: OIDCProviderConfig,
+    *,
+    code: str,
+) -> ExternalIdentityClaims:
+    """Exchange an authorization code and return normalized user claims."""
+    metadata = await fetch_oidc_discovery(provider)
+    redirect_uri = provider.redirect_uri or default_redirect_uri(request)
+    async with httpx.AsyncClient(
+        timeout=10,
+        verify=not provider.skip_ssl_verify,
+        follow_redirects=True,
+    ) as client:
+        token_response = await client.post(
+            metadata["token_endpoint"],
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": provider.client_id,
+                "client_secret": provider.client_secret,
+            },
+            headers={"Accept": "application/json"},
+        )
+        token_response.raise_for_status()
+        token_payload = token_response.json()
+
+        access_token = token_payload.get("access_token")
+        claims_payload: dict[str, Any] = {}
+        userinfo_endpoint = metadata.get("userinfo_endpoint")
+        if access_token and userinfo_endpoint:
+            userinfo_response = await client.get(
+                userinfo_endpoint,
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            userinfo_response.raise_for_status()
+            claims_payload = userinfo_response.json()
+        elif token_payload.get("id_token"):
+            claims_payload = jwt.get_unverified_claims(token_payload["id_token"])
+
+    return normalize_external_claims(
+        provider.provider,
+        claims_payload,
+        allowed_emails=provider.allowed_emails,
+        allowed_domains=provider.allowed_domains,
+    )
+
+
+def normalize_external_claims(
+    provider: str,
+    payload: dict[str, Any],
+    *,
+    allowed_emails: Optional[str] = None,
+    allowed_domains: Optional[str] = None,
+) -> ExternalIdentityClaims:
+    """Normalize provider-specific claim JSON into the DMARQ user shape."""
+    subject = str(payload.get("sub") or payload.get("uid") or "").strip()
+    email = str(payload.get("email") or "").strip().lower()
+    if not subject:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="OIDC provider did not return a stable subject claim.",
+        )
+    if not email_allowed(email, allowed_emails=allowed_emails, allowed_domains=allowed_domains):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Authenticated identity is not allowed to access this DMARQ instance.",
+        )
+    return ExternalIdentityClaims(
+        provider=provider,
+        subject=subject,
+        email=email,
+        name=payload.get("name"),
+        username=payload.get("preferred_username") or payload.get("username"),
+        picture=payload.get("picture"),
+        email_verified=bool(payload.get("email_verified", False)),
+    )
+
+
+def sync_external_user(claims: ExternalIdentityClaims, db: Session) -> User:
+    """Upsert a local user for a non-Logto external identity."""
+    identity_id = f"{claims.provider}:{claims.subject}"
+    user: Optional[User] = db.query(User).filter(User.logto_id == identity_id).first()
+    if user is None:
+        user = db.query(User).filter(User.email == claims.email).first()
+        if user is not None:
+            user.logto_id = identity_id
+            logger.info("Linked user id=%d (%s) to %s", user.id, claims.email, identity_id)
+    if user is None:
+        user = User(
+            logto_id=identity_id,
+            email=claims.email,
+            is_active=True,
+            is_superuser=True,
+            is_verified=claims.email_verified,
+        )
+        db.add(user)
+        db.flush()
+        logger.info("Created user id=%d from %s", user.id, identity_id)
+
+    user.full_name = claims.name or user.full_name
+    user.username = claims.username or user.username
+    user.picture = claims.picture or user.picture
+    user.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def trusted_proxy_claims_from_request(
+    request: Request,
+    settings: Settings | None = None,
+) -> Optional[ExternalIdentityClaims]:
+    """Return trusted-proxy claims when explicit trusted proxy auth is enabled."""
+    cfg = settings or get_settings()
+    if not getattr(cfg, "trusted_proxy_configured", False):
+        return None
+    email = request.headers.get(cfg.AUTH_TRUSTED_PROXY_EMAIL_HEADER, "").strip().lower()
+    subject = request.headers.get(cfg.AUTH_TRUSTED_PROXY_SUBJECT_HEADER, "").strip()
+    if not email:
+        return None
+    if not email_allowed(
+        email,
+        allowed_emails=cfg.AUTH_TRUSTED_PROXY_ALLOWED_EMAILS,
+        allowed_domains=cfg.AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS,
+    ):
+        return None
+    provider = (cfg.AUTH_TRUSTED_PROXY_PROVIDER or "trusted_proxy").strip().lower()
+    return ExternalIdentityClaims(
+        provider=provider,
+        subject=subject or email,
+        email=email,
+        name=request.headers.get(cfg.AUTH_TRUSTED_PROXY_NAME_HEADER),
+        username=request.headers.get(cfg.AUTH_TRUSTED_PROXY_USERNAME_HEADER),
+        email_verified=True,
+    )
+
+
+def trusted_proxy_auth_context(
+    request: Request,
+    settings: Settings | None = None,
+) -> Optional[dict[str, Any]]:
+    """Return an auth context for a trusted proxy identity."""
+    claims = trusted_proxy_claims_from_request(request, settings)
+    if claims is None:
+        return None
+    return {
+        "auth_type": "trusted_proxy",
+        "provider": claims.provider,
+        "sub": f"{claims.provider}:{claims.subject}",
+        "email": claims.email,
+        "name": claims.name,
+        "username": claims.username,
+    }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     API_V1_STR: str = "/api/v1"
     ENVIRONMENT: str = "development"
     DEMO_MODE: bool = False
+    PUBLIC_BASE_URL: Optional[str] = None
 
     # Database
     # Default to a sub-directory so the SQLite file lives in a location that
@@ -76,6 +77,44 @@ class Settings(BaseSettings):
     #     Never expose an AUTH_DISABLED instance directly to the internet.
     AUTH_DISABLED: bool = False
     ALLOW_AUTH_DISABLED_IN_PRODUCTION: bool = False
+    # Optional explicit auth mode.  Keep unset/"auto" for backwards-compatible
+    # Logto auto-detection.  Supported values: auto, disabled, logto, oidc,
+    # authentik, trusted_proxy.
+    AUTH_MODE: str = "auto"
+
+    # ── Generic OIDC / Authentik OIDC ────────────────────────────────────────
+    # DMARQ can authenticate directly against any standards-based OIDC provider.
+    # For Authentik, set AUTH_MODE=authentik and the AUTHENTIK_* values below.
+    OIDC_ISSUER_URL: Optional[str] = None
+    OIDC_CLIENT_ID: Optional[str] = None
+    OIDC_CLIENT_SECRET: Optional[str] = None
+    OIDC_REDIRECT_URI: Optional[str] = None
+    OIDC_SCOPES: str = "openid email profile"
+    OIDC_PROVIDER_LABEL: str = "OpenID Connect"
+    OIDC_SKIP_SSL_VERIFY: bool = False
+    ALLOW_OIDC_SKIP_SSL_VERIFY_IN_PRODUCTION: bool = False
+    OIDC_ALLOWED_EMAILS: Optional[str] = None
+    OIDC_ALLOWED_DOMAINS: Optional[str] = None
+
+    AUTHENTIK_ISSUER_URL: Optional[str] = None
+    AUTHENTIK_CLIENT_ID: Optional[str] = None
+    AUTHENTIK_CLIENT_SECRET: Optional[str] = None
+    AUTHENTIK_REDIRECT_URI: Optional[str] = None
+    AUTHENTIK_SCOPES: str = "openid email profile"
+    AUTHENTIK_ALLOWED_EMAILS: Optional[str] = None
+    AUTHENTIK_ALLOWED_DOMAINS: Optional[str] = None
+
+    # ── Trusted proxy / Authentik Outpost mode ───────────────────────────────
+    # Use only when DMARQ is reachable exclusively through the trusted proxy.
+    AUTH_TRUSTED_PROXY_ENABLED: bool = False
+    AUTH_TRUSTED_PROXY_PROVIDER: str = "authentik"
+    AUTH_TRUSTED_PROXY_EMAIL_HEADER: str = "X-Authentik-Email"
+    AUTH_TRUSTED_PROXY_NAME_HEADER: str = "X-Authentik-Name"
+    AUTH_TRUSTED_PROXY_USERNAME_HEADER: str = "X-Authentik-Username"
+    AUTH_TRUSTED_PROXY_SUBJECT_HEADER: str = "X-Authentik-Uid"
+    AUTH_TRUSTED_PROXY_GROUPS_HEADER: str = "X-Authentik-Groups"
+    AUTH_TRUSTED_PROXY_ALLOWED_EMAILS: Optional[str] = None
+    AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS: Optional[str] = None
 
     # ── Logto OIDC ────────────────────────────────────────────────────────────
     # Set these to enable Logto-based authentication.
@@ -99,6 +138,79 @@ class Settings(BaseSettings):
     def logto_configured(self) -> bool:
         """Return True when the minimum Logto settings are present."""
         return bool(self.LOGTO_ENDPOINT and self.LOGTO_APP_ID and self.LOGTO_APP_SECRET)
+
+    @property
+    def generic_oidc_configured(self) -> bool:
+        """Return True when the generic OIDC settings are present."""
+        return bool(self.OIDC_ISSUER_URL and self.OIDC_CLIENT_ID and self.OIDC_CLIENT_SECRET)
+
+    @property
+    def authentik_configured(self) -> bool:
+        """Return True when Authentik direct OIDC settings are present."""
+        return bool(
+            self.AUTHENTIK_ISSUER_URL and self.AUTHENTIK_CLIENT_ID and self.AUTHENTIK_CLIENT_SECRET
+        )
+
+    @property
+    def trusted_proxy_configured(self) -> bool:
+        """Return True when trusted proxy authentication is explicitly enabled."""
+        return self.AUTH_TRUSTED_PROXY_ENABLED or self.AUTH_MODE.strip().lower() in {
+            "trusted_proxy",
+            "authentik_proxy",
+            "proxy",
+        }
+
+    @property
+    def active_auth_provider(self) -> str:
+        """Return the configured browser authentication provider."""
+        mode = (self.AUTH_MODE or "auto").strip().lower()
+        if self.AUTH_DISABLED or mode in {"disabled", "none", "off", "no_auth"}:
+            return "disabled"
+        if mode in {"trusted_proxy", "authentik_proxy", "proxy"}:
+            return "trusted_proxy"
+        if mode == "logto":
+            return "logto"
+        if mode in {"authentik", "authentik_oidc"}:
+            return "authentik"
+        if mode in {"oidc", "generic_oidc", "multi_user_oidc", "single_external_user"}:
+            return "oidc"
+        if self.trusted_proxy_configured:
+            return "trusted_proxy"
+        if self.logto_configured:
+            return "logto"
+        if self.authentik_configured:
+            return "authentik"
+        if self.generic_oidc_configured:
+            return "oidc"
+        return "unconfigured"
+
+    @property
+    def auth_configured(self) -> bool:
+        """Return True when browser authentication has a usable path."""
+        return self.active_auth_provider in {
+            "disabled",
+            "logto",
+            "authentik",
+            "oidc",
+            "trusted_proxy",
+        }
+
+    @property
+    def auth_provider_label(self) -> str:
+        """Return a short UI label for the active auth provider."""
+        provider = self.active_auth_provider
+        if provider == "disabled":
+            return "No authentication"
+        if provider == "logto":
+            return "Logto"
+        if provider == "authentik":
+            return "Authentik"
+        if provider == "trusted_proxy":
+            proxy = (self.AUTH_TRUSTED_PROXY_PROVIDER or "trusted proxy").strip()
+            return "Authentik Outpost" if proxy.lower() == "authentik" else proxy
+        if provider == "oidc":
+            return self.OIDC_PROVIDER_LABEL or "OpenID Connect"
+        return "Not configured"
 
     @property
     def is_production(self) -> bool:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -173,7 +173,8 @@ async def require_admin_auth(
 
     Accepts (in priority order):
     1. ``AUTH_DISABLED=true`` env var – passes through with a synthetic context.
-    2. ``dmarq_session`` cookie – set after a successful Logto login.
+    2. Trusted proxy headers – only when explicitly configured.
+    3. ``dmarq_session`` cookie – set after a successful browser login.
     3. ``X-API-Key`` header    – static admin key for programmatic access.
     4. ``Authorization: Bearer <token>`` header – app-issued JWT.
 
@@ -181,10 +182,17 @@ async def require_admin_auth(
     authenticated.  Raises ``HTTP 401`` when no valid credential is present.
     """
     # 0. Auth globally disabled
-    if settings.AUTH_DISABLED:
+    if settings.AUTH_DISABLED or getattr(settings, "active_auth_provider", "") == "disabled":
         return {"auth_type": "disabled"}
 
-    # 1. Session cookie (Logto-backed app session)
+    # 1. Trusted proxy / Authentik Outpost headers
+    from app.core.auth_providers import trusted_proxy_auth_context  # local import
+
+    proxy_context = trusted_proxy_auth_context(request, settings)
+    if proxy_context is not None:
+        return proxy_context
+
+    # 2. Session cookie (external-IdP-backed app session)
     from app.core.logto import SESSION_COOKIE, decode_session_token  # local import
 
     session_token = request.cookies.get(SESSION_COOKIE)
@@ -193,11 +201,11 @@ async def require_admin_auth(
         if user_id is not None:
             return {"auth_type": "session", "user_id": user_id}
 
-    # 2. Static admin API key
+    # 3. Static admin API key
     if api_key and verify_api_key(api_key):
         return {"auth_type": "api_key"}
 
-    # 3. Bearer JWT (app-issued; also covers Bearer tokens set by older clients)
+    # 4. Bearer JWT (app-issued; also covers Bearer tokens set by older clients)
     if bearer:
         from app.core.logto import decode_session_token as _dec  # local import
 

--- a/backend/app/core/startup_checks.py
+++ b/backend/app/core/startup_checks.py
@@ -58,10 +58,19 @@ def validate_startup_configuration(settings: Settings) -> StartupCheckResult:
             "ALLOW_LOGTO_SKIP_SSL_VERIFY_IN_PRODUCTION=true is also set."
         )
 
-    if not settings.AUTH_DISABLED and not settings.ADMIN_API_KEY and not settings.logto_configured:
+    if (
+        settings.OIDC_SKIP_SSL_VERIFY
+        and not settings.ALLOW_OIDC_SKIP_SSL_VERIFY_IN_PRODUCTION
+    ):
         errors.append(
-            "Production startup requires Logto settings or ADMIN_API_KEY. "
-            "Set LOGTO_ENDPOINT, LOGTO_APP_ID, and LOGTO_APP_SECRET, or set ADMIN_API_KEY."
+            "OIDC_SKIP_SSL_VERIFY=true is not allowed in production unless "
+            "ALLOW_OIDC_SKIP_SSL_VERIFY_IN_PRODUCTION=true is also set."
+        )
+
+    if not settings.AUTH_DISABLED and not settings.ADMIN_API_KEY and not settings.auth_configured:
+        errors.append(
+            "Production startup requires an authentication path or ADMIN_API_KEY. "
+            "Configure Logto, Authentik/OIDC, trusted proxy auth, or set ADMIN_API_KEY."
         )
 
     if settings.ADMIN_API_KEY and len(settings.ADMIN_API_KEY) < 32:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -597,6 +597,9 @@ async def login(request: Request, next: str = "/"):
         {
             "app_name": settings.PROJECT_NAME,
             "logto_configured": settings.logto_configured,
+            "auth_configured": settings.auth_configured,
+            "auth_provider": settings.active_auth_provider,
+            "auth_provider_label": settings.auth_provider_label,
             "auth_disabled": settings.AUTH_DISABLED,
             "next": next,
         },
@@ -611,6 +614,9 @@ async def setup(request: Request):
         {
             "app_name": settings.PROJECT_NAME,
             "logto_configured": settings.logto_configured,
+            "auth_configured": settings.auth_configured,
+            "auth_provider": settings.active_auth_provider,
+            "auth_provider_label": settings.auth_provider_label,
         },
     )
 
@@ -716,6 +722,9 @@ async def profile_page(request: Request):
         {
             "app_name": settings.PROJECT_NAME,
             "logto_configured": settings.logto_configured,
+            "auth_configured": settings.auth_configured,
+            "auth_provider": settings.active_auth_provider,
+            "auth_provider_label": settings.auth_provider_label,
             "auth_disabled": settings.AUTH_DISABLED,
         },
     )

--- a/backend/app/middleware/auth.py
+++ b/backend/app/middleware/auth.py
@@ -63,8 +63,8 @@ class AuthRedirectMiddleware(BaseHTTPMiddleware):
     Decision tree
     -------------
     1. Path is public → pass through.
-    2. Session cookie present and valid → pass through.
-    3. Logto not configured → redirect to ``/setup``.
+    2. Trusted proxy headers or session cookie present and valid → pass through.
+    3. Browser auth not configured → redirect to ``/setup``.
     4. Otherwise → redirect to ``/login?next=<original_path>``.
     """
 
@@ -78,7 +78,7 @@ class AuthRedirectMiddleware(BaseHTTPMiddleware):
         from app.core.config import get_settings  # local import avoids circular dep
 
         cfg = get_settings()
-        if cfg.AUTH_DISABLED:
+        if cfg.AUTH_DISABLED or getattr(cfg, "active_auth_provider", "") == "disabled":
             return await call_next(request)
 
         # ── 1. Public paths & prefixes ────────────────────────────────────────
@@ -89,16 +89,22 @@ class AuthRedirectMiddleware(BaseHTTPMiddleware):
         if any(path.endswith(ext) for ext in _STATIC_EXTENSIONS):
             return await call_next(request)
 
-        # ── 2. Valid session cookie ───────────────────────────────────────────
+        # ── 2. Trusted proxy / Authentik Outpost headers ─────────────────────
+        from app.core.auth_providers import trusted_proxy_auth_context
+
+        if trusted_proxy_auth_context(request, cfg) is not None:
+            return await call_next(request)
+
+        # ── 3. Valid session cookie ───────────────────────────────────────────
         token = request.cookies.get(SESSION_COOKIE)
         if token and decode_session_token(token) is not None:
             return await call_next(request)
 
-        # ── 3. Logto not configured ───────────────────────────────────────────
-        if not cfg.logto_configured:
+        # ── 4. Browser auth not configured ───────────────────────────────────
+        if not getattr(cfg, "auth_configured", False):
             return RedirectResponse(url="/setup", status_code=302)
 
-        # ── 4. Redirect to login ──────────────────────────────────────────────
+        # ── 5. Redirect to login ──────────────────────────────────────────────
         next_path = request.url.path
         if request.url.query:
             next_path = f"{next_path}?{request.url.query}"

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -120,7 +120,7 @@ def role_for_auth_context(auth_context: dict) -> str:
     authenticated admin context until they are moved to workspace-aware checks.
     """
     auth_type = (auth_context or {}).get("auth_type")
-    if auth_type in {"session", "bearer", "jwt", *PLATFORM_ADMIN_AUTH_TYPES}:
+    if auth_type in {"session", "bearer", "jwt", "trusted_proxy", *PLATFORM_ADMIN_AUTH_TYPES}:
         return ROLE_WORKSPACE_OWNER
     return ROLE_AUDITOR
 
@@ -195,7 +195,7 @@ def role_for_workspace(
 ) -> str:
     """Resolve the caller's effective role for one workspace."""
     auth_type = (auth_context or {}).get("auth_type")
-    if auth_type in {"api_key", "disabled"}:
+    if auth_type in {"api_key", "disabled", "trusted_proxy"}:
         return ROLE_WORKSPACE_OWNER
     if auth_type == "api_token":
         try:

--- a/backend/app/templates/login.html
+++ b/backend/app/templates/login.html
@@ -41,15 +41,15 @@
                     </p>
                 </div>
             </div>
-            {% elif not logto_configured %}
-            <!-- Logto not yet configured -->
+            {% elif not auth_configured %}
+            <!-- Authentication not yet configured -->
             <div role="alert" class="alert alert-warning">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
                 </svg>
                 <div>
                     <p class="font-semibold">Authentication not configured</p>
-                    <p class="text-sm">Logto is not set up yet. Please visit the
+                    <p class="text-sm">No identity provider is set up yet. Please visit the
                         <a href="/setup" class="link link-warning font-medium">setup page</a>
                         for configuration instructions.
                     </p>
@@ -80,27 +80,30 @@
             <div class="space-y-3">
                 <a href="/api/v1/auth/sign-in?next={{ next | urlencode }}"
                    class="btn btn-primary btn-lg w-full gap-2">
-                    <!-- Logto "shield" icon approximation -->
+                    <!-- Identity-provider shield icon -->
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                               d="M12 2L4 5v6c0 5.25 3.5 9.74 8 11 4.5-1.26 8-5.75 8-11V5L12 2z"/>
                     </svg>
-                    Sign in with Logto
+                    Sign in with {{ auth_provider_label }}
                 </a>
 
+                {% if auth_provider == 'logto' %}
                 <div class="text-center">
                     <a href="/api/v1/auth/forgot-password"
                        class="link link-primary text-sm">
                         Forgot your password?
                     </a>
                 </div>
+                {% endif %}
 
                 <p class="text-center text-xs text-base-content/50">
-                    Logto securely handles authentication.
+                    {{ auth_provider_label }} securely handles authentication.
                     Your credentials are never sent to {{ app_name }}.
                 </p>
             </div>
 
+            {% if auth_provider == 'logto' %}
             <div class="divider text-xs text-base-content/40">What is Logto?</div>
 
             <div class="text-sm text-base-content/60 space-y-1">
@@ -115,6 +118,26 @@
                     free tier.
                 </p>
             </div>
+            {% elif auth_provider == 'authentik' %}
+            <div class="divider text-xs text-base-content/40">What is Authentik?</div>
+
+            <div class="text-sm text-base-content/60 space-y-1">
+                <p>
+                    <a href="https://goauthentik.io" target="_blank" rel="noopener" class="link link-primary">Authentik</a>
+                    is an open-source identity provider. DMARQ can use it directly
+                    via OIDC or sit behind an Authentik Outpost reverse proxy.
+                </p>
+            </div>
+            {% else %}
+            <div class="divider text-xs text-base-content/40">External identity</div>
+
+            <div class="text-sm text-base-content/60 space-y-1">
+                <p>
+                    DMARQ delegates sign-in to your configured identity provider.
+                    Passwords, MFA, and account recovery stay with that provider.
+                </p>
+            </div>
+            {% endif %}
             {% endif %}
         </div>
     </div>

--- a/backend/app/templates/profile.html
+++ b/backend/app/templates/profile.html
@@ -51,7 +51,7 @@
                     </p>
                 </div>
                 <div>
-                    <span class="font-medium text-base-content/70">Logto ID</span>
+                    <span class="font-medium text-base-content/70">External ID</span>
                     <p class="mt-0.5 font-mono text-xs truncate"
                        x-text="user && user.logto_id ? user.logto_id : '—'"></p>
                 </div>
@@ -62,7 +62,7 @@
                             <span class="badge badge-warning badge-sm">Auth disabled</span>
                         </template>
                         <template x-if="user && !user.auth_disabled">
-                            <span class="badge badge-success badge-sm">Logto OIDC</span>
+                            <span class="badge badge-success badge-sm" x-text="user.auth_provider_label || 'External auth'"></span>
                         </template>
                     </p>
                 </div>
@@ -71,7 +71,7 @@
     {% endcall %}
 
     <!-- Account actions card -->
-    {% if logto_configured and not auth_disabled %}
+    {% if logto_configured and auth_provider == 'logto' and not auth_disabled %}
     {% call card() %}
         {% call card_header() %}
             {% call card_title() %}Account Security{% endcall %}
@@ -135,9 +135,24 @@
         <div>
             <p class="font-semibold">Authentication is disabled</p>
             <p class="text-sm">
-                Password reset and MFA management require Logto to be configured.
+                Password reset and MFA management require an identity provider to be configured.
                 Set <code class="font-mono bg-base-200 px-1 rounded">AUTH_DISABLED=false</code>
-                and configure Logto to enable these features.
+                and configure an identity provider to enable these features.
+            </p>
+        </div>
+    </div>
+    {% elif auth_configured %}
+    <div role="alert" class="alert alert-info">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24"
+             stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20A10 10 0 0012 2z"/>
+        </svg>
+        <div>
+            <p class="font-semibold">Account security is managed by {{ auth_provider_label }}</p>
+            <p class="text-sm">
+                Password reset, MFA, and account recovery remain in your configured
+                identity provider.
             </p>
         </div>
     </div>
@@ -149,9 +164,9 @@
                   d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
         </svg>
         <div>
-            <p class="font-semibold">Logto not configured</p>
+            <p class="font-semibold">Authentication not configured</p>
             <p class="text-sm">
-                Password reset and MFA management require Logto. Visit the
+                Password reset and MFA management require an identity provider. Visit the
                 <a href="/setup" class="link link-warning font-medium">setup page</a>
                 to configure it.
             </p>

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -18,10 +18,21 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from app.api.api_v1.endpoints.auth import _create_next_cookie
-from app.core.config import get_settings
+from app.core.auth_providers import (
+    ExternalIdentityClaims,
+    configured_oidc_provider,
+    create_oidc_state,
+    decode_oidc_state,
+    normalize_external_claims,
+    sync_external_user,
+    trusted_proxy_auth_context,
+)
+from app.core.config import Settings, get_settings
 from app.core.logto import (
     SESSION_COOKIE,
     CookieStorage,
@@ -160,6 +171,122 @@ class TestSyncLogtoUser:
         claims2 = self._claims(name="New Name")
         user = sync_logto_user(claims2, db_session)
         assert user.full_name == "New Name"
+
+
+# ── Authentik / generic OIDC helpers ─────────────────────────────────────────
+
+
+class TestExternalAuthProviders:
+    def test_authentik_config_selects_direct_oidc_provider(self):
+        settings = Settings(
+            AUTH_MODE="authentik",
+            AUTHENTIK_ISSUER_URL="https://idp.example.test/application/o/dmarq",
+            AUTHENTIK_CLIENT_ID="client-id",
+            AUTHENTIK_CLIENT_SECRET="client-secret",
+        )
+
+        provider = configured_oidc_provider(settings)
+
+        assert settings.active_auth_provider == "authentik"
+        assert provider is not None
+        assert provider.provider == "authentik"
+        assert provider.label == "Authentik"
+        assert provider.issuer_url == "https://idp.example.test/application/o/dmarq"
+
+    def test_generic_oidc_config_selects_provider_label(self):
+        settings = Settings(
+            AUTH_MODE="oidc",
+            OIDC_ISSUER_URL="https://idp.example.test",
+            OIDC_CLIENT_ID="client-id",
+            OIDC_CLIENT_SECRET="client-secret",
+            OIDC_PROVIDER_LABEL="Keycloak",
+        )
+
+        provider = configured_oidc_provider(settings)
+
+        assert settings.active_auth_provider == "oidc"
+        assert provider is not None
+        assert provider.label == "Keycloak"
+
+    def test_oidc_state_round_trip(self):
+        settings = Settings(SECRET_KEY="s" * 32)
+        token = create_oidc_state("/domains", settings)
+
+        payload = decode_oidc_state(token, settings)
+
+        assert payload is not None
+        assert payload["next"] == "/domains"
+
+    def test_normalize_external_claims_applies_domain_allowlist(self):
+        claims = normalize_external_claims(
+            "authentik",
+            {
+                "sub": "authentik-user-1",
+                "email": "owner@example.com",
+                "name": "Owner",
+                "preferred_username": "owner",
+                "email_verified": True,
+            },
+            allowed_domains="example.com",
+        )
+
+        assert claims.provider == "authentik"
+        assert claims.subject == "authentik-user-1"
+        assert claims.email == "owner@example.com"
+        assert claims.username == "owner"
+        assert claims.email_verified is True
+
+    def test_normalize_external_claims_rejects_unlisted_email(self):
+        with pytest.raises(HTTPException) as exc:
+            normalize_external_claims(
+                "authentik",
+                {"sub": "authentik-user-1", "email": "owner@other.test"},
+                allowed_domains="example.com",
+            )
+
+        assert exc.value.status_code == 403
+
+    def test_sync_external_user_uses_provider_scoped_subject(self, db_session):
+        user = sync_external_user(
+            ExternalIdentityClaims(
+                provider="authentik",
+                subject="authentik-user-1",
+                email="owner@example.com",
+                name="Owner",
+                username="owner",
+                email_verified=True,
+            ),
+            db_session,
+        )
+
+        assert user.id is not None
+        assert user.logto_id == "authentik:authentik-user-1"
+        assert user.email == "owner@example.com"
+        assert user.full_name == "Owner"
+
+    def test_trusted_proxy_auth_context_uses_authentik_headers(self):
+        settings = Settings(
+            AUTH_MODE="trusted_proxy",
+            AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS="example.com",
+        )
+        request = MagicMock()
+        request.headers = {
+            "X-Authentik-Email": "owner@example.com",
+            "X-Authentik-Uid": "authentik-user-1",
+            "X-Authentik-Name": "Owner",
+            "X-Authentik-Username": "owner",
+        }
+
+        context = trusted_proxy_auth_context(request, settings)
+
+        assert context == {
+            "auth_type": "trusted_proxy",
+            "provider": "authentik",
+            "sub": "authentik:authentik-user-1",
+            "email": "owner@example.com",
+            "name": "Owner",
+            "username": "owner",
+        }
 
 
 # ── /api/v1/auth/me ───────────────────────────────────────────────────────────
@@ -384,6 +511,31 @@ class TestAuthDisabled:
             mock_req.cookies = {}
             result = asyncio.run(require_admin_auth(request=mock_req, api_key=None, bearer=None))
         assert result["auth_type"] == "disabled"
+
+    def test_require_admin_auth_accepts_trusted_proxy_headers(self):
+        """Trusted proxy mode accepts explicitly configured Authentik headers."""
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from app.core.config import Settings
+        from app.core.security import require_admin_auth
+
+        trusted_settings = Settings(
+            AUTH_MODE="trusted_proxy",
+            AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS="example.com",
+        )
+        mock_req = MagicMock()
+        mock_req.cookies = {}
+        mock_req.headers = {
+            "X-Authentik-Email": "owner@example.com",
+            "X-Authentik-Uid": "authentik-user-1",
+        }
+        with patch("app.core.security.settings", trusted_settings):
+            result = asyncio.run(require_admin_auth(request=mock_req, api_key=None, bearer=None))
+
+        assert result["auth_type"] == "trusted_proxy"
+        assert result["email"] == "owner@example.com"
+        assert result["sub"] == "authentik:authentik-user-1"
 
     def test_middleware_passes_all_requests_when_auth_disabled(self, client: TestClient):
         """The auth middleware must let every request through when AUTH_DISABLED=True."""

--- a/backend/app/tests/test_config.py
+++ b/backend/app/tests/test_config.py
@@ -250,7 +250,24 @@ class TestProductionStartupSettings:
         result = validate_startup_configuration(settings)
 
         assert result.ok is False
-        assert any("Logto settings or ADMIN_API_KEY" in error for error in result.errors)
+        assert any("authentication path or ADMIN_API_KEY" in error for error in result.errors)
+
+    def test_production_startup_accepts_authentik_oidc(self):
+        from app.core.startup_checks import validate_startup_configuration
+
+        settings = Settings(
+            ENVIRONMENT="production",
+            SECRET_KEY="s" * 32,
+            AUTH_MODE="authentik",
+            AUTHENTIK_ISSUER_URL="https://idp.example.test/application/o/dmarq",
+            AUTHENTIK_CLIENT_ID="client-id",
+            AUTHENTIK_CLIENT_SECRET="client-secret",
+            DATABASE_URL="postgresql://dmarq:password@db/dmarq",
+        )
+
+        result = validate_startup_configuration(settings)
+
+        assert result.ok is True
 
     def test_production_startup_rejects_auth_disabled_without_override(self):
         from app.core.startup_checks import validate_startup_configuration

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -26,6 +26,7 @@ from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.mail_source_backfill import MailSourceBackfillJob
 from app.models.mail_source_import import MailSourceImport
+from app.models.setting import Setting
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
@@ -164,6 +165,56 @@ class TestOAuthStateHelpers:
 
         assert exc.value.status_code == 400
         assert exc.value.detail == expected_detail
+
+
+class TestOAuthRedirectBaseUrl:
+    """OAuth redirect URIs use the public app URL, not the internal proxy URL."""
+
+    @staticmethod
+    def _request(base_url: str = "http://app.dmarc.org/", headers: Optional[dict] = None):
+        request = MagicMock()
+        request.base_url = base_url
+        request.headers = headers or {}
+        return request
+
+    def test_public_base_url_prefers_environment_setting(self, db_session, monkeypatch):
+        monkeypatch.setattr(
+            mail_sources_endpoint.get_settings(),
+            "PUBLIC_BASE_URL",
+            "https://app.dmarc.org/",
+        )
+
+        assert (
+            mail_sources_endpoint._public_base_url(self._request(), db_session)
+            == "https://app.dmarc.org"
+        )
+
+    def test_public_base_url_prefers_setup_setting(self, db_session, monkeypatch):
+        monkeypatch.setattr(mail_sources_endpoint.get_settings(), "PUBLIC_BASE_URL", None)
+        db_session.add(
+            Setting(
+                key="general.base_url",
+                value="https://setup.dmarc.org/",
+                category="general",
+            )
+        )
+        db_session.commit()
+
+        assert (
+            mail_sources_endpoint._public_base_url(self._request(), db_session)
+            == "https://setup.dmarc.org"
+        )
+
+    def test_public_base_url_respects_forwarded_proto(self, db_session, monkeypatch):
+        monkeypatch.setattr(mail_sources_endpoint.get_settings(), "PUBLIC_BASE_URL", None)
+
+        assert (
+            mail_sources_endpoint._public_base_url(
+                self._request(headers={"x-forwarded-proto": "https"}),
+                db_session,
+            )
+            == "https://app.dmarc.org"
+        )
 
 
 def _add_user(db_session: Session, email: str):

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -41,6 +41,17 @@ For deployment verification, upgrades, rollback, and routine checks, use the [Op
 
 ### Logto Authentication Settings
 
+DMARQ supports multiple authentication modes. Keep `AUTH_MODE=auto` to preserve
+the existing Logto auto-detection behavior, or choose an explicit mode.
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `AUTH_MODE` | Browser authentication mode: `auto`, `disabled`, `logto`, `authentik`, `oidc`, or `trusted_proxy` | `auto` | `authentik` |
+| `AUTH_DISABLED` | Disable authentication entirely. Only use for local development or a separately protected deployment. | `false` | `true`, `false` |
+| `PUBLIC_BASE_URL` | Public URL used when building OAuth callback URLs behind a reverse proxy or ingress | Auto-detected | `https://dmarq.example.com` |
+
+#### Logto
+
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
 | `LOGTO_ENDPOINT` | Base URL of your Logto instance | - | `https://your-tenant.logto.app` |
@@ -48,6 +59,56 @@ For deployment verification, upgrades, rollback, and routine checks, use the [Op
 | `LOGTO_APP_SECRET` | Client Secret of the Logto application | - | `your-app-secret` |
 | `LOGTO_REDIRECT_URI` | Override the OAuth callback URL | Auto-detected | `https://dmarq.example.com/api/v1/auth/callback` |
 | `LOGTO_SKIP_SSL_VERIFY` | Disable SSL certificate verification for connections to the Logto endpoint. **Only use this when your Logto instance uses a self-signed certificate that you control. Never enable in production environments.** | `false` | `true`, `false` |
+
+#### Authentik Direct OIDC
+
+Create an Authentik OAuth2/OpenID provider and register DMARQ's callback URL:
+`https://<your-dmarq-host>/api/v1/auth/callback`.
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `AUTH_MODE` | Set to `authentik` for direct Authentik OIDC | `auto` | `authentik` |
+| `AUTHENTIK_ISSUER_URL` | Authentik provider issuer URL | - | `https://idp.example.com/application/o/dmarq` |
+| `AUTHENTIK_CLIENT_ID` | Authentik OAuth client ID | - | `client-id` |
+| `AUTHENTIK_CLIENT_SECRET` | Authentik OAuth client secret | - | `client-secret` |
+| `AUTHENTIK_REDIRECT_URI` | Optional callback URL override | Auto-detected | `https://dmarq.example.com/api/v1/auth/callback` |
+| `AUTHENTIK_ALLOWED_EMAILS` | Optional comma-separated email allowlist | - | `admin@example.com` |
+| `AUTHENTIK_ALLOWED_DOMAINS` | Optional comma-separated email-domain allowlist | - | `example.com,example.org` |
+
+#### Generic OIDC
+
+Use this for Keycloak, Entra ID, Google Workspace, Okta, Ping/OneLogin, and
+other OIDC-capable providers.
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `AUTH_MODE` | Set to `oidc` for generic OIDC | `auto` | `oidc` |
+| `OIDC_ISSUER_URL` | OIDC issuer URL | - | `https://idp.example.com/realms/dmarq` |
+| `OIDC_CLIENT_ID` | OIDC client ID | - | `dmarq` |
+| `OIDC_CLIENT_SECRET` | OIDC client secret | - | `client-secret` |
+| `OIDC_REDIRECT_URI` | Optional callback URL override | Auto-detected | `https://dmarq.example.com/api/v1/auth/callback` |
+| `OIDC_PROVIDER_LABEL` | UI label for the sign-in provider | `OpenID Connect` | `Keycloak` |
+| `OIDC_ALLOWED_EMAILS` | Optional comma-separated email allowlist | - | `admin@example.com` |
+| `OIDC_ALLOWED_DOMAINS` | Optional comma-separated email-domain allowlist | - | `example.com` |
+| `OIDC_SKIP_SSL_VERIFY` | Disable TLS verification for provider requests. Do not use in production unless explicitly allowed. | `false` | `true`, `false` |
+
+#### Authentik Outpost / Trusted Proxy
+
+Use `AUTH_MODE=trusted_proxy` only when DMARQ is not reachable except through a
+trusted authentication proxy such as an Authentik Outpost. DMARQ trusts the
+configured headers and treats the authenticated user as the self-hosted instance
+owner.
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `AUTH_MODE` | Enable trusted proxy mode | `auto` | `trusted_proxy` |
+| `AUTH_TRUSTED_PROXY_PROVIDER` | Provider label stored in auth context | `authentik` | `authentik` |
+| `AUTH_TRUSTED_PROXY_EMAIL_HEADER` | Header containing the authenticated email | `X-Authentik-Email` | `X-Authentik-Email` |
+| `AUTH_TRUSTED_PROXY_SUBJECT_HEADER` | Header containing the stable user id | `X-Authentik-Uid` | `X-Authentik-Uid` |
+| `AUTH_TRUSTED_PROXY_NAME_HEADER` | Header containing display name | `X-Authentik-Name` | `X-Authentik-Name` |
+| `AUTH_TRUSTED_PROXY_USERNAME_HEADER` | Header containing username | `X-Authentik-Username` | `X-Authentik-Username` |
+| `AUTH_TRUSTED_PROXY_ALLOWED_EMAILS` | Optional comma-separated email allowlist | - | `admin@example.com` |
+| `AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS` | Optional comma-separated domain allowlist | - | `example.com` |
 
 ### IMAP Settings
 

--- a/docs/deployment/secrets.md
+++ b/docs/deployment/secrets.md
@@ -15,10 +15,16 @@ Store these values in a 1Password Environment for each deployment target:
 | `DATABASE_URL` | Secret when it contains credentials | Prefer this single URL for production PostgreSQL deployments. |
 | `IMAP_PASSWORD` | Secret | Required when IMAP polling is enabled. |
 | `LOGTO_APP_SECRET` | Secret | Required when Logto authentication is enabled. |
+| `AUTHENTIK_CLIENT_SECRET` | Secret | Required when Authentik direct OIDC authentication is enabled. |
+| `OIDC_CLIENT_SECRET` | Secret | Required when generic OIDC authentication is enabled. |
 | `CLOUDFLARE_API_TOKEN` | Secret | Optional DNS inspection/integration token. |
 | `FIRST_SUPERUSER_PASSWORD` | Secret | Only needed for bootstrap flows that create an initial local admin. |
 
-Non-sensitive values, such as `IMAP_SERVER`, `IMAP_USERNAME`, `LOGTO_ENDPOINT`, `LOGTO_APP_ID`, and `BACKEND_CORS_ORIGINS`, may also live in the Environment so each deployment has one complete configuration bundle.
+Non-sensitive values, such as `IMAP_SERVER`, `IMAP_USERNAME`, `LOGTO_ENDPOINT`,
+`LOGTO_APP_ID`, `AUTHENTIK_ISSUER_URL`, `AUTHENTIK_CLIENT_ID`,
+`OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, `PUBLIC_BASE_URL`, and
+`BACKEND_CORS_ORIGINS`, may also live in the Environment so each deployment has
+one complete configuration bundle.
 
 OAuth mail connectors can also store provider client secrets and refresh/access tokens in encrypted database fields after an administrator authorizes the source. Treat values such as `GMAIL_CLIENT_SECRET`, Microsoft 365 client secrets, refresh tokens, and access tokens as secrets even when they are provider-generated and short-lived.
 
@@ -93,7 +99,9 @@ Restrict the service user and file permissions so only the DMARQ process and the
 - Never paste mailbox passwords, OAuth secrets, API tokens, database passwords, or generated session keys into issues, pull requests, logs, or chat.
 - Never include provider tokens, authorization headers, client secrets, raw mailbox payloads, or message bodies in connector diagnostics, import history, webhook payloads, screenshots, or support notes.
 - Keep `AUTH_DISABLED=true` limited to local development or a deployment protected by a separate authentication proxy.
+- Use `AUTH_MODE=trusted_proxy` only when DMARQ is reachable exclusively through the trusted proxy or Authentik Outpost.
 - Keep `LOGTO_SKIP_SSL_VERIFY=false` in production.
+- Keep `OIDC_SKIP_SSL_VERIFY=false` in production.
 - Use separate 1Password Environments for development, preprod, and production.
 
 ## Connector Development

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -55,18 +55,20 @@ Actions:
 
 Likely causes:
 
-- Logto redirect URL does not match the deployed public URL.
+- Identity-provider redirect URL does not match the deployed public URL.
+- OAuth mail-source redirects are built from an internal `http://` proxy URL instead of the public `https://` URL.
 - `ALLOWED_HOSTS` does not include the public hostname.
 - `SECRET_KEY` changed unexpectedly, invalidating sessions.
-- `AUTH_DISABLED` or `LOGTO_SKIP_SSL_VERIFY` is set incorrectly for the environment.
+- `AUTH_DISABLED`, `LOGTO_SKIP_SSL_VERIFY`, or `OIDC_SKIP_SSL_VERIFY` is set incorrectly for the environment.
 
 Actions:
 
 1. Confirm `ALLOWED_HOSTS` includes the host users open in the browser.
-2. Confirm Logto callback URLs match the DMARQ callback URL exactly.
+2. Confirm Logto, Authentik, or generic OIDC callback URLs match the DMARQ callback URL exactly.
 3. Confirm `SECRET_KEY` is stable across restarts.
 4. Clear browser cookies after intentional auth changes.
-5. Keep `AUTH_DISABLED=false` and `LOGTO_SKIP_SSL_VERIFY=false` in production.
+5. Set `PUBLIC_BASE_URL=https://<your-public-host>` if Gmail, Microsoft 365, or identity-provider callbacks show `http://` behind a proxy.
+6. Keep `AUTH_DISABLED=false`, `LOGTO_SKIP_SSL_VERIFY=false`, and `OIDC_SKIP_SSL_VERIFY=false` in production.
 
 ## Mailbox Test Fails
 


### PR DESCRIPTION
## Summary

Refs #422.

Adds the first modular IdP slice for DMARQ:

- adds explicit auth mode selection for Logto, Authentik direct OIDC, generic OIDC, trusted proxy, and disabled/local-style deployments
- adds provider-neutral OIDC helpers for discovery, authorization URL generation, callback exchange, normalized claims, allowlists, and local user sync
- supports Authentik Outpost / trusted proxy headers with explicit allowlist controls
- updates browser auth, profile UI, middleware, API auth, workspace-owner mapping, and startup checks to avoid hard Logto-only assumptions
- fixes Gmail and Microsoft 365 OAuth callback URL construction behind proxies via PUBLIC_BASE_URL, persisted setup base URL, or X-Forwarded-Proto
- documents Authentik direct OIDC, generic OIDC, trusted proxy mode, secrets, and troubleshooting

## Not in this PR

- SAML support
- SCIM/user lifecycle provisioning
- IdP group to workspace-role mapping
- database rename of the legacy logto_id column
- full local username/password auth mode

Those remain follow-up pieces under #422 / #243.

## Validation

- python -m compileall -q backend/app
- black --check on changed backend files
- isort --check-only on changed backend files
- flake8 on changed backend files
- pytest backend/app/tests/test_auth.py backend/app/tests/test_mail_sources.py::TestOAuthRedirectBaseUrl backend/app/tests/test_mail_sources.py::TestOAuthStateHelpers backend/app/tests/test_config.py::TestProductionStartupSettings -q
- pytest backend/app/tests -q: 1427 passed
- mkdocs build: passed with existing documentation link warnings

## References

- Authentik OAuth2/OIDC provider docs: https://docs.goauthentik.io/add-secure-apps/providers/oauth2/
- Authentik proxy provider docs: https://docs.goauthentik.io/add-secure-apps/providers/proxy/
