### PR TITLE
Fix external auth hardening follow-up

### DIFF
--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -136,11 +136,11 @@ async def sign_in(
 
     Logto keeps its SDK-backed PKCE storage.  Generic OIDC/AuthentiK uses a
     signed state cookie.  Trusted proxy mode does not own the upstream sign-in
-    flow, so this route simply returns to the requested page.
+    flow, so this route returns to a fixed local page.
     """
     provider_name = _active_auth_provider()
     if provider_name == "trusted_proxy":
-        return RedirectResponse(url=_safe_next(next), status_code=302)
+        return RedirectResponse(url="/", status_code=302)
 
     if provider_name in {"oidc", "authentik"}:
         provider = configured_oidc_provider(settings)

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -222,7 +222,18 @@ async def exchange_oidc_callback(
             userinfo_response.raise_for_status()
             claims_payload = userinfo_response.json()
         elif token_payload.get("id_token"):
-            claims_payload = jwt.get_unverified_claims(token_payload["id_token"])
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=(
+                    "OIDC provider did not expose a userinfo endpoint; "
+                    "refusing to trust unvalidated ID-token claims."
+                ),
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="OIDC provider did not return usable identity claims.",
+            )
 
     return normalize_external_claims(
         provider.provider,

--- a/backend/app/core/startup_checks.py
+++ b/backend/app/core/startup_checks.py
@@ -43,9 +43,12 @@ def validate_startup_configuration(settings: Settings) -> StartupCheckResult:
     if not settings.is_production:
         return StartupCheckResult(errors=(), warnings=())
 
-    if settings.AUTH_DISABLED and not settings.ALLOW_AUTH_DISABLED_IN_PRODUCTION:
+    auth_provider = getattr(settings, "active_auth_provider", "unconfigured")
+    auth_disabled = settings.AUTH_DISABLED or auth_provider == "disabled"
+
+    if auth_disabled and not settings.ALLOW_AUTH_DISABLED_IN_PRODUCTION:
         errors.append(
-            "AUTH_DISABLED=true is not allowed in production unless "
+            "AUTH_DISABLED=true or AUTH_MODE=disabled is not allowed in production unless "
             "ALLOW_AUTH_DISABLED_IN_PRODUCTION=true is also set."
         )
 
@@ -67,7 +70,7 @@ def validate_startup_configuration(settings: Settings) -> StartupCheckResult:
             "ALLOW_OIDC_SKIP_SSL_VERIFY_IN_PRODUCTION=true is also set."
         )
 
-    if not settings.AUTH_DISABLED and not settings.ADMIN_API_KEY and not settings.auth_configured:
+    if not auth_disabled and not settings.ADMIN_API_KEY and not settings.auth_configured:
         errors.append(
             "Production startup requires an authentication path or ADMIN_API_KEY. "
             "Configure Logto, Authentik/OIDC, trusted proxy auth, or set ADMIN_API_KEY."

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -25,9 +25,11 @@ from fastapi.testclient import TestClient
 from app.api.api_v1.endpoints.auth import _create_next_cookie
 from app.core.auth_providers import (
     ExternalIdentityClaims,
+    OIDCProviderConfig,
     configured_oidc_provider,
     create_oidc_state,
     decode_oidc_state,
+    exchange_oidc_callback,
     normalize_external_claims,
     sync_external_user,
     trusted_proxy_auth_context,
@@ -288,6 +290,42 @@ class TestExternalAuthProviders:
             "username": "owner",
         }
 
+    @pytest.mark.asyncio
+    async def test_oidc_callback_rejects_unverified_id_token_without_userinfo(self):
+        provider = OIDCProviderConfig(
+            provider="oidc",
+            label="OpenID Connect",
+            issuer_url="https://idp.example.test",
+            client_id="client-id",
+            client_secret="client-secret",
+            redirect_uri=None,
+            scopes="openid email profile",
+            skip_ssl_verify=False,
+        )
+        request = MagicMock()
+        request.base_url = "https://dmarq.example.test/"
+        token_response = MagicMock()
+        token_response.raise_for_status = MagicMock()
+        token_response.json.return_value = {
+            "id_token": "header.payload.signature",
+            "access_token": "access-token",
+        }
+
+        with patch(
+            "app.core.auth_providers.fetch_oidc_discovery",
+            new=AsyncMock(
+                return_value={
+                    "authorization_endpoint": "https://idp.example.test/auth",
+                    "token_endpoint": "https://idp.example.test/token",
+                }
+            ),
+        ), patch("httpx.AsyncClient.post", new=AsyncMock(return_value=token_response)):
+            with pytest.raises(HTTPException) as exc:
+                await exchange_oidc_callback(request, provider, code="callback-code")
+
+        assert exc.value.status_code == 401
+        assert "unvalidated ID-token claims" in exc.value.detail
+
 
 # ── /api/v1/auth/me ───────────────────────────────────────────────────────────
 
@@ -450,6 +488,18 @@ class TestSignInEndpoint:
             mock_settings.logto_configured = False
             res = client.get("/api/v1/auth/sign-in", follow_redirects=False)
         assert res.status_code == 503
+
+    def test_trusted_proxy_sign_in_uses_fixed_local_redirect(self, client: TestClient):
+        """Trusted-proxy mode must not redirect to caller-controlled destinations."""
+        with patch("app.api.api_v1.endpoints.auth.settings") as mock_settings:
+            mock_settings.active_auth_provider = "trusted_proxy"
+            res = client.get(
+                "/api/v1/auth/sign-in?next=/domains",
+                follow_redirects=False,
+            )
+
+        assert res.status_code == 302
+        assert res.headers["location"] == "/"
 
 
 # ── /api/v1/auth/sign-out ────────────────────────────────────────────────────

--- a/backend/app/tests/test_config.py
+++ b/backend/app/tests/test_config.py
@@ -283,6 +283,21 @@ class TestProductionStartupSettings:
 
         assert any("AUTH_DISABLED=true" in error for error in result.errors)
 
+    def test_production_startup_rejects_auth_mode_disabled_without_override(self):
+        from app.core.startup_checks import validate_startup_configuration
+
+        settings = Settings(
+            ENVIRONMENT="production",
+            SECRET_KEY="s" * 32,
+            AUTH_MODE="disabled",
+            DATABASE_URL="postgresql://dmarq:password@db/dmarq",
+        )
+
+        result = validate_startup_configuration(settings)
+
+        assert result.ok is False
+        assert any("AUTH_MODE=disabled" in error for error in result.errors)
+
     def test_production_startup_allows_auth_disabled_with_explicit_override(self):
         from app.core.startup_checks import validate_startup_configuration
 


### PR DESCRIPTION
## Summary
- block AUTH_MODE=disabled in production unless the explicit disabled-auth override is set
- fail closed when external OIDC only returns an unvalidated ID token without userinfo claims
- avoid caller-controlled redirects in trusted-proxy sign-in

## Validation
- python3 -m compileall -q backend/app/core/startup_checks.py backend/app/core/auth_providers.py backend/app/api/api_v1/endpoints/auth.py backend/app/tests/test_auth.py backend/app/tests/test_config.py
- git diff --check

Note: focused pytest could not run locally because the available old dmarq venv hung loading its native cryptography module; GitHub Actions should run the full suite.