### PR TITLE
Improve mail source domain verification guidance

### DIFF
--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -323,7 +323,7 @@ def _raise_if_workspace_domains_unverified(db: Session, workspace, *, action: st
                 "production DMARC reports."
             ),
             "summary": (
-                "DMARQ blocks production mail-source fetches until at least one active "
+                "DMARQ blocks production mail-source fetches until every active "
                 "domain in this workspace is verified. This prevents a mailbox or OAuth "
                 "connection from importing reports for domains the workspace has not "
                 "proven it controls."

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -311,16 +311,45 @@ def _raise_if_workspace_domains_unverified(db: Session, workspace, *, action: st
     unverified_domains = [domain.name for domain in domains if not domain.verified]
     if not unverified_domains:
         return
+    domain_label = ", ".join(unverified_domains[:5])
+    if len(unverified_domains) > 5:
+        domain_label = f"{domain_label}, and {len(unverified_domains) - 5} more"
     raise HTTPException(
         status_code=status.HTTP_409_CONFLICT,
         detail={
             "code": "domain_verification_required",
             "message": (
-                "Verify domain ownership before enabling or fetching production "
-                "DMARC report mail sources."
+                "Domain ownership verification is required before DMARQ can fetch "
+                "production DMARC reports."
+            ),
+            "summary": (
+                "DMARQ blocks production mail-source fetches until at least one active "
+                "domain in this workspace is verified. This prevents a mailbox or OAuth "
+                "connection from importing reports for domains the workspace has not "
+                "proven it controls."
             ),
             "action": action,
             "unverified_domains": unverified_domains,
+            "next_steps": [
+                f"Open Domains and verify ownership for: {domain_label}.",
+                (
+                    "If the domain lives in a connected DNS provider, import it from "
+                    "the DNS provider so DMARQ can mark it as provider-verified."
+                ),
+                (
+                    "If you added the domain manually, confirm that you control its DNS "
+                    "or reporting address before enabling the mail source."
+                ),
+                (
+                    "After verification, return to Mail Sources and retry the backfill "
+                    "or enable the source."
+                ),
+            ],
+            "links": [
+                {"label": "Domains", "href": "/domains"},
+                {"label": "DNS provider import", "href": "/domains?panel=dns-import"},
+                {"label": "Mail Sources", "href": "/mail-sources"},
+            ],
         },
     )
 

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -49,6 +49,11 @@
                         <li x-text="step"></li>
                     </template>
                 </ul>
+                <div class="mt-3 flex flex-wrap gap-2" x-show="feedback.links && feedback.links.length">
+                    <template x-for="link in feedback.links" :key="link.href">
+                        <a class="btn btn-xs btn-outline" :href="link.href" x-text="link.label"></a>
+                    </template>
+                </div>
             {% endcall %}
         {% endcall %}
     </template>
@@ -795,7 +800,7 @@ function mailSourcesApp() {
 
         async fetchSource(source, days = 7) {
             this.fetching[source.id] = true;
-            this.feedback = { message: '', type: '' };
+            this.feedback = this.emptyFeedback();
             try {
                 const safeDays = Math.min(365, Math.max(1, Number(days) || 7));
                 const resp = await fetch(`/api/v1/mail-sources/${source.id}/fetch?days=${safeDays}`, {
@@ -803,7 +808,8 @@ function mailSourcesApp() {
                 });
                 const result = await resp.json();
                 if (!resp.ok) {
-                    throw new Error(result.detail || 'Import failed');
+                    this.feedback = this.apiErrorFeedback(result, 'Import error', 'Import failed');
+                    return;
                 }
                 this.feedback = {
                     message: `Import finished for ${source.name} (${safeDays} day${safeDays === 1 ? '' : 's'}): ${result.reports_found} report${result.reports_found === 1 ? '' : 's'}, ${result.duplicate_reports || 0} duplicate${result.duplicate_reports === 1 ? '' : 's'}.`,
@@ -816,7 +822,7 @@ function mailSourcesApp() {
                 }
                 await this.loadBackfills(source, true);
             } catch (e) {
-                this.feedback = { message: `Import error: ${e.message}`, type: 'error' };
+                this.feedback = { ...this.emptyFeedback(), message: `Import error: ${e.message}`, type: 'error' };
             } finally {
                 this.fetching[source.id] = false;
             }
@@ -893,7 +899,8 @@ function mailSourcesApp() {
                 });
                 const data = await resp.json();
                 if (!resp.ok) {
-                    throw new Error(this.apiErrorMessage(data, 'Failed to queue backfill'));
+                    this.feedback = this.apiErrorFeedback(data, 'Backfill error', 'Failed to queue backfill');
+                    return;
                 }
                 this.feedback = {
                     message: `Backfill queued for ${source.name} (${safeDays} day${safeDays === 1 ? '' : 's'}).`,
@@ -903,7 +910,7 @@ function mailSourcesApp() {
                 this.backfillJobs = { ...this.backfillJobs, [source.id]: [data, ...existing].slice(0, 5) };
                 await this.loadBackfills(source, true);
             } catch (e) {
-                this.feedback = { message: `Backfill error: ${e.message}`, type: 'error' };
+                this.feedback = { ...this.emptyFeedback(), message: `Backfill error: ${e.message}`, type: 'error' };
             } finally {
                 this.backfillAction = { ...this.backfillAction, [source.id]: '' };
             }
@@ -1032,6 +1039,22 @@ function mailSourcesApp() {
             return detail.message || JSON.stringify(detail);
         },
 
+        apiErrorFeedback(data, prefix, fallback) {
+            const detail = data && data.detail;
+            const message = this.apiErrorMessage(data, fallback);
+            if (!detail || typeof detail === 'string' || Array.isArray(detail)) {
+                return { ...this.emptyFeedback(), message: `${prefix}: ${message}`, type: 'error' };
+            }
+            return {
+                ...this.emptyFeedback(),
+                message: `${prefix}: ${message}`,
+                type: 'error',
+                diagnostic_summary: detail.summary || detail.diagnostic_summary || '',
+                recovery_steps: detail.next_steps || detail.recovery_steps || [],
+                links: detail.links || [],
+            };
+        },
+
         latestBackfill(source) {
             const rows = source ? this.backfillJobs[source.id] || [] : [];
             return rows.length ? rows[0] : null;
@@ -1120,7 +1143,7 @@ function mailSourcesApp() {
         },
 
         emptyFeedback() {
-            return { message: '', type: '', diagnostic_summary: '', recovery_steps: [] };
+            return { message: '', type: '', diagnostic_summary: '', recovery_steps: [], links: [] };
         },
 
         diagnosticFromResult(result) {

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -591,6 +591,8 @@ def test_mail_sources_template_exposes_backfill_progress_controls():
     assert "canCancelBackfill" in template
     assert "canRetryBackfill" in template
     assert "latestBackfill(source)" in template
+    assert "apiErrorFeedback" in template
+    assert "feedback.links" in template
     assert "x-html" not in template
 
 
@@ -877,6 +879,9 @@ class TestMailSourcesAPIAuthed:
         assert blocked.status_code == 409
         detail = blocked.json()["detail"]
         assert detail["code"] == "domain_verification_required"
+        assert detail["summary"].startswith("DMARQ blocks production mail-source fetches")
+        assert detail["next_steps"][0] == "Open Domains and verify ownership for: example.com."
+        assert {"label": "Domains", "href": "/domains"} in detail["links"]
         assert detail["unverified_domains"] == ["example.com"]
         assert disabled.status_code == 201
         assert disabled.json()["enabled"] is False
@@ -2351,7 +2356,10 @@ class TestManualSourceFetchEndpoint:
             response = authed_client.post(f"/api/v1/mail-sources/{source.id}/fetch?days=30")
 
         assert response.status_code == 409
-        assert response.json()["detail"]["action"] == "mail_source.fetch"
+        detail = response.json()["detail"]
+        assert detail["action"] == "mail_source.fetch"
+        assert "prevents a mailbox or OAuth connection" in detail["summary"]
+        assert "After verification" in detail["next_steps"][-1]
         mock_imap.assert_not_called()
 
     def test_provider_fetches_require_verified_domains(

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -879,7 +879,9 @@ class TestMailSourcesAPIAuthed:
         assert blocked.status_code == 409
         detail = blocked.json()["detail"]
         assert detail["code"] == "domain_verification_required"
-        assert detail["summary"].startswith("DMARQ blocks production mail-source fetches")
+        assert detail["summary"].startswith(
+            "DMARQ blocks production mail-source fetches until every active"
+        )
         assert detail["next_steps"][0] == "Open Domains and verify ownership for: example.com."
         assert {"label": "Domains", "href": "/domains"} in detail["links"]
         assert detail["unverified_domains"] == ["example.com"]


### PR DESCRIPTION
## Summary
- replace the terse production backfill guard with a structured explanation of why domain ownership verification is required
- show actionable next steps and navigation links in the Mail Sources UI
- cover the structured API error and UI rendering with mail-source tests

## Validation
- /tmp/dmarq-380-demo-flow/.venv/bin/python -m pytest backend/app/tests/test_mail_sources.py -q
- /tmp/dmarq-380-demo-flow/.venv/bin/python -m compileall -q backend/app/api/api_v1/endpoints/mail_sources.py
- /tmp/dmarq-380-demo-flow/.venv/bin/black --check backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- git diff --check -- backend/app/api/api_v1/endpoints/mail_sources.py backend/app/templates/mail_sources.html backend/app/tests/test_mail_sources.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mail Source errors now show richer guidance, including a short summary, next steps, and helpful links.
  * Domain verification failures now present a clearer list of unverified domains with a readable label.

* **Bug Fixes**
  * Improved error handling during source import and backfill actions so users see structured feedback instead of generic failures.
  * Added support for displaying actionable links in the Mail Sources error panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->