### PR TITLE
Allow report mailbox access to drive ingestion

### DIFF
--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -22,7 +22,6 @@ from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.redaction import sanitize_for_log
 from app.core.security import require_admin_auth
-from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.mail_source_backfill import MailSourceBackfillJob
 from app.models.mail_source_import import MailSourceImport
@@ -49,7 +48,6 @@ from app.services.workspace_access import (
 )
 from app.services.workspace_audit import changed_fields, record_workspace_audit_log
 from app.services.workspaces import (
-    workspace_domain_query,
     workspace_mail_source_query,
 )
 
@@ -298,60 +296,6 @@ def _get_source_or_404(source_id: int, db: Session, workspace=None) -> MailSourc
             detail=f"Mail source {source_id} not found",
         )
     return source
-
-
-def _raise_if_workspace_domains_unverified(db: Session, workspace, *, action: str) -> None:
-    """Require configured domains to be verified before production mail-source use."""
-    domains = (
-        workspace_domain_query(db, workspace)
-        .filter(Domain.active.is_(True))
-        .order_by(Domain.name)
-        .all()
-    )
-    unverified_domains = [domain.name for domain in domains if not domain.verified]
-    if not unverified_domains:
-        return
-    domain_label = ", ".join(unverified_domains[:5])
-    if len(unverified_domains) > 5:
-        domain_label = f"{domain_label}, and {len(unverified_domains) - 5} more"
-    raise HTTPException(
-        status_code=status.HTTP_409_CONFLICT,
-        detail={
-            "code": "domain_verification_required",
-            "message": (
-                "Domain ownership verification is required before DMARQ can fetch "
-                "production DMARC reports."
-            ),
-            "summary": (
-                "DMARQ blocks production mail-source fetches until every active "
-                "domain in this workspace is verified. This prevents a mailbox or OAuth "
-                "connection from importing reports for domains the workspace has not "
-                "proven it controls."
-            ),
-            "action": action,
-            "unverified_domains": unverified_domains,
-            "next_steps": [
-                f"Open Domains and verify ownership for: {domain_label}.",
-                (
-                    "If the domain lives in a connected DNS provider, import it from "
-                    "the DNS provider so DMARQ can mark it as provider-verified."
-                ),
-                (
-                    "If you added the domain manually, confirm that you control its DNS "
-                    "or reporting address before enabling the mail source."
-                ),
-                (
-                    "After verification, return to Mail Sources and retry the backfill "
-                    "or enable the source."
-                ),
-            ],
-            "links": [
-                {"label": "Domains", "href": "/domains"},
-                {"label": "DNS provider import", "href": "/domains?panel=dns-import"},
-                {"label": "Mail Sources", "href": "/mail-sources"},
-            ],
-        },
-    )
 
 
 def _selected_workspace_id(selected_workspace: Optional[str]) -> Optional[int]:
@@ -1048,8 +992,6 @@ async def create_mail_source(
         db,
         _selected_workspace_id(selected_workspace),
     )
-    if payload.enabled:
-        _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.create_enabled")
     source = MailSource(
         workspace_id=workspace.id,
         name=payload.name,
@@ -1216,8 +1158,6 @@ async def create_mail_source_backfill(
     )
     source = _get_source_or_404(source_id, db, workspace)
     _ensure_backfill_supported(source)
-    _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.backfill.create")
-
     now = datetime.utcnow()
     row = MailSourceBackfillJob(
         workspace_id=workspace.id,
@@ -1439,7 +1379,6 @@ async def fetch_mail_source(
         _auth, db, _selected_workspace_id(selected_workspace)
     )
     source = _get_source_or_404(source_id, db, workspace)
-    _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.fetch")
     results = _fetch_source(source, db, days)
     logger.info(
         "Manual fetch for source id=%d: processed=%d reports_found=%d "
@@ -1478,9 +1417,6 @@ async def update_mail_source(
     update_data = payload.model_dump(exclude_unset=True)
     if "method" in update_data and update_data["method"]:
         update_data["method"] = update_data["method"].upper()
-    if update_data.get("enabled") is True:
-        _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.update_enabled")
-
     for field, value in update_data.items():
         setattr(source, field, value)
 
@@ -1545,8 +1481,6 @@ async def toggle_mail_source(
         _auth, db, _selected_workspace_id(selected_workspace)
     )
     source = _get_source_or_404(source_id, db, workspace)
-    if not source.enabled:
-        _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.toggle_enabled")
     source.enabled = not source.enabled
     source.updated_at = datetime.utcnow()
     db.commit()
@@ -2007,8 +1941,6 @@ async def m365_fetch_reports(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="This endpoint is only available for M365_GRAPH sources.",
         )
-    _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.m365_fetch")
-
     results = _fetch_m365_source(source, db, days=days)
     logger.info(
         "Microsoft 365 fetch for source id=%d: processed=%d reports_found=%d",
@@ -2323,7 +2255,6 @@ async def gmail_fetch_reports(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="This endpoint is only available for GMAIL_API sources.",
         )
-    _raise_if_workspace_domains_unverified(db, workspace, action="mail_source.gmail_fetch")
     if not source.gmail_access_token:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -859,7 +859,7 @@ class TestMailSourcesAPIAuthed:
         assert resp.status_code == 201
         assert resp.json()["method"] == "IMAP"
 
-    def test_create_enabled_source_requires_verified_domains(
+    def test_create_enabled_source_allows_unverified_report_domains(
         self,
         authed_client: TestClient,
         db_session: Session,
@@ -867,24 +867,17 @@ class TestMailSourcesAPIAuthed:
         workspace = get_or_create_default_workspace(db_session)
         _add_domain(db_session, workspace, verified=False)
 
-        blocked = authed_client.post(
+        enabled = authed_client.post(
             "/api/v1/mail-sources",
-            json={"name": "Blocked IMAP", "method": "IMAP", "enabled": True},
+            json={"name": "Report mailbox", "method": "IMAP", "enabled": True},
         )
         disabled = authed_client.post(
             "/api/v1/mail-sources",
             json={"name": "Staged IMAP", "method": "IMAP", "enabled": False},
         )
 
-        assert blocked.status_code == 409
-        detail = blocked.json()["detail"]
-        assert detail["code"] == "domain_verification_required"
-        assert detail["summary"].startswith(
-            "DMARQ blocks production mail-source fetches until every active"
-        )
-        assert detail["next_steps"][0] == "Open Domains and verify ownership for: example.com."
-        assert {"label": "Domains", "href": "/domains"} in detail["links"]
-        assert detail["unverified_domains"] == ["example.com"]
+        assert enabled.status_code == 201
+        assert enabled.json()["enabled"] is True
         assert disabled.status_code == 201
         assert disabled.json()["enabled"] is False
 
@@ -989,6 +982,8 @@ class TestMailSourcesAPIAuthed:
         authed_client: TestClient,
         db_session: Session,
     ):
+        workspace = get_or_create_default_workspace(db_session)
+        _add_domain(db_session, workspace, verified=False)
         create_resp = authed_client.post(
             "/api/v1/mail-sources",
             json={"name": "Backfill API", "method": "IMAP"},
@@ -1283,7 +1278,7 @@ class TestMailSourcesAPIAuthed:
         assert update_resp.status_code == 200
         assert update_resp.json()["method"] == "POP3"
 
-    def test_update_enable_requires_verified_domains(
+    def test_update_enable_allows_unverified_report_domains(
         self,
         authed_client: TestClient,
         db_session: Session,
@@ -1305,9 +1300,9 @@ class TestMailSourcesAPIAuthed:
         )
 
         db_session.refresh(source)
-        assert response.status_code == 409
-        assert response.json()["detail"]["code"] == "domain_verification_required"
-        assert source.enabled is False
+        assert response.status_code == 200
+        assert response.json()["enabled"] is True
+        assert source.enabled is True
 
     def test_update_nonexistent_source_returns_404(self, authed_client: TestClient):
         resp = authed_client.put("/api/v1/mail-sources/99999", json={"name": "x"})
@@ -1365,7 +1360,7 @@ class TestMailSourcesAPIAuthed:
         assert toggle_resp2.status_code == 200
         assert toggle_resp2.json()["enabled"] is True
 
-    def test_toggle_enable_requires_verified_domains(
+    def test_toggle_enable_allows_unverified_report_domains(
         self,
         authed_client: TestClient,
         db_session: Session,
@@ -1384,9 +1379,9 @@ class TestMailSourcesAPIAuthed:
         response = authed_client.post(f"/api/v1/mail-sources/{source.id}/toggle")
 
         db_session.refresh(source)
-        assert response.status_code == 409
-        assert response.json()["detail"]["action"] == "mail_source.toggle_enabled"
-        assert source.enabled is False
+        assert response.status_code == 200
+        assert response.json()["enabled"] is True
+        assert source.enabled is True
 
     def test_toggle_nonexistent_returns_404(self, authed_client: TestClient):
         resp = authed_client.post("/api/v1/mail-sources/99999/toggle")
@@ -2337,7 +2332,7 @@ class TestMicrosoft365GraphMailSource:
 class TestManualSourceFetchEndpoint:
     """Tests for POST /api/v1/mail-sources/{source_id}/fetch."""
 
-    def test_fetch_requires_verified_domains(
+    def test_fetch_allows_unverified_report_domains(
         self,
         authed_client: TestClient,
         db_session: Session,
@@ -2354,17 +2349,28 @@ class TestManualSourceFetchEndpoint:
         db_session.add(source)
         db_session.commit()
 
-        with patch("app.api.api_v1.endpoints.mail_sources.IMAPClient") as mock_imap:
+        mock_client = MagicMock()
+        mock_client.fetch_reports.return_value = {
+            "success": True,
+            "processed": 1,
+            "reports_found": 1,
+            "duplicate_reports": 0,
+            "new_domains": ["example.com"],
+            "errors": [],
+            "details": [],
+        }
+        with patch(
+            "app.api.api_v1.endpoints.mail_sources.IMAPClient",
+            return_value=mock_client,
+        ) as mock_imap:
             response = authed_client.post(f"/api/v1/mail-sources/{source.id}/fetch?days=30")
 
-        assert response.status_code == 409
-        detail = response.json()["detail"]
-        assert detail["action"] == "mail_source.fetch"
-        assert "prevents a mailbox or OAuth connection" in detail["summary"]
-        assert "After verification" in detail["next_steps"][-1]
-        mock_imap.assert_not_called()
+        assert response.status_code == 200
+        assert response.json()["reports_found"] == 1
+        mock_imap.assert_called_once()
+        mock_client.fetch_reports.assert_called_once()
 
-    def test_provider_fetches_require_verified_domains(
+    def test_provider_fetches_reach_connection_validation_with_unverified_domains(
         self,
         authed_client: TestClient,
         db_session: Session,
@@ -2389,10 +2395,10 @@ class TestManualSourceFetchEndpoint:
         gmail_response = authed_client.post(f"/api/v1/mail-sources/{gmail_source.id}/gmail/fetch")
         m365_response = authed_client.post(f"/api/v1/mail-sources/{m365_source.id}/m365/fetch")
 
-        assert gmail_response.status_code == 409
-        assert gmail_response.json()["detail"]["action"] == "mail_source.gmail_fetch"
-        assert m365_response.status_code == 409
-        assert m365_response.json()["detail"]["action"] == "mail_source.m365_fetch"
+        assert gmail_response.status_code == 400
+        assert "Gmail account not yet authorised" in gmail_response.json()["detail"]
+        assert m365_response.status_code == 400
+        assert "Microsoft 365 account not yet authorised" in m365_response.json()["detail"]
 
     def test_fetch_imap_source(self, authed_client: TestClient, caplog):
         create_resp = authed_client.post(


### PR DESCRIPTION
## Summary
- remove the domain-ownership verification gate from mail-source enablement, manual fetch, provider fetch, and backfill creation
- treat access to the configured report mailbox as sufficient authority to ingest and view DMARC reports
- keep domain verification as the trust boundary for DNS/provider-managed actions rather than report parsing
- update regression tests so unverified/report-observed domains can still be imported and backfilled

## Validation
- /tmp/dmarq-380-demo-flow/.venv/bin/python -m pytest backend/app/tests/test_mail_sources.py -q
- /tmp/dmarq-380-demo-flow/.venv/bin/python -m compileall -q backend/app/api/api_v1/endpoints/mail_sources.py
- /tmp/dmarq-380-demo-flow/.venv/bin/black --check backend/app/api/api_v1/endpoints/mail_sources.py backend/app/tests/test_mail_sources.py
- git diff --check