### PR TITLE
Fix dashboard trigger poll action

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime
 from typing import List, Optional
 
-from fastapi import Depends, FastAPI, Query, Request
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
@@ -956,7 +956,24 @@ def _poll_enabled_sources_for_trigger(days: int) -> list[dict]:
     return results_summary
 
 
-# API endpoint to manually trigger IMAP polling
+# API endpoint to manually trigger mail-source polling
+@app.get("/api/v1/admin/trigger-poll")
+async def trigger_imap_poll_get() -> None:
+    """Explain that manual polling is a POST action when opened directly."""
+    raise HTTPException(
+        status_code=405,
+        detail={
+            "code": "method_not_allowed",
+            "message": "Manual polling must be started with the dashboard button or a POST request.",
+            "next_steps": [
+                "Open the dashboard and use Trigger Poll Now.",
+                "For API usage, send POST /api/v1/admin/trigger-poll with admin authentication.",
+            ],
+        },
+        headers={"Allow": "POST"},
+    )
+
+
 @app.post("/api/v1/admin/trigger-poll")
 async def trigger_imap_poll(
     auth: dict = Depends(require_admin_auth),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -957,7 +957,7 @@ def _poll_enabled_sources_for_trigger(days: int) -> list[dict]:
 
 
 # API endpoint to manually trigger mail-source polling
-@app.get("/api/v1/admin/trigger-poll")
+@app.get("/api/v1/admin/trigger-poll", include_in_schema=False)
 async def trigger_imap_poll_get() -> None:
     """Explain that manual polling is a POST action when opened directly."""
     raise HTTPException(

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -351,14 +351,23 @@
             {% call card_header() %}
                 <div class="flex items-center justify-between">
                     {% call card_title() %}IMAP Integration Status{% endcall %}
-                    {% call button_link(href="/api/v1/admin/trigger-poll", variant="outline", size="sm") %}
+                    <button type="button"
+                            class="btn btn-outline btn-sm"
+                            :disabled="triggerPollRunning"
+                            @click="triggerPollNow()">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="m3 2 2 4h8L7 14h2l-4 8 1-6H4l2-8H3z"></path></svg>
-                        Trigger Poll Now
-                    {% endcall %}
+                        <span x-text="triggerPollRunning ? 'Polling...' : 'Trigger Poll Now'"></span>
+                    </button>
                 </div>
             {% endcall %}
             {% call card_content() %}
                 <div class="flex flex-col gap-4">
+                    <div x-show="triggerPollMessage"
+                         x-cloak
+                         class="rounded-md border px-3 py-2 text-sm"
+                         :class="triggerPollStatus === 'error' ? 'border-[#ff6f3c] bg-[#fff2ec] text-[#8a2d0d]' : 'border-[#d7efe8] bg-[#eefaf6] text-[#0f6b4d]'">
+                        <span x-text="triggerPollMessage"></span>
+                    </div>
                     <div class="flex items-center">
                         <span class="w-40 text-sm text-muted-foreground">Status:</span>
                         <span class="inline-flex items-center gap-1.5">
@@ -425,6 +434,9 @@ function dashboardApp() {
         healthSummary: null,
         healthHistory: null,
         selectedDnsDomain: '',
+        triggerPollRunning: false,
+        triggerPollStatus: '',
+        triggerPollMessage: '',
         demoDeployment: null,
         selectedDemoScenarioId: 'single-user-multiple-domains',
         selectedDemoZoomLevel: 'workspace',
@@ -519,6 +531,38 @@ function dashboardApp() {
                 }
             } catch (error) {
                 console.error('Error checking IMAP status:', error);
+            }
+        },
+
+        async triggerPollNow() {
+            this.triggerPollRunning = true;
+            this.triggerPollStatus = '';
+            this.triggerPollMessage = '';
+            try {
+                const response = await fetch('/api/v1/admin/trigger-poll', {
+                    method: 'POST',
+                    headers: { 'Accept': 'application/json' }
+                });
+                const data = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    const detail = data.detail;
+                    const message = typeof detail === 'string'
+                        ? detail
+                        : (detail?.message || data.message || 'Could not trigger polling.');
+                    throw new Error(message);
+                }
+                const count = data.sources_polled || 0;
+                this.triggerPollStatus = 'success';
+                this.triggerPollMessage = count
+                    ? `Polling finished for ${count} source${count === 1 ? '' : 's'}.`
+                    : (data.message || 'No enabled mail sources configured.');
+                await this.getImapStatus();
+                await this.fetchDomainSummary();
+            } catch (error) {
+                this.triggerPollStatus = 'error';
+                this.triggerPollMessage = error.message || 'Could not trigger polling.';
+            } finally {
+                this.triggerPollRunning = false;
             }
         },
         

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -364,6 +364,9 @@
                 <div class="flex flex-col gap-4">
                     <div x-show="triggerPollMessage"
                          x-cloak
+                         role="status"
+                         aria-live="polite"
+                         aria-atomic="true"
                          class="rounded-md border px-3 py-2 text-sm"
                          :class="triggerPollStatus === 'error' ? 'border-[#ff6f3c] bg-[#fff2ec] text-[#8a2d0d]' : 'border-[#d7efe8] bg-[#eefaf6] text-[#0f6b4d]'">
                         <span x-text="triggerPollMessage"></span>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -117,3 +117,6 @@ def test_dashboard_trigger_poll_uses_post_action_not_get_link():
     assert "triggerPollNow()" in template
     assert "method: 'POST'" in template
     assert "triggerPollMessage" in template
+    assert 'role="status"' in template
+    assert 'aria-live="polite"' in template
+    assert 'aria-atomic="true"' in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -108,3 +108,12 @@ def test_dashboard_hides_multi_user_demo_mode_controls():
     assert "Provider billing samples" not in template
     assert "/api/v1/operator/demo/multi-user" not in template
     assert "x-html" not in template
+
+
+def test_dashboard_trigger_poll_uses_post_action_not_get_link():
+    template = (Path(__file__).resolve().parents[1] / "templates" / "index.html").read_text()
+
+    assert 'href="/api/v1/admin/trigger-poll"' not in template
+    assert "triggerPollNow()" in template
+    assert "method: 'POST'" in template
+    assert "triggerPollMessage" in template

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -3987,6 +3987,9 @@ class TestTriggerPollEndpoint:
         assert detail["code"] == "method_not_allowed"
         assert "dashboard button" in detail["message"]
         assert "POST /api/v1/admin/trigger-poll" in detail["next_steps"][1]
+        trigger_poll_schema = main_app.openapi()["paths"]["/api/v1/admin/trigger-poll"]
+        assert "get" not in trigger_poll_schema
+        assert "post" in trigger_poll_schema
 
     def test_trigger_poll_with_enabled_sources(self):
         """With enabled sources, the endpoint dispatches and returns results."""

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -3974,6 +3974,20 @@ class TestPollAllEnabledSources:
 class TestTriggerPollEndpoint:
     """Tests for the POST /api/v1/admin/trigger-poll endpoint with sources."""
 
+    def test_trigger_poll_get_returns_actionable_method_guidance(self):
+        """Direct browser visits should explain that polling is a POST action."""
+        from app.main import app as main_app
+
+        with TestClient(main_app) as tc:
+            resp = tc.get("/api/v1/admin/trigger-poll")
+
+        assert resp.status_code == 405
+        assert resp.headers["allow"] == "POST"
+        detail = resp.json()["detail"]
+        assert detail["code"] == "method_not_allowed"
+        assert "dashboard button" in detail["message"]
+        assert "POST /api/v1/admin/trigger-poll" in detail["next_steps"][1]
+
     def test_trigger_poll_with_enabled_sources(self):
         """With enabled sources, the endpoint dispatches and returns results."""
         from app.core.security import require_admin_auth


### PR DESCRIPTION
## Summary
- change the dashboard Trigger Poll Now control from a GET link to an in-place POST action
- show success/error feedback on the dashboard instead of navigating to raw JSON
- add a structured GET /api/v1/admin/trigger-poll 405 response with next steps for direct browser/API visits
- add template and endpoint regressions for the method behavior

## Validation
- /tmp/dmarq-380-demo-flow/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_mail_sources.py -q
- /tmp/dmarq-380-demo-flow/.venv/bin/flake8 backend/app/main.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_mail_sources.py
- /tmp/dmarq-380-demo-flow/.venv/bin/black --check backend/app/main.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_mail_sources.py
- git diff --check