### PR TITLE
Fix GitOps preprod manifest path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
         with:
           cmd: |
             for manifest in \
-              k8s-cluster-state/apps/dmarq/preprod/dmarq-stack.yaml \
+              k8s-cluster-state/apps/dmarq/greenfield-preprod/dmarq-stack.yaml \
               k8s-cluster-state/apps/dmarq/greenfield-demo/dmarq-stack.yaml
             do
               test -f "$manifest"
@@ -336,7 +336,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${{ env.K8S_STATE_REPO }}.git"
           git add \
-            apps/dmarq/preprod/dmarq-stack.yaml \
+            apps/dmarq/greenfield-preprod/dmarq-stack.yaml \
             apps/dmarq/greenfield-demo/dmarq-stack.yaml
           if git diff --staged --quiet; then
             echo "No changes to commit"

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -77,9 +77,15 @@ Runs only on pushes to `main` after both **Test** and **Security** pass.
 
 Runs only on pushes to `main` after the Docker stage succeeds.
 
-Updates the image tag in the preprod Kubernetes manifest at
-`apps/dmarq/preprod/dmarq-stack.yaml` in the `christianlouis/k8s-cluster-state`
-repository.
+Updates the image tag in the GitOps manifests that Argo CD actually reconciles
+for the self-hosted demo and preprod environments:
+
+- `apps/dmarq/greenfield-demo/dmarq-stack.yaml` for `demo.dmarq.org`
+- `apps/dmarq/greenfield-preprod/dmarq-stack.yaml` for `preprod.app.dmarq.org`
+
+Production (`apps/dmarq/prod/dmarq-stack.yaml` for `app.dmarq.org`) is not
+updated automatically by this stage. Promote the tested image to production with
+an explicit GitOps change after reviewing the release.
 
 !!! note "Optional"
     This stage requires a `GH_PAT` repository secret with write access to the


### PR DESCRIPTION
## Summary
- update the main CI GitOps manifest rewrite to target `apps/dmarq/greenfield-preprod/dmarq-stack.yaml`, which is the path used by the `dmarq-preprod` Argo CD application
- keep the self-hosted demo manifest update in place
- document that production promotion remains an explicit GitOps step instead of an automatic main-branch side effect

## Root cause
The workflow was updating `apps/dmarq/preprod/dmarq-stack.yaml`, but the live `dmarq-preprod` Argo app reconciles `apps/dmarq/greenfield-preprod`. That left preprod on an older image until manually corrected.

Closes #433.

## Validation
- parsed `.github/workflows/ci.yml` and `.github/workflows/release.yml` with Ruby YAML
- confirmed the old `apps/dmarq/preprod/dmarq-stack.yaml` path is absent from the workflow and CI/CD docs
- ran `git diff --check`
