### PR TITLE
Derive DANE TLSA suggestions

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1031,6 +1031,21 @@ class TLSARecordResponse(BaseModel):
     warnings: List[str] = Field(default_factory=list)
 
 
+class TLSASuggestionResponse(BaseModel):
+    """One TLSA record suggestion derived from a live MX certificate."""
+
+    query_name: str
+    mx_host: str
+    record: str = ""
+    certificate_usage: int = 3
+    selector: int = 1
+    matching_type: int = 1
+    association_data: str = ""
+    status: str = "unavailable"
+    source: str = "smtp-starttls-live-certificate"
+    error: Optional[str] = None
+
+
 class DANEResponse(BaseModel):
     """DANE/TLSA posture result for a domain."""
 
@@ -1038,6 +1053,7 @@ class DANEResponse(BaseModel):
     port: int = 25
     mx_hosts: List[str] = Field(default_factory=list)
     records: List[TLSARecordResponse] = Field(default_factory=list)
+    suggested_records: List[TLSASuggestionResponse] = Field(default_factory=list)
     errors: List[str] = Field(default_factory=list)
     warnings: List[str] = Field(default_factory=list)
     cached: bool = False
@@ -1960,6 +1976,7 @@ async def _build_domain_dns_guidance(
         provider,
         domain_id,
         refresh=refresh,
+        derive_suggestions=True,
     )
     mail_service_records = await mail_service_dns_records_for_domain(db, domain_id)
     guidance = await build_dns_guidance(
@@ -4362,12 +4379,16 @@ async def get_domain_dane(
         domain_id,
         port=port,
         refresh=refresh,
+        derive_suggestions=True,
     )
     return DANEResponse(
         status=result.status,
         port=result.port,
         mx_hosts=result.mx_hosts,
         records=[TLSARecordResponse(**asdict(record)) for record in result.records],
+        suggested_records=[
+            TLSASuggestionResponse(**asdict(suggestion)) for suggestion in result.suggested_records
+        ],
         errors=result.errors,
         warnings=result.warnings,
         cached=cached,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1976,7 +1976,6 @@ async def _build_domain_dns_guidance(
         provider,
         domain_id,
         refresh=refresh,
-        derive_suggestions=True,
     )
     mail_service_records = await mail_service_dns_records_for_domain(db, domain_id)
     guidance = await build_dns_guidance(
@@ -4361,6 +4360,10 @@ async def get_domain_dane(
     domain_id: str = Path(..., title="The domain ID or name"),
     port: int = Query(25, ge=1, le=65535, title="SMTP service port for TLSA lookup"),
     refresh: bool = Query(False, title="Refresh cached DANE result"),
+    derive_suggestions: bool = Query(
+        False,
+        title="Derive live SMTP STARTTLS TLSA suggestions",
+    ),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -4379,7 +4382,7 @@ async def get_domain_dane(
         domain_id,
         port=port,
         refresh=refresh,
-        derive_suggestions=True,
+        derive_suggestions=derive_suggestions,
     )
     return DANEResponse(
         status=result.status,

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import json
 import re
+import smtplib
+import ssl
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
@@ -20,6 +24,9 @@ _HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
 _VALID_CERTIFICATE_USAGES = {0, 1, 2, 3}
 _VALID_SELECTORS = {0, 1}
 _VALID_MATCHING_TYPES = {0, 1, 2}
+_LIVE_TLSA_CACHE_SUFFIX = "live-tlsa-v1"
+_MAX_LIVE_TLSA_HOSTS = 3
+_SMTP_TIMEOUT_SECONDS = 5.0
 
 
 @dataclass
@@ -39,6 +46,22 @@ class TLSARecord:
 
 
 @dataclass
+class TLSASuggestion:
+    """TLSA value derived from a live SMTP STARTTLS certificate."""
+
+    query_name: str
+    mx_host: str
+    record: str = ""
+    certificate_usage: int = 3
+    selector: int = 1
+    matching_type: int = 1
+    association_data: str = ""
+    status: str = "unavailable"
+    source: str = "smtp-starttls-live-certificate"
+    error: Optional[str] = None
+
+
+@dataclass
 class DANEResult:
     """Operator-facing DANE/TLSA posture evidence."""
 
@@ -46,6 +69,7 @@ class DANEResult:
     port: int = 25
     mx_hosts: List[str] = field(default_factory=list)
     records: List[TLSARecord] = field(default_factory=list)
+    suggested_records: List[TLSASuggestion] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
 
@@ -73,6 +97,21 @@ def _record_from_json(value: dict) -> TLSARecord:
     )
 
 
+def _suggestion_from_json(value: dict) -> TLSASuggestion:
+    return TLSASuggestion(
+        query_name=str(value.get("query_name") or ""),
+        mx_host=str(value.get("mx_host") or ""),
+        record=str(value.get("record") or ""),
+        certificate_usage=int(value.get("certificate_usage") or 3),
+        selector=int(value.get("selector") or 1),
+        matching_type=int(value.get("matching_type") or 1),
+        association_data=str(value.get("association_data") or ""),
+        status=str(value.get("status") or "unavailable"),
+        source=str(value.get("source") or "smtp-starttls-live-certificate"),
+        error=value.get("error"),
+    )
+
+
 def _result_from_json(value: str) -> DANEResult:
     data = json.loads(value)
     return DANEResult(
@@ -80,6 +119,9 @@ def _result_from_json(value: str) -> DANEResult:
         port=int(data.get("port") or 25),
         mx_hosts=list(data.get("mx_hosts") or []),
         records=[_record_from_json(row) for row in data.get("records") or []],
+        suggested_records=[
+            _suggestion_from_json(row) for row in data.get("suggested_records") or []
+        ],
         errors=list(data.get("errors") or []),
         warnings=list(data.get("warnings") or []),
     )
@@ -137,22 +179,147 @@ def parse_tlsa_record(record: str, *, query_name: str, mx_host: str) -> TLSAReco
     return result
 
 
-async def check_dane(domain: str, provider: BaseDNSProvider, *, port: int = 25) -> DANEResult:
-    """Resolve MX hosts and lint their SMTP DANE TLSA records."""
-    normalized_domain = domain.strip().strip(".").lower()
-    result = DANEResult(port=port)
-    raw_mx_hosts = await provider.lookup_mx(normalized_domain)
+def _derive_tlsa_suggestion_sync(mx_host: str, port: int, timeout: float) -> TLSASuggestion:
+    query_name = f"_{port}._tcp.{mx_host}"
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+    except ImportError as exc:  # pragma: no cover - dependency is present in packaged builds
+        return TLSASuggestion(
+            query_name=query_name,
+            mx_host=mx_host,
+            error=f"cryptography dependency is unavailable: {exc}",
+        )
+
+    try:
+        context = ssl._create_unverified_context()  # nosec B323 - read-only certificate fetch.
+        with smtplib.SMTP(mx_host, port, timeout=timeout) as smtp:
+            smtp.ehlo_or_helo_if_needed()
+            if not smtp.has_extn("starttls"):
+                return TLSASuggestion(
+                    query_name=query_name,
+                    mx_host=mx_host,
+                    error="SMTP server did not advertise STARTTLS.",
+                )
+            smtp.starttls(context=context)
+            if smtp.sock is None:
+                return TLSASuggestion(
+                    query_name=query_name,
+                    mx_host=mx_host,
+                    error="STARTTLS completed without an accessible socket.",
+                )
+            certificate_der = smtp.sock.getpeercert(binary_form=True)
+    except (OSError, smtplib.SMTPException, ssl.SSLError, TimeoutError) as exc:
+        return TLSASuggestion(query_name=query_name, mx_host=mx_host, error=str(exc))
+
+    if not certificate_der:
+        return TLSASuggestion(
+            query_name=query_name,
+            mx_host=mx_host,
+            error="SMTP server did not return a certificate.",
+        )
+
+    try:
+        certificate = x509.load_der_x509_certificate(certificate_der)
+        spki_der = certificate.public_key().public_bytes(
+            Encoding.DER,
+            PublicFormat.SubjectPublicKeyInfo,
+        )
+    except ValueError as exc:
+        return TLSASuggestion(
+            query_name=query_name,
+            mx_host=mx_host,
+            error=f"SMTP certificate could not be parsed: {exc}",
+        )
+
+    digest = hashlib.sha256(spki_der).hexdigest()
+    return TLSASuggestion(
+        query_name=query_name,
+        mx_host=mx_host,
+        record=f"3 1 1 {digest}",
+        association_data=digest,
+        status="ready",
+    )
+
+
+async def _derive_tlsa_suggestions(
+    mx_hosts: List[str],
+    *,
+    port: int,
+    timeout: float = _SMTP_TIMEOUT_SECONDS,
+) -> List[TLSASuggestion]:
+    limited_hosts = mx_hosts[:_MAX_LIVE_TLSA_HOSTS]
+    if not limited_hosts:
+        return []
+    return await asyncio.gather(
+        *(
+            asyncio.to_thread(_derive_tlsa_suggestion_sync, mx_host, port, timeout)
+            for mx_host in limited_hosts
+        )
+    )
+
+
+def _compare_live_tlsa_suggestions(result: DANEResult) -> None:
+    ready_by_host = {
+        suggestion.mx_host: suggestion
+        for suggestion in result.suggested_records
+        if suggestion.status == "ready" and suggestion.association_data
+    }
+    if not ready_by_host:
+        return
+
+    mismatched_hosts: List[str] = []
+    for record in result.records:
+        if not (
+            record.valid
+            and record.certificate_usage == 3
+            and record.selector == 1
+            and record.matching_type == 1
+            and record.association_data
+        ):
+            continue
+        suggestion = ready_by_host.get(record.mx_host)
+        if suggestion and record.association_data.lower() != suggestion.association_data.lower():
+            record.warnings.append(
+                "TLSA 3 1 1 value does not match the live SMTP STARTTLS certificate SPKI hash."
+            )
+            mismatched_hosts.append(record.mx_host)
+
+    if mismatched_hosts:
+        result.errors.append(
+            "TLSA records do not match the live SMTP STARTTLS certificate for MX host(s): "
+            + ", ".join(sorted(set(mismatched_hosts)))
+        )
+
+
+def _normalize_mx_hosts(raw_mx_hosts: object) -> List[str]:
     mx_hosts = raw_mx_hosts if isinstance(raw_mx_hosts, (list, tuple)) else []
     normalized_hosts = (str(host).strip(".").lower() for host in mx_hosts)
-    result.mx_hosts = list(dict.fromkeys(host for host in normalized_hosts if host))
-    if not result.mx_hosts:
-        result.errors.append("No MX hosts were found for DANE/TLSA evaluation.")
-        return result
+    return list(dict.fromkeys(host for host in normalized_hosts if host))
 
+
+async def _apply_live_tlsa_suggestions(result: DANEResult) -> None:
+    result.suggested_records = await _derive_tlsa_suggestions(result.mx_hosts, port=result.port)
+    unavailable = [
+        f"{suggestion.mx_host}: {suggestion.error}"
+        for suggestion in result.suggested_records
+        if suggestion.status != "ready" and suggestion.error
+    ]
+    if unavailable:
+        result.warnings.append(
+            "Live TLSA suggestion could not be derived for "
+            + "; ".join(unavailable[:_MAX_LIVE_TLSA_HOSTS])
+        )
+
+
+async def _collect_tlsa_records(
+    result: DANEResult,
+    provider: BaseDNSProvider,
+) -> Tuple[List[str], List[str]]:
     missing_hosts: List[str] = []
     invalid_hosts: List[str] = []
     for mx_host in result.mx_hosts:
-        query_name = f"_{port}._tcp.{mx_host}"
+        query_name = f"_{result.port}._tcp.{mx_host}"
         raw_records = await provider.lookup_tlsa(query_name)
         records = raw_records if isinstance(raw_records, (list, tuple)) else []
         if not records:
@@ -164,7 +331,15 @@ async def check_dane(domain: str, provider: BaseDNSProvider, *, port: int = 25) 
         result.records.extend(parsed_records)
         if not any(record.valid for record in parsed_records):
             invalid_hosts.append(mx_host)
+    return missing_hosts, invalid_hosts
 
+
+def _append_tlsa_coverage_errors(
+    result: DANEResult,
+    *,
+    missing_hosts: List[str],
+    invalid_hosts: List[str],
+) -> None:
     if missing_hosts:
         result.errors.append(
             "No TLSA records were found for MX host(s): " + ", ".join(missing_hosts)
@@ -173,17 +348,50 @@ async def check_dane(domain: str, provider: BaseDNSProvider, *, port: int = 25) 
         result.errors.append(
             "TLSA records need syntax review for MX host(s): " + ", ".join(invalid_hosts)
         )
-    if result.records:
-        result.warnings.append(
-            "DMARQ validates TLSA syntax and MX coverage, but does not yet validate DNSSEC chains "
-            "or compare TLSA hashes with live SMTP certificates."
-        )
 
+
+def _finalize_dane_status(result: DANEResult) -> None:
     valid_hosts = {record.mx_host for record in result.records if record.valid}
     if not result.errors:
         result.status = "pass"
+    elif any(error.startswith("TLSA records do not match") for error in result.errors):
+        result.status = "fail"
     elif valid_hosts:
         result.status = "partial"
+
+
+async def check_dane(
+    domain: str,
+    provider: BaseDNSProvider,
+    *,
+    port: int = 25,
+    derive_suggestions: bool = False,
+) -> DANEResult:
+    """Resolve MX hosts and lint their SMTP DANE TLSA records."""
+    normalized_domain = domain.strip().strip(".").lower()
+    result = DANEResult(port=port)
+    result.mx_hosts = _normalize_mx_hosts(await provider.lookup_mx(normalized_domain))
+    if not result.mx_hosts:
+        result.errors.append("No MX hosts were found for DANE/TLSA evaluation.")
+        return result
+
+    if derive_suggestions:
+        await _apply_live_tlsa_suggestions(result)
+
+    missing_hosts, invalid_hosts = await _collect_tlsa_records(result, provider)
+    _append_tlsa_coverage_errors(
+        result,
+        missing_hosts=missing_hosts,
+        invalid_hosts=invalid_hosts,
+    )
+    if result.records:
+        result.warnings.append(
+            "DMARQ validates TLSA syntax and MX coverage. When live SMTP access succeeds, "
+            "DMARQ compares DANE-EE SPKI hashes with the STARTTLS certificate; DNSSEC chain "
+            "validation is still operator-confirmed."
+        )
+    _compare_live_tlsa_suggestions(result)
+    _finalize_dane_status(result)
     return result
 
 
@@ -193,6 +401,7 @@ async def check_dane_cached(
     domain: str,
     *,
     port: int = 25,
+    derive_suggestions: bool = False,
     ttl_seconds: int = DEFAULT_DNS_CACHE_TTL_SECONDS,
     refresh: bool = False,
 ) -> Tuple[DANEResult, bool, datetime]:
@@ -201,6 +410,8 @@ async def check_dane_cached(
     normalized_domain = domain.strip().strip(".").lower()
     provider_name = f"{provider.__class__.__name__}:dane"
     cache_key = f"{_CACHE_KEY}:{port}"
+    if derive_suggestions:
+        cache_key = f"{cache_key}:{_LIVE_TLSA_CACHE_SUFFIX}"
     row = (
         db.query(DNSCache)
         .filter(
@@ -213,7 +424,12 @@ async def check_dane_cached(
     if row and not refresh and _is_fresh(row, ttl_seconds, now):
         return _result_from_json(row.result_json), True, row.checked_at
 
-    result = await check_dane(normalized_domain, provider, port=port)
+    result = await check_dane(
+        normalized_domain,
+        provider,
+        port=port,
+        derive_suggestions=derive_suggestions,
+    )
     payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
     if row is None:
         row = DNSCache(

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import ipaddress
 import json
 import re
 import smtplib
+import socket
 import ssl
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -179,10 +181,27 @@ def parse_tlsa_record(record: str, *, query_name: str, mx_host: str) -> TLSAReco
     return result
 
 
+def _is_public_smtp_address(address: str) -> bool:
+    try:
+        return ipaddress.ip_address(address).is_global
+    except ValueError:
+        return False
+
+
+def _resolve_public_smtp_address(mx_host: str, port: int) -> str:
+    candidates = socket.getaddrinfo(mx_host, port, type=socket.SOCK_STREAM)
+    for candidate in candidates:
+        sockaddr = candidate[4]
+        if sockaddr and _is_public_smtp_address(str(sockaddr[0])):
+            return str(sockaddr[0])
+    raise OSError("MX host did not resolve to a public SMTP address.")
+
+
 def _derive_tlsa_suggestion_sync(mx_host: str, port: int, timeout: float) -> TLSASuggestion:
     query_name = f"_{port}._tcp.{mx_host}"
     try:
         from cryptography import x509
+        from cryptography.exceptions import UnsupportedAlgorithm
         from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
     except ImportError as exc:  # pragma: no cover - dependency is present in packaged builds
         return TLSASuggestion(
@@ -192,8 +211,11 @@ def _derive_tlsa_suggestion_sync(mx_host: str, port: int, timeout: float) -> TLS
         )
 
     try:
-        context = ssl._create_unverified_context()  # nosec B323 - read-only certificate fetch.
-        with smtplib.SMTP(mx_host, port, timeout=timeout) as smtp:
+        smtp_address = _resolve_public_smtp_address(mx_host, port)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        with smtplib.SMTP(smtp_address, port, timeout=timeout) as smtp:
             smtp.ehlo_or_helo_if_needed()
             if not smtp.has_extn("starttls"):
                 return TLSASuggestion(
@@ -225,7 +247,7 @@ def _derive_tlsa_suggestion_sync(mx_host: str, port: int, timeout: float) -> TLS
             Encoding.DER,
             PublicFormat.SubjectPublicKeyInfo,
         )
-    except ValueError as exc:
+    except (UnsupportedAlgorithm, ValueError) as exc:
         return TLSASuggestion(
             query_name=query_name,
             mx_host=mx_host,
@@ -251,12 +273,26 @@ async def _derive_tlsa_suggestions(
     limited_hosts = mx_hosts[:_MAX_LIVE_TLSA_HOSTS]
     if not limited_hosts:
         return []
-    return await asyncio.gather(
+    results = await asyncio.gather(
         *(
             asyncio.to_thread(_derive_tlsa_suggestion_sync, mx_host, port, timeout)
             for mx_host in limited_hosts
-        )
+        ),
+        return_exceptions=True,
     )
+    suggestions: List[TLSASuggestion] = []
+    for mx_host, result in zip(limited_hosts, results):
+        if isinstance(result, TLSASuggestion):
+            suggestions.append(result)
+            continue
+        suggestions.append(
+            TLSASuggestion(
+                query_name=f"_{port}._tcp.{mx_host}",
+                mx_host=mx_host,
+                error=f"Live TLSA suggestion failed: {result}",
+            )
+        )
+    return suggestions
 
 
 def _compare_live_tlsa_suggestions(result: DANEResult) -> None:

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -145,17 +145,42 @@ def _target_by_code(records: List[DNSGuidanceRecord], code: str) -> DNSGuidanceR
 
 
 def _dane_target_record(domain: str, result: DANEResult) -> DNSGuidanceRecord:
-    mx_host = result.mx_hosts[0] if result.mx_hosts else f"<mx-host>.{domain}"
+    ready_suggestion = next(
+        (
+            suggestion
+            for suggestion in result.suggested_records
+            if suggestion.status == "ready" and suggestion.record
+        ),
+        None,
+    )
+    mx_host = (
+        ready_suggestion.mx_host
+        if ready_suggestion
+        else result.mx_hosts[0] if result.mx_hosts else f"<mx-host>.{domain}"
+    )
+    value = (
+        ready_suggestion.record
+        if ready_suggestion
+        else "3 1 1 <derive-sha256-spki-from-live-mx-certificate>"
+    )
+    purpose = (
+        f"DANE SMTP TLSA value derived from the live STARTTLS certificate for {mx_host}. "
+        "Publish it only after DNSSEC is signed and validating, and rotate it with "
+        "certificate changes."
+        if ready_suggestion
+        else (
+            "DANE SMTP TLSA certificate pinning for one MX host. The value is not "
+            "guessable: derive one matching TLSA record from each live MX certificate, "
+            "publish it only after DNSSEC is signed and validating, and rotate it with "
+            "certificate changes."
+        )
+    )
     return DNSGuidanceRecord(
         code="target_dane",
         record_type="TLSA",
         name=f"_{result.port}._tcp.{mx_host}",
-        value="3 1 1 <derive-sha256-spki-from-live-mx-certificate>",
-        purpose=(
-            "DANE SMTP TLSA certificate pinning for one MX host. The value is not guessable: "
-            "derive one matching TLSA record from each live MX certificate, publish it only "
-            "after DNSSEC is signed and validating, and rotate it with certificate changes."
-        ),
+        value=value,
+        purpose=purpose,
         priority="optional",
     )
 
@@ -973,6 +998,9 @@ def _actionable_dane_warnings(result: DANEResult) -> List[str]:
         for warning in result.warnings
         if not warning.startswith(
             "DMARQ validates TLSA syntax and MX coverage, but does not yet validate DNSSEC chains"
+        )
+        and not warning.startswith(
+            "DMARQ validates TLSA syntax and MX coverage. When live SMTP access succeeds"
         )
     ]
 

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -178,7 +178,7 @@ def _dane_target_record(domain: str, result: DANEResult) -> DNSGuidanceRecord:
     return DNSGuidanceRecord(
         code="target_dane",
         record_type="TLSA",
-        name=f"_{result.port}._tcp.{mx_host}",
+        name=ready_suggestion.query_name if ready_suggestion else f"_{result.port}._tcp.{mx_host}",
         value=value,
         purpose=purpose,
         priority="optional",

--- a/backend/app/tests/test_dane.py
+++ b/backend/app/tests/test_dane.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.services.dane import (
     TLSASuggestion,
+    _derive_tlsa_suggestions,
     check_dane,
     check_dane_cached,
     parse_tlsa_record,
@@ -162,6 +163,69 @@ async def test_check_dane_flags_live_tlsa_mismatch(monkeypatch):
         "do not match the live SMTP STARTTLS certificate" in error for error in result.errors
     )
     assert any("does not match the live SMTP" in warning for warning in result.records[0].warnings)
+
+
+@pytest.mark.asyncio
+async def test_check_dane_accepts_matching_live_tlsa_suggestion(monkeypatch):
+    provider = FakeDANEDNSProvider(
+        mx_hosts=["mx1.example.com"],
+        tlsa_records={
+            "_25._tcp.mx1.example.com": [
+                "3 1 1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ],
+        },
+    )
+
+    async def fake_suggestions(mx_hosts, *, port, timeout=5.0):
+        return [
+            TLSASuggestion(
+                query_name="_25._tcp.mx1.example.com",
+                mx_host="mx1.example.com",
+                record=(
+                    "3 1 1 " "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                association_data="a" * 64,
+                status="ready",
+            )
+        ]
+
+    monkeypatch.setattr("app.services.dane._derive_tlsa_suggestions", fake_suggestions)
+
+    result = await check_dane("example.com", provider, derive_suggestions=True)
+
+    assert result.status == "pass"
+    assert not any(
+        "do not match the live SMTP STARTTLS certificate" in error for error in result.errors
+    )
+    assert not any(
+        "does not match the live SMTP" in warning for warning in result.records[0].warnings
+    )
+
+
+@pytest.mark.asyncio
+async def test_derive_tlsa_suggestions_keeps_host_failures_as_data(monkeypatch):
+    def fake_suggestion(mx_host, port, timeout):
+        if mx_host == "mx1.example.com":
+            raise RuntimeError("transient STARTTLS failure")
+        return TLSASuggestion(
+            query_name="_25._tcp.mx2.example.com",
+            mx_host="mx2.example.com",
+            record="3 1 1 " + "a" * 64,
+            association_data="a" * 64,
+            status="ready",
+        )
+
+    monkeypatch.setattr("app.services.dane._derive_tlsa_suggestion_sync", fake_suggestion)
+
+    suggestions = await _derive_tlsa_suggestions(
+        ["mx1.example.com", "mx2.example.com"],
+        port=25,
+    )
+
+    assert suggestions[0].mx_host == "mx1.example.com"
+    assert suggestions[0].status == "unavailable"
+    assert "transient STARTTLS failure" in str(suggestions[0].error)
+    assert suggestions[1].status == "ready"
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dane.py
+++ b/backend/app/tests/test_dane.py
@@ -2,7 +2,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from app.services.dane import check_dane, check_dane_cached, parse_tlsa_record
+from app.services.dane import (
+    TLSASuggestion,
+    check_dane,
+    check_dane_cached,
+    parse_tlsa_record,
+)
 from app.services.dns_resolver import BaseDNSProvider
 
 
@@ -97,6 +102,69 @@ async def test_check_dane_reports_partial_mx_coverage_with_one_valid_host():
 
 
 @pytest.mark.asyncio
+async def test_check_dane_derives_live_tlsa_suggestion(monkeypatch):
+    provider = FakeDANEDNSProvider(mx_hosts=["mx1.example.com"])
+
+    async def fake_suggestions(mx_hosts, *, port, timeout=5.0):
+        assert mx_hosts == ["mx1.example.com"]
+        assert port == 25
+        return [
+            TLSASuggestion(
+                query_name="_25._tcp.mx1.example.com",
+                mx_host="mx1.example.com",
+                record=(
+                    "3 1 1 " "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                association_data="a" * 64,
+                status="ready",
+            )
+        ]
+
+    monkeypatch.setattr("app.services.dane._derive_tlsa_suggestions", fake_suggestions)
+
+    result = await check_dane("example.com", provider, derive_suggestions=True)
+
+    assert result.status == "fail"
+    assert result.suggested_records[0].record == "3 1 1 " + "a" * 64
+    assert "No TLSA records were found for MX host(s): mx1.example.com" in result.errors
+
+
+@pytest.mark.asyncio
+async def test_check_dane_flags_live_tlsa_mismatch(monkeypatch):
+    provider = FakeDANEDNSProvider(
+        mx_hosts=["mx1.example.com"],
+        tlsa_records={
+            "_25._tcp.mx1.example.com": [
+                "3 1 1 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ],
+        },
+    )
+
+    async def fake_suggestions(mx_hosts, *, port, timeout=5.0):
+        return [
+            TLSASuggestion(
+                query_name="_25._tcp.mx1.example.com",
+                mx_host="mx1.example.com",
+                record=(
+                    "3 1 1 " "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                association_data="a" * 64,
+                status="ready",
+            )
+        ]
+
+    monkeypatch.setattr("app.services.dane._derive_tlsa_suggestions", fake_suggestions)
+
+    result = await check_dane("example.com", provider, derive_suggestions=True)
+
+    assert result.status == "fail"
+    assert any(
+        "do not match the live SMTP STARTTLS certificate" in error for error in result.errors
+    )
+    assert any("does not match the live SMTP" in warning for warning in result.records[0].warnings)
+
+
+@pytest.mark.asyncio
 async def test_check_dane_filters_null_mx_marker():
     provider = FakeDANEDNSProvider(mx_hosts=["."])
 
@@ -137,3 +205,39 @@ async def test_check_dane_cached_reuses_fresh_result(db_session):
     assert second_checked == first_checked
     provider.lookup_mx.assert_awaited_once()
     provider.lookup_tlsa.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_dane_cached_keeps_live_suggestions_in_separate_cache(
+    db_session,
+    monkeypatch,
+):
+    provider = FakeDANEDNSProvider(mx_hosts=["mx.example.com"])
+
+    async def fake_suggestions(mx_hosts, *, port, timeout=5.0):
+        return [
+            TLSASuggestion(
+                query_name="_25._tcp.mx.example.com",
+                mx_host="mx.example.com",
+                record=(
+                    "3 1 1 " "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                association_data="a" * 64,
+                status="ready",
+            )
+        ]
+
+    monkeypatch.setattr("app.services.dane._derive_tlsa_suggestions", fake_suggestions)
+
+    plain, plain_cached, _ = await check_dane_cached(db_session, provider, "example.com")
+    live, live_cached, _ = await check_dane_cached(
+        db_session,
+        provider,
+        "example.com",
+        derive_suggestions=True,
+    )
+
+    assert plain_cached is False
+    assert live_cached is False
+    assert plain.suggested_records == []
+    assert live.suggested_records[0].association_data == "a" * 64

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -941,7 +941,7 @@ def test_bimi_endpoint_returns_404_for_unknown_domain(authed_client: TestClient)
 def test_dane_endpoint_returns_cached_posture(authed_client: TestClient):
     """The domain detail page can fetch DANE/TLSA posture with cache metadata."""
     checked_at = datetime(2026, 5, 23, 12, 0, 0)
-    result = DANEResult(
+    passive_result = DANEResult(
         status="pass",
         port=25,
         mx_hosts=["mx.example.com"],
@@ -961,26 +961,46 @@ def test_dane_endpoint_returns_cached_posture(authed_client: TestClient):
                 valid=True,
             )
         ],
-        suggested_records=[
-            TLSASuggestion(
-                query_name="_25._tcp.mx.example.com",
-                mx_host="mx.example.com",
-                record=(
-                    "3 1 1 " "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-                ),
-                association_data=(
-                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-                ),
-                status="ready",
-            )
-        ],
     )
+    live_result = DANEResult(
+        **{
+            **passive_result.__dict__,
+            "suggested_records": [
+                TLSASuggestion(
+                    query_name="_25._tcp.mx.example.com",
+                    mx_host="mx.example.com",
+                    record=(
+                        "3 1 1 " "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                    ),
+                    association_data=(
+                        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                    ),
+                    status="ready",
+                )
+            ],
+        }
+    )
+    calls = []
+
+    async def fake_check(db, provider, domain, *, port=25, refresh=False, derive_suggestions=False):
+        calls.append(
+            {
+                "domain": domain,
+                "port": port,
+                "refresh": refresh,
+                "derive_suggestions": derive_suggestions,
+            }
+        )
+        return (live_result if derive_suggestions else passive_result), True, checked_at
 
     with patch(
         "app.api.api_v1.endpoints.domains.check_dane_cached",
-        new=AsyncMock(return_value=(result, True, checked_at)),
+        new=fake_check,
     ):
         response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/dane")
+        live_response = authed_client.get(
+            f"/api/v1/domains/{DOMAIN}/dns/dane?derive_suggestions=true"
+        )
 
     assert response.status_code == 200
     data = response.json()
@@ -989,10 +1009,17 @@ def test_dane_endpoint_returns_cached_posture(authed_client: TestClient):
     assert data["records"][0]["query_name"] == "_25._tcp.mx.example.com"
     assert data["records"][0]["certificate_usage"] == 3
     assert data["records"][0]["valid"] is True
-    assert data["suggested_records"][0]["record"].startswith("3 1 1 ")
-    assert data["suggested_records"][0]["status"] == "ready"
+    assert data["suggested_records"] == []
     assert data["cached"] is True
     assert data["checked_at"] == checked_at.isoformat()
+    assert live_response.status_code == 200
+    live_data = live_response.json()
+    assert live_data["suggested_records"][0]["record"].startswith("3 1 1 ")
+    assert live_data["suggested_records"][0]["status"] == "ready"
+    assert calls == [
+        {"domain": DOMAIN, "port": 25, "refresh": False, "derive_suggestions": False},
+        {"domain": DOMAIN, "port": 25, "refresh": False, "derive_suggestions": True},
+    ]
 
 
 def test_dane_endpoint_returns_404_for_unknown_domain(authed_client: TestClient):

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -24,7 +24,7 @@ from app.models.organization import Entitlement, Organization
 from app.models.report import DMARCReport, ReportRecord
 from app.models.workspace import Workspace
 from app.services.bimi import BIMIResult
-from app.services.dane import DANEResult, TLSARecord
+from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
 from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
 from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import DomainDNSResult
@@ -961,6 +961,19 @@ def test_dane_endpoint_returns_cached_posture(authed_client: TestClient):
                 valid=True,
             )
         ],
+        suggested_records=[
+            TLSASuggestion(
+                query_name="_25._tcp.mx.example.com",
+                mx_host="mx.example.com",
+                record=(
+                    "3 1 1 " "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                ),
+                association_data=(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                ),
+                status="ready",
+            )
+        ],
     )
 
     with patch(
@@ -976,6 +989,8 @@ def test_dane_endpoint_returns_cached_posture(authed_client: TestClient):
     assert data["records"][0]["query_name"] == "_25._tcp.mx.example.com"
     assert data["records"][0]["certificate_usage"] == 3
     assert data["records"][0]["valid"] is True
+    assert data["suggested_records"][0]["record"].startswith("3 1 1 ")
+    assert data["suggested_records"][0]["status"] == "ready"
     assert data["cached"] is True
     assert data["checked_at"] == checked_at.isoformat()
 

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app.services.bimi import BIMIResult
-from app.services.dane import DANEResult
+from app.services.dane import DANEResult, TLSASuggestion
 from app.services.dns_guidance import build_dns_guidance
 from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult
 from app.services.mta_sts import MTAStsResult
@@ -130,6 +130,55 @@ async def test_build_dns_guidance_ignores_dane_limitation_notice_for_pass_status
     )
 
     assert "dane_review" not in {finding.code for finding in guidance.findings}
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_uses_live_tlsa_suggestion_as_dane_target():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+    dane = DANEResult(
+        status="fail",
+        port=25,
+        mx_hosts=["mx.example.com"],
+        errors=["No TLSA records were found for MX host(s): mx.example.com"],
+        suggested_records=[
+            TLSASuggestion(
+                query_name="_25._tcp.mx.example.com",
+                mx_host="mx.example.com",
+                record=(
+                    "3 1 1 " "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                association_data="a" * 64,
+                status="ready",
+            )
+        ],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        dane=dane,
+    )
+
+    target = next(record for record in guidance.target_records if record.code == "target_dane")
+    assert target.name == "_25._tcp.mx.example.com"
+    assert target.value == "3 1 1 " + "a" * 64
+    assert "derived from the live STARTTLS certificate" in target.purpose
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -155,7 +155,7 @@ async def test_build_dns_guidance_uses_live_tlsa_suggestion_as_dane_target():
         errors=["No TLSA records were found for MX host(s): mx.example.com"],
         suggested_records=[
             TLSASuggestion(
-                query_name="_25._tcp.mx.example.com",
+                query_name="_25._tcp.mail.example.net",
                 mx_host="mx.example.com",
                 record=(
                     "3 1 1 " "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -176,7 +176,7 @@ async def test_build_dns_guidance_uses_live_tlsa_suggestion_as_dane_target():
     )
 
     target = next(record for record in guidance.target_records if record.code == "target_dane")
-    assert target.name == "_25._tcp.mx.example.com"
+    assert target.name == "_25._tcp.mail.example.net"
     assert target.value == "3 1 1 " + "a" * 64
     assert "derived from the live STARTTLS certificate" in target.purpose
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -109,7 +109,9 @@ The main open strategic issues are:
   parity tracker for DMARC monitoring platforms.
 - [Issue #310](https://github.com/christianlouis/dmarq/issues/310): DANE, ARC,
   and ARF competitive protocol coverage. The first shipped slice is passive
-  DANE/TLSA posture; ARC and deeper ARF work remain separate design slices.
+  DANE/TLSA posture with live STARTTLS SPKI hash suggestions for TLSA `3 1 1`
+  records when MX access succeeds; ARC and deeper ARF work remain separate
+  design slices.
 - [Issue #384](https://github.com/christianlouis/dmarq/issues/384): autonomous
   mail health remediation loop with human approval.
 - [Issue #385](https://github.com/christianlouis/dmarq/issues/385): sender IP

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -572,10 +572,11 @@ GET /domains/{domain_id}/dns/dane
 
 Returns cached read-only SMTP DANE evidence for the domain's MX hosts. The
 response lists discovered MX hosts, queried TLSA owner names, parsed TLSA
-fields, syntax errors, live `3 1 1` SPKI SHA-256 suggestions when SMTP
-STARTTLS certificate retrieval succeeds, warnings, cache state, and the check
-timestamp. DMARQ validates MX coverage and TLSA syntax, and compares DANE-EE
-SPKI hashes with the live STARTTLS certificate when reachable. DNSSEC chain
+fields, syntax errors, warnings, cache state, and the check timestamp. Pass
+`derive_suggestions=true` to explicitly run live SMTP STARTTLS certificate
+retrieval and return `3 1 1` SPKI SHA-256 suggestions when reachable. DMARQ
+validates MX coverage and TLSA syntax, and compares DANE-EE SPKI hashes with
+the live STARTTLS certificate only for that opt-in live check. DNSSEC chain
 validation is still operator-confirmed.
 
 #### Get DNS Lint Guidance

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -572,9 +572,11 @@ GET /domains/{domain_id}/dns/dane
 
 Returns cached read-only SMTP DANE evidence for the domain's MX hosts. The
 response lists discovered MX hosts, queried TLSA owner names, parsed TLSA
-fields, syntax errors, warnings, cache state, and the check timestamp. DMARQ
-currently validates MX coverage and TLSA syntax only; it does not yet validate
-DNSSEC chains or compare TLSA hashes with live SMTP certificates.
+fields, syntax errors, live `3 1 1` SPKI SHA-256 suggestions when SMTP
+STARTTLS certificate retrieval succeeds, warnings, cache state, and the check
+timestamp. DMARQ validates MX coverage and TLSA syntax, and compares DANE-EE
+SPKI hashes with the live STARTTLS certificate when reachable. DNSSEC chain
+validation is still operator-confirmed.
 
 #### Get DNS Lint Guidance
 

--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -74,8 +74,9 @@ Live DNS checks parse DMARC policy records according to RFC 9989:
   for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, BIMI, and passive DANE/TLSA
   readiness. Provider writes are never automatic; safe TXT/CNAME changes
   require an explicit apply request. DANE/TLSA support is currently read-only
-  MX/TLSA syntax and coverage guidance, not DNSSEC chain validation or live SMTP
-  certificate pinning verification.
+  MX/TLSA syntax and coverage guidance with optional live SMTP STARTTLS SPKI
+  hash suggestions when the MX is reachable; DNSSEC chain validation remains
+  operator-confirmed.
 
 ## Preserved Metadata
 


### PR DESCRIPTION
## Summary
- derive optional DANE TLSA `3 1 1` suggestions from live SMTP STARTTLS certificates when MX access succeeds
- expose `suggested_records` from `/api/v1/domains/{domain}/dns/dane` and use ready suggestions as the DANE DNS Guidance target value
- compare existing valid DANE-EE SPKI TLSA records with the live certificate hash when available and flag mismatches
- update API, compatibility, and roadmap docs for the read-only DANE scope

## Scope
This is a DANE-only slice for #310. It does not implement ARC or broader ARF work, and it does not apply DNS changes automatically.

## Validation
- `black --check backend/app/services/dane.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dane.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py`
- `flake8 backend/app/services/dane.py backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dane.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py`
- `pytest backend/app/tests/test_dns_guidance.py backend/app/tests/test_dane.py backend/app/tests/test_dns_endpoints.py::test_dane_endpoint_returns_cached_posture -q`
- confirmed `cryptography` imports are available in the project runtime

Refs #310.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live TLSA suggestions for domains that can be reached over SMTP STARTTLS, helping users compare DNS TLSA records with a certificate-derived recommendation.
  * DANE/TLSA responses and guidance now include suggested records when available.

* **Bug Fixes**
  * Improved DANE results so TLSA coverage, mismatches, and missing-record cases are reported more clearly.
  * Guidance now prefers a live suggestion as the target TLSA value when one is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->