### PR TITLE
Expose modular auth provider registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,17 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # Authentik Outpost / trusted proxy mode.
 # Only enable when DMARQ is reachable exclusively through that proxy.
 # AUTH_MODE="trusted_proxy"
+# AUTH_TRUSTED_PROXY_EMAIL_HEADER="X-Authentik-Email"
+# AUTH_TRUSTED_PROXY_SUBJECT_HEADER="X-Authentik-Uid"
 # AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS="example.com"
+
+# Generic OIDC for Keycloak, Entra ID, Google Workspace, Okta, and similar.
+# AUTH_MODE="oidc"
+# OIDC_PROVIDER_LABEL="Keycloak"
+# OIDC_ISSUER_URL="https://idp.example.com/realms/dmarq"
+# OIDC_CLIENT_ID="dmarq"
+# OIDC_CLIENT_SECRET="your_oidc_client_secret"
+# OIDC_ALLOWED_EMAILS="admin@example.com"
 
 # Optional mail service sender-domain discovery
 # POSTMARK_ACCOUNT_TOKEN="your_postmark_account_token"

--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 from app.core.auth_providers import (
     OIDC_STATE_COOKIE,
     OIDC_STATE_MAX_AGE,
+    auth_provider_registry,
     build_oidc_authorization_url,
     configured_oidc_provider,
     decode_oidc_state,
@@ -124,6 +125,17 @@ def _get_redirect_uri(request: Request) -> str:
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
+
+
+@router.get("/providers")
+async def auth_providers() -> dict[str, Any]:
+    """Return configured and available browser-auth provider options."""
+    return {
+        "active_provider": _active_auth_provider(),
+        "active_label": settings.auth_provider_label,
+        "auth_configured": settings.auth_configured,
+        "providers": auth_provider_registry(settings),
+    }
 
 
 @router.get("/sign-in")

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -51,6 +51,227 @@ class ExternalIdentityClaims:
     email_verified: bool = False
 
 
+@dataclass(frozen=True)
+class AuthProviderOption:
+    """Operator-facing auth provider preset metadata."""
+
+    provider: str
+    label: str
+    auth_mode: str
+    status: str
+    deployment_model: str
+    setup_hint: str
+    secret_fields: tuple[str, ...] = ()
+    docs_url: str | None = None
+    supports_direct_oidc: bool = False
+    supports_trusted_proxy: bool = False
+    supports_single_user: bool = False
+    supports_multi_user: bool = False
+
+    def as_dict(self, settings: Settings | None = None) -> dict[str, Any]:
+        """Return JSON/template-safe provider metadata."""
+        cfg = settings or get_settings()
+        return {
+            "provider": self.provider,
+            "label": self.label,
+            "auth_mode": self.auth_mode,
+            "status": self.status,
+            "deployment_model": self.deployment_model,
+            "setup_hint": self.setup_hint,
+            "secret_fields": list(self.secret_fields),
+            "docs_url": self.docs_url,
+            "supports_direct_oidc": self.supports_direct_oidc,
+            "supports_trusted_proxy": self.supports_trusted_proxy,
+            "supports_single_user": self.supports_single_user,
+            "supports_multi_user": self.supports_multi_user,
+            "active": getattr(cfg, "active_auth_provider", "unconfigured") == self.provider,
+            "configured": auth_provider_configured(self.provider, cfg),
+        }
+
+
+AUTH_PROVIDER_OPTIONS: tuple[AuthProviderOption, ...] = (
+    AuthProviderOption(
+        provider="disabled",
+        label="No app auth",
+        auth_mode="disabled",
+        status="ready",
+        deployment_model="Self-hosted behind a trusted network, VPN, or access proxy",
+        setup_hint=(
+            "Use only when DMARQ is protected outside the app. Public unauthenticated "
+            "deployments are blocked in production unless explicitly allowed."
+        ),
+        supports_single_user=True,
+    ),
+    AuthProviderOption(
+        provider="local",
+        label="Local admin",
+        auth_mode="local",
+        status="planned",
+        deployment_model="Standalone self-hosted recovery and small installs",
+        setup_hint=(
+            "Local bootstrap users exist, but a full browser login/session flow is still "
+            "tracked separately from this provider registry."
+        ),
+        secret_fields=("FIRST_SUPERUSER_PASSWORD",),
+        supports_single_user=True,
+    ),
+    AuthProviderOption(
+        provider="logto",
+        label="Logto",
+        auth_mode="logto",
+        status="ready",
+        deployment_model="Hosted or self-hosted OIDC identity provider",
+        setup_hint="Set LOGTO_ENDPOINT, LOGTO_APP_ID, and LOGTO_APP_SECRET.",
+        secret_fields=("LOGTO_APP_SECRET",),
+        docs_url="https://docs.logto.io/",
+        supports_direct_oidc=True,
+        supports_single_user=True,
+        supports_multi_user=True,
+    ),
+    AuthProviderOption(
+        provider="authentik",
+        label="Authentik OIDC",
+        auth_mode="authentik",
+        status="ready",
+        deployment_model="Direct Authentik OAuth2/OpenID provider",
+        setup_hint=(
+            "Create an Authentik OAuth2/OpenID provider and set AUTHENTIK_ISSUER_URL, "
+            "AUTHENTIK_CLIENT_ID, and AUTHENTIK_CLIENT_SECRET."
+        ),
+        secret_fields=("AUTHENTIK_CLIENT_SECRET",),
+        docs_url="https://docs.goauthentik.io/docs/add-secure-apps/providers/oauth2/",
+        supports_direct_oidc=True,
+        supports_single_user=True,
+        supports_multi_user=True,
+    ),
+    AuthProviderOption(
+        provider="trusted_proxy",
+        label="Trusted proxy / Authentik Outpost",
+        auth_mode="trusted_proxy",
+        status="ready",
+        deployment_model="Reverse-proxy enforced SSO in front of DMARQ",
+        setup_hint=(
+            "Use only when the proxy is the sole public path to DMARQ and strips any "
+            "incoming spoofed identity headers."
+        ),
+        docs_url="https://docs.goauthentik.io/docs/add-secure-apps/outposts/",
+        supports_trusted_proxy=True,
+        supports_single_user=True,
+        supports_multi_user=True,
+    ),
+    AuthProviderOption(
+        provider="oidc",
+        label="Generic OIDC",
+        auth_mode="oidc",
+        status="ready",
+        deployment_model="Provider-neutral OIDC for Keycloak, Entra ID, Google, Okta, and others",
+        setup_hint=(
+            "Set OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, and optionally "
+            "OIDC_PROVIDER_LABEL plus allowlists."
+        ),
+        secret_fields=("OIDC_CLIENT_SECRET",),
+        docs_url="https://openid.net/developers/how-connect-works/",
+        supports_direct_oidc=True,
+        supports_single_user=True,
+        supports_multi_user=True,
+    ),
+    AuthProviderOption(
+        provider="keycloak",
+        label="Keycloak",
+        auth_mode="oidc",
+        status="ready_via_generic_oidc",
+        deployment_model="Self-hosted or enterprise Keycloak realm/client",
+        setup_hint="Use AUTH_MODE=oidc and set OIDC_PROVIDER_LABEL=Keycloak.",
+        secret_fields=("OIDC_CLIENT_SECRET",),
+        docs_url="https://www.keycloak.org/docs/latest/securing_apps/",
+        supports_direct_oidc=True,
+        supports_single_user=True,
+        supports_multi_user=True,
+    ),
+    AuthProviderOption(
+        provider="entra_id",
+        label="Microsoft Entra ID",
+        auth_mode="oidc",
+        status="ready_via_generic_oidc",
+        deployment_model="Commercial enterprise IdP",
+        setup_hint="Use AUTH_MODE=oidc with the Entra issuer and group/app-role claims.",
+        secret_fields=("OIDC_CLIENT_SECRET",),
+        docs_url="https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc",
+        supports_direct_oidc=True,
+        supports_single_user=True,
+        supports_multi_user=True,
+    ),
+    AuthProviderOption(
+        provider="google_workspace",
+        label="Google Workspace",
+        auth_mode="oidc",
+        status="ready_via_generic_oidc",
+        deployment_model="Google-managed identity for self-hosted or team deployments",
+        setup_hint="Use AUTH_MODE=oidc and restrict access with OIDC_ALLOWED_EMAILS or domains.",
+        secret_fields=("OIDC_CLIENT_SECRET",),
+        docs_url="https://developers.google.com/identity/openid-connect/openid-connect",
+        supports_direct_oidc=True,
+        supports_single_user=True,
+        supports_multi_user=True,
+    ),
+    AuthProviderOption(
+        provider="cloudflare_access",
+        label="Cloudflare Access",
+        auth_mode="trusted_proxy",
+        status="planned",
+        deployment_model="Access proxy in front of DMARQ",
+        setup_hint=(
+            "Tracked as a trusted-proxy preset. DMARQ must validate the trusted proxy "
+            "boundary before accepting Cloudflare identity headers."
+        ),
+        docs_url="https://developers.cloudflare.com/cloudflare-one/applications/",
+        supports_trusted_proxy=True,
+        supports_single_user=True,
+        supports_multi_user=True,
+    ),
+    AuthProviderOption(
+        provider="akamai_eaa",
+        label="Akamai EAA",
+        auth_mode="trusted_proxy",
+        status="planned",
+        deployment_model="Enterprise access proxy in front of DMARQ",
+        setup_hint=(
+            "Tracked as a trusted-proxy preset for EAA-protected deployments; DNS account "
+            "linking belongs to the separate Edge DNS/FastDNS connector work."
+        ),
+        docs_url="https://techdocs.akamai.com/eaa/docs",
+        supports_trusted_proxy=True,
+        supports_single_user=True,
+        supports_multi_user=True,
+    ),
+)
+
+
+def auth_provider_registry(settings: Settings | None = None) -> list[dict[str, Any]]:
+    """Return operator-facing auth provider presets."""
+    return [option.as_dict(settings) for option in AUTH_PROVIDER_OPTIONS]
+
+
+def auth_provider_configured(provider: str, settings: Settings | None = None) -> bool:
+    """Return True when a provider has enough config to be used."""
+    cfg = settings or get_settings()
+    if provider == "disabled":
+        return cfg.active_auth_provider == "disabled"
+    if provider == "logto":
+        return cfg.logto_configured
+    if provider == "authentik":
+        return cfg.authentik_configured
+    if provider == "trusted_proxy":
+        return cfg.trusted_proxy_configured
+    if provider == "oidc":
+        return cfg.generic_oidc_configured
+    if provider in {"keycloak", "entra_id", "google_workspace"}:
+        return cfg.active_auth_provider == "oidc" and cfg.generic_oidc_configured
+    if provider == "local":
+        return bool(cfg.FIRST_SUPERUSER and cfg.FIRST_SUPERUSER_PASSWORD)
+    return False
+
+
 def _split_csv(value: Optional[str]) -> set[str]:
     if not value:
         return set()

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -252,6 +252,27 @@ def auth_provider_registry(settings: Settings | None = None) -> list[dict[str, A
     return [option.as_dict(settings) for option in AUTH_PROVIDER_OPTIONS]
 
 
+OIDC_PRESET_DISCRIMINATORS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    "keycloak": (("keycloak",), ("keycloak",)),
+    "entra_id": (
+        ("entra id", "microsoft entra id", "azure ad", "microsoft"),
+        ("login.microsoftonline.com", "sts.windows.net", "microsoftonline.com"),
+    ),
+    "google_workspace": (
+        ("google workspace", "google"),
+        ("accounts.google.com", "google.com"),
+    ),
+}
+
+
+def _generic_oidc_matches_preset(provider: str, settings: Settings) -> bool:
+    """Return True when generic OIDC config explicitly names a known preset."""
+    labels, issuer_fragments = OIDC_PRESET_DISCRIMINATORS.get(provider, ((), ()))
+    provider_label = (settings.OIDC_PROVIDER_LABEL or "").strip().lower()
+    issuer_url = (settings.OIDC_ISSUER_URL or "").strip().lower()
+    return provider_label in labels or any(fragment in issuer_url for fragment in issuer_fragments)
+
+
 def auth_provider_configured(provider: str, settings: Settings | None = None) -> bool:
     """Return True when a provider has enough config to be used."""
     cfg = settings or get_settings()
@@ -266,7 +287,11 @@ def auth_provider_configured(provider: str, settings: Settings | None = None) ->
     if provider == "oidc":
         return cfg.generic_oidc_configured
     if provider in {"keycloak", "entra_id", "google_workspace"}:
-        return cfg.active_auth_provider == "oidc" and cfg.generic_oidc_configured
+        return (
+            cfg.active_auth_provider == "oidc"
+            and cfg.generic_oidc_configured
+            and _generic_oidc_matches_preset(provider, cfg)
+        )
     if provider == "local":
         return bool(cfg.FIRST_SUPERUSER and cfg.FIRST_SUPERUSER_PASSWORD)
     return False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ import app.models.webhook  # noqa: F401 – ensure webhook tables are registered
 import app.models.workspace  # noqa: F401 – ensure workspace table is registered
 import app.models.workspace_access  # noqa: F401 – ensure RBAC/audit tables are registered
 from app.api.api_v1.api import api_router
+from app.core.auth_providers import auth_provider_registry
 from app.core.config import get_settings
 from app.core.database import Base, SessionLocal, engine
 from app.core.security import add_api_key, generate_api_key, require_admin_auth
@@ -617,6 +618,7 @@ async def setup(request: Request):
             "auth_configured": settings.auth_configured,
             "auth_provider": settings.active_auth_provider,
             "auth_provider_label": settings.auth_provider_label,
+            "auth_provider_options": auth_provider_registry(settings),
         },
     )
 

--- a/backend/app/templates/setup.html
+++ b/backend/app/templates/setup.html
@@ -136,7 +136,7 @@
                         </div>
                         <div class="flex flex-wrap gap-3">
                             <a href="/login" class="btn btn-primary">Sign in</a>
-                            {% if logto_configured %}
+                            {% if auth_configured %}
                             <a href="/onboarding" class="btn btn-secondary">Start workspace onboarding</a>
                             {% endif %}
                             <a href="/" class="btn btn-outline">Open dashboard</a>
@@ -150,20 +150,39 @@
             <div class="card bg-base-100 shadow">
                 <div class="card-body">
                     <h2 class="card-title text-lg">Authentication</h2>
-                    {% if logto_configured %}
+                    {% if auth_configured %}
                     <div role="alert" class="alert alert-success py-3 text-sm">
-                        <span>Logto is configured.</span>
+                        <span>{{ auth_provider_label }} is configured.</span>
                     </div>
                     {% else %}
                     <p class="text-sm leading-6 text-base-content/70">
-                        Configure Logto after setup to enable user sign-in.
+                        Choose the authentication mode that matches this deployment.
                     </p>
-                    <div class="mockup-code mt-2 text-xs">
-                        <pre><code>LOGTO_ENDPOINT=https://tenant.logto.app</code></pre>
-                        <pre><code>LOGTO_APP_ID=...</code></pre>
-                        <pre><code>LOGTO_APP_SECRET=...</code></pre>
-                    </div>
                     {% endif %}
+                    <div class="mt-3 space-y-3">
+                        {% for option in auth_provider_options %}
+                        {% if option.status in ['ready', 'ready_via_generic_oidc'] %}
+                        <div class="rounded-lg border border-base-300 p-3">
+                            <div class="flex items-center justify-between gap-3">
+                                <p class="font-semibold text-sm">{{ option.label }}</p>
+                                {% if option.configured %}
+                                <span class="badge badge-success badge-sm">configured</span>
+                                {% elif option.active %}
+                                <span class="badge badge-info badge-sm">active</span>
+                                {% else %}
+                                <span class="badge badge-ghost badge-sm">{{ option.auth_mode }}</span>
+                                {% endif %}
+                            </div>
+                            <p class="mt-1 text-xs leading-5 text-base-content/60">
+                                {{ option.deployment_model }}
+                            </p>
+                            <p class="mt-1 text-xs leading-5 text-base-content/50">
+                                {{ option.setup_hint }}
+                            </p>
+                        </div>
+                        {% endif %}
+                        {% endfor %}
+                    </div>
                 </div>
             </div>
 

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -26,6 +26,7 @@ from app.api.api_v1.endpoints.auth import _create_next_cookie
 from app.core.auth_providers import (
     ExternalIdentityClaims,
     OIDCProviderConfig,
+    auth_provider_registry,
     configured_oidc_provider,
     create_oidc_state,
     decode_oidc_state,
@@ -179,6 +180,26 @@ class TestSyncLogtoUser:
 
 
 class TestExternalAuthProviders:
+    def test_auth_provider_registry_exposes_required_modes(self):
+        settings = Settings(
+            AUTH_MODE="authentik",
+            AUTHENTIK_ISSUER_URL="https://idp.example.test/application/o/dmarq",
+            AUTHENTIK_CLIENT_ID="client-id",
+            AUTHENTIK_CLIENT_SECRET="client-secret",
+        )
+
+        providers = {entry["provider"]: entry for entry in auth_provider_registry(settings)}
+
+        assert providers["disabled"]["status"] == "ready"
+        assert providers["local"]["status"] == "planned"
+        assert providers["logto"]["auth_mode"] == "logto"
+        assert providers["authentik"]["configured"] is True
+        assert providers["authentik"]["active"] is True
+        assert providers["oidc"]["auth_mode"] == "oidc"
+        assert providers["keycloak"]["status"] == "ready_via_generic_oidc"
+        assert providers["cloudflare_access"]["auth_mode"] == "trusted_proxy"
+        assert providers["akamai_eaa"]["status"] == "planned"
+
     def test_authentik_config_selects_direct_oidc_provider(self):
         settings = Settings(
             AUTH_MODE="authentik",
@@ -311,20 +332,47 @@ class TestExternalAuthProviders:
             "access_token": "access-token",
         }
 
-        with patch(
-            "app.core.auth_providers.fetch_oidc_discovery",
-            new=AsyncMock(
-                return_value={
-                    "authorization_endpoint": "https://idp.example.test/auth",
-                    "token_endpoint": "https://idp.example.test/token",
-                }
+        with (
+            patch(
+                "app.core.auth_providers.fetch_oidc_discovery",
+                new=AsyncMock(
+                    return_value={
+                        "authorization_endpoint": "https://idp.example.test/auth",
+                        "token_endpoint": "https://idp.example.test/token",
+                    }
+                ),
             ),
-        ), patch("httpx.AsyncClient.post", new=AsyncMock(return_value=token_response)):
+            patch("httpx.AsyncClient.post", new=AsyncMock(return_value=token_response)),
+        ):
             with pytest.raises(HTTPException) as exc:
                 await exchange_oidc_callback(request, provider, code="callback-code")
 
         assert exc.value.status_code == 401
         assert "unvalidated ID-token claims" in exc.value.detail
+
+
+class TestAuthProviderEndpoint:
+    def test_auth_providers_endpoint_reports_active_authentik(self, client: TestClient):
+        from app.api.api_v1.endpoints import auth as auth_endpoint
+
+        endpoint_settings = Settings(
+            AUTH_MODE="authentik",
+            AUTHENTIK_ISSUER_URL="https://idp.example.test/application/o/dmarq",
+            AUTHENTIK_CLIENT_ID="client-id",
+            AUTHENTIK_CLIENT_SECRET="client-secret",
+        )
+
+        with patch.object(auth_endpoint, "settings", endpoint_settings):
+            res = client.get("/api/v1/auth/providers")
+
+        assert res.status_code == 200
+        data = res.json()
+        assert data["active_provider"] == "authentik"
+        assert data["active_label"] == "Authentik"
+        assert data["auth_configured"] is True
+        providers = {entry["provider"]: entry for entry in data["providers"]}
+        assert providers["authentik"]["configured"] is True
+        assert providers["keycloak"]["status"] == "ready_via_generic_oidc"
 
 
 # ── /api/v1/auth/me ───────────────────────────────────────────────────────────

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -231,6 +231,22 @@ class TestExternalAuthProviders:
         assert provider is not None
         assert provider.label == "Keycloak"
 
+    def test_generic_oidc_presets_require_explicit_provider_match(self):
+        settings = Settings(
+            AUTH_MODE="oidc",
+            OIDC_ISSUER_URL="https://idp.example.test/realms/dmarq",
+            OIDC_CLIENT_ID="client-id",
+            OIDC_CLIENT_SECRET="client-secret",
+            OIDC_PROVIDER_LABEL="Keycloak",
+        )
+
+        providers = {entry["provider"]: entry for entry in auth_provider_registry(settings)}
+
+        assert providers["oidc"]["configured"] is True
+        assert providers["keycloak"]["configured"] is True
+        assert providers["entra_id"]["configured"] is False
+        assert providers["google_workspace"]["configured"] is False
+
     def test_oidc_state_round_trip(self):
         settings = Settings(SECRET_KEY="s" * 32)
         token = create_oidc_state("/domains", settings)

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -113,6 +113,27 @@ class TestSetupPage:
         assert response.status_code == 200
         assert "/onboarding" in response.text
 
+    def test_setup_page_links_onboarding_when_authentik_is_configured(self, monkeypatch):
+        from app.main import app as main_app
+        from app.main import settings as main_settings
+
+        monkeypatch.setattr(main_settings, "AUTH_MODE", "authentik")
+        monkeypatch.setattr(
+            main_settings,
+            "AUTHENTIK_ISSUER_URL",
+            "https://idp.example.test/application/o/dmarq",
+        )
+        monkeypatch.setattr(main_settings, "AUTHENTIK_CLIENT_ID", "client-id")
+        monkeypatch.setattr(main_settings, "AUTHENTIK_CLIENT_SECRET", "client-secret")
+
+        with TestClient(main_app) as test_client:
+            response = test_client.get("/setup")
+
+        assert response.status_code == 200
+        assert "/onboarding" in response.text
+        assert "Authentik is configured." in response.text
+        assert "Logto is configured." not in response.text
+
     def test_onboarding_page_renders_workspace_bootstrap_flow(self):
         from unittest.mock import MagicMock, patch
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -43,6 +43,10 @@ For deployment verification, upgrades, rollback, and routine checks, use the [Op
 
 DMARQ supports multiple authentication modes. Keep `AUTH_MODE=auto` to preserve
 the existing Logto auto-detection behavior, or choose an explicit mode.
+The setup page and `GET /api/v1/auth/providers` expose the same provider
+registry so operators can see which identity modes are ready, which values are
+missing, and which ecosystem presets use the generic OIDC or trusted-proxy
+paths.
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
@@ -92,6 +96,11 @@ other OIDC-capable providers.
 | `OIDC_ALLOWED_DOMAINS` | Optional comma-separated email-domain allowlist | - | `example.com` |
 | `OIDC_SKIP_SSL_VERIFY` | Disable TLS verification for provider requests. Do not use in production unless explicitly allowed. | `false` | `true`, `false` |
 
+Presets such as Keycloak, Microsoft Entra ID, and Google Workspace do not need
+bespoke DMARQ code paths. Use `AUTH_MODE=oidc`, set `OIDC_PROVIDER_LABEL` to
+the provider name, and restrict single-user/self-hosted installs with
+`OIDC_ALLOWED_EMAILS` or `OIDC_ALLOWED_DOMAINS`.
+
 #### Authentik Outpost / Trusted Proxy
 
 Use `AUTH_MODE=trusted_proxy` only when DMARQ is not reachable except through a
@@ -109,6 +118,12 @@ owner.
 | `AUTH_TRUSTED_PROXY_USERNAME_HEADER` | Header containing username | `X-Authentik-Username` | `X-Authentik-Username` |
 | `AUTH_TRUSTED_PROXY_ALLOWED_EMAILS` | Optional comma-separated email allowlist | - | `admin@example.com` |
 | `AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS` | Optional comma-separated domain allowlist | - | `example.com` |
+
+Cloudflare Access and Akamai EAA are tracked as trusted-proxy presets, not DNS
+provider account connectors. Use them only when they are the sole path to
+DMARQ, strip spoofed identity headers, and provide a stable verified identity.
+DNS zone access for Cloudflare, Akamai Edge DNS/FastDNS, Route53, Hetzner, and
+Linode is separate from login and belongs to the DNS provider connector flow.
 
 ### IMAP Settings
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -8,6 +8,18 @@ Stable automation endpoints live under `/api/v1/public` and require a scoped
 API token in the `X-API-Key` header. Admin endpoints continue to require an
 administrator session or admin API key.
 
+`GET /api/v1/auth/providers` returns the browser-auth provider registry used by
+the setup UI. It contains provider metadata and configured/active booleans, but
+never returns client secrets. Each provider entry includes its `provider`,
+`label`, `auth_mode`, `status`, deployment model, setup hint, secret field names,
+docs URL, direct-OIDC/trusted-proxy support flags, and configured/active state.
+
+Current ready modes are no-app-auth, Logto, Authentik direct OIDC, generic OIDC,
+and trusted-proxy/AuthentiK Outpost. Keycloak, Microsoft Entra ID, and Google
+Workspace are exposed as generic-OIDC presets. Cloudflare Access and Akamai EAA
+are tracked as trusted-proxy presets and remain separate from DNS provider
+account connectors.
+
 ### API Keys
 
 To use the API, you need to generate an API key:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -12,13 +12,16 @@ administrator session or admin API key.
 the setup UI. It contains provider metadata and configured/active booleans, but
 never returns client secrets. Each provider entry includes its `provider`,
 `label`, `auth_mode`, `status`, deployment model, setup hint, secret field names,
-docs URL, direct-OIDC/trusted-proxy support flags, and configured/active state.
+docs URL, `supports_direct_oidc`, `supports_trusted_proxy`,
+`supports_single_user`, `supports_multi_user`, and configured/active state.
 
-Current ready modes are no-app-auth, Logto, Authentik direct OIDC, generic OIDC,
-and trusted-proxy/AuthentiK Outpost. Keycloak, Microsoft Entra ID, and Google
-Workspace are exposed as generic-OIDC presets. Cloudflare Access and Akamai EAA
-are tracked as trusted-proxy presets and remain separate from DNS provider
-account connectors.
+Current ready providers include `disabled` (`No app auth`), `logto`,
+`authentik` (`Authentik OIDC`), `oidc` (`Generic OIDC`), and
+`trusted_proxy` (`Trusted proxy / Authentik Outpost`). Keycloak, Microsoft
+Entra ID, and Google Workspace are exposed as generic-OIDC presets and only
+report `configured=true` when the generic OIDC settings explicitly match that
+preset. Cloudflare Access and Akamai EAA are tracked as trusted-proxy presets
+and remain separate from DNS provider account connectors.
 
 ### API Keys
 


### PR DESCRIPTION
## Summary

- add a provider-neutral auth registry for DMARQ browser authentication modes
- expose `GET /api/v1/auth/providers` so setup/admin surfaces can show available IdP modes without leaking secrets
- make the setup authentication card provider-neutral instead of Logto-only
- document Authentik, generic OIDC presets, trusted-proxy modes, Cloudflare Access, and Akamai EAA boundaries

## Scope

This is a #422 groundwork slice. It does not change live login behavior or add SAML/SCIM. It makes the supported and planned auth modes explicit so Authentik, Logto, generic OIDC, Keycloak/Entra/Google presets, and trusted-proxy modes are visible through one registry.

## Validation

- `black --check backend/app/core/auth_providers.py backend/app/api/api_v1/endpoints/auth.py backend/app/main.py backend/app/tests/test_auth.py backend/app/tests/test_setup_endpoints.py`
- `isort --check-only backend/app/core/auth_providers.py backend/app/api/api_v1/endpoints/auth.py backend/app/main.py backend/app/tests/test_auth.py backend/app/tests/test_setup_endpoints.py`
- `flake8 backend/app/core/auth_providers.py backend/app/api/api_v1/endpoints/auth.py backend/app/main.py backend/app/tests/test_auth.py backend/app/tests/test_setup_endpoints.py`
- `PYTHONPATH=backend pytest backend/app/tests/test_auth.py::TestExternalAuthProviders backend/app/tests/test_auth.py::TestAuthProviderEndpoint backend/app/tests/test_setup_endpoints.py::TestSetupPage backend/app/tests/test_config.py::TestProductionStartupSettings -q`
- `PYTHONPATH=backend python -m py_compile backend/app/core/auth_providers.py backend/app/api/api_v1/endpoints/auth.py backend/app/main.py && git diff --check`

All local checks passed on Python 3.13.13.

Refs #422.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a provider list to the setup flow so users can see available authentication options, their status, and whether they’re configured or active.
  * Added a new API response for authentication provider metadata used by the setup page.

* **Bug Fixes**
  * Improved the setup experience to show generic authentication messages instead of Logto-specific text.

* **Documentation**
  * Expanded configuration guidance for authentication and trusted-proxy options.
  * Updated API docs to describe the new provider metadata endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->