### PR TITLE
Require verified domains for live DNS writes

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1556,6 +1556,32 @@ def _domain_exists(db: Session, store: ReportStore, domain_name: str, workspace=
     return domain_name in store.get_domains()
 
 
+def _require_verified_domain_for_dns_write(
+    db: Session, workspace: Workspace, domain_name: str
+) -> None:
+    """Require explicit DNS ownership proof before mutating provider DNS."""
+    domain = workspace_domain_query(db, workspace).filter(Domain.name == domain_name).first()
+    if domain is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "Add this domain to the workspace and verify ownership before applying live "
+                "DNS changes. You can still preview the proposed DNS repair first."
+            ),
+        )
+    if not domain.verified:
+        proof_name = _ownership_record_name(domain.name)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "Verify domain ownership before applying live DNS changes. Publish the "
+                f"{proof_name} TXT proof shown on the domain ownership page, use Check "
+                "ownership after DNS propagation, then retry this repair. DNS previews remain "
+                "available before verification."
+            ),
+        )
+
+
 def _stored_domain_exists(db: Session, domain_id: str) -> bool:
     query = db.query(Domain.id)
     if domain_id.isdigit() and query.filter(Domain.id == int(domain_id)).first() is not None:
@@ -3813,6 +3839,7 @@ async def apply_domain_dns_change_plan(
                 ttl=payload.ttl,
             )
         else:
+            _require_verified_domain_for_dns_write(db, workspace, resolved_domain)
             result = await apply_dns_write(
                 db,
                 workspace=workspace,

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1204,11 +1204,78 @@ def test_dns_change_plan_apply_rejects_unconfirmed_real_write(
     assert db_session.query(WorkspaceAuditLog).count() == 0
 
 
+def test_dns_change_plan_apply_requires_verified_domain_for_live_write(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN, verified=False))
+    db_session.commit()
+    plan = _dns_plan(operation="update")
+    provider = FakeWriteCloudflareProvider(
+        zones=[{"id": "zone-1", "name": DOMAIN}],
+        records=[_record("dmarc", "TXT", f"_dmarc.{DOMAIN}", "v=DMARC1; p=none")],
+    )
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.build_cloudflare_provider",
+            return_value=provider,
+        ) as build_provider,
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={
+                "plan_id": plan["plan_id"],
+                "provider": "cloudflare",
+                "dry_run": False,
+                "confirm": True,
+            },
+        )
+
+    assert response.status_code == 422
+    assert "Verify domain ownership before applying live DNS changes" in response.json()["detail"]
+    build_provider.assert_not_called()
+    assert provider.updated == []
+    assert db_session.query(WorkspaceAuditLog).count() == 0
+
+
+def test_dns_change_plan_apply_requires_stored_domain_for_live_write(
+    authed_client: TestClient,
+):
+    plan = _dns_plan(operation="update")
+
+    with (
+        patch("app.api.api_v1.endpoints.domains._domain_exists", return_value=True),
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch("app.services.dns_provider_writes.build_cloudflare_provider") as build_provider,
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={
+                "plan_id": plan["plan_id"],
+                "provider": "cloudflare",
+                "dry_run": False,
+                "confirm": True,
+            },
+        )
+
+    assert response.status_code == 422
+    assert "Add this domain to the workspace" in response.json()["detail"]
+    build_provider.assert_not_called()
+
+
 def test_dns_change_plan_apply_updates_cloudflare_and_audits(
     authed_client: TestClient,
     db_session,
 ):
-    db_session.add(Domain(name=DOMAIN))
+    db_session.add(Domain(name=DOMAIN, verified=True))
     db_session.commit()
     plan = _dns_plan(operation="update")
     provider = FakeWriteCloudflareProvider(
@@ -1266,7 +1333,7 @@ def test_dns_change_plan_apply_reports_unverified_provider_readback(
     authed_client: TestClient,
     db_session,
 ):
-    db_session.add(Domain(name=DOMAIN))
+    db_session.add(Domain(name=DOMAIN, verified=True))
     db_session.commit()
     plan = _dns_plan(operation="update")
     provider = FakeUnverifiedWriteCloudflareProvider(
@@ -1379,7 +1446,7 @@ def test_dns_change_plan_apply_allows_explicit_provider_mismatch_override_and_au
     authed_client: TestClient,
     db_session,
 ):
-    db_session.add(Domain(name=DOMAIN))
+    db_session.add(Domain(name=DOMAIN, verified=True))
     db_session.commit()
     plan = _dns_plan(operation="update")
     guidance = _dns_guidance_with_plan(plan)


### PR DESCRIPTION
## Summary

- block confirmed provider DNS writes unless the workspace domain has passed ownership verification
- keep dry-run previews available before verification so users can inspect the exact repair first
- add regression coverage proving unverified live writes stop before the provider client is built

## Validation

- `/tmp/dmarq-auth-venv/bin/pytest backend/app/tests/test_cloudflare_dns.py`
- `/tmp/dmarq-auth-venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `/tmp/dmarq-auth-venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `/tmp/dmarq-auth-venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`
- `/tmp/dmarq-auth-venv/bin/python -m py_compile backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py`

Refs #380