### PR TITLE
[codex] Add Route53 DNS zone import

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # CLOUDFLARE_ZONE_ID="your_cloudflare_zone_id"
 # HETZNER_DNS_API_TOKEN="your_hetzner_read_only_api_token"
 # HETZNER_API_TOKEN="your_hetzner_read_only_api_token"
+# Route 53 zone import uses the standard boto3/AWS credential chain.
+# Prefer DMARQ_ROUTE53_ROLE_ARN with DMARQ_ROUTE53_EXTERNAL_ID in hosted setups.
+# AWS_PROFILE="your_local_read_only_profile"
+# DMARQ_ROUTE53_PROFILE="your_local_read_only_profile"
+# DMARQ_ROUTE53_ROLE_ARN="arn:aws:iam::123456789012:role/dmarq-route53-readonly"
+# DMARQ_ROUTE53_EXTERNAL_ID="customer-or-instance-external-id"
 
 # Authentication
 # AUTH_MODE options: auto, disabled, logto, authentik, oidc, trusted_proxy

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -55,6 +55,11 @@ class Settings(BaseSettings):
     CLOUDFLARE_ZONE_ID: Optional[str] = None
     HETZNER_DNS_API_TOKEN: Optional[str] = None
     HETZNER_API_TOKEN: Optional[str] = None
+    AWS_PROFILE: Optional[str] = None
+    AWS_REGION: Optional[str] = None
+    DMARQ_ROUTE53_PROFILE: Optional[str] = None
+    DMARQ_ROUTE53_ROLE_ARN: Optional[str] = None
+    DMARQ_ROUTE53_EXTERNAL_ID: Optional[str] = None
     POSTMARK_ACCOUNT_TOKEN: Optional[str] = None
     WEBHOOK_SECRET: Optional[str] = None
 

--- a/backend/app/services/dns_provider_connectors.py
+++ b/backend/app/services/dns_provider_connectors.py
@@ -62,7 +62,7 @@ _CONNECTORS: tuple[DNSProviderConnector, ...] = (
         name="Amazon Route 53",
         tier=1,
         auth_models=["iam_role_external_id", "aws_profile", "environment_credentials"],
-        zone_import_status="planned",
+        zone_import_status="ready",
         record_read_status="planned",
         record_write_status="lexicon_available",
         dry_run_supported=True,
@@ -74,10 +74,11 @@ _CONNECTORS: tuple[DNSProviderConnector, ...] = (
             "route53:ChangeResourceRecordSets only when repair is enabled",
         ],
         setup_hint=(
+            "Use the boto3 AWS credential chain for read-only hosted-zone import. "
             "Prefer IAM role assumption with an external ID for hosted deployments; "
-            "static access keys should be limited to self-hosted environments."
+            "static access keys should stay limited to self-hosted environments."
         ),
-        docs_url="https://docs.aws.amazon.com/Route53/latest/APIReference/Welcome.html",
+        docs_url="https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListHostedZones.html",
     ),
     DNSProviderConnector(
         id="akamai-edgedns",

--- a/backend/app/services/dns_provider_imports.py
+++ b/backend/app/services/dns_provider_imports.py
@@ -11,6 +11,7 @@ from app.services.cloudflare_dns import discover_cloudflare_zones, import_cloudf
 from app.services.dns_provider_connectors import provider_connector_registry
 from app.services.dns_provider_writes import normalize_provider_id
 from app.services.hetzner_dns import discover_hetzner_zones, import_hetzner_domains
+from app.services.route53_dns import discover_route53_zones, import_route53_domains
 
 
 @dataclass
@@ -58,6 +59,8 @@ async def preview_dns_provider_import(
     provider_id = normalize_provider_id(provider)
     if provider_id == "cloudflare":
         zones = await discover_cloudflare_zones(db, workspace_id=workspace_id)
+    elif provider_id == "route53":
+        zones = await discover_route53_zones(db, workspace_id=workspace_id)
     elif provider_id == "hetzner":
         zones = await discover_hetzner_zones(db, workspace_id=workspace_id)
     else:
@@ -104,6 +107,12 @@ async def import_dns_provider_domains(
     provider_id = normalize_provider_id(provider)
     if provider_id == "cloudflare":
         result = await import_cloudflare_domains(
+            db,
+            requested_domains=requested_domains,
+            workspace_id=workspace_id,
+        )
+    elif provider_id == "route53":
+        result = await import_route53_domains(
             db,
             requested_domains=requested_domains,
             workspace_id=workspace_id,

--- a/backend/app/services/route53_dns.py
+++ b/backend/app/services/route53_dns.py
@@ -1,0 +1,254 @@
+"""Amazon Route 53 hosted-zone discovery and domain import helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.models.domain import Domain
+from app.models.workspace import Workspace
+from app.services.organizations import require_organization_plan_limit
+from app.services.workspaces import assign_default_workspace_to_unscoped_rows
+
+try:  # pragma: no cover - exercised through monkeypatched fakes in tests.
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
+except ImportError:  # pragma: no cover - depends on optional runtime dependency.
+    boto3 = None  # type: ignore[assignment]
+    BotoCoreError = ClientError = NoCredentialsError = Exception  # type: ignore[misc]
+
+PROVIDER_NAME = "route53"
+ROUTE53_ROLE_SESSION_NAME = "dmarq-route53-zone-import"
+
+
+@dataclass
+class Route53DNSCredentials:
+    """Resolved Route 53 credential hints for the boto3 credential chain."""
+
+    profile_name: Optional[str] = None
+    region_name: Optional[str] = None
+    role_arn: Optional[str] = None
+    external_id: Optional[str] = None
+
+    @property
+    def configured(self) -> bool:
+        return any(
+            [
+                self.profile_name,
+                self.role_arn,
+                os.getenv("AWS_ACCESS_KEY_ID"),
+                os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"),
+                os.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"),
+            ]
+        )
+
+
+class Route53DNSClient:
+    """Small read-only client for Route 53 hosted-zone discovery."""
+
+    def __init__(self, *, route53_client: Any, account_name: str = "Amazon Route 53") -> None:
+        self.route53_client = route53_client
+        self.account_name = account_name
+
+    @staticmethod
+    def _zone_id(zone: Dict[str, Any]) -> str:
+        return str(zone.get("Id") or zone.get("id") or "").rsplit("/", maxsplit=1)[-1]
+
+    @staticmethod
+    def _zone_name(zone: Dict[str, Any]) -> str:
+        return str(zone.get("Name") or zone.get("name") or "").strip().strip(".").lower()
+
+    @staticmethod
+    def _zone_status(zone: Dict[str, Any]) -> str:
+        config = zone.get("Config") or zone.get("config") or {}
+        return "private" if config.get("PrivateZone") or config.get("private_zone") else "public"
+
+    def _list_zones_sync(self) -> List[Dict[str, Any]]:
+        try:
+            paginator = self.route53_client.get_paginator("list_hosted_zones")
+            pages = paginator.paginate()
+            zones: List[Dict[str, Any]] = []
+            for page in pages:
+                page_zones = page.get("HostedZones") or page.get("hosted_zones") or []
+                if isinstance(page_zones, list):
+                    zones.extend(page_zones)
+            return zones
+        except (BotoCoreError, ClientError, NoCredentialsError) as exc:
+            raise LookupError(f"Route 53 hosted-zone listing failed: {exc}") from exc
+
+    async def list_zones(self) -> List[Dict[str, Any]]:
+        """Return Route 53 hosted zones visible to the configured AWS credentials."""
+        return await asyncio.to_thread(self._list_zones_sync)
+
+
+def get_route53_dns_credentials() -> Route53DNSCredentials:
+    """Resolve Route 53 credential hints from settings and standard AWS env vars."""
+    settings = get_settings()
+    return Route53DNSCredentials(
+        profile_name=settings.DMARQ_ROUTE53_PROFILE or settings.AWS_PROFILE,
+        region_name=settings.AWS_REGION,
+        role_arn=settings.DMARQ_ROUTE53_ROLE_ARN,
+        external_id=settings.DMARQ_ROUTE53_EXTERNAL_ID,
+    )
+
+
+def _build_route53_boto_client(credentials: Route53DNSCredentials) -> Any:
+    if boto3 is None:
+        raise LookupError("boto3 is not installed; Route 53 DNS import is unavailable")
+
+    session_kwargs: Dict[str, str] = {}
+    if credentials.profile_name:
+        session_kwargs["profile_name"] = credentials.profile_name
+    if credentials.region_name:
+        session_kwargs["region_name"] = credentials.region_name
+
+    session = boto3.Session(**session_kwargs)
+    if not credentials.role_arn:
+        return session.client("route53")
+
+    assume_kwargs = {
+        "RoleArn": credentials.role_arn,
+        "RoleSessionName": ROUTE53_ROLE_SESSION_NAME,
+    }
+    if credentials.external_id:
+        assume_kwargs["ExternalId"] = credentials.external_id
+    try:
+        assumed = session.client("sts").assume_role(**assume_kwargs)
+    except (BotoCoreError, ClientError, NoCredentialsError) as exc:
+        raise LookupError(f"Route 53 role assumption failed: {exc}") from exc
+
+    temporary = assumed["Credentials"]
+    return session.client(
+        "route53",
+        aws_access_key_id=temporary["AccessKeyId"],
+        aws_secret_access_key=temporary["SecretAccessKey"],
+        aws_session_token=temporary["SessionToken"],
+    )
+
+
+def build_route53_dns_client() -> Route53DNSClient:
+    """Return a Route 53 client configured from the boto3 credential chain."""
+    credentials = get_route53_dns_credentials()
+    account_name = credentials.profile_name or "Amazon Route 53"
+    if credentials.role_arn:
+        account_name = f"Route 53 role {credentials.role_arn.rsplit('/', maxsplit=1)[-1]}"
+    return Route53DNSClient(
+        route53_client=_build_route53_boto_client(credentials),
+        account_name=account_name,
+    )
+
+
+def _resolve_workspace_id(db: Session, workspace_id: Optional[int]) -> int:
+    if workspace_id is not None:
+        return workspace_id
+    return assign_default_workspace_to_unscoped_rows(db).id
+
+
+def _workspace_domain_names(db: Session, workspace_id: Optional[int]) -> set[str]:
+    resolved_workspace_id = _resolve_workspace_id(db, workspace_id)
+    query = db.query(Domain.name).filter(Domain.workspace_id == resolved_workspace_id)
+    return {name for (name,) in query.all()}
+
+
+def _normalize_domain_name(domain: str) -> str:
+    return domain.strip().strip(".").lower()
+
+
+async def discover_route53_zones(
+    db: Session,
+    *,
+    workspace_id: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Return Route 53 hosted zones visible to AWS credentials with import state."""
+    client = build_route53_dns_client()
+    known_domains = _workspace_domain_names(db, workspace_id)
+    zones = await client.list_zones()
+    discovered: List[Dict[str, Any]] = []
+    for zone in zones:
+        zone_id = Route53DNSClient._zone_id(zone)  # pylint: disable=protected-access
+        name = Route53DNSClient._zone_name(zone)  # pylint: disable=protected-access
+        if not zone_id or not name:
+            continue
+        discovered.append(
+            {
+                "id": zone_id,
+                "name": name,
+                "status": Route53DNSClient._zone_status(zone),  # pylint: disable=protected-access
+                "account_name": client.account_name,
+                "imported": name in known_domains,
+            }
+        )
+    return discovered
+
+
+async def import_route53_domains(
+    db: Session,
+    *,
+    requested_domains: Optional[List[str]] = None,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Create Domain rows for Route 53 hosted zones."""
+    workspace_id = _resolve_workspace_id(db, workspace_id)
+    workspace = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+
+    zones = await discover_route53_zones(db, workspace_id=workspace_id)
+    requested = None
+    if requested_domains is not None:
+        requested = {
+            _normalize_domain_name(domain)
+            for domain in requested_domains
+            if _normalize_domain_name(domain)
+        }
+    candidate_names: List[str] = []
+    imported: List[str] = []
+    existing: List[str] = []
+    skipped: List[str] = []
+
+    for zone in zones:
+        name = str(zone["name"]).lower()
+        if requested is not None and name not in requested:
+            skipped.append(name)
+            continue
+        candidate_names.append(name)
+
+    existing_names = set()
+    if candidate_names:
+        existing_names = {
+            row[0] for row in db.query(Domain.name).filter(Domain.name.in_(candidate_names)).all()
+        }
+    new_names = [name for name in candidate_names if name not in existing_names]
+    if workspace and workspace.organization and new_names:
+        require_organization_plan_limit(
+            db,
+            workspace.organization,
+            "monitored_domains",
+            increment=len(new_names),
+        )
+
+    for name in candidate_names:
+        if name in existing_names:
+            existing.append(name)
+        else:
+            db.add(
+                Domain(
+                    name=name,
+                    description="DNS-discovered from Route 53 hosted-zone import",
+                    active=True,
+                    verified=True,
+                    workspace_id=workspace_id,
+                )
+            )
+            imported.append(name)
+
+    db.commit()
+    return {
+        "imported": imported,
+        "existing": existing,
+        "skipped": skipped,
+        "total_discovered": len(zones),
+    }

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -26,6 +26,7 @@ from app.services import (
     dns_provider_imports,
     dns_provider_writes,
     hetzner_dns,
+    route53_dns,
 )
 from app.services.cloudflare_dns import analyze_dns_records, sync_dns_record_changes
 from app.services.dns_provider_writes import (
@@ -116,6 +117,35 @@ class FakeHetznerDNSClient:
 
     async def list_zones(self):
         return self.zones
+
+
+class FakeRoute53DNSClient:
+    def __init__(self, *, zones=None, account_name="Amazon Route 53"):
+        self.zones = zones or []
+        self.account_name = account_name
+
+    async def list_zones(self):
+        return self.zones
+
+
+class FakeRoute53Paginator:
+    def __init__(self, pages):
+        self.pages = pages
+
+    def paginate(self):
+        return self.pages
+
+
+class FakeRoute53BotoClient:
+    def __init__(self, *, pages=None, error=None):
+        self.pages = pages or []
+        self.error = error
+
+    def get_paginator(self, name):
+        assert name == "list_hosted_zones"
+        if self.error:
+            raise self.error
+        return FakeRoute53Paginator(self.pages)
 
 
 class FakeHetznerResponse:
@@ -515,6 +545,91 @@ def test_hetzner_dns_credentials_and_build_client(monkeypatch):
         hetzner_dns.build_hetzner_dns_client()
 
 
+def test_route53_dns_client_list_zones_uses_boto3_paginator():
+    boto_client = FakeRoute53BotoClient(
+        pages=[
+            {"HostedZones": [{"Id": "/hostedzone/Z1", "Name": f"{DOMAIN}."}]},
+            {
+                "HostedZones": [
+                    {
+                        "Id": "/hostedzone/Z2",
+                        "Name": "private.example.",
+                        "Config": {"PrivateZone": True},
+                    }
+                ]
+            },
+        ]
+    )
+    client = route53_dns.Route53DNSClient(route53_client=boto_client)
+
+    zones = asyncio.run(client.list_zones())
+
+    assert [route53_dns.Route53DNSClient._zone_id(zone) for zone in zones] == ["Z1", "Z2"]
+    assert route53_dns.Route53DNSClient._zone_name(zones[0]) == DOMAIN
+    assert route53_dns.Route53DNSClient._zone_status(zones[0]) == "public"
+    assert route53_dns.Route53DNSClient._zone_status(zones[1]) == "private"
+
+
+def test_route53_dns_client_maps_provider_errors():
+    client = route53_dns.Route53DNSClient(
+        route53_client=FakeRoute53BotoClient(error=route53_dns.NoCredentialsError())
+    )
+
+    with pytest.raises(LookupError, match="hosted-zone listing failed"):
+        asyncio.run(client.list_zones())
+
+
+def test_route53_dns_credentials_and_build_client(monkeypatch):
+    created_sessions = []
+
+    class FakeSTSClient:
+        def assume_role(self, **kwargs):
+            assert kwargs == {
+                "RoleArn": "arn:aws:iam::123456789012:role/dmarq",
+                "RoleSessionName": route53_dns.ROUTE53_ROLE_SESSION_NAME,
+                "ExternalId": "external-1",
+            }
+            return {
+                "Credentials": {
+                    "AccessKeyId": "akid",
+                    "SecretAccessKey": "secret",
+                    "SessionToken": "session",
+                }
+            }
+
+    class FakeSession:
+        def __init__(self, **kwargs):
+            created_sessions.append(kwargs)
+
+        def client(self, service_name, **kwargs):
+            if service_name == "sts":
+                return FakeSTSClient()
+            assert service_name == "route53"
+            assert kwargs["aws_access_key_id"] == "akid"
+            return FakeRoute53BotoClient()
+
+    monkeypatch.setattr(
+        route53_dns,
+        "get_settings",
+        lambda: SimpleNamespace(
+            AWS_PROFILE="fallback-profile",
+            AWS_REGION="eu-central-1",
+            DMARQ_ROUTE53_PROFILE="route53-profile",
+            DMARQ_ROUTE53_ROLE_ARN="arn:aws:iam::123456789012:role/dmarq",
+            DMARQ_ROUTE53_EXTERNAL_ID="external-1",
+        ),
+    )
+    monkeypatch.setattr(route53_dns, "boto3", SimpleNamespace(Session=FakeSession))
+
+    credentials = route53_dns.get_route53_dns_credentials()
+    client = route53_dns.build_route53_dns_client()
+
+    assert credentials.profile_name == "route53-profile"
+    assert credentials.configured is True
+    assert created_sessions == [{"profile_name": "route53-profile", "region_name": "eu-central-1"}]
+    assert client.account_name == "Route 53 role dmarq"
+
+
 def test_discover_hetzner_zones_marks_imported_and_filters_invalid(db_session):
     workspace = get_or_create_default_workspace(db_session)
     db_session.add(Domain(name=DOMAIN, workspace_id=workspace.id))
@@ -562,6 +677,59 @@ def test_discover_hetzner_zones_scopes_default_workspace_import_state(db_session
 
     with patch("app.services.hetzner_dns.build_hetzner_dns_client", return_value=client):
         zones = asyncio.run(hetzner_dns.discover_hetzner_zones(db_session))
+
+    assert default_workspace.id != other_workspace.id
+    assert zones[0]["imported"] is False
+
+
+def test_discover_route53_zones_marks_imported_and_filters_invalid(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add(Domain(name=DOMAIN, workspace_id=workspace.id))
+    db_session.commit()
+    client = FakeRoute53DNSClient(
+        zones=[
+            {"Id": "/hostedzone/Z1", "Name": f"{DOMAIN}.", "Config": {"PrivateZone": False}},
+            {"Id": "/hostedzone/Z2", "Name": "private.example.", "Config": {"PrivateZone": True}},
+            {"Id": None, "Name": "invalid.example."},
+            {"Id": "/hostedzone/Z3", "Name": ""},
+        ],
+        account_name="route53-profile",
+    )
+
+    with patch("app.services.route53_dns.build_route53_dns_client", return_value=client):
+        zones = asyncio.run(
+            route53_dns.discover_route53_zones(db_session, workspace_id=workspace.id)
+        )
+
+    assert zones == [
+        {
+            "id": "Z1",
+            "name": DOMAIN,
+            "status": "public",
+            "account_name": "route53-profile",
+            "imported": True,
+        },
+        {
+            "id": "Z2",
+            "name": "private.example",
+            "status": "private",
+            "account_name": "route53-profile",
+            "imported": False,
+        },
+    ]
+
+
+def test_discover_route53_zones_scopes_default_workspace_import_state(db_session):
+    default_workspace = get_or_create_default_workspace(db_session)
+    other_workspace = Workspace(slug="route53-other", name="Route53 Other", active=True)
+    db_session.add(other_workspace)
+    db_session.commit()
+    db_session.add(Domain(name=DOMAIN, workspace_id=other_workspace.id))
+    db_session.commit()
+    client = FakeRoute53DNSClient(zones=[{"Id": "/hostedzone/Z1", "Name": f"{DOMAIN}."}])
+
+    with patch("app.services.route53_dns.build_route53_dns_client", return_value=client):
+        zones = asyncio.run(route53_dns.discover_route53_zones(db_session))
 
     assert default_workspace.id != other_workspace.id
     assert zones[0]["imported"] is False
@@ -655,6 +823,94 @@ def test_import_hetzner_domains_reports_globally_existing_domain(db_session):
     assert db_session.query(Domain).filter(Domain.name == DOMAIN).count() == 1
 
 
+def test_import_route53_domains_imports_requested_and_skips_others(db_session):
+    async def fake_discover(_db, workspace_id=None):
+        return [
+            {"id": "Z1", "name": DOMAIN, "imported": False},
+            {"id": "Z2", "name": "skip.example", "imported": False},
+        ]
+
+    with patch("app.services.route53_dns.discover_route53_zones", new=fake_discover):
+        result = asyncio.run(
+            route53_dns.import_route53_domains(
+                db_session,
+                requested_domains=[f"{DOMAIN}."],
+            )
+        )
+
+    assert result["imported"] == [DOMAIN]
+    assert result["existing"] == []
+    assert result["skipped"] == ["skip.example"]
+    imported = db_session.query(Domain).filter(Domain.name == DOMAIN).first()
+    assert imported is not None
+    assert imported.verified is True
+    assert imported.description == "DNS-discovered from Route 53 hosted-zone import"
+
+
+def test_import_route53_domains_treats_global_duplicate_as_existing(db_session):
+    workspace = Workspace(slug="route53-target", name="Route53 Target")
+    db_session.add(workspace)
+    db_session.add(Domain(name=DOMAIN, workspace_id=None))
+    db_session.commit()
+
+    async def fake_discover(_db, workspace_id=None):
+        assert workspace_id == workspace.id
+        return [{"id": "Z1", "name": DOMAIN, "imported": False}]
+
+    with patch("app.services.route53_dns.discover_route53_zones", new=fake_discover):
+        result = asyncio.run(
+            route53_dns.import_route53_domains(
+                db_session,
+                requested_domains=[DOMAIN],
+                workspace_id=workspace.id,
+            )
+        )
+
+    assert result["imported"] == []
+    assert result["existing"] == [DOMAIN]
+    assert db_session.query(Domain).filter(Domain.name == DOMAIN).count() == 1
+
+
+def test_import_route53_domains_empty_selection_imports_nothing(db_session):
+    async def fake_discover(_db, workspace_id=None):
+        return [
+            {"id": "Z1", "name": DOMAIN, "imported": False},
+            {"id": "Z2", "name": "skip.example", "imported": False},
+        ]
+
+    with patch("app.services.route53_dns.discover_route53_zones", new=fake_discover):
+        result = asyncio.run(
+            route53_dns.import_route53_domains(
+                db_session,
+                requested_domains=[],
+            )
+        )
+
+    assert result["imported"] == []
+    assert result["existing"] == []
+    assert sorted(result["skipped"]) == [DOMAIN, "skip.example"]
+    assert db_session.query(Domain).filter(Domain.name.in_([DOMAIN, "skip.example"])).count() == 0
+
+
+def test_import_route53_domains_reports_globally_existing_domain(db_session):
+    other_workspace = Workspace(slug="route53-existing", name="Route53 Existing", active=True)
+    db_session.add(other_workspace)
+    db_session.commit()
+    db_session.add(Domain(name=DOMAIN, workspace_id=other_workspace.id))
+    db_session.commit()
+
+    async def fake_discover(_db, workspace_id=None):
+        return [{"id": "Z1", "name": DOMAIN, "imported": False}]
+
+    with patch("app.services.route53_dns.discover_route53_zones", new=fake_discover):
+        result = asyncio.run(route53_dns.import_route53_domains(db_session))
+
+    assert result["imported"] == []
+    assert result["existing"] == [DOMAIN]
+    assert result["skipped"] == []
+    assert db_session.query(Domain).filter(Domain.name == DOMAIN).count() == 1
+
+
 def test_dns_provider_import_preview_wraps_cloudflare_zones(db_session):
     async def fake_discover(_db, workspace_id=None):
         assert workspace_id == 123
@@ -723,6 +979,36 @@ def test_dns_provider_import_preview_wraps_hetzner_zones(db_session):
     assert "Hetzner DNS zone" in result["zones"][0]["next_action"]
 
 
+def test_dns_provider_import_preview_wraps_route53_zones(db_session):
+    async def fake_discover(_db, workspace_id=None):
+        assert workspace_id == 123
+        return [
+            {
+                "id": "Z1",
+                "name": DOMAIN,
+                "status": "public",
+                "account_name": "route53-profile",
+                "imported": False,
+            }
+        ]
+
+    with patch("app.services.dns_provider_imports.discover_route53_zones", new=fake_discover):
+        result = asyncio.run(
+            dns_provider_imports.preview_dns_provider_import(
+                db_session,
+                provider="route53",
+                workspace_id=123,
+            )
+        )
+
+    assert result["provider"] == "route53"
+    assert result["provider_name"] == "Amazon Route 53"
+    assert result["total_discovered"] == 1
+    assert result["importable_count"] == 1
+    assert result["zones"][0]["domain"] == DOMAIN
+    assert "Amazon Route 53 zone" in result["zones"][0]["next_action"]
+
+
 def test_dns_provider_import_apply_wraps_hetzner_import(db_session):
     async def fake_import(_db, requested_domains=None, workspace_id=None):
         assert requested_domains == [DOMAIN]
@@ -746,6 +1032,32 @@ def test_dns_provider_import_apply_wraps_hetzner_import(db_session):
 
     assert result["provider"] == "hetzner"
     assert result["provider_name"] == "Hetzner DNS"
+    assert result["imported"] == [DOMAIN]
+
+
+def test_dns_provider_import_apply_wraps_route53_import(db_session):
+    async def fake_import(_db, requested_domains=None, workspace_id=None):
+        assert requested_domains == [DOMAIN]
+        assert workspace_id == 456
+        return {
+            "imported": [DOMAIN],
+            "existing": [],
+            "skipped": [],
+            "total_discovered": 1,
+        }
+
+    with patch("app.services.dns_provider_imports.import_route53_domains", new=fake_import):
+        result = asyncio.run(
+            dns_provider_imports.import_dns_provider_domains(
+                db_session,
+                provider="route53",
+                requested_domains=[DOMAIN],
+                workspace_id=456,
+            )
+        )
+
+    assert result["provider"] == "route53"
+    assert result["provider_name"] == "Amazon Route 53"
     assert result["imported"] == [DOMAIN]
 
 
@@ -1066,8 +1378,8 @@ def test_dns_provider_capabilities_mark_cloudflare_import_available(authed_clien
     assert providers["hetzner"]["record_read_status"] == "planned"
     assert providers["hetzner"]["record_write_status"] == "lexicon_available"
     assert "api_token" in providers["hetzner"]["auth_models"]
-    assert providers["route53"]["import_available"] is False
-    assert providers["route53"]["zone_import_status"] == "planned"
+    assert providers["route53"]["import_available"] is True
+    assert providers["route53"]["zone_import_status"] == "ready"
     assert "iam_role_external_id" in providers["route53"]["auth_models"]
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,3 +32,4 @@ google-auth>=2.0.0
 google-api-python-client>=2.0.0
 google-auth-httplib2>=0.2.0
 litellm>=1.40.0
+boto3>=1.34.0

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -125,6 +125,26 @@ DMARQ, strip spoofed identity headers, and provide a stable verified identity.
 DNS zone access for Cloudflare, Akamai Edge DNS/FastDNS, Route53, Hetzner, and
 Linode is separate from login and belongs to the DNS provider connector flow.
 
+### DNS Provider Integrations
+
+DNS provider integrations are read-only by default. They let DMARQ import
+domains from zones you already manage, even before DMARC reports have arrived.
+Live DNS writes stay behind the separate DNS repair approval flow.
+
+| Provider | Zone import | Configuration |
+|----------|-------------|---------------|
+| Cloudflare | Ready | `CLOUDFLARE_API_TOKEN` with Zone/DNS read permissions |
+| Amazon Route 53 | Ready | boto3/AWS credential chain, `DMARQ_ROUTE53_PROFILE`, or `DMARQ_ROUTE53_ROLE_ARN` with optional `DMARQ_ROUTE53_EXTERNAL_ID` |
+| Hetzner DNS | Ready | `HETZNER_DNS_API_TOKEN` or `HETZNER_API_TOKEN` with DNS zone read access |
+| Akamai Edge DNS/FastDNS | Planned | EdgeGrid DNS credentials, separate from Akamai EAA login |
+| Linode DNS | Planned | Domains-scoped token |
+
+For Route 53 self-hosted installs, use a local AWS profile or environment
+credentials with `route53:ListHostedZones`. Hosted/provider deployments should
+prefer role assumption with an external ID. Add `route53:ListResourceRecordSets`
+or `route53:ChangeResourceRecordSets` only when future DNS inspection or
+approved repair actions require them.
+
 ### IMAP Settings
 
 | Variable | Description | Default | Example |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -638,9 +638,10 @@ actually available today. Use `GET /domains/dns/import/{provider}/preview` to
 list DNS zones visible to a connected provider without creating anything. Use
 `POST /domains/dns/import/{provider}` with an optional `domains` array to import
 selected zones as monitored DMARQ domains before reports have arrived.
-Cloudflare and Hetzner DNS currently support ready DNS-zone import. Route 53,
-Akamai Edge DNS/FastDNS, and Linode are exposed as connector roadmap metadata
-until their read/import implementations land. The legacy
+Cloudflare, Route 53, and Hetzner DNS currently support ready DNS-zone import.
+Route 53 uses the server-side boto3/AWS credential chain and only lists hosted
+zones in this flow. Akamai Edge DNS/FastDNS and Linode are exposed as connector
+roadmap metadata until their read/import implementations land. The legacy
 `/domains/cloudflare/discover` and `/domains/cloudflare/import` endpoints remain
 available for compatibility.
 

--- a/docs/user_guide/settings.md
+++ b/docs/user_guide/settings.md
@@ -111,6 +111,19 @@ For ticketing and chatops workflows, use
 Jira and GitHub issue templates, Slack and Microsoft Teams message templates,
 dedupe keys, and recommended ownership/noise-control rules.
 
+## DNS Provider Imports
+
+Use DNS provider imports when you want DMARQ to monitor domains that exist at
+your DNS provider even if no DMARC reports have arrived yet.
+
+- Cloudflare uses a scoped API token with zone/DNS read access.
+- Amazon Route 53 uses the server-side AWS credential chain, a configured AWS
+  profile, or a role ARN plus external ID.
+- Hetzner DNS uses a read-only DNS API token.
+
+The import flow only creates monitored domains in DMARQ. It does not change DNS
+records. DNS repair remains a separate preview-and-approve action.
+
 ## API Access
 
 DMARQ provides an API for integration with other systems:


### PR DESCRIPTION
## What changed
- Added a read-only Amazon Route 53 hosted-zone import service using boto3's AWS credential chain.
- Wired Route 53 into the generic DNS provider import preview/apply endpoints next to Cloudflare and Hetzner.
- Marked Route 53 zone import as ready in the provider connector metadata while keeping record read/write outside this slice.
- Documented Route 53 configuration via AWS profile, standard environment credentials, or role assumption with external ID.
- Added focused tests for hosted-zone pagination, credential/role setup, import preview/apply behavior, normalization, duplicate handling, and provider capability metadata.

## Scope boundary
This is read-only zone import only. It does not apply Route 53 DNS changes and does not add Route 53 record-set inspection. Live DNS repair remains behind the separate approval/audit flow.

## Validation
- `/tmp/dmarq-auth-venv/bin/pytest backend/app/tests/test_cloudflare_dns.py -k "route53 or hetzner or dns_provider_import or dns_provider_capabilities_mark" -q`
- `/tmp/dmarq-auth-venv/bin/coverage run --source=backend/app -m pytest backend/app/tests/test_cloudflare_dns.py -q && /tmp/dmarq-auth-venv/bin/coverage report -m backend/app/services/route53_dns.py backend/app/services/dns_provider_imports.py backend/app/services/dns_provider_connectors.py`
- `/tmp/dmarq-auth-venv/bin/black --check backend/app/services/route53_dns.py backend/app/services/dns_provider_imports.py backend/app/services/dns_provider_connectors.py backend/app/core/config.py backend/app/tests/test_cloudflare_dns.py`
- `/tmp/dmarq-auth-venv/bin/isort --check-only backend/app/services/route53_dns.py backend/app/services/dns_provider_imports.py backend/app/services/dns_provider_connectors.py backend/app/core/config.py backend/app/tests/test_cloudflare_dns.py`
- `/tmp/dmarq-auth-venv/bin/flake8 backend/app/services/route53_dns.py backend/app/services/dns_provider_imports.py backend/app/services/dns_provider_connectors.py backend/app/core/config.py backend/app/tests/test_cloudflare_dns.py`
- `git diff --check`
- `/tmp/dmarq-auth-venv/bin/pytest backend/app/tests -q` (`1483 passed`)

Part of #423.
