### PR TITLE
Harden Route53 import edge cases

### DIFF
--- a/backend/app/services/route53_dns.py
+++ b/backend/app/services/route53_dns.py
@@ -44,6 +44,7 @@ class Route53DNSCredentials:
                 os.getenv("AWS_ACCESS_KEY_ID"),
                 os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"),
                 os.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"),
+                os.getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"),
             ]
         )
 
@@ -208,12 +209,16 @@ async def import_route53_domains(
     imported: List[str] = []
     existing: List[str] = []
     skipped: List[str] = []
+    seen_candidates: set[str] = set()
 
     for zone in zones:
         name = str(zone["name"]).lower()
         if requested is not None and name not in requested:
             skipped.append(name)
             continue
+        if name in seen_candidates:
+            continue
+        seen_candidates.add(name)
         candidate_names.append(name)
 
     existing_names = set()

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -630,6 +630,16 @@ def test_route53_dns_credentials_and_build_client(monkeypatch):
     assert client.account_name == "Route 53 role dmarq"
 
 
+def test_route53_dns_credentials_detect_full_container_credentials(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_WEB_IDENTITY_TOKEN_FILE", raising=False)
+    monkeypatch.delenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", raising=False)
+    monkeypatch.setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://169.254.170.23/credentials")
+    credentials = route53_dns.Route53DNSCredentials()
+
+    assert credentials.configured is True
+
+
 def test_discover_hetzner_zones_marks_imported_and_filters_invalid(db_session):
     workspace = get_or_create_default_workspace(db_session)
     db_session.add(Domain(name=DOMAIN, workspace_id=workspace.id))
@@ -907,6 +917,22 @@ def test_import_route53_domains_reports_globally_existing_domain(db_session):
 
     assert result["imported"] == []
     assert result["existing"] == [DOMAIN]
+    assert result["skipped"] == []
+    assert db_session.query(Domain).filter(Domain.name == DOMAIN).count() == 1
+
+
+def test_import_route53_domains_deduplicates_hosted_zone_names(db_session):
+    async def fake_discover(_db, workspace_id=None):
+        return [
+            {"id": "Z1", "name": DOMAIN, "imported": False},
+            {"id": "Z2", "name": DOMAIN, "imported": False},
+        ]
+
+    with patch("app.services.route53_dns.discover_route53_zones", new=fake_discover):
+        result = asyncio.run(route53_dns.import_route53_domains(db_session))
+
+    assert result["imported"] == [DOMAIN]
+    assert result["existing"] == []
     assert result["skipped"] == []
     assert db_session.query(Domain).filter(Domain.name == DOMAIN).count() == 1
 


### PR DESCRIPTION
## Summary
- Deduplicate Route53 hosted-zone domain candidates before plan-limit checks and inserts
- Recognize AWS_CONTAINER_CREDENTIALS_FULL_URI as a configured AWS credential-chain hint
- Add regression coverage for both PR #440 Copilot review findings

## Validation
- pytest backend/app/tests/test_cloudflare_dns.py -k route53 -q
- black --check backend/app/services/route53_dns.py backend/app/tests/test_cloudflare_dns.py
- isort --check-only backend/app/services/route53_dns.py backend/app/tests/test_cloudflare_dns.py
- flake8 backend/app/services/route53_dns.py backend/app/tests/test_cloudflare_dns.py
- git diff --check

Follow-up for #440.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Route 53 credential detection so imports work in more container-based AWS environments.
  * Prevented duplicate hosted-zone names from being imported more than once, reducing repeated entries during domain import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->