### PR TITLE
[codex] Add Cloudflare OAuth ownership and source intelligence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,11 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # Optional DNS provider integrations
 # CLOUDFLARE_API_TOKEN="your_cloudflare_api_token"
 # CLOUDFLARE_ZONE_ID="your_cloudflare_zone_id"
+# Optional one-click Cloudflare connector. Create a Cloudflare OAuth client with
+# read-only zone/DNS scopes first; keep DNS write scope separate until repair is enabled.
+# CLOUDFLARE_OAUTH_CLIENT_ID="your_cloudflare_oauth_client_id"
+# CLOUDFLARE_OAUTH_CLIENT_SECRET="your_cloudflare_oauth_client_secret"
+# CLOUDFLARE_OAUTH_SCOPES="zone.read dns.read"
 # HETZNER_DNS_API_TOKEN="your_hetzner_read_only_api_token"
 # HETZNER_API_TOKEN="your_hetzner_read_only_api_token"
 # Route 53 zone import uses the standard boto3/AWS credential chain.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -5618,7 +5618,10 @@ async def get_domain_sources(
         )
         reputations_by_ip = source_reputation_by_ip(reputation_result)
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.info("Source reputation enrichment failed for %s: %s", domain_id, exc)
+        logger.info(
+            "Source reputation enrichment failed for domain sources: %s",
+            type(exc).__name__,
+        )
 
     for source, hostname, sender in source_context:
         ip = source.get("source_ip", "unknown")

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -21,6 +21,7 @@ from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.report import DMARCReport
+from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.services.bimi import BIMIResult, check_bimi_cached
 from app.services.cloudflare_dns import (
@@ -30,6 +31,15 @@ from app.services.cloudflare_dns import (
     import_cloudflare_domains,
     list_dns_record_changes,
     sync_dns_record_changes,
+    verify_cloudflare_domain_ownership,
+)
+from app.services.cloudflare_oauth import (
+    build_cloudflare_authorization_url,
+    build_cloudflare_oauth_state,
+    cloudflare_oauth_configured,
+    decode_cloudflare_oauth_state,
+    exchange_cloudflare_oauth_code,
+    persist_cloudflare_oauth_tokens,
 )
 from app.services.dane import check_dane_cached
 from app.services.demo_data import DEMO_DAYS, build_demo_health_score_history
@@ -156,6 +166,27 @@ def _raise_plan_limit_error(exc: OrganizationPlanLimitError) -> None:
         status_code=status.HTTP_402_PAYMENT_REQUIRED,
         detail=exc.to_detail(),
     ) from exc
+
+
+def _setting_value(db: Session, key: str) -> Optional[str]:
+    row = db.query(Setting).filter(Setting.key == key).first()
+    return row.value if row and row.value else None
+
+
+def _public_base_url(request: Request, db: Session) -> str:
+    """Return the externally visible base URL for provider OAuth redirects."""
+    configured = get_settings().PUBLIC_BASE_URL or _setting_value(db, "general.base_url")
+    if configured:
+        return configured.rstrip("/")
+
+    base_url = str(request.base_url).rstrip("/")
+    forwarded_proto = (
+        (request.headers.get("x-forwarded-proto") or "").split(",", maxsplit=1)[0].strip()
+    )
+    if forwarded_proto in {"http", "https"} and "://" in base_url:
+        _, rest = base_url.split("://", maxsplit=1)
+        return f"{forwarded_proto}://{rest}".rstrip("/")
+    return base_url
 
 
 def _normalize_reported_policy(policy_value: Any) -> Optional[str]:
@@ -1095,6 +1126,38 @@ class CloudflareImportResponse(BaseModel):
     existing: List[str]
     skipped: List[str]
     total_discovered: int
+
+
+class CloudflareOAuthAuthorizeResponse(BaseModel):
+    """Cloudflare OAuth authorization details."""
+
+    authorization_url: str
+    redirect_uri: str
+    scopes: str
+
+
+class CloudflareOAuthStatusResponse(BaseModel):
+    """Cloudflare connector status for the settings UI."""
+
+    oauth_configured: bool
+    connected: bool
+    auth_mode: Optional[str] = None
+    scopes: Optional[str] = None
+    connected_at: Optional[str] = None
+
+
+class CloudflareOwnershipVerifyResponse(BaseModel):
+    """Cloudflare-backed domain ownership verification result."""
+
+    domain: str
+    verified: bool
+    provider: str = "cloudflare"
+    zone_id: Optional[str] = None
+    zone_name: Optional[str] = None
+    zone_status: Optional[str] = None
+    account_name: Optional[str] = None
+    proof_reason: str
+    next_steps: List[str] = Field(default_factory=list)
 
 
 class DNSProviderImportZoneResponse(BaseModel):
@@ -2936,7 +2999,7 @@ async def read_domain(
     """
     workspace = _authorized_domain_read_workspace(_auth, db)
     store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
     domains = _domain_names_for_summary(db, store, workspace)
     stored_domain = workspace_domain_query(db, workspace).filter(Domain.name == domain_name).first()
 
@@ -3339,6 +3402,42 @@ async def verify_domain_ownership(
         matched=matched,
         observed_values=[str(value) for value in observed],
     )
+
+
+@router.post(
+    "/{domain_id}/ownership/cloudflare",
+    response_model=CloudflareOwnershipVerifyResponse,
+)
+async def verify_domain_ownership_with_cloudflare(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Verify a monitored domain through connected Cloudflare zone access."""
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    try:
+        return await verify_cloudflare_domain_ownership(
+            db,
+            domain_name=normalize_domain_name(domain_id),
+            workspace_id=workspace.id,
+        )
+    except LookupError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "message": str(exc),
+                "next_steps": [
+                    "Connect Cloudflare from Settings, or use a scoped Cloudflare API token.",
+                    "Make sure the connected Cloudflare account can list this domain's zone.",
+                    "If the domain is not on Cloudflare, use the TXT ownership proof instead.",
+                ],
+            },
+        ) from exc
 
 
 @router.get("/{domain_id}/migration/readiness", response_model=MigrationReadinessResponse)
@@ -4496,6 +4595,90 @@ async def discover_cloudflare_domains(
         ) from exc
 
 
+@router.get("/cloudflare/oauth/status", response_model=CloudflareOAuthStatusResponse)
+async def get_cloudflare_oauth_status(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return Cloudflare connector status without exposing token material."""
+    auth_mode = _setting_value(db, "cloudflare.auth_mode")
+    token_row = db.query(Setting).filter(Setting.key == "cloudflare.api_token").first()
+    return CloudflareOAuthStatusResponse(
+        oauth_configured=cloudflare_oauth_configured(),
+        connected=bool(token_row and token_row.value),
+        auth_mode=auth_mode,
+        scopes=_setting_value(db, "cloudflare.oauth_scopes"),
+        connected_at=_setting_value(db, "cloudflare.oauth_connected_at"),
+    )
+
+
+@router.get("/cloudflare/oauth/authorize-url", response_model=CloudflareOAuthAuthorizeResponse)
+async def get_cloudflare_oauth_authorize_url(
+    request: Request,
+    return_to: str = Query("/settings", title="Path to return to after OAuth"),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return the Cloudflare OAuth authorization URL for DNS provider access."""
+    workspace = _authorized_domain_workspace(
+        _auth,
+        db,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    redirect_uri = f"{_public_base_url(request, db)}/api/v1/domains/cloudflare/oauth/callback"
+    try:
+        payload = build_cloudflare_authorization_url(
+            redirect_uri=redirect_uri,
+            state=build_cloudflare_oauth_state(workspace_id=workspace.id, return_to=return_to),
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return CloudflareOAuthAuthorizeResponse(**payload)
+
+
+@router.get("/cloudflare/oauth/callback")
+async def cloudflare_oauth_callback(
+    request: Request,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Handle the Cloudflare OAuth redirect and store the scoped access token."""
+    from fastapi.responses import HTMLResponse, RedirectResponse
+
+    error = request.query_params.get("error")
+    code = request.query_params.get("code")
+    state_value = request.query_params.get("state")
+    if error or not code or not state_value:
+        return HTMLResponse(
+            content=(
+                "<html><body><p>Cloudflare connection failed. "
+                "Please close this window and try again from DMARQ settings.</p></body></html>"
+            ),
+            status_code=400,
+        )
+
+    try:
+        state_payload = decode_cloudflare_oauth_state(state_value)
+        _authorized_domain_workspace(_auth, db, selected_workspace_id=state_payload["workspace_id"])
+        token_data = await exchange_cloudflare_oauth_code(
+            code=code,
+            redirect_uri=f"{_public_base_url(request, db)}/api/v1/domains/cloudflare/oauth/callback",
+        )
+        persist_cloudflare_oauth_tokens(db, token_data)
+    except LookupError as exc:
+        logger.info("Cloudflare OAuth callback failed: %s", exc)
+        return HTMLResponse(
+            content=(
+                "<html><body><p>Cloudflare connection failed. "
+                "Please close this window and retry after checking the connector settings.</p></body></html>"
+            ),
+            status_code=400,
+        )
+
+    return RedirectResponse(url=state_payload.get("return_to") or "/settings", status_code=303)
+
+
 @router.post("/cloudflare/import", response_model=CloudflareImportResponse)
 async def import_cloudflare_domain_zones(
     payload: CloudflareImportRequest,
@@ -5422,16 +5605,20 @@ async def get_domain_sources(
         sender_by_ip[ip] = identify_sender(ip, source, hostname=hostname, domain=domain_id)
         source_context.append((source, hostname, sender_by_ip[ip]))
 
-    reputation_result, _, _ = await build_source_reputation_cached(
-        db,
-        domain_id,
-        reports,
-        sources,
-        senders_by_ip=sender_by_ip,
-        anomalies_by_ip=anomalies_by_ip,
-        days=days,
-    )
-    reputations_by_ip = source_reputation_by_ip(reputation_result)
+    reputations_by_ip = {}
+    try:
+        reputation_result, _, _ = await build_source_reputation_cached(
+            db,
+            domain_id,
+            reports,
+            sources,
+            senders_by_ip=sender_by_ip,
+            anomalies_by_ip=anomalies_by_ip,
+            days=days,
+        )
+        reputations_by_ip = source_reputation_by_ip(reputation_result)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.info("Source reputation enrichment failed for %s: %s", domain_id, exc)
 
     for source, hostname, sender in source_context:
         ip = source.get("source_ip", "unknown")

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -815,10 +815,16 @@ async def get_report_by_id(
     source_rows = [_source_row_from_report_record(rec) for rec in raw_records]
     provider = get_default_provider(db)
     ips = [str(row.get("source_ip") or "unknown") for row in source_rows]
-    hostnames = await asyncio.gather(*[_safe_ptr_lookup(provider, ip) for ip in ips])
+    ptr_semaphore = asyncio.Semaphore(20)
+
+    async def _bounded_ptr_lookup(ip: str) -> Optional[str]:
+        async with ptr_semaphore:
+            return await _safe_ptr_lookup(provider, ip)
+
+    hostnames = await asyncio.gather(*[_bounded_ptr_lookup(ip) for ip in ips])
     sender_by_ip = {
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))
-        for ip, row, hostname in zip(ips, source_rows, hostnames)
+        for ip, row, hostname in zip(ips, source_rows, hostnames, strict=True)
     }
     reputations_by_ip: Dict[str, SourceReputation] = {}
     try:
@@ -840,7 +846,7 @@ async def get_report_by_id(
 
     # Normalize records
     record_details = []
-    for rec, row, hostname in zip(raw_records, source_rows, hostnames):
+    for rec, row, hostname in zip(raw_records, source_rows, hostnames, strict=True):
         ip = str(row.get("source_ip") or "unknown")
         guidance = _record_review_guidance(rec)
         reputation = reputations_by_ip.get(ip)

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -1,3 +1,5 @@
+import asyncio
+import ipaddress
 import logging
 from typing import Any, Dict, List, Optional
 
@@ -18,6 +20,13 @@ from app.services.report_persistence import (
     save_parsed_report,
 )
 from app.services.report_store import ReportStore
+from app.services.dns_resolver import get_default_provider
+from app.services.sender_intelligence import identify_sender, source_geo_for
+from app.services.source_reputation import (
+    SourceReputation,
+    build_source_reputation_cached,
+    source_reputation_by_ip,
+)
 from app.services.workspace_access import (
     PERMISSION_REPORTS_READ,
     PERMISSION_REPORTS_WRITE,
@@ -617,6 +626,8 @@ class ReportRecordDetail(BaseModel):
     review_status: str = "pass"
     failure_reasons: List[str] = Field(default_factory=list)
     next_steps: List[str] = Field(default_factory=list)
+    source_details: Dict[str, Any] = Field(default_factory=dict)
+    reputation: Optional[Dict[str, Any]] = None
 
 
 class ReportPolicyDetail(BaseModel):
@@ -692,6 +703,79 @@ def _record_review_guidance(record: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Optional[str]:
+    """Return reverse DNS for an IP without letting enrichment break report loading."""
+    try:
+        ipaddress.ip_address(ip)
+    except ValueError:
+        return None
+    try:
+        return await asyncio.wait_for(provider.lookup_ptr(ip), timeout=timeout)
+    except Exception:
+        return None
+
+
+def _source_row_from_report_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert one report record into the source-row shape used by reputation scoring."""
+    count = int(record.get("count") or 0)
+    spf_result = str(record.get("spf_result") or "unknown").lower()
+    dkim_result = str(record.get("dkim_result") or "unknown").lower()
+    dmarc_pass = spf_result == "pass" or dkim_result == "pass"
+    row = dict(record)
+    row.update(
+        {
+            "source_ip": str(record.get("source_ip") or "unknown"),
+            "count": count,
+            "spf_result": spf_result,
+            "dkim_result": dkim_result,
+            "dmarc_result": "pass" if dmarc_pass else "fail",
+            "spf_pass_count": count if spf_result == "pass" else 0,
+            "spf_fail_count": count if spf_result == "fail" else 0,
+            "dkim_pass_count": count if dkim_result == "pass" else 0,
+            "dkim_fail_count": count if dkim_result == "fail" else 0,
+            "dmarc_pass_count": count if dmarc_pass else 0,
+            "dmarc_fail_count": 0 if dmarc_pass else count,
+        }
+    )
+    return row
+
+
+def _source_reputation_dict(item: SourceReputation) -> Dict[str, Any]:
+    """Return a template-friendly reputation payload."""
+    return {
+        "ip": item.ip,
+        "status": item.status,
+        "risk_score": item.risk_score,
+        "summary": item.summary,
+        "listings": item.listings,
+        "evidence": [
+            {"label": evidence.label, "value": evidence.value, "source": evidence.source}
+            for evidence in item.evidence
+        ],
+        "recommendations": item.recommendations,
+        "checked_at": item.checked_at,
+    }
+
+
+def _source_details(
+    ip: str,
+    record: Dict[str, Any],
+    hostname: Optional[str],
+    sender: Dict[str, Any],
+) -> Dict[str, Any]:
+    geo = source_geo_for(ip, record)
+    return {
+        "hostname": hostname,
+        "sender": sender,
+        "country": geo.get("country"),
+        "country_code": geo.get("country_code"),
+        "region": geo.get("region"),
+        "asn": geo.get("asn"),
+        "network": geo.get("network"),
+        "geo_source": geo.get("source"),
+    }
+
+
 @router.get("/{report_id}", response_model=ReportDetail)
 async def get_report_by_id(
     report_id: str,
@@ -727,10 +811,36 @@ async def get_report_by_id(
         pct=str(policy_val.get("pct", "100")),
     )
 
+    raw_records = list(report.get("records", []))
+    source_rows = [_source_row_from_report_record(rec) for rec in raw_records]
+    provider = get_default_provider(db)
+    ips = [str(row.get("source_ip") or "unknown") for row in source_rows]
+    hostnames = await asyncio.gather(*[_safe_ptr_lookup(provider, ip) for ip in ips])
+    sender_by_ip = {
+        ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))
+        for ip, row, hostname in zip(ips, source_rows, hostnames)
+    }
+    reputations_by_ip: Dict[str, SourceReputation] = {}
+    try:
+        reputation_result, _, _ = await build_source_reputation_cached(
+            db,
+            str(report.get("domain", "")),
+            [report],
+            source_rows,
+            senders_by_ip=sender_by_ip,
+            anomalies_by_ip={},
+            days=1,
+        )
+        reputations_by_ip = source_reputation_by_ip(reputation_result)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.info("Report source reputation enrichment failed for %s: %s", report_id, exc)
+
     # Normalize records
     record_details = []
-    for rec in report.get("records", []):
+    for rec, row, hostname in zip(raw_records, source_rows, hostnames):
+        ip = str(row.get("source_ip") or "unknown")
         guidance = _record_review_guidance(rec)
+        reputation = reputations_by_ip.get(ip)
         record_details.append(
             ReportRecordDetail(
                 source_ip=rec.get("source_ip", ""),
@@ -741,6 +851,8 @@ async def get_report_by_id(
                 header_from=rec.get("header_from", ""),
                 spf=rec.get("spf") if isinstance(rec.get("spf"), list) else None,
                 dkim=rec.get("dkim") if isinstance(rec.get("dkim"), list) else None,
+                source_details=_source_details(ip, rec, hostname, sender_by_ip.get(ip, {})),
+                reputation=_source_reputation_dict(reputation) if reputation else None,
                 **guidance,
             )
         )

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -12,6 +12,7 @@ from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.services.dmarc_parser import DMARCParser
+from app.services.dns_resolver import get_default_provider
 from app.services.organizations import OrganizationPlanLimitError
 from app.services.report_persistence import (
     delete_persisted_report,
@@ -20,7 +21,6 @@ from app.services.report_persistence import (
     save_parsed_report,
 )
 from app.services.report_store import ReportStore
-from app.services.dns_resolver import get_default_provider
 from app.services.sender_intelligence import identify_sender, source_geo_for
 from app.services.source_reputation import (
     SourceReputation,
@@ -833,7 +833,10 @@ async def get_report_by_id(
         )
         reputations_by_ip = source_reputation_by_ip(reputation_result)
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.info("Report source reputation enrichment failed for %s: %s", report_id, exc)
+        logger.info(
+            "Report source reputation enrichment failed for report detail: %s",
+            type(exc).__name__,
+        )
 
     # Normalize records
     record_details = []

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -134,6 +134,27 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
         "value_type": "string",
         "category": "cloudflare",
     },
+    {
+        "key": "cloudflare.auth_mode",
+        "value": "",
+        "description": "Cloudflare connector authentication mode",
+        "value_type": "string",
+        "category": "cloudflare",
+    },
+    {
+        "key": "cloudflare.oauth_scopes",
+        "value": "",
+        "description": "Granted Cloudflare OAuth scopes",
+        "value_type": "string",
+        "category": "cloudflare",
+    },
+    {
+        "key": "cloudflare.oauth_connected_at",
+        "value": "",
+        "description": "Last successful Cloudflare OAuth connection time",
+        "value_type": "string",
+        "category": "cloudflare",
+    },
     # ── Mail service integrations ───────────────────────────────────────────
     {
         "key": "postmark.account_token",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -53,6 +53,9 @@ class Settings(BaseSettings):
     # Optional Cloudflare Integration
     CLOUDFLARE_API_TOKEN: Optional[str] = None
     CLOUDFLARE_ZONE_ID: Optional[str] = None
+    CLOUDFLARE_OAUTH_CLIENT_ID: Optional[str] = None
+    CLOUDFLARE_OAUTH_CLIENT_SECRET: Optional[str] = None
+    CLOUDFLARE_OAUTH_SCOPES: str = "zone.read dns.read"
     HETZNER_DNS_API_TOKEN: Optional[str] = None
     HETZNER_API_TOKEN: Optional[str] = None
     AWS_PROFILE: Optional[str] = None

--- a/backend/app/services/cloudflare_dns.py
+++ b/backend/app/services/cloudflare_dns.py
@@ -192,7 +192,7 @@ async def verify_cloudflare_domain_ownership(
     db: Session,
     *,
     domain_name: str,
-    workspace_id: Optional[int] = None,
+    workspace_id: int,
 ) -> Dict[str, Any]:
     """Verify a monitored domain by proving Cloudflare zone access."""
     normalized = domain_name.strip().lower().rstrip(".")
@@ -204,10 +204,11 @@ async def verify_cloudflare_domain_ownership(
     if not zone:
         raise LookupError(f"No Cloudflare zone visible for {normalized}")
 
-    query = db.query(Domain).filter(Domain.name == normalized)
-    if workspace_id is not None:
-        query = query.filter(Domain.workspace_id == workspace_id)
-    domain = query.first()
+    domain = (
+        db.query(Domain)
+        .filter(Domain.name == normalized, Domain.workspace_id == workspace_id)
+        .first()
+    )
     if domain is None:
         raise LookupError(f"Domain {normalized} is not monitored in this workspace")
 

--- a/backend/app/services/cloudflare_dns.py
+++ b/backend/app/services/cloudflare_dns.py
@@ -188,6 +188,55 @@ async def get_zone_for_domain(db: Session, domain: str) -> Dict[str, Any]:
     return {"id": zone["id"], "name": zone["name"], "records": records}
 
 
+async def verify_cloudflare_domain_ownership(
+    db: Session,
+    *,
+    domain_name: str,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Verify a monitored domain by proving Cloudflare zone access."""
+    normalized = domain_name.strip().lower().rstrip(".")
+    if not normalized:
+        raise LookupError("Domain name is required")
+
+    provider = build_cloudflare_provider(db)
+    zone = await provider.find_zone_for_domain(normalized)
+    if not zone:
+        raise LookupError(f"No Cloudflare zone visible for {normalized}")
+
+    query = db.query(Domain).filter(Domain.name == normalized)
+    if workspace_id is not None:
+        query = query.filter(Domain.workspace_id == workspace_id)
+    domain = query.first()
+    if domain is None:
+        raise LookupError(f"Domain {normalized} is not monitored in this workspace")
+
+    if not domain.verified:
+        domain.verified = True
+    domain.description = domain.description or "Verified through Cloudflare zone access"
+    db.commit()
+    db.refresh(domain)
+    return {
+        "domain": normalized,
+        "verified": bool(domain.verified),
+        "provider": PROVIDER_NAME,
+        "zone_id": zone.get("id"),
+        "zone_name": zone.get("name"),
+        "zone_status": zone.get("status"),
+        "account_name": (zone.get("account") or {}).get("name"),
+        "proof_reason": (
+            "DMARQ can see this domain as a Cloudflare zone through the connected "
+            "provider account. This verifies provider control for DNS guidance and "
+            "future human-approved repair workflows."
+        ),
+        "next_steps": [
+            "Review the imported Cloudflare zones and monitored domain list.",
+            "Use DNS linting to preview DMARC/SPF/DKIM fixes.",
+            "Enable a separate DNS write scope only when one-click repair should be available.",
+        ],
+    }
+
+
 def _record_key(record: Dict[str, Any]) -> str:
     record_id = record.get("id")
     if record_id:

--- a/backend/app/services/cloudflare_oauth.py
+++ b/backend/app/services/cloudflare_oauth.py
@@ -1,0 +1,210 @@
+"""Cloudflare OAuth connector helpers for DNS-provider access."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+import httpx
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.core.credential_encryption import encrypt_secret
+from app.models.setting import Setting
+
+CLOUDFLARE_AUTHORIZATION_URL = "https://dash.cloudflare.com/oauth2/auth"
+CLOUDFLARE_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token"
+CLOUDFLARE_DEFAULT_READ_SCOPES = "zone.read dns.read"
+_STATE_ALGORITHM = "HS256"
+_STATE_TTL = timedelta(minutes=10)
+
+
+@dataclass(frozen=True)
+class CloudflareOAuthConfig:
+    """Configured Cloudflare OAuth client settings."""
+
+    client_id: str
+    client_secret: str
+    scopes: str
+
+
+def cloudflare_oauth_configured() -> bool:
+    """Return whether a Cloudflare OAuth client can be used."""
+    settings = get_settings()
+    return bool(settings.CLOUDFLARE_OAUTH_CLIENT_ID and settings.CLOUDFLARE_OAUTH_CLIENT_SECRET)
+
+
+def get_cloudflare_oauth_config() -> CloudflareOAuthConfig:
+    """Return the Cloudflare OAuth client config or raise a clear setup error."""
+    settings = get_settings()
+    if not settings.CLOUDFLARE_OAUTH_CLIENT_ID or not settings.CLOUDFLARE_OAUTH_CLIENT_SECRET:
+        raise LookupError(
+            "Cloudflare OAuth is not configured. Set CLOUDFLARE_OAUTH_CLIENT_ID and "
+            "CLOUDFLARE_OAUTH_CLIENT_SECRET, or use a scoped Cloudflare API token."
+        )
+    return CloudflareOAuthConfig(
+        client_id=settings.CLOUDFLARE_OAUTH_CLIENT_ID,
+        client_secret=settings.CLOUDFLARE_OAUTH_CLIENT_SECRET,
+        scopes=settings.CLOUDFLARE_OAUTH_SCOPES or CLOUDFLARE_DEFAULT_READ_SCOPES,
+    )
+
+
+def _state_signing_key() -> str:
+    return f"{get_settings().SECRET_KEY}:cloudflare-oauth-state"
+
+
+def build_cloudflare_oauth_state(
+    *,
+    workspace_id: int,
+    return_to: str = "/settings",
+) -> str:
+    """Return a signed, short-lived state token for Cloudflare OAuth."""
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "workspace_id": int(workspace_id),
+            "return_to": return_to if return_to.startswith("/") else "/settings",
+            "iat": now,
+            "exp": now + _STATE_TTL,
+        },
+        _state_signing_key(),
+        algorithm=_STATE_ALGORITHM,
+    )
+    return f"v1.{token}"
+
+
+def decode_cloudflare_oauth_state(state_value: str) -> Dict[str, Any]:
+    """Validate and decode a Cloudflare OAuth state token."""
+    token = (state_value or "").removeprefix("v1.")
+    if not token:
+        raise LookupError("Invalid Cloudflare OAuth state.")
+    try:
+        payload = jwt.decode(
+            token,
+            _state_signing_key(),
+            algorithms=[_STATE_ALGORITHM],
+            options={"verify_aud": False},
+        )
+        return {
+            "workspace_id": int(payload["workspace_id"]),
+            "return_to": str(payload.get("return_to") or "/settings"),
+        }
+    except (JWTError, ValueError, KeyError, TypeError) as exc:
+        raise LookupError("Invalid Cloudflare OAuth state.") from exc
+
+
+def build_cloudflare_authorization_url(
+    *,
+    redirect_uri: str,
+    state: str,
+) -> Dict[str, str]:
+    """Return the Cloudflare authorization URL and request metadata."""
+    config = get_cloudflare_oauth_config()
+    params = {
+        "client_id": config.client_id,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "scope": config.scopes,
+        "state": state,
+    }
+    return {
+        "authorization_url": f"{CLOUDFLARE_AUTHORIZATION_URL}?{urlencode(params)}",
+        "redirect_uri": redirect_uri,
+        "scopes": config.scopes,
+    }
+
+
+async def exchange_cloudflare_oauth_code(
+    *,
+    code: str,
+    redirect_uri: str,
+) -> Dict[str, Any]:
+    """Exchange a Cloudflare OAuth authorization code for an access token."""
+    config = get_cloudflare_oauth_config()
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(
+                CLOUDFLARE_TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "client_id": config.client_id,
+                    "client_secret": config.client_secret,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+    except (httpx.RequestError, httpx.HTTPStatusError, ValueError) as exc:
+        raise LookupError("Cloudflare OAuth token exchange failed.") from exc
+
+    if not data.get("access_token"):
+        raise LookupError("Cloudflare OAuth did not return an access token.")
+    return data
+
+
+def _upsert_setting(
+    db: Session,
+    *,
+    key: str,
+    value: str,
+    category: str = "cloudflare",
+    value_type: str = "string",
+    description: Optional[str] = None,
+) -> Setting:
+    row = db.query(Setting).filter(Setting.key == key).first()
+    if row is None:
+        row = Setting(
+            key=key,
+            value=value,
+            category=category,
+            value_type=value_type,
+            description=description,
+        )
+        db.add(row)
+    else:
+        row.value = value
+        row.category = category
+        row.value_type = value_type
+        if description is not None:
+            row.description = description
+    return row
+
+
+def persist_cloudflare_oauth_tokens(
+    db: Session,
+    token_data: Dict[str, Any],
+) -> None:
+    """Persist the Cloudflare OAuth access token as the active provider token."""
+    access_token = str(token_data.get("access_token") or "").strip()
+    if not access_token:
+        raise LookupError("Cloudflare OAuth did not return an access token.")
+    scope = str(token_data.get("scope") or get_cloudflare_oauth_config().scopes)
+    _upsert_setting(
+        db,
+        key="cloudflare.api_token",
+        value=encrypt_secret(access_token),
+        description="Cloudflare OAuth access token for DNS zone discovery",
+    )
+    _upsert_setting(
+        db,
+        key="cloudflare.auth_mode",
+        value="oauth",
+        description="Cloudflare connector authentication mode",
+    )
+    _upsert_setting(
+        db,
+        key="cloudflare.oauth_scopes",
+        value=scope,
+        description="Granted Cloudflare OAuth scopes",
+    )
+    _upsert_setting(
+        db,
+        key="cloudflare.oauth_connected_at",
+        value=datetime.now(timezone.utc).isoformat(),
+        description="Last successful Cloudflare OAuth connection time",
+    )
+    db.commit()

--- a/backend/app/services/cloudflare_oauth.py
+++ b/backend/app/services/cloudflare_oauth.py
@@ -56,6 +56,13 @@ def _state_signing_key() -> str:
     return f"{get_settings().SECRET_KEY}:cloudflare-oauth-state"
 
 
+def _safe_return_to(value: str) -> str:
+    path = str(value or "")
+    if not path.startswith("/") or path.startswith("//") or "\\" in path:
+        return "/settings"
+    return path
+
+
 def build_cloudflare_oauth_state(
     *,
     workspace_id: int,
@@ -66,7 +73,7 @@ def build_cloudflare_oauth_state(
     token = jwt.encode(
         {
             "workspace_id": int(workspace_id),
-            "return_to": return_to if return_to.startswith("/") else "/settings",
+            "return_to": _safe_return_to(return_to),
             "iat": now,
             "exp": now + _STATE_TTL,
         },
@@ -90,7 +97,7 @@ def decode_cloudflare_oauth_state(state_value: str) -> Dict[str, Any]:
         )
         return {
             "workspace_id": int(payload["workspace_id"]),
-            "return_to": str(payload.get("return_to") or "/settings"),
+            "return_to": _safe_return_to(str(payload.get("return_to") or "/settings")),
         }
     except (JWTError, ValueError, KeyError, TypeError) as exc:
         raise LookupError("Invalid Cloudflare OAuth state.") from exc

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -83,12 +83,18 @@
                         TXT value
                         <input readonly class="input input-sm input-bordered mt-1 w-full font-mono text-xs" :value="ownership.proof_record_value || ''">
                     </label>
-                    <div class="flex items-end">
+                    <div class="flex flex-col justify-end gap-2">
                         <button type="button"
                                 class="btn btn-sm bg-[#2f9da5] text-white hover:bg-[#272a5f]"
                                 :disabled="ownership.loading"
                                 @click="verifyDomainOwnership()">
                             <span x-text="ownership.loading ? 'Checking...' : 'Check ownership'"></span>
+                        </button>
+                        <button type="button"
+                                class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5]"
+                                :disabled="ownership.loading"
+                                @click="verifyDomainOwnershipCloudflare()">
+                            <span x-text="ownership.loading ? 'Checking...' : 'Verify via Cloudflare'"></span>
                         </button>
                     </div>
                 </div>
@@ -2248,6 +2254,39 @@ function domainDetailsApp(domainId) {
             }
         },
 
+        async verifyDomainOwnershipCloudflare() {
+            this.ownership.loading = true;
+            this.ownership.error = '';
+            this.ownership.message = '';
+            try {
+                const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/ownership/cloudflare`, {
+                    method: 'POST'
+                });
+                const data = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                    throw new Error(detail || 'Cloudflare ownership could not be verified.');
+                }
+                this.ownership = {
+                    ...this.ownership,
+                    verified: data.verified,
+                    proof_reason: data.proof_reason || this.ownership.proof_reason,
+                    next_steps: data.next_steps || this.ownership.next_steps,
+                    loading: false,
+                    error: '',
+                    message: `Cloudflare verified ${data.domain} through zone ${data.zone_name || data.zone_id}.`
+                };
+            } catch (error) {
+                this.ownership = {
+                    ...this.ownership,
+                    loading: false,
+                    error: error.message || 'Cloudflare ownership could not be verified.',
+                    message: error.message || 'Cloudflare ownership could not be verified.'
+                };
+                console.error('Error verifying Cloudflare ownership:', error);
+            }
+        },
+
         async deleteDomain() {
             const typed = window.prompt(`Delete ${this.domainId}? Type the domain name to confirm.`);
             if (typed !== this.domainId) return;
@@ -2731,7 +2770,9 @@ function domainDetailsApp(domainId) {
             try {
                 const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/sources?days=${this.sourceDateWindow()}`);
                 if (!response.ok) {
-                    throw new Error('Sending sources could not be loaded.');
+                    const data = await response.json().catch(() => ({}));
+                    const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                    throw new Error(detail || 'Sending sources could not be loaded.');
                 }
                 const data = await response.json();
                 this.sources = data.sources || [];
@@ -2765,9 +2806,12 @@ function domainDetailsApp(domainId) {
             }
             
             const labels = timelineData.map(item => item.date);
-            const complianceData = timelineData.map(item => item.compliance_rate);
-            const failureData = timelineData.map(item => item.failure_rate || 0);
-            const volumeData = timelineData.map(item => item.volume || item.total || 0);
+            const complianceData = timelineData.map(item => (item.volume || item.total || 0) > 0 ? item.compliance_rate : null);
+            const failureData = timelineData.map(item => (item.volume || item.total || 0) > 0 ? (item.failure_rate || 0) : null);
+            const volumeRawData = timelineData.map(item => item.volume || item.total || 0);
+            const volumeData = volumeRawData.map(value => value > 0 ? value : null);
+            const observedCompliance = complianceData.filter(value => value !== null && Number.isFinite(value));
+            const observedVolumes = volumeRawData.filter(value => value > 0 && Number.isFinite(value));
             
             // Calculate the threshold line data (recommended 98% for policy advancement)
             const thresholdData = Array(labels.length).fill(98);
@@ -2787,7 +2831,8 @@ function domainDetailsApp(domainId) {
                             fill: true,
                             pointBackgroundColor: 'rgb(59, 130, 246)',
                             pointRadius: 3,
-                            pointHoverRadius: 5
+                            pointHoverRadius: 5,
+                            spanGaps: false
                         },
                         {
                             label: 'Failure Rate',
@@ -2799,7 +2844,8 @@ function domainDetailsApp(domainId) {
                             fill: false,
                             pointBackgroundColor: 'rgb(220, 38, 38)',
                             pointRadius: 3,
-                            pointHoverRadius: 5
+                            pointHoverRadius: 5,
+                            spanGaps: false
                         },
                         {
                             label: 'Message Volume',
@@ -2833,7 +2879,7 @@ function domainDetailsApp(domainId) {
                             type: 'linear',
                             position: 'left',
                             beginAtZero: false,
-                            min: Math.max(0, Math.min(...complianceData) - 10), // Dynamic min value
+                            min: observedCompliance.length ? Math.max(0, Math.min(...observedCompliance) - 10) : 0,
                             max: 100,
                             ticks: {
                                 callback: value => value + '%'
@@ -2850,15 +2896,22 @@ function domainDetailsApp(domainId) {
                             }
                         },
                         yVolume: {
-                            type: 'linear',
+                            type: observedVolumes.length ? 'logarithmic' : 'linear',
                             position: 'right',
-                            beginAtZero: true,
+                            min: observedVolumes.length ? 1 : 0,
                             ticks: {
-                                precision: 0
+                                precision: 0,
+                                callback: function(value) {
+                                    const numeric = Number(value);
+                                    if (!Number.isFinite(numeric)) return value;
+                                    if (numeric >= 1000000) return `${(numeric / 1000000).toFixed(numeric % 1000000 === 0 ? 0 : 1)}m`;
+                                    if (numeric >= 1000) return `${(numeric / 1000).toFixed(numeric % 1000 === 0 ? 0 : 1)}k`;
+                                    return numeric;
+                                }
                             },
                             title: {
                                 display: true,
-                                text: 'Messages',
+                                text: observedVolumes.length ? 'Messages (log scale)' : 'Messages',
                                 font: {
                                     weight: 'bold'
                                 }
@@ -2893,13 +2946,17 @@ function domainDetailsApp(domainId) {
                             callbacks: {
                                 label: function(context) {
                                     if (context.dataset.label === 'Compliance Rate') {
+                                        if (context.parsed.y === null) return 'Compliance: no observed mail volume';
                                         return `Compliance: ${context.parsed.y}%`;
                                     }
                                     if (context.dataset.label === 'Failure Rate') {
+                                        if (context.parsed.y === null) return 'Failures: no observed mail volume';
                                         return `Failures: ${context.parsed.y}%`;
                                     }
                                     if (context.dataset.label === 'Message Volume') {
-                                        return `Messages: ${context.parsed.y}`;
+                                        const rawVolume = volumeRawData[context.dataIndex] || 0;
+                                        if (rawVolume <= 0) return 'Messages: no observed mail volume';
+                                        return `Messages: ${rawVolume.toLocaleString()}`;
                                     }
                                     return context.dataset.label;
                                 },

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2114,6 +2114,19 @@ function domainDetailsApp(domainId) {
             return 'bg-base-200 text-base-content/70';
         },
 
+        apiHeaders() {
+            return { 'Content-Type': 'application/json' };
+        },
+
+        workspaceHeaders() {
+            const headers = this.apiHeaders();
+            const workspaceId = localStorage.getItem('dmarq.selectedWorkspaceId');
+            if (workspaceId) {
+                headers['X-DMARQ-Workspace-ID'] = workspaceId;
+            }
+            return headers;
+        },
+
         recommendationSeverityClass(severity) {
             if (severity === 'error') return 'bg-red-500';
             if (severity === 'warning') return 'bg-yellow-500';
@@ -2259,12 +2272,18 @@ function domainDetailsApp(domainId) {
             this.ownership.error = '';
             this.ownership.message = '';
             try {
+                const headers = this.workspaceHeaders();
                 const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/ownership/cloudflare`, {
-                    method: 'POST'
+                    method: 'POST',
+                    headers
                 });
                 const data = await response.json().catch(() => ({}));
                 if (!response.ok) {
                     const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                    const nextSteps = Array.isArray(data.detail?.next_steps) ? data.detail.next_steps : data.next_steps;
+                    if (nextSteps) {
+                        this.ownership.next_steps = nextSteps;
+                    }
                     throw new Error(detail || 'Cloudflare ownership could not be verified.');
                 }
                 this.ownership = {
@@ -2810,7 +2829,8 @@ function domainDetailsApp(domainId) {
             const failureData = timelineData.map(item => (item.volume || item.total || 0) > 0 ? (item.failure_rate || 0) : null);
             const volumeRawData = timelineData.map(item => item.volume || item.total || 0);
             const volumeData = volumeRawData.map(value => value > 0 ? value : null);
-            const observedCompliance = complianceData.filter(value => value !== null && Number.isFinite(value));
+            const observedRates = [...complianceData, ...failureData]
+                .filter(value => value !== null && Number.isFinite(value));
             const observedVolumes = volumeRawData.filter(value => value > 0 && Number.isFinite(value));
             
             // Calculate the threshold line data (recommended 98% for policy advancement)
@@ -2879,7 +2899,7 @@ function domainDetailsApp(domainId) {
                             type: 'linear',
                             position: 'left',
                             beginAtZero: false,
-                            min: observedCompliance.length ? Math.max(0, Math.min(...observedCompliance) - 10) : 0,
+                            min: observedRates.length ? Math.max(0, Math.min(...observedRates) - 10) : 0,
                             max: 100,
                             ticks: {
                                 callback: value => value + '%'

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -178,6 +178,7 @@
                         {% call thead() %}
                             {% call tr() %}
                                 {% call th() %}Source IP{% endcall %}
+                                {% call th() %}Source intelligence{% endcall %}
                                 {% call th() %}Count{% endcall %}
                                 {% call th() %}Disposition{% endcall %}
                                 {% call th() %}DKIM{% endcall %}
@@ -189,7 +190,7 @@
                         {% call tbody() %}
                             <template x-if="report.records.length === 0">
                                 <tr>
-                                    <td colspan="7" class="text-center py-4">
+                                    <td colspan="8" class="text-center py-4">
                                         <div class="text-muted-foreground">No records in this report</div>
                                     </td>
                                 </tr>
@@ -198,6 +199,35 @@
                                 {% call tr() %}
                                     {% call td() %}
                                         <span class="font-mono text-sm" x-text="record.source_ip"></span>
+                                    {% endcall %}
+                                    {% call td() %}
+                                        <div class="min-w-64 max-w-sm space-y-1 text-xs text-[#5f5c78]">
+                                            <div class="font-semibold text-[#120d36]" x-text="record.source_details?.sender?.name || 'Unknown sender'"></div>
+                                            <div x-show="record.source_details?.hostname">
+                                                PTR: <span class="font-mono" x-text="record.source_details.hostname"></span>
+                                            </div>
+                                            <div>
+                                                <span x-text="sourceLocation(record)"></span>
+                                            </div>
+                                            <div x-show="record.source_details?.asn || record.source_details?.network">
+                                                <span x-text="record.source_details?.asn || 'ASN unknown'"></span>
+                                                <span x-show="record.source_details?.network"> · </span>
+                                                <span x-text="record.source_details?.network || ''"></span>
+                                            </div>
+                                            <template x-if="record.reputation">
+                                                <div class="pt-1">
+                                                    <span class="inline-flex items-center px-2 py-1 rounded text-xs"
+                                                          :class="reputationClass(record.reputation.status)"
+                                                          x-text="`Reputation ${record.reputation.risk_score}/100 · ${record.reputation.status}`"></span>
+                                                    <div class="mt-1" x-text="record.reputation.summary"></div>
+                                                    <template x-if="record.reputation.listings?.length">
+                                                        <div class="font-semibold text-[#ff6f3c]">
+                                                            DNSBL: <span x-text="record.reputation.listings.join(', ')"></span>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                            </template>
+                                        </div>
                                     {% endcall %}
                                     {% call td() %}
                                         <span x-text="record.count"></span>
@@ -332,6 +362,21 @@ function reportDetailApp(reportId) {
         reviewStatusLabel(status) {
             if (status === 'needs_review') return 'Needs review';
             return 'Pass';
+        },
+
+        sourceLocation(record) {
+            const details = record.source_details || {};
+            const country = details.country || 'Unknown country';
+            const region = details.region || 'Unknown region';
+            const code = details.country_code && details.country_code !== 'ZZ' ? ` (${details.country_code})` : '';
+            return `${region}, ${country}${code}`;
+        },
+
+        reputationClass(status) {
+            if (status === 'listed' || status === 'critical') return 'bg-red-100 text-red-800';
+            if (status === 'suspicious') return 'bg-yellow-100 text-yellow-800';
+            if (status === 'clean') return 'bg-green-100 text-green-800';
+            return 'bg-gray-100 text-gray-800';
         },
     };
 }

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -162,12 +162,40 @@
         {% call card_header() %}
             {% call card_title() %}Cloudflare Integration{% endcall %}
             {% call card_description() %}
-                Provide a Cloudflare API token and Zone ID to enable automated DNS record management and DoH lookups.
-                Obtain your token from <a href="https://dash.cloudflare.com/profile/api-tokens" target="_blank" class="underline">Cloudflare API Tokens</a>.
+                Connect Cloudflare to verify domain ownership, import zones, and read DNS records.
+                DNS write access is a separate approval step for future one-click repairs.
             {% endcall %}
         {% endcall %}
         {% call card_content() %}
             <form @submit.prevent="saveCategory('cloudflare')" class="space-y-4">
+                <div class="rounded-lg border border-[#dfdfdf] bg-[#f8f7f4] p-4">
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <h3 class="text-sm font-semibold text-[#120d36]">Cloudflare OAuth</h3>
+                            <p class="text-sm text-[#5f5c78]">
+                                <span x-show="cfOAuthStatus.oauth_configured && cfOAuthStatus.connected">Connected with scoped access.</span>
+                                <span x-show="cfOAuthStatus.oauth_configured && !cfOAuthStatus.connected">Ready to connect with read-only zone and DNS access.</span>
+                                <span x-show="!cfOAuthStatus.oauth_configured">Configure Cloudflare OAuth client credentials on the server to enable one-click connect.</span>
+                            </p>
+                            <p class="mt-1 text-xs text-[#5f5c78]" x-show="cfOAuthStatus.scopes">
+                                Granted scopes: <span class="font-mono" x-text="cfOAuthStatus.scopes"></span>
+                            </p>
+                        </div>
+                        <button type="button" class="btn btn-default btn-sm"
+                            :disabled="connectingCloudflare || !cfOAuthStatus.oauth_configured"
+                            @click="connectCloudflare()">
+                            <template x-if="!connectingCloudflare">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
+                                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+                                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
+                                </svg>
+                            </template>
+                            <template x-if="connectingCloudflare"><span class="loading loading-spinner loading-xs mr-2"></span></template>
+                            Connect Cloudflare
+                        </button>
+                    </div>
+                </div>
                 <div class="form-control w-full">
                     <label class="label"><span class="label-text font-medium">API Token</span></label>
                     <div class="relative">
@@ -182,7 +210,7 @@
                             <svg x-show="showCfToken" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line></svg>
                         </button>
                     </div>
-                    <label class="label"><span class="label-text-alt text-muted-foreground">Stored securely; leave as-is to keep existing token</span></label>
+                    <label class="label"><span class="label-text-alt text-muted-foreground">Optional fallback. Use Zone:Read and DNS:Read for discovery; add DNS:Edit only when repair is enabled.</span></label>
                 </div>
                 <div class="form-control w-full">
                     <label class="label"><span class="label-text font-medium">Zone ID</span></label>
@@ -1026,6 +1054,14 @@ function settingsApp() {
         configAudit: [],
         loadingCfZones: false,
         importingCfZones: false,
+        connectingCloudflare: false,
+        cfOAuthStatus: {
+            oauth_configured: false,
+            connected: false,
+            auth_mode: null,
+            scopes: null,
+            connected_at: null,
+        },
         cfZones: [],
         showCfToken: false,
         loadingMailServiceDomains: false,
@@ -1083,6 +1119,7 @@ function settingsApp() {
                 await this.loadConfigAudit(false);
                 await this.loadWebhooks(false);
                 await this.loadWebhookDeliveries(false);
+                await this.loadCloudflareOAuthStatus(false);
             } catch (err) {
                 this.showFlash('Error loading settings: ' + err.message, false);
             }
@@ -1334,6 +1371,46 @@ function settingsApp() {
                 this.showFlash('Error discovering Cloudflare zones: ' + err.message, false);
             } finally {
                 this.loadingCfZones = false;
+            }
+        },
+
+        async loadCloudflareOAuthStatus(showMessage = false) {
+            try {
+                const res = await fetch('/api/v1/domains/cloudflare/oauth/status', {
+                    headers: this.workspaceHeaders(),
+                });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok) {
+                    if (showMessage) {
+                        this.showFlash('Cloudflare status failed: ' + (data.detail || res.statusText), false);
+                    }
+                    return;
+                }
+                this.cfOAuthStatus = data;
+            } catch (err) {
+                if (showMessage) {
+                    this.showFlash('Error loading Cloudflare status: ' + err.message, false);
+                }
+            }
+        },
+
+        async connectCloudflare() {
+            this.connectingCloudflare = true;
+            try {
+                const res = await fetch('/api/v1/domains/cloudflare/oauth/authorize-url?return_to=/settings', {
+                    headers: this.workspaceHeaders(),
+                });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok) {
+                    const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                    this.showFlash('Cloudflare connect failed: ' + (detail || res.statusText), false);
+                    return;
+                }
+                window.location.href = data.authorization_url;
+            } catch (err) {
+                this.showFlash('Error starting Cloudflare connection: ' + err.message, false);
+            } finally {
+                this.connectingCloudflare = false;
             }
         },
 

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.api.api_v1.endpoints.domains import _policy_enforcement_suggestions
 from app.core.credential_encryption import encrypt_secret
 from app.core.database import get_db
@@ -1446,8 +1447,26 @@ def _cloudflare_oauth_zone_read_settings():
     return _cloudflare_oauth_settings(CLOUDFLARE_OAUTH_SCOPES="zone.read")
 
 
+def _cloudflare_oauth_empty_scope_settings():
+    return _cloudflare_oauth_settings(CLOUDFLARE_OAUTH_SCOPES="")
+
+
+def _cloudflare_oauth_missing_credential_settings():
+    return _cloudflare_oauth_settings(
+        CLOUDFLARE_OAUTH_CLIENT_ID="",
+        CLOUDFLARE_OAUTH_CLIENT_SECRET="",
+    )
+
+
 def _encrypted_secret(value):
     return f"encrypted:{value}"
+
+
+def _cloudflare_provider_factory(provider):
+    def build_provider(_db):
+        return provider
+
+    return build_provider
 
 
 def test_cloudflare_oauth_state_round_trips_and_sanitizes_return_to(
@@ -1487,21 +1506,43 @@ def test_cloudflare_oauth_authorization_url_uses_configured_scopes(
     assert "state=state-token" in result["authorization_url"]
 
 
+def test_cloudflare_oauth_config_defaults_to_read_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_empty_scope_settings)
+
+    assert (
+        cloudflare_oauth.get_cloudflare_oauth_config().scopes
+        == cloudflare_oauth.CLOUDFLARE_DEFAULT_READ_SCOPES
+    )
+
+
 def test_cloudflare_oauth_config_requires_client_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setattr(
         cloudflare_oauth,
         "get_settings",
-        lambda: _cloudflare_oauth_settings(
-            CLOUDFLARE_OAUTH_CLIENT_ID="",
-            CLOUDFLARE_OAUTH_CLIENT_SECRET="",
-        ),
+        _cloudflare_oauth_missing_credential_settings,
     )
 
     assert cloudflare_oauth.cloudflare_oauth_configured() is False
     with pytest.raises(LookupError, match="Cloudflare OAuth is not configured"):
         cloudflare_oauth.get_cloudflare_oauth_config()
+
+
+def test_cloudflare_oauth_decode_rejects_state_without_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_settings)
+    token = cloudflare_oauth.jwt.encode(
+        {"return_to": "/settings"},
+        "s" * 32 + ":cloudflare-oauth-state",
+        algorithm="HS256",
+    )
+
+    with pytest.raises(LookupError, match="Invalid Cloudflare OAuth state"):
+        cloudflare_oauth.decode_cloudflare_oauth_state(f"v1.{token}")
 
 
 @pytest.mark.asyncio
@@ -1675,6 +1716,34 @@ def test_persist_cloudflare_oauth_tokens_defaults_to_configured_scopes(
     assert scope.value == "zone.read"
 
 
+def test_persist_cloudflare_oauth_tokens_updates_existing_settings(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    db_session.add(
+        Setting(
+            key="cloudflare.auth_mode",
+            value="token",
+            category="legacy",
+            value_type="secret",
+            description="old mode",
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(cloudflare_oauth, "encrypt_secret", _encrypted_secret)
+
+    cloudflare_oauth.persist_cloudflare_oauth_tokens(
+        db_session,
+        {"access_token": "provider-token", "scope": "zone.read"},
+    )
+
+    auth_mode = db_session.query(Setting).filter(Setting.key == "cloudflare.auth_mode").one()
+    assert auth_mode.value == "oauth"
+    assert auth_mode.category == "cloudflare"
+    assert auth_mode.value_type == "string"
+    assert auth_mode.description == "Cloudflare connector authentication mode"
+
+
 def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(
     authed_client: TestClient,
 ):
@@ -1832,19 +1901,20 @@ async def test_verify_cloudflare_domain_ownership_marks_domain_verified(
     db_session.add(domain)
     db_session.commit()
 
+    provider = FakeCloudflareProvider(
+        zones=[
+            {
+                "id": "zone-1",
+                "name": DOMAIN,
+                "status": "active",
+                "account": {"name": "Example Account"},
+            }
+        ]
+    )
     monkeypatch.setattr(
         cloudflare_dns,
         "build_cloudflare_provider",
-        lambda _db: FakeCloudflareProvider(
-            zones=[
-                {
-                    "id": "zone-1",
-                    "name": DOMAIN,
-                    "status": "active",
-                    "account": {"name": "Example Account"},
-                }
-            ]
-        ),
+        _cloudflare_provider_factory(provider),
     )
 
     result = await cloudflare_dns.verify_cloudflare_domain_ownership(
@@ -1865,10 +1935,11 @@ async def test_verify_cloudflare_domain_ownership_rejects_missing_zone(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    provider = FakeCloudflareProvider(zones=[])
     monkeypatch.setattr(
         cloudflare_dns,
         "build_cloudflare_provider",
-        lambda _db: FakeCloudflareProvider(zones=[]),
+        _cloudflare_provider_factory(provider),
     )
 
     with pytest.raises(LookupError, match="No Cloudflare zone visible"):
@@ -1883,10 +1954,11 @@ async def test_verify_cloudflare_domain_ownership_requires_monitored_domain(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    provider = FakeCloudflareProvider(zones=[{"id": "zone-1", "name": DOMAIN}])
     monkeypatch.setattr(
         cloudflare_dns,
         "build_cloudflare_provider",
-        lambda _db: FakeCloudflareProvider(zones=[{"id": "zone-1", "name": DOMAIN}]),
+        _cloudflare_provider_factory(provider),
     )
 
     with pytest.raises(LookupError, match="is not monitored"):
@@ -1894,6 +1966,62 @@ async def test_verify_cloudflare_domain_ownership_requires_monitored_domain(
             db_session,
             domain_name=DOMAIN,
         )
+
+
+@pytest.mark.asyncio
+async def test_verify_cloudflare_domain_ownership_requires_domain_name(
+    db_session: Session,
+):
+    with pytest.raises(LookupError, match="Domain name is required"):
+        await cloudflare_dns.verify_cloudflare_domain_ownership(
+            db_session,
+            domain_name=" ",
+        )
+
+
+def test_cloudflare_ownership_endpoint_returns_provider_proof(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add(Domain(name=DOMAIN, workspace_id=workspace.id, verified=False, active=True))
+    db_session.commit()
+    ownership_result = {
+        "domain": DOMAIN,
+        "verified": True,
+        "provider": "cloudflare",
+        "zone_id": "zone-1",
+        "zone_name": DOMAIN,
+        "zone_status": "active",
+        "account_name": "Example Account",
+        "proof_reason": "DMARQ can see this domain as a Cloudflare zone.",
+        "next_steps": ["Review the imported Cloudflare zones."],
+    }
+
+    verify_mock = AsyncMock(return_value=ownership_result)
+    with patch.object(domains_endpoint, "verify_cloudflare_domain_ownership", verify_mock):
+        response = authed_client.post(f"/api/v1/domains/{DOMAIN}/ownership/cloudflare")
+
+    assert response.status_code == 200
+    assert response.json() == ownership_result
+    verify_mock.assert_awaited_once_with(
+        db_session,
+        domain_name=DOMAIN,
+        workspace_id=workspace.id,
+    )
+
+
+def test_cloudflare_ownership_endpoint_returns_next_steps_on_provider_error(
+    authed_client: TestClient,
+):
+    verify_mock = AsyncMock(side_effect=LookupError(f"No Cloudflare zone visible for {DOMAIN}"))
+    with patch.object(domains_endpoint, "verify_cloudflare_domain_ownership", verify_mock):
+        response = authed_client.post(f"/api/v1/domains/{DOMAIN}/ownership/cloudflare")
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["message"] == f"No Cloudflare zone visible for {DOMAIN}"
+    assert "Connect Cloudflare from Settings" in detail["next_steps"][0]
 
 
 def test_cloudflare_dns_analysis_endpoint_persists_history(

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1478,9 +1478,17 @@ def test_cloudflare_oauth_state_round_trips_and_sanitizes_return_to(
         workspace_id=42,
         return_to="https://evil.example/settings",
     )
+    scheme_relative_state = cloudflare_oauth.build_cloudflare_oauth_state(
+        workspace_id=42,
+        return_to="//evil.example/settings",
+    )
 
     assert state.startswith("v1.")
     assert cloudflare_oauth.decode_cloudflare_oauth_state(state) == {
+        "workspace_id": 42,
+        "return_to": "/settings",
+    }
+    assert cloudflare_oauth.decode_cloudflare_oauth_state(scheme_relative_state) == {
         "workspace_id": 42,
         "return_to": "/settings",
     }

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1442,10 +1442,18 @@ def _cloudflare_oauth_settings(**overrides):
     return SimpleNamespace(**defaults)
 
 
+def _cloudflare_oauth_zone_read_settings():
+    return _cloudflare_oauth_settings(CLOUDFLARE_OAUTH_SCOPES="zone.read")
+
+
+def _encrypted_secret(value):
+    return f"encrypted:{value}"
+
+
 def test_cloudflare_oauth_state_round_trips_and_sanitizes_return_to(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setattr(cloudflare_oauth, "get_settings", lambda: _cloudflare_oauth_settings())
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_settings)
 
     state = cloudflare_oauth.build_cloudflare_oauth_state(
         workspace_id=42,
@@ -1464,11 +1472,7 @@ def test_cloudflare_oauth_state_round_trips_and_sanitizes_return_to(
 def test_cloudflare_oauth_authorization_url_uses_configured_scopes(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setattr(
-        cloudflare_oauth,
-        "get_settings",
-        lambda: _cloudflare_oauth_settings(CLOUDFLARE_OAUTH_SCOPES="zone.read"),
-    )
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_zone_read_settings)
 
     result = cloudflare_oauth.build_cloudflare_authorization_url(
         redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
@@ -1488,7 +1492,7 @@ async def test_cloudflare_oauth_exchange_posts_token_request(
     monkeypatch: pytest.MonkeyPatch,
 ):
     requests = []
-    monkeypatch.setattr(cloudflare_oauth, "get_settings", lambda: _cloudflare_oauth_settings())
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_settings)
 
     class FakeTokenResponse:
         def raise_for_status(self):
@@ -1539,7 +1543,7 @@ def test_persist_cloudflare_oauth_tokens_stores_encrypted_provider_token(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setattr(cloudflare_oauth, "encrypt_secret", lambda value: f"encrypted:{value}")
+    monkeypatch.setattr(cloudflare_oauth, "encrypt_secret", _encrypted_secret)
 
     cloudflare_oauth.persist_cloudflare_oauth_tokens(
         db_session,
@@ -1599,6 +1603,49 @@ def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(
     assert authorize_mock.call_args.kwargs["redirect_uri"] == (
         "https://app.example.test/api/v1/domains/cloudflare/oauth/callback"
     )
+
+
+def test_cloudflare_oauth_status_endpoint_reports_connected_token(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    db_session.add(
+        Setting(
+            key="cloudflare.api_token",
+            value="encrypted-token",
+            category="cloudflare",
+            value_type="string",
+        )
+    )
+    db_session.add(
+        Setting(
+            key="cloudflare.auth_mode",
+            value="oauth",
+            category="cloudflare",
+            value_type="string",
+        )
+    )
+    db_session.add(
+        Setting(
+            key="cloudflare.oauth_scopes",
+            value="zone.read dns.read",
+            category="cloudflare",
+            value_type="string",
+        )
+    )
+    db_session.commit()
+
+    with patch("app.api.api_v1.endpoints.domains.cloudflare_oauth_configured", return_value=True):
+        response = authed_client.get("/api/v1/domains/cloudflare/oauth/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "oauth_configured": True,
+        "connected": True,
+        "auth_mode": "oauth",
+        "scopes": "zone.read dns.read",
+        "connected_at": None,
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1487,6 +1487,23 @@ def test_cloudflare_oauth_authorization_url_uses_configured_scopes(
     assert "state=state-token" in result["authorization_url"]
 
 
+def test_cloudflare_oauth_config_requires_client_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        cloudflare_oauth,
+        "get_settings",
+        lambda: _cloudflare_oauth_settings(
+            CLOUDFLARE_OAUTH_CLIENT_ID="",
+            CLOUDFLARE_OAUTH_CLIENT_SECRET="",
+        ),
+    )
+
+    assert cloudflare_oauth.cloudflare_oauth_configured() is False
+    with pytest.raises(LookupError, match="Cloudflare OAuth is not configured"):
+        cloudflare_oauth.get_cloudflare_oauth_config()
+
+
 @pytest.mark.asyncio
 async def test_cloudflare_oauth_exchange_posts_token_request(
     monkeypatch: pytest.MonkeyPatch,
@@ -1537,6 +1554,41 @@ async def test_cloudflare_oauth_exchange_posts_token_request(
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_oauth_exchange_rejects_missing_access_token(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_settings)
+
+    class FakeTokenResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"scope": "zone.read"}
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, *, data):
+            return FakeTokenResponse()
+
+    monkeypatch.setattr(cloudflare_oauth.httpx, "AsyncClient", FakeAsyncClient)
+
+    with pytest.raises(LookupError, match="did not return an access token"):
+        await cloudflare_oauth.exchange_cloudflare_oauth_code(
+            code="oauth-code",
+            redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+        )
 
 
 def test_persist_cloudflare_oauth_tokens_stores_encrypted_provider_token(
@@ -1603,6 +1655,62 @@ def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(
     assert authorize_mock.call_args.kwargs["redirect_uri"] == (
         "https://app.example.test/api/v1/domains/cloudflare/oauth/callback"
     )
+
+
+def test_cloudflare_oauth_authorize_url_endpoint_returns_setup_error(
+    authed_client: TestClient,
+):
+    with patch(
+        "app.api.api_v1.endpoints.domains.build_cloudflare_authorization_url",
+        side_effect=LookupError("Cloudflare OAuth is not configured."),
+    ):
+        response = authed_client.get("/api/v1/domains/cloudflare/oauth/authorize-url")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Cloudflare OAuth is not configured."
+
+
+def test_cloudflare_oauth_callback_requires_code_and_state(
+    authed_client: TestClient,
+):
+    response = authed_client.get("/api/v1/domains/cloudflare/oauth/callback?state=state-token")
+
+    assert response.status_code == 400
+    assert "Cloudflare connection failed" in response.text
+
+
+def test_cloudflare_oauth_callback_stores_token_and_redirects(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    workspace = get_or_create_default_workspace(db_session)
+    exchange_mock = AsyncMock(return_value={"access_token": "provider-token"})
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains.decode_cloudflare_oauth_state",
+            return_value={"workspace_id": workspace.id, "return_to": "/settings/cloudflare"},
+        ) as decode_mock,
+        patch(
+            "app.api.api_v1.endpoints.domains.exchange_cloudflare_oauth_code",
+            exchange_mock,
+        ),
+        patch("app.api.api_v1.endpoints.domains.persist_cloudflare_oauth_tokens") as persist_mock,
+    ):
+        response = authed_client.get(
+            "/api/v1/domains/cloudflare/oauth/callback?code=oauth-code&state=state-token",
+            headers={"x-forwarded-proto": "https", "host": "app.example.test"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings/cloudflare"
+    decode_mock.assert_called_once_with("state-token")
+    exchange_mock.assert_awaited_once_with(
+        code="oauth-code",
+        redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+    )
+    persist_mock.assert_called_once_with(db_session, {"access_token": "provider-token"})
 
 
 def test_cloudflare_oauth_status_endpoint_reports_connected_token(

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1430,6 +1430,77 @@ def test_cloudflare_import_endpoint_returns_import_summary(authed_client: TestCl
     assert response.json()["imported"] == [DOMAIN]
 
 
+def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(
+    authed_client: TestClient,
+):
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains.build_cloudflare_oauth_state",
+            return_value="state-token",
+        ) as state_mock,
+        patch(
+            "app.api.api_v1.endpoints.domains.build_cloudflare_authorization_url",
+            return_value={
+                "authorization_url": "https://dash.cloudflare.com/oauth2/auth?state=state-token",
+                "redirect_uri": "https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+                "scopes": "zone.read dns.read",
+            },
+        ) as authorize_mock,
+    ):
+        response = authed_client.get(
+            "/api/v1/domains/cloudflare/oauth/authorize-url?return_to=/settings",
+            headers={"x-forwarded-proto": "https", "host": "app.example.test"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["authorization_url"].startswith("https://dash.cloudflare.com/oauth2/auth")
+    assert data["scopes"] == "zone.read dns.read"
+    state_mock.assert_called_once()
+    authorize_mock.assert_called_once()
+    assert authorize_mock.call_args.kwargs["redirect_uri"] == (
+        "https://app.example.test/api/v1/domains/cloudflare/oauth/callback"
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_cloudflare_domain_ownership_marks_domain_verified(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    workspace = get_or_create_default_workspace(db_session)
+    domain = Domain(name=DOMAIN, workspace_id=workspace.id, verified=False, active=True)
+    db_session.add(domain)
+    db_session.commit()
+
+    monkeypatch.setattr(
+        cloudflare_dns,
+        "build_cloudflare_provider",
+        lambda _db: FakeCloudflareProvider(
+            zones=[
+                {
+                    "id": "zone-1",
+                    "name": DOMAIN,
+                    "status": "active",
+                    "account": {"name": "Example Account"},
+                }
+            ]
+        ),
+    )
+
+    result = await cloudflare_dns.verify_cloudflare_domain_ownership(
+        db_session,
+        domain_name=DOMAIN,
+        workspace_id=workspace.id,
+    )
+
+    db_session.refresh(domain)
+    assert result["verified"] is True
+    assert result["zone_id"] == "zone-1"
+    assert result["account_name"] == "Example Account"
+    assert domain.verified is True
+
+
 def test_cloudflare_dns_analysis_endpoint_persists_history(
     authed_client: TestClient,
     db_session,

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1954,6 +1954,7 @@ async def test_verify_cloudflare_domain_ownership_rejects_missing_zone(
         await cloudflare_dns.verify_cloudflare_domain_ownership(
             db_session,
             domain_name=DOMAIN,
+            workspace_id=1,
         )
 
 
@@ -1973,6 +1974,7 @@ async def test_verify_cloudflare_domain_ownership_requires_monitored_domain(
         await cloudflare_dns.verify_cloudflare_domain_ownership(
             db_session,
             domain_name=DOMAIN,
+            workspace_id=1,
         )
 
 
@@ -1984,6 +1986,7 @@ async def test_verify_cloudflare_domain_ownership_requires_domain_name(
         await cloudflare_dns.verify_cloudflare_domain_ownership(
             db_session,
             domain_name=" ",
+            workspace_id=1,
         )
 
 

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1591,6 +1591,34 @@ async def test_cloudflare_oauth_exchange_rejects_missing_access_token(
         )
 
 
+@pytest.mark.asyncio
+async def test_cloudflare_oauth_exchange_wraps_http_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_settings)
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, *, data):
+            raise cloudflare_oauth.httpx.RequestError("network unavailable")
+
+    monkeypatch.setattr(cloudflare_oauth.httpx, "AsyncClient", FakeAsyncClient)
+
+    with pytest.raises(LookupError, match="token exchange failed"):
+        await cloudflare_oauth.exchange_cloudflare_oauth_code(
+            code="oauth-code",
+            redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+        )
+
+
 def test_persist_cloudflare_oauth_tokens_stores_encrypted_provider_token(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
@@ -1622,6 +1650,29 @@ def test_persist_cloudflare_oauth_tokens_stores_encrypted_provider_token(
     assert settings["cloudflare.auth_mode"] == "oauth"
     assert settings["cloudflare.oauth_scopes"] == "zone.read dns.read"
     assert settings["cloudflare.oauth_connected_at"]
+
+
+def test_persist_cloudflare_oauth_tokens_requires_access_token(
+    db_session: Session,
+):
+    with pytest.raises(LookupError, match="did not return an access token"):
+        cloudflare_oauth.persist_cloudflare_oauth_tokens(db_session, {})
+
+
+def test_persist_cloudflare_oauth_tokens_defaults_to_configured_scopes(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(cloudflare_oauth, "encrypt_secret", _encrypted_secret)
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_zone_read_settings)
+
+    cloudflare_oauth.persist_cloudflare_oauth_tokens(
+        db_session,
+        {"access_token": "provider-token"},
+    )
+
+    scope = db_session.query(Setting).filter(Setting.key == "cloudflare.oauth_scopes").first()
+    assert scope.value == "zone.read"
 
 
 def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(
@@ -1677,6 +1728,21 @@ def test_cloudflare_oauth_callback_requires_code_and_state(
 
     assert response.status_code == 400
     assert "Cloudflare connection failed" in response.text
+
+
+def test_cloudflare_oauth_callback_returns_failure_for_invalid_state(
+    authed_client: TestClient,
+):
+    with patch(
+        "app.api.api_v1.endpoints.domains.decode_cloudflare_oauth_state",
+        side_effect=LookupError("Invalid Cloudflare OAuth state."),
+    ):
+        response = authed_client.get(
+            "/api/v1/domains/cloudflare/oauth/callback?code=oauth-code&state=bad-state"
+        )
+
+    assert response.status_code == 400
+    assert "retry after checking the connector settings" in response.text
 
 
 def test_cloudflare_oauth_callback_stores_token_and_redirects(
@@ -1792,6 +1858,42 @@ async def test_verify_cloudflare_domain_ownership_marks_domain_verified(
     assert result["zone_id"] == "zone-1"
     assert result["account_name"] == "Example Account"
     assert domain.verified is True
+
+
+@pytest.mark.asyncio
+async def test_verify_cloudflare_domain_ownership_rejects_missing_zone(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        cloudflare_dns,
+        "build_cloudflare_provider",
+        lambda _db: FakeCloudflareProvider(zones=[]),
+    )
+
+    with pytest.raises(LookupError, match="No Cloudflare zone visible"):
+        await cloudflare_dns.verify_cloudflare_domain_ownership(
+            db_session,
+            domain_name=DOMAIN,
+        )
+
+
+@pytest.mark.asyncio
+async def test_verify_cloudflare_domain_ownership_requires_monitored_domain(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        cloudflare_dns,
+        "build_cloudflare_provider",
+        lambda _db: FakeCloudflareProvider(zones=[{"id": "zone-1", "name": DOMAIN}]),
+    )
+
+    with pytest.raises(LookupError, match="is not monitored"):
+        await cloudflare_dns.verify_cloudflare_domain_ownership(
+            db_session,
+            domain_name=DOMAIN,
+        )
 
 
 def test_cloudflare_dns_analysis_endpoint_persists_history(

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -22,6 +22,7 @@ from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services import (
     cloudflare_dns,
+    cloudflare_oauth,
     dns_provider_connectors,
     dns_provider_imports,
     dns_provider_writes,
@@ -1428,6 +1429,143 @@ def test_cloudflare_import_endpoint_returns_import_summary(authed_client: TestCl
 
     assert response.status_code == 200
     assert response.json()["imported"] == [DOMAIN]
+
+
+def _cloudflare_oauth_settings(**overrides):
+    defaults = {
+        "SECRET_KEY": "s" * 32,
+        "CLOUDFLARE_OAUTH_CLIENT_ID": "client-id",
+        "CLOUDFLARE_OAUTH_CLIENT_SECRET": "client-secret",
+        "CLOUDFLARE_OAUTH_SCOPES": "zone.read dns.read",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_cloudflare_oauth_state_round_trips_and_sanitizes_return_to(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", lambda: _cloudflare_oauth_settings())
+
+    state = cloudflare_oauth.build_cloudflare_oauth_state(
+        workspace_id=42,
+        return_to="https://evil.example/settings",
+    )
+
+    assert state.startswith("v1.")
+    assert cloudflare_oauth.decode_cloudflare_oauth_state(state) == {
+        "workspace_id": 42,
+        "return_to": "/settings",
+    }
+    with pytest.raises(LookupError, match="Invalid Cloudflare OAuth state"):
+        cloudflare_oauth.decode_cloudflare_oauth_state("not-a-valid-token")
+
+
+def test_cloudflare_oauth_authorization_url_uses_configured_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        cloudflare_oauth,
+        "get_settings",
+        lambda: _cloudflare_oauth_settings(CLOUDFLARE_OAUTH_SCOPES="zone.read"),
+    )
+
+    result = cloudflare_oauth.build_cloudflare_authorization_url(
+        redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+        state="state-token",
+    )
+
+    assert result["redirect_uri"].endswith("/cloudflare/oauth/callback")
+    assert result["scopes"] == "zone.read"
+    assert result["authorization_url"].startswith("https://dash.cloudflare.com/oauth2/auth?")
+    assert "client_id=client-id" in result["authorization_url"]
+    assert "scope=zone.read" in result["authorization_url"]
+    assert "state=state-token" in result["authorization_url"]
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_oauth_exchange_posts_token_request(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    requests = []
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", lambda: _cloudflare_oauth_settings())
+
+    class FakeTokenResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"access_token": "provider-token", "scope": "zone.read dns.read"}
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, *, data):
+            requests.append({"url": url, "data": data})
+            return FakeTokenResponse()
+
+    monkeypatch.setattr(cloudflare_oauth.httpx, "AsyncClient", FakeAsyncClient)
+
+    token_data = await cloudflare_oauth.exchange_cloudflare_oauth_code(
+        code="oauth-code",
+        redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+    )
+
+    assert token_data["access_token"] == "provider-token"
+    assert requests == [
+        {
+            "url": cloudflare_oauth.CLOUDFLARE_TOKEN_URL,
+            "data": {
+                "grant_type": "authorization_code",
+                "code": "oauth-code",
+                "redirect_uri": (
+                    "https://app.example.test/api/v1/domains/cloudflare/oauth/callback"
+                ),
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+            },
+        }
+    ]
+
+
+def test_persist_cloudflare_oauth_tokens_stores_encrypted_provider_token(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(cloudflare_oauth, "encrypt_secret", lambda value: f"encrypted:{value}")
+
+    cloudflare_oauth.persist_cloudflare_oauth_tokens(
+        db_session,
+        {"access_token": "provider-token", "scope": "zone.read dns.read"},
+    )
+
+    settings = {
+        row.key: row.value
+        for row in db_session.query(Setting)
+        .filter(
+            Setting.key.in_(
+                [
+                    "cloudflare.api_token",
+                    "cloudflare.auth_mode",
+                    "cloudflare.oauth_scopes",
+                    "cloudflare.oauth_connected_at",
+                ]
+            )
+        )
+        .all()
+    }
+    assert settings["cloudflare.api_token"] == "encrypted:provider-token"
+    assert settings["cloudflare.api_token"] != "provider-token"
+    assert settings["cloudflare.auth_mode"] == "oauth"
+    assert settings["cloudflare.oauth_scopes"] == "zone.read dns.read"
+    assert settings["cloudflare.oauth_connected_at"]
 
 
 def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -166,6 +166,29 @@ def test_get_domain_reports_returns_200(seeded_client: TestClient):
     assert "compliance_timeline" in data
 
 
+def test_compliance_timeline_does_not_treat_no_volume_as_perfect_compliance():
+    """Zero-volume report periods must not become 100% compliance points."""
+    store = ReportStore()
+    store.add_report(
+        {
+            **REPORT_DICT_POLICY,
+            "report_id": "rpt-zero-volume",
+            "begin_timestamp": 1597536000,
+            "begin_date": "2020-08-16T00:00:00",
+            "end_date": "2020-08-16T23:59:59",
+            "records": [],
+            "summary": {"total_count": 0, "passed_count": 0, "failed_count": 0},
+        }
+    )
+
+    timeline = domains_endpoint._build_compliance_timeline(store, DOMAIN)
+
+    assert timeline[0].volume == 0
+    assert timeline[0].total == 0
+    assert timeline[0].compliance_rate == 0.0
+    assert timeline[0].failure_rate == 0.0
+
+
 def test_domain_read_stats_selectors_and_search_use_workspace_auth(
     seeded_client: TestClient,
 ):

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -941,6 +941,10 @@ def test_get_report_by_id_continues_when_reputation_enrichment_fails(
     async def failing_reputation(*_args, **_kwargs):
         raise RuntimeError("provider unavailable")
 
+    async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
+        return None
+
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", failing_reputation)
 
     response = authed_client.get("/api/v1/reports/source-intel-fallback-report")

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import zipfile
 from contextlib import contextmanager
@@ -948,6 +949,15 @@ def test_get_report_by_id_continues_when_reputation_enrichment_fails(
     record = response.json()["records"][0]
     assert record["source_details"]["sender"]
     assert record["reputation"] is None
+
+
+def test_safe_ptr_lookup_returns_none_for_invalid_or_failed_lookup():
+    class FailingProvider:
+        async def lookup_ptr(self, _ip):
+            raise RuntimeError("dns unavailable")
+
+    assert asyncio.run(reports_endpoint._safe_ptr_lookup(FailingProvider(), "not-an-ip")) is None
+    assert asyncio.run(reports_endpoint._safe_ptr_lookup(FailingProvider(), "192.0.2.55")) is None
 
 
 def test_get_report_by_id_not_found(authed_client: TestClient):

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -19,6 +19,7 @@ from app.models.workspace_access import WorkspaceMembership
 from app.services.organizations import OrganizationPlanLimitError
 from app.services.report_persistence import persisted_report_to_dict, save_parsed_report
 from app.services.report_store import ReportStore
+from app.services.source_reputation import DomainReputation, ReputationEvidence, SourceReputation
 from app.services.workspace_access import ROLE_ANALYST
 from app.services.workspaces import get_or_create_default_workspace
 from app.tests.test_data import SAMPLE_XML, load_dmarc_fixture
@@ -833,7 +834,95 @@ def test_get_report_by_id_includes_record_review_guidance(
     assert any(
         "Open the domain sending-source view" in step for step in failed_record["next_steps"]
     )
-    assert any("Header From alignment" in step for step in failed_record["next_steps"])
+
+
+def test_get_report_by_id_includes_source_intelligence_and_reputation(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Report records expose PTR, geo/network metadata, and reputation evidence."""
+    workspace = get_or_create_default_workspace(db_session)
+    _persist_parsed_report(
+        db_session,
+        {
+            "domain": "example.com",
+            "report_id": "source-intel-report",
+            "org_name": "google.com",
+            "email": "noreply@example.com",
+            "begin_timestamp": 1782691200,
+            "end_timestamp": 1782777599,
+            "policy": {"p": "reject", "sp": "reject", "pct": "100"},
+            "records": [
+                {
+                    "source_ip": "193.138.195.141",
+                    "count": 2,
+                    "disposition": "reject",
+                    "dkim_result": "fail",
+                    "spf_result": "fail",
+                    "header_from": "example.com",
+                    "extensions": {
+                        "geo:country": "Germany",
+                        "geo:country_code": "DE",
+                        "geo:region": "Europe",
+                        "geo:asn": "AS64555",
+                        "geo:network": "Example Sender Network",
+                        "demo:blacklists": "Example DNSBL",
+                    },
+                }
+            ],
+            "summary": {"total_count": 2, "passed_count": 0, "failed_count": 2},
+        },
+        workspace_id=workspace.id,
+    )
+
+    async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
+        return "mail.example-sender.net"
+
+    async def fake_reputation(*_args, **_kwargs):
+        return (
+            DomainReputation(
+                domain="example.com",
+                status="listed",
+                checked_at="2026-07-01T00:00:00Z",
+                sources=[
+                    SourceReputation(
+                        ip="193.138.195.141",
+                        status="listed",
+                        risk_score=82,
+                        summary="Observed source has blacklist or reputation-list evidence.",
+                        listings=["Example DNSBL"],
+                        evidence=[
+                            ReputationEvidence(
+                                label="External reputation feeds",
+                                value="Example DNSBL",
+                                source="external",
+                            )
+                        ],
+                        recommendations=["Follow the provider delisting process."],
+                        checked_at="2026-07-01T00:00:00Z",
+                    )
+                ],
+                summary={"total_sources": 1, "listed": 1},
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+
+    response = authed_client.get("/api/v1/reports/source-intel-report")
+
+    assert response.status_code == 200
+    record = response.json()["records"][0]
+    assert record["source_details"]["hostname"] == "mail.example-sender.net"
+    assert record["source_details"]["country"] == "Germany"
+    assert record["source_details"]["asn"] == "AS64555"
+    assert record["source_details"]["network"] == "Example Sender Network"
+    assert record["reputation"]["status"] == "listed"
+    assert record["reputation"]["risk_score"] == 82
+    assert record["reputation"]["listings"] == ["Example DNSBL"]
 
 
 def test_get_report_by_id_not_found(authed_client: TestClient):

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -925,6 +925,31 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
     assert record["reputation"]["listings"] == ["Example DNSBL"]
 
 
+def test_get_report_by_id_continues_when_reputation_enrichment_fails(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    workspace = get_or_create_default_workspace(db_session)
+    _persist_parsed_report(
+        db_session,
+        _parsed_report(domain="example.com", report_id="source-intel-fallback-report"),
+        workspace_id=workspace.id,
+    )
+
+    async def failing_reputation(*_args, **_kwargs):
+        raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", failing_reputation)
+
+    response = authed_client.get("/api/v1/reports/source-intel-fallback-report")
+
+    assert response.status_code == 200
+    record = response.json()["records"][0]
+    assert record["source_details"]["sender"]
+    assert record["reputation"] is None
+
+
 def test_get_report_by_id_not_found(authed_client: TestClient):
     """GET /api/v1/reports/{report_id} returns 404 when report does not exist."""
     response = authed_client.get("/api/v1/reports/no-such-report-id")

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -133,7 +133,7 @@ Live DNS writes stay behind the separate DNS repair approval flow.
 
 | Provider | Zone import | Configuration |
 |----------|-------------|---------------|
-| Cloudflare | Ready | `CLOUDFLARE_API_TOKEN` with Zone/DNS read permissions |
+| Cloudflare | Ready | OAuth client with `zone.read`/`dns.read`, or `CLOUDFLARE_API_TOKEN` with Zone/DNS read permissions |
 | Amazon Route 53 | Ready | boto3/AWS credential chain, `DMARQ_ROUTE53_PROFILE`, or `DMARQ_ROUTE53_ROLE_ARN` with optional `DMARQ_ROUTE53_EXTERNAL_ID` |
 | Hetzner DNS | Ready | `HETZNER_DNS_API_TOKEN` or `HETZNER_API_TOKEN` with DNS zone read access |
 | Akamai Edge DNS/FastDNS | Planned | EdgeGrid DNS credentials, separate from Akamai EAA login |
@@ -265,6 +265,9 @@ operational policy if long-term storage size matters.
 |----------|-------------|---------|---------|
 | `CLOUDFLARE_API_TOKEN` | Cloudflare API token for zone discovery, DNS inspection, and optional approved DNS writes | - | `your_cloudflare_api_token` |
 | `CLOUDFLARE_ZONE_ID` | Optional default Cloudflare Zone ID | - | `your_cloudflare_zone_id` |
+| `CLOUDFLARE_OAUTH_CLIENT_ID` | Optional Cloudflare OAuth client ID for one-click provider connect | - | `your_cloudflare_oauth_client_id` |
+| `CLOUDFLARE_OAUTH_CLIENT_SECRET` | Optional Cloudflare OAuth client secret for one-click provider connect | - | `your_cloudflare_oauth_client_secret` |
+| `CLOUDFLARE_OAUTH_SCOPES` | Cloudflare OAuth scopes requested for read-only zone import and ownership checks | `zone.read dns.read` | `zone.read dns.read` |
 | `HETZNER_DNS_API_TOKEN` | Hetzner Console API token for read-only DNS zone import through `api.hetzner.cloud` | - | `your_hetzner_read_only_api_token` |
 | `HETZNER_API_TOKEN` | Fallback Hetzner token name if you already inject generic Hetzner Cloud credentials | - | `your_hetzner_read_only_api_token` |
 

--- a/docs/deployment/secrets.md
+++ b/docs/deployment/secrets.md
@@ -18,6 +18,7 @@ Store these values in a 1Password Environment for each deployment target:
 | `AUTHENTIK_CLIENT_SECRET` | Secret | Required when Authentik direct OIDC authentication is enabled. |
 | `OIDC_CLIENT_SECRET` | Secret | Required when generic OIDC authentication is enabled. |
 | `CLOUDFLARE_API_TOKEN` | Secret | Optional DNS inspection/integration token. |
+| `CLOUDFLARE_OAUTH_CLIENT_SECRET` | Secret | Optional Cloudflare OAuth connector secret for one-click zone import and ownership verification. |
 | `FIRST_SUPERUSER_PASSWORD` | Secret | Only needed for bootstrap flows that create an initial local admin. |
 
 Non-sensitive values, such as `IMAP_SERVER`, `IMAP_USERNAME`, `LOGTO_ENDPOINT`,


### PR DESCRIPTION
## What changed
- Adds Cloudflare OAuth connection plumbing for read-scope DNS/zone access.
- Allows domain ownership verification through a connected Cloudflare zone.
- Keeps report ingestion/viewing independent from DNS ownership, while reserving provider-managed DNS actions for verified domains.
- Adds source intelligence on report detail records: PTR, sender/provider identity, region/ASN/network context, and cached source reputation/DNSBL evidence where configured.
- Hardens the domain sending-sources endpoint so reputation enrichment failures do not make the whole table fail.
- Fixes Compliance over Time so no-mail periods are not shown as perfect compliance, and switches message volume to a log scale so large outliers do not flatten normal days.
- Documents Cloudflare OAuth configuration and secret requirements.

## Validation
- `/tmp/dmarq-auth-venv/bin/pytest backend/app/tests/test_domain_detail_endpoints.py -k "compliance_timeline or domain_reports_returns_200" -q`
- `/tmp/dmarq-auth-venv/bin/pytest backend/app/tests/test_domain_detail_endpoints.py -q`
- `/tmp/dmarq-auth-venv/bin/pytest backend/app/tests -q` before the latest chart-only amendment: 1488 passed
- `/tmp/dmarq-auth-venv/bin/python -m compileall -q backend/app/api/api_v1/endpoints backend/app/services/cloudflare_oauth.py backend/app/services/cloudflare_dns.py backend/app/core/config.py`
- `git diff --check`

## Live-data notes
- `https://app.dmarq.com` currently fails browser navigation with `ERR_CERT_COMMON_NAME_INVALID`.
- `https://app.dmarq.org` is reachable, but the current in-app browser session is unauthenticated and redirects to login, so production timeline validation still needs an authenticated read-only session or export.

## Notes
- Draft until the final CI run completes after this amendment.
- Snyk is currently reporting an external quota/check error, not a product test failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare OAuth connection support for DNS provider setup.
  * Added a Cloudflare-based domain ownership verification option.
  * Expanded report and domain detail pages with richer source intelligence, including location and reputation info.

* **Bug Fixes**
  * Report details now continue loading even if reputation or enrichment data can’t be fetched.
  * Compliance charts handle zero-volume periods more accurately instead of showing misleading defaults.

* **Documentation**
  * Updated setup guidance with new Cloudflare OAuth configuration and secret entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->