### PR TITLE
feat: add Linode DNS domain import

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,8 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # CLOUDFLARE_OAUTH_SCOPES="zone.read dns.read"
 # HETZNER_DNS_API_TOKEN="your_hetzner_read_only_api_token"
 # HETZNER_API_TOKEN="your_hetzner_read_only_api_token"
+# LINODE_API_TOKEN="your_linode_domains_read_only_token"
+# LINODE_TOKEN="your_linode_domains_read_only_token"
 # Route 53 zone import uses the standard boto3/AWS credential chain.
 # Prefer DMARQ_ROUTE53_ROLE_ARN with DMARQ_ROUTE53_EXTERNAL_ID in hosted setups.
 # AWS_PROFILE="your_local_read_only_profile"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -58,6 +58,8 @@ class Settings(BaseSettings):
     CLOUDFLARE_OAUTH_SCOPES: str = "zone.read dns.read"
     HETZNER_DNS_API_TOKEN: Optional[str] = None
     HETZNER_API_TOKEN: Optional[str] = None
+    LINODE_API_TOKEN: Optional[str] = None
+    LINODE_TOKEN: Optional[str] = None
     AWS_PROFILE: Optional[str] = None
     AWS_REGION: Optional[str] = None
     DMARQ_ROUTE53_PROFILE: Optional[str] = None

--- a/backend/app/services/dns_provider_connectors.py
+++ b/backend/app/services/dns_provider_connectors.py
@@ -127,19 +127,19 @@ _CONNECTORS: tuple[DNSProviderConnector, ...] = (
         name="Linode DNS",
         tier=1,
         auth_models=["personal_access_token", "lexicon_environment"],
-        zone_import_status="planned",
+        zone_import_status="ready",
         record_read_status="planned",
         record_write_status="lexicon_available",
         dry_run_supported=True,
         verification_supported=False,
         rollback_supported=True,
         minimum_permissions=[
-            "Domains read access",
+            "Domains read-only access",
             "Domains write access only when repair is enabled",
         ],
         setup_hint=(
-            "Use a Linode token scoped to domains. Linode/Akamai Cloud users can "
-            "connect DNS context separately from application login."
+            "Use a Linode personal access token scoped to read DNS domains. "
+            "Keep write-scoped tokens separate until approved repair actions are enabled."
         ),
         docs_url="https://techdocs.akamai.com/linode-api/reference/get-domains",
     ),

--- a/backend/app/services/dns_provider_imports.py
+++ b/backend/app/services/dns_provider_imports.py
@@ -11,6 +11,7 @@ from app.services.cloudflare_dns import discover_cloudflare_zones, import_cloudf
 from app.services.dns_provider_connectors import provider_connector_registry
 from app.services.dns_provider_writes import normalize_provider_id
 from app.services.hetzner_dns import discover_hetzner_zones, import_hetzner_domains
+from app.services.linode_dns import discover_linode_domains, import_linode_domains
 from app.services.route53_dns import discover_route53_zones, import_route53_domains
 
 
@@ -63,6 +64,8 @@ async def preview_dns_provider_import(
         zones = await discover_route53_zones(db, workspace_id=workspace_id)
     elif provider_id == "hetzner":
         zones = await discover_hetzner_zones(db, workspace_id=workspace_id)
+    elif provider_id == "linode":
+        zones = await discover_linode_domains(db, workspace_id=workspace_id)
     else:
         raise LookupError(f"Unsupported DNS provider import: {provider_id}")
 
@@ -119,6 +122,12 @@ async def import_dns_provider_domains(
         )
     elif provider_id == "hetzner":
         result = await import_hetzner_domains(
+            db,
+            requested_domains=requested_domains,
+            workspace_id=workspace_id,
+        )
+    elif provider_id == "linode":
+        result = await import_linode_domains(
             db,
             requested_domains=requested_domains,
             workspace_id=workspace_id,

--- a/backend/app/services/dns_provider_imports.py
+++ b/backend/app/services/dns_provider_imports.py
@@ -50,6 +50,10 @@ def _provider_name(provider_id: str) -> str:
     return PROVIDER_NAMES.get(provider_id, provider_id)
 
 
+def _provider_import_item_label(provider_id: str) -> str:
+    return "domain" if provider_id == "linode" else "zone"
+
+
 async def preview_dns_provider_import(
     db: Session,
     *,
@@ -69,6 +73,7 @@ async def preview_dns_provider_import(
     else:
         raise LookupError(f"Unsupported DNS provider import: {provider_id}")
 
+    item_label = _provider_import_item_label(provider_id)
     items = [
         DNSProviderImportZone(
             provider=provider_id,
@@ -83,7 +88,7 @@ async def preview_dns_provider_import(
                 "Already monitored in this workspace."
                 if zone.get("imported")
                 else (
-                    f"Import this {_provider_name(provider_id)} zone to monitor DNS posture "
+                    f"Import this {_provider_name(provider_id)} {item_label} to monitor DNS posture "
                     "before reports arrive."
                 )
             ),

--- a/backend/app/services/linode_dns.py
+++ b/backend/app/services/linode_dns.py
@@ -1,0 +1,220 @@
+"""Linode DNS domain discovery and monitored-domain import helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.models.domain import Domain
+from app.models.workspace import Workspace
+from app.services.organizations import require_organization_plan_limit
+from app.services.workspaces import assign_default_workspace_to_unscoped_rows
+
+PROVIDER_NAME = "linode"
+LINODE_API_BASE = "https://api.linode.com/v4"
+LINODE_API_TIMEOUT = 30.0
+LINODE_PAGE_SIZE = 500
+
+
+@dataclass
+class LinodeDNSCredentials:
+    """Resolved Linode API credentials for DNS domain discovery."""
+
+    api_token: Optional[str] = None
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.api_token)
+
+
+class LinodeDNSClient:
+    """Small read-only client for Linode DNS domain discovery."""
+
+    def __init__(
+        self,
+        *,
+        api_token: Optional[str],
+        api_base: str = LINODE_API_BASE,
+    ) -> None:
+        self.api_token = api_token
+        self.api_base = api_base.rstrip("/")
+
+    def _headers(self) -> Dict[str, str]:
+        if not self.api_token:
+            raise LookupError("Linode API token is not configured")
+        return {
+            "Authorization": f"Bearer {self.api_token}",
+            "Accept": "application/json",
+        }
+
+    async def _api_get(
+        self,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.api_base}{path}"
+        try:
+            async with httpx.AsyncClient(timeout=LINODE_API_TIMEOUT) as client:
+                response = await client.get(url, params=params, headers=self._headers())
+                response.raise_for_status()
+                return response.json()
+        except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException) as exc:
+            raise LookupError(f"Linode API request failed for {path}: {exc}") from exc
+        except ValueError as exc:
+            raise LookupError(f"Linode API returned invalid JSON for {path}") from exc
+
+    async def list_domains(self) -> List[Dict[str, Any]]:
+        """Return DNS domains visible to the configured Linode token."""
+        domains: List[Dict[str, Any]] = []
+        page = 1
+        while True:
+            data = await self._api_get(
+                "/domains",
+                params={"page": page, "page_size": LINODE_PAGE_SIZE},
+            )
+            result = data.get("data") or []
+            if not isinstance(result, list):
+                return domains
+            domains.extend(result)
+
+            pages = int(data.get("pages") or page)
+            if page >= pages:
+                break
+            page += 1
+        return domains
+
+
+def get_linode_dns_credentials() -> LinodeDNSCredentials:
+    """Resolve Linode API credentials from environment settings."""
+    settings = get_settings()
+    return LinodeDNSCredentials(
+        api_token=settings.LINODE_API_TOKEN or settings.LINODE_TOKEN,
+    )
+
+
+def build_linode_dns_client() -> LinodeDNSClient:
+    """Return a Linode DNS client configured from environment settings."""
+    credentials = get_linode_dns_credentials()
+    if not credentials.configured:
+        raise LookupError("Linode API token is not configured")
+    return LinodeDNSClient(api_token=credentials.api_token)
+
+
+def _resolve_workspace_id(db: Session, workspace_id: Optional[int]) -> int:
+    if workspace_id is not None:
+        return workspace_id
+    return assign_default_workspace_to_unscoped_rows(db).id
+
+
+def _workspace_domain_names(db: Session, workspace_id: Optional[int]) -> set[str]:
+    resolved_workspace_id = _resolve_workspace_id(db, workspace_id)
+    query = db.query(Domain.name).filter(Domain.workspace_id == resolved_workspace_id)
+    return {name for (name,) in query.all()}
+
+
+def _normalize_domain_name(domain: str) -> str:
+    return domain.strip().strip(".").lower()
+
+
+async def discover_linode_domains(
+    db: Session,
+    *,
+    workspace_id: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Return Linode DNS domains visible to the configured token with import state."""
+    client = build_linode_dns_client()
+    known_domains = _workspace_domain_names(db, workspace_id)
+    domains = await client.list_domains()
+    discovered: List[Dict[str, Any]] = []
+    for domain in domains:
+        name = _normalize_domain_name(str(domain.get("domain") or ""))
+        domain_id = domain.get("id")
+        if not domain_id or not name:
+            continue
+        discovered.append(
+            {
+                "id": str(domain_id),
+                "name": name,
+                "status": domain.get("type"),
+                "account_name": "Linode DNS",
+                "imported": name in known_domains,
+            }
+        )
+    return discovered
+
+
+async def import_linode_domains(
+    db: Session,
+    *,
+    requested_domains: Optional[List[str]] = None,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Create Domain rows for Linode DNS domains."""
+    workspace_id = _resolve_workspace_id(db, workspace_id)
+    workspace = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+
+    zones = await discover_linode_domains(db, workspace_id=workspace_id)
+    requested = None
+    if requested_domains is not None:
+        requested = {
+            _normalize_domain_name(domain)
+            for domain in requested_domains
+            if _normalize_domain_name(domain)
+        }
+    candidate_names: List[str] = []
+    imported: List[str] = []
+    existing: List[str] = []
+    skipped: List[str] = []
+    seen_candidates: set[str] = set()
+
+    for zone in zones:
+        name = str(zone["name"]).lower()
+        if requested is not None and name not in requested:
+            skipped.append(name)
+            continue
+        if name in seen_candidates:
+            continue
+        seen_candidates.add(name)
+        candidate_names.append(name)
+
+    existing_names = set()
+    if candidate_names:
+        existing_names = {
+            row[0] for row in db.query(Domain.name).filter(Domain.name.in_(candidate_names)).all()
+        }
+    new_names = [name for name in candidate_names if name not in existing_names]
+    if workspace and workspace.organization and new_names:
+        require_organization_plan_limit(
+            db,
+            workspace.organization,
+            "monitored_domains",
+            increment=len(new_names),
+        )
+
+    for name in candidate_names:
+        if name in existing_names:
+            existing.append(name)
+        else:
+            db.add(
+                Domain(
+                    name=name,
+                    description="DNS-discovered from Linode DNS domain import",
+                    active=True,
+                    verified=True,
+                    workspace_id=workspace_id,
+                )
+            )
+            imported.append(name)
+
+    db.commit()
+    return {
+        "imported": imported,
+        "existing": existing,
+        "skipped": skipped,
+        "total_discovered": len(zones),
+    }

--- a/backend/app/services/linode_dns.py
+++ b/backend/app/services/linode_dns.py
@@ -56,13 +56,19 @@ class LinodeDNSClient:
         path: str,
         *,
         params: Optional[Dict[str, Any]] = None,
+        client: Optional[httpx.AsyncClient] = None,
     ) -> Dict[str, Any]:
         url = f"{self.api_base}{path}"
         try:
-            async with httpx.AsyncClient(timeout=LINODE_API_TIMEOUT) as client:
+            if client is not None:
                 response = await client.get(url, params=params, headers=self._headers())
                 response.raise_for_status()
                 return response.json()
+
+            async with httpx.AsyncClient(timeout=LINODE_API_TIMEOUT) as http_client:
+                response = await http_client.get(url, params=params, headers=self._headers())
+            response.raise_for_status()
+            return response.json()
         except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException) as exc:
             raise LookupError(f"Linode API request failed for {path}: {exc}") from exc
         except ValueError as exc:
@@ -72,20 +78,22 @@ class LinodeDNSClient:
         """Return DNS domains visible to the configured Linode token."""
         domains: List[Dict[str, Any]] = []
         page = 1
-        while True:
-            data = await self._api_get(
-                "/domains",
-                params={"page": page, "page_size": LINODE_PAGE_SIZE},
-            )
-            result = data.get("data") or []
-            if not isinstance(result, list):
-                return domains
-            domains.extend(result)
+        async with httpx.AsyncClient(timeout=LINODE_API_TIMEOUT) as client:
+            while True:
+                data = await self._api_get(
+                    "/domains",
+                    params={"page": page, "page_size": LINODE_PAGE_SIZE},
+                    client=client,
+                )
+                result = data.get("data") or []
+                if not isinstance(result, list):
+                    return domains
+                domains.extend(result)
 
-            pages = int(data.get("pages") or page)
-            if page >= pages:
-                break
-            page += 1
+                pages = int(data.get("pages") or page)
+                if page >= pages:
+                    break
+                page += 1
         return domains
 
 

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1259,7 +1259,7 @@ def test_dns_provider_import_preview_wraps_linode_domains(db_session):
     assert result["total_discovered"] == 1
     assert result["importable_count"] == 1
     assert result["zones"][0]["domain"] == DOMAIN
-    assert "Linode DNS zone" in result["zones"][0]["next_action"]
+    assert "Linode DNS domain" in result["zones"][0]["next_action"]
 
 
 def test_dns_provider_import_preview_wraps_route53_zones(db_session):

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -563,8 +563,9 @@ def test_hetzner_dns_credentials_and_build_client(monkeypatch):
 def test_linode_dns_client_list_domains_paginates(monkeypatch):
     client = linode_dns.LinodeDNSClient(api_token="token")
 
-    async def fake_get(path, *, params=None):
+    async def fake_get(path, *, params=None, client=None):
         assert path == "/domains"
+        assert client is not None
         assert params["page_size"] == linode_dns.LINODE_PAGE_SIZE
         if params["page"] == 1:
             return {
@@ -641,7 +642,8 @@ def test_linode_dns_client_api_get_maps_invalid_json(monkeypatch):
 def test_linode_dns_client_list_domains_ignores_malformed_payload(monkeypatch):
     client = linode_dns.LinodeDNSClient(api_token="token")
 
-    async def fake_get(path, *, params=None):
+    async def fake_get(path, *, params=None, client=None):
+        assert client is not None
         return {"data": "not-a-list"}
 
     monkeypatch.setattr(client, "_api_get", fake_get)

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -28,6 +28,7 @@ from app.services import (
     dns_provider_imports,
     dns_provider_writes,
     hetzner_dns,
+    linode_dns,
     route53_dns,
 )
 from app.services.cloudflare_dns import analyze_dns_records, sync_dns_record_changes
@@ -121,6 +122,14 @@ class FakeHetznerDNSClient:
         return self.zones
 
 
+class FakeLinodeDNSClient:
+    def __init__(self, *, domains=None):
+        self.domains = domains or []
+
+    async def list_domains(self):
+        return self.domains
+
+
 class FakeRoute53DNSClient:
     def __init__(self, *, zones=None, account_name="Amazon Route 53"):
         self.zones = zones or []
@@ -164,6 +173,10 @@ class FakeHetznerResponse:
         if self.json_error:
             raise ValueError("bad json")
         return self.payload
+
+
+class FakeLinodeResponse(FakeHetznerResponse):
+    pass
 
 
 def test_analyze_dns_records_reports_healthy_auth_records():
@@ -547,6 +560,118 @@ def test_hetzner_dns_credentials_and_build_client(monkeypatch):
         hetzner_dns.build_hetzner_dns_client()
 
 
+def test_linode_dns_client_list_domains_paginates(monkeypatch):
+    client = linode_dns.LinodeDNSClient(api_token="token")
+
+    async def fake_get(path, *, params=None):
+        assert path == "/domains"
+        assert params["page_size"] == linode_dns.LINODE_PAGE_SIZE
+        if params["page"] == 1:
+            return {
+                "data": [{"id": 1, "domain": DOMAIN}],
+                "pages": 2,
+            }
+        return {
+            "data": [{"id": 2, "domain": "second.example"}],
+            "pages": 2,
+        }
+
+    monkeypatch.setattr(client, "_api_get", fake_get)
+
+    domains = asyncio.run(client.list_domains())
+
+    assert [domain["domain"] for domain in domains] == [DOMAIN, "second.example"]
+
+
+def test_linode_dns_client_headers_api_get_and_error_paths(monkeypatch):
+    requests = []
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, *, params=None, headers=None):
+            requests.append({"url": url, "params": params, "headers": headers})
+            return FakeLinodeResponse({"data": []})
+
+    monkeypatch.setattr(linode_dns.httpx, "AsyncClient", FakeAsyncClient)
+    client = linode_dns.LinodeDNSClient(api_token="token", api_base="https://example.test/")
+
+    result = asyncio.run(client._api_get("/domains", params={"page": 1}))
+
+    assert result == {"data": []}
+    assert requests == [
+        {
+            "url": "https://example.test/domains",
+            "params": {"page": 1},
+            "headers": {"Authorization": "Bearer token", "Accept": "application/json"},
+        }
+    ]
+    with pytest.raises(LookupError, match="not configured"):
+        linode_dns.LinodeDNSClient(api_token=None)._headers()
+
+
+def test_linode_dns_client_api_get_maps_invalid_json(monkeypatch):
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, *, params=None, headers=None):
+            return FakeLinodeResponse(json_error=True)
+
+    monkeypatch.setattr(linode_dns.httpx, "AsyncClient", FakeAsyncClient)
+    client = linode_dns.LinodeDNSClient(api_token="token")
+
+    with pytest.raises(LookupError, match="invalid JSON"):
+        asyncio.run(client._api_get("/domains"))
+
+
+def test_linode_dns_client_list_domains_ignores_malformed_payload(monkeypatch):
+    client = linode_dns.LinodeDNSClient(api_token="token")
+
+    async def fake_get(path, *, params=None):
+        return {"data": "not-a-list"}
+
+    monkeypatch.setattr(client, "_api_get", fake_get)
+
+    assert asyncio.run(client.list_domains()) == []
+
+
+def test_linode_dns_credentials_and_build_client(monkeypatch):
+    monkeypatch.setattr(
+        linode_dns,
+        "get_settings",
+        lambda: SimpleNamespace(LINODE_API_TOKEN="", LINODE_TOKEN="fallback"),
+    )
+
+    credentials = linode_dns.get_linode_dns_credentials()
+    client = linode_dns.build_linode_dns_client()
+
+    assert credentials.configured is True
+    assert client.api_token == "fallback"
+
+    monkeypatch.setattr(
+        linode_dns,
+        "get_settings",
+        lambda: SimpleNamespace(LINODE_API_TOKEN="", LINODE_TOKEN=""),
+    )
+    assert linode_dns.get_linode_dns_credentials().configured is False
+    with pytest.raises(LookupError, match="not configured"):
+        linode_dns.build_linode_dns_client()
+
+
 def test_route53_dns_client_list_zones_uses_boto3_paginator():
     boto_client = FakeRoute53BotoClient(
         pages=[
@@ -694,6 +819,58 @@ def test_discover_hetzner_zones_scopes_default_workspace_import_state(db_session
     assert zones[0]["imported"] is False
 
 
+def test_discover_linode_domains_marks_imported_and_filters_invalid(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add(Domain(name=DOMAIN, workspace_id=workspace.id))
+    db_session.commit()
+    client = FakeLinodeDNSClient(
+        domains=[
+            {"id": 1, "domain": f"{DOMAIN}.", "type": "master"},
+            {"id": 2, "domain": "New.EXAMPLE", "type": "slave"},
+            {"id": None, "domain": "invalid.example"},
+            {"id": 3, "domain": ""},
+        ]
+    )
+
+    with patch("app.services.linode_dns.build_linode_dns_client", return_value=client):
+        domains = asyncio.run(
+            linode_dns.discover_linode_domains(db_session, workspace_id=workspace.id)
+        )
+
+    assert domains == [
+        {
+            "id": "1",
+            "name": DOMAIN,
+            "status": "master",
+            "account_name": "Linode DNS",
+            "imported": True,
+        },
+        {
+            "id": "2",
+            "name": "new.example",
+            "status": "slave",
+            "account_name": "Linode DNS",
+            "imported": False,
+        },
+    ]
+
+
+def test_discover_linode_domains_scopes_default_workspace_import_state(db_session):
+    default_workspace = get_or_create_default_workspace(db_session)
+    other_workspace = Workspace(slug="linode-other", name="Linode Other", active=True)
+    db_session.add(other_workspace)
+    db_session.commit()
+    db_session.add(Domain(name=DOMAIN, workspace_id=other_workspace.id))
+    db_session.commit()
+    client = FakeLinodeDNSClient(domains=[{"id": 1, "domain": DOMAIN}])
+
+    with patch("app.services.linode_dns.build_linode_dns_client", return_value=client):
+        domains = asyncio.run(linode_dns.discover_linode_domains(db_session))
+
+    assert default_workspace.id != other_workspace.id
+    assert domains[0]["imported"] is False
+
+
 def test_discover_route53_zones_marks_imported_and_filters_invalid(db_session):
     workspace = get_or_create_default_workspace(db_session)
     db_session.add(Domain(name=DOMAIN, workspace_id=workspace.id))
@@ -833,6 +1010,54 @@ def test_import_hetzner_domains_reports_globally_existing_domain(db_session):
     assert result["existing"] == [DOMAIN]
     assert result["skipped"] == []
     assert db_session.query(Domain).filter(Domain.name == DOMAIN).count() == 1
+
+
+def test_import_linode_domains_imports_requested_and_skips_others(db_session):
+    async def fake_discover(_db, workspace_id=None):
+        return [
+            {"id": "1", "name": DOMAIN, "imported": False},
+            {"id": "2", "name": "skip.example", "imported": False},
+        ]
+
+    with patch("app.services.linode_dns.discover_linode_domains", new=fake_discover):
+        result = asyncio.run(
+            linode_dns.import_linode_domains(
+                db_session,
+                requested_domains=[f"{DOMAIN}."],
+            )
+        )
+
+    assert result["imported"] == [DOMAIN]
+    assert result["existing"] == []
+    assert result["skipped"] == ["skip.example"]
+    imported = db_session.query(Domain).filter(Domain.name == DOMAIN).first()
+    assert imported is not None
+    assert imported.verified is True
+    assert imported.description == "DNS-discovered from Linode DNS domain import"
+
+
+def test_import_linode_domains_reports_globally_existing_and_deduplicates(db_session):
+    other_workspace = Workspace(slug="linode-existing", name="Linode Existing", active=True)
+    db_session.add(other_workspace)
+    db_session.commit()
+    db_session.add(Domain(name=DOMAIN, workspace_id=other_workspace.id))
+    db_session.commit()
+
+    async def fake_discover(_db, workspace_id=None):
+        return [
+            {"id": "1", "name": DOMAIN, "imported": False},
+            {"id": "2", "name": DOMAIN, "imported": False},
+            {"id": "3", "name": "new.example", "imported": False},
+        ]
+
+    with patch("app.services.linode_dns.discover_linode_domains", new=fake_discover):
+        result = asyncio.run(linode_dns.import_linode_domains(db_session))
+
+    assert result["imported"] == ["new.example"]
+    assert result["existing"] == [DOMAIN]
+    assert result["skipped"] == []
+    assert db_session.query(Domain).filter(Domain.name == DOMAIN).count() == 1
+    assert db_session.query(Domain).filter(Domain.name == "new.example").count() == 1
 
 
 def test_import_route53_domains_imports_requested_and_skips_others(db_session):
@@ -1007,6 +1232,36 @@ def test_dns_provider_import_preview_wraps_hetzner_zones(db_session):
     assert "Hetzner DNS zone" in result["zones"][0]["next_action"]
 
 
+def test_dns_provider_import_preview_wraps_linode_domains(db_session):
+    async def fake_discover(_db, workspace_id=None):
+        assert workspace_id == 123
+        return [
+            {
+                "id": "1",
+                "name": DOMAIN,
+                "status": "master",
+                "account_name": "Linode DNS",
+                "imported": False,
+            }
+        ]
+
+    with patch("app.services.dns_provider_imports.discover_linode_domains", new=fake_discover):
+        result = asyncio.run(
+            dns_provider_imports.preview_dns_provider_import(
+                db_session,
+                provider="linode",
+                workspace_id=123,
+            )
+        )
+
+    assert result["provider"] == "linode"
+    assert result["provider_name"] == "Linode DNS"
+    assert result["total_discovered"] == 1
+    assert result["importable_count"] == 1
+    assert result["zones"][0]["domain"] == DOMAIN
+    assert "Linode DNS zone" in result["zones"][0]["next_action"]
+
+
 def test_dns_provider_import_preview_wraps_route53_zones(db_session):
     async def fake_discover(_db, workspace_id=None):
         assert workspace_id == 123
@@ -1060,6 +1315,32 @@ def test_dns_provider_import_apply_wraps_hetzner_import(db_session):
 
     assert result["provider"] == "hetzner"
     assert result["provider_name"] == "Hetzner DNS"
+    assert result["imported"] == [DOMAIN]
+
+
+def test_dns_provider_import_apply_wraps_linode_import(db_session):
+    async def fake_import(_db, requested_domains=None, workspace_id=None):
+        assert requested_domains == [DOMAIN]
+        assert workspace_id == 456
+        return {
+            "imported": [DOMAIN],
+            "existing": [],
+            "skipped": [],
+            "total_discovered": 1,
+        }
+
+    with patch("app.services.dns_provider_imports.import_linode_domains", new=fake_import):
+        result = asyncio.run(
+            dns_provider_imports.import_dns_provider_domains(
+                db_session,
+                provider="linode",
+                requested_domains=[DOMAIN],
+                workspace_id=456,
+            )
+        )
+
+    assert result["provider"] == "linode"
+    assert result["provider_name"] == "Linode DNS"
     assert result["imported"] == [DOMAIN]
 
 
@@ -1409,6 +1690,10 @@ def test_dns_provider_capabilities_mark_cloudflare_import_available(authed_clien
     assert providers["route53"]["import_available"] is True
     assert providers["route53"]["zone_import_status"] == "ready"
     assert "iam_role_external_id" in providers["route53"]["auth_models"]
+    assert providers["linode"]["import_available"] is True
+    assert providers["linode"]["zone_import_status"] == "ready"
+    assert providers["linode"]["record_write_status"] == "lexicon_available"
+    assert "personal_access_token" in providers["linode"]["auth_models"]
 
 
 def test_cloudflare_import_endpoint_returns_import_summary(authed_client: TestClient):

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -136,14 +136,19 @@ Live DNS writes stay behind the separate DNS repair approval flow.
 | Cloudflare | Ready | OAuth client with `zone.read`/`dns.read`, or `CLOUDFLARE_API_TOKEN` with Zone/DNS read permissions |
 | Amazon Route 53 | Ready | boto3/AWS credential chain, `DMARQ_ROUTE53_PROFILE`, or `DMARQ_ROUTE53_ROLE_ARN` with optional `DMARQ_ROUTE53_EXTERNAL_ID` |
 | Hetzner DNS | Ready | `HETZNER_DNS_API_TOKEN` or `HETZNER_API_TOKEN` with DNS zone read access |
+| Linode DNS | Ready | `LINODE_API_TOKEN` or `LINODE_TOKEN` with Domains read-only access |
 | Akamai Edge DNS/FastDNS | Planned | EdgeGrid DNS credentials, separate from Akamai EAA login |
-| Linode DNS | Planned | Domains-scoped token |
 
 For Route 53 self-hosted installs, use a local AWS profile or environment
 credentials with `route53:ListHostedZones`. Hosted/provider deployments should
 prefer role assumption with an external ID. Add `route53:ListResourceRecordSets`
 or `route53:ChangeResourceRecordSets` only when future DNS inspection or
 approved repair actions require them.
+
+For Linode self-hosted installs, use a personal access token or OAuth token
+limited to Domains read-only access, such as the Linode `domains:read_only`
+scope or equivalent `domain_viewer` role. Keep write-scoped tokens separate
+until approved DNS repair actions are intentionally enabled.
 
 ### IMAP Settings
 
@@ -270,6 +275,8 @@ operational policy if long-term storage size matters.
 | `CLOUDFLARE_OAUTH_SCOPES` | Cloudflare OAuth scopes requested for read-only zone import and ownership checks | `zone.read dns.read` | `zone.read dns.read` |
 | `HETZNER_DNS_API_TOKEN` | Hetzner Console API token for read-only DNS zone import through `api.hetzner.cloud` | - | `your_hetzner_read_only_api_token` |
 | `HETZNER_API_TOKEN` | Fallback Hetzner token name if you already inject generic Hetzner Cloud credentials | - | `your_hetzner_read_only_api_token` |
+| `LINODE_API_TOKEN` | Linode API token for read-only DNS domain import through `api.linode.com/v4` | - | `your_linode_domains_read_only_token` |
+| `LINODE_TOKEN` | Fallback Linode token name if you already inject generic Linode credentials | - | `your_linode_domains_read_only_token` |
 
 ### Email Service and Webhook Integrations
 
@@ -290,6 +297,8 @@ The integration exposes these operational routes:
 | `POST /api/v1/domains/dns/import/cloudflare` | Import selected Cloudflare zones as monitored domains before reports arrive. |
 | `GET /api/v1/domains/dns/import/hetzner/preview` | Preview zones visible to the configured Hetzner read-only token without creating rows. |
 | `POST /api/v1/domains/dns/import/hetzner` | Import selected Hetzner DNS zones as monitored domains before reports arrive. |
+| `GET /api/v1/domains/dns/import/linode/preview` | Preview domains visible to the configured Linode read-only token without creating rows. |
+| `POST /api/v1/domains/dns/import/linode` | Import selected Linode DNS domains as monitored domains before reports arrive. |
 | `GET /api/v1/domains/cloudflare/discover` | List available zones. |
 | `POST /api/v1/domains/cloudflare/import` | Create monitored domain rows from zones. |
 | `GET /api/v1/domains/{domain}/dns/cloudflare` | Inspect managed DNS records, return DMARC/SPF/DKIM suggestions, and record detected DNS changes. |
@@ -321,7 +330,8 @@ through a configured DNS provider connector.
 
 Cloudflare is implemented natively and supports DNS-zone import, record
 readback, dry-run, approved apply, verification, and rollback evidence. Hetzner
-DNS supports read-only zone import via Hetzner Console API tokens. `GET
+DNS supports read-only zone import via Hetzner Console API tokens. Linode DNS
+supports read-only domain import via a Domains-scoped token. `GET
 /api/v1/domains/dns/providers` exposes the broader connector registry so
 operators can see which providers are ready, planned, or Lexicon-backed before
 wiring credentials.
@@ -329,15 +339,15 @@ wiring credentials.
 Tier 1 connector metadata currently covers:
 
 - Cloudflare: API token, ready for zone import and approved DNS repair.
-- Amazon Route 53: planned zone import/read path; Lexicon-backed write path
+- Amazon Route 53: read-only hosted-zone import; Lexicon-backed write path
   where the runtime and credentials are available. Prefer IAM role assumption
   with external ID for hosted deployments.
 - Akamai Edge DNS / FastDNS: planned EdgeGrid-backed DNS connector. Akamai EAA
   is an access/SSO frontdoor option and does not replace the Edge DNS connector.
 - Hetzner DNS: read-only zone import using `HETZNER_DNS_API_TOKEN`;
   Lexicon-backed write path where the runtime and credentials are available.
-- Linode DNS: planned zone import/read path; Lexicon-backed write path where
-  the runtime and credentials are available.
+- Linode DNS: read-only domain import using `LINODE_API_TOKEN`; Lexicon-backed
+  write path where the runtime and credentials are available.
 
 Additional API-backed providers use DNS-Lexicon where the provider is available
 in the runtime and its credentials are supplied through Lexicon-compatible

--- a/docs/deployment/secrets.md
+++ b/docs/deployment/secrets.md
@@ -19,6 +19,8 @@ Store these values in a 1Password Environment for each deployment target:
 | `OIDC_CLIENT_SECRET` | Secret | Required when generic OIDC authentication is enabled. |
 | `CLOUDFLARE_API_TOKEN` | Secret | Optional DNS inspection/integration token. |
 | `CLOUDFLARE_OAUTH_CLIENT_SECRET` | Secret | Optional Cloudflare OAuth connector secret for one-click zone import and ownership verification. |
+| `HETZNER_DNS_API_TOKEN` | Secret | Optional read-only Hetzner DNS zone import token. |
+| `LINODE_API_TOKEN` | Secret | Optional read-only Linode DNS domain import token. |
 | `FIRST_SUPERUSER_PASSWORD` | Secret | Only needed for bootstrap flows that create an initial local admin. |
 
 Non-sensitive values, such as `IMAP_SERVER`, `IMAP_USERNAME`, `LOGTO_ENDPOINT`,

--- a/docs/deployment/secrets.md
+++ b/docs/deployment/secrets.md
@@ -20,7 +20,9 @@ Store these values in a 1Password Environment for each deployment target:
 | `CLOUDFLARE_API_TOKEN` | Secret | Optional DNS inspection/integration token. |
 | `CLOUDFLARE_OAUTH_CLIENT_SECRET` | Secret | Optional Cloudflare OAuth connector secret for one-click zone import and ownership verification. |
 | `HETZNER_DNS_API_TOKEN` | Secret | Optional read-only Hetzner DNS zone import token. |
+| `HETZNER_API_TOKEN` | Secret | Optional fallback Hetzner DNS token name for deployments that already inject generic Hetzner credentials. |
 | `LINODE_API_TOKEN` | Secret | Optional read-only Linode DNS domain import token. |
+| `LINODE_TOKEN` | Secret | Optional fallback Linode token name for deployments that already inject generic Linode credentials. |
 | `FIRST_SUPERUSER_PASSWORD` | Secret | Only needed for bootstrap flows that create an initial local admin. |
 
 Non-sensitive values, such as `IMAP_SERVER`, `IMAP_USERNAME`, `LOGTO_ENDPOINT`,


### PR DESCRIPTION
## Summary
- add a read-only Linode DNS connector for domain discovery and monitored-domain import
- expose Linode through the generic DNS provider import preview/apply flow
- document Linode token settings and 1Password secret handling

## Validation
- /tmp/dmarq-auth-venv/bin/pytest backend/app/tests/test_cloudflare_dns.py -k "linode or dns_provider_import or provider_capabilities" -q
- /tmp/dmarq-auth-venv/bin/pytest backend/app/tests/test_cloudflare_dns.py -q
- /tmp/dmarq-auth-venv/bin/python -m compileall -q backend/app/services/linode_dns.py backend/app/services/dns_provider_imports.py backend/app/services/dns_provider_connectors.py backend/app/core/config.py
- /tmp/dmarq-auth-venv/bin/black --check backend/app/services/linode_dns.py backend/app/services/dns_provider_imports.py backend/app/services/dns_provider_connectors.py backend/app/core/config.py backend/app/tests/test_cloudflare_dns.py
- /tmp/dmarq-auth-venv/bin/isort --check-only backend/app/services/linode_dns.py backend/app/services/dns_provider_imports.py backend/app/services/dns_provider_connectors.py backend/app/core/config.py backend/app/tests/test_cloudflare_dns.py
- git diff --check

Refs #423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linode DNS integration for discovering and importing domains.
  * You can now preview and import Linode-managed DNS zones through the app.
  * Added support for optional Linode DNS credentials in configuration.

* **Documentation**
  * Updated deployment guidance with Linode setup instructions, recommended read-only token usage, and new import API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->