### PR TITLE
Fix Cloudflare setup credential persistence

### DIFF
--- a/backend/app/api/api_v1/endpoints/setup.py
+++ b/backend/app/api/api_v1/endpoints/setup.py
@@ -5,6 +5,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
+from app.core.credential_encryption import encrypt_secret
 from app.core.database import get_db
 from app.core.security import api_key_header, require_admin_auth, security_bearer
 from app.models.domain import Domain
@@ -26,6 +27,10 @@ SETUP_COMPLETE_KEY = "setup.is_complete"
 SETUP_ADMIN_EMAIL_KEY = "setup.admin_email"
 GENERAL_APP_NAME_KEY = "general.app_name"
 GENERAL_BASE_URL_KEY = "general.base_url"
+CLOUDFLARE_API_TOKEN_KEY = "cloudflare.api_token"
+CLOUDFLARE_ZONE_ID_KEY = "cloudflare.zone_id"
+CLOUDFLARE_AUTH_MODE_KEY = "cloudflare.auth_mode"
+DNS_RESOLVER_KEY = "dns.resolver"
 
 
 def _setting_value(db: Session, key: str) -> Optional[str]:
@@ -112,6 +117,9 @@ class SystemConfigRequest(BaseModel):
 
     app_name: str
     base_url: str
+    cloudflare_enabled: bool = False
+    cloudflare_api_token: Optional[str] = None
+    cloudflare_zone_id: Optional[str] = None
 
 
 async def require_setup_write_auth(
@@ -193,8 +201,18 @@ async def setup_system(
 ):
     """
     Setup system configuration.
-    For Milestone 1, this simply stores the app name in memory.
+    Stores first-run system settings. Optional Cloudflare credentials are
+    written server-side so setup never needs to persist provider tokens in the
+    browser.
     """
+    cloudflare_api_token = (request.cloudflare_api_token or "").strip()
+    cloudflare_zone_id = (request.cloudflare_zone_id or "").strip()
+    if request.cloudflare_enabled and not cloudflare_api_token:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cloudflare API token is required when Cloudflare integration is enabled.",
+        )
+
     # Store app name
     setup_status["app_name"] = request.app_name
     setup_status["is_setup_complete"] = True
@@ -219,6 +237,35 @@ async def setup_system(
         description="Whether initial setup has been completed",
         value_type="boolean",
     )
+    if request.cloudflare_enabled:
+        _upsert_setting(
+            db,
+            CLOUDFLARE_API_TOKEN_KEY,
+            encrypt_secret(cloudflare_api_token),
+            description="Cloudflare API token for DNS zone discovery and DNS record management",
+            category="cloudflare",
+        )
+        _upsert_setting(
+            db,
+            CLOUDFLARE_ZONE_ID_KEY,
+            cloudflare_zone_id,
+            description="Optional preferred Cloudflare Zone ID for DNS record management",
+            category="cloudflare",
+        )
+        _upsert_setting(
+            db,
+            CLOUDFLARE_AUTH_MODE_KEY,
+            "api_token",
+            description="Cloudflare connector authentication mode",
+            category="cloudflare",
+        )
+        _upsert_setting(
+            db,
+            DNS_RESOLVER_KEY,
+            "cloudflare",
+            description="DNS resolver to use: system or cloudflare",
+            category="dns",
+        )
     db.commit()
 
     return {"message": "System settings saved successfully"}

--- a/backend/app/static/js/setup.js
+++ b/backend/app/static/js/setup.js
@@ -170,29 +170,73 @@ function setupWizardEventListeners() {
         });
         
         // Next button
-        systemForm.addEventListener('submit', (e) => {
+        systemForm.addEventListener('submit', async (e) => {
             e.preventDefault();
             
             // Store values
             const appName = document.getElementById('app-name').value;
             const baseUrl = document.getElementById('base-url').value;
+            const nextButton = document.getElementById('system-next-button');
+            const errorElement = document.getElementById('system-error');
+            const cloudflareTokenInput = document.getElementById('cloudflare-token');
+            const cloudflareZoneInput = document.getElementById('cloudflare-zone');
             
-            localStorage.setItem('setup_app_name', appName);
-            localStorage.setItem('setup_base_url', baseUrl);
-            
+            errorElement.classList.add('hidden');
+            errorElement.textContent = '';
+
+            const payload = {
+                app_name: appName,
+                base_url: baseUrl,
+                cloudflare_enabled: enableCloudflare.checked,
+                cloudflare_api_token: '',
+                cloudflare_zone_id: '',
+            };
+
             if (enableCloudflare.checked) {
-                const cloudflareToken = document.getElementById('cloudflare-token').value;
-                const cloudflareZone = document.getElementById('cloudflare-zone').value;
+                const cloudflareToken = cloudflareTokenInput.value.trim();
+                const cloudflareZone = cloudflareZoneInput.value.trim();
+                if (!cloudflareToken) {
+                    errorElement.textContent = 'Enter a Cloudflare API token or leave Cloudflare disabled for now.';
+                    errorElement.classList.remove('hidden');
+                    return;
+                }
                 
-                // Store only the flag that Cloudflare is enabled
-                // Credentials should be sent directly to backend, never stored client-side
-                localStorage.setItem('setup_cloudflare_enabled', 'true');
-                // TODO: Send cloudflareToken and cloudflareZone to backend API instead of localStorage
-                // For now, these credentials are not persisted client-side for security
+                payload.cloudflare_api_token = cloudflareToken;
+                payload.cloudflare_zone_id = cloudflareZone;
             }
-            
-            // Move to step 3
-            goToStep(3);
+
+            nextButton.disabled = true;
+            nextButton.textContent = 'Saving...';
+
+            try {
+                const response = await fetch('/api/v1/setup/system', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                if (!response.ok) {
+                    const data = await response.json().catch(() => ({ detail: 'System settings could not be saved.' }));
+                    throw new Error(data.detail || 'System settings could not be saved.');
+                }
+
+                localStorage.setItem('setup_app_name', appName);
+                localStorage.setItem('setup_base_url', baseUrl);
+                if (enableCloudflare.checked) {
+                    localStorage.setItem('setup_cloudflare_enabled', 'true');
+                    cloudflareTokenInput.value = '';
+                } else {
+                    localStorage.removeItem('setup_cloudflare_enabled');
+                }
+
+                // Move to step 3
+                goToStep(3);
+            } catch (error) {
+                errorElement.textContent = error.message || 'System settings could not be saved.';
+                errorElement.classList.remove('hidden');
+            } finally {
+                nextButton.disabled = false;
+                nextButton.textContent = 'Next';
+            }
         });
     }
     

--- a/backend/app/static/js/setup.js
+++ b/backend/app/static/js/setup.js
@@ -219,13 +219,8 @@ function setupWizardEventListeners() {
                     throw new Error(data.detail || 'System settings could not be saved.');
                 }
 
-                localStorage.setItem('setup_app_name', appName);
-                localStorage.setItem('setup_base_url', baseUrl);
                 if (enableCloudflare.checked) {
-                    localStorage.setItem('setup_cloudflare_enabled', 'true');
                     cloudflareTokenInput.value = '';
-                } else {
-                    localStorage.removeItem('setup_cloudflare_enabled');
                 }
 
                 // Move to step 3

--- a/backend/app/templates/setup.html
+++ b/backend/app/templates/setup.html
@@ -115,6 +115,30 @@
                             </label>
                         </div>
 
+                        <div class="rounded-lg border border-base-300 bg-base-200/60 p-4">
+                            <label class="flex items-start gap-3">
+                                <input x-model="system.cloudflare_enabled" type="checkbox" class="checkbox checkbox-primary mt-1">
+                                <span>
+                                    <span class="block font-semibold">Connect Cloudflare during setup</span>
+                                    <span class="mt-1 block text-sm leading-6 text-base-content/65">
+                                        Use a scoped Cloudflare API token to verify zone ownership, import domains, and prepare DNS repair previews. The token is sent directly to DMARQ and encrypted at rest.
+                                    </span>
+                                </span>
+                            </label>
+                            <div x-show="system.cloudflare_enabled" class="mt-4 grid gap-4 sm:grid-cols-2">
+                                <label class="form-control">
+                                    <span class="label-text font-medium">Cloudflare API token</span>
+                                    <input x-model.trim="system.cloudflare_api_token" type="password" autocomplete="off" class="input input-bordered" :required="system.cloudflare_enabled">
+                                    <span class="label-text-alt text-base-content/60">Zone read permission is enough for discovery; DNS edit is only needed for approved repairs.</span>
+                                </label>
+                                <label class="form-control">
+                                    <span class="label-text font-medium">Default Zone ID</span>
+                                    <input x-model.trim="system.cloudflare_zone_id" type="text" autocomplete="off" class="input input-bordered">
+                                    <span class="label-text-alt text-base-content/60">Optional. Leave empty when this token can access multiple zones.</span>
+                                </label>
+                            </div>
+                        </div>
+
                         <div class="flex justify-between gap-3">
                             <button type="button" class="btn btn-ghost" @click="currentStep = 1" :disabled="saving">Back</button>
                             <button type="submit" class="btn btn-primary" :disabled="saving">
@@ -253,6 +277,9 @@
             system: {
                 app_name: {{ app_name | tojson }},
                 base_url: window.location.origin,
+                cloudflare_enabled: false,
+                cloudflare_api_token: '',
+                cloudflare_zone_id: '',
             },
             async init() {
                 this.applyTheme();
@@ -310,10 +337,17 @@
             },
             async submitSystem() {
                 this.error = '';
+                if (this.system.cloudflare_enabled && !this.system.cloudflare_api_token) {
+                    this.error = 'Enter a Cloudflare API token or leave Cloudflare disabled for now.';
+                    return;
+                }
                 await this.save('/api/v1/setup/system', this.system, () => {
+                    this.system.cloudflare_api_token = '';
                     this.complete = true;
                     this.currentStep = 3;
-                    this.message = 'Your setup settings have been saved.';
+                    this.message = this.system.cloudflare_enabled
+                        ? 'Your setup settings and Cloudflare connector have been saved.'
+                        : 'Your setup settings have been saved.';
                 });
             },
             async save(url, payload, onSuccess) {

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.api.api_v1.endpoints.setup import setup_status
+from app.core.credential_encryption import decrypt_secret, is_encrypted_secret
 from app.core.security import _api_keys, add_api_key
 from app.models.setting import Setting
 
@@ -283,3 +284,53 @@ class TestSetupSystem:
 
         assert response.status_code == 200
         assert setup_status["app_name"] == "Changed"
+
+    def test_system_setup_persists_cloudflare_credentials_server_side(
+        self, client: TestClient, db_session
+    ):
+        response = client.post(
+            "/api/v1/setup/system",
+            json={
+                "app_name": "DMARQ",
+                "base_url": "https://dmarq.example.com",
+                "cloudflare_enabled": True,
+                "cloudflare_api_token": "cf-secret-token",
+                "cloudflare_zone_id": "zone-123",
+            },
+        )
+
+        assert response.status_code == 200
+        rows = {
+            row.key: row.value
+            for row in db_session.query(Setting)
+            .filter(
+                Setting.key.in_(
+                    [
+                        "cloudflare.api_token",
+                        "cloudflare.zone_id",
+                        "cloudflare.auth_mode",
+                        "dns.resolver",
+                    ]
+                )
+            )
+            .all()
+        }
+        assert is_encrypted_secret(rows["cloudflare.api_token"])
+        assert decrypt_secret(rows["cloudflare.api_token"]) == "cf-secret-token"
+        assert rows["cloudflare.zone_id"] == "zone-123"
+        assert rows["cloudflare.auth_mode"] == "api_token"
+        assert rows["dns.resolver"] == "cloudflare"
+
+    def test_system_setup_rejects_enabled_cloudflare_without_token(self, client: TestClient):
+        response = client.post(
+            "/api/v1/setup/system",
+            json={
+                "app_name": "DMARQ",
+                "base_url": "https://dmarq.example.com",
+                "cloudflare_enabled": True,
+                "cloudflare_api_token": " ",
+            },
+        )
+
+        assert response.status_code == 400
+        assert "Cloudflare API token is required" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- extend first-run system setup to accept optional Cloudflare credentials server-side
- encrypt the Cloudflare API token at rest and set Cloudflare resolver/auth metadata when enabled
- wire both setup UIs to POST system setup instead of keeping provider setup only in localStorage

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_setup_endpoints.py backend/app/tests/test_settings.py -q
- .venv/bin/python -m compileall backend/app/api/api_v1/endpoints/setup.py
- node --check backend/app/static/js/setup.js
- git diff --check

Part of #426.