### PR TITLE
Refactor auth setup scripts for CSP migration

### DIFF
--- a/backend/app/static/css/page-utilities.css
+++ b/backend/app/static/css/page-utilities.css
@@ -1,0 +1,3 @@
+[x-cloak] {
+    display: none !important;
+}

--- a/backend/app/static/js/login-page.js
+++ b/backend/app/static/js/login-page.js
@@ -1,0 +1,9 @@
+document.addEventListener('alpine:init', () => {
+    Alpine.data('loginErrorBanner', () => ({
+        error: new URLSearchParams(window.location.search).get('error'),
+    }));
+});
+
+if (localStorage.getItem('darkMode') === 'true') {
+    document.documentElement.setAttribute('data-theme', 'dmarqdark');
+}

--- a/backend/app/static/js/setup-page.js
+++ b/backend/app/static/js/setup-page.js
@@ -1,0 +1,120 @@
+function setupWizard() {
+    return {
+        statusLoading: true,
+        saving: false,
+        currentStep: 1,
+        complete: false,
+        error: '',
+        message: '',
+        totalDomains: 0,
+        totalMailSources: 0,
+        enabledMailSources: 0,
+        mailboxRecoveryHint: null,
+        steps: [
+            { id: 1, title: 'Admin', detail: 'Contact details' },
+            { id: 2, title: 'System', detail: 'Name and URL' },
+            { id: 3, title: 'Ready', detail: 'Start using DMARQ' },
+        ],
+        admin: {
+            email: '',
+            username: '',
+            password: '',
+            confirmPassword: '',
+        },
+        system: {
+            app_name: document.querySelector('[data-app-name]')?.dataset.appName || 'DMARQ',
+            base_url: window.location.origin,
+            cloudflare_enabled: false,
+            cloudflare_api_token: '',
+            cloudflare_zone_id: '',
+        },
+        async init() {
+            this.applyTheme();
+            try {
+                const response = await fetch('/api/v1/setup/status');
+                if (!response.ok) {
+                    throw new Error('Could not load setup status.');
+                }
+                const status = await response.json();
+                this.system.app_name = status.app_name || this.system.app_name;
+                this.complete = Boolean(status.is_setup_complete);
+                this.currentStep = this.complete ? 3 : 1;
+                this.totalDomains = status.total_domains || 0;
+                this.totalMailSources = status.total_mail_sources || 0;
+                this.enabledMailSources = status.enabled_mail_sources || 0;
+                this.mailboxRecoveryHint = status.mailbox_recovery_hint || null;
+            } catch (err) {
+                this.error = err.message || 'Could not load setup status.';
+            } finally {
+                this.statusLoading = false;
+            }
+        },
+        applyTheme() {
+            if (localStorage.getItem('darkMode') === 'true') {
+                document.documentElement.setAttribute('data-theme', 'dmarqdark');
+            }
+        },
+        stepClass(stepId) {
+            if (this.complete && stepId === 3) return 'border-success bg-success/10';
+            if (stepId === this.currentStep) return 'border-primary bg-primary/10';
+            if (stepId < this.currentStep) return 'border-success bg-success/10';
+            return 'border-base-300 bg-base-100';
+        },
+        stepBadgeClass(stepId) {
+            if (this.complete && stepId === 3) return 'bg-success text-success-content';
+            if (stepId === this.currentStep) return 'bg-primary text-primary-content';
+            if (stepId < this.currentStep) return 'bg-success text-success-content';
+            return 'bg-base-200 text-base-content/70';
+        },
+        async submitAdmin() {
+            this.error = '';
+            if (this.admin.password !== this.admin.confirmPassword) {
+                this.error = 'Passwords do not match.';
+                return;
+            }
+            await this.save('/api/v1/setup/admin', {
+                email: this.admin.email,
+                username: this.admin.username,
+                password: this.admin.password,
+            }, () => {
+                this.currentStep = 2;
+                this.admin.password = '';
+                this.admin.confirmPassword = '';
+            });
+        },
+        async submitSystem() {
+            this.error = '';
+            if (this.system.cloudflare_enabled && !this.system.cloudflare_api_token) {
+                this.error = 'Enter a Cloudflare API token or leave Cloudflare disabled for now.';
+                return;
+            }
+            await this.save('/api/v1/setup/system', this.system, () => {
+                this.system.cloudflare_api_token = '';
+                this.complete = true;
+                this.currentStep = 3;
+                this.message = this.system.cloudflare_enabled
+                    ? 'Your setup settings and Cloudflare connector have been saved.'
+                    : 'Your setup settings have been saved.';
+            });
+        },
+        async save(url, payload, onSuccess) {
+            this.saving = true;
+            try {
+                const response = await fetch(url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                if (!response.ok) {
+                    const data = await response.json().catch(() => ({}));
+                    throw new Error(data.detail || 'Setup could not be saved.');
+                }
+                onSuccess();
+            } catch (err) {
+                this.error = err.message || 'Setup could not be saved.';
+            } finally {
+                this.saving = false;
+            }
+        },
+    };
+}

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -21,7 +21,7 @@
     <!-- Alpine.js for interactivity -->
     <script src="/static/js/pages.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
-    <style>[x-cloak] { display: none !important; }</style>
+    <link href="/static/css/page-utilities.css" rel="stylesheet" type="text/css"/>
 
     {% block head %}{% endblock %}
 </head>

--- a/backend/app/templates/login.html
+++ b/backend/app/templates/login.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;500;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.24/dist/full.css" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/page-utilities.css" rel="stylesheet" type="text/css"/>
     <script src="/static/js/pages.js"></script>
     <script defer src="/static/js/login-page.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/backend/app/templates/login.html
+++ b/backend/app/templates/login.html
@@ -9,6 +9,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.24/dist/full.css" rel="stylesheet" type="text/css"/>
     <script src="/static/js/pages.js"></script>
+    <script defer src="/static/js/login-page.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen bg-base-200 flex items-center justify-center font-sans antialiased">
@@ -59,7 +60,7 @@
             {% else %}
 
             <!-- Error banner (shown when ?error= is present) -->
-            <div x-data="{ error: new URLSearchParams(window.location.search).get('error') }"
+            <div x-data="loginErrorBanner()"
                  x-show="error" x-cloak>
                 <div role="alert" class="alert alert-error">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -147,14 +148,5 @@
         &copy; {{ app_name }} – DMARC Monitoring Platform
     </p>
 </div>
-
-<script>
-    // Restore dark-mode preference from localStorage (mirrors base.html logic)
-    (function () {
-        if (localStorage.getItem('darkMode') === 'true') {
-            document.documentElement.setAttribute('data-theme', 'dmarqdark');
-        }
-    })();
-</script>
 </body>
 </html>

--- a/backend/app/templates/setup.html
+++ b/backend/app/templates/setup.html
@@ -13,11 +13,12 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.24/dist/full.css" rel="stylesheet" type="text/css"/>
     <script src="/static/js/pages.js"></script>
+    <script defer src="/static/js/setup-page.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
-    <style>[x-cloak] { display: none !important; }</style>
+    <link href="/static/css/page-utilities.css" rel="stylesheet" type="text/css"/>
 </head>
 <body class="min-h-screen bg-base-200 font-sans antialiased">
-<div class="min-h-screen" x-data="setupWizard()" x-init="init()" x-cloak>
+<div class="min-h-screen" x-data="setupWizard()" x-init="init()" x-cloak data-app-name="{{ app_name }}">
     <header class="border-b border-base-300 bg-base-100">
         <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
             <a href="/" class="inline-flex items-center gap-3">
@@ -250,128 +251,5 @@
         </aside>
     </main>
 </div>
-
-<script>
-    function setupWizard() {
-        return {
-            statusLoading: true,
-            saving: false,
-            currentStep: 1,
-            complete: false,
-            error: '',
-            message: '',
-            totalDomains: 0,
-            totalMailSources: 0,
-            enabledMailSources: 0,
-            mailboxRecoveryHint: null,
-            steps: [
-                { id: 1, title: 'Admin', detail: 'Contact details' },
-                { id: 2, title: 'System', detail: 'Name and URL' },
-                { id: 3, title: 'Ready', detail: 'Start using DMARQ' },
-            ],
-            admin: {
-                email: '',
-                username: '',
-                password: '',
-                confirmPassword: '',
-            },
-            system: {
-                app_name: {{ app_name | tojson }},
-                base_url: window.location.origin,
-                cloudflare_enabled: false,
-                cloudflare_api_token: '',
-                cloudflare_zone_id: '',
-            },
-            async init() {
-                this.applyTheme();
-                try {
-                    const response = await fetch('/api/v1/setup/status');
-                    if (!response.ok) {
-                        throw new Error('Could not load setup status.');
-                    }
-                    const status = await response.json();
-                    this.system.app_name = status.app_name || this.system.app_name;
-                    this.complete = Boolean(status.is_setup_complete);
-                    this.currentStep = this.complete ? 3 : 1;
-                    this.totalDomains = status.total_domains || 0;
-                    this.totalMailSources = status.total_mail_sources || 0;
-                    this.enabledMailSources = status.enabled_mail_sources || 0;
-                    this.mailboxRecoveryHint = status.mailbox_recovery_hint || null;
-                } catch (err) {
-                    this.error = err.message || 'Could not load setup status.';
-                } finally {
-                    this.statusLoading = false;
-                }
-            },
-            applyTheme() {
-                if (localStorage.getItem('darkMode') === 'true') {
-                    document.documentElement.setAttribute('data-theme', 'dmarqdark');
-                }
-            },
-            stepClass(stepId) {
-                if (this.complete && stepId === 3) return 'border-success bg-success/10';
-                if (stepId === this.currentStep) return 'border-primary bg-primary/10';
-                if (stepId < this.currentStep) return 'border-success bg-success/10';
-                return 'border-base-300 bg-base-100';
-            },
-            stepBadgeClass(stepId) {
-                if (this.complete && stepId === 3) return 'bg-success text-success-content';
-                if (stepId === this.currentStep) return 'bg-primary text-primary-content';
-                if (stepId < this.currentStep) return 'bg-success text-success-content';
-                return 'bg-base-200 text-base-content/70';
-            },
-            async submitAdmin() {
-                this.error = '';
-                if (this.admin.password !== this.admin.confirmPassword) {
-                    this.error = 'Passwords do not match.';
-                    return;
-                }
-                await this.save('/api/v1/setup/admin', {
-                    email: this.admin.email,
-                    username: this.admin.username,
-                    password: this.admin.password,
-                }, () => {
-                    this.currentStep = 2;
-                    this.admin.password = '';
-                    this.admin.confirmPassword = '';
-                });
-            },
-            async submitSystem() {
-                this.error = '';
-                if (this.system.cloudflare_enabled && !this.system.cloudflare_api_token) {
-                    this.error = 'Enter a Cloudflare API token or leave Cloudflare disabled for now.';
-                    return;
-                }
-                await this.save('/api/v1/setup/system', this.system, () => {
-                    this.system.cloudflare_api_token = '';
-                    this.complete = true;
-                    this.currentStep = 3;
-                    this.message = this.system.cloudflare_enabled
-                        ? 'Your setup settings and Cloudflare connector have been saved.'
-                        : 'Your setup settings have been saved.';
-                });
-            },
-            async save(url, payload, onSuccess) {
-                this.saving = true;
-                try {
-                    const response = await fetch(url, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify(payload),
-                    });
-                    if (!response.ok) {
-                        const data = await response.json().catch(() => ({}));
-                        throw new Error(data.detail || 'Setup could not be saved.');
-                    }
-                    onSuccess();
-                } catch (err) {
-                    this.error = err.message || 'Setup could not be saved.';
-                } finally {
-                    this.saving = false;
-                }
-            },
-        };
-    }
-</script>
 </body>
 </html>

--- a/backend/app/tests/test_security.py
+++ b/backend/app/tests/test_security.py
@@ -4,6 +4,7 @@ Security-focused tests for DMARQ application.
 Covers API key management, domain validation, file upload limits, and XML parsing security.
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -143,7 +144,7 @@ class TestSecurityHeaders:
 
         assert "alpinejs@3.x.x/dist/cdn.min.js" in body
         assert "@alpinejs/csp" not in body
-        assert "<style>" not in body
+        assert not re.search(r"<style\b", body, re.IGNORECASE)
         assert 'href="/static/css/page-utilities.css"' in body
 
     @pytest.mark.parametrize("template_name", ["login.html", "setup.html"])
@@ -152,9 +153,10 @@ class TestSecurityHeaders:
         template = Path(__file__).resolve().parents[1] / "templates" / template_name
         body = template.read_text()
 
-        assert "<script>" not in body
-        assert "<style>" not in body
+        assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", body, re.IGNORECASE)
+        assert not re.search(r"<style\b", body, re.IGNORECASE)
         assert f'src="/static/js/{template_name.removesuffix(".html")}-page.js"' in body
+        assert 'href="/static/css/page-utilities.css"' in body
 
     def test_csp_report_only_header_appears_when_flag_enabled(
         self, client: TestClient, monkeypatch

--- a/backend/app/tests/test_security.py
+++ b/backend/app/tests/test_security.py
@@ -143,6 +143,18 @@ class TestSecurityHeaders:
 
         assert "alpinejs@3.x.x/dist/cdn.min.js" in body
         assert "@alpinejs/csp" not in body
+        assert "<style>" not in body
+        assert 'href="/static/css/page-utilities.css"' in body
+
+    @pytest.mark.parametrize("template_name", ["login.html", "setup.html"])
+    def test_auth_templates_use_external_page_scripts(self, template_name: str):
+        """Login and setup should not add page-specific inline script blocks."""
+        template = Path(__file__).resolve().parents[1] / "templates" / template_name
+        body = template.read_text()
+
+        assert "<script>" not in body
+        assert "<style>" not in body
+        assert f'src="/static/js/{template_name.removesuffix(".html")}-page.js"' in body
 
     def test_csp_report_only_header_appears_when_flag_enabled(
         self, client: TestClient, monkeypatch

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -95,9 +95,8 @@ class TestSetupPage:
         assert "First-run setup" in response.text
         assert '@submit.prevent="submitAdmin"' in response.text
         assert '@submit.prevent="submitSystem"' in response.text
-        assert "/api/v1/setup/status" in response.text
-        assert "/api/v1/setup/admin" in response.text
-        assert "/api/v1/setup/system" in response.text
+        assert 'data-app-name="DMARQ"' in response.text
+        assert 'src="/static/js/setup-page.js"' in response.text
         assert "/onboarding" not in response.text
 
     def test_setup_page_links_onboarding_when_logto_is_configured(self, monkeypatch):


### PR DESCRIPTION
## Summary
- move login error/theme logic into /static/js/login-page.js
- move setup wizard logic into /static/js/setup-page.js
- move x-cloak styling into /static/css/page-utilities.css and remove inline style blocks from base/setup
- add regression coverage that login/setup use external page scripts

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_security.py backend/app/tests/test_setup_endpoints.py backend/app/tests/test_auth.py -q
- .venv/bin/black --check backend/app/tests/test_security.py backend/app/tests/test_setup_endpoints.py
- .venv/bin/isort --check-only backend/app/tests/test_security.py backend/app/tests/test_setup_endpoints.py
- .venv/bin/python -m compileall backend/app/tests/test_security.py backend/app/tests/test_setup_endpoints.py
- node --check backend/app/static/js/login-page.js
- node --check backend/app/static/js/setup-page.js
- git diff --check

Part of #426. Does not tighten the enforced CSP yet.