### PR TITLE
Refactor base layout scripts for CSP migration

### DIFF
--- a/backend/app/static/js/base-layout.js
+++ b/backend/app/static/js/base-layout.js
@@ -1,0 +1,95 @@
+document.addEventListener('alpine:init', () => {
+    Alpine.data('userMenu', () => ({
+        user: null,
+        workspaces: [],
+        selectedWorkspaceId: localStorage.getItem('dmarq.selectedWorkspaceId') || '',
+        async loadUser() {
+            try {
+                const res = await fetch('/api/v1/auth/me');
+                if (res.ok) {
+                    this.user = await res.json();
+                }
+            } catch (_) {
+                // User identity is optional for public or setup views.
+            }
+            await this.loadWorkspaces();
+        },
+        async loadWorkspaces() {
+            try {
+                const res = await fetch('/api/v1/workspaces');
+                if (!res.ok) {
+                    return;
+                }
+                const data = await res.json();
+                this.workspaces = data.workspaces || [];
+                const saved = String(this.selectedWorkspaceId || '');
+                const selected = this.workspaces.find(
+                    (workspace) => String(workspace.id) === saved && workspace.active
+                );
+                const fallback =
+                    this.workspaces.find((workspace) => workspace.active) || this.workspaces[0];
+                if (!selected && fallback) {
+                    this.selectWorkspace(String(fallback.id));
+                } else if (selected) {
+                    this.selectWorkspace(String(selected.id));
+                }
+            } catch (_) {
+                // Workspace selection is optional for single-tenant installs.
+            }
+        },
+        selectWorkspace(workspaceId) {
+            this.selectedWorkspaceId = workspaceId || '';
+            if (this.selectedWorkspaceId) {
+                localStorage.setItem('dmarq.selectedWorkspaceId', this.selectedWorkspaceId);
+            } else {
+                localStorage.removeItem('dmarq.selectedWorkspaceId');
+            }
+            window.dispatchEvent(
+                new CustomEvent('dmarq:workspace-changed', {
+                    detail: { workspaceId: this.selectedWorkspaceId },
+                })
+            );
+        },
+        workspaceLabel(workspace) {
+            const prefix = workspace.organization ? `${workspace.organization.name} / ` : '';
+            const suffix = workspace.active ? '' : ' (inactive)';
+            return `${prefix}${workspace.name}${suffix}`;
+        },
+    }));
+});
+
+(function attachWorkspaceContextToFetch() {
+    const originalFetch = window.fetch;
+    window.fetch = function dmarqWorkspaceFetch(input, init) {
+        const workspaceId = localStorage.getItem('dmarq.selectedWorkspaceId');
+        const url =
+            input instanceof URL
+                ? input.toString()
+                : typeof input === 'string'
+                  ? input
+                  : (input && input.url) || '';
+        const isApiRequest =
+            url.startsWith('/api/') || url.startsWith(window.location.origin + '/api/');
+        if (!workspaceId || !isApiRequest) {
+            return originalFetch(input, init);
+        }
+        const nextInit = Object.assign({}, init || {});
+        const headers = new Headers(nextInit.headers || (input && input.headers) || {});
+        if (!headers.has('X-DMARQ-Workspace-ID')) {
+            headers.set('X-DMARQ-Workspace-ID', workspaceId);
+        }
+        nextInit.headers = headers;
+        return originalFetch(input, nextInit);
+    };
+})();
+
+(function restoreThemePreference() {
+    const darkMode = localStorage.getItem('darkMode') === 'true';
+    if (darkMode) {
+        document.documentElement.classList.add('dark');
+        document.documentElement.setAttribute('data-theme', 'dmarqdark');
+    } else {
+        document.documentElement.classList.remove('dark');
+        document.documentElement.setAttribute('data-theme', 'dmarqlight');
+    }
+})();

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -20,6 +20,7 @@
 
     <!-- Alpine.js for interactivity -->
     <script src="/static/js/pages.js"></script>
+    <script src="/static/js/base-layout.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <link href="/static/css/page-utilities.css" rel="stylesheet" type="text/css"/>
 
@@ -135,99 +136,5 @@
     <!-- Scripts -->
     {% block scripts %}{% endblock %}
 
-    <!-- User-menu Alpine component -->
-    <script>
-        function userMenu() {
-            return {
-                user: null,
-                workspaces: [],
-                selectedWorkspaceId: localStorage.getItem('dmarq.selectedWorkspaceId') || '',
-                async loadUser() {
-                    try {
-                        const res = await fetch('/api/v1/auth/me');
-                        if (res.ok) {
-                            this.user = await res.json();
-                        }
-                    } catch (_) {
-                        // silently ignore – user is simply not shown
-                    }
-                    await this.loadWorkspaces();
-                },
-                async loadWorkspaces() {
-                    try {
-                        const res = await fetch('/api/v1/workspaces');
-                        if (!res.ok) {
-                            return;
-                        }
-                        const data = await res.json();
-                        this.workspaces = data.workspaces || [];
-                        const saved = String(this.selectedWorkspaceId || '');
-                        const selected = this.workspaces.find((workspace) => String(workspace.id) === saved && workspace.active);
-                        const fallback = this.workspaces.find((workspace) => workspace.active) || this.workspaces[0];
-                        if (!selected && fallback) {
-                            this.selectWorkspace(String(fallback.id));
-                        } else if (selected) {
-                            this.selectWorkspace(String(selected.id));
-                        }
-                    } catch (_) {
-                        // workspace selection is optional for single-tenant installs
-                    }
-                },
-                selectWorkspace(workspaceId) {
-                    this.selectedWorkspaceId = workspaceId || '';
-                    if (this.selectedWorkspaceId) {
-                        localStorage.setItem('dmarq.selectedWorkspaceId', this.selectedWorkspaceId);
-                    } else {
-                        localStorage.removeItem('dmarq.selectedWorkspaceId');
-                    }
-                    window.dispatchEvent(new CustomEvent('dmarq:workspace-changed', {
-                        detail: { workspaceId: this.selectedWorkspaceId },
-                    }));
-                },
-                workspaceLabel(workspace) {
-                    const prefix = workspace.organization ? `${workspace.organization.name} / ` : '';
-                    const suffix = workspace.active ? '' : ' (inactive)';
-                    return `${prefix}${workspace.name}${suffix}`;
-                },
-            };
-        }
-    </script>
-
-    <script>
-        (function attachWorkspaceContextToFetch() {
-            const originalFetch = window.fetch;
-            window.fetch = function(input, init) {
-                const workspaceId = localStorage.getItem('dmarq.selectedWorkspaceId');
-                const url = input instanceof URL
-                    ? input.toString()
-                    : (typeof input === 'string' ? input : (input && input.url) || '');
-                const isApiRequest = url.startsWith('/api/') || url.startsWith(window.location.origin + '/api/');
-                if (!workspaceId || !isApiRequest) {
-                    return originalFetch(input, init);
-                }
-                const nextInit = Object.assign({}, init || {});
-                const headers = new Headers(nextInit.headers || (input && input.headers) || {});
-                if (!headers.has('X-DMARQ-Workspace-ID')) {
-                    headers.set('X-DMARQ-Workspace-ID', workspaceId);
-                }
-                nextInit.headers = headers;
-                return originalFetch(input, nextInit);
-            };
-        })();
-    </script>
-
-    <!-- Initialize theme from localStorage -->
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const darkMode = localStorage.getItem('darkMode') === 'true';
-            if (darkMode) {
-                document.documentElement.classList.add('dark');
-                document.documentElement.setAttribute('data-theme', 'dmarqdark');
-            } else {
-                document.documentElement.classList.remove('dark');
-                document.documentElement.setAttribute('data-theme', 'dmarqlight');
-            }
-        });
-    </script>
 </body>
 </html>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -117,12 +117,14 @@ def test_base_template_propagates_selected_workspace_context():
     template = (
         Path(__file__).resolve().parents[1] / "templates" / "layouts" / "base.html"
     ).read_text()
+    script = (Path(__file__).resolve().parents[1] / "static" / "js" / "base-layout.js").read_text()
 
-    assert "/api/v1/workspaces" in template
-    assert "dmarq.selectedWorkspaceId" in template
-    assert "X-DMARQ-Workspace-ID" in template
-    assert "dmarq:workspace-changed" in template
-    assert "input instanceof URL" in template
+    assert 'src="/static/js/base-layout.js"' in template
+    assert "/api/v1/workspaces" in script
+    assert "dmarq.selectedWorkspaceId" in script
+    assert "X-DMARQ-Workspace-ID" in script
+    assert "dmarq:workspace-changed" in script
+    assert "input instanceof URL" in script
 
 
 def test_dashboard_hides_multi_user_demo_mode_controls():

--- a/backend/app/tests/test_security.py
+++ b/backend/app/tests/test_security.py
@@ -144,7 +144,9 @@ class TestSecurityHeaders:
 
         assert "alpinejs@3.x.x/dist/cdn.min.js" in body
         assert "@alpinejs/csp" not in body
+        assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", body, re.IGNORECASE)
         assert not re.search(r"<style\b", body, re.IGNORECASE)
+        assert 'src="/static/js/base-layout.js"' in body
         assert 'href="/static/css/page-utilities.css"' in body
 
     @pytest.mark.parametrize("template_name", ["login.html", "setup.html"])


### PR DESCRIPTION
## Summary\n- move the base layout user-menu Alpine component, workspace fetch header injection, and theme bootstrap into /static/js/base-layout.js\n- keep the base template on external scripts only for this shared layout logic\n- update regression tests so workspace context checks follow the new template/static-script boundary\n\nPart of #426. This does not tighten the enforced CSP yet and does not migrate the larger page-level inline scripts.\n\n## Local validation\n- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py backend/app/tests/test_setup_endpoints.py backend/app/tests/test_auth.py -q\n- .venv/bin/python -m pytest backend/app/tests -q\n- .venv/bin/black --check backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py backend/app/tests/test_setup_endpoints.py\n- .venv/bin/isort --check-only backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py backend/app/tests/test_setup_endpoints.py\n- node --check backend/app/static/js/base-layout.js\n- node --check backend/app/static/js/login-page.js\n- node --check backend/app/static/js/setup-page.js\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace selection now persists across visits and is automatically restored.
  * The app now tracks workspace changes and updates requests with the active workspace context.
  * Theme preference is restored on load for consistent light/dark appearance.

* **Bug Fixes**
  * Improved page security by removing inline JavaScript from the base layout.
  * Updated template checks to ensure the external client script is loaded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->