### PR TITLE
Validate workspace header injection

### DIFF
--- a/backend/app/static/js/base-layout.js
+++ b/backend/app/static/js/base-layout.js
@@ -60,8 +60,13 @@ document.addEventListener('alpine:init', () => {
 
 (function attachWorkspaceContextToFetch() {
     const originalFetch = window.fetch;
+    const normalizeWorkspaceId = (workspaceId) => {
+        const trimmed = String(workspaceId || '').trim();
+        return /^[1-9]\d*$/.test(trimmed) ? trimmed : '';
+    };
+
     window.fetch = function dmarqWorkspaceFetch(input, init) {
-        const workspaceId = localStorage.getItem('dmarq.selectedWorkspaceId');
+        const workspaceId = normalizeWorkspaceId(localStorage.getItem('dmarq.selectedWorkspaceId'));
         const url =
             input instanceof URL
                 ? input.toString()

--- a/backend/app/tests/test_security.py
+++ b/backend/app/tests/test_security.py
@@ -17,6 +17,11 @@ from app.services.dmarc_parser import DMARCParser
 from app.utils.domain_validator import validate_domain, validate_domain_config
 
 
+def _script_tags_without_src(body: str) -> list[str]:
+    script_tags = re.findall(r"<script\b[^>]*>", body, re.IGNORECASE)
+    return [tag for tag in script_tags if not re.search(r"\ssrc\s*=", tag, re.IGNORECASE)]
+
+
 class TestAPIKeySecurity:
     """Test API key generation and verification."""
 
@@ -144,7 +149,7 @@ class TestSecurityHeaders:
 
         assert "alpinejs@3.x.x/dist/cdn.min.js" in body
         assert "@alpinejs/csp" not in body
-        assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", body, re.IGNORECASE)
+        assert not _script_tags_without_src(body)
         assert not re.search(r"<style\b", body, re.IGNORECASE)
         assert 'src="/static/js/base-layout.js"' in body
         assert 'href="/static/css/page-utilities.css"' in body
@@ -155,7 +160,7 @@ class TestSecurityHeaders:
         template = Path(__file__).resolve().parents[1] / "templates" / template_name
         body = template.read_text()
 
-        assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", body, re.IGNORECASE)
+        assert not _script_tags_without_src(body)
         assert not re.search(r"<style\b", body, re.IGNORECASE)
         assert f'src="/static/js/{template_name.removesuffix(".html")}-page.js"' in body
         assert 'href="/static/css/page-utilities.css"' in body


### PR DESCRIPTION
## Summary
- validate the stored workspace ID before adding X-DMARQ-Workspace-ID to API requests
- tighten CSP script-tag regression tests so only a real src attribute is accepted

Follow-up to #450 after CodeRabbit review comments landed as #450 was being merged.

## Local validation
- /tmp/dmarq-auth-venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py backend/app/tests/test_setup_endpoints.py backend/app/tests/test_auth.py -q
- /tmp/dmarq-auth-venv/bin/black --check backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py backend/app/tests/test_setup_endpoints.py
- /tmp/dmarq-auth-venv/bin/isort --check-only backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py backend/app/tests/test_setup_endpoints.py
- node --check backend/app/static/js/base-layout.js
- node --check backend/app/static/js/login-page.js
- node --check backend/app/static/js/setup-page.js
- git diff --check