### PR TITLE
Refactor operations page script for CSP migration

### DIFF
--- a/backend/app/static/js/operations-page.js
+++ b/backend/app/static/js/operations-page.js
@@ -1,0 +1,38 @@
+function operationsHealth() {
+    return {
+        loading: false,
+        error: '',
+        health: {},
+
+        async load() {
+            this.loading = true;
+            this.error = '';
+            try {
+                const response = await fetch('/api/v1/health/operations');
+                if (!response.ok) {
+                    throw new Error('Health details could not be loaded.');
+                }
+                this.health = await response.json();
+            } catch (error) {
+                this.error = error.message || 'Health details could not be loaded.';
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        formatDate(value) {
+            if (!value) return 'Not recorded';
+            return new Date(value).toLocaleString();
+        },
+
+        formatImport(value) {
+            if (!value) return 'Not recorded';
+            return `${value.status} (${value.reports_found} reports) at ${this.formatDate(value.finished_at)}`;
+        },
+
+        categoryLabel(value) {
+            if (!value) return 'Mailbox';
+            return value.replaceAll('_', ' ');
+        },
+    };
+}

--- a/backend/app/templates/operations.html
+++ b/backend/app/templates/operations.html
@@ -132,44 +132,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
-function operationsHealth() {
-    return {
-        loading: false,
-        error: '',
-        health: {},
-
-        async load() {
-            this.loading = true;
-            this.error = '';
-            try {
-                const response = await fetch('/api/v1/health/operations');
-                if (!response.ok) {
-                    throw new Error('Health details could not be loaded.');
-                }
-                this.health = await response.json();
-            } catch (error) {
-                this.error = error.message || 'Health details could not be loaded.';
-            } finally {
-                this.loading = false;
-            }
-        },
-
-        formatDate(value) {
-            if (!value) return 'Not recorded';
-            return new Date(value).toLocaleString();
-        },
-
-        formatImport(value) {
-            if (!value) return 'Not recorded';
-            return `${value.status} (${value.reports_found} reports) at ${this.formatDate(value.finished_at)}`;
-        },
-
-        categoryLabel(value) {
-            if (!value) return 'Mailbox';
-            return value.replaceAll('_', ' ');
-        },
-    };
-}
-</script>
+<script src="/static/js/operations-page.js"></script>
 {% endblock %}

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2,22 +2,24 @@ import re
 from pathlib import Path
 
 
+def _read_project_file(*parts: str) -> str:
+    return (Path(__file__).resolve().parents[1].joinpath(*parts)).read_text()
+
+
 def _dashboard_template() -> str:
-    return (Path(__file__).resolve().parents[1] / "templates" / "index.html").read_text()
+    return _read_project_file("templates", "index.html")
 
 
 def _dashboard_script() -> str:
-    return (Path(__file__).resolve().parents[1] / "static" / "js" / "dashboard-page.js").read_text()
+    return _read_project_file("static", "js", "dashboard-page.js")
 
 
 def _operations_template() -> str:
-    return (Path(__file__).resolve().parents[1] / "templates" / "operations.html").read_text()
+    return _read_project_file("templates", "operations.html")
 
 
 def _operations_script() -> str:
-    return (
-        Path(__file__).resolve().parents[1] / "static" / "js" / "operations-page.js"
-    ).read_text()
+    return _read_project_file("static", "js", "operations-page.js")
 
 
 def test_dashboard_domain_table_uses_safe_dom_rendering():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -10,6 +10,16 @@ def _dashboard_script() -> str:
     return (Path(__file__).resolve().parents[1] / "static" / "js" / "dashboard-page.js").read_text()
 
 
+def _operations_template() -> str:
+    return (Path(__file__).resolve().parents[1] / "templates" / "operations.html").read_text()
+
+
+def _operations_script() -> str:
+    return (
+        Path(__file__).resolve().parents[1] / "static" / "js" / "operations-page.js"
+    ).read_text()
+
+
 def test_dashboard_domain_table_uses_safe_dom_rendering():
     """Domain names and counts come from report data and must not be HTML-rendered."""
     script = _dashboard_script()
@@ -56,6 +66,17 @@ def test_dashboard_uses_external_page_script_for_csp_migration():
 
     assert 'src="/static/js/chart.umd.min.js"' in template
     assert 'src="/static/js/dashboard-page.js"' in template
+    assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
+
+
+def test_operations_uses_external_page_script_for_csp_migration():
+    template = _operations_template()
+    script = _operations_script()
+
+    assert 'src="/static/js/operations-page.js"' in template
+    assert "operationsHealth()" in template
+    assert "/api/v1/health/operations" in script
+    assert "Health details could not be loaded." in script
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 


### PR DESCRIPTION
## Summary
- move the Operations/System Health Alpine controller from `operations.html` into `/static/js/operations-page.js`
- keep the operations template on an external page script for CSP migration
- add regression coverage that rejects new inline `<script>` blocks in `operations.html`

Part of #426. This does not tighten the enforced CSP yet and does not migrate the remaining large page scripts.

## Local validation
- `.venv/bin/python -m pytest backend/app/tests -q` -> 1533 passed
- `.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py -q` -> 51 passed
- `.venv/bin/black --check backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py`
- `.venv/bin/isort --check-only backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py`
- `node --check backend/app/static/js/operations-page.js`
- `node --check backend/app/static/js/dashboard-page.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Operations page so health data loads more reliably and shows clearer status messages when requests fail.
  * Dates and import details now display in a more user-friendly format, including fallback text when values are missing.
* **Chores**
  * The Operations page now uses an external script, supporting safer page rendering and future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->