### PR TITLE
Refactor profile page script for CSP migration

### DIFF
--- a/backend/app/static/js/profile-page.js
+++ b/backend/app/static/js/profile-page.js
@@ -1,0 +1,15 @@
+function profileApp() {
+    return {
+        user: null,
+        async init() {
+            try {
+                const response = await fetch('/api/v1/auth/me');
+                if (response.ok) {
+                    this.user = await response.json();
+                }
+            } catch (error) {
+                console.error('Failed to load user profile:', error);
+            }
+        },
+    };
+}

--- a/backend/app/templates/profile.html
+++ b/backend/app/templates/profile.html
@@ -175,23 +175,8 @@
     {% endif %}
 
 </div>
+{% endblock %}
 
-<script>
-    function profileApp() {
-        return {
-            user: null,
-            async init() {
-                try {
-                    const res = await fetch('/api/v1/auth/me');
-                    if (res.ok) {
-                        this.user = await res.json();
-                    }
-                } catch (e) {
-                    console.error('Failed to load user profile:', e);
-                    // ignore – profile info simply won't be shown
-                }
-            },
-        };
-    }
-</script>
+{% block scripts %}
+<script src="/static/js/profile-page.js"></script>
 {% endblock %}

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -46,6 +46,14 @@ def _upload_script() -> str:
     return _read_project_file("static", "js", "upload-page.js")
 
 
+def _profile_template() -> str:
+    return _read_project_file("templates", "profile.html")
+
+
+def _profile_script() -> str:
+    return _read_project_file("static", "js", "profile-page.js")
+
+
 def test_dashboard_domain_table_uses_safe_dom_rendering():
     """Domain names and counts come from report data and must not be HTML-rendered."""
     script = _dashboard_script()
@@ -140,6 +148,17 @@ def test_upload_uses_external_page_script_for_csp_migration():
     assert "UPLOAD_TIMEOUT_MS" in script
     assert "this.isUploading = false" in script
     assert "dmarq:refresh-data" in script
+    assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
+
+
+def test_profile_uses_external_page_script_for_csp_migration():
+    template = _profile_template()
+    script = _profile_script()
+
+    assert 'src="/static/js/profile-page.js"' in template
+    assert "profileApp()" in template
+    assert "/api/v1/auth/me" in script
+    assert "Failed to load user profile" in script
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 


### PR DESCRIPTION
## Summary
- move the profile page Alpine controller from `profile.html` into `/static/js/profile-page.js`
- keep the existing `/api/v1/auth/me` profile loading behavior intact
- add a CSP migration regression test that fails if the profile template reintroduces an inline script

## Validation
- `node --check backend/app/static/js/profile-page.js`
- `.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py -q` (`55 passed`)
- `.venv/bin/black --check backend/app/tests/test_dashboard_template_security.py`
- `.venv/bin/isort --check-only backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`
- `.venv/bin/python -m pytest backend/app/tests -q` (`1537 passed`)

Part of #426.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the profile page to load its client-side behavior more reliably, helping user details appear correctly on the page.
  * Improved handling when profile information cannot be retrieved, reducing silent failures.

* **Tests**
  * Added coverage to ensure the profile page uses external scripting and avoids inline scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->