### PR TITLE
Loosen profile script assertion

### DIFF
--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -20,7 +20,7 @@ def _render_template(name: str, **context: object) -> str:
 def _has_script_src(markup: str, src: str) -> bool:
     return bool(
         re.search(
-            rf"<script\b(?=[^>]*\bsrc=[\"']{re.escape(src)}[\"'])[^>]*>",
+            rf"<script\b(?=[^>]*\ssrc=[\"']{re.escape(src)}[\"'])[^>]*>",
             markup,
             re.IGNORECASE,
         )
@@ -195,6 +195,10 @@ def test_profile_renders_external_page_script_for_csp_migration():
     )
 
     assert _has_script_src(rendered, "/static/js/profile-page.js")
+    assert not _has_script_src(
+        '<script data-src="/static/js/profile-page.js"></script>',
+        "/static/js/profile-page.js",
+    )
 
 
 def test_domain_details_exposes_health_history_without_html_injection():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -17,6 +17,16 @@ def _render_template(name: str, **context: object) -> str:
     return env.get_template(name).render(**context)
 
 
+def _has_script_src(markup: str, src: str) -> bool:
+    return bool(
+        re.search(
+            rf"<script\b(?=[^>]*\bsrc=[\"']{re.escape(src)}[\"'])[^>]*>",
+            markup,
+            re.IGNORECASE,
+        )
+    )
+
+
 def _dashboard_template() -> str:
     return _read_project_file("templates", "index.html")
 
@@ -184,7 +194,7 @@ def test_profile_renders_external_page_script_for_csp_migration():
         logto_configured=False,
     )
 
-    assert '<script src="/static/js/profile-page.js"></script>' in rendered
+    assert _has_script_src(rendered, "/static/js/profile-page.js")
 
 
 def test_domain_details_exposes_health_history_without_html_injection():


### PR DESCRIPTION
## Summary
- Replace the rendered profile script exact-string assertion with a src-aware script tag matcher
- Keep the CSP regression focused on a real script tag that points at /static/js/profile-page.js while allowing harmless attribute or whitespace changes

## Validation
- /tmp/dmarq-auth-venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q
- /tmp/dmarq-auth-venv/bin/black --check backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-auth-venv/bin/isort --check-only backend/app/tests/test_dashboard_template_security.py
- git diff --check