### PR TITLE
Fix DNS posture false negatives from empty resolver results

### DIFF
--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from typing import List, Tuple
@@ -13,9 +14,17 @@ from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
 from app.services.dns_provider_detection import detection_from_json
-from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult
+from app.services.dns_resolver import (
+    BaseDNSProvider,
+    CloudflareDNSProvider,
+    DomainDNSResult,
+    SystemDNSProvider,
+)
 
 DEFAULT_DNS_CACHE_TTL_SECONDS = 900
+NEGATIVE_DNS_CACHE_TTL_SECONDS = 60
+
+logger = logging.getLogger(__name__)
 
 
 def _utcnow_naive() -> datetime:
@@ -56,6 +65,56 @@ def _is_fresh(row: DNSCache, ttl_seconds: int, now: datetime) -> bool:
     return row.checked_at >= now - timedelta(seconds=ttl_seconds)
 
 
+def _has_dns_evidence(result: DomainDNSResult) -> bool:
+    return any(
+        (
+            result.dmarc,
+            result.dmarc_record,
+            result.spf,
+            result.spf_record,
+            result.dkim,
+            result.dkim_record,
+            result.dkim_selectors,
+            result.nameservers,
+            result.dmarc_policy_domain,
+        )
+    )
+
+
+def _negative_ttl_for_result(result: DomainDNSResult, ttl_seconds: int) -> int:
+    if _has_dns_evidence(result):
+        return ttl_seconds
+    return min(ttl_seconds, NEGATIVE_DNS_CACHE_TTL_SECONDS)
+
+
+async def _resolve_with_fallback(
+    provider: BaseDNSProvider,
+    domain: str,
+    *,
+    selectors: List[str],
+) -> DomainDNSResult:
+    """Resolve DNS, using a public fallback when the primary result has no evidence."""
+    result = await provider.check_domain(domain, selectors=selectors)
+    if _has_dns_evidence(result):
+        return result
+    if not isinstance(provider, (CloudflareDNSProvider, SystemDNSProvider)):
+        return result
+
+    fallback: BaseDNSProvider
+    if isinstance(provider, CloudflareDNSProvider):
+        fallback = SystemDNSProvider()
+    else:
+        fallback = CloudflareDNSProvider()
+
+    try:
+        fallback_result = await fallback.check_domain(domain, selectors=selectors)
+    except Exception as exc:  # pragma: no cover - defensive against DNS/network issues
+        logger.debug("Fallback DNS resolver failed for %s: %s", domain, exc)
+        return result
+
+    return fallback_result if _has_dns_evidence(fallback_result) else result
+
+
 async def resolve_domain_dns_cached(
     db: Session,
     provider: BaseDNSProvider,
@@ -79,10 +138,13 @@ async def resolve_domain_dns_cached(
         .first()
     )
 
-    if row and not refresh and _is_fresh(row, ttl_seconds, now):
-        return _result_from_json(row.result_json), True, row.checked_at
+    if row and not refresh:
+        cached_result = _result_from_json(row.result_json)
+        cache_ttl = _negative_ttl_for_result(cached_result, ttl_seconds)
+        if _is_fresh(row, cache_ttl, now):
+            return cached_result, True, row.checked_at
 
-    result = await provider.check_domain(domain, selectors=selectors)
+    result = await _resolve_with_fallback(provider, domain, selectors=selectors)
     payload = _result_to_json(result)
     if row is None:
         row = DNSCache(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -8,7 +8,9 @@ that the endpoints can find the test domain.
 DNS lookups are mocked so no real network calls are made.
 """
 
-from datetime import datetime
+import json
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -27,7 +29,7 @@ from app.services.bimi import BIMIResult
 from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
 from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
 from app.services.dns_provider_detection import detect_dns_provider
-from app.services.dns_resolver import DomainDNSResult
+from app.services.dns_resolver import DomainDNSResult, SystemDNSProvider
 from app.services.mta_sts import MTAStsResult
 from app.services.report_persistence import save_parsed_report
 from app.services.report_store import ReportStore
@@ -689,6 +691,80 @@ async def test_dns_cache_preserves_provider_detection(db_session):
     assert second.nameservers == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
     assert second.dns_provider is not None
     assert second.dns_provider.provider_id == "cloudflare"
+
+
+@pytest.mark.asyncio
+async def test_dns_cache_refreshes_stale_empty_dns_result(db_session):
+    """Resolver failures with no DNS evidence should not poison posture for the full TTL."""
+    stale_empty = DomainDNSResult(dmarc=False, spf=False, dkim=False)
+    healthy = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject",
+        spf=True,
+        spf_record="v=spf1 -all",
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+        dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
+    )
+    provider = AsyncMock(check_domain=AsyncMock(return_value=healthy))
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=provider.__class__.__name__,
+            selectors_key=_selectors_key([]),
+            result_json=json.dumps(asdict(stale_empty), sort_keys=True, separators=(",", ":")),
+            checked_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=120),
+        )
+    )
+    db_session.commit()
+
+    result, cached, _checked = await resolve_domain_dns_cached(
+        db_session,
+        provider,
+        DOMAIN,
+        selectors=[],
+    )
+
+    assert cached is False
+    assert result.dmarc is True
+    assert result.spf is True
+    assert result.dns_provider is not None
+    assert provider.check_domain.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_session):
+    """A primary resolver with no evidence should not force a false F grade."""
+    primary_provider = SystemDNSProvider()
+    primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
+    fallback_result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject",
+        spf=True,
+        spf_record="v=spf1 -all",
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+        dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
+    )
+
+    with (
+        patch.object(primary_provider, "check_domain", new=primary_check),
+        patch(
+            "app.services.dns_cache.CloudflareDNSProvider.check_domain",
+            new=AsyncMock(return_value=fallback_result),
+        ) as fallback,
+    ):
+        result, cached, _checked = await resolve_domain_dns_cached(
+            db_session,
+            primary_provider,
+            DOMAIN,
+            selectors=[],
+        )
+
+    assert cached is False
+    assert result.dmarc is True
+    assert result.spf is True
+    assert result.dns_provider is not None
+    primary_check.assert_awaited_once()
+    fallback.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- shorten caching for total-empty DNS results so transient resolver failures do not poison posture for the normal TTL\n- retry real DNS providers through a safe fallback resolver when the primary path returns no DNS evidence at all\n- keep mocked/missing-record semantics intact and add regression coverage for stale empty cache plus fallback recovery\n\n## Validation\n- .venv/bin/pytest backend/app/tests/test_dns_endpoints.py\n- .venv/bin/black --check backend/app/services/dns_cache.py backend/app/tests/test_dns_endpoints.py\n- .venv/bin/isort --check-only backend/app/services/dns_cache.py backend/app/tests/test_dns_endpoints.py\n- git diff --check\n- .venv/bin/pytest backend/app/tests\n\nFixes #469