### PR TITLE
Harden DNS fallback error handling

### DIFF
--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -111,7 +111,7 @@ async def _resolve_with_fallback(
         fallback_result = await fallback.check_domain(domain, selectors=selectors)
     except asyncio.CancelledError:
         raise
-    except Exception as exc:  # pragma: no cover - defensive against DNS/network issues
+    except Exception as exc:
         logger.debug(
             "Fallback DNS resolver failed with %s; returning primary DNS result",
             exc.__class__.__name__,

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -108,8 +109,13 @@ async def _resolve_with_fallback(
 
     try:
         fallback_result = await fallback.check_domain(domain, selectors=selectors)
+    except asyncio.CancelledError:
+        raise
     except Exception as exc:  # pragma: no cover - defensive against DNS/network issues
-        logger.debug("Fallback DNS resolver failed for %s: %s", domain, exc)
+        logger.debug(
+            "Fallback DNS resolver failed with %s; returning primary DNS result",
+            exc.__class__.__name__,
+        )
         return result
 
     return fallback_result if _has_dns_evidence(fallback_result) else result

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -8,7 +8,9 @@ that the endpoints can find the test domain.
 DNS lookups are mocked so no real network calls are made.
 """
 
+import asyncio
 import json
+import logging
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -765,6 +767,64 @@ async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_sessio
     assert result.dns_provider is not None
     primary_check.assert_awaited_once()
     fallback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dns_cache_propagates_fallback_cancellation(db_session):
+    """Request cancellation must not be swallowed by defensive fallback handling."""
+    primary_provider = SystemDNSProvider()
+    primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
+    fallback_check = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with (
+        patch.object(primary_provider, "check_domain", new=primary_check),
+        patch(
+            "app.services.dns_cache.CloudflareDNSProvider.check_domain",
+            new=fallback_check,
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await resolve_domain_dns_cached(
+            db_session,
+            primary_provider,
+            DOMAIN,
+            selectors=[],
+        )
+
+    primary_check.assert_awaited_once()
+    fallback_check.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dns_cache_fallback_failure_log_omits_user_values(db_session, caplog):
+    """Fallback failure logging should not echo domains or exception messages."""
+    domain = "bad.example\nforged-log-line"
+    primary_provider = SystemDNSProvider()
+    primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
+    fallback_check = AsyncMock(side_effect=RuntimeError(f"resolver failed for {domain}"))
+    caplog.set_level(logging.DEBUG, logger="app.services.dns_cache")
+
+    with (
+        patch.object(primary_provider, "check_domain", new=primary_check),
+        patch(
+            "app.services.dns_cache.CloudflareDNSProvider.check_domain",
+            new=fallback_check,
+        ),
+    ):
+        result, cached, _checked = await resolve_domain_dns_cached(
+            db_session,
+            primary_provider,
+            domain,
+            selectors=[],
+        )
+
+    assert cached is False
+    assert result.dmarc is False
+    assert "RuntimeError" in caplog.text
+    assert domain not in caplog.text
+    assert f"resolver failed for {domain}" not in caplog.text
+    primary_check.assert_awaited_once()
+    fallback_check.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Let DNS fallback cancellations propagate instead of being swallowed by broad exception handling
- Remove user-controlled domain and exception text from fallback failure logs
- Add regression coverage for cancellation propagation and sanitized fallback logging

## Validation
- /tmp/dmarq-auth-venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py -q
- /tmp/dmarq-auth-venv/bin/black --check backend/app/services/dns_cache.py backend/app/tests/test_dns_endpoints.py
- /tmp/dmarq-auth-venv/bin/isort --check-only backend/app/services/dns_cache.py backend/app/tests/test_dns_endpoints.py
- git diff --check origin/main..HEAD