### PR TITLE
Cover domain delete redirect

### DIFF
--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -257,6 +257,22 @@ def test_domain_details_exposes_ownership_and_delete_controls_without_html_injec
     assert "x-html" not in template
 
 
+def test_domain_details_redirects_to_domain_management_after_delete_success():
+    template = (
+        Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"
+    ).read_text()
+    delete_start = template.index("        async deleteDomain()")
+    delete_end = template.index("        enableMigrationTools()", delete_start)
+    delete_body = template[delete_start:delete_end]
+
+    assert "if (response.status === 204)" in delete_body
+    assert "window.location.href = '/domains';" in delete_body
+    assert "return;" in delete_body
+    assert delete_body.index("window.location.href = '/domains';") < delete_body.index(
+        "window.alert(data.detail"
+    )
+
+
 def test_report_detail_exposes_record_review_guidance_without_html_injection():
     template = (
         Path(__file__).resolve().parents[1] / "templates" / "report_detail.html"


### PR DESCRIPTION
## Summary
- adds regression coverage for the domain detail delete success path
- verifies successful deletes redirect back to /domains before any error alert path

Closes #461

## Validation
- .venv/bin/pytest backend/app/tests/test_dashboard_template_security.py -k "domain_details_redirects_to_domain_management_after_delete_success or domain_details_exposes_ownership_and_delete_controls_without_html_injection"
- .venv/bin/pytest backend/app/tests/test_dashboard_template_security.py
- .venv/bin/black --check backend/app/tests/test_dashboard_template_security.py
- .venv/bin/isort --check-only backend/app/tests/test_dashboard_template_security.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the delete flow on the domain details page so users are returned to the domain list after a successful delete.
  * Added coverage to help prevent regressions in this navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->