### PR TITLE
Add domain management edit flow

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -210,6 +210,7 @@ class DomainResponse(DomainBase):
     reports_count: int = 0
     emails_count: int = 0
     compliance_rate: float = 0.0
+    dkim_selectors: List[str] = Field(default_factory=list)
     mail_service_context: List[Dict[str, Any]] = Field(default_factory=list)
 
 
@@ -217,6 +218,13 @@ class DomainCreate(BaseModel):
     """Payload for creating a monitored domain."""
 
     name: str
+    description: Optional[str] = None
+    dkim_selectors: Optional[List[str]] = None
+
+
+class DomainUpdate(BaseModel):
+    """Payload for updating editable monitored-domain metadata."""
+
     description: Optional[str] = None
     dkim_selectors: Optional[List[str]] = None
 
@@ -1479,6 +1487,26 @@ def _get_selectors_from_reports(store: "ReportStore", domain: str) -> List[str]:
     return selectors
 
 
+def _normalize_domain_selectors(selectors: Optional[List[str]]) -> List[str]:
+    """Normalize user-supplied DKIM selectors while preserving order."""
+    normalized: List[str] = []
+    seen = set()
+    for selector in selectors or []:
+        value = selector.strip() if selector else ""
+        if value and value not in seen:
+            normalized.append(value)
+            seen.add(value)
+    return normalized
+
+
+def _domain_update_fields(payload: BaseModel) -> set[str]:
+    """Return fields explicitly present in a Pydantic v1/v2 payload."""
+    fields = getattr(payload, "model_fields_set", None)
+    if fields is None:
+        fields = getattr(payload, "__fields_set__", set())
+    return set(fields)
+
+
 def _ownership_record_name(domain: str) -> str:
     return f"_dmarq-verify.{domain}"
 
@@ -2692,6 +2720,10 @@ async def get_domains_summary(
     # Perform DNS checks for all domains, reusing fresh cached results.
     provider = get_default_provider(db)
     manual_selectors_by_domain = _get_domain_selectors_map_from_db(db, domains)
+    stored_domains_by_name = {
+        domain.name: domain
+        for domain in workspace_domain_query(db, workspace).filter(Domain.name.in_(domains)).all()
+    }
 
     async def _dns_for_domain(domain_name: str) -> DomainDNSResult:
         manual_selectors = manual_selectors_by_domain.get(domain_name, [])
@@ -2723,6 +2755,7 @@ async def get_domains_summary(
 
     for domain_name, dns in zip(domains, dns_results):
         summary = summaries.get(domain_name, {})
+        stored_domain = stored_domains_by_name.get(domain_name)
         total_emails += summary.get("total_count", 0)
         total_passed += summary.get("passed_count", 0)
         total_reports += summary.get("reports_processed", 0)
@@ -2736,6 +2769,8 @@ async def get_domains_summary(
         domain_row = {
             "id": domain_name,
             "domain_name": domain_name,
+            "description": stored_domain.description if stored_domain else None,
+            "dkim_selectors": manual_selectors_by_domain.get(domain_name, []),
             "total_emails": summary.get("total_count", 0),
             "passed_count": summary.get("passed_count", 0),
             "failed_count": summary.get("failed_count", 0),
@@ -2919,6 +2954,9 @@ async def read_domains(
             reports_count=summary.get("reports_processed", 0),
             emails_count=summary.get("total_count", 0),
             compliance_rate=summary.get("compliance_rate", 0.0),
+            dkim_selectors=_normalize_domain_selectors(
+                (stored_domain.dkim_selectors or "").split(",") if stored_domain else []
+            ),
             mail_service_context=mail_service_context_from_domain(stored_domain),
         )
         result.append(domain_response)
@@ -2957,11 +2995,7 @@ async def create_domain(
         except OrganizationPlanLimitError as exc:
             _raise_plan_limit_error(exc)
 
-    selectors = ",".join(
-        selector.strip()
-        for selector in payload.dkim_selectors or []
-        if selector and selector.strip()
-    )
+    selectors = ",".join(_normalize_domain_selectors(payload.dkim_selectors))
     domain = Domain(
         workspace_id=workspace.id,
         name=name,
@@ -2984,6 +3018,7 @@ async def create_domain(
         name=domain.name,
         description=domain.description,
         policy=domain.dmarc_policy or "unknown",
+        dkim_selectors=_normalize_domain_selectors((domain.dkim_selectors or "").split(",")),
         mail_service_context=mail_service_context_from_domain(domain),
     )
 
@@ -3019,7 +3054,88 @@ async def read_domain(
         reports_count=summary.get("reports_processed", 0),
         emails_count=summary.get("total_count", 0),
         compliance_rate=summary.get("compliance_rate", 0.0),
+        dkim_selectors=_normalize_domain_selectors(
+            (stored_domain.dkim_selectors or "").split(",") if stored_domain else []
+        ),
         mail_service_context=mail_service_context_from_domain(stored_domain),
+    )
+
+
+@router.patch("/domains/{domain_name}", response_model=DomainResponse)
+async def update_domain(
+    payload: DomainUpdate,
+    request: Request,
+    domain_name: str,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Update editable metadata for a monitored domain."""
+    workspace = _authorized_domain_workspace(_auth, db)
+    name = normalize_domain_name(domain_name)
+    fields = _domain_update_fields(payload)
+    if not fields:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="At least one editable field must be provided",
+        )
+
+    validation = validate_domain_config({"name": name, "description": payload.description or ""})
+    if "description" in fields and not validation["valid"]:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=validation["errors"],
+        )
+
+    store = ReportStore.get_instance()
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    existing_domain_names = _domain_names_for_summary(db, store, workspace)
+    domain = workspace_domain_query(db, workspace).filter(Domain.name == name).first()
+    if domain is None and name not in existing_domain_names:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Domain not found",
+        )
+    if domain is None:
+        domain = Domain(name=name, workspace_id=workspace.id, active=True)
+        db.add(domain)
+
+    if "description" in fields:
+        domain.description = payload.description
+    if "dkim_selectors" in fields:
+        selectors = _normalize_domain_selectors(payload.dkim_selectors)
+        domain.dkim_selectors = ",".join(selectors) if selectors else None
+
+    db.commit()
+    db.refresh(domain)
+    record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action="domain.updated",
+        entity_type="domain",
+        entity_id=domain.id,
+        entity_name=domain.name,
+        details={
+            "updated_fields": sorted(fields),
+            "dkim_selector_count": len(
+                _normalize_domain_selectors((domain.dkim_selectors or "").split(","))
+            ),
+        },
+        auth_context=_auth,
+        request=request,
+        commit=True,
+    )
+
+    summary = store.get_domain_summary(name)
+    policy = _normalize_reported_policy(summary.get("policy"))
+    return DomainResponse(
+        name=domain.name,
+        description=domain.description,
+        policy=policy or domain.dmarc_policy or "unknown",
+        reports_count=summary.get("reports_processed", 0),
+        emails_count=summary.get("total_count", 0),
+        compliance_rate=summary.get("compliance_rate", 0.0),
+        dkim_selectors=_normalize_domain_selectors((domain.dkim_selectors or "").split(",")),
+        mail_service_context=mail_service_context_from_domain(domain),
     )
 
 

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -2,9 +2,16 @@ function domainsApp() {
     return {
         domains: [],
         openCreate: false,
+        openEdit: false,
         saving: false,
         createError: '',
+        editError: '',
         newDomain: {
+            name: '',
+            description: '',
+            dkim_selectors: '',
+        },
+        editDomain: {
             name: '',
             description: '',
             dkim_selectors: '',
@@ -29,6 +36,10 @@ function domainsApp() {
                         reports_count: domain.report_count,
                         emails_count: domain.total_emails,
                         compliance_rate: domain.pass_rate,
+                        description: domain.description || '',
+                        dkim_selectors: Array.isArray(domain.dkim_selectors)
+                            ? domain.dkim_selectors
+                            : [],
                     }));
                 } else {
                     console.error('Error fetching domains:', response.status);
@@ -42,6 +53,24 @@ function domainsApp() {
             this.openCreate = false;
             this.createError = '';
             this.newDomain = { name: '', description: '', dkim_selectors: '' };
+        },
+
+        openEditDialog(domain) {
+            this.editError = '';
+            this.editDomain = {
+                name: domain.name,
+                description: domain.description || '',
+                dkim_selectors: Array.isArray(domain.dkim_selectors)
+                    ? domain.dkim_selectors.join(', ')
+                    : '',
+            };
+            this.openEdit = true;
+        },
+
+        closeEdit() {
+            this.openEdit = false;
+            this.editError = '';
+            this.editDomain = { name: '', description: '', dkim_selectors: '' };
         },
 
         async createDomain() {
@@ -73,6 +102,42 @@ function domainsApp() {
                 await this.fetchDomains();
             } catch (error) {
                 this.createError = error.message || 'Domain could not be added.';
+            } finally {
+                this.saving = false;
+            }
+        },
+
+        async updateDomain() {
+            this.saving = true;
+            this.editError = '';
+            try {
+                const selectors = this.editDomain.dkim_selectors
+                    .split(',')
+                    .map((selector) => selector.trim())
+                    .filter(Boolean);
+                const response = await fetch(
+                    `/api/v1/domains/domains/${encodeURIComponent(this.editDomain.name)}`,
+                    {
+                        method: 'PATCH',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            description: this.editDomain.description || null,
+                            dkim_selectors: selectors,
+                        }),
+                    }
+                );
+                if (!response.ok) {
+                    const data = await response.json().catch(() => ({}));
+                    const detail =
+                        typeof data.detail === 'string'
+                            ? data.detail
+                            : Object.values(data.detail || {}).join(', ');
+                    throw new Error(detail || 'Domain could not be updated.');
+                }
+                this.closeEdit();
+                await this.fetchDomains();
+            } catch (error) {
+                this.editError = error.message || 'Domain could not be updated.';
             } finally {
                 this.saving = false;
             }

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -79,9 +79,9 @@
                                         <a :href="'/domains/' + domain.name" class="btn btn-sm btn-outline">
                                             Details
                                         </a>
-                                        {% call button(variant="outline", size="sm") %}
+                                        <button type="button" class="btn btn-outline btn-sm" @click="openEditDialog(domain)">
                                             Edit
-                                        {% endcall %}
+                                        </button>
                                     </div>
                                 {% endcall %}
                             {% endcall %}
@@ -123,6 +123,36 @@
         </div>
         <form method="dialog" class="modal-backdrop">
             <button type="button" @click="closeCreate">close</button>
+        </form>
+    </dialog>
+
+    <dialog class="modal" :open="openEdit">
+        <div class="modal-box max-w-2xl">
+            <h2 class="text-xl font-semibold">Edit monitored domain</h2>
+            <p class="mt-1 text-sm text-base-content/70" x-text="editDomain.name"></p>
+            <form class="mt-5 space-y-4" @submit.prevent="updateDomain">
+                <label class="form-control">
+                    <span class="label-text font-medium">Description</span>
+                    <textarea x-model.trim="editDomain.description" rows="3" class="textarea textarea-bordered" placeholder="Production mail domain"></textarea>
+                </label>
+                <label class="form-control">
+                    <span class="label-text font-medium">DKIM selectors</span>
+                    <input x-model.trim="editDomain.dkim_selectors" type="text" placeholder="default, google, selector1" class="input input-bordered">
+                </label>
+                <div x-show="editError" role="alert" class="alert alert-error py-3">
+                    <span x-text="editError"></span>
+                </div>
+                <div class="modal-action">
+                    <button type="button" class="btn btn-ghost" @click="closeEdit" :disabled="saving">Cancel</button>
+                    <button type="submit" class="btn btn-primary" :disabled="saving">
+                        <span x-show="saving" class="loading loading-spinner loading-xs"></span>
+                        Save changes
+                    </button>
+                </div>
+            </form>
+        </div>
+        <form method="dialog" class="modal-backdrop">
+            <button type="button" @click="closeEdit">close</button>
         </form>
     </dialog>
 </div>

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -38,6 +38,43 @@ def test_create_domain_without_reports(authed_client: TestClient):
     assert list_response.json()[0]["reports_count"] == 0
 
 
+def test_update_domain_metadata_without_reports(authed_client: TestClient):
+    """Editable monitored-domain metadata can be changed from the domain list."""
+    created = authed_client.post(
+        "/api/v1/domains/domains",
+        json={
+            "name": "Example.COM.",
+            "description": "Primary mail domain",
+            "dkim_selectors": ["default"],
+        },
+    )
+    assert created.status_code == 201
+
+    response = authed_client.patch(
+        "/api/v1/domains/domains/example.com",
+        json={
+            "description": "Updated production mail domain",
+            "dkim_selectors": ["google", "default", "google"],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "example.com"
+    assert data["description"] == "Updated production mail domain"
+    assert data["dkim_selectors"] == ["google", "default"]
+
+    list_response = authed_client.get("/api/v1/domains/domains")
+    assert list_response.status_code == 200
+    listed = list_response.json()[0]
+    assert listed["description"] == "Updated production mail domain"
+    assert listed["dkim_selectors"] == ["google", "default"]
+
+    selectors_response = authed_client.get("/api/v1/domains/example.com/selectors")
+    assert selectors_response.status_code == 200
+    assert selectors_response.json()["selectors"] == ["google", "default"]
+
+
 def test_create_domain_rejects_duplicates(authed_client: TestClient):
     """Creating the same monitored domain twice returns a conflict."""
     first = authed_client.post("/api/v1/domains/domains", json={"name": "example.com"})

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -155,6 +155,11 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert "/api/v1/domains/summary" in script
     assert "/api/v1/domains/domains" in script
     assert "createDomain()" in script
+    assert "openEditDialog(domain)" in template
+    assert "Edit monitored domain" in template
+    assert "updateDomain()" in script
+    assert "method: 'PATCH'" in script
+    assert "editError" in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 


### PR DESCRIPTION
## Summary
- add a PATCH endpoint for editable domain metadata
- wire the domain management Edit button to a populated dialog
- persist description and DKIM selectors, including report-only domains
- refresh the domain list and show inline save errors

Closes #462

## Validation
- .venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py
- .venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py
- .venv/bin/pytest backend/app/tests/test_api.py
- .venv/bin/pytest backend/app/tests/test_dashboard_template_security.py
- git diff --check