### PR TITLE
Fix domain edit review follow-ups

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1570,9 +1570,7 @@ def _get_domain_selectors_map_from_db(db: Session, domain_names: List[str]) -> D
         chunk = unique_names[index : index + DOMAIN_SELECTOR_LOOKUP_CHUNK_SIZE]
         rows = db.query(Domain.name, Domain.dkim_selectors).filter(Domain.name.in_(chunk)).all()
         for name, selectors in rows:
-            selectors_by_domain[name] = [
-                selector.strip() for selector in (selectors or "").split(",") if selector.strip()
-            ]
+            selectors_by_domain[name] = _normalize_domain_selectors((selectors or "").split(","))
     return selectors_by_domain
 
 
@@ -3105,7 +3103,14 @@ async def update_domain(
         selectors = _normalize_domain_selectors(payload.dkim_selectors)
         domain.dkim_selectors = ",".join(selectors) if selectors else None
 
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Domain is already monitored",
+        ) from exc
     db.refresh(domain)
     record_workspace_audit_log(
         db,

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -73,6 +73,30 @@ function domainsApp() {
             this.editDomain = { name: '', description: '', dkim_selectors: '' };
         },
 
+        apiErrorDetail(data, fallback) {
+            const detail = data?.detail;
+            if (typeof detail === 'string') {
+                return detail;
+            }
+            if (Array.isArray(detail)) {
+                return (
+                    detail
+                        .map((item) => item?.msg || item?.message || item?.detail || '')
+                        .filter(Boolean)
+                        .join(', ') || fallback
+                );
+            }
+            if (detail && typeof detail === 'object') {
+                return Object.values(detail)
+                    .map((value) =>
+                        typeof value === 'string' ? value : value?.msg || value?.message || ''
+                    )
+                    .filter(Boolean)
+                    .join(', ');
+            }
+            return fallback;
+        },
+
         async createDomain() {
             this.saving = true;
             this.createError = '';
@@ -92,10 +116,7 @@ function domainsApp() {
                 });
                 if (!response.ok) {
                     const data = await response.json().catch(() => ({}));
-                    const detail =
-                        typeof data.detail === 'string'
-                            ? data.detail
-                            : Object.values(data.detail || {}).join(', ');
+                    const detail = this.apiErrorDetail(data, 'Domain could not be added.');
                     throw new Error(detail || 'Domain could not be added.');
                 }
                 this.closeCreate();
@@ -128,10 +149,7 @@ function domainsApp() {
                 );
                 if (!response.ok) {
                     const data = await response.json().catch(() => ({}));
-                    const detail =
-                        typeof data.detail === 'string'
-                            ? data.detail
-                            : Object.values(data.detail || {}).join(', ');
+                    const detail = this.apiErrorDetail(data, 'Domain could not be updated.');
                     throw new Error(detail || 'Domain could not be updated.');
                 }
                 this.closeEdit();

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
 from starlette.requests import Request
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
@@ -127,6 +128,60 @@ def test_update_report_only_domain_creates_monitored_domain(
     domain = db_session.query(Domain).filter(Domain.name == report_domain).one()
     assert domain.description == "Persisted from report-only summary"
     assert domain.dkim_selectors == "google,default"
+
+
+def test_update_report_only_domain_insert_race_returns_conflict(
+    authed_client: TestClient, db_session, monkeypatch
+):
+    """Concurrent monitor-domain creation returns a controlled conflict."""
+    report_domain = "raced-report-only.example"
+    report = {
+        "domain": report_domain,
+        "report_id": "report-only-race",
+        "org_name": "Example RUA",
+        "begin_timestamp": 1597449600,
+        "end_timestamp": 1597535999,
+        "policy": "none",
+        "records": [
+            {
+                "source_ip": "192.0.2.10",
+                "count": 1,
+                "disposition": "none",
+                "dkim_result": "pass",
+                "spf_result": "pass",
+                "header_from": report_domain,
+            }
+        ],
+    }
+
+    def fake_hydrate(_db, store, workspace_id=None):
+        del workspace_id
+        store.clear()
+        store.add_report(report)
+        return 1
+
+    def fail_commit():
+        raise IntegrityError("insert domain", {}, Exception("duplicate domain"))
+
+    workspace = domains_endpoint._authorized_domain_workspace(  # pylint: disable=protected-access
+        {"auth_type": "api_key"},
+        db_session,
+    )
+    monkeypatch.setattr(
+        domains_endpoint,
+        "_authorized_domain_workspace",
+        lambda *_args, **_kwargs: workspace,
+    )
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
+    monkeypatch.setattr(db_session, "commit", fail_commit)
+
+    response = authed_client.patch(
+        f"/api/v1/domains/domains/{report_domain}",
+        json={"description": "Race loser"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Domain is already monitored"
 
 
 def test_domain_selectors_map_normalizes_legacy_duplicates(db_session):

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -3,7 +3,9 @@ import asyncio
 from fastapi.testclient import TestClient
 from starlette.requests import Request
 
+from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.main import app, members_page
+from app.models.domain import Domain
 
 
 def test_health_check(authed_client: TestClient):
@@ -73,6 +75,69 @@ def test_update_domain_metadata_without_reports(authed_client: TestClient):
     selectors_response = authed_client.get("/api/v1/domains/example.com/selectors")
     assert selectors_response.status_code == 200
     assert selectors_response.json()["selectors"] == ["google", "default"]
+
+
+def test_update_report_only_domain_creates_monitored_domain(
+    authed_client: TestClient, db_session, monkeypatch
+):
+    """PATCH can persist metadata for a domain that only exists in report summaries."""
+    report_domain = "report-only.example"
+    report = {
+        "domain": report_domain,
+        "report_id": "report-only-update",
+        "org_name": "Example RUA",
+        "begin_timestamp": 1597449600,
+        "end_timestamp": 1597535999,
+        "policy": "none",
+        "records": [
+            {
+                "source_ip": "192.0.2.10",
+                "count": 3,
+                "disposition": "none",
+                "dkim_result": "pass",
+                "spf_result": "pass",
+                "header_from": report_domain,
+            }
+        ],
+    }
+
+    def fake_hydrate(_db, store, workspace_id=None):
+        del workspace_id
+        store.clear()
+        store.add_report(report)
+        return 1
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
+
+    response = authed_client.patch(
+        f"/api/v1/domains/domains/{report_domain}",
+        json={
+            "description": "Persisted from report-only summary",
+            "dkim_selectors": ["google", "default", "google"],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == report_domain
+    assert data["description"] == "Persisted from report-only summary"
+    assert data["reports_count"] == 1
+    assert data["dkim_selectors"] == ["google", "default"]
+
+    domain = db_session.query(Domain).filter(Domain.name == report_domain).one()
+    assert domain.description == "Persisted from report-only summary"
+    assert domain.dkim_selectors == "google,default"
+
+
+def test_domain_selectors_map_normalizes_legacy_duplicates(db_session):
+    """Summary selector lookups return the same normalized selector shape as read APIs."""
+    db_session.add(Domain(name="legacy.example", dkim_selectors=" google,default,google, "))
+    db_session.commit()
+
+    assert domains_endpoint._get_domain_selectors_map_from_db(  # pylint: disable=protected-access
+        db_session,
+        ["legacy.example"],
+    ) == {"legacy.example": ["google", "default"]}
 
 
 def test_create_domain_rejects_duplicates(authed_client: TestClient):


### PR DESCRIPTION
## Summary
- normalize legacy duplicate DKIM selectors in domain summary lookups
- surface structured FastAPI/Pydantic validation errors in the domain edit UI
- handle update-domain insert races with a controlled conflict response
- cover report-only domain metadata updates and legacy selector normalization

## Validation
- /tmp/dmarq-auth-venv/bin/python -m pytest backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py -q
- /tmp/dmarq-auth-venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_api.py
- /tmp/dmarq-auth-venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_api.py
- git diff --check