### PR TITLE
Add domain volume scale toggle

### DIFF
--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -189,10 +189,34 @@
         <section id="compliance-chart-section">
         {% call card() %}
             {% call card_header() %}
-                {% call card_title() %}Compliance Over Time{% endcall %}
-                {% call card_description() %}
-                    Daily DMARC volume, pass rate, and failure rate
-                {% endcall %}
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                        {% call card_title() %}Compliance Over Time{% endcall %}
+                        {% call card_description() %}
+                            Daily DMARC volume, pass rate, and failure rate
+                        {% endcall %}
+                    </div>
+                    <div class="flex items-center gap-2 text-sm" role="group" aria-label="Volume scale">
+                        <span class="text-[#5f5c78]">Volume scale</span>
+                        <div class="join">
+                            <button type="button"
+                                    class="btn btn-xs join-item"
+                                    :class="effectiveVolumeScale() === 'logarithmic' ? 'btn-primary' : 'btn-outline'"
+                                    :aria-pressed="effectiveVolumeScale() === 'logarithmic'"
+                                    :disabled="!hasObservedVolume"
+                                    @click="setVolumeScale('logarithmic')">
+                                Log
+                            </button>
+                            <button type="button"
+                                    class="btn btn-xs join-item"
+                                    :class="effectiveVolumeScale() === 'linear' ? 'btn-primary' : 'btn-outline'"
+                                    :aria-pressed="effectiveVolumeScale() === 'linear'"
+                                    @click="setVolumeScale('linear')">
+                                Linear
+                            </button>
+                        </div>
+                    </div>
+                </div>
             {% endcall %}
             {% call card_content() %}
                 <div class="h-64">
@@ -1884,8 +1908,16 @@ function domainDetailsApp(domainId) {
             exportStartDate: '',
             exportEndDate: ''
         },
+        volumeScale: 'logarithmic',
+        hasObservedVolume: false,
+        lastComplianceTimeline: [],
 
         init() {
+            const storedVolumeScale = this.loadStoredVolumeScale();
+            if (storedVolumeScale === 'linear' || storedVolumeScale === 'logarithmic') {
+                this.volumeScale = storedVolumeScale;
+            }
+
             this.fetchDomainStats();
             this.fetchDomainOwnership();
             this.fetchDNSRecords();
@@ -1906,6 +1938,26 @@ function domainDetailsApp(domainId) {
                 this.fetchSources();
                 this.fetchSourceIntelligence();
             });
+        },
+
+        loadStoredVolumeScale() {
+            try {
+                return window.localStorage?.getItem('dmarq:domain-volume-scale') || null;
+            } catch (error) {
+                return null;
+            }
+        },
+
+        persistVolumeScale(scale) {
+            try {
+                window.localStorage?.setItem('dmarq:domain-volume-scale', scale);
+            } catch (error) {
+                // Private browsing and locked-down environments may reject local storage.
+            }
+        },
+
+        effectiveVolumeScale() {
+            return this.hasObservedVolume && this.volumeScale === 'logarithmic' ? 'logarithmic' : 'linear';
         },
 
         get sourceEvidenceCount() {
@@ -2776,10 +2828,21 @@ function domainDetailsApp(domainId) {
                 if (response.ok) {
                     const data = await response.json();
                     this.reports = data.reports;
+                    this.lastComplianceTimeline = data.compliance_timeline || [];
                     this.initComplianceChart(data.compliance_timeline);
                 }
             } catch (error) {
                 console.error('Error fetching reports:', error);
+            }
+        },
+
+        setVolumeScale(scale) {
+            if (!['linear', 'logarithmic'].includes(scale)) return;
+            if (scale === 'logarithmic' && !this.hasObservedVolume) return;
+            this.volumeScale = scale;
+            this.persistVolumeScale(scale);
+            if (this.lastComplianceTimeline.length) {
+                this.initComplianceChart(this.lastComplianceTimeline);
             }
         },
         
@@ -2832,6 +2895,8 @@ function domainDetailsApp(domainId) {
             const observedRates = [...complianceData, ...failureData]
                 .filter(value => value !== null && Number.isFinite(value));
             const observedVolumes = volumeRawData.filter(value => value > 0 && Number.isFinite(value));
+            this.hasObservedVolume = observedVolumes.length > 0;
+            const volumeScale = this.effectiveVolumeScale();
             
             // Calculate the threshold line data (recommended 98% for policy advancement)
             const thresholdData = Array(labels.length).fill(98);
@@ -2916,9 +2981,9 @@ function domainDetailsApp(domainId) {
                             }
                         },
                         yVolume: {
-                            type: observedVolumes.length ? 'logarithmic' : 'linear',
+                            type: volumeScale,
                             position: 'right',
-                            min: observedVolumes.length ? 1 : 0,
+                            min: volumeScale === 'logarithmic' ? 1 : 0,
                             ticks: {
                                 precision: 0,
                                 callback: function(value) {
@@ -2931,7 +2996,7 @@ function domainDetailsApp(domainId) {
                             },
                             title: {
                                 display: true,
-                                text: observedVolumes.length ? 'Messages (log scale)' : 'Messages',
+                                text: volumeScale === 'logarithmic' ? 'Messages (log scale)' : 'Messages (linear scale)',
                                 font: {
                                     weight: 'bold'
                                 }

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -228,6 +228,29 @@ def test_domain_details_exposes_health_history_without_html_injection():
     assert "x-html" not in template
 
 
+def test_domain_details_exposes_volume_scale_controls_without_html_injection():
+    template = (
+        Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"
+    ).read_text()
+
+    assert "Volume scale" in template
+    assert 'role="group" aria-label="Volume scale"' in template
+    assert "setVolumeScale('logarithmic')" in template
+    assert "setVolumeScale('linear')" in template
+    assert ':aria-pressed="effectiveVolumeScale() === \'logarithmic\'"' in template
+    assert ':aria-pressed="effectiveVolumeScale() === \'linear\'"' in template
+    assert ':disabled="!hasObservedVolume"' in template
+    assert "dmarq:domain-volume-scale" in template
+    assert "effectiveVolumeScale()" in template
+    assert "const volumeScale =" in template
+    assert "type: volumeScale" in template
+    assert "Messages (log scale)" in template
+    assert "Messages (linear scale)" in template
+    assert "context.parsed.y === null" in template
+    assert "no observed mail volume" in template
+    assert "x-html" not in template
+
+
 def test_domain_details_exposes_migration_readiness_without_html_injection():
     template = (
         Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"


### PR DESCRIPTION
## Summary
- add a visible Log/Linear volume-scale control to the domain detail compliance chart
- persist the selected scale in local storage so navigation keeps the view stable
- keep zero-volume periods omitted from rate/volume points and label them as no observed mail volume
- add template regression coverage for the chart scale configuration

Closes #463

## Validation
- .venv/bin/pytest backend/app/tests/test_dashboard_template_security.py
- .venv/bin/pytest backend/app/tests/test_domain_detail_endpoints.py -k "compliance_timeline_does_not_treat_no_volume_as_perfect_compliance"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a control on the domain details page to switch the compliance chart’s message-volume axis between logarithmic and linear views.
  * The selected axis scale is remembered between visits and restored automatically.

* **Bug Fixes**
  * The compliance chart now refreshes using the latest available timeline when the scale is changed.
  * The chart falls back to a linear scale when no positive volume data is available.

* **Tests**
  * Added coverage to verify the new scale controls render correctly and that the page remains safe from HTML injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->