### PR TITLE
Show source IP intelligence

### DIFF
--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2318,7 +2318,11 @@ function domainDetailsApp(domainId) {
 
         sourceGeoSummary(source) {
             const geo = source?.geo || {};
-            const parts = [geo.region, geo.network || geo.country].filter(Boolean);
+            const isKnown = (value) => value && String(value).trim().toLowerCase() !== 'unknown';
+            const region = isKnown(geo.region) ? geo.region : null;
+            const country = isKnown(geo.country) ? geo.country : null;
+            const network = isKnown(geo.network) ? geo.network : null;
+            const parts = [region, network || country].filter(Boolean);
             return parts.length ? parts.join(' · ') : 'Geo unavailable';
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1440,6 +1440,7 @@
                         {% call tr() %}
                             {% call th() %}Source IP / Hostname{% endcall %}
                             {% call th() %}Sender{% endcall %}
+                            {% call th() %}IP Intelligence{% endcall %}
                             {% call th() %}Total Emails{% endcall %}
                             {% call th() %}SPF{% endcall %}
                             {% call th() %}DKIM{% endcall %}
@@ -1451,7 +1452,7 @@
                     {% call tbody() %}
                         <template x-if="sources.length === 0">
                             <tr>
-                                <td colspan="8" class="text-center py-4">
+                                <td colspan="9" class="text-center py-4">
                                     <div class="text-muted-foreground" x-show="sourcesLoading">Loading sending sources...</div>
                                     <div class="text-red-700" x-show="!sourcesLoading && sourcesError" x-text="sourcesError"></div>
                                     <div class="text-muted-foreground" x-show="!sourcesLoading && !sourcesError && sourceEvidenceCount === 0">
@@ -1469,10 +1470,16 @@
                                     <div class="flex flex-col">
                                         <span class="font-mono text-sm" x-text="source.ip"></span>
                                         <template x-if="source.hostname">
-                                            <span class="text-xs text-muted-foreground" x-text="source.hostname"></span>
+                                            <span class="text-xs text-muted-foreground">
+                                                <span>PTR </span>
+                                                <span x-text="source.hostname"></span>
+                                            </span>
+                                        </template>
+                                        <template x-if="!source.hostname">
+                                            <span class="text-xs text-muted-foreground">PTR unavailable</span>
                                         </template>
                                         <template x-if="source.geo">
-                                            <span class="text-xs text-muted-foreground" x-text="source.geo.region + ' · ' + (source.geo.network || source.geo.country)"></span>
+                                            <span class="text-xs text-muted-foreground" x-text="sourceGeoSummary(source)"></span>
                                         </template>
                                         <template x-if="source.anomalies?.length">
                                             <span class="mt-1 inline-flex w-fit rounded-full px-2 py-0.5 text-xs font-semibold"
@@ -1501,6 +1508,46 @@
                                         </template>
                                         <template x-if="source.sender?.remediation_hint">
                                             <p class="text-xs" x-text="source.sender.remediation_hint"></p>
+                                        </template>
+                                    </div>
+                                {% endcall %}
+                                {% call td() %}
+                                    <div class="min-w-60 space-y-2 text-xs">
+                                        <div class="flex flex-wrap gap-1.5">
+                                            <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80">
+                                                <span x-text="source.geo?.country_code || 'ZZ'"></span>
+                                                <span class="mx-1">·</span>
+                                                <span x-text="source.geo?.country && source.geo.country !== 'Unknown' ? source.geo.country : 'Country unknown'"></span>
+                                            </span>
+                                            <template x-if="source.geo?.asn">
+                                                <span class="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 font-medium text-blue-800" x-text="source.geo.asn"></span>
+                                            </template>
+                                            <template x-if="source.geo?.network">
+                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80" x-text="source.geo.network"></span>
+                                            </template>
+                                        </div>
+                                        <div class="flex flex-wrap items-center gap-1.5">
+                                            <span
+                                                class="inline-flex items-center rounded-full px-2 py-0.5 font-semibold"
+                                                :class="reputationStatusClass(source.reputation?.status)"
+                                                x-text="source.reputation?.status || 'reputation unknown'"
+                                            ></span>
+                                            <template x-if="source.reputation?.risk_score !== undefined && source.reputation?.risk_score !== null">
+                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80" x-text="'risk ' + source.reputation.risk_score + '/100'"></span>
+                                            </template>
+                                        </div>
+                                        <template x-if="source.reputation?.listings?.length">
+                                            <p class="text-muted-foreground">
+                                                <span>Listed on </span>
+                                                <span x-text="source.reputation.listings.slice(0, 2).join(', ')"></span>
+                                                <span x-show="source.reputation.listings.length > 2" x-text="' +' + (source.reputation.listings.length - 2)"></span>
+                                            </p>
+                                        </template>
+                                        <template x-if="source.reputation?.summary">
+                                            <p class="text-muted-foreground" x-text="source.reputation.summary"></p>
+                                        </template>
+                                        <template x-if="!source.geo?.asn && !source.geo?.network && !source.reputation">
+                                            <p class="text-muted-foreground">No ASN or reputation evidence available yet.</p>
                                         </template>
                                     </div>
                                 {% endcall %}
@@ -1984,6 +2031,14 @@ function domainDetailsApp(domainId) {
                     source.sender?.name,
                     source.sender?.provider,
                     source.sender?.status,
+                    source.geo?.country,
+                    source.geo?.country_code,
+                    source.geo?.region,
+                    source.geo?.asn,
+                    source.geo?.network,
+                    source.reputation?.status,
+                    source.reputation?.summary,
+                    ...(source.reputation?.listings || []),
                 ].some(value => String(value || '').toLowerCase().includes(needle));
             });
         },
@@ -2252,6 +2307,19 @@ function domainDetailsApp(domainId) {
             if (status === 'ambiguous') return 'bg-yellow-100 text-yellow-800';
             if (status === 'suspicious') return 'bg-red-100 text-red-800';
             return 'bg-gray-100 text-gray-700';
+        },
+
+        reputationStatusClass(status) {
+            if (['listed', 'critical'].includes(status)) return 'bg-red-100 text-red-800';
+            if (['suspicious', 'watch', 'warning'].includes(status)) return 'bg-yellow-100 text-yellow-800';
+            if (status === 'clean') return 'bg-green-100 text-green-800';
+            return 'bg-gray-100 text-gray-700';
+        },
+
+        sourceGeoSummary(source) {
+            const geo = source?.geo || {};
+            const parts = [geo.region, geo.network || geo.country].filter(Boolean);
+            return parts.length ? parts.join(' · ') : 'Geo unavailable';
         },
 
         formatLargeNumber(value) {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -294,6 +294,27 @@ def test_domain_details_exposes_ownership_and_delete_controls_without_html_injec
     assert "x-html" not in template
 
 
+def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
+    template = (
+        Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"
+    ).read_text()
+
+    assert "IP Intelligence" in template
+    assert "PTR unavailable" in template
+    assert "sourceGeoSummary(source)" in template
+    assert "source.geo?.country_code" in template
+    assert "source.geo?.country" in template
+    assert "source.geo?.region" in template
+    assert "source.geo?.asn" in template
+    assert "source.geo?.network" in template
+    assert "source.reputation?.status" in template
+    assert "source.reputation?.risk_score" in template
+    assert "source.reputation?.listings" in template
+    assert "reputationStatusClass" in template
+    assert 'colspan="9"' in template
+    assert "x-html" not in template
+
+
 def test_domain_details_redirects_to_domain_management_after_delete_success():
     template = (
         Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -237,8 +237,8 @@ def test_domain_details_exposes_volume_scale_controls_without_html_injection():
     assert 'role="group" aria-label="Volume scale"' in template
     assert "setVolumeScale('logarithmic')" in template
     assert "setVolumeScale('linear')" in template
-    assert ':aria-pressed="effectiveVolumeScale() === \'logarithmic\'"' in template
-    assert ':aria-pressed="effectiveVolumeScale() === \'linear\'"' in template
+    assert ":aria-pressed=\"effectiveVolumeScale() === 'logarithmic'\"" in template
+    assert ":aria-pressed=\"effectiveVolumeScale() === 'linear'\"" in template
     assert ':disabled="!hasObservedVolume"' in template
     assert "dmarq:domain-volume-scale" in template
     assert "effectiveVolumeScale()" in template
@@ -302,6 +302,8 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "IP Intelligence" in template
     assert "PTR unavailable" in template
     assert "sourceGeoSummary(source)" in template
+    assert "String(value).trim().toLowerCase() !== 'unknown'" in template
+    assert "Geo unavailable" in template
     assert "source.geo?.country_code" in template
     assert "source.geo?.country" in template
     assert "source.geo?.region" in template

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -26,6 +26,11 @@ from app.models.workspace_access import WorkspaceAuditLog
 from app.services import report_persistence
 from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.report_store import ReportStore
+from app.services.source_reputation import (
+    DomainReputation,
+    ReputationEvidence,
+    SourceReputation,
+)
 from app.services.webhook_events import (
     EVENT_REMEDIATION_APPROVAL_REQUIRED,
     create_webhook_endpoint,
@@ -2370,6 +2375,93 @@ def test_get_domain_sources_includes_geo_and_anomaly_hints(seeded_client: TestCl
     assert any(anomaly["type"] == "new_sender" for anomaly in source["anomalies"])
     recommendation_types = {item["type"] for item in source["recommendations"]}
     assert "anomaly_new_sender" in recommendation_types
+
+
+def test_get_domain_sources_includes_ip_intelligence_and_reputation(
+    seeded_client: TestClient, db_session, monkeypatch: pytest.MonkeyPatch
+):
+    """Source rows include PTR, geo/ASN, and reputation details for UI guidance."""
+
+    source_ip = "193.138.195.141"
+
+    async def fake_ptr_lookup(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
+        return "smtp.customer.example" if ip == source_ip else None
+
+    async def fake_reputation(*_args, **_kwargs):
+        return (
+            DomainReputation(
+                domain=DOMAIN,
+                status="attention",
+                checked_at="2026-07-02T08:00:00Z",
+                summary={"listed": 1, "suspicious": 0, "clean": 0, "unknown": 0},
+                sources=[
+                    SourceReputation(
+                        ip=source_ip,
+                        status="listed",
+                        risk_score=85,
+                        summary="Observed source is listed by a reputation feed.",
+                        listings=["Spamhaus Zen"],
+                        evidence=[
+                            ReputationEvidence(
+                                label="External feed",
+                                value="Spamhaus Zen",
+                                source="dnsbl",
+                            )
+                        ],
+                        recommendations=[
+                            "Review the listed IP with the named reputation provider.",
+                        ],
+                        checked_at="2026-07-02T08:00:00Z",
+                    )
+                ],
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
+    workspace = get_or_create_default_workspace(db_session)
+    report = {
+        **REPORT_DICT_POLICY,
+        "report_id": "rpt-source-intelligence",
+        "records": [
+            {
+                "source_ip": source_ip,
+                "count": 20,
+                "disposition": "reject",
+                "dkim_result": "fail",
+                "spf_result": "fail",
+                "header_from": DOMAIN,
+                "extensions": {
+                    "geo:country": "Germany",
+                    "geo:country_code": "DE",
+                    "geo:region": "Europe",
+                    "geo:asn": "AS24940",
+                    "geo:network": "Hetzner Online GmbH",
+                },
+            }
+        ],
+        "summary": {"total_count": 20, "passed_count": 0, "failed_count": 20},
+    }
+    report_persistence.save_parsed_report(db_session, report, workspace_id=workspace.id)
+    db_session.commit()
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=30")
+
+    assert response.status_code == 200
+    source = next(item for item in response.json()["sources"] if item["ip"] == source_ip)
+    assert source["hostname"] == "smtp.customer.example"
+    assert source["geo"]["country"] == "Germany"
+    assert source["geo"]["country_code"] == "DE"
+    assert source["geo"]["region"] == "Europe"
+    assert source["geo"]["asn"] == "AS24940"
+    assert source["geo"]["network"] == "Hetzner Online GmbH"
+    assert source["reputation"]["status"] == "listed"
+    assert source["reputation"]["risk_score"] == 85
+    assert source["reputation"]["listings"] == ["Spamhaus Zen"]
+    recommendation_types = {item["type"] for item in source["recommendations"]}
+    assert "source_reputation" in recommendation_types
 
 
 def test_source_recommendations_cover_common_cases():


### PR DESCRIPTION
## Summary
- add visible PTR, geo, ASN/network, reputation, and DNSBL/listing context to the domain sending sources table
- make the sending-source search cover geo/reputation/listing fields
- add API and template regression coverage for persisted report source intelligence

Fixes #464

## Local validation
- .venv/bin/pytest backend/app/tests/test_domain_detail_endpoints.py -k "domain_sources"
- .venv/bin/pytest backend/app/tests/test_dashboard_template_security.py -k "source_ip_intelligence or ownership"
- git diff --check