### PR TITLE
Hide workspace controls in single-user mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ ENVIRONMENT="development"
 # Public URL used for OAuth callbacks when DMARQ is behind a proxy/ingress.
 # PUBLIC_BASE_URL="https://app.example.com"
 
+# Self-hosted installs default to a single visible workspace. Enable this for
+# SaaS, ISP/MSP, or operator deployments that need workspace switching and
+# member management in the UI.
+# MULTI_WORKSPACE_UI_ENABLED=false
+
 # Database
 DATABASE_URL="sqlite:///./dmarq.db"
 # For production, use PostgreSQL:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -24,6 +24,9 @@ class Settings(BaseSettings):
     ENVIRONMENT: str = "development"
     DEMO_MODE: bool = False
     PUBLIC_BASE_URL: Optional[str] = None
+    # Self-hosted installs default to a single workspace. Enable this for SaaS,
+    # ISP/MSP, or admin deployments that need explicit workspace switching.
+    MULTI_WORKSPACE_UI_ENABLED: bool = False
 
     # Database
     # Default to a sub-directory so the SQLite file lives in a location that

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -572,6 +572,7 @@ app = create_app()  # noqa: F811 – intentional rebind; `app` package imported 
 # Initialize Jinja2 templates
 templates_dir = os.path.join(os.path.dirname(__file__), "templates")
 templates = Jinja2Templates(directory=templates_dir)
+templates.env.globals["multi_workspace_ui_enabled"] = settings.MULTI_WORKSPACE_UI_ENABLED
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/backend/app/static/js/base-layout.js
+++ b/backend/app/static/js/base-layout.js
@@ -80,14 +80,25 @@ document.addEventListener('alpine:init', () => {
     const originalFetch = window.fetch;
     const multiWorkspaceUiEnabled = () =>
         document.documentElement.dataset.multiWorkspaceUi === 'true';
+    const workspaceHeaderName = 'X-DMARQ-Workspace-ID';
     const normalizeWorkspaceId = (workspaceId) => {
         const trimmed = String(workspaceId || '').trim();
         return /^[1-9]\d*$/.test(trimmed) ? trimmed : '';
     };
+    const withoutWorkspaceContext = (input, init) => {
+        const headers = new Headers((init && init.headers) || (input && input.headers) || {});
+        if (!headers.has(workspaceHeaderName)) {
+            return init;
+        }
+        const nextInit = Object.assign({}, init || {});
+        headers.delete(workspaceHeaderName);
+        nextInit.headers = headers;
+        return nextInit;
+    };
 
     window.fetch = function dmarqWorkspaceFetch(input, init) {
         if (!multiWorkspaceUiEnabled()) {
-            return originalFetch(input, init);
+            return originalFetch(input, withoutWorkspaceContext(input, init));
         }
         const workspaceId = normalizeWorkspaceId(localStorage.getItem('dmarq.selectedWorkspaceId'));
         const url =
@@ -103,8 +114,8 @@ document.addEventListener('alpine:init', () => {
         }
         const nextInit = Object.assign({}, init || {});
         const headers = new Headers(nextInit.headers || (input && input.headers) || {});
-        if (!headers.has('X-DMARQ-Workspace-ID')) {
-            headers.set('X-DMARQ-Workspace-ID', workspaceId);
+        if (!headers.has(workspaceHeaderName)) {
+            headers.set(workspaceHeaderName, workspaceId);
         }
         nextInit.headers = headers;
         return originalFetch(input, nextInit);

--- a/backend/app/static/js/base-layout.js
+++ b/backend/app/static/js/base-layout.js
@@ -1,71 +1,94 @@
 document.addEventListener('alpine:init', () => {
-    Alpine.data('userMenu', () => ({
-        user: null,
-        workspaces: [],
-        selectedWorkspaceId: localStorage.getItem('dmarq.selectedWorkspaceId') || '',
-        async loadUser() {
-            try {
-                const res = await fetch('/api/v1/auth/me');
-                if (res.ok) {
-                    this.user = await res.json();
+    const multiWorkspaceUiEnabled = () =>
+        document.documentElement.dataset.multiWorkspaceUi === 'true';
+
+    Alpine.data('userMenu', (options = {}) => {
+        const enabled =
+            options.multiWorkspaceUiEnabled === undefined
+                ? multiWorkspaceUiEnabled()
+                : Boolean(options.multiWorkspaceUiEnabled);
+        return {
+            user: null,
+            workspaces: [],
+            multiWorkspaceUiEnabled: enabled,
+            selectedWorkspaceId: enabled
+                ? localStorage.getItem('dmarq.selectedWorkspaceId') || ''
+                : '',
+            async loadUser() {
+                try {
+                    const res = await fetch('/api/v1/auth/me');
+                    if (res.ok) {
+                        this.user = await res.json();
+                    }
+                } catch (_) {
+                    // User identity is optional for public or setup views.
                 }
-            } catch (_) {
-                // User identity is optional for public or setup views.
-            }
-            await this.loadWorkspaces();
-        },
-        async loadWorkspaces() {
-            try {
-                const res = await fetch('/api/v1/workspaces');
-                if (!res.ok) {
+                if (!this.multiWorkspaceUiEnabled) {
+                    localStorage.removeItem('dmarq.selectedWorkspaceId');
+                    this.workspaces = [];
+                    this.selectedWorkspaceId = '';
                     return;
                 }
-                const data = await res.json();
-                this.workspaces = data.workspaces || [];
-                const saved = String(this.selectedWorkspaceId || '');
-                const selected = this.workspaces.find(
-                    (workspace) => String(workspace.id) === saved && workspace.active
-                );
-                const fallback =
-                    this.workspaces.find((workspace) => workspace.active) || this.workspaces[0];
-                if (!selected && fallback) {
-                    this.selectWorkspace(String(fallback.id));
-                } else if (selected) {
-                    this.selectWorkspace(String(selected.id));
+                await this.loadWorkspaces();
+            },
+            async loadWorkspaces() {
+                try {
+                    const res = await fetch('/api/v1/workspaces');
+                    if (!res.ok) {
+                        return;
+                    }
+                    const data = await res.json();
+                    this.workspaces = data.workspaces || [];
+                    const saved = String(this.selectedWorkspaceId || '');
+                    const selected = this.workspaces.find(
+                        (workspace) => String(workspace.id) === saved && workspace.active
+                    );
+                    const fallback =
+                        this.workspaces.find((workspace) => workspace.active) || this.workspaces[0];
+                    if (!selected && fallback) {
+                        this.selectWorkspace(String(fallback.id));
+                    } else if (selected) {
+                        this.selectWorkspace(String(selected.id));
+                    }
+                } catch (_) {
+                    // Workspace selection is optional for single-tenant installs.
                 }
-            } catch (_) {
-                // Workspace selection is optional for single-tenant installs.
-            }
-        },
-        selectWorkspace(workspaceId) {
-            this.selectedWorkspaceId = workspaceId || '';
-            if (this.selectedWorkspaceId) {
-                localStorage.setItem('dmarq.selectedWorkspaceId', this.selectedWorkspaceId);
-            } else {
-                localStorage.removeItem('dmarq.selectedWorkspaceId');
-            }
-            window.dispatchEvent(
-                new CustomEvent('dmarq:workspace-changed', {
-                    detail: { workspaceId: this.selectedWorkspaceId },
-                })
-            );
-        },
-        workspaceLabel(workspace) {
-            const prefix = workspace.organization ? `${workspace.organization.name} / ` : '';
-            const suffix = workspace.active ? '' : ' (inactive)';
-            return `${prefix}${workspace.name}${suffix}`;
-        },
-    }));
+            },
+            selectWorkspace(workspaceId) {
+                this.selectedWorkspaceId = workspaceId || '';
+                if (this.selectedWorkspaceId) {
+                    localStorage.setItem('dmarq.selectedWorkspaceId', this.selectedWorkspaceId);
+                } else {
+                    localStorage.removeItem('dmarq.selectedWorkspaceId');
+                }
+                window.dispatchEvent(
+                    new CustomEvent('dmarq:workspace-changed', {
+                        detail: { workspaceId: this.selectedWorkspaceId },
+                    })
+                );
+            },
+            workspaceLabel(workspace) {
+                const prefix = workspace.organization ? `${workspace.organization.name} / ` : '';
+                const suffix = workspace.active ? '' : ' (inactive)';
+                return `${prefix}${workspace.name}${suffix}`;
+            },
+        };
+    });
 });
 
 (function attachWorkspaceContextToFetch() {
     const originalFetch = window.fetch;
+    const multiWorkspaceUiEnabled = () =>
+        document.documentElement.dataset.multiWorkspaceUi === 'true';
     const normalizeWorkspaceId = (workspaceId) => {
         const trimmed = String(workspaceId || '').trim();
         return /^[1-9]\d*$/.test(trimmed) ? trimmed : '';
     };
 
     window.fetch = function dmarqWorkspaceFetch(input, init) {
+        if (!multiWorkspaceUiEnabled()) {
+            return originalFetch(input, init);
+        }
         const workspaceId = normalizeWorkspaceId(localStorage.getItem('dmarq.selectedWorkspaceId'));
         const url =
             input instanceof URL

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{% set multi_workspace_ui_enabled = multi_workspace_ui_enabled | default(false) %}
 <html lang="en" data-theme="dmarqlight" data-multi-workspace-ui="{{ 'true' if multi_workspace_ui_enabled else 'false' }}" class="dark:data-theme-dmarqdark">
 <head>
     <meta charset="UTF-8">

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dmarqlight" class="dark:data-theme-dmarqdark">
+<html lang="en" data-theme="dmarqlight" data-multi-workspace-ui="{{ 'true' if multi_workspace_ui_enabled else 'false' }}" class="dark:data-theme-dmarqdark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -28,7 +28,7 @@
 </head>
 <body class="min-h-screen bg-[#f4f3f2] font-body antialiased text-[#07071f]">
     <header class="fixed inset-x-0 top-0 z-40 flex h-24 items-center bg-[#272a5f] px-5 text-white shadow-sm md:px-10"
-            x-data="userMenu()" x-init="loadUser()">
+            x-data="userMenu({ multiWorkspaceUiEnabled: {{ multi_workspace_ui_enabled | tojson }} })" x-init="loadUser()">
         <div class="flex flex-1 items-center">
             <a href="/" class="inline-flex items-center gap-4" aria-label="DMARQ Dashboard">
                 <span class="grid h-12 w-12 place-items-center bg-[#272a5f]" aria-hidden="true">
@@ -42,6 +42,7 @@
             </a>
         </div>
         <div class="flex items-center gap-3">
+            {% if multi_workspace_ui_enabled %}
             <div class="hidden min-w-48 md:block" x-show="workspaces.length > 0" x-cloak>
                 <label class="sr-only" for="workspace-switcher">Workspace</label>
                 <select id="workspace-switcher"
@@ -55,13 +56,16 @@
                     </template>
                 </select>
             </div>
+            {% endif %}
             <nav class="hidden items-center gap-1 text-sm font-semibold lg:flex" aria-label="Primary">
                 <a href="/" class="rounded-md px-3 py-2 text-white/90 hover:bg-white/10">Dashboard</a>
                 <a href="/domains" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Domains</a>
                 <a href="/reports" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Reports</a>
                 <a href="/forensics" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Forensics</a>
                 <a href="/tls-reports" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">TLS</a>
+                {% if multi_workspace_ui_enabled %}
                 <a href="/members" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Members</a>
+                {% endif %}
                 <a href="/onboarding" class="rounded-md px-3 py-2 text-white/80 hover:bg-white/10">Onboarding</a>
             </nav>
             <div>
@@ -83,7 +87,9 @@
                                 <span class="text-xs text-base-content/50 truncate" x-text="user.email" x-show="user.full_name"></span>
                             </li>
                             <li><a href="/profile">Profile &amp; Security</a></li>
+                            {% if multi_workspace_ui_enabled %}
                             <li><a href="/members">Members</a></li>
+                            {% endif %}
                             <li><a href="/settings">Settings</a></li>
                             <li>
                                 <a href="/api/v1/auth/sign-out" class="text-error">
@@ -116,9 +122,11 @@
         <a href="/forensics" aria-label="Forensics" title="Forensics" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 4h14v16H5V4Zm3 4v2h8V8H8Zm0 4v2h8v-2H8Zm0 4v2h5v-2H8Z"/></svg>
         </a>
+        {% if multi_workspace_ui_enabled %}
         <a href="/members" aria-label="Members" title="Members" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8.5 11a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Zm7 1a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM2 19.5C2 15.9 4.9 13 8.5 13S15 15.9 15 19.5V21H2v-1.5Zm12.8 1.5v-1.5c0-2-.7-3.8-1.9-5.2.8-.2 1.7-.3 2.6-.3 3 0 5.5 2.5 5.5 5.5V21h-6.2Z"/></svg>
         </a>
+        {% endif %}
         <a href="/onboarding" aria-label="Onboarding" title="Onboarding" class="rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4 4h16v4H4V4Zm0 6h7v10H4V10Zm9 0h7v4h-7v-4Zm0 6h7v4h-7v-4Z"/></svg>
         </a>

--- a/backend/app/tests/test_config.py
+++ b/backend/app/tests/test_config.py
@@ -69,6 +69,20 @@ class TestBackendCorsOriginsValidator:
         ]
 
 
+class TestWorkspaceUiMode:
+    """Tests for self-hosted versus multi-workspace UI settings."""
+
+    def test_multi_workspace_ui_defaults_to_disabled(self):
+        settings = Settings()
+
+        assert settings.MULTI_WORKSPACE_UI_ENABLED is False
+
+    def test_multi_workspace_ui_can_be_enabled_explicitly(self):
+        settings = Settings(MULTI_WORKSPACE_UI_ENABLED=True)
+
+        assert settings.MULTI_WORKSPACE_UI_ENABLED is True
+
+
 class TestMakeSyncDbUrl:
     """Tests for the _make_sync_db_url() URL normalization helper."""
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -344,11 +344,34 @@ def test_base_template_propagates_selected_workspace_context():
     script = (Path(__file__).resolve().parents[1] / "static" / "js" / "base-layout.js").read_text()
 
     assert 'src="/static/js/base-layout.js"' in template
+    assert "data-multi-workspace-ui" in template
+    assert "multiWorkspaceUiEnabled" in template
     assert "/api/v1/workspaces" in script
     assert "dmarq.selectedWorkspaceId" in script
     assert "X-DMARQ-Workspace-ID" in script
     assert "dmarq:workspace-changed" in script
+    assert "localStorage.removeItem('dmarq.selectedWorkspaceId')" in script
     assert "input instanceof URL" in script
+
+
+def test_base_template_hides_workspace_controls_in_single_user_mode():
+    rendered = _render_template("layouts/base.html", multi_workspace_ui_enabled=False)
+
+    assert 'data-multi-workspace-ui="false"' in rendered
+    assert 'id="workspace-switcher"' not in rendered
+    assert 'href="/members"' not in rendered
+    assert 'aria-label="Members"' not in rendered
+    assert "Members</a>" not in rendered
+
+
+def test_base_template_shows_workspace_controls_when_multi_workspace_enabled():
+    rendered = _render_template("layouts/base.html", multi_workspace_ui_enabled=True)
+
+    assert 'data-multi-workspace-ui="true"' in rendered
+    assert 'id="workspace-switcher"' in rendered
+    assert 'href="/members"' in rendered
+    assert 'aria-label="Members"' in rendered
+    assert "Members</a>" in rendered
 
 
 def test_dashboard_hides_multi_user_demo_mode_controls():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -237,8 +237,8 @@ def test_domain_details_exposes_volume_scale_controls_without_html_injection():
     assert 'role="group" aria-label="Volume scale"' in template
     assert "setVolumeScale('logarithmic')" in template
     assert "setVolumeScale('linear')" in template
-    assert ':aria-pressed="effectiveVolumeScale() === \'logarithmic\'"' in template
-    assert ':aria-pressed="effectiveVolumeScale() === \'linear\'"' in template
+    assert ":aria-pressed=\"effectiveVolumeScale() === 'logarithmic'\"" in template
+    assert ":aria-pressed=\"effectiveVolumeScale() === 'linear'\"" in template
     assert ':disabled="!hasObservedVolume"' in template
     assert "dmarq:domain-volume-scale" in template
     assert "effectiveVolumeScale()" in template
@@ -349,6 +349,8 @@ def test_base_template_propagates_selected_workspace_context():
     assert "/api/v1/workspaces" in script
     assert "dmarq.selectedWorkspaceId" in script
     assert "X-DMARQ-Workspace-ID" in script
+    assert "withoutWorkspaceContext(input, init)" in script
+    assert "headers.delete(workspaceHeaderName)" in script
     assert "dmarq:workspace-changed" in script
     assert "localStorage.removeItem('dmarq.selectedWorkspaceId')" in script
     assert "input instanceof URL" in script

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -53,6 +53,7 @@ paths.
 | `AUTH_MODE` | Browser authentication mode: `auto`, `disabled`, `logto`, `authentik`, `oidc`, or `trusted_proxy` | `auto` | `authentik` |
 | `AUTH_DISABLED` | Disable authentication entirely. Only use for local development or a separately protected deployment. | `false` | `true`, `false` |
 | `PUBLIC_BASE_URL` | Public URL used when building OAuth callback URLs behind a reverse proxy or ingress | Auto-detected | `https://dmarq.example.com` |
+| `MULTI_WORKSPACE_UI_ENABLED` | Show workspace switching and Members access-control navigation. Keep disabled for self-hosted single-workspace installs. | `false` | `true`, `false` |
 
 #### Logto
 


### PR DESCRIPTION
## Summary
- add an explicit MULTI_WORKSPACE_UI_ENABLED flag, defaulting self-hosted installs to single-workspace UI
- hide workspace switcher and Members navigation unless multi-workspace UI is enabled
- prevent stale selected workspace localStorage from adding workspace headers when the UI mode is disabled
- document the flag in .env.example and deployment configuration

Fixes #465

## Local validation
- .venv/bin/pytest backend/app/tests/test_dashboard_template_security.py -k "base_template"
- .venv/bin/pytest backend/app/tests/test_config.py -k "WorkspaceUiMode"
- .venv/bin/pytest backend/app/tests/test_security.py -k "base_template"
- node --check backend/app/static/js/base-layout.js
- git diff --check