### PR TITLE
Simplify single-user onboarding

### DIFF
--- a/backend/app/templates/onboarding.html
+++ b/backend/app/templates/onboarding.html
@@ -1,16 +1,25 @@
 {% extends "layouts/base.html" %}
 
-{% block title %}DMARQ - Workspace Onboarding{% endblock %}
+{% block title %}DMARQ - {{ "Workspace Onboarding" if multi_workspace_ui_enabled else "Mail Health Setup" }}{% endblock %}
 
 {% block content %}
-<div class="mx-auto max-w-7xl space-y-6" x-data="workspaceOnboarding()" x-init="init()" x-cloak>
+<div class="mx-auto max-w-7xl space-y-6"
+     x-data="workspaceOnboarding({ multiWorkspaceUiEnabled: {{ multi_workspace_ui_enabled | tojson }} })"
+     x-init="init()" x-cloak>
     <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
             <p class="text-sm font-semibold uppercase tracking-wide text-[#2f9da6]">Guided setup</p>
-            <h1 class="mt-1 text-3xl font-semibold text-[#07071f]">Workspace onboarding</h1>
+            <h1 class="mt-1 text-3xl font-semibold text-[#07071f]">
+                {{ "Workspace onboarding" if multi_workspace_ui_enabled else "Mail health setup" }}
+            </h1>
             <p class="mt-2 max-w-3xl text-sm leading-6 text-[#07071f]/70">
+                {% if multi_workspace_ui_enabled %}
                 Create the customer boundary, monitored domain, safe starter entitlement,
                 and the next DNS/reporting tasks from one browser flow.
+                {% else %}
+                Connect DMARC reports, add your first domain, check DNS posture,
+                and prepare the next safe remediation steps for this instance.
+                {% endif %}
             </p>
         </div>
         <div class="flex flex-wrap gap-2">
@@ -20,7 +29,7 @@
             </button>
             <button type="button" class="btn btn-primary" @click="applyPlan" :disabled="saving">
                 <span x-show="applying" class="loading loading-spinner loading-xs"></span>
-                Create workspace
+                {{ "Create workspace" if multi_workspace_ui_enabled else "Apply setup" }}
             </button>
         </div>
     </div>
@@ -32,7 +41,7 @@
     <div x-show="success" role="alert" class="alert alert-success">
         <div>
             <p class="font-semibold" x-text="success"></p>
-            <p class="text-sm" x-show="result?.workspace">
+            <p class="text-sm" x-show="multiWorkspaceUiEnabled && result?.workspace">
                 The active browser workspace has been switched to
                 <span class="font-medium" x-text="result?.workspace?.name"></span>.
             </p>
@@ -42,6 +51,7 @@
     <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]">
         <section class="space-y-6">
             <div class="grid gap-6 xl:grid-cols-2">
+                {% if multi_workspace_ui_enabled %}
                 <div class="rounded-lg bg-white p-6 shadow-sm">
                     <div class="flex items-start justify-between gap-4">
                         <div>
@@ -73,14 +83,49 @@
                                   placeholder="Primary domains and DMARC aggregate reports for Acme."></textarea>
                     </label>
                 </div>
+                {% else %}
+                <div class="rounded-lg bg-white p-6 shadow-sm">
+                    <div class="flex items-start justify-between gap-4">
+                        <div>
+                            <h2 class="text-xl font-semibold">Setup path</h2>
+                            <p class="mt-1 text-sm leading-6 text-[#07071f]/65">
+                                Start with one monitored domain, then expand from the domain list
+                                once reports and DNS checks are working.
+                            </p>
+                        </div>
+                        <span class="rounded-full bg-[#2f9da6]/10 px-3 py-1 text-xs font-semibold text-[#1f747b]">
+                            Self-hosted
+                        </span>
+                    </div>
+                    <ol class="mt-5 space-y-3 text-sm text-[#07071f]/70">
+                        <li class="flex gap-3">
+                            <span class="grid h-6 w-6 flex-none place-items-center rounded-full bg-[#272a5f] text-xs font-semibold text-white">1</span>
+                            <span>Connect Gmail or IMAP so DMARQ can discover aggregate reports.</span>
+                        </li>
+                        <li class="flex gap-3">
+                            <span class="grid h-6 w-6 flex-none place-items-center rounded-full bg-[#2f9da6] text-xs font-semibold text-white">2</span>
+                            <span>Add or import domains, then verify ownership before DNS repair actions.</span>
+                        </li>
+                        <li class="flex gap-3">
+                            <span class="grid h-6 w-6 flex-none place-items-center rounded-full bg-[#ff6b35] text-xs font-semibold text-white">3</span>
+                            <span>Review DMARC, SPF, DKIM, MTA-STS, and remediation readiness.</span>
+                        </li>
+                    </ol>
+                </div>
+                {% endif %}
 
                 <div class="rounded-lg bg-white p-6 shadow-sm">
                     <div class="flex items-start justify-between gap-4">
                         <div>
                             <h2 class="text-xl font-semibold">Domain and DNS</h2>
                             <p class="mt-1 text-sm leading-6 text-[#07071f]/65">
+                                {% if multi_workspace_ui_enabled %}
                                 The domain starts unverified, so production fetching stays blocked
                                 until DNS ownership is confirmed.
+                                {% else %}
+                                Add the first domain to monitor. DMARQ will show DNS health,
+                                report coverage, and human-approved repair steps.
+                                {% endif %}
                             </p>
                         </div>
                         <span class="rounded-full bg-[#ff6b35]/10 px-3 py-1 text-xs font-semibold text-[#c94c21]">
@@ -117,8 +162,13 @@
                     <div>
                         <h2 class="text-xl font-semibold">Report ingestion path</h2>
                         <p class="mt-1 max-w-2xl text-sm leading-6 text-[#07071f]/65">
+                            {% if multi_workspace_ui_enabled %}
                             Choose whether this workspace should stage a disabled IMAP source now
                             or start as a DNS-only assessment.
+                            {% else %}
+                            Choose whether DMARQ should prepare a report mailbox connection now
+                            or start with DNS posture checks first.
+                            {% endif %}
                         </p>
                     </div>
                     <div class="join">
@@ -150,8 +200,12 @@
                 </div>
 
                 <div x-show="form.mailSourcePath === 'dns_only'" class="mt-5 rounded-lg border border-[#2f9da6]/25 bg-[#2f9da6]/10 p-4 text-sm leading-6 text-[#07071f]/75">
-                    DMARQ will create the workspace and DNS checklist without storing mailbox
-                    credentials. A report source can be connected later from Mail Sources.
+                    {% if multi_workspace_ui_enabled %}
+                    DMARQ will create the workspace and DNS checklist without storing mailbox credentials.
+                    {% else %}
+                    DMARQ will create the domain checklist without storing mailbox credentials.
+                    {% endif %}
+                    A report source can be connected later from Mail Sources.
                 </div>
             </div>
         </section>
@@ -160,6 +214,7 @@
             <div class="rounded-lg bg-white p-6 shadow-sm">
                 <h2 class="text-lg font-semibold">What will be created</h2>
                 <ul class="mt-4 space-y-3 text-sm text-[#07071f]/70">
+                    {% if multi_workspace_ui_enabled %}
                     <li class="flex gap-3">
                         <span class="mt-2 h-2 w-2 rounded-full bg-[#272a5f]"></span>
                         <span>Organization and workspace, with the signed-in user as owner when a local user exists.</span>
@@ -176,6 +231,24 @@
                         <span class="mt-2 h-2 w-2 rounded-full bg-[#62678f]"></span>
                         <span>Actionable DNS, mail-source, import, and alerting follow-up tasks.</span>
                     </li>
+                    {% else %}
+                    <li class="flex gap-3">
+                        <span class="mt-2 h-2 w-2 rounded-full bg-[#272a5f]"></span>
+                        <span>One monitored domain with DMARC report and DNS setup tasks.</span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="mt-2 h-2 w-2 rounded-full bg-[#2f9da6]"></span>
+                        <span>A report ingestion path for Gmail, IMAP, or later mailbox setup.</span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="mt-2 h-2 w-2 rounded-full bg-[#ff6b35]"></span>
+                        <span>DNS health checks and ownership-gated repair guidance.</span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="mt-2 h-2 w-2 rounded-full bg-[#62678f]"></span>
+                        <span>Remediation follow-up tasks focused on safer mail delivery.</span>
+                    </li>
+                    {% endif %}
                 </ul>
             </div>
 
@@ -187,7 +260,9 @@
                 </div>
                 <div class="mt-4 space-y-3">
                     <template x-if="!tasks.length">
-                        <p class="rounded-lg border border-dashed border-[#07071f]/20 p-4 text-sm text-[#07071f]/60">Preview or create the workspace to see the exact follow-up list.</p>
+                        <p class="rounded-lg border border-dashed border-[#07071f]/20 p-4 text-sm text-[#07071f]/60">
+                            Preview or apply setup to see the exact follow-up list.
+                        </p>
                     </template>
                     <template x-for="task in tasks" :key="task.id">
                         <a :href="task.href || '#'"
@@ -210,8 +285,9 @@
 
 {% block scripts %}
 <script>
-function workspaceOnboarding() {
+function workspaceOnboarding(options = {}) {
     return {
+        multiWorkspaceUiEnabled: Boolean(options.multiWorkspaceUiEnabled),
         previewing: false,
         applying: false,
         error: '',
@@ -233,6 +309,9 @@ function workspaceOnboarding() {
         },
         get saving() {
             return this.previewing || this.applying;
+        },
+        get singleUserMode() {
+            return !this.multiWorkspaceUiEnabled;
         },
         init() {
             this.draftFields().forEach((field) => {
@@ -261,8 +340,13 @@ function workspaceOnboarding() {
         },
         payload() {
             const domain = this.normalizeDomain(this.form.domain);
-            const workspaceName = this.form.workspaceName.trim() || this.form.organizationName.trim() || domain;
-            const organizationName = this.form.organizationName.trim() || workspaceName;
+            const fallbackName = domain || 'Default workspace';
+            const workspaceName = this.singleUserMode
+                ? fallbackName
+                : this.form.workspaceName.trim() || this.form.organizationName.trim() || fallbackName;
+            const organizationName = this.singleUserMode
+                ? workspaceName
+                : this.form.organizationName.trim() || workspaceName;
             const reportMailbox = this.form.reportMailbox.trim() || (domain ? `dmarc@${domain}` : '');
             const templateId = this.form.mailSourcePath === 'dns_only' ? 'dns_only_assessment' : 'standard_monitoring';
             const variables = {
@@ -290,7 +374,11 @@ function workspaceOnboarding() {
             if (!this.normalizeDomain(this.form.domain)) {
                 throw new Error('Domain is required.');
             }
-            if (!this.form.workspaceName.trim() && !this.form.organizationName.trim()) {
+            if (
+                this.multiWorkspaceUiEnabled &&
+                !this.form.workspaceName.trim() &&
+                !this.form.organizationName.trim()
+            ) {
                 throw new Error('Organization or workspace name is required.');
             }
         },
@@ -325,11 +413,15 @@ function workspaceOnboarding() {
                 if (mode === 'preview') {
                     this.plan = data.plan;
                     this.tasks = data.plan?.tasks || [];
-                    this.success = 'Preview is ready. Review the task list before creating the workspace.';
+                    this.success = this.singleUserMode
+                        ? 'Preview is ready. Review the task list before applying setup.'
+                        : 'Preview is ready. Review the task list before creating the workspace.';
                 } else {
                     this.result = data.result;
                     this.tasks = data.result?.tasks || [];
-                    this.success = 'Workspace onboarding was applied.';
+                    this.success = this.singleUserMode
+                        ? 'Mail health setup was applied.'
+                        : 'Workspace onboarding was applied.';
                     this.persistAppliedWorkspace(data.result);
                 }
                 this.persistDraft();
@@ -352,6 +444,7 @@ function workspaceOnboarding() {
             return detail || '';
         },
         persistAppliedWorkspace(result) {
+            if (!this.multiWorkspaceUiEnabled) return;
             const workspaceId = result?.workspace?.id;
             if (!workspaceId) return;
             localStorage.setItem('dmarq.selectedWorkspaceId', String(workspaceId));

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -399,6 +399,31 @@ def test_base_template_shows_workspace_controls_when_multi_workspace_enabled():
     assert "Members</a>" in rendered
 
 
+def test_onboarding_template_uses_single_user_setup_story_by_default():
+    rendered = _render_template("onboarding.html", multi_workspace_ui_enabled=False)
+
+    assert "Mail health setup" in rendered
+    assert "Setup path" in rendered
+    assert "Connect Gmail or IMAP" in rendered
+    assert "Apply setup" in rendered
+    assert "One monitored domain with DMARC report and DNS setup tasks." in rendered
+    assert "multiWorkspaceUiEnabled: false" in rendered
+    assert "Account boundary" not in rendered
+    assert "Owner ready" not in rendered
+    assert "Starter plan entitlement records" not in rendered
+
+
+def test_onboarding_template_keeps_workspace_story_for_multi_workspace_mode():
+    rendered = _render_template("onboarding.html", multi_workspace_ui_enabled=True)
+
+    assert "Workspace onboarding" in rendered
+    assert "Account boundary" in rendered
+    assert "Create workspace" in rendered
+    assert "Organization and workspace" in rendered
+    assert "Starter plan entitlement records" in rendered
+    assert "multiWorkspaceUiEnabled: true" in rendered
+
+
 def test_dashboard_hides_multi_user_demo_mode_controls():
     template = _dashboard_template()
 

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -147,8 +147,9 @@ class TestSetupPage:
                 response = test_client.get("/onboarding")
 
         assert response.status_code == 200
-        assert "Workspace onboarding" in response.text
-        assert "workspaceOnboarding()" in response.text
+        assert "Mail health setup" in response.text
+        assert "Apply setup" in response.text
+        assert "workspaceOnboarding({" in response.text
         assert "/api/v1/onboarding/preview" in response.text
         assert "/api/v1/onboarding/apply" in response.text
         assert "draftFields()" in response.text


### PR DESCRIPTION
## Summary
- simplify the onboarding copy and setup flow for self-hosted single-user deployments
- hide workspace/organization framing unless multi-workspace UI is enabled
- keep multi-workspace onboarding coverage via explicit template tests

Fixes #466

## Validation
- `.venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py -k "onboarding_template or base_template"`
- `.venv/bin/pytest -q backend/app/tests/test_setup_endpoints.py -k "onboarding_page"`
- `git diff --check origin/main...HEAD`
