### PR TITLE
Add dashboard loading states

### DIFF
--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -7,6 +7,8 @@ function dashboardApp() {
         domains: [],
         healthSummary: null,
         healthHistory: null,
+        dashboardLoading: true,
+        dashboardError: '',
         selectedDnsDomain: '',
         triggerPollRunning: false,
         triggerPollStatus: '',
@@ -141,8 +143,13 @@ function dashboardApp() {
         },
         
         async fetchDomainSummary() {
+            this.dashboardLoading = true;
+            this.dashboardError = '';
             try {
                 const response = await fetch('/api/v1/domains/summary');
+                if (!response.ok) {
+                    throw new Error('Dashboard data could not be loaded. Check the API service and try again.');
+                }
                 const data = await response.json();
                 
                 if (data && data.domains && data.domains.length > 0) {
@@ -172,6 +179,7 @@ function dashboardApp() {
                 }
             } catch (error) {
                 console.error('Error fetching domain summary:', error);
+                this.dashboardError = error.message || 'Dashboard data could not be loaded.';
                 this.domains = [];
                 this.healthSummary = null;
                 this.healthHistory = null;
@@ -180,6 +188,8 @@ function dashboardApp() {
                 this.clearDashboardCharts();
                 this.populateChangeSummary([]);
                 this.populateTopSources([]);
+            } finally {
+                this.dashboardLoading = false;
             }
         },
 

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -3,6 +3,8 @@ function domainsApp() {
         domains: [],
         openCreate: false,
         openEdit: false,
+        loading: true,
+        loadError: '',
         saving: false,
         createError: '',
         editError: '',
@@ -22,30 +24,35 @@ function domainsApp() {
         },
 
         async fetchDomains() {
+            this.loading = true;
+            this.loadError = '';
             try {
                 const response = await fetch('/api/v1/domains/summary');
-                if (response.ok) {
-                    const data = await response.json();
-
-                    this.domains = data.domains.map((domain) => ({
-                        name: domain.domain_name,
-                        dmarc_status: domain.dmarc_status ?? false,
-                        dmarc_policy: domain.dmarc_policy || 'Not configured',
-                        spf_status: domain.spf_status ?? false,
-                        dkim_status: domain.dkim_status ?? false,
-                        reports_count: domain.report_count,
-                        emails_count: domain.total_emails,
-                        compliance_rate: domain.pass_rate,
-                        description: domain.description || '',
-                        dkim_selectors: Array.isArray(domain.dkim_selectors)
-                            ? domain.dkim_selectors
-                            : [],
-                    }));
-                } else {
-                    console.error('Error fetching domains:', response.status);
+                if (!response.ok) {
+                    throw new Error('Domains could not be loaded. Refresh the page or check the API service.');
                 }
+                const data = await response.json();
+
+                this.domains = data.domains.map((domain) => ({
+                    name: domain.domain_name,
+                    dmarc_status: domain.dmarc_status ?? false,
+                    dmarc_policy: domain.dmarc_policy || 'Not configured',
+                    spf_status: domain.spf_status ?? false,
+                    dkim_status: domain.dkim_status ?? false,
+                    reports_count: domain.report_count,
+                    emails_count: domain.total_emails,
+                    compliance_rate: domain.pass_rate,
+                    description: domain.description || '',
+                    dkim_selectors: Array.isArray(domain.dkim_selectors)
+                        ? domain.dkim_selectors
+                        : [],
+                }));
             } catch (error) {
+                this.domains = [];
+                this.loadError = error.message || 'Domains could not be loaded.';
                 console.error('Error fetching domains:', error);
+            } finally {
+                this.loading = false;
             }
         },
 

--- a/backend/app/static/js/reports-page.js
+++ b/backend/app/static/js/reports-page.js
@@ -6,7 +6,7 @@ function reportsApp() {
         },
         domains: [],
         reports: [],
-        loading: false,
+        loading: true,
         error: '',
 
         init() {

--- a/backend/app/static/js/reports-page.js
+++ b/backend/app/static/js/reports-page.js
@@ -7,6 +7,7 @@ function reportsApp() {
         domains: [],
         reports: [],
         loading: false,
+        error: '',
 
         init() {
             this.fetchReports();
@@ -46,11 +47,18 @@ function reportsApp() {
 
         async fetchReports() {
             this.loading = true;
+            this.error = '';
             try {
                 const response = await fetch('/api/v1/reports');
+                if (!response.ok) {
+                    throw new Error('Reports could not be loaded. Refresh the page or check the import service.');
+                }
                 this.reports = await response.json();
                 this.domains = [...new Set(this.reports.map((report) => report.domain))].sort();
             } catch (error) {
+                this.reports = [];
+                this.domains = [];
+                this.error = error.message || 'Reports could not be loaded.';
                 console.error('Error fetching reports:', error);
             } finally {
                 this.loading = false;

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1377,7 +1377,7 @@
                             <template x-if="!sourceIntelligence.loading && !sourceIntelligence.error && !sourceIntelligence.regions.length">
                                 <p class="text-sm text-muted-foreground">No region data available for this time period.</p>
                             </template>
-                            <template x-for="region in sourceIntelligence.regions.slice(0, 4)" :key="region.region">
+                            <template x-for="region in (!sourceIntelligence.loading && !sourceIntelligence.error ? sourceIntelligence.regions.slice(0, 4) : [])" :key="region.region">
                                 <div class="rounded-md border border-[#e6e3e1] bg-white p-3">
                                     <div class="flex items-start justify-between gap-3">
                                         <div>
@@ -1413,7 +1413,7 @@
                             <template x-if="!sourceIntelligence.loading && !sourceIntelligence.error && !sourceIntelligence.anomalies.length">
                                 <p class="text-sm text-muted-foreground">No notable source changes detected.</p>
                             </template>
-                            <template x-for="anomaly in sourceIntelligence.anomalies.slice(0, 4)" :key="anomaly.type + anomaly.source_ip">
+                            <template x-for="anomaly in (!sourceIntelligence.loading && !sourceIntelligence.error ? sourceIntelligence.anomalies.slice(0, 4) : [])" :key="anomaly.type + anomaly.source_ip">
                                 <a :href="anomaly.source_ip ? '#sending-sources' : '#reports'"
                                    class="block rounded-md border border-[#e6e3e1] bg-white p-3 transition hover:border-[#2f9da5] hover:shadow-sm">
                                     <div class="flex items-start gap-2">
@@ -1496,7 +1496,7 @@
                                 </td>
                             </tr>
                         </template>
-                        <template x-for="source in filteredSources" :key="source.ip">
+                        <template x-for="source in (!sourcesLoading && !sourcesError ? filteredSources : [])" :key="source.ip">
                             {% call tr() %}
                                 {% call td() %}
                                     <div class="flex flex-col">
@@ -1785,7 +1785,7 @@
                                 </td>
                             </tr>
                         </template>
-                        <template x-for="report in reports" :key="report.id">
+                        <template x-for="report in (!reportsLoading && !reportsError ? reports : [])" :key="report.id">
                             {% call tr() %}
                                 {% call td() %}
                                     <span x-text="formatDate(report.begin_date)"></span>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -972,18 +972,20 @@
                     <div>
                         <h3 class="font-semibold mb-1 flex items-center">
                             <span class="mr-2">DMARC Record</span>
-                            <span x-show="dns.dmarc" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
-                            <span x-show="!dns.dmarc" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
+                            <span x-show="dnsRecordsLoading" class="loading loading-spinner loading-xs"></span>
+                            <span x-show="!dnsRecordsLoading && dns.dmarc" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
+                            <span x-show="!dnsRecordsLoading && !dns.dmarc" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
                         </h3>
-                        <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono" x-text="dns.dmarcRecord || 'No DMARC record found'">-</div>
+                        <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono" x-text="dnsRecordsLoading ? 'Checking DMARC record...' : (dns.dmarcRecord || 'No DMARC record found')">-</div>
                     </div>
                     <div>
                         <h3 class="font-semibold mb-1 flex items-center">
                             <span class="mr-2">SPF Record</span>
-                            <span x-show="dns.spf" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
-                            <span x-show="!dns.spf" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
+                            <span x-show="dnsRecordsLoading" class="loading loading-spinner loading-xs"></span>
+                            <span x-show="!dnsRecordsLoading && dns.spf" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
+                            <span x-show="!dnsRecordsLoading && !dns.spf" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
                         </h3>
-                        <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono" x-text="dns.spfRecord || 'No SPF record found'">-</div>
+                        <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono" x-text="dnsRecordsLoading ? 'Checking SPF record...' : (dns.spfRecord || 'No SPF record found')">-</div>
                     </div>
                     <div id="mta-sts-posture">
                         <h3 class="font-semibold mb-1 flex items-center">
@@ -1037,12 +1039,17 @@
                     <div>
                         <h3 class="font-semibold mb-1 flex items-center">
                             <span class="mr-2">DKIM (live check)</span>
-                            <span x-show="dns.dkim" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
-                            <span x-show="!dns.dkim" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
+                            <span x-show="dnsRecordsLoading" class="loading loading-spinner loading-xs"></span>
+                            <span x-show="!dnsRecordsLoading && dns.dkim" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
+                            <span x-show="!dnsRecordsLoading && !dns.dkim" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
                         </h3>
                         <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono"
                              x-text="dkimLiveText">-</div>
                     </div>
+                    <p x-show="dnsRecordsError"
+                       x-cloak
+                       class="rounded-md border border-[#ffcfbd] bg-[#fff2ec] px-3 py-2 text-sm text-[#8a2d0d]"
+                       x-text="dnsRecordsError"></p>
                     <!-- DKIM Selector Management -->
                     <div class="border rounded-lg p-4">
                         <h3 class="font-semibold mb-3">DKIM Selectors</h3>
@@ -1357,8 +1364,17 @@
                 <div class="grid gap-4 lg:grid-cols-2">
                     <div>
                         <h3 class="mb-3 text-sm font-semibold uppercase tracking-wide text-[#5f5c78]">Top regions</h3>
+                        <template x-if="sourceIntelligence.loading">
+                            <div class="flex items-center gap-2 rounded-md border border-[#e6e3e1] bg-white p-3 text-sm text-muted-foreground" role="status">
+                                <span class="loading loading-spinner loading-sm"></span>
+                                <span>Loading source intelligence...</span>
+                            </div>
+                        </template>
+                        <template x-if="!sourceIntelligence.loading && sourceIntelligence.error">
+                            <p class="rounded-md border border-[#ffcfbd] bg-[#fff2ec] p-3 text-sm text-[#8a2d0d]" x-text="sourceIntelligence.error"></p>
+                        </template>
                         <div class="space-y-3">
-                            <template x-if="!sourceIntelligence.regions.length">
+                            <template x-if="!sourceIntelligence.loading && !sourceIntelligence.error && !sourceIntelligence.regions.length">
                                 <p class="text-sm text-muted-foreground">No region data available for this time period.</p>
                             </template>
                             <template x-for="region in sourceIntelligence.regions.slice(0, 4)" :key="region.region">
@@ -1385,7 +1401,16 @@
                     <div>
                         <h3 class="mb-3 text-sm font-semibold uppercase tracking-wide text-[#5f5c78]">Actionable anomalies</h3>
                         <div class="space-y-3">
-                            <template x-if="!sourceIntelligence.anomalies.length">
+                            <template x-if="sourceIntelligence.loading">
+                                <div class="flex items-center gap-2 rounded-md border border-[#e6e3e1] bg-white p-3 text-sm text-muted-foreground" role="status">
+                                    <span class="loading loading-spinner loading-sm"></span>
+                                    <span>Checking source changes...</span>
+                                </div>
+                            </template>
+                            <template x-if="!sourceIntelligence.loading && sourceIntelligence.error">
+                                <p class="rounded-md border border-[#ffcfbd] bg-[#fff2ec] p-3 text-sm text-[#8a2d0d]" x-text="sourceIntelligence.error"></p>
+                            </template>
+                            <template x-if="!sourceIntelligence.loading && !sourceIntelligence.error && !sourceIntelligence.anomalies.length">
                                 <p class="text-sm text-muted-foreground">No notable source changes detected.</p>
                             </template>
                             <template x-for="anomaly in sourceIntelligence.anomalies.slice(0, 4)" :key="anomaly.type + anomaly.source_ip">
@@ -1461,6 +1486,13 @@
                                     <div class="text-muted-foreground" x-show="!sourcesLoading && !sourcesError && sourceEvidenceCount > 0">
                                         Source summary is available, but row details are not loaded for this window. Try All time or refresh the page.
                                     </div>
+                                </td>
+                            </tr>
+                        </template>
+                        <template x-if="!sourcesLoading && !sourcesError && sources.length > 0 && filteredSources.length === 0">
+                            <tr>
+                                <td colspan="9" class="text-center py-4">
+                                    <div class="text-muted-foreground">No sending sources match this filter.</div>
                                 </td>
                             </tr>
                         </template>
@@ -1729,7 +1761,24 @@
                         {% endcall %}
                     {% endcall %}
                     {% call tbody() %}
-                        <template x-if="reports.length === 0">
+                        <template x-if="reportsLoading">
+                            <tr>
+                                <td colspan="6" class="text-center py-4">
+                                    <div class="flex items-center justify-center gap-2 text-muted-foreground" role="status">
+                                        <span class="loading loading-spinner loading-sm"></span>
+                                        <span>Loading recent reports...</span>
+                                    </div>
+                                </td>
+                            </tr>
+                        </template>
+                        <template x-if="!reportsLoading && reportsError">
+                            <tr>
+                                <td colspan="6" class="text-center py-4">
+                                    <div class="text-red-700" x-text="reportsError"></div>
+                                </td>
+                            </tr>
+                        </template>
+                        <template x-if="!reportsLoading && !reportsError && reports.length === 0">
                             <tr>
                                 <td colspan="6" class="text-center py-4">
                                     <div class="text-muted-foreground">No reports available</div>
@@ -1794,6 +1843,8 @@ function domainDetailsApp(domainId) {
             nameservers: [],
             dnsProvider: null
         },
+        dnsRecordsLoading: true,
+        dnsRecordsError: '',
         dnsHealth: {
             status: '',
             checks: [],
@@ -1876,13 +1927,17 @@ function domainDetailsApp(domainId) {
         newSelector: '',
         selectorError: '',
         reports: [],
+        reportsLoading: true,
+        reportsError: '',
         sources: [],
         sourcesLoading: false,
         sourcesError: '',
         sourceIntelligence: {
             regions: [],
             anomalies: [],
-            summary: {}
+            summary: {},
+            loading: true,
+            error: ''
         },
         ownership: {
             loading: false,
@@ -2086,6 +2141,7 @@ function domainDetailsApp(domainId) {
         },
 
         get dkimLiveText() {
+            if (this.dnsRecordsLoading) return 'Checking DKIM selectors...';
             if (!this.dns.dkim) return 'No DKIM record found for configured selectors';
             if (this.dns.dkimSelectors && this.dns.dkimSelectors.length > 0) {
                 return 'selectors: ' + this.dns.dkimSelectors.join(', ');
@@ -2098,14 +2154,18 @@ function domainDetailsApp(domainId) {
         },
 
         get dnsProviderName() {
+            if (this.dnsRecordsLoading) return 'Checking DNS provider...';
             return this.detectedDnsProvider?.provider_name || 'Unknown provider';
         },
 
         get dnsProviderConfidence() {
+            if (this.dnsRecordsLoading) return 'checking';
             return this.detectedDnsProvider?.confidence || 'unknown';
         },
 
         get dnsProviderAction() {
+            if (this.dnsRecordsLoading) return 'Looking up authoritative nameservers and authentication records.';
+            if (this.dnsRecordsError) return this.dnsRecordsError;
             return this.detectedDnsProvider?.suggested_action || 'Review nameservers and select the DNS provider manually before making changes.';
         },
 
@@ -2118,6 +2178,7 @@ function domainDetailsApp(domainId) {
         },
 
         get dnsNameserverText() {
+            if (this.dnsRecordsLoading) return 'Checking nameservers...';
             const nameservers = this.dns.nameservers || this.detectedDnsProvider?.evidence || [];
             return nameservers.length ? nameservers.join(', ') : 'No NS evidence available yet';
         },
@@ -2469,15 +2530,23 @@ function domainDetailsApp(domainId) {
         },
 
         async fetchDNSRecords() {
+            this.dnsRecordsLoading = true;
+            this.dnsRecordsError = '';
             try {
                 const response = await fetch(`/api/v1/domains/${this.domainId}/dns`);
-                if (response.ok) {
-                    const data = await response.json();
-                    this.dns = data;
-                    this.syncDetectedDnsProvider();
+                if (!response.ok) {
+                    const data = await response.json().catch(() => ({}));
+                    const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                    throw new Error(detail || 'DNS records could not be loaded.');
                 }
+                const data = await response.json();
+                this.dns = data;
+                this.syncDetectedDnsProvider();
             } catch (error) {
+                this.dnsRecordsError = error.message || 'DNS records could not be loaded.';
                 console.error('Error fetching DNS records:', error);
+            } finally {
+                this.dnsRecordsLoading = false;
             }
         },
 
@@ -2895,16 +2964,25 @@ function domainDetailsApp(domainId) {
         },
 
         async fetchReports() {
+            this.reportsLoading = true;
+            this.reportsError = '';
             try {
                 const response = await fetch(`/api/v1/domains/${this.domainId}/reports?limit=10`);
-                if (response.ok) {
-                    const data = await response.json();
-                    this.reports = data.reports;
-                    this.lastComplianceTimeline = data.compliance_timeline || [];
-                    this.initComplianceChart(data.compliance_timeline);
+                if (!response.ok) {
+                    const data = await response.json().catch(() => ({}));
+                    const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                    throw new Error(detail || 'Recent reports could not be loaded.');
                 }
+                const data = await response.json();
+                this.reports = data.reports || [];
+                this.lastComplianceTimeline = data.compliance_timeline || [];
+                this.initComplianceChart(data.compliance_timeline);
             } catch (error) {
+                this.reports = [];
+                this.reportsError = error.message || 'Recent reports could not be loaded.';
                 console.error('Error fetching reports:', error);
+            } finally {
+                this.reportsLoading = false;
             }
         },
 
@@ -2940,13 +3018,32 @@ function domainDetailsApp(domainId) {
         },
 
         async fetchSourceIntelligence() {
+            this.sourceIntelligence.loading = true;
+            this.sourceIntelligence.error = '';
             try {
                 const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/source-intelligence?days=${this.sourceDateWindow()}`);
-                if (response.ok) {
-                    this.sourceIntelligence = await response.json();
+                if (!response.ok) {
+                    const data = await response.json().catch(() => ({}));
+                    const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                    throw new Error(detail || 'Source intelligence could not be loaded.');
                 }
+                const data = await response.json();
+                this.sourceIntelligence = {
+                    ...data,
+                    loading: false,
+                    error: ''
+                };
             } catch (error) {
+                this.sourceIntelligence = {
+                    regions: [],
+                    anomalies: [],
+                    summary: {},
+                    loading: false,
+                    error: error.message || 'Source intelligence could not be loaded.'
+                };
                 console.error('Error fetching source intelligence:', error);
+            } finally {
+                this.sourceIntelligence.loading = false;
             }
         },
         

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -41,7 +41,24 @@
                         {% endcall %}
                     {% endcall %}
                     {% call tbody() %}
-                        <template x-if="domains.length === 0">
+                        <template x-if="loading">
+                            {% call tr() %}
+                                {% call td(colspan="5", class="text-center") %}
+                                    <div class="flex items-center justify-center gap-2 py-4 text-muted-foreground" role="status">
+                                        <span class="loading loading-spinner loading-sm"></span>
+                                        <span>Loading monitored domains...</span>
+                                    </div>
+                                {% endcall %}
+                            {% endcall %}
+                        </template>
+                        <template x-if="!loading && loadError">
+                            {% call tr() %}
+                                {% call td(colspan="5", class="text-center") %}
+                                    <p class="py-4 text-red-700" x-text="loadError"></p>
+                                {% endcall %}
+                            {% endcall %}
+                        </template>
+                        <template x-if="!loading && !loadError && domains.length === 0">
                             {% call tr() %}
                                 {% call td(colspan="5", class="text-center") %}
                                     <p class="py-4 text-muted-foreground">No domains found. Add a domain to get started.</p>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -10,6 +10,28 @@
 
 {% block content %}
 <div class="dashboard-page space-y-6" x-data="dashboardApp()">
+    <div x-show="dashboardLoading"
+         x-cloak
+         class="rounded-lg border border-[#e6e3e1] bg-white p-6 shadow-sm"
+         role="status"
+         aria-live="polite">
+        <div class="flex items-center gap-3">
+            <span class="loading loading-spinner loading-sm text-[#2f9da5]"></span>
+            <div>
+                <h2 class="font-semibold text-[#120d36]">Loading dashboard data</h2>
+                <p class="text-sm text-[#5f5c78]">DMARQ is checking domains, report volume, DNS health, and sender signals.</p>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="!dashboardLoading && dashboardError"
+         x-cloak
+         class="rounded-lg border border-[#ffcfbd] bg-[#fff2ec] p-4 text-sm text-[#8a2d0d]"
+         role="alert">
+        <p class="font-semibold">Dashboard could not be loaded</p>
+        <p class="mt-1" x-text="dashboardError"></p>
+    </div>
+
     <div class="rounded-lg bg-white p-4 shadow-sm" x-show="hasDomainData" x-cloak data-tour="date-filter">
         <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div class="grid gap-1">
@@ -321,7 +343,7 @@
     </div>
     
     <!-- No Data Message -->
-    <div x-show="!hasDomainData" x-cloak>
+    <div x-show="!dashboardLoading && !dashboardError && !hasDomainData" x-cloak>
         {% call card() %}
             {% call card_content() %}
                 <div class="flex flex-col items-center justify-center py-12 text-center">

--- a/backend/app/templates/reports.html
+++ b/backend/app/templates/reports.html
@@ -95,7 +95,7 @@
                                 {% endcall %}
                             {% endcall %}
                         </template>
-                        <template x-for="(report, index) in filteredReports" :key="index">
+                        <template x-for="(report, index) in (!loading && !error ? filteredReports : [])" :key="index">
                             {% call tr() %}
                                 {% call td() %}
                                     <div x-text="formatDate(report.end_date)"></div>

--- a/backend/app/templates/reports.html
+++ b/backend/app/templates/reports.html
@@ -52,7 +52,9 @@
                     {% call card_title() %}DMARC Reports{% endcall %}
                 </div>
                 {% call card_description() %}
-                    Showing <span x-text="filteredReports.length"></span> reports
+                    <span x-show="loading">Loading reports...</span>
+                    <span x-show="!loading && !error">Showing <span x-text="filteredReports.length"></span> reports</span>
+                    <span x-show="!loading && error">Reports unavailable</span>
                 {% endcall %}
             {% endcall %}
             {% call card_content() %}
@@ -69,6 +71,30 @@
                         {% endcall %}
                     {% endcall %}
                     {% call tbody() %}
+                        <template x-if="loading">
+                            {% call tr() %}
+                                {% call td(colspan="7", class="text-center") %}
+                                    <div class="flex items-center justify-center gap-2 py-4 text-muted-foreground" role="status">
+                                        <span class="loading loading-spinner loading-sm"></span>
+                                        <span>Loading DMARC reports...</span>
+                                    </div>
+                                {% endcall %}
+                            {% endcall %}
+                        </template>
+                        <template x-if="!loading && error">
+                            {% call tr() %}
+                                {% call td(colspan="7", class="text-center") %}
+                                    <p class="py-4 text-red-700" x-text="error"></p>
+                                {% endcall %}
+                            {% endcall %}
+                        </template>
+                        <template x-if="!loading && !error && filteredReports.length === 0">
+                            {% call tr() %}
+                                {% call td(colspan="7", class="text-center") %}
+                                    <p class="py-4 text-muted-foreground">No reports match this filter.</p>
+                                {% endcall %}
+                            {% endcall %}
+                        </template>
                         <template x-for="(report, index) in filteredReports" :key="index">
                             {% call tr() %}
                                 {% call td() %}

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -155,6 +155,17 @@ def test_reports_uses_external_page_script_for_csp_migration():
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
+def test_reports_page_distinguishes_loading_error_and_empty_states():
+    template = _reports_template()
+    script = _reports_script()
+
+    assert "Loading DMARC reports..." in template
+    assert "Reports could not be loaded." in script
+    assert "No reports match this filter." in template
+    assert "x-show=\"!loading && error\"" in template
+    assert "throw new Error('Reports could not be loaded." in script
+
+
 def test_domains_uses_external_page_script_for_csp_migration():
     template = _domains_template()
     script = _domains_script()
@@ -170,6 +181,17 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert "method: 'PATCH'" in script
     assert "editError" in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
+
+
+def test_domains_page_distinguishes_loading_error_and_empty_states():
+    template = _domains_template()
+    script = _domains_script()
+
+    assert "Loading monitored domains..." in template
+    assert "Domains could not be loaded." in script
+    assert "No domains found. Add a domain to get started." in template
+    assert "x-if=\"!loading && loadError\"" in template
+    assert "x-if=\"!loading && !loadError && domains.length === 0\"" in template
 
 
 def test_upload_uses_external_page_script_for_csp_migration():
@@ -317,6 +339,24 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "x-html" not in template
 
 
+def test_domain_details_distinguishes_loading_error_and_empty_states():
+    template = (
+        Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"
+    ).read_text()
+
+    assert "dnsRecordsLoading" in template
+    assert "Checking DMARC record..." in template
+    assert "DNS records could not be loaded." in template
+    assert "reportsLoading" in template
+    assert "Loading recent reports..." in template
+    assert "Recent reports could not be loaded." in template
+    assert "sourceIntelligence.loading" in template
+    assert "Loading source intelligence..." in template
+    assert "Source intelligence could not be loaded." in template
+    assert "No sending sources match this filter." in template
+    assert "x-html" not in template
+
+
 def test_domain_details_redirects_to_domain_management_after_delete_success():
     template = (
         Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"
@@ -412,6 +452,18 @@ def test_dashboard_hides_multi_user_demo_mode_controls():
     assert "Provider billing samples" not in template
     assert "/api/v1/operator/demo/multi-user" not in template
     assert "x-html" not in template
+
+
+def test_dashboard_distinguishes_loading_error_and_empty_states():
+    template = _dashboard_template()
+    script = _dashboard_script()
+
+    assert "Loading dashboard data" in template
+    assert "Dashboard could not be loaded" in template
+    assert "dashboardLoading" in script
+    assert "dashboardError" in script
+    assert "Dashboard data could not be loaded." in script
+    assert 'x-show="!dashboardLoading && !dashboardError && !hasDomainData"' in template
 
 
 def test_dashboard_trigger_poll_uses_post_action_not_get_link():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -162,7 +162,9 @@ def test_reports_page_distinguishes_loading_error_and_empty_states():
     assert "Loading DMARC reports..." in template
     assert "Reports could not be loaded." in script
     assert "No reports match this filter." in template
-    assert "x-show=\"!loading && error\"" in template
+    assert 'x-show="!loading && error"' in template
+    assert "(!loading && !error ? filteredReports : [])" in template
+    assert "loading: true" in script
     assert "throw new Error('Reports could not be loaded." in script
 
 
@@ -190,8 +192,8 @@ def test_domains_page_distinguishes_loading_error_and_empty_states():
     assert "Loading monitored domains..." in template
     assert "Domains could not be loaded." in script
     assert "No domains found. Add a domain to get started." in template
-    assert "x-if=\"!loading && loadError\"" in template
-    assert "x-if=\"!loading && !loadError && domains.length === 0\"" in template
+    assert 'x-if="!loading && loadError"' in template
+    assert 'x-if="!loading && !loadError && domains.length === 0"' in template
 
 
 def test_upload_uses_external_page_script_for_csp_migration():
@@ -354,6 +356,16 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "Loading source intelligence..." in template
     assert "Source intelligence could not be loaded." in template
     assert "No sending sources match this filter." in template
+    assert (
+        "(!sourceIntelligence.loading && !sourceIntelligence.error ? sourceIntelligence.regions.slice(0, 4) : [])"
+        in template
+    )
+    assert (
+        "(!sourceIntelligence.loading && !sourceIntelligence.error ? sourceIntelligence.anomalies.slice(0, 4) : [])"
+        in template
+    )
+    assert "(!sourcesLoading && !sourcesError ? filteredSources : [])" in template
+    assert "(!reportsLoading && !reportsError ? reports : [])" in template
     assert "x-html" not in template
 
 


### PR DESCRIPTION
## Summary
- add explicit loading, empty, and error states for dashboard, domains, reports, and domain-detail sections
- prevent DNS record health from showing missing/red signals while DNS lookup is still in flight
- add source-intelligence and recent-report loading/error states plus focused regression coverage

Fixes #467

## Validation
- `.venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py`
- `node --check backend/app/static/js/dashboard-page.js && node --check backend/app/static/js/domains-page.js && node --check backend/app/static/js/reports-page.js`
- `git diff --check origin/main...HEAD`
