### PR TITLE
fix: preserve recent DNS evidence on transient misses

### DIFF
--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -24,6 +24,7 @@ from app.services.dns_resolver import (
 
 DEFAULT_DNS_CACHE_TTL_SECONDS = 900
 NEGATIVE_DNS_CACHE_TTL_SECONDS = 60
+STALE_DNS_EVIDENCE_GRACE_SECONDS = 86_400
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,10 @@ def _negative_ttl_for_result(result: DomainDNSResult, ttl_seconds: int) -> int:
     if _has_dns_evidence(result):
         return ttl_seconds
     return min(ttl_seconds, NEGATIVE_DNS_CACHE_TTL_SECONDS)
+
+
+def _within_stale_evidence_grace(row: DNSCache, now: datetime) -> bool:
+    return row.checked_at >= now - timedelta(seconds=STALE_DNS_EVIDENCE_GRACE_SECONDS)
 
 
 async def _resolve_with_fallback(
@@ -151,6 +156,15 @@ async def resolve_domain_dns_cached(
             return cached_result, True, row.checked_at
 
     result = await _resolve_with_fallback(provider, domain, selectors=selectors)
+    if row and _has_dns_evidence(_result_from_json(row.result_json)) and not _has_dns_evidence(result):
+        cached_result = _result_from_json(row.result_json)
+        if _within_stale_evidence_grace(row, now):
+            logger.warning(
+                "DNS resolver returned no evidence; keeping last known DNS evidence for %s",
+                provider_name,
+            )
+            return cached_result, True, row.checked_at
+
     payload = _result_to_json(result)
     if row is None:
         row = DNSCache(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -734,6 +734,81 @@ async def test_dns_cache_refreshes_stale_empty_dns_result(db_session):
 
 
 @pytest.mark.asyncio
+async def test_dns_cache_keeps_recent_positive_evidence_when_lookup_turns_empty(db_session):
+    """Transient resolver misses should not overwrite known-good DNS posture."""
+    healthy = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject",
+        spf=True,
+        spf_record="v=spf1 -all",
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+        dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
+    )
+    empty = DomainDNSResult(dmarc=False, spf=False, dkim=False)
+    provider = AsyncMock(check_domain=AsyncMock(return_value=empty))
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=provider.__class__.__name__,
+            selectors_key=_selectors_key([]),
+            result_json=json.dumps(asdict(healthy), sort_keys=True, separators=(",", ":")),
+            checked_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=30),
+        )
+    )
+    db_session.commit()
+
+    result, cached, _checked = await resolve_domain_dns_cached(
+        db_session,
+        provider,
+        DOMAIN,
+        selectors=[],
+    )
+
+    assert cached is True
+    assert result.dmarc is True
+    assert result.spf is True
+    assert result.nameservers == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
+    assert provider.check_domain.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_dns_cache_allows_old_positive_evidence_to_expire(db_session):
+    """Very old DNS evidence should not mask a persistently empty resolver result."""
+    healthy = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject",
+        spf=True,
+        spf_record="v=spf1 -all",
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+        dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
+    )
+    empty = DomainDNSResult(dmarc=False, spf=False, dkim=False)
+    provider = AsyncMock(check_domain=AsyncMock(return_value=empty))
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=provider.__class__.__name__,
+            selectors_key=_selectors_key([]),
+            result_json=json.dumps(asdict(healthy), sort_keys=True, separators=(",", ":")),
+            checked_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=2),
+        )
+    )
+    db_session.commit()
+
+    result, cached, _checked = await resolve_domain_dns_cached(
+        db_session,
+        provider,
+        DOMAIN,
+        selectors=[],
+    )
+
+    assert cached is False
+    assert result.dmarc is False
+    assert result.spf is False
+    assert provider.check_domain.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_session):
     """A primary resolver with no evidence should not force a false F grade."""
     primary_provider = SystemDNSProvider()


### PR DESCRIPTION
## Summary

Fixes #482.

This prevents transient DNS resolver misses from immediately replacing recent known-good DNS evidence with an empty posture result. If DMARQ has recent cached evidence for DMARC/SPF/NS and a later lookup returns no evidence at all, the cache now serves the previous evidence within a bounded 24-hour stale-evidence grace window instead of dropping the domain to an F score.

## Why

Production showed `cklnet.com` as having no authoritative nameservers, no SPF, and no DMARC even though live DNS resolves Cloudflare NS plus valid SPF/DMARC records. That class of failure should be treated as a resolver miss, not as proof that DNS posture disappeared.

## Validation

- `PYTHONPATH=backend ./.venv/bin/pytest -q backend/app/tests/test_dns_endpoints.py -k 'dns_cache'`
- `PYTHONPATH=backend ./.venv/bin/pytest -q backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dns_resolver.py`
- Local live resolver check for `cklnet.com` confirmed Cloudflare NS, SPF, DMARC, and provider detection.
