### PR TITLE
feat: add Akamai Edge DNS zone import

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,15 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # DMARQ_ROUTE53_PROFILE="your_local_read_only_profile"
 # DMARQ_ROUTE53_ROLE_ARN="arn:aws:iam::123456789012:role/dmarq-route53-readonly"
 # DMARQ_ROUTE53_EXTERNAL_ID="customer-or-instance-external-id"
+# Akamai Edge DNS / FastDNS zone import uses EdgeGrid credentials.
+# Prefer an .edgerc file or inject these values through 1Password/secrets.
+# AKAMAI_EDGERC_PATH="/run/secrets/edgerc"
+# AKAMAI_EDGERC_SECTION="default"
+# AKAMAI_HOST="akab-example.luna.akamaiapis.net"
+# AKAMAI_CLIENT_TOKEN="your_akamai_client_token"
+# AKAMAI_CLIENT_SECRET="your_akamai_client_secret"
+# AKAMAI_ACCESS_TOKEN="your_akamai_access_token"
+# AKAMAI_ACCOUNT_SWITCH_KEY="optional_account_switch_key"
 
 # Authentication
 # AUTH_MODE options: auto, disabled, logto, authentik, oidc, trusted_proxy

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -68,6 +68,14 @@ class Settings(BaseSettings):
     DMARQ_ROUTE53_PROFILE: Optional[str] = None
     DMARQ_ROUTE53_ROLE_ARN: Optional[str] = None
     DMARQ_ROUTE53_EXTERNAL_ID: Optional[str] = None
+    AKAMAI_EDGERC_PATH: Optional[str] = None
+    AKAMAI_EDGERC_SECTION: str = "default"
+    AKAMAI_HOST: Optional[str] = None
+    AKAMAI_CLIENT_TOKEN: Optional[str] = None
+    AKAMAI_CLIENT_SECRET: Optional[str] = None
+    AKAMAI_ACCESS_TOKEN: Optional[str] = None
+    AKAMAI_ACCOUNT_SWITCH_KEY: Optional[str] = None
+    AKAMAI_ACCOUNT_KEY: Optional[str] = None
     POSTMARK_ACCOUNT_TOKEN: Optional[str] = None
     WEBHOOK_SECRET: Optional[str] = None
 

--- a/backend/app/services/akamai_edgedns.py
+++ b/backend/app/services/akamai_edgedns.py
@@ -1,0 +1,289 @@
+"""Akamai Edge DNS / FastDNS zone discovery and monitored-domain import helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.models.domain import Domain
+from app.models.workspace import Workspace
+from app.services.organizations import require_organization_plan_limit
+from app.services.workspaces import assign_default_workspace_to_unscoped_rows
+
+PROVIDER_NAME = "akamai-edgedns"
+AKAMAI_EDGE_DNS_PAGE_SIZE = 100
+
+
+@dataclass
+class AkamaiEdgeDNSCredentials:
+    """Resolved EdgeGrid credential hints for Edge DNS zone discovery."""
+
+    edgerc_path: Optional[str] = None
+    edgerc_section: str = "default"
+    host: Optional[str] = None
+    client_token: Optional[str] = None
+    client_secret: Optional[str] = None
+    access_token: Optional[str] = None
+    account_switch_key: Optional[str] = None
+
+    @property
+    def configured(self) -> bool:
+        if self.edgerc_path:
+            return True
+        return all([self.host, self.client_token, self.client_secret, self.access_token])
+
+
+class AkamaiEdgeDNSClient:
+    """Small read-only client for Akamai Edge DNS/FastDNS zone discovery."""
+
+    def __init__(self, *, session: Any, base_url: str, account_switch_key: Optional[str] = None):
+        self.session = session
+        self.base_url = base_url.rstrip("/")
+        self.account_switch_key = account_switch_key
+
+    @staticmethod
+    def _zone_name(zone: Dict[str, Any]) -> str:
+        return str(zone.get("zone") or zone.get("name") or "").strip().strip(".").lower()
+
+    @staticmethod
+    def _zone_id(zone: Dict[str, Any]) -> str:
+        return AkamaiEdgeDNSClient._zone_name(zone)
+
+    @staticmethod
+    def _zone_status(zone: Dict[str, Any]) -> Optional[str]:
+        for key in ("type", "zoneType", "activationState", "status"):
+            if zone.get(key):
+                return str(zone[key])
+        return None
+
+    @staticmethod
+    def _account_name(zone: Dict[str, Any]) -> str:
+        contract_id = zone.get("contractId") or zone.get("contract_id")
+        group_id = zone.get("groupId") or zone.get("group_id")
+        if contract_id and group_id:
+            return f"Akamai contract {contract_id} / group {group_id}"
+        if contract_id:
+            return f"Akamai contract {contract_id}"
+        return "Akamai Edge DNS"
+
+    def _api_get_sync(self, path: str, *, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        request_params = dict(params or {})
+        if self.account_switch_key:
+            request_params.setdefault("accountSwitchKey", self.account_switch_key)
+
+        response = self.session.get(f"{self.base_url}{path}", params=request_params)
+        try:
+            response.raise_for_status()
+            return response.json()
+        except ValueError as exc:
+            raise LookupError(f"Akamai Edge DNS API returned invalid JSON for {path}") from exc
+        except Exception as exc:
+            raise LookupError(f"Akamai Edge DNS API request failed for {path}: {exc}") from exc
+
+    async def _api_get(
+        self, path: str, *, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        return await asyncio.to_thread(self._api_get_sync, path, params=params)
+
+    async def list_zones(self) -> List[Dict[str, Any]]:
+        """Return Edge DNS zones visible to the configured EdgeGrid credentials."""
+        zones: List[Dict[str, Any]] = []
+        page = 1
+        while True:
+            data = await self._api_get(
+                "/config-dns/v2/zones",
+                params={"page": page, "pageSize": AKAMAI_EDGE_DNS_PAGE_SIZE},
+            )
+            page_zones = data.get("zones") or data.get("data") or data.get("items") or []
+            if not isinstance(page_zones, list):
+                return zones
+            zones.extend(page_zones)
+
+            metadata = data.get("metadata") or data.get("page") or {}
+            total_pages_value = (
+                metadata.get("totalPages") or metadata.get("total_pages") or metadata.get("lastPage")
+            )
+            total_pages = int(total_pages_value or page)
+            if page >= total_pages:
+                break
+            if total_pages_value is None and len(page_zones) < AKAMAI_EDGE_DNS_PAGE_SIZE:
+                break
+            page += 1
+        return zones
+
+
+def get_akamai_edgedns_credentials() -> AkamaiEdgeDNSCredentials:
+    """Resolve Akamai EdgeGrid credentials from environment settings."""
+    settings = get_settings()
+    return AkamaiEdgeDNSCredentials(
+        edgerc_path=settings.AKAMAI_EDGERC_PATH,
+        edgerc_section=settings.AKAMAI_EDGERC_SECTION or "default",
+        host=settings.AKAMAI_HOST,
+        client_token=settings.AKAMAI_CLIENT_TOKEN,
+        client_secret=settings.AKAMAI_CLIENT_SECRET,
+        access_token=settings.AKAMAI_ACCESS_TOKEN,
+        account_switch_key=settings.AKAMAI_ACCOUNT_SWITCH_KEY or settings.AKAMAI_ACCOUNT_KEY,
+    )
+
+
+def build_akamai_edgedns_client() -> AkamaiEdgeDNSClient:
+    """Return an Akamai Edge DNS client configured from EdgeGrid credentials."""
+    credentials = get_akamai_edgedns_credentials()
+    if not credentials.configured:
+        raise LookupError("Akamai EdgeGrid credentials are not configured")
+
+    try:
+        import requests  # type: ignore[import]
+        from akamai.edgegrid import EdgeGridAuth, EdgeRc  # type: ignore[import]
+    except ImportError as exc:
+        raise LookupError(
+            "edgegrid-python and requests are required for Akamai Edge DNS import"
+        ) from exc
+
+    session = requests.Session()
+    if credentials.edgerc_path:
+        edgerc = EdgeRc(credentials.edgerc_path)
+        session.auth = EdgeGridAuth.from_edgerc(edgerc, credentials.edgerc_section)
+        host = edgerc.get(credentials.edgerc_section, "host")
+        try:
+            edgerc_account_key = edgerc.get(credentials.edgerc_section, "account_key")
+        except Exception:
+            edgerc_account_key = None
+        account_key = credentials.account_switch_key or edgerc_account_key
+    else:
+        session.auth = EdgeGridAuth(
+            client_token=credentials.client_token,
+            client_secret=credentials.client_secret,
+            access_token=credentials.access_token,
+        )
+        host = credentials.host
+        account_key = credentials.account_switch_key
+
+    if not host:
+        raise LookupError("Akamai EdgeGrid host is not configured")
+    return AkamaiEdgeDNSClient(
+        session=session,
+        base_url=f"https://{str(host).strip().removeprefix('https://').rstrip('/')}",
+        account_switch_key=account_key,
+    )
+
+
+def _resolve_workspace_id(db: Session, workspace_id: Optional[int]) -> int:
+    if workspace_id is not None:
+        return workspace_id
+    return assign_default_workspace_to_unscoped_rows(db).id
+
+
+def _workspace_domain_names(db: Session, workspace_id: Optional[int]) -> set[str]:
+    resolved_workspace_id = _resolve_workspace_id(db, workspace_id)
+    query = db.query(Domain.name).filter(Domain.workspace_id == resolved_workspace_id)
+    return {name for (name,) in query.all()}
+
+
+def _normalize_domain_name(domain: str) -> str:
+    return domain.strip().strip(".").lower()
+
+
+async def discover_akamai_edgedns_zones(
+    db: Session,
+    *,
+    workspace_id: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Return Akamai Edge DNS zones visible to EdgeGrid credentials with import state."""
+    client = build_akamai_edgedns_client()
+    known_domains = _workspace_domain_names(db, workspace_id)
+    zones = await client.list_zones()
+    discovered: List[Dict[str, Any]] = []
+    for zone in zones:
+        name = AkamaiEdgeDNSClient._zone_name(zone)  # pylint: disable=protected-access
+        zone_id = AkamaiEdgeDNSClient._zone_id(zone)  # pylint: disable=protected-access
+        if not zone_id or not name:
+            continue
+        discovered.append(
+            {
+                "id": zone_id,
+                "name": name,
+                "status": AkamaiEdgeDNSClient._zone_status(zone),  # pylint: disable=protected-access
+                "account_name": AkamaiEdgeDNSClient._account_name(  # pylint: disable=protected-access
+                    zone
+                ),
+                "imported": name in known_domains,
+            }
+        )
+    return discovered
+
+
+async def import_akamai_edgedns_domains(
+    db: Session,
+    *,
+    requested_domains: Optional[List[str]] = None,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Create Domain rows for Akamai Edge DNS zones."""
+    workspace_id = _resolve_workspace_id(db, workspace_id)
+    workspace = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+
+    zones = await discover_akamai_edgedns_zones(db, workspace_id=workspace_id)
+    requested = None
+    if requested_domains is not None:
+        requested = {
+            _normalize_domain_name(domain)
+            for domain in requested_domains
+            if _normalize_domain_name(domain)
+        }
+    candidate_names: List[str] = []
+    imported: List[str] = []
+    existing: List[str] = []
+    skipped: List[str] = []
+    seen_candidates: set[str] = set()
+
+    for zone in zones:
+        name = str(zone["name"]).lower()
+        if requested is not None and name not in requested:
+            skipped.append(name)
+            continue
+        if name in seen_candidates:
+            continue
+        seen_candidates.add(name)
+        candidate_names.append(name)
+
+    existing_names = set()
+    if candidate_names:
+        existing_names = {
+            row[0] for row in db.query(Domain.name).filter(Domain.name.in_(candidate_names)).all()
+        }
+    new_names = [name for name in candidate_names if name not in existing_names]
+    if workspace and workspace.organization and new_names:
+        require_organization_plan_limit(
+            db,
+            workspace.organization,
+            "monitored_domains",
+            increment=len(new_names),
+        )
+
+    for name in candidate_names:
+        if name in existing_names:
+            existing.append(name)
+        else:
+            db.add(
+                Domain(
+                    name=name,
+                    description="DNS-discovered from Akamai Edge DNS zone import",
+                    active=True,
+                    verified=True,
+                    workspace_id=workspace_id,
+                )
+            )
+            imported.append(name)
+
+    db.commit()
+    return {
+        "imported": imported,
+        "existing": existing,
+        "skipped": skipped,
+        "total_discovered": len(zones),
+    }

--- a/backend/app/services/dns_provider_connectors.py
+++ b/backend/app/services/dns_provider_connectors.py
@@ -84,19 +84,19 @@ _CONNECTORS: tuple[DNSProviderConnector, ...] = (
         id="akamai-edgedns",
         name="Akamai Edge DNS / FastDNS",
         tier=1,
-        auth_models=["edgegrid"],
-        zone_import_status="planned",
+        auth_models=["edgegrid", "edgerc"],
+        zone_import_status="ready",
         record_read_status="planned",
         record_write_status="planned",
         dry_run_supported=False,
         verification_supported=False,
         rollback_supported=True,
         minimum_permissions=[
-            "Edge DNS read access",
+            "Edge DNS Zone Record Management read access",
             "Edge DNS edit access only when repair is enabled",
         ],
         setup_hint=(
-            "Use Akamai EdgeGrid credentials for Edge DNS/FastDNS zone access. "
+            "Use Akamai EdgeGrid credentials or an .edgerc section for Edge DNS/FastDNS zone access. "
             "Akamai EAA is an access frontdoor option, not the DNS connector."
         ),
         docs_url="https://techdocs.akamai.com/edge-dns/reference/edge-dns-api",

--- a/backend/app/services/dns_provider_imports.py
+++ b/backend/app/services/dns_provider_imports.py
@@ -7,6 +7,10 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
+from app.services.akamai_edgedns import (
+    discover_akamai_edgedns_zones,
+    import_akamai_edgedns_domains,
+)
 from app.services.cloudflare_dns import discover_cloudflare_zones, import_cloudflare_domains
 from app.services.dns_provider_connectors import provider_connector_registry
 from app.services.dns_provider_writes import normalize_provider_id
@@ -50,6 +54,17 @@ def _provider_name(provider_id: str) -> str:
     return PROVIDER_NAMES.get(provider_id, provider_id)
 
 
+def _normalize_import_provider_id(provider: str) -> str:
+    provider_id = normalize_provider_id(provider)
+    aliases = {
+        "akamai": "akamai-edgedns",
+        "akamai-edgedns": "akamai-edgedns",
+        "edgedns": "akamai-edgedns",
+        "fastdns": "akamai-edgedns",
+    }
+    return aliases.get(provider_id, provider_id)
+
+
 def _provider_import_item_label(provider_id: str) -> str:
     return "domain" if provider_id == "linode" else "zone"
 
@@ -61,7 +76,7 @@ async def preview_dns_provider_import(
     workspace_id: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Return importable zones/domains for a DNS provider without creating rows."""
-    provider_id = normalize_provider_id(provider)
+    provider_id = _normalize_import_provider_id(provider)
     if provider_id == "cloudflare":
         zones = await discover_cloudflare_zones(db, workspace_id=workspace_id)
     elif provider_id == "route53":
@@ -70,6 +85,8 @@ async def preview_dns_provider_import(
         zones = await discover_hetzner_zones(db, workspace_id=workspace_id)
     elif provider_id == "linode":
         zones = await discover_linode_domains(db, workspace_id=workspace_id)
+    elif provider_id == "akamai-edgedns":
+        zones = await discover_akamai_edgedns_zones(db, workspace_id=workspace_id)
     else:
         raise LookupError(f"Unsupported DNS provider import: {provider_id}")
 
@@ -112,7 +129,7 @@ async def import_dns_provider_domains(
     workspace_id: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Import selected DNS provider zones as monitored domains."""
-    provider_id = normalize_provider_id(provider)
+    provider_id = _normalize_import_provider_id(provider)
     if provider_id == "cloudflare":
         result = await import_cloudflare_domains(
             db,
@@ -133,6 +150,12 @@ async def import_dns_provider_domains(
         )
     elif provider_id == "linode":
         result = await import_linode_domains(
+            db,
+            requested_domains=requested_domains,
+            workspace_id=workspace_id,
+        )
+    elif provider_id == "akamai-edgedns":
+        result = await import_akamai_edgedns_domains(
             db,
             requested_domains=requested_domains,
             workspace_id=workspace_id,

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -22,6 +24,7 @@ from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services import (
+    akamai_edgedns,
     cloudflare_dns,
     cloudflare_oauth,
     dns_provider_connectors,
@@ -134,6 +137,14 @@ class FakeRoute53DNSClient:
     def __init__(self, *, zones=None, account_name="Amazon Route 53"):
         self.zones = zones or []
         self.account_name = account_name
+
+    async def list_zones(self):
+        return self.zones
+
+
+class FakeAkamaiEdgeDNSClient:
+    def __init__(self, *, zones=None):
+        self.zones = zones or []
 
     async def list_zones(self):
         return self.zones
@@ -672,6 +683,128 @@ def test_linode_dns_credentials_and_build_client(monkeypatch):
     assert linode_dns.get_linode_dns_credentials().configured is False
     with pytest.raises(LookupError, match="not configured"):
         linode_dns.build_linode_dns_client()
+
+
+def test_akamai_edgedns_client_list_zones_paginates(monkeypatch):
+    class FakeAkamaiResponse:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class FakeAkamaiSession:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, url, *, params=None):
+            self.calls.append({"url": url, "params": params})
+            if params["page"] == 1:
+                return FakeAkamaiResponse(
+                    {
+                        "zones": [{"zone": DOMAIN, "type": "PRIMARY", "contractId": "ctr_1"}],
+                        "metadata": {"totalPages": 2},
+                    }
+                )
+            return FakeAkamaiResponse(
+                {
+                    "zones": [
+                        {"zone": "second.example.", "zoneType": "SECONDARY", "groupId": "grp_1"}
+                    ],
+                    "metadata": {"totalPages": 2},
+                }
+            )
+
+    session = FakeAkamaiSession()
+    client = akamai_edgedns.AkamaiEdgeDNSClient(
+        session=session,
+        base_url="https://akab.example.luna.akamaiapis.net/",
+        account_switch_key="A-CCT1234:A-CCT5432",
+    )
+
+    zones = asyncio.run(client.list_zones())
+
+    assert [akamai_edgedns.AkamaiEdgeDNSClient._zone_name(zone) for zone in zones] == [
+        DOMAIN,
+        "second.example",
+    ]
+    assert session.calls[0]["params"]["accountSwitchKey"] == "A-CCT1234:A-CCT5432"
+    assert session.calls[0]["url"].endswith("/config-dns/v2/zones")
+
+
+def test_akamai_edgedns_client_ignores_malformed_zone_payload():
+    class FakeAkamaiSession:
+        def get(self, url, *, params=None):
+            return FakeHetznerResponse({"zones": "not-a-list"})
+
+    client = akamai_edgedns.AkamaiEdgeDNSClient(
+        session=FakeAkamaiSession(),
+        base_url="https://akab.example.luna.akamaiapis.net",
+    )
+
+    assert asyncio.run(client.list_zones()) == []
+
+
+def test_akamai_edgedns_credentials_and_direct_build_client(monkeypatch):
+    class FakeEdgeGridAuth:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeSession:
+        auth = None
+
+    fake_requests = types.ModuleType("requests")
+    fake_requests.Session = lambda: FakeSession()
+    fake_edgegrid = types.ModuleType("akamai.edgegrid")
+    fake_edgegrid.EdgeGridAuth = FakeEdgeGridAuth
+    fake_edgegrid.EdgeRc = None
+    fake_akamai = types.ModuleType("akamai")
+    fake_akamai.edgegrid = fake_edgegrid
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+    monkeypatch.setitem(sys.modules, "akamai", fake_akamai)
+    monkeypatch.setitem(sys.modules, "akamai.edgegrid", fake_edgegrid)
+    monkeypatch.setattr(
+        akamai_edgedns,
+        "get_settings",
+        lambda: SimpleNamespace(
+            AKAMAI_EDGERC_PATH="",
+            AKAMAI_EDGERC_SECTION="default",
+            AKAMAI_HOST="https://akab.example.luna.akamaiapis.net",
+            AKAMAI_CLIENT_TOKEN="client-token",
+            AKAMAI_CLIENT_SECRET="client-secret",
+            AKAMAI_ACCESS_TOKEN="access-token",
+            AKAMAI_ACCOUNT_SWITCH_KEY="switch-key",
+            AKAMAI_ACCOUNT_KEY="",
+        ),
+    )
+
+    credentials = akamai_edgedns.get_akamai_edgedns_credentials()
+    client = akamai_edgedns.build_akamai_edgedns_client()
+
+    assert credentials.configured is True
+    assert client.base_url == "https://akab.example.luna.akamaiapis.net"
+    assert client.account_switch_key == "switch-key"
+
+    monkeypatch.setattr(
+        akamai_edgedns,
+        "get_settings",
+        lambda: SimpleNamespace(
+            AKAMAI_EDGERC_PATH="",
+            AKAMAI_EDGERC_SECTION="default",
+            AKAMAI_HOST="",
+            AKAMAI_CLIENT_TOKEN="",
+            AKAMAI_CLIENT_SECRET="",
+            AKAMAI_ACCESS_TOKEN="",
+            AKAMAI_ACCOUNT_SWITCH_KEY="",
+            AKAMAI_ACCOUNT_KEY="",
+        ),
+    )
+    assert akamai_edgedns.get_akamai_edgedns_credentials().configured is False
+    with pytest.raises(LookupError, match="not configured"):
+        akamai_edgedns.build_akamai_edgedns_client()
 
 
 def test_route53_dns_client_list_zones_uses_boto3_paginator():
@@ -1696,6 +1829,61 @@ def test_dns_provider_capabilities_mark_cloudflare_import_available(authed_clien
     assert providers["linode"]["zone_import_status"] == "ready"
     assert providers["linode"]["record_write_status"] == "lexicon_available"
     assert "personal_access_token" in providers["linode"]["auth_models"]
+    assert providers["akamai-edgedns"]["import_available"] is True
+    assert providers["akamai-edgedns"]["zone_import_status"] == "ready"
+    assert providers["akamai-edgedns"]["record_write_status"] == "planned"
+    assert "edgerc" in providers["akamai-edgedns"]["auth_models"]
+
+
+def test_dns_provider_import_preview_supports_akamai_alias(db_session, monkeypatch):
+    monkeypatch.setattr(
+        akamai_edgedns,
+        "build_akamai_edgedns_client",
+        lambda: FakeAkamaiEdgeDNSClient(
+            zones=[
+                {
+                    "zone": DOMAIN,
+                    "type": "PRIMARY",
+                    "contractId": "ctr_1",
+                    "groupId": "grp_1",
+                }
+            ]
+        ),
+    )
+
+    preview = asyncio.run(
+        dns_provider_imports.preview_dns_provider_import(db_session, provider="fastdns")
+    )
+
+    assert preview["provider"] == "akamai-edgedns"
+    assert preview["provider_name"] == "Akamai Edge DNS / FastDNS"
+    assert preview["zones"][0]["domain"] == DOMAIN
+    assert preview["zones"][0]["account_name"] == "Akamai contract ctr_1 / group grp_1"
+
+
+def test_dns_provider_import_apply_supports_akamai(db_session, monkeypatch):
+    monkeypatch.setattr(
+        akamai_edgedns,
+        "build_akamai_edgedns_client",
+        lambda: FakeAkamaiEdgeDNSClient(
+            zones=[
+                {"zone": DOMAIN, "type": "PRIMARY"},
+                {"zone": "ignored.example", "type": "ALIAS"},
+            ]
+        ),
+    )
+
+    result = asyncio.run(
+        dns_provider_imports.import_dns_provider_domains(
+            db_session,
+            provider="akamai",
+            requested_domains=[DOMAIN],
+        )
+    )
+
+    assert result["provider"] == "akamai-edgedns"
+    assert result["imported"] == [DOMAIN]
+    assert result["skipped"] == ["ignored.example"]
 
 
 def test_cloudflare_import_endpoint_returns_import_summary(authed_client: TestClient):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,3 +33,5 @@ google-api-python-client>=2.0.0
 google-auth-httplib2>=0.2.0
 litellm>=1.40.0
 boto3>=1.34.0
+requests>=2.31.0
+edgegrid-python>=1.3.1

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -138,7 +138,7 @@ Live DNS writes stay behind the separate DNS repair approval flow.
 | Amazon Route 53 | Ready | boto3/AWS credential chain, `DMARQ_ROUTE53_PROFILE`, or `DMARQ_ROUTE53_ROLE_ARN` with optional `DMARQ_ROUTE53_EXTERNAL_ID` |
 | Hetzner DNS | Ready | `HETZNER_DNS_API_TOKEN` or `HETZNER_API_TOKEN` with DNS zone read access |
 | Linode DNS | Ready | `LINODE_API_TOKEN` or `LINODE_TOKEN` with Domains read-only access |
-| Akamai Edge DNS/FastDNS | Planned | EdgeGrid DNS credentials, separate from Akamai EAA login |
+| Akamai Edge DNS/FastDNS | Ready | EdgeGrid DNS credentials via `.edgerc` or `AKAMAI_*` variables, separate from Akamai EAA login |
 
 For Route 53 self-hosted installs, use a local AWS profile or environment
 credentials with `route53:ListHostedZones`. Hosted/provider deployments should
@@ -150,6 +150,13 @@ For Linode self-hosted installs, use a personal access token or OAuth token
 limited to Domains read-only access, such as the Linode `domains:read_only`
 scope or equivalent `domain_viewer` role. Keep write-scoped tokens separate
 until approved DNS repair actions are intentionally enabled.
+
+For Akamai Edge DNS/FastDNS self-hosted installs, create an Akamai API client
+with DNS Zone Record Management read access. Use an `.edgerc` file where
+possible, or inject `AKAMAI_HOST`, `AKAMAI_CLIENT_TOKEN`,
+`AKAMAI_CLIENT_SECRET`, and `AKAMAI_ACCESS_TOKEN` through your secret manager.
+Use `AKAMAI_ACCOUNT_SWITCH_KEY` only when your Akamai client needs to operate
+against a delegated account.
 
 ### IMAP Settings
 
@@ -278,6 +285,13 @@ operational policy if long-term storage size matters.
 | `HETZNER_API_TOKEN` | Fallback Hetzner token name if you already inject generic Hetzner Cloud credentials | - | `your_hetzner_read_only_api_token` |
 | `LINODE_API_TOKEN` | Linode API token for read-only DNS domain import through `api.linode.com/v4` | - | `your_linode_domains_read_only_token` |
 | `LINODE_TOKEN` | Fallback Linode token name if you already inject generic Linode credentials | - | `your_linode_domains_read_only_token` |
+| `AKAMAI_EDGERC_PATH` | Optional path to an Akamai `.edgerc` file for Edge DNS zone import | - | `/run/secrets/edgerc` |
+| `AKAMAI_EDGERC_SECTION` | `.edgerc` section name to use | `default` | `default` |
+| `AKAMAI_HOST` | Akamai API hostname when not using `.edgerc` | - | `akab-example.luna.akamaiapis.net` |
+| `AKAMAI_CLIENT_TOKEN` | Akamai EdgeGrid client token when not using `.edgerc` | - | `your_akamai_client_token` |
+| `AKAMAI_CLIENT_SECRET` | Akamai EdgeGrid client secret when not using `.edgerc` | - | `your_akamai_client_secret` |
+| `AKAMAI_ACCESS_TOKEN` | Akamai EdgeGrid access token when not using `.edgerc` | - | `your_akamai_access_token` |
+| `AKAMAI_ACCOUNT_SWITCH_KEY` | Optional Akamai account switch key for managed-account access | - | `A-CCT1234:A-CCT5432` |
 
 ### Email Service and Webhook Integrations
 
@@ -300,6 +314,8 @@ The integration exposes these operational routes:
 | `POST /api/v1/domains/dns/import/hetzner` | Import selected Hetzner DNS zones as monitored domains before reports arrive. |
 | `GET /api/v1/domains/dns/import/linode/preview` | Preview domains visible to the configured Linode read-only token without creating rows. |
 | `POST /api/v1/domains/dns/import/linode` | Import selected Linode DNS domains as monitored domains before reports arrive. |
+| `GET /api/v1/domains/dns/import/akamai-edgedns/preview` | Preview zones visible to the configured Akamai EdgeGrid credentials without creating rows. |
+| `POST /api/v1/domains/dns/import/akamai-edgedns` | Import selected Akamai Edge DNS/FastDNS zones as monitored domains before reports arrive. |
 | `GET /api/v1/domains/cloudflare/discover` | List available zones. |
 | `POST /api/v1/domains/cloudflare/import` | Create monitored domain rows from zones. |
 | `GET /api/v1/domains/{domain}/dns/cloudflare` | Inspect managed DNS records, return DMARC/SPF/DKIM suggestions, and record detected DNS changes. |
@@ -332,7 +348,8 @@ through a configured DNS provider connector.
 Cloudflare is implemented natively and supports DNS-zone import, record
 readback, dry-run, approved apply, verification, and rollback evidence. Hetzner
 DNS supports read-only zone import via Hetzner Console API tokens. Linode DNS
-supports read-only domain import via a Domains-scoped token. `GET
+supports read-only domain import via a Domains-scoped token. Akamai Edge
+DNS/FastDNS supports read-only zone import via EdgeGrid credentials. `GET
 /api/v1/domains/dns/providers` exposes the broader connector registry so
 operators can see which providers are ready, planned, or Lexicon-backed before
 wiring credentials.
@@ -343,7 +360,7 @@ Tier 1 connector metadata currently covers:
 - Amazon Route 53: read-only hosted-zone import; Lexicon-backed write path
   where the runtime and credentials are available. Prefer IAM role assumption
   with external ID for hosted deployments.
-- Akamai Edge DNS / FastDNS: planned EdgeGrid-backed DNS connector. Akamai EAA
+- Akamai Edge DNS / FastDNS: read-only EdgeGrid-backed zone import. Akamai EAA
   is an access/SSO frontdoor option and does not replace the Edge DNS connector.
 - Hetzner DNS: read-only zone import using `HETZNER_DNS_API_TOKEN`;
   Lexicon-backed write path where the runtime and credentials are available.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -638,10 +638,11 @@ actually available today. Use `GET /domains/dns/import/{provider}/preview` to
 list DNS zones visible to a connected provider without creating anything. Use
 `POST /domains/dns/import/{provider}` with an optional `domains` array to import
 selected zones as monitored DMARQ domains before reports have arrived.
-Cloudflare, Route 53, and Hetzner DNS currently support ready DNS-zone import.
-Route 53 uses the server-side boto3/AWS credential chain and only lists hosted
-zones in this flow. Akamai Edge DNS/FastDNS and Linode are exposed as connector
-roadmap metadata until their read/import implementations land. The legacy
+Cloudflare, Route 53, Hetzner DNS, Linode DNS, and Akamai Edge DNS/FastDNS
+currently support ready DNS-zone import. Route 53 uses the server-side
+boto3/AWS credential chain and only lists hosted zones in this flow. Akamai
+Edge DNS/FastDNS uses EdgeGrid credentials and only lists zones in this flow.
+The legacy
 `/domains/cloudflare/discover` and `/domains/cloudflare/import` endpoints remain
 available for compatibility.
 


### PR DESCRIPTION
## Summary

Part of #423.

Adds the next provider connector slice: read-only Akamai Edge DNS / FastDNS zone import.

What changed:
- Adds an Akamai Edge DNS client for `GET /config-dns/v2/zones` with EdgeGrid auth support through `.edgerc` or direct `AKAMAI_*` environment variables.
- Wires Akamai into the generic DNS provider import preview/apply endpoints with aliases for `akamai`, `edgedns`, `fastdns`, and `akamai-edgedns`.
- Marks Akamai Edge DNS/FastDNS zone import as ready in provider capabilities while keeping record read/write as planned.
- Documents Akamai EdgeGrid setup, account switch key usage, routes, and secret handling in `.env.example` and deployment/API docs.
- Adds tests for Akamai pagination, credential wiring, malformed payload handling, provider capability metadata, alias preview, and import apply.

Risk boundary:
- This is read-only zone import only.
- No Akamai DNS record writes are added.
- Secrets are read from environment/.edgerc and are not returned by API responses.

## Validation

- `PYTHONPATH=backend ./.venv/bin/pytest -q backend/app/tests/test_cloudflare_dns.py -k 'akamai or provider_import or provider_capabilities_mark'`
- `PYTHONPATH=backend ./.venv/bin/pytest -q backend/app/tests/test_cloudflare_dns.py`
- `PYTHONPATH=backend ./.venv/bin/python -m compileall -q backend/app/services/akamai_edgedns.py backend/app/services/dns_provider_imports.py backend/app/services/dns_provider_connectors.py backend/app/core/config.py backend/app/tests/test_cloudflare_dns.py`
- `git diff --check`
- `./.venv/bin/python -m pip index versions edgegrid-python` confirmed the dependency is available on PyPI.
