### PR TITLE
Fix single-user workspace navigation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.concurrency import run_in_threadpool
@@ -735,6 +735,8 @@ async def profile_page(request: Request):
 
 @app.get("/members", response_class=HTMLResponse)
 async def members_page(request: Request):
+    if not settings.MULTI_WORKSPACE_UI_ENABLED:
+        return RedirectResponse(url="/settings", status_code=303)
     return templates.TemplateResponse(request, "members.html")
 
 

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -44,7 +44,7 @@
         </div>
         <div class="flex items-center gap-3">
             {% if multi_workspace_ui_enabled %}
-            <div class="hidden min-w-48 md:block" x-show="workspaces.length > 0" x-cloak>
+            <div class="hidden min-w-48 md:block" x-show="workspaces.length > 1" x-cloak>
                 <label class="sr-only" for="workspace-switcher">Workspace</label>
                 <select id="workspace-switcher"
                         class="select select-sm w-full border-white/30 bg-white/95 text-[#272a5f]"

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -231,13 +231,13 @@ def test_members_page_route_is_registered():
     assert any(getattr(route, "path", None) == "/members" for route in app.routes)
 
 
-def test_members_page_renders_template():
-    """The membership management page renders the server-side template."""
+def test_members_page_redirects_when_multi_workspace_ui_disabled():
+    """Single-workspace installs should not expose the membership management UI."""
     request = Request({"type": "http", "method": "GET", "path": "/members", "headers": []})
     response = asyncio.run(members_page(request))
 
-    assert response.status_code == 200
-    assert response.template.name == "members.html"
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings"
 
 
 def test_reports_upload_invalid_extension(authed_client: TestClient):

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import IntegrityError
 from starlette.requests import Request
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
-from app.main import app, members_page
+from app.main import app, members_page, settings
 from app.models.domain import Domain
 
 
@@ -231,13 +231,26 @@ def test_members_page_route_is_registered():
     assert any(getattr(route, "path", None) == "/members" for route in app.routes)
 
 
-def test_members_page_redirects_when_multi_workspace_ui_disabled():
+def test_members_page_redirects_when_multi_workspace_ui_disabled(monkeypatch):
     """Single-workspace installs should not expose the membership management UI."""
+    monkeypatch.setattr(settings, "MULTI_WORKSPACE_UI_ENABLED", False)
+
     request = Request({"type": "http", "method": "GET", "path": "/members", "headers": []})
     response = asyncio.run(members_page(request))
 
     assert response.status_code == 303
     assert response.headers["location"] == "/settings"
+
+
+def test_members_page_renders_when_multi_workspace_ui_enabled(monkeypatch):
+    """Multi-workspace installs keep the membership management UI available."""
+    monkeypatch.setattr(settings, "MULTI_WORKSPACE_UI_ENABLED", True)
+
+    request = Request({"type": "http", "method": "GET", "path": "/members", "headers": []})
+    response = asyncio.run(members_page(request))
+
+    assert response.status_code == 200
+    assert response.template.name == "members.html"
 
 
 def test_reports_upload_invalid_extension(authed_client: TestClient):

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -449,6 +449,7 @@ def test_base_template_propagates_selected_workspace_context():
     assert "withoutWorkspaceContext(input, init)" in script
     assert "headers.delete(workspaceHeaderName)" in script
     assert "dmarq:workspace-changed" in script
+    assert "workspaces.length > 1" in template
     assert "localStorage.removeItem('dmarq.selectedWorkspaceId')" in script
     assert "input instanceof URL" in script
 


### PR DESCRIPTION
## Summary
- hide the workspace switcher unless more than one workspace is available
- redirect `/members` to settings when multi-workspace UI is disabled
- keep the multi-workspace/member UI available when the explicit feature flag is enabled

Fixes #489.

## Local validation
- `PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_api.py`
- `PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/python -m compileall -q backend/app/main.py`
- `git diff --check`