### PR TITLE
Add sender IP network enrichment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,13 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # Optional mail service sender-domain discovery
 # POSTMARK_ACCOUNT_TOKEN="your_postmark_account_token"
 
+# Sender IP network enrichment
+# Uses cached Team Cymru DNS lookups to show ASN, BGP prefix, registry, and
+# likely network operator for observed sending IPs.
+# SOURCE_NETWORK_ENRICHMENT_ENABLED=true
+# SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS=86400
+# SOURCE_NETWORK_ENRICHMENT_MAX_IPS=100
+
 # Optional sender IP reputation feeds
 # Disabled by default. Enable only after reviewing provider terms, credentials,
 # query limits, and privacy implications for sending observed source IPs to

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -106,6 +106,11 @@ from app.services.source_reputation import (
     source_reputation_by_ip,
 )
 from app.services.source_reputation_feeds import feed_registry
+from app.services.source_network import (
+    SourceNetworkIntelligence,
+    lookup_sources_network_cached,
+    merge_network_into_geo,
+)
 from app.services.webhook_events import delivery_to_dict, enqueue_webhook_event
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
@@ -1358,6 +1363,12 @@ class SourceGeo(BaseModel):
     region: str
     asn: Optional[str] = None
     network: Optional[str] = None
+    bgp_prefix: Optional[str] = None
+    registry: Optional[str] = None
+    allocated: Optional[str] = None
+    network_source: Optional[str] = None
+    network_checked_at: Optional[str] = None
+    network_error: Optional[str] = None
     source: str
 
 
@@ -5714,9 +5725,25 @@ async def get_domain_sources(
     )
     anomalies_by_ip = intelligence.get("anomalies_by_ip", {})
     provider = get_default_provider(db)
+    settings = get_settings()
 
     ips = [s.get("source_ip", "unknown") for s in sources]
     hostnames = await asyncio.gather(*[_safe_ptr_lookup(provider, ip) for ip in ips])
+    networks_by_ip: Dict[str, SourceNetworkIntelligence] = {}
+    if settings.SOURCE_NETWORK_ENRICHMENT_ENABLED:
+        try:
+            networks_by_ip = await lookup_sources_network_cached(
+                db,
+                provider,
+                ips,
+                ttl_seconds=settings.SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS,
+                max_ips=settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS,
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.info(
+                "Source network enrichment failed for domain sources: %s",
+                type(exc).__name__,
+            )
 
     source_entries = []
     sender_by_ip: Dict[str, Dict[str, Any]] = {}
@@ -5772,7 +5799,9 @@ async def get_domain_sources(
                 disposition_counts=source.get("disposition_counts", {}),
                 hostname=hostname,
                 sender=SenderIdentity(**sender),
-                geo=SourceGeo(**source_geo_for(ip, source)),
+                geo=SourceGeo(
+                    **merge_network_into_geo(source_geo_for(ip, source), networks_by_ip.get(ip))
+                ),
                 anomalies=[SourceAnomaly(**anomaly) for anomaly in source_anomalies],
                 reputation=(
                     _source_reputation_response(reputation) if reputation is not None else None

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
@@ -26,6 +27,11 @@ from app.services.source_reputation import (
     SourceReputation,
     build_source_reputation_cached,
     source_reputation_by_ip,
+)
+from app.services.source_network import (
+    SourceNetworkIntelligence,
+    lookup_sources_network_cached,
+    merge_network_into_geo,
 )
 from app.services.workspace_access import (
     PERMISSION_REPORTS_READ,
@@ -762,8 +768,9 @@ def _source_details(
     record: Dict[str, Any],
     hostname: Optional[str],
     sender: Dict[str, Any],
+    network: Optional[SourceNetworkIntelligence] = None,
 ) -> Dict[str, Any]:
-    geo = source_geo_for(ip, record)
+    geo = merge_network_into_geo(source_geo_for(ip, record), network)
     return {
         "hostname": hostname,
         "sender": sender,
@@ -772,6 +779,12 @@ def _source_details(
         "region": geo.get("region"),
         "asn": geo.get("asn"),
         "network": geo.get("network"),
+        "bgp_prefix": geo.get("bgp_prefix"),
+        "registry": geo.get("registry"),
+        "allocated": geo.get("allocated"),
+        "network_source": geo.get("network_source"),
+        "network_checked_at": geo.get("network_checked_at"),
+        "network_error": geo.get("network_error"),
         "geo_source": geo.get("source"),
     }
 
@@ -814,6 +827,7 @@ async def get_report_by_id(
     raw_records = list(report.get("records", []))
     source_rows = [_source_row_from_report_record(rec) for rec in raw_records]
     provider = get_default_provider(db)
+    settings = get_settings()
     ips = [str(row.get("source_ip") or "unknown") for row in source_rows]
     ptr_semaphore = asyncio.Semaphore(20)
 
@@ -822,6 +836,21 @@ async def get_report_by_id(
             return await _safe_ptr_lookup(provider, ip)
 
     hostnames = await asyncio.gather(*[_bounded_ptr_lookup(ip) for ip in ips])
+    networks_by_ip: Dict[str, SourceNetworkIntelligence] = {}
+    if settings.SOURCE_NETWORK_ENRICHMENT_ENABLED:
+        try:
+            networks_by_ip = await lookup_sources_network_cached(
+                db,
+                provider,
+                ips,
+                ttl_seconds=settings.SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS,
+                max_ips=settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS,
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.info(
+                "Report source network enrichment failed for report detail: %s",
+                type(exc).__name__,
+            )
     sender_by_ip = {
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))
         for ip, row, hostname in zip(ips, source_rows, hostnames, strict=True)
@@ -860,7 +889,13 @@ async def get_report_by_id(
                 header_from=rec.get("header_from", ""),
                 spf=rec.get("spf") if isinstance(rec.get("spf"), list) else None,
                 dkim=rec.get("dkim") if isinstance(rec.get("dkim"), list) else None,
-                source_details=_source_details(ip, rec, hostname, sender_by_ip.get(ip, {})),
+                source_details=_source_details(
+                    ip,
+                    rec,
+                    hostname,
+                    sender_by_ip.get(ip, {}),
+                    networks_by_ip.get(ip),
+                ),
                 reputation=_source_reputation_dict(reputation) if reputation else None,
                 **guidance,
             )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -87,6 +87,9 @@ class Settings(BaseSettings):
     SOURCE_REPUTATION_FEED_TIMEOUT_SECONDS: float = 2.0
     SOURCE_REPUTATION_FEED_CACHE_SECONDS: int = 86_400
     SOURCE_REPUTATION_FEED_MAX_IPS: int = 100
+    SOURCE_NETWORK_ENRICHMENT_ENABLED: bool = True
+    SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS: int = 86_400
+    SOURCE_NETWORK_ENRICHMENT_MAX_IPS: int = 100
 
     # Optional Stripe Billing integration. Self-hosted and provider-billed
     # deployments work without these values.

--- a/backend/app/services/source_network.py
+++ b/backend/app/services/source_network.py
@@ -1,0 +1,308 @@
+"""Network ownership enrichment for observed sender IPs."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.dns_cache import DNSCache
+
+_CACHE_PROVIDER = "source-network-intelligence-v1"
+_SELECTORS_KEY = "team-cymru-dns-v1"
+
+COUNTRY_NAMES = {
+    "AT": "Austria",
+    "AU": "Australia",
+    "BE": "Belgium",
+    "BR": "Brazil",
+    "CA": "Canada",
+    "CH": "Switzerland",
+    "CZ": "Czechia",
+    "DE": "Germany",
+    "DK": "Denmark",
+    "ES": "Spain",
+    "FI": "Finland",
+    "FR": "France",
+    "GB": "United Kingdom",
+    "IE": "Ireland",
+    "IN": "India",
+    "IT": "Italy",
+    "JP": "Japan",
+    "NL": "Netherlands",
+    "NO": "Norway",
+    "PL": "Poland",
+    "SE": "Sweden",
+    "SG": "Singapore",
+    "US": "United States",
+}
+
+COUNTRY_REGIONS = {
+    "AT": "Europe",
+    "BE": "Europe",
+    "CH": "Europe",
+    "CZ": "Europe",
+    "DE": "Europe",
+    "DK": "Europe",
+    "ES": "Europe",
+    "FI": "Europe",
+    "FR": "Europe",
+    "GB": "Europe",
+    "IE": "Europe",
+    "IT": "Europe",
+    "NL": "Europe",
+    "NO": "Europe",
+    "PL": "Europe",
+    "SE": "Europe",
+    "AU": "Oceania",
+    "BR": "South America",
+    "CA": "North America",
+    "IN": "Asia",
+    "JP": "Asia",
+    "SG": "Asia",
+    "US": "North America",
+}
+
+
+@dataclass
+class SourceNetworkIntelligence:
+    """Network ownership and routing context for one source IP."""
+
+    ip: str
+    asn: Optional[str] = None
+    as_name: Optional[str] = None
+    bgp_prefix: Optional[str] = None
+    country_code: Optional[str] = None
+    country: Optional[str] = None
+    region: Optional[str] = None
+    registry: Optional[str] = None
+    allocated: Optional[str] = None
+    source: str = "unknown"
+    checked_at: str = ""
+    error: Optional[str] = None
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _is_fresh(row: DNSCache, ttl_seconds: int, now: datetime) -> bool:
+    return row.checked_at >= now - timedelta(seconds=ttl_seconds)
+
+
+def _query_name(ip: str) -> str:
+    address = ipaddress.ip_address(ip)
+    if address.version == 4:
+        return f"{'.'.join(reversed(str(address).split('.')))}.origin.asn.cymru.com"
+    reversed_nibbles = ".".join(reversed(address.exploded.replace(":", "")))
+    return f"{reversed_nibbles}.origin6.asn.cymru.com"
+
+
+def _normalize_asn(value: str) -> Optional[str]:
+    text = value.strip()
+    if not text or text.upper() == "NA":
+        return None
+    return text if text.upper().startswith("AS") else f"AS{text}"
+
+
+def _from_json(value: str) -> SourceNetworkIntelligence:
+    data = json.loads(value)
+    return SourceNetworkIntelligence(**data)
+
+
+def _from_cymru_txt(ip: str, txt_records: Iterable[str]) -> SourceNetworkIntelligence:
+    checked_at = _utcnow_iso()
+    for record in txt_records:
+        cleaned = str(record).strip().strip('"')
+        if "|" not in cleaned or cleaned.lower().startswith("as |"):
+            continue
+        parts = [part.strip().strip('"') for part in cleaned.split("|")]
+        if len(parts) < 6:
+            continue
+        country_code = parts[2].upper() if parts[2] else None
+        return SourceNetworkIntelligence(
+            ip=ip,
+            asn=_normalize_asn(parts[0]),
+            bgp_prefix=parts[1] or None,
+            country_code=country_code,
+            country=COUNTRY_NAMES.get(country_code or ""),
+            region=COUNTRY_REGIONS.get(country_code or ""),
+            registry=parts[3].lower() if parts[3] else None,
+            allocated=parts[4] or None,
+            as_name=parts[5] or None,
+            source="team-cymru",
+            checked_at=checked_at,
+        )
+    return SourceNetworkIntelligence(
+        ip=ip,
+        source="team-cymru",
+        checked_at=checked_at,
+        error="No ASN record returned.",
+    )
+
+
+async def lookup_source_network(
+    provider: Any,
+    ip: str,
+) -> SourceNetworkIntelligence:
+    """Lookup ASN and network context for one public IP using Team Cymru DNS."""
+    checked_at = _utcnow_iso()
+    try:
+        address = ipaddress.ip_address(ip)
+    except ValueError:
+        return SourceNetworkIntelligence(
+            ip=ip,
+            source="local",
+            checked_at=checked_at,
+            error="Invalid source IP.",
+        )
+    if not address.is_global:
+        return SourceNetworkIntelligence(
+            ip=ip,
+            source="local",
+            checked_at=checked_at,
+            error="Non-global IP address.",
+        )
+
+    try:
+        records = await provider.lookup_txt(_query_name(ip))
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return SourceNetworkIntelligence(
+            ip=ip,
+            source="team-cymru",
+            checked_at=checked_at,
+            error=f"ASN lookup failed: {type(exc).__name__}.",
+        )
+    return _from_cymru_txt(ip, records)
+
+
+async def lookup_source_network_cached(
+    db: Session,
+    provider: Any,
+    ip: str,
+    *,
+    ttl_seconds: int = 86_400,
+    refresh: bool = False,
+) -> Tuple[SourceNetworkIntelligence, bool, datetime]:
+    """Lookup one IP network context with persistent cache semantics."""
+    now = _utcnow_naive()
+    row = (
+        db.query(DNSCache)
+        .filter(
+            DNSCache.domain == ip,
+            DNSCache.provider == _CACHE_PROVIDER,
+            DNSCache.selectors_key == _SELECTORS_KEY,
+        )
+        .first()
+    )
+    if row and not refresh and _is_fresh(row, ttl_seconds, now):
+        return _from_json(row.result_json), True, row.checked_at
+
+    result = await lookup_source_network(provider, ip)
+    payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
+    if row is None:
+        row = DNSCache(
+            domain=ip,
+            provider=_CACHE_PROVIDER,
+            selectors_key=_SELECTORS_KEY,
+            result_json=payload,
+            checked_at=now,
+        )
+        db.add(row)
+    else:
+        row.result_json = payload
+        row.checked_at = now
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        row = (
+            db.query(DNSCache)
+            .filter(
+                DNSCache.domain == ip,
+                DNSCache.provider == _CACHE_PROVIDER,
+                DNSCache.selectors_key == _SELECTORS_KEY,
+            )
+            .first()
+        )
+        if row is None:
+            raise
+        row.result_json = payload
+        row.checked_at = now
+        db.commit()
+
+    db.refresh(row)
+    return result, False, row.checked_at
+
+
+async def lookup_sources_network_cached(
+    db: Session,
+    provider: Any,
+    source_ips: Iterable[str],
+    *,
+    ttl_seconds: int = 86_400,
+    max_ips: int = 100,
+    refresh: bool = False,
+) -> Dict[str, SourceNetworkIntelligence]:
+    """Lookup network context for a bounded set of observed source IPs."""
+    results: Dict[str, SourceNetworkIntelligence] = {}
+    seen: set[str] = set()
+    unique_ips: List[str] = []
+    for raw_ip in source_ips:
+        ip = str(raw_ip or "").strip()
+        if not ip or ip in seen:
+            continue
+        seen.add(ip)
+        unique_ips.append(ip)
+        if len(unique_ips) >= max_ips:
+            break
+    for ip in unique_ips:
+        result, _, _ = await lookup_source_network_cached(
+            db,
+            provider,
+            ip,
+            ttl_seconds=ttl_seconds,
+            refresh=refresh,
+        )
+        results[ip] = result
+    return results
+
+
+def merge_network_into_geo(
+    geo: Dict[str, Any],
+    network: Optional[SourceNetworkIntelligence],
+) -> Dict[str, Any]:
+    """Return source geo metadata enriched with ASN/network ownership."""
+    merged = dict(geo)
+    if network is None:
+        return merged
+    if network.country_code and merged.get("country_code") in {None, "", "ZZ"}:
+        merged["country_code"] = network.country_code
+    if network.country and merged.get("country") in {None, "", "Unknown"}:
+        merged["country"] = network.country
+    if network.region and merged.get("region") in {None, "", "Unknown"}:
+        merged["region"] = network.region
+    if network.asn and not merged.get("asn"):
+        merged["asn"] = network.asn
+    if network.as_name and not merged.get("network"):
+        merged["network"] = network.as_name
+    merged["bgp_prefix"] = network.bgp_prefix
+    merged["registry"] = network.registry
+    merged["allocated"] = network.allocated
+    merged["network_source"] = network.source
+    merged["network_checked_at"] = network.checked_at
+    if network.error:
+        merged["network_error"] = network.error
+    elif merged.get("source") == "inferred":
+        merged["source"] = "network"
+    return merged

--- a/backend/app/services/source_network.py
+++ b/backend/app/services/source_network.py
@@ -114,6 +114,19 @@ def _normalize_asn(value: str) -> Optional[str]:
     return text if text.upper().startswith("AS") else f"AS{text}"
 
 
+def _normalize_global_source_ip(value: Any) -> Optional[str]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        address = ipaddress.ip_address(text)
+    except ValueError:
+        return None
+    if not address.is_global:
+        return None
+    return str(address)
+
+
 def _from_json(value: str) -> SourceNetworkIntelligence:
     data = json.loads(value)
     return SourceNetworkIntelligence(**data)
@@ -259,8 +272,8 @@ async def lookup_sources_network_cached(
     seen: set[str] = set()
     unique_ips: List[str] = []
     for raw_ip in source_ips:
-        ip = str(raw_ip or "").strip()
-        if not ip or ip in seen:
+        ip = _normalize_global_source_ip(raw_ip)
+        if ip is None or ip in seen:
             continue
         seen.add(ip)
         unique_ips.append(ip)

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1557,7 +1557,23 @@
                                             <template x-if="source.geo?.network">
                                                 <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80" x-text="source.geo.network"></span>
                                             </template>
+                                            <template x-if="source.geo?.bgp_prefix">
+                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-mono font-medium text-base-content/80" x-text="source.geo.bgp_prefix"></span>
+                                            </template>
+                                            <template x-if="source.geo?.registry">
+                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium uppercase text-base-content/70" x-text="source.geo.registry"></span>
+                                            </template>
                                         </div>
+                                        <template x-if="source.geo?.allocated || source.geo?.network_source">
+                                            <p class="text-muted-foreground">
+                                                <span x-show="source.geo?.allocated">Allocated <span x-text="source.geo.allocated"></span></span>
+                                                <span x-show="source.geo?.allocated && source.geo?.network_source"> · </span>
+                                                <span x-show="source.geo?.network_source">Network data: <span x-text="source.geo.network_source"></span></span>
+                                            </p>
+                                        </template>
+                                        <template x-if="source.geo?.network_error && !source.geo?.asn && !source.geo?.network">
+                                            <p class="text-muted-foreground" x-text="source.geo.network_error"></p>
+                                        </template>
                                         <div class="flex flex-wrap items-center gap-1.5">
                                             <span
                                                 class="inline-flex items-center rounded-full px-2 py-0.5 font-semibold"
@@ -2091,6 +2107,10 @@ function domainDetailsApp(domainId) {
                     source.geo?.region,
                     source.geo?.asn,
                     source.geo?.network,
+                    source.geo?.bgp_prefix,
+                    source.geo?.registry,
+                    source.geo?.allocated,
+                    source.geo?.network_source,
                     source.reputation?.status,
                     source.reputation?.summary,
                     ...(source.reputation?.listings || []),
@@ -2383,7 +2403,9 @@ function domainDetailsApp(domainId) {
             const region = isKnown(geo.region) ? geo.region : null;
             const country = isKnown(geo.country) ? geo.country : null;
             const network = isKnown(geo.network) ? geo.network : null;
-            const parts = [region, network || country].filter(Boolean);
+            const asn = isKnown(geo.asn) ? geo.asn : null;
+            const prefix = isKnown(geo.bgp_prefix) ? geo.bgp_prefix : null;
+            const parts = [region, country, [asn, network, prefix].filter(Boolean).join(' · ')].filter(Boolean);
             return parts.length ? parts.join(' · ') : 'Geo unavailable';
         },
 

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -214,6 +214,22 @@
                                                 <span x-show="record.source_details?.network"> · </span>
                                                 <span x-text="record.source_details?.network || ''"></span>
                                             </div>
+                                            <div class="flex flex-wrap gap-1" x-show="record.source_details?.bgp_prefix || record.source_details?.registry || record.source_details?.allocated">
+                                                <span x-show="record.source_details?.bgp_prefix"
+                                                      class="inline-flex items-center rounded bg-base-200 px-2 py-0.5 font-mono"
+                                                      x-text="record.source_details.bgp_prefix"></span>
+                                                <span x-show="record.source_details?.registry"
+                                                      class="inline-flex items-center rounded bg-base-200 px-2 py-0.5 uppercase"
+                                                      x-text="record.source_details.registry"></span>
+                                                <span x-show="record.source_details?.allocated"
+                                                      class="inline-flex items-center rounded bg-base-200 px-2 py-0.5"
+                                                      x-text="'allocated ' + record.source_details.allocated"></span>
+                                            </div>
+                                            <div x-show="record.source_details?.network_source">
+                                                Network data: <span x-text="record.source_details.network_source"></span>
+                                            </div>
+                                            <div x-show="record.source_details?.network_error && !record.source_details?.asn && !record.source_details?.network"
+                                                 x-text="record.source_details.network_error"></div>
                                             <template x-if="record.reputation">
                                                 <div class="pt-1">
                                                     <span class="inline-flex items-center px-2 py-1 rounded text-xs"
@@ -369,7 +385,8 @@ function reportDetailApp(reportId) {
             const country = details.country || 'Unknown country';
             const region = details.region || 'Unknown region';
             const code = details.country_code && details.country_code !== 'ZZ' ? ` (${details.country_code})` : '';
-            return `${region}, ${country}${code}`;
+            const network = [details.asn, details.network, details.bgp_prefix].filter(Boolean).join(' · ');
+            return [region, `${country}${code}`, network].filter(Boolean).join(' · ');
         },
 
         reputationClass(status) {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -355,6 +355,10 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "source.geo?.region" in template
     assert "source.geo?.asn" in template
     assert "source.geo?.network" in template
+    assert "source.geo?.bgp_prefix" in template
+    assert "source.geo?.registry" in template
+    assert "source.geo?.allocated" in template
+    assert "source.geo?.network_source" in template
     assert "source.reputation?.status" in template
     assert "source.reputation?.risk_score" in template
     assert "source.reputation?.listings" in template

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -31,6 +31,7 @@ from app.services.source_reputation import (
     ReputationEvidence,
     SourceReputation,
 )
+from app.services.source_network import SourceNetworkIntelligence
 from app.services.webhook_events import (
     EVENT_REMEDIATION_APPROVAL_REQUIRED,
     create_webhook_endpoint,
@@ -155,6 +156,16 @@ def seeded_client(authed_client: TestClient, db_session):
     db_session.commit()
     ReportStore.get_instance().add_report(REPORT_DICT_POLICY)
     return authed_client
+
+
+@pytest.fixture(autouse=True)
+def _stub_source_network_enrichment(monkeypatch):
+    """Keep domain endpoint tests deterministic unless a test overrides enrichment."""
+
+    async def fake_networks(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(domains_endpoint, "lookup_sources_network_cached", fake_networks)
 
 
 # ---------------------------------------------------------------------------
@@ -2419,8 +2430,26 @@ def test_get_domain_sources_includes_ip_intelligence_and_reputation(
             None,
         )
 
+    async def fake_networks(*_args, **_kwargs):
+        return {
+            source_ip: SourceNetworkIntelligence(
+                ip=source_ip,
+                asn="AS24940",
+                as_name="Hetzner Online GmbH",
+                bgp_prefix="193.138.192.0/19",
+                country_code="DE",
+                country="Germany",
+                region="Europe",
+                registry="ripencc",
+                allocated="2004-02-17",
+                source="team-cymru",
+                checked_at="2026-07-02T08:00:00Z",
+            )
+        }
+
     monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
+    monkeypatch.setattr(domains_endpoint, "lookup_sources_network_cached", fake_networks)
     workspace = get_or_create_default_workspace(db_session)
     report = {
         **REPORT_DICT_POLICY,
@@ -2433,13 +2462,6 @@ def test_get_domain_sources_includes_ip_intelligence_and_reputation(
                 "dkim_result": "fail",
                 "spf_result": "fail",
                 "header_from": DOMAIN,
-                "extensions": {
-                    "geo:country": "Germany",
-                    "geo:country_code": "DE",
-                    "geo:region": "Europe",
-                    "geo:asn": "AS24940",
-                    "geo:network": "Hetzner Online GmbH",
-                },
             }
         ],
         "summary": {"total_count": 20, "passed_count": 0, "failed_count": 20},
@@ -2457,6 +2479,10 @@ def test_get_domain_sources_includes_ip_intelligence_and_reputation(
     assert source["geo"]["region"] == "Europe"
     assert source["geo"]["asn"] == "AS24940"
     assert source["geo"]["network"] == "Hetzner Online GmbH"
+    assert source["geo"]["bgp_prefix"] == "193.138.192.0/19"
+    assert source["geo"]["registry"] == "ripencc"
+    assert source["geo"]["allocated"] == "2004-02-17"
+    assert source["geo"]["network_source"] == "team-cymru"
     assert source["reputation"]["status"] == "listed"
     assert source["reputation"]["risk_score"] == 85
     assert source["reputation"]["listings"] == ["Spamhaus Zen"]

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -4,6 +4,7 @@ import zipfile
 from contextlib import contextmanager
 from datetime import date, datetime
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
@@ -21,11 +22,22 @@ from app.services.organizations import OrganizationPlanLimitError
 from app.services.report_persistence import persisted_report_to_dict, save_parsed_report
 from app.services.report_store import ReportStore
 from app.services.source_reputation import DomainReputation, ReputationEvidence, SourceReputation
+from app.services.source_network import SourceNetworkIntelligence
 from app.services.workspace_access import ROLE_ANALYST
 from app.services.workspaces import get_or_create_default_workspace
 from app.tests.test_data import SAMPLE_XML, load_dmarc_fixture
 
 SAMPLE_RFC9990_XML = load_dmarc_fixture("rfc9990-treewalk-extension.xml")
+
+
+@pytest.fixture(autouse=True)
+def _stub_source_network_enrichment(monkeypatch):
+    """Keep report endpoint tests deterministic unless a test overrides enrichment."""
+
+    async def fake_networks(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", fake_networks)
 
 
 def _make_zip(xml_content: str) -> bytes:
@@ -863,11 +875,6 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
                     "spf_result": "fail",
                     "header_from": "example.com",
                     "extensions": {
-                        "geo:country": "Germany",
-                        "geo:country_code": "DE",
-                        "geo:region": "Europe",
-                        "geo:asn": "AS64555",
-                        "geo:network": "Example Sender Network",
                         "demo:blacklists": "Example DNSBL",
                     },
                 }
@@ -910,8 +917,26 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
             None,
         )
 
+    async def fake_networks(*_args, **_kwargs):
+        return {
+            "193.138.195.141": SourceNetworkIntelligence(
+                ip="193.138.195.141",
+                asn="AS24940",
+                as_name="Hetzner Online GmbH",
+                bgp_prefix="193.138.192.0/19",
+                country_code="DE",
+                country="Germany",
+                region="Europe",
+                registry="ripencc",
+                allocated="2004-02-17",
+                source="team-cymru",
+                checked_at="2026-07-02T08:00:00Z",
+            )
+        }
+
     monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+    monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", fake_networks)
 
     response = authed_client.get("/api/v1/reports/source-intel-report")
 
@@ -919,8 +944,12 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
     record = response.json()["records"][0]
     assert record["source_details"]["hostname"] == "mail.example-sender.net"
     assert record["source_details"]["country"] == "Germany"
-    assert record["source_details"]["asn"] == "AS64555"
-    assert record["source_details"]["network"] == "Example Sender Network"
+    assert record["source_details"]["asn"] == "AS24940"
+    assert record["source_details"]["network"] == "Hetzner Online GmbH"
+    assert record["source_details"]["bgp_prefix"] == "193.138.192.0/19"
+    assert record["source_details"]["registry"] == "ripencc"
+    assert record["source_details"]["allocated"] == "2004-02-17"
+    assert record["source_details"]["network_source"] == "team-cymru"
     assert record["reputation"]["status"] == "listed"
     assert record["reputation"]["risk_score"] == 82
     assert record["reputation"]["listings"] == ["Example DNSBL"]

--- a/backend/app/tests/test_source_network.py
+++ b/backend/app/tests/test_source_network.py
@@ -1,0 +1,109 @@
+import pytest
+
+from app.services.source_network import (
+    SourceNetworkIntelligence,
+    lookup_source_network,
+    lookup_source_network_cached,
+    merge_network_into_geo,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+class FakeProvider:
+    def __init__(self, records=None):
+        self.records = records or []
+        self.queries = []
+
+    async def lookup_txt(self, name):
+        self.queries.append(name)
+        return self.records
+
+
+async def test_lookup_source_network_parses_team_cymru_txt():
+    provider = FakeProvider(
+        [
+            '"24940 | 193.138.192.0/19 | DE | ripencc | 2004-02-17 | HETZNER-AS, DE"',
+        ]
+    )
+
+    result = await lookup_source_network(provider, "193.138.195.141")
+
+    assert provider.queries == ["141.195.138.193.origin.asn.cymru.com"]
+    assert result.asn == "AS24940"
+    assert result.as_name == "HETZNER-AS, DE"
+    assert result.bgp_prefix == "193.138.192.0/19"
+    assert result.country_code == "DE"
+    assert result.country == "Germany"
+    assert result.region == "Europe"
+    assert result.registry == "ripencc"
+    assert result.allocated == "2004-02-17"
+    assert result.source == "team-cymru"
+    assert result.error is None
+
+
+async def test_lookup_source_network_skips_non_global_ip():
+    provider = FakeProvider()
+
+    result = await lookup_source_network(provider, "192.0.2.10")
+
+    assert provider.queries == []
+    assert result.error == "Non-global IP address."
+    assert result.source == "local"
+
+
+async def test_lookup_source_network_cached_reuses_fresh_result(db_session):
+    provider = FakeProvider(
+        [
+            '"64500 | 198.51.100.0/24 | US | arin | 2026-01-01 | EXAMPLE-AS, US"',
+        ]
+    )
+
+    first, first_cached, first_checked = await lookup_source_network_cached(
+        db_session,
+        provider,
+        "8.8.8.8",
+    )
+    provider.records = [
+        '"64501 | 198.51.101.0/24 | US | arin | 2026-01-02 | OTHER-AS, US"',
+    ]
+    second, second_cached, second_checked = await lookup_source_network_cached(
+        db_session,
+        provider,
+        "8.8.8.8",
+    )
+
+    assert first_cached is False
+    assert second_cached is True
+    assert first_checked == second_checked
+    assert first.asn == "AS64500"
+    assert second.asn == "AS64500"
+    assert provider.queries == ["8.8.8.8.origin.asn.cymru.com"]
+
+
+def test_merge_network_into_geo_preserves_report_metadata_and_adds_prefix():
+    network = SourceNetworkIntelligence(
+        ip="193.138.195.141",
+        asn="AS24940",
+        as_name="Hetzner Online GmbH",
+        bgp_prefix="193.138.192.0/19",
+        country_code="DE",
+        country="Germany",
+        region="Europe",
+        registry="ripencc",
+        allocated="2004-02-17",
+        source="team-cymru",
+        checked_at="2026-07-02T08:00:00Z",
+    )
+    merged = merge_network_into_geo(
+        {"country": "France", "country_code": "FR", "source": "report"},
+        network,
+    )
+
+    assert merged["country"] == "France"
+    assert merged["country_code"] == "FR"
+    assert merged["asn"] == "AS24940"
+    assert merged["network"] == "Hetzner Online GmbH"
+    assert merged["bgp_prefix"] == "193.138.192.0/19"
+    assert merged["registry"] == "ripencc"
+    assert merged["network_source"] == "team-cymru"

--- a/backend/app/tests/test_source_network.py
+++ b/backend/app/tests/test_source_network.py
@@ -4,6 +4,7 @@ from app.services.source_network import (
     SourceNetworkIntelligence,
     lookup_source_network,
     lookup_source_network_cached,
+    lookup_sources_network_cached,
     merge_network_into_geo,
 )
 
@@ -78,6 +79,24 @@ async def test_lookup_source_network_cached_reuses_fresh_result(db_session):
     assert first_checked == second_checked
     assert first.asn == "AS64500"
     assert second.asn == "AS64500"
+    assert provider.queries == ["8.8.8.8.origin.asn.cymru.com"]
+
+
+async def test_lookup_sources_network_cached_filters_invalid_and_non_global_ips(db_session):
+    provider = FakeProvider(
+        [
+            '"15169 | 8.8.8.0/24 | US | arin | 1992-12-01 | GOOGLE, US"',
+        ]
+    )
+
+    results = await lookup_sources_network_cached(
+        db_session,
+        provider,
+        ["unknown", "", None, "10.0.0.1", "192.0.2.10", "8.8.8.8", "8.8.8.8"],
+    )
+
+    assert list(results) == ["8.8.8.8"]
+    assert results["8.8.8.8"].asn == "AS15169"
     assert provider.queries == ["8.8.8.8.origin.asn.cymru.com"]
 
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -207,6 +207,23 @@ non-global IP addresses. Feed failures are shown as evidence, but they do not
 create blacklist findings by themselves. A source is treated as listed only when
 a configured provider returns a positive listing response.
 
+### Sender Network Enrichment
+
+DMARQ can enrich observed sender IPs with cached ASN, BGP prefix, registry, and
+likely network-operator evidence. This is separate from reputation feeds: network
+enrichment answers "who operates this sending network?", while reputation feeds
+answer "is this IP listed or risky according to a configured provider?"
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `SOURCE_NETWORK_ENRICHMENT_ENABLED` | Enable cached Team Cymru DNS lookups for ASN and BGP prefix metadata. | `true` | `false` |
+| `SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS` | Persistent cache TTL for per-IP network metadata. | `86400` | `604800` |
+| `SOURCE_NETWORK_ENRICHMENT_MAX_IPS` | Maximum unique source IPs enriched per domain/report request. | `100` | `250` |
+
+The lookup is read-only and skips private, reserved, loopback, and otherwise
+non-global IP addresses. Disable it for deployments that do not want observed
+source IPs sent to an external DNS-based metadata service.
+
 ### Demo Mode
 
 Set `DEMO_MODE=true` only for public demo environments such as `demo.dmarq.org`.

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -110,14 +110,20 @@ webhook delivery state.
 
 ### Source Intelligence
 
-The domain detail page groups sending sources into coarse regions and networks
-when that information is available from report metadata or demo intelligence.
+The domain detail page groups sending sources into regions, reverse DNS
+hostnames, ASNs, BGP prefixes, registries, and likely network operators when
+that evidence is available from reports or cached sender-network enrichment.
 It also flags unusual source behavior, including new senders, new regions,
 source volume spikes, and increased SPF/DKIM alignment failures.
 
 Use these findings before editing DNS. A new source is not automatically a
 trusted sender; confirm the service owner first, then update SPF or DKIM only
 when the source is legitimate.
+
+Reputation evidence is shown separately from network ownership. ASN and BGP
+prefix data explains who appears to operate the sending infrastructure; optional
+reputation feeds can add DNSBL or blacklist evidence when an administrator has
+enabled those providers.
 
 ### DNS Guidance
 


### PR DESCRIPTION
## Summary
- enrich observed sender IPs with cached ASN, BGP prefix, registry, allocation, and likely network operator data
- show the new IP intelligence on domain source tables and aggregate report detail records
- document the Team Cymru based network enrichment separately from optional reputation/DNSBL feeds

Closes #490.

## Local validation
- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_source_network.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_reports_api.py backend/app/tests/test_dashboard_template_security.py
- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/python -m compileall -q backend/app/services/source_network.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/reports.py backend/app/core/config.py
- git diff --check