### PR TITLE
fix: verify release image tags before gitops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image: ${{ steps.verify-image.outputs.image }}
+      short_sha: ${{ steps.verify-image.outputs.short_sha }}
 
     steps:
       - name: Checkout code
@@ -262,6 +265,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Verify short SHA image tag
+        id: verify-image
+        env:
+          IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          IMAGE="${IMAGE_REPOSITORY}:${SHORT_SHA}"
+          docker buildx imagetools inspect "$IMAGE" >/dev/null
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
   # ── Stage 4: GitOps – update k8s manifests ───────────────────────────────
   update-k8s-manifest:
     name: Update K8s Manifests
@@ -275,9 +289,9 @@ jobs:
       - name: Compute image tag
         id: tag
         run: |
-          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          echo "image=ghcr.io/${{ github.repository }}:${SHORT_SHA}" >> "$GITHUB_OUTPUT"
-          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          test -n "${{ needs.docker.outputs.image }}"
+          echo "image=${{ needs.docker.outputs.image }}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${{ needs.docker.outputs.short_sha }}" >> "$GITHUB_OUTPUT"
           echo "image_pattern=^ghcr\\.io/${{ github.repository }}:" >> "$GITHUB_OUTPUT"
 
       - name: Check if GH_PAT is configured and has repo access

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,15 @@ jobs:
         with:
           ref: ${{ github.event.inputs.release_ref || github.ref }}
 
+      - name: Resolve release image tag
+        id: release_ref
+        env:
+          IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          echo "image=${IMAGE_REPOSITORY}:${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -249,7 +258,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=semver,pattern={{version}}
-            type=sha,prefix=
+            type=raw,value=${{ steps.release_ref.outputs.short_sha }}
             type=raw,value=${{ github.event.inputs.release_tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' }}
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') || github.event.inputs.promote_stable == 'true' }}
             type=raw,value=latest,enable={{is_default_branch}}
@@ -267,14 +276,18 @@ jobs:
 
       - name: Verify short SHA image tag
         id: verify-image
-        env:
-          IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
         run: |
-          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          IMAGE="${IMAGE_REPOSITORY}:${SHORT_SHA}"
-          docker buildx imagetools inspect "$IMAGE" >/dev/null
-          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          IMAGE="${{ steps.release_ref.outputs.image }}"
+          for attempt in 1 2 3 4 5; do
+            if docker buildx imagetools inspect "$IMAGE" >/dev/null; then
+              echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+              echo "short_sha=${{ steps.release_ref.outputs.short_sha }}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep $((attempt * 5))
+          done
+          echo "::error::Verified image tag did not become available in GHCR: $IMAGE"
+          exit 1
 
   # ── Stage 4: GitOps – update k8s manifests ───────────────────────────────
   update-k8s-manifest:

--- a/docs/deployment/release-checklist.md
+++ b/docs/deployment/release-checklist.md
@@ -36,9 +36,10 @@ DMARQ releases from the `main` branch through GitHub Actions.
    - `feat!:` or `BREAKING CHANGE` for major releases.
    - `docs:` for documentation-only changes that do not need a new app version.
 2. Watch the Release workflow.
-3. Watch the CI workflow through lint, tests, security scan, CodeQL, Docker build, and preprod manifest update.
-4. If the preprod manifest update fails because the k8s state repo moved during the run, rerun the failed job after confirming the image build succeeded.
-5. Pull tags locally after release automation completes.
+3. Watch the CI workflow through lint, tests, security scan, CodeQL, Docker build, image-tag verification, and preprod manifest update.
+4. Confirm the Docker job verifies the short-SHA image tag before GitOps updates any manifests. The manifest update must use that verified image output instead of recomputing an expected tag.
+5. If the preprod manifest update fails because the k8s state repo moved during the run, rerun the failed job after confirming the image build and short-SHA verification succeeded.
+6. Pull tags locally after release automation completes.
 
 ## Smoke Checks
 


### PR DESCRIPTION
## Summary
- verify the short-SHA GHCR image tag immediately after Docker publish
- pass the verified image/tag from the Docker job into the GitOps manifest job
- update the release checklist so operators check image-tag verification before rollout

## Why
The previous workflow allowed GitOps to recompute an expected image tag. If the image publish path reported success without the tag being available in GHCR, manifests could point to an image that Kubernetes could not pull.

Closes #492.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release.yml"); puts "workflow yaml ok"'`
- `git diff --check`
