### PR TITLE
fix: parse source network intelligence records

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,15 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # SOURCE_NETWORK_ENRICHMENT_ENABLED=true
 # SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS=86400
 # SOURCE_NETWORK_ENRICHMENT_MAX_IPS=100
+# Optional API-backed source IP enrichment. When set, these are preferred over
+# the public Team Cymru DNS fallback and can add ASN, provider, city, and
+# Cloudflare Radar context to domain/report source tables.
+# IPINFO_TOKEN="your_ipinfo_lite_token"
+# IPINFO_TIMEOUT_SECONDS=2
+# IPGEOLOCATION_API_KEY="your_ipgeolocation_api_key"
+# IPGEOLOCATION_TIMEOUT_SECONDS=2
+# CLOUDFLARE_RADAR_API_TOKEN="your_cloudflare_radar_read_token"
+# CLOUDFLARE_RADAR_TIMEOUT_SECONDS=2
 
 # Optional sender IP reputation feeds
 # Disabled by default. Enable only after reviewing provider terms, credentials,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1364,8 +1364,17 @@ class SourceGeo(BaseModel):
     asn: Optional[str] = None
     network: Optional[str] = None
     bgp_prefix: Optional[str] = None
+    city: Optional[str] = None
+    latitude: Optional[str] = None
+    longitude: Optional[str] = None
     registry: Optional[str] = None
     allocated: Optional[str] = None
+    organization: Optional[str] = None
+    domain: Optional[str] = None
+    cloudflare_location: Optional[str] = None
+    cloudflare_asn_name: Optional[str] = None
+    cloudflare_asn_org_name: Optional[str] = None
+    radar_url: Optional[str] = None
     network_source: Optional[str] = None
     network_checked_at: Optional[str] = None
     network_error: Optional[str] = None

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -23,15 +23,15 @@ from app.services.report_persistence import (
 )
 from app.services.report_store import ReportStore
 from app.services.sender_intelligence import identify_sender, source_geo_for
-from app.services.source_reputation import (
-    SourceReputation,
-    build_source_reputation_cached,
-    source_reputation_by_ip,
-)
 from app.services.source_network import (
     SourceNetworkIntelligence,
     lookup_sources_network_cached,
     merge_network_into_geo,
+)
+from app.services.source_reputation import (
+    SourceReputation,
+    build_source_reputation_cached,
+    source_reputation_by_ip,
 )
 from app.services.workspace_access import (
     PERMISSION_REPORTS_READ,
@@ -780,8 +780,17 @@ def _source_details(
         "asn": geo.get("asn"),
         "network": geo.get("network"),
         "bgp_prefix": geo.get("bgp_prefix"),
+        "city": geo.get("city"),
+        "latitude": geo.get("latitude"),
+        "longitude": geo.get("longitude"),
         "registry": geo.get("registry"),
         "allocated": geo.get("allocated"),
+        "organization": geo.get("organization"),
+        "domain": geo.get("domain"),
+        "cloudflare_location": geo.get("cloudflare_location"),
+        "cloudflare_asn_name": geo.get("cloudflare_asn_name"),
+        "cloudflare_asn_org_name": geo.get("cloudflare_asn_org_name"),
+        "radar_url": geo.get("radar_url"),
         "network_source": geo.get("network_source"),
         "network_checked_at": geo.get("network_checked_at"),
         "network_error": geo.get("network_error"),

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -90,6 +90,12 @@ class Settings(BaseSettings):
     SOURCE_NETWORK_ENRICHMENT_ENABLED: bool = True
     SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS: int = 86_400
     SOURCE_NETWORK_ENRICHMENT_MAX_IPS: int = 100
+    IPINFO_TOKEN: Optional[str] = None
+    IPINFO_TIMEOUT_SECONDS: float = 2.0
+    IPGEOLOCATION_API_KEY: Optional[str] = None
+    IPGEOLOCATION_TIMEOUT_SECONDS: float = 2.0
+    CLOUDFLARE_RADAR_API_TOKEN: Optional[str] = None
+    CLOUDFLARE_RADAR_TIMEOUT_SECONDS: float = 2.0
 
     # Optional Stripe Billing integration. Self-hosted and provider-billed
     # deployments work without these values.

--- a/backend/app/services/source_network.py
+++ b/backend/app/services/source_network.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ipaddress
 import json
+import logging
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -15,6 +16,9 @@ from app.models.dns_cache import DNSCache
 
 _CACHE_PROVIDER = "source-network-intelligence-v1"
 _SELECTORS_KEY = "team-cymru-dns-v2"
+_ASN_NAME_CACHE: Dict[str, str] = {}
+
+logger = logging.getLogger(__name__)
 
 COUNTRY_NAMES = {
     "AT": "Austria",
@@ -121,15 +125,42 @@ def _asn_name_query(asn: str) -> str:
     return f"{normalized}.asn.cymru.com"
 
 
-def _as_name_from_cymru_txt(txt_records: Iterable[str]) -> Optional[str]:
+def _iter_cymru_txt_parts(txt_records: Iterable[str]) -> Iterable[List[str]]:
     for record in txt_records:
         cleaned = str(record).strip().strip('"')
         if "|" not in cleaned or cleaned.lower().startswith("as |"):
             continue
-        parts = [part.strip().strip('"') for part in cleaned.split("|")]
+        yield [part.strip().strip('"') for part in cleaned.split("|")]
+
+
+def _as_name_from_cymru_txt(txt_records: Iterable[str]) -> Optional[str]:
+    for parts in _iter_cymru_txt_parts(txt_records):
         if len(parts) >= 5 and parts[4]:
             return parts[4]
     return None
+
+
+async def _lookup_as_name(provider: Any, asn: str) -> Optional[str]:
+    normalized = _normalize_asn(asn)
+    if not normalized:
+        return None
+    if normalized in _ASN_NAME_CACHE:
+        return _ASN_NAME_CACHE[normalized]
+    query = _asn_name_query(normalized)
+    if not query:
+        return None
+    try:
+        as_name = _as_name_from_cymru_txt(await provider.lookup_txt(query))
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.debug(
+            "ASN name lookup failed for %s: %s",
+            normalized,
+            type(exc).__name__,
+        )
+        return None
+    if as_name:
+        _ASN_NAME_CACHE[normalized] = as_name
+    return as_name
 
 
 def _normalize_global_source_ip(value: Any) -> Optional[str]:
@@ -152,11 +183,7 @@ def _from_json(value: str) -> SourceNetworkIntelligence:
 
 def _from_cymru_txt(ip: str, txt_records: Iterable[str]) -> SourceNetworkIntelligence:
     checked_at = _utcnow_iso()
-    for record in txt_records:
-        cleaned = str(record).strip().strip('"')
-        if "|" not in cleaned or cleaned.lower().startswith("as |"):
-            continue
-        parts = [part.strip().strip('"') for part in cleaned.split("|")]
+    for parts in _iter_cymru_txt_parts(txt_records):
         if len(parts) < 5:
             continue
         country_code = parts[2].upper() if parts[2] else None
@@ -215,12 +242,7 @@ async def lookup_source_network(
         )
     result = _from_cymru_txt(ip, records)
     if result.asn and not result.as_name:
-        query = _asn_name_query(result.asn)
-        if query:
-            try:
-                result.as_name = _as_name_from_cymru_txt(await provider.lookup_txt(query))
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
+        result.as_name = await _lookup_as_name(provider, result.asn)
     return result
 
 

--- a/backend/app/services/source_network.py
+++ b/backend/app/services/source_network.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 from app.models.dns_cache import DNSCache
 
 _CACHE_PROVIDER = "source-network-intelligence-v1"
-_SELECTORS_KEY = "team-cymru-dns-v1"
+_SELECTORS_KEY = "team-cymru-dns-v2"
 
 COUNTRY_NAMES = {
     "AT": "Austria",
@@ -114,6 +114,24 @@ def _normalize_asn(value: str) -> Optional[str]:
     return text if text.upper().startswith("AS") else f"AS{text}"
 
 
+def _asn_name_query(asn: str) -> str:
+    normalized = _normalize_asn(asn)
+    if not normalized:
+        return ""
+    return f"{normalized}.asn.cymru.com"
+
+
+def _as_name_from_cymru_txt(txt_records: Iterable[str]) -> Optional[str]:
+    for record in txt_records:
+        cleaned = str(record).strip().strip('"')
+        if "|" not in cleaned or cleaned.lower().startswith("as |"):
+            continue
+        parts = [part.strip().strip('"') for part in cleaned.split("|")]
+        if len(parts) >= 5 and parts[4]:
+            return parts[4]
+    return None
+
+
 def _normalize_global_source_ip(value: Any) -> Optional[str]:
     text = str(value or "").strip()
     if not text:
@@ -139,7 +157,7 @@ def _from_cymru_txt(ip: str, txt_records: Iterable[str]) -> SourceNetworkIntelli
         if "|" not in cleaned or cleaned.lower().startswith("as |"):
             continue
         parts = [part.strip().strip('"') for part in cleaned.split("|")]
-        if len(parts) < 6:
+        if len(parts) < 5:
             continue
         country_code = parts[2].upper() if parts[2] else None
         return SourceNetworkIntelligence(
@@ -151,7 +169,7 @@ def _from_cymru_txt(ip: str, txt_records: Iterable[str]) -> SourceNetworkIntelli
             region=COUNTRY_REGIONS.get(country_code or ""),
             registry=parts[3].lower() if parts[3] else None,
             allocated=parts[4] or None,
-            as_name=parts[5] or None,
+            as_name=parts[5] if len(parts) >= 6 and parts[5] else None,
             source="team-cymru",
             checked_at=checked_at,
         )
@@ -195,7 +213,15 @@ async def lookup_source_network(
             checked_at=checked_at,
             error=f"ASN lookup failed: {type(exc).__name__}.",
         )
-    return _from_cymru_txt(ip, records)
+    result = _from_cymru_txt(ip, records)
+    if result.asn and not result.as_name:
+        query = _asn_name_query(result.asn)
+        if query:
+            try:
+                result.as_name = _as_name_from_cymru_txt(await provider.lookup_txt(query))
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+    return result
 
 
 async def lookup_source_network_cached(

--- a/backend/app/services/source_network.py
+++ b/backend/app/services/source_network.py
@@ -82,7 +82,7 @@ COUNTRY_REGIONS = {
 
 
 @dataclass
-class SourceNetworkIntelligence:
+class SourceNetworkIntelligence:  # pylint: disable=too-many-instance-attributes
     """Network ownership and routing context for one source IP."""
 
     ip: str
@@ -612,7 +612,7 @@ async def lookup_sources_network_cached(
     return results
 
 
-def merge_network_into_geo(
+def merge_network_into_geo(  # noqa: C901 - centralizes source metadata precedence rules.
     geo: Dict[str, Any],
     network: Optional[SourceNetworkIntelligence],
 ) -> Dict[str, Any]:

--- a/backend/app/services/source_network.py
+++ b/backend/app/services/source_network.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import json
 import logging
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.models.dns_cache import DNSCache
 
 _CACHE_PROVIDER = "source-network-intelligence-v1"
-_SELECTORS_KEY = "team-cymru-dns-v2"
+_SELECTORS_KEY = "source-network-v3"
 _ASN_NAME_CACHE: Dict[str, str] = {}
+_IPINFO_LITE_URL = "https://api.ipinfo.io/lite"
+_IPGEOLOCATION_URL = "https://api.ipgeolocation.io/v3/ipgeo"
+_CLOUDFLARE_RADAR_IP_URL = "https://api.cloudflare.com/client/v4/radar/entities/ip"
 
 logger = logging.getLogger(__name__)
 
@@ -84,8 +92,17 @@ class SourceNetworkIntelligence:
     country_code: Optional[str] = None
     country: Optional[str] = None
     region: Optional[str] = None
+    city: Optional[str] = None
+    latitude: Optional[str] = None
+    longitude: Optional[str] = None
     registry: Optional[str] = None
     allocated: Optional[str] = None
+    organization: Optional[str] = None
+    domain: Optional[str] = None
+    cloudflare_location: Optional[str] = None
+    cloudflare_asn_name: Optional[str] = None
+    cloudflare_asn_org_name: Optional[str] = None
+    radar_url: Optional[str] = None
     source: str = "unknown"
     checked_at: str = ""
     error: Optional[str] = None
@@ -181,6 +198,65 @@ def _from_json(value: str) -> SourceNetworkIntelligence:
     return SourceNetworkIntelligence(**data)
 
 
+def _radar_url(ip: str) -> str:
+    return f"https://radar.cloudflare.com/ip/{quote(ip, safe='')}"
+
+
+def _first(*values: Optional[str]) -> Optional[str]:
+    for value in values:
+        if value not in {None, ""}:
+            return value
+    return None
+
+
+def _merge_network_results(
+    ip: str,
+    *results: Optional[SourceNetworkIntelligence],
+) -> Optional[SourceNetworkIntelligence]:
+    usable = [result for result in results if result and not result.error]
+    if not usable:
+        return None
+
+    sources: List[str] = []
+    for result in usable:
+        if result.source and result.source not in sources:
+            sources.append(result.source)
+
+    return SourceNetworkIntelligence(
+        ip=ip,
+        asn=_first(*(result.asn for result in usable)),
+        as_name=_first(*(result.as_name for result in usable)),
+        bgp_prefix=_first(*(result.bgp_prefix for result in usable)),
+        country_code=_first(*(result.country_code for result in usable)),
+        country=_first(*(result.country for result in usable)),
+        region=_first(*(result.region for result in usable)),
+        city=_first(*(result.city for result in usable)),
+        latitude=_first(*(result.latitude for result in usable)),
+        longitude=_first(*(result.longitude for result in usable)),
+        registry=_first(*(result.registry for result in usable)),
+        allocated=_first(*(result.allocated for result in usable)),
+        organization=_first(*(result.organization for result in usable)),
+        domain=_first(*(result.domain for result in usable)),
+        cloudflare_location=_first(*(result.cloudflare_location for result in usable)),
+        cloudflare_asn_name=_first(*(result.cloudflare_asn_name for result in usable)),
+        cloudflare_asn_org_name=_first(*(result.cloudflare_asn_org_name for result in usable)),
+        radar_url=_radar_url(ip),
+        source=", ".join(sources),
+        checked_at=_utcnow_iso(),
+    )
+
+
+def _set_when_missing(
+    target: Dict[str, Any],
+    key: str,
+    value: Optional[str],
+    *,
+    missing_values: set[Any],
+) -> None:
+    if value and target.get(key) in missing_values:
+        target[key] = value
+
+
 def _from_cymru_txt(ip: str, txt_records: Iterable[str]) -> SourceNetworkIntelligence:
     checked_at = _utcnow_iso()
     for parts in _iter_cymru_txt_parts(txt_records):
@@ -197,6 +273,7 @@ def _from_cymru_txt(ip: str, txt_records: Iterable[str]) -> SourceNetworkIntelli
             registry=parts[3].lower() if parts[3] else None,
             allocated=parts[4] or None,
             as_name=parts[5] if len(parts) >= 6 and parts[5] else None,
+            radar_url=_radar_url(ip),
             source="team-cymru",
             checked_at=checked_at,
         )
@@ -208,11 +285,188 @@ def _from_cymru_txt(ip: str, txt_records: Iterable[str]) -> SourceNetworkIntelli
     )
 
 
+def _ipinfo_network_sync(
+    ip: str, token: str, timeout: float
+) -> Optional[SourceNetworkIntelligence]:
+    request = Request(
+        f"{_IPINFO_LITE_URL}/{quote(ip, safe='')}",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "DMARQ source intelligence",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:  # nosec B310 - fixed API host.
+            payload = json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, ValueError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    asn = _normalize_asn(str(payload.get("asn") or ""))
+    country_code = str(payload.get("country_code") or "").upper() or None
+    region = str(payload.get("continent") or "").strip() or COUNTRY_REGIONS.get(country_code or "")
+    return SourceNetworkIntelligence(
+        ip=ip,
+        asn=asn,
+        as_name=str(payload.get("as_name") or "").strip() or None,
+        bgp_prefix=str(payload.get("network") or "").strip() or None,
+        country_code=country_code,
+        country=str(payload.get("country") or "").strip() or COUNTRY_NAMES.get(country_code or ""),
+        region=region or None,
+        domain=str(payload.get("as_domain") or "").strip() or None,
+        radar_url=_radar_url(ip),
+        source="ipinfo-lite",
+        checked_at=_utcnow_iso(),
+    )
+
+
+def _ipgeolocation_network_sync(
+    ip: str,
+    api_key: str,
+    timeout: float,
+) -> Optional[SourceNetworkIntelligence]:
+    query = urlencode({"apiKey": api_key, "ip": ip})
+    request = Request(
+        f"{_IPGEOLOCATION_URL}?{query}",
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "DMARQ source intelligence",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:  # nosec B310 - fixed API host.
+            payload = json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, ValueError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    asn_payload = payload.get("asn") if isinstance(payload.get("asn"), dict) else {}
+    location = payload.get("location") if isinstance(payload.get("location"), dict) else {}
+    country_code = (
+        str(
+            location.get("country_code2")
+            or location.get("country_code")
+            or asn_payload.get("country")
+            or ""
+        ).upper()
+        or None
+    )
+    return SourceNetworkIntelligence(
+        ip=ip,
+        asn=_normalize_asn(str(asn_payload.get("as_number") or payload.get("asn") or "")),
+        as_name=str(asn_payload.get("organization") or "").strip() or None,
+        bgp_prefix=str(asn_payload.get("route") or asn_payload.get("network") or "").strip()
+        or None,
+        country_code=country_code,
+        country=str(location.get("country_name") or "").strip()
+        or COUNTRY_NAMES.get(country_code or ""),
+        region=str(location.get("continent_name") or "").strip()
+        or COUNTRY_REGIONS.get(country_code or ""),
+        city=str(location.get("city") or "").strip() or None,
+        latitude=str(location.get("latitude") or "").strip() or None,
+        longitude=str(location.get("longitude") or "").strip() or None,
+        organization=str(asn_payload.get("organization") or "").strip() or None,
+        radar_url=_radar_url(ip),
+        source="ipgeolocation",
+        checked_at=_utcnow_iso(),
+    )
+
+
+def _cloudflare_radar_network_sync(
+    ip: str,
+    token: str,
+    timeout: float,
+) -> Optional[SourceNetworkIntelligence]:
+    query = urlencode({"ip": ip, "format": "JSON"})
+    request = Request(
+        f"{_CLOUDFLARE_RADAR_IP_URL}?{query}",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "DMARQ source intelligence",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:  # nosec B310 - fixed API host.
+            payload = json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, ValueError, OSError):
+        return None
+    if not isinstance(payload, dict) or payload.get("success") is False:
+        return None
+
+    result = payload.get("result") if isinstance(payload.get("result"), dict) else {}
+    ip_payload = result.get("ip") if isinstance(result.get("ip"), dict) else {}
+    country_code = str(ip_payload.get("location") or "").upper() or None
+    asn_org = str(ip_payload.get("asnOrgName") or "").strip() or None
+    asn_name = str(ip_payload.get("asnName") or "").strip() or None
+    return SourceNetworkIntelligence(
+        ip=ip,
+        asn=_normalize_asn(str(ip_payload.get("asn") or "")),
+        as_name=asn_org or asn_name,
+        country_code=country_code,
+        country=str(ip_payload.get("locationName") or "").strip()
+        or COUNTRY_NAMES.get(country_code or ""),
+        organization=asn_org,
+        cloudflare_location=str(ip_payload.get("locationName") or "").strip() or None,
+        cloudflare_asn_name=asn_name,
+        cloudflare_asn_org_name=asn_org,
+        radar_url=_radar_url(ip),
+        source="cloudflare-radar",
+        checked_at=_utcnow_iso(),
+    )
+
+
+async def _lookup_ipinfo_network(ip: str) -> Optional[SourceNetworkIntelligence]:
+    settings = get_settings()
+    token = (getattr(settings, "IPINFO_TOKEN", None) or "").strip()
+    if not token:
+        return None
+    return await asyncio.to_thread(
+        _ipinfo_network_sync,
+        ip,
+        token,
+        getattr(settings, "IPINFO_TIMEOUT_SECONDS", 2.0),
+    )
+
+
+async def _lookup_ipgeolocation_network(ip: str) -> Optional[SourceNetworkIntelligence]:
+    settings = get_settings()
+    api_key = (getattr(settings, "IPGEOLOCATION_API_KEY", None) or "").strip()
+    if not api_key:
+        return None
+    return await asyncio.to_thread(
+        _ipgeolocation_network_sync,
+        ip,
+        api_key,
+        getattr(settings, "IPGEOLOCATION_TIMEOUT_SECONDS", 2.0),
+    )
+
+
+async def _lookup_cloudflare_radar_network(ip: str) -> Optional[SourceNetworkIntelligence]:
+    settings = get_settings()
+    token = (
+        getattr(settings, "CLOUDFLARE_RADAR_API_TOKEN", None)
+        or getattr(settings, "CLOUDFLARE_API_TOKEN", None)
+        or ""
+    ).strip()
+    if not token:
+        return None
+    return await asyncio.to_thread(
+        _cloudflare_radar_network_sync,
+        ip,
+        token,
+        getattr(settings, "CLOUDFLARE_RADAR_TIMEOUT_SECONDS", 2.0),
+    )
+
+
 async def lookup_source_network(
     provider: Any,
     ip: str,
 ) -> SourceNetworkIntelligence:
-    """Lookup ASN and network context for one public IP using Team Cymru DNS."""
+    """Lookup ASN and network context for one public IP."""
     checked_at = _utcnow_iso()
     try:
         address = ipaddress.ip_address(ip)
@@ -231,6 +485,18 @@ async def lookup_source_network(
             error="Non-global IP address.",
         )
 
+    ipinfo_result = await _lookup_ipinfo_network(ip)
+    ipgeolocation_result = await _lookup_ipgeolocation_network(ip)
+    cloudflare_radar_result = await _lookup_cloudflare_radar_network(ip)
+    api_merged = _merge_network_results(
+        ip,
+        ipinfo_result,
+        ipgeolocation_result,
+        cloudflare_radar_result,
+    )
+    if api_merged and api_merged.asn and api_merged.country_code:
+        return api_merged
+
     try:
         records = await provider.lookup_txt(_query_name(ip))
     except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -243,7 +509,14 @@ async def lookup_source_network(
     result = _from_cymru_txt(ip, records)
     if result.asn and not result.as_name:
         result.as_name = await _lookup_as_name(provider, result.asn)
-    return result
+    merged = _merge_network_results(
+        ip,
+        ipinfo_result,
+        ipgeolocation_result,
+        cloudflare_radar_result,
+        result,
+    )
+    return merged or result
 
 
 async def lookup_source_network_cached(
@@ -347,19 +620,26 @@ def merge_network_into_geo(
     merged = dict(geo)
     if network is None:
         return merged
-    if network.country_code and merged.get("country_code") in {None, "", "ZZ"}:
-        merged["country_code"] = network.country_code
-    if network.country and merged.get("country") in {None, "", "Unknown"}:
-        merged["country"] = network.country
-    if network.region and merged.get("region") in {None, "", "Unknown"}:
-        merged["region"] = network.region
-    if network.asn and not merged.get("asn"):
-        merged["asn"] = network.asn
-    if network.as_name and not merged.get("network"):
-        merged["network"] = network.as_name
+
+    empty = {None, ""}
+    _set_when_missing(merged, "country_code", network.country_code, missing_values={*empty, "ZZ"})
+    _set_when_missing(merged, "country", network.country, missing_values={*empty, "Unknown"})
+    _set_when_missing(merged, "region", network.region, missing_values={*empty, "Unknown"})
+    _set_when_missing(merged, "city", network.city, missing_values=empty)
+    _set_when_missing(merged, "latitude", network.latitude, missing_values=empty)
+    _set_when_missing(merged, "longitude", network.longitude, missing_values=empty)
+    _set_when_missing(merged, "asn", network.asn, missing_values=empty)
+    _set_when_missing(merged, "network", network.as_name, missing_values=empty)
+
     merged["bgp_prefix"] = network.bgp_prefix
     merged["registry"] = network.registry
     merged["allocated"] = network.allocated
+    merged["organization"] = network.organization
+    merged["domain"] = network.domain
+    merged["cloudflare_location"] = network.cloudflare_location
+    merged["cloudflare_asn_name"] = network.cloudflare_asn_name
+    merged["cloudflare_asn_org_name"] = network.cloudflare_asn_org_name
+    merged["radar_url"] = network.radar_url
     merged["network_source"] = network.source
     merged["network_checked_at"] = network.checked_at
     if network.error:

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1560,16 +1560,29 @@
                                             <template x-if="source.geo?.bgp_prefix">
                                                 <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-mono font-medium text-base-content/80" x-text="source.geo.bgp_prefix"></span>
                                             </template>
+                                            <template x-if="source.geo?.city">
+                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80" x-text="source.geo.city"></span>
+                                            </template>
                                             <template x-if="source.geo?.registry">
                                                 <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium uppercase text-base-content/70" x-text="source.geo.registry"></span>
                                             </template>
                                         </div>
-                                        <template x-if="source.geo?.allocated || source.geo?.network_source">
+                                        <template x-if="source.geo?.allocated || source.geo?.organization || source.geo?.domain || source.geo?.network_source">
                                             <p class="text-muted-foreground">
                                                 <span x-show="source.geo?.allocated">Allocated <span x-text="source.geo.allocated"></span></span>
-                                                <span x-show="source.geo?.allocated && source.geo?.network_source"> · </span>
+                                                <span x-show="source.geo?.allocated && (source.geo?.organization || source.geo?.domain || source.geo?.network_source)"> · </span>
+                                                <span x-show="source.geo?.organization" x-text="source.geo.organization"></span>
+                                                <span x-show="source.geo?.organization && source.geo?.domain"> · </span>
+                                                <span x-show="source.geo?.domain" x-text="source.geo.domain"></span>
+                                                <span x-show="(source.geo?.organization || source.geo?.domain) && source.geo?.network_source"> · </span>
                                                 <span x-show="source.geo?.network_source">Network data: <span x-text="source.geo.network_source"></span></span>
                                             </p>
+                                        </template>
+                                        <template x-if="source.geo?.radar_url">
+                                            <a class="text-xs font-medium text-primary hover:underline"
+                                               :href="source.geo.radar_url"
+                                               target="_blank"
+                                               rel="noopener noreferrer">Open in Cloudflare Radar</a>
                                         </template>
                                         <template x-if="source.geo?.network_error && !source.geo?.asn && !source.geo?.network">
                                             <p class="text-muted-foreground" x-text="source.geo.network_error"></p>

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -209,6 +209,9 @@
                                             <div>
                                                 <span x-text="sourceLocation(record)"></span>
                                             </div>
+                                            <div x-show="record.source_details?.city">
+                                                City: <span x-text="record.source_details.city"></span>
+                                            </div>
                                             <div x-show="record.source_details?.asn || record.source_details?.network">
                                                 <span x-text="record.source_details?.asn || 'ASN unknown'"></span>
                                                 <span x-show="record.source_details?.network"> · </span>
@@ -228,6 +231,16 @@
                                             <div x-show="record.source_details?.network_source">
                                                 Network data: <span x-text="record.source_details.network_source"></span>
                                             </div>
+                                            <div x-show="record.source_details?.organization || record.source_details?.domain">
+                                                <span x-show="record.source_details?.organization" x-text="record.source_details.organization"></span>
+                                                <span x-show="record.source_details?.organization && record.source_details?.domain"> · </span>
+                                                <span x-show="record.source_details?.domain" x-text="record.source_details.domain"></span>
+                                            </div>
+                                            <a x-show="record.source_details?.radar_url"
+                                               :href="record.source_details.radar_url"
+                                               target="_blank"
+                                               rel="noopener noreferrer"
+                                               class="inline-flex text-primary hover:underline">Open in Cloudflare Radar</a>
                                             <div x-show="record.source_details?.network_error && !record.source_details?.asn && !record.source_details?.network"
                                                  x-text="record.source_details.network_error"></div>
                                             <template x-if="record.reputation">

--- a/backend/app/tests/test_source_network.py
+++ b/backend/app/tests/test_source_network.py
@@ -13,13 +13,16 @@ pytestmark = pytest.mark.anyio
 
 class FakeProvider:
     def __init__(self, records=None):
-        self.records = records or []
+        self.records = [] if records is None else records
         self.queries = []
 
     async def lookup_txt(self, name):
         self.queries.append(name)
         if isinstance(self.records, dict):
-            return self.records.get(name, [])
+            response = self.records.get(name, [])
+            if isinstance(response, Exception):
+                raise response
+            return response
         return self.records
 
 
@@ -98,6 +101,28 @@ async def test_lookup_source_network_uses_origin6_for_ipv6_sources():
     assert result.bgp_prefix == "2a01:4f8::/32"
     assert result.country == "Germany"
     assert result.region == "Europe"
+    assert result.error is None
+
+
+async def test_lookup_source_network_tolerates_asn_name_lookup_failure():
+    provider = FakeProvider(
+        {
+            "203.205.31.50.origin.asn.cymru.com": [
+                '"64501 | 50.31.205.0/24 | US | arin | 2011-02-03"',
+            ],
+            "AS64501.asn.cymru.com": RuntimeError("temporary DNS failure"),
+        }
+    )
+
+    result = await lookup_source_network(provider, "50.31.205.203")
+
+    assert provider.queries == [
+        "203.205.31.50.origin.asn.cymru.com",
+        "AS64501.asn.cymru.com",
+    ]
+    assert result.asn == "AS64501"
+    assert result.as_name is None
+    assert result.bgp_prefix == "50.31.205.0/24"
     assert result.error is None
 
 

--- a/backend/app/tests/test_source_network.py
+++ b/backend/app/tests/test_source_network.py
@@ -18,6 +18,8 @@ class FakeProvider:
 
     async def lookup_txt(self, name):
         self.queries.append(name)
+        if isinstance(self.records, dict):
+            return self.records.get(name, [])
         return self.records
 
 
@@ -40,6 +42,62 @@ async def test_lookup_source_network_parses_team_cymru_txt():
     assert result.registry == "ripencc"
     assert result.allocated == "2004-02-17"
     assert result.source == "team-cymru"
+    assert result.error is None
+
+
+async def test_lookup_source_network_accepts_team_cymru_dns_without_as_name():
+    provider = FakeProvider(
+        {
+            "203.205.31.50.origin.asn.cymru.com": [
+                '"23352 | 50.31.205.0/24 | US | arin | 2011-02-03"',
+            ],
+            "AS23352.asn.cymru.com": [
+                '"23352 | US | arin | 2002-03-05 | SERVERCENTRAL - DEFT.COM, US"',
+            ],
+        }
+    )
+
+    result = await lookup_source_network(provider, "50.31.205.203")
+
+    assert provider.queries == [
+        "203.205.31.50.origin.asn.cymru.com",
+        "AS23352.asn.cymru.com",
+    ]
+    assert result.asn == "AS23352"
+    assert result.as_name == "SERVERCENTRAL - DEFT.COM, US"
+    assert result.bgp_prefix == "50.31.205.0/24"
+    assert result.country == "United States"
+    assert result.region == "North America"
+    assert result.error is None
+
+
+async def test_lookup_source_network_uses_origin6_for_ipv6_sources():
+    provider = FakeProvider(
+        {
+            (
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0."
+                "b.1.1.3.7.1.c.0.8.f.4.0.1.0.a.2.origin6.asn.cymru.com"
+            ): ['"24940 | 2a01:4f8::/32 | DE | ripencc | 2007-10-10"'],
+            "AS24940.asn.cymru.com": [
+                '"24940 | DE | ripencc | 2002-06-03 | HETZNER-AS - Hetzner Online GmbH, DE"',
+            ],
+        }
+    )
+
+    result = await lookup_source_network(provider, "2a01:4f8:c17:311b::1")
+
+    assert provider.queries == [
+        (
+            "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0."
+            "b.1.1.3.7.1.c.0.8.f.4.0.1.0.a.2.origin6.asn.cymru.com"
+        ),
+        "AS24940.asn.cymru.com",
+    ]
+    assert result.asn == "AS24940"
+    assert result.as_name == "HETZNER-AS - Hetzner Online GmbH, DE"
+    assert result.bgp_prefix == "2a01:4f8::/32"
+    assert result.country == "Germany"
+    assert result.region == "Europe"
     assert result.error is None
 
 

--- a/backend/app/tests/test_source_network.py
+++ b/backend/app/tests/test_source_network.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from app.services.source_network import (
@@ -155,6 +157,163 @@ async def test_lookup_source_network_reuses_asn_name_lookup_cache():
     assert second.as_name == "EXAMPLE-AS, US"
 
 
+async def test_lookup_source_network_prefers_ipinfo_lite(monkeypatch):
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        @staticmethod
+        def read():
+            return (
+                b'{"ip":"104.245.209.200","network":"104.245.208.0/21",'
+                b'"asn":"AS23352","as_name":"SERVERCENTRAL - DEFT.COM",'
+                b'"as_domain":"deft.com","country_code":"US",'
+                b'"country":"United States","continent":"North America"}'
+            )
+
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["authorization"] = request.headers.get("Authorization")
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "app.services.source_network.get_settings",
+        lambda: SimpleNamespace(IPINFO_TOKEN="secret-token", IPINFO_TIMEOUT_SECONDS=1.5),
+    )
+    monkeypatch.setattr("app.services.source_network.urlopen", fake_urlopen)
+    provider = FakeProvider()
+
+    result = await lookup_source_network(provider, "104.245.209.200")
+
+    assert provider.queries == []
+    assert captured["url"] == "https://api.ipinfo.io/lite/104.245.209.200"
+    assert captured["authorization"] == "Bearer secret-token"
+    assert captured["timeout"] == 1.5
+    assert result.source == "ipinfo-lite"
+    assert result.asn == "AS23352"
+    assert result.as_name == "SERVERCENTRAL - DEFT.COM"
+    assert result.bgp_prefix == "104.245.208.0/21"
+    assert result.country == "United States"
+    assert result.region == "North America"
+    assert result.error is None
+
+
+async def test_lookup_source_network_uses_ipgeolocation_when_configured(monkeypatch):
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        @staticmethod
+        def read():
+            return (
+                b'{"ip":"104.245.209.200","location":{"continent_name":"North America",'
+                b'"country_code2":"US","country_name":"United States","city":"Chicago",'
+                b'"latitude":"41.87810","longitude":"-87.62980"},'
+                b'"asn":{"as_number":"AS23352","organization":"SERVERCENTRAL - DEFT.COM",'
+                b'"country":"US","route":"104.245.208.0/21"}}'
+            )
+
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "app.services.source_network.get_settings",
+        lambda: SimpleNamespace(
+            IPINFO_TOKEN=None,
+            IPGEOLOCATION_API_KEY="geo-key",
+            IPGEOLOCATION_TIMEOUT_SECONDS=1.25,
+            CLOUDFLARE_RADAR_API_TOKEN=None,
+            CLOUDFLARE_API_TOKEN=None,
+        ),
+    )
+    monkeypatch.setattr("app.services.source_network.urlopen", fake_urlopen)
+    provider = FakeProvider()
+
+    result = await lookup_source_network(provider, "104.245.209.200")
+
+    assert provider.queries == []
+    assert captured["url"].startswith("https://api.ipgeolocation.io/v3/ipgeo?")
+    assert "apiKey=geo-key" in captured["url"]
+    assert "ip=104.245.209.200" in captured["url"]
+    assert captured["timeout"] == 1.25
+    assert result.source == "ipgeolocation"
+    assert result.asn == "AS23352"
+    assert result.as_name == "SERVERCENTRAL - DEFT.COM"
+    assert result.bgp_prefix == "104.245.208.0/21"
+    assert result.country == "United States"
+    assert result.region == "North America"
+    assert result.city == "Chicago"
+    assert result.radar_url == "https://radar.cloudflare.com/ip/104.245.209.200"
+    assert result.error is None
+
+
+async def test_lookup_source_network_uses_cloudflare_radar_when_configured(monkeypatch):
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        @staticmethod
+        def read():
+            return (
+                b'{"success":true,"result":{"ip":{"asn":"23352","asnLocation":"US",'
+                b'"asnName":"SERVERCENTRAL","asnOrgName":"Deft.com",'
+                b'"ip":"104.245.209.200","ipVersion":"IPv4",'
+                b'"location":"US","locationName":"United States"}}}'
+            )
+
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["authorization"] = request.headers.get("Authorization")
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "app.services.source_network.get_settings",
+        lambda: SimpleNamespace(
+            IPINFO_TOKEN=None,
+            IPGEOLOCATION_API_KEY=None,
+            CLOUDFLARE_RADAR_API_TOKEN="radar-token",
+            CLOUDFLARE_RADAR_TIMEOUT_SECONDS=1.75,
+        ),
+    )
+    monkeypatch.setattr("app.services.source_network.urlopen", fake_urlopen)
+    provider = FakeProvider()
+
+    result = await lookup_source_network(provider, "104.245.209.200")
+
+    assert provider.queries == []
+    assert captured["url"].startswith("https://api.cloudflare.com/client/v4/radar/entities/ip?")
+    assert "ip=104.245.209.200" in captured["url"]
+    assert captured["authorization"] == "Bearer radar-token"
+    assert captured["timeout"] == 1.75
+    assert result.source == "cloudflare-radar"
+    assert result.asn == "AS23352"
+    assert result.as_name == "Deft.com"
+    assert result.country == "United States"
+    assert result.cloudflare_asn_name == "SERVERCENTRAL"
+    assert result.cloudflare_asn_org_name == "Deft.com"
+    assert result.radar_url == "https://radar.cloudflare.com/ip/104.245.209.200"
+    assert result.error is None
+
+
 async def test_lookup_source_network_skips_non_global_ip():
     provider = FakeProvider()
 
@@ -221,8 +380,12 @@ def test_merge_network_into_geo_preserves_report_metadata_and_adds_prefix():
         country_code="DE",
         country="Germany",
         region="Europe",
+        city="Falkenstein",
         registry="ripencc",
         allocated="2004-02-17",
+        organization="Hetzner Online GmbH",
+        domain="hetzner.com",
+        radar_url="https://radar.cloudflare.com/ip/193.138.195.141",
         source="team-cymru",
         checked_at="2026-07-02T08:00:00Z",
     )
@@ -236,5 +399,9 @@ def test_merge_network_into_geo_preserves_report_metadata_and_adds_prefix():
     assert merged["asn"] == "AS24940"
     assert merged["network"] == "Hetzner Online GmbH"
     assert merged["bgp_prefix"] == "193.138.192.0/19"
+    assert merged["city"] == "Falkenstein"
     assert merged["registry"] == "ripencc"
+    assert merged["organization"] == "Hetzner Online GmbH"
+    assert merged["domain"] == "hetzner.com"
+    assert merged["radar_url"] == "https://radar.cloudflare.com/ip/193.138.195.141"
     assert merged["network_source"] == "team-cymru"

--- a/backend/app/tests/test_source_network.py
+++ b/backend/app/tests/test_source_network.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.services.source_network import (
+    _ASN_NAME_CACHE,
     SourceNetworkIntelligence,
     lookup_source_network,
     lookup_source_network_cached,
@@ -124,6 +125,34 @@ async def test_lookup_source_network_tolerates_asn_name_lookup_failure():
     assert result.as_name is None
     assert result.bgp_prefix == "50.31.205.0/24"
     assert result.error is None
+
+
+async def test_lookup_source_network_reuses_asn_name_lookup_cache():
+    _ASN_NAME_CACHE.pop("AS64502", None)
+    provider = FakeProvider(
+        {
+            "8.8.8.8.origin.asn.cymru.com": [
+                '"64502 | 8.8.8.0/24 | US | arin | 2011-02-03"',
+            ],
+            "4.4.8.8.origin.asn.cymru.com": [
+                '"64502 | 8.8.4.0/24 | US | arin | 2011-02-03"',
+            ],
+            "AS64502.asn.cymru.com": [
+                '"64502 | US | arin | 2002-03-05 | EXAMPLE-AS, US"',
+            ],
+        }
+    )
+
+    first = await lookup_source_network(provider, "8.8.8.8")
+    second = await lookup_source_network(provider, "8.8.4.4")
+
+    assert provider.queries == [
+        "8.8.8.8.origin.asn.cymru.com",
+        "AS64502.asn.cymru.com",
+        "4.4.8.8.origin.asn.cymru.com",
+    ]
+    assert first.as_name == "EXAMPLE-AS, US"
+    assert second.as_name == "EXAMPLE-AS, US"
 
 
 async def test_lookup_source_network_skips_non_global_ip():

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -216,13 +216,20 @@ answer "is this IP listed or risky according to a configured provider?"
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `SOURCE_NETWORK_ENRICHMENT_ENABLED` | Enable cached Team Cymru DNS lookups for ASN and BGP prefix metadata. | `true` | `false` |
+| `SOURCE_NETWORK_ENRICHMENT_ENABLED` | Enable cached sender-IP network enrichment for ASN, BGP prefix, location, and operator metadata. | `true` | `false` |
 | `SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS` | Persistent cache TTL for per-IP network metadata. | `86400` | `604800` |
 | `SOURCE_NETWORK_ENRICHMENT_MAX_IPS` | Maximum unique source IPs enriched per domain/report request. | `100` | `250` |
+| `IPINFO_TOKEN` | Optional IPinfo Lite token. When set, DMARQ uses IPinfo before the Team Cymru DNS fallback. | - | `op://...` |
+| `IPINFO_TIMEOUT_SECONDS` | IPinfo lookup timeout. | `2` | `2` |
+| `IPGEOLOCATION_API_KEY` | Optional IPGeolocation.io API key for additional city, ASN, and organization context. | - | `op://...` |
+| `IPGEOLOCATION_TIMEOUT_SECONDS` | IPGeolocation.io lookup timeout. | `2` | `2` |
+| `CLOUDFLARE_RADAR_API_TOKEN` | Optional read-only Cloudflare API token for `GET /client/v4/radar/entities/ip`. DMARQ also links every enriched IP to Cloudflare Radar. | - | `op://...` |
+| `CLOUDFLARE_RADAR_TIMEOUT_SECONDS` | Cloudflare Radar lookup timeout. | `2` | `2` |
 
 The lookup is read-only and skips private, reserved, loopback, and otherwise
-non-global IP addresses. Disable it for deployments that do not want observed
-source IPs sent to an external DNS-based metadata service.
+non-global IP addresses. Without API keys, DMARQ falls back to Team Cymru DNS
+for ASN and prefix metadata. Disable it for deployments that do not want
+observed source IPs sent to any external metadata service.
 
 ### Demo Mode
 


### PR DESCRIPTION
## Summary
- fixes Team Cymru parsing for current 5-field origin ASN responses and keeps ASN-name lookups cached
- adds optional IPinfo Lite, IPGeolocation.io, and Cloudflare Radar source-IP enrichment before the Team Cymru fallback
- exposes richer sender-IP context in domain/report views: ASN, network, prefix, city, organization/domain, provider source, and Cloudflare Radar links
- documents the new source intelligence environment variables

## Validation
- `PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_source_network.py backend/app/tests/test_reports_api.py::test_get_report_by_id_includes_source_intelligence_and_reputation backend/app/tests/test_domain_detail_endpoints.py::test_get_domain_sources_includes_ip_intelligence_and_reputation`
- `/tmp/dmarq-provider-connectors-423/.venv/bin/black --check backend/app/core/config.py backend/app/services/source_network.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/reports.py backend/app/tests/test_source_network.py`
- `/tmp/dmarq-provider-connectors-423/.venv/bin/isort --check-only backend/app/core/config.py backend/app/services/source_network.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/reports.py backend/app/tests/test_source_network.py`
- `PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/python -m compileall -q backend/app/services/source_network.py backend/app/core/config.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/reports.py`
- `git diff --check`

## Deployment notes
- IPinfo and IPGeolocation keys are configuration only; no secret values are committed.
- Cloudflare Radar uses `GET /client/v4/radar/entities/ip` when `CLOUDFLARE_RADAR_API_TOKEN` is set, and every enriched source still gets a Radar deep link.
