### PR TITLE
feat: clarify dns provider import setup guidance

### DIFF
--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -1409,7 +1409,7 @@ function settingsApp() {
             }
             const permissions = (provider.minimum_permissions || []).join('; ');
             return permissions
-                ? ` import requires ${permissions}.`
+                ? ` import can use ${permissions}.`
                 : ' import is available with configured provider credentials.';
         },
 

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -261,10 +261,24 @@
                             </button>
                         </div>
                     </div>
-                    <p class="rounded-md bg-base-200 px-3 py-2 text-xs text-base-content/70">
-                        <span class="font-semibold" x-text="selectedDnsProviderName()"></span>
-                        <span x-text="selectedDnsProviderHint()"></span>
-                    </p>
+                    <div class="rounded-md bg-base-200 px-3 py-2 text-xs text-base-content/70">
+                        <div>
+                            <span class="font-semibold" x-text="selectedDnsProviderName()"></span>
+                            <span x-text="selectedDnsProviderHint()"></span>
+                        </div>
+                        <div class="mt-1" x-show="selectedDnsProviderAuthHint()">
+                            Auth: <span class="font-medium" x-text="selectedDnsProviderAuthHint()"></span>
+                        </div>
+                        <div class="mt-1" x-show="selectedDnsProviderSetupHint()"
+                             x-text="selectedDnsProviderSetupHint()"></div>
+                        <a class="mt-1 inline-block link"
+                           x-show="selectedDnsProviderDocsUrl()"
+                           :href="selectedDnsProviderDocsUrl()"
+                           target="_blank"
+                           rel="noopener noreferrer">
+                            Provider setup docs
+                        </a>
+                    </div>
                     <template x-if="cfZones.length > 0">
                         <div class="overflow-x-auto rounded-md border border-border">
                             <table class="table table-sm">
@@ -1390,13 +1404,28 @@ function settingsApp() {
         selectedDnsProviderHint() {
             const provider = this.selectedDnsProviderMetadata();
             const status = provider.zone_import_status || (provider.import_available ? 'ready' : 'planned');
-            const permissions = (provider.minimum_permissions || []).slice(0, 2).join(', ');
             if (status !== 'ready') {
                 return ' is tracked in the connector registry, but zone import is not ready yet.';
             }
+            const permissions = (provider.minimum_permissions || []).join('; ');
             return permissions
-                ? ` import uses ${permissions}.`
+                ? ` import requires ${permissions}.`
                 : ' import is available with configured provider credentials.';
+        },
+
+        selectedDnsProviderAuthHint() {
+            const provider = this.selectedDnsProviderMetadata();
+            return (provider.auth_models || [])
+                .map(value => String(value).replaceAll('_', ' '))
+                .join(', ');
+        },
+
+        selectedDnsProviderSetupHint() {
+            return this.selectedDnsProviderMetadata().setup_hint || '';
+        },
+
+        selectedDnsProviderDocsUrl() {
+            return this.selectedDnsProviderMetadata().docs_url || '';
         },
 
         async loadDNSProviders(showMessage = false) {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -254,6 +254,10 @@ def test_settings_exposes_provider_agnostic_dns_import_without_html_injection():
     assert "/api/v1/domains/dns/providers" in template
     assert "discoverDNSProviderZones" in template
     assert "importDNSProviderZones" in template
+    assert "selectedDnsProviderAuthHint" in template
+    assert "selectedDnsProviderSetupHint" in template
+    assert "selectedDnsProviderDocsUrl" in template
+    assert "Provider setup docs" in template
     assert "/api/v1/domains/dns/import/${encodeURIComponent(providerId)}/preview" in template
     assert "/api/v1/domains/dns/import/${encodeURIComponent(providerId)}" in template
     assert "discoverCloudflareZones()" in template

--- a/docs/user_guide/settings.md
+++ b/docs/user_guide/settings.md
@@ -122,7 +122,8 @@ your DNS provider even if no DMARC reports have arrived yet.
 - Hetzner DNS uses a read-only DNS API token.
 - Linode DNS uses a Domains read-only personal access token.
 - Akamai Edge DNS/FastDNS uses EdgeGrid credentials through an `.edgerc`
-  section or the `AKAMAI_*` environment variables.
+  section selected by `AKAMAI_EDGERC_SECTION` or the `AKAMAI_*` environment
+  variables.
 
 The import flow only creates monitored domains in DMARQ. It does not change DNS
 records. DNS repair remains a separate preview-and-approve action.
@@ -164,9 +165,9 @@ DNS, Linode DNS, and Akamai Edge DNS/FastDNS can import zones or domains before
 reports arrive. Hetzner import uses a read-only Hetzner Console API token from
 `HETZNER_DNS_API_TOKEN` (or the fallback `HETZNER_API_TOKEN`). Linode import
 uses `LINODE_API_TOKEN` (or `LINODE_TOKEN`). Akamai import uses EdgeGrid
-credentials from `AKAMAI_EDGERC_PATH` or the direct `AKAMAI_HOST`,
-`AKAMAI_CLIENT_TOKEN`, `AKAMAI_CLIENT_SECRET`, and `AKAMAI_ACCESS_TOKEN`
-variables.
+credentials from `AKAMAI_EDGERC_PATH` plus optional `AKAMAI_EDGERC_SECTION`
+(defaulting to `default`) or the direct `AKAMAI_HOST`, `AKAMAI_CLIENT_TOKEN`,
+`AKAMAI_CLIENT_SECRET`, and `AKAMAI_ACCESS_TOKEN` variables.
 
 DMARQ never performs background DNS edits. A write-capable token only enables
 operator-approved actions from the DNS change plan UI, and each applied change

--- a/docs/user_guide/settings.md
+++ b/docs/user_guide/settings.md
@@ -120,6 +120,9 @@ your DNS provider even if no DMARC reports have arrived yet.
 - Amazon Route 53 uses the server-side AWS credential chain, a configured AWS
   profile, or a role ARN plus external ID.
 - Hetzner DNS uses a read-only DNS API token.
+- Linode DNS uses a Domains read-only personal access token.
+- Akamai Edge DNS/FastDNS uses EdgeGrid credentials through an `.edgerc`
+  section or the `AKAMAI_*` environment variables.
 
 The import flow only creates monitored domains in DMARQ. It does not change DNS
 records. DNS repair remains a separate preview-and-approve action.
@@ -156,10 +159,14 @@ DNS records, detect missing or malformed DMARC/SPF/DKIM entries, record DNS
 additions, modifications, or removals over time, and apply explicitly approved
 TXT/CNAME remediation plans.
 
-The DNS-zone import workflow is provider-shaped. Cloudflare and Hetzner DNS can
-import zones before reports arrive; Hetzner import uses a read-only Hetzner
-Console API token from `HETZNER_DNS_API_TOKEN` (or the fallback
-`HETZNER_API_TOKEN`).
+The DNS-zone import workflow is provider-shaped. Cloudflare, Route 53, Hetzner
+DNS, Linode DNS, and Akamai Edge DNS/FastDNS can import zones or domains before
+reports arrive. Hetzner import uses a read-only Hetzner Console API token from
+`HETZNER_DNS_API_TOKEN` (or the fallback `HETZNER_API_TOKEN`). Linode import
+uses `LINODE_API_TOKEN` (or `LINODE_TOKEN`). Akamai import uses EdgeGrid
+credentials from `AKAMAI_EDGERC_PATH` or the direct `AKAMAI_HOST`,
+`AKAMAI_CLIENT_TOKEN`, `AKAMAI_CLIENT_SECRET`, and `AKAMAI_ACCESS_TOKEN`
+variables.
 
 DMARQ never performs background DNS edits. A write-capable token only enables
 operator-approved actions from the DNS change plan UI, and each applied change


### PR DESCRIPTION
## Summary
- expand the DNS provider import hint in Settings with auth model, required permissions, setup guidance, and provider docs
- keep provider docs as an external link from the selected connector metadata
- update the user guide so Cloudflare, Route 53, Hetzner, Linode, and Akamai Edge DNS/FastDNS match the implemented import path

## Why
The provider connector registry already exposes useful metadata, but the Settings import UI only showed a short permission hint. For Route 53, Linode, Hetzner, and Akamai this left users without enough next-step context when discovery fails because credentials are not configured.

Part of #423.

## Validation
- `PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py::test_settings_exposes_provider_agnostic_dns_import_without_html_injection backend/app/tests/test_cloudflare_dns.py::test_dns_provider_capabilities_mark_cloudflare_import_available backend/app/tests/test_cloudflare_dns.py::test_dns_provider_import_preview_supports_akamai_alias backend/app/tests/test_cloudflare_dns.py::test_dns_provider_import_apply_supports_akamai`
- `/tmp/dmarq-provider-connectors-423/.venv/bin/black --check backend/app/tests/test_dashboard_template_security.py`
- `/tmp/dmarq-provider-connectors-423/.venv/bin/isort --check-only backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`
