### PR TITLE
Fix dashboard poll for Gmail mail sources

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -789,6 +789,7 @@ def _trigger_poll_imap_source(source: MailSource, db, days: int = 7) -> dict:
     return {
         "source_id": source.id,
         "name": source.name,
+        "method": "IMAP",
         "success": results["success"],
         "processed": results.get("processed", 0),
         "reports_found": results.get("reports_found", 0),
@@ -830,6 +831,7 @@ def _trigger_poll_gmail_source(source: MailSource, db) -> dict:
     return {
         "source_id": source.id,
         "name": source.name,
+        "method": "GMAIL_API",
         "success": results["success"],
         "processed": results.get("processed", 0),
         "reports_found": results.get("reports_found", 0),
@@ -875,6 +877,7 @@ def _trigger_poll_m365_source(source: MailSource, db, days: int = 7) -> dict:
     return {
         "source_id": source.id,
         "name": source.name,
+        "method": "M365_GRAPH",
         "success": results["success"],
         "processed": results.get("processed", 0),
         "reports_found": results.get("reports_found", 0),
@@ -894,6 +897,7 @@ def _poll_source_for_trigger(source: MailSource, db, days: int = 7) -> dict:  # 
             return {
                 "source_id": source.id,
                 "name": source.name,
+                "method": "GMAIL_API",
                 "skipped": True,
                 "reason": "Gmail account not yet authorised",
             }
@@ -904,6 +908,7 @@ def _poll_source_for_trigger(source: MailSource, db, days: int = 7) -> dict:  # 
             return {
                 "source_id": source.id,
                 "name": source.name,
+                "method": "GMAIL_API",
                 "success": False,
                 "error": "Failed to poll. Check server logs for details.",
             }
@@ -912,6 +917,7 @@ def _poll_source_for_trigger(source: MailSource, db, days: int = 7) -> dict:  # 
             return {
                 "source_id": source.id,
                 "name": source.name,
+                "method": "M365_GRAPH",
                 "skipped": True,
                 "reason": "Microsoft 365 account not yet authorised",
             }
@@ -922,6 +928,7 @@ def _poll_source_for_trigger(source: MailSource, db, days: int = 7) -> dict:  # 
             return {
                 "source_id": source.id,
                 "name": source.name,
+                "method": "M365_GRAPH",
                 "success": False,
                 "error": "Failed to poll. Check server logs for details.",
             }
@@ -933,12 +940,14 @@ def _poll_source_for_trigger(source: MailSource, db, days: int = 7) -> dict:  # 
             return {
                 "source_id": source.id,
                 "name": source.name,
+                "method": "IMAP",
                 "success": False,
                 "error": "Failed to poll. Check server logs for details.",
             }
     return {
         "source_id": source.id,
         "name": source.name,
+        "method": source.method,
         "skipped": True,
         "reason": f"method '{source.method}' not yet implemented",
     }
@@ -985,7 +994,7 @@ async def trigger_imap_poll(
     days: int = Query(7, ge=1, le=365, title="Number of days to fetch for mail sources"),
 ):
     """
-    Manually trigger IMAP polling for all enabled mail sources (admin only).
+    Manually trigger polling for all enabled mail sources (admin only).
 
     Security: Requires either X-API-Key header or Bearer token
     """
@@ -1001,20 +1010,75 @@ async def trigger_imap_poll(
 
     return {
         "success": all(r.get("success", True) for r in results_summary),
+        "message": "Mail-source polling completed.",
         "timestamp": last_check_time.isoformat() if last_check_time else None,
         "days": days,
+        "sources_polled": len(results_summary),
         "sources": results_summary,
+        "source_methods": sorted(
+            {
+                str(result.get("method") or "").upper()
+                for result in results_summary
+                if result.get("method")
+            }
+        ),
         "authenticated_by": auth.get("auth_type"),
     }
 
 
-# API endpoint to check status of IMAP polling (public, read-only)
+def _source_display_label(source: MailSource) -> str:
+    """Return a short, non-secret label for a configured mail source."""
+    method = (source.method or "IMAP").upper()
+    if method == "GMAIL_API":
+        account = source.gmail_email or source.name
+        return f"Gmail API: {account}"
+    if method == "M365_GRAPH":
+        account = source.m365_email or source.m365_mailbox or source.name
+        return f"Microsoft 365: {account}"
+    if method == "IMAP":
+        mailbox = source.username or source.name
+        return f"IMAP: {mailbox}"
+    return f"{method}: {source.name}"
+
+
+def _mail_source_status_summary() -> dict:
+    """Summarize enabled report intake sources without exposing credentials."""
+    db = SessionLocal()
+    try:
+        enabled_sources = (
+            db.query(MailSource).filter(MailSource.enabled == True).all()  # noqa: E712
+        )
+        by_method: dict[str, int] = {}
+        source_labels = []
+        latest_checked = None
+        for source in enabled_sources:
+            method = (source.method or "IMAP").upper()
+            by_method[method] = by_method.get(method, 0) + 1
+            source_labels.append(_source_display_label(source))
+            if source.last_checked and (
+                latest_checked is None or source.last_checked > latest_checked
+            ):
+                latest_checked = source.last_checked
+
+        return {
+            "enabled_sources": len(enabled_sources),
+            "sources_by_method": by_method,
+            "source_labels": source_labels,
+            "latest_source_check": latest_checked.isoformat() if latest_checked else None,
+        }
+    finally:
+        db.close()
+
+
+# API endpoint to check status of report intake polling (public, read-only)
 @app.get("/api/v1/poll-status")
 async def get_poll_status():
     """
-    Get the status of IMAP polling (read-only, no authentication required).
+    Get the status of report intake polling (read-only, no authentication required).
     """
+    source_summary = await run_in_threadpool(_mail_source_status_summary)
     return {
         "is_running": background_task is not None and not background_task.done(),
         "last_check": last_check_time.isoformat() if last_check_time else None,
+        **source_summary,
     }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -972,7 +972,7 @@ def _poll_enabled_sources_for_trigger(days: int) -> list[dict]:
 
 # API endpoint to manually trigger mail-source polling
 @app.get("/api/v1/admin/trigger-poll", include_in_schema=False)
-async def trigger_imap_poll_get() -> None:
+async def trigger_mail_source_poll_get() -> None:
     """Explain that manual polling is a POST action when opened directly."""
     raise HTTPException(
         status_code=405,
@@ -989,7 +989,7 @@ async def trigger_imap_poll_get() -> None:
 
 
 @app.post("/api/v1/admin/trigger-poll")
-async def trigger_imap_poll(
+async def trigger_mail_source_poll(
     auth: dict = Depends(require_admin_auth),
     days: int = Query(7, ge=1, le=365, title="Number of days to fetch for mail sources"),
 ):
@@ -1070,15 +1070,16 @@ def _mail_source_status_summary() -> dict:
         db.close()
 
 
-# API endpoint to check status of report intake polling (public, read-only)
+# API endpoint to check status of report intake polling
 @app.get("/api/v1/poll-status")
-async def get_poll_status():
+async def get_poll_status(auth: dict = Depends(require_admin_auth)):
     """
-    Get the status of report intake polling (read-only, no authentication required).
+    Get the status of report intake polling (admin only).
     """
     source_summary = await run_in_threadpool(_mail_source_status_summary)
     return {
         "is_running": background_task is not None and not background_task.done(),
         "last_check": last_check_time.isoformat() if last_check_time else None,
+        "authenticated_by": auth.get("auth_type"),
         **source_summary,
     }

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -72,16 +72,25 @@ function dashboardApp() {
             // Fetch domain summary on page load
             this.fetchDomainSummary();
             
-            // Check IMAP status
-            this.getImapStatus();
+            // Check report intake status
+            this.getReportIntakeStatus();
             this.fetchForensicSummary();
         },
         
-        async getImapStatus() {
+        formatSourceMethods(methods) {
+            const labels = {
+                IMAP: 'IMAP',
+                GMAIL_API: 'Gmail API',
+                M365_GRAPH: 'Microsoft 365'
+            };
+            return (methods || []).map(method => labels[method] || method).join(', ');
+        },
+
+        async getReportIntakeStatus() {
             try {
                 const response = await fetch('/api/v1/poll-status');
                 if (!response.ok) {
-                    console.error('Error checking IMAP status:', response.status);
+                    console.error('Error checking report intake status:', response.status);
                     return;
                 }
                 const data = await response.json();
@@ -90,23 +99,33 @@ function dashboardApp() {
                 const statusText = document.getElementById('imap-status-text');
                 const lastCheck = document.getElementById('imap-last-check');
                 
-                if (data.is_running) {
+                if (data.is_running && (data.enabled_sources || 0) > 0) {
                     statusIcon.classList.remove('bg-red-500');
                     statusIcon.classList.add('bg-green-500');
                     statusText.textContent = 'Running';
                 } else {
                     statusIcon.classList.remove('bg-green-500');
                     statusIcon.classList.add('bg-red-500');
-                    statusText.textContent = 'Stopped';
+                    statusText.textContent = (data.enabled_sources || 0) > 0 ? 'Stopped' : 'No enabled sources';
                 }
                 
-                if (data.last_check) {
-                    lastCheck.textContent = new Date(data.last_check).toLocaleString();
+                const lastCheckValue = data.latest_source_check || data.last_check;
+                if (lastCheckValue) {
+                    lastCheck.textContent = new Date(lastCheckValue).toLocaleString();
                 } else {
                     lastCheck.textContent = 'Never';
                 }
+
+                const mailbox = document.getElementById('imap-mailbox');
+                if (mailbox) {
+                    if (data.source_labels && data.source_labels.length) {
+                        mailbox.textContent = data.source_labels.join(', ');
+                    } else {
+                        mailbox.textContent = 'No enabled mail sources configured';
+                    }
+                }
             } catch (error) {
-                console.error('Error checking IMAP status:', error);
+                console.error('Error checking report intake status:', error);
             }
         },
 
@@ -128,11 +147,13 @@ function dashboardApp() {
                     throw new Error(message);
                 }
                 const count = data.sources_polled || 0;
+                const sourceMethods = this.formatSourceMethods(data.source_methods || []);
+                const methodSuffix = sourceMethods ? ` (${sourceMethods})` : '';
                 this.triggerPollStatus = 'success';
                 this.triggerPollMessage = count
-                    ? `Polling finished for ${count} source${count === 1 ? '' : 's'}.`
+                    ? `Polling finished for ${count} source${count === 1 ? '' : 's'}${methodSuffix}.`
                     : (data.message || 'No enabled mail sources configured.');
-                await this.getImapStatus();
+                await this.getReportIntakeStatus();
                 await this.fetchDomainSummary();
             } catch (error) {
                 this.triggerPollStatus = 'error';

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -359,7 +359,7 @@
                         {% endcall %}
                         {% call button_link(href="/settings", variant="outline") %}
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
-                            Configure IMAP
+                            Configure mail sources
                         {% endcall %}
                     </div>
                 </div>
@@ -367,12 +367,12 @@
         {% endcall %}
     </div>
     
-    <!-- IMAP Status -->
+    <!-- Report intake status -->
     <div>
         {% call card() %}
             {% call card_header() %}
                 <div class="flex items-center justify-between">
-                    {% call card_title() %}IMAP Integration Status{% endcall %}
+                    {% call card_title() %}Report Intake Status{% endcall %}
                     <button type="button"
                             class="btn btn-outline btn-sm"
                             :disabled="triggerPollRunning"
@@ -405,7 +405,7 @@
                         <span id="imap-last-check">Never</span>
                     </div>
                     <div class="flex items-center">
-                        <span class="w-40 text-sm text-muted-foreground">Mailbox:</span>
+                        <span class="w-40 text-sm text-muted-foreground">Sources:</span>
                         <span id="imap-mailbox">dmarc-reports@hosterra.net</span>
                     </div>
                 </div>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -406,7 +406,7 @@
                     </div>
                     <div class="flex items-center">
                         <span class="w-40 text-sm text-muted-foreground">Sources:</span>
-                        <span id="imap-mailbox">dmarc-reports@hosterra.net</span>
+                        <span id="imap-mailbox">Loading configured mail sources...</span>
                     </div>
                 </div>
             {% endcall %}

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -548,6 +548,8 @@ def test_dashboard_trigger_poll_uses_post_action_not_get_link():
     assert 'href="/api/v1/admin/trigger-poll"' not in template
     assert "triggerPollNow()" in template
     assert "method: 'POST'" in script
+    assert "Report Intake Status" in template
+    assert "Gmail API" in script
     assert "triggerPollMessage" in script
     assert 'role="status"' in template
     assert 'aria-live="polite"' in template

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -4014,6 +4014,7 @@ class TestTriggerPollEndpoint:
             mock_result = {
                 "source_id": 1,
                 "name": "Trigger GMAIL",
+                "method": "GMAIL_API",
                 "success": True,
                 "processed": 0,
                 "reports_found": 0,
@@ -4032,6 +4033,9 @@ class TestTriggerPollEndpoint:
             assert resp.status_code == 200
             data = resp.json()
             assert data["days"] == 30
+            assert data["message"] == "Mail-source polling completed."
+            assert data["sources_polled"] == 1
+            assert data["source_methods"] == ["GMAIL_API"]
             assert "sources" in data
             assert len(data["sources"]) == 1
             assert data["sources"][0]["success"] is True
@@ -4039,6 +4043,30 @@ class TestTriggerPollEndpoint:
             assert mock_poll.call_args.kwargs["days"] == 30
         finally:
             main_app.dependency_overrides.clear()
+
+    def test_poll_status_reports_enabled_gmail_sources(self):
+        """The dashboard status endpoint reports Gmail API sources, not just IMAP."""
+        from app.main import app as main_app
+
+        mock_source = MagicMock()
+        mock_source.method = "GMAIL_API"
+        mock_source.name = "Reports Gmail"
+        mock_source.gmail_email = "dmarc-reports@example.com"
+        mock_source.last_checked = datetime(2026, 7, 2, 12, 0, 0)
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = [mock_source]
+
+        with TestClient(main_app) as tc:
+            with patch("app.main.SessionLocal", return_value=mock_db):
+                resp = tc.get("/api/v1/poll-status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled_sources"] == 1
+        assert data["sources_by_method"] == {"GMAIL_API": 1}
+        assert data["source_labels"] == ["Gmail API: dmarc-reports@example.com"]
+        assert data["latest_source_check"] == "2026-07-02T12:00:00"
 
     def test_trigger_poll_with_no_enabled_sources(self):
         """With no enabled sources, the endpoint returns an empty-success response."""

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -4046,7 +4046,13 @@ class TestTriggerPollEndpoint:
 
     def test_poll_status_reports_enabled_gmail_sources(self):
         """The dashboard status endpoint reports Gmail API sources, not just IMAP."""
+        from app.core.security import require_admin_auth
         from app.main import app as main_app
+
+        async def mock_auth():
+            return {"auth_type": "session"}
+
+        main_app.dependency_overrides[require_admin_auth] = mock_auth
 
         mock_source = MagicMock()
         mock_source.method = "GMAIL_API"
@@ -4057,9 +4063,12 @@ class TestTriggerPollEndpoint:
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.all.return_value = [mock_source]
 
-        with TestClient(main_app) as tc:
-            with patch("app.main.SessionLocal", return_value=mock_db):
-                resp = tc.get("/api/v1/poll-status")
+        try:
+            with TestClient(main_app) as tc:
+                with patch("app.main.SessionLocal", return_value=mock_db):
+                    resp = tc.get("/api/v1/poll-status")
+        finally:
+            main_app.dependency_overrides.clear()
 
         assert resp.status_code == 200
         data = resp.json()
@@ -4067,6 +4076,7 @@ class TestTriggerPollEndpoint:
         assert data["sources_by_method"] == {"GMAIL_API": 1}
         assert data["source_labels"] == ["Gmail API: dmarc-reports@example.com"]
         assert data["latest_source_check"] == "2026-07-02T12:00:00"
+        assert data["authenticated_by"] == "session"
 
     def test_trigger_poll_with_no_enabled_sources(self):
         """With no enabled sources, the endpoint returns an empty-success response."""


### PR DESCRIPTION
## Summary
- make the dashboard Trigger Poll Now response count all enabled mail sources, including Gmail API and Microsoft 365
- return source methods and enabled-source status from the polling endpoints
- update the dashboard card from IMAP-only wording to report-intake wording and show live source labels

## Validation
- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_mail_sources.py::TestTriggerPollEndpoint backend/app/tests/test_dashboard_template_security.py::test_dashboard_trigger_poll_uses_post_action_not_get_link
- /tmp/dmarq-provider-connectors-423/.venv/bin/black --check backend/app/main.py backend/app/tests/test_mail_sources.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-provider-connectors-423/.venv/bin/isort --check-only backend/app/main.py backend/app/tests/test_mail_sources.py backend/app/tests/test_dashboard_template_security.py
- git diff --check