### PR TITLE
[codex] Fix Cloudflare OAuth token exchange fallback

### DIFF
--- a/backend/app/services/cloudflare_oauth.py
+++ b/backend/app/services/cloudflare_oauth.py
@@ -124,6 +124,14 @@ def build_cloudflare_authorization_url(
     }
 
 
+def _cloudflare_token_request_data(*, code: str, redirect_uri: str) -> Dict[str, str]:
+    return {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+    }
+
+
 async def exchange_cloudflare_oauth_code(
     *,
     code: str,
@@ -136,13 +144,17 @@ async def exchange_cloudflare_oauth_code(
             response = await client.post(
                 CLOUDFLARE_TOKEN_URL,
                 data={
-                    "grant_type": "authorization_code",
-                    "code": code,
-                    "redirect_uri": redirect_uri,
+                    **_cloudflare_token_request_data(code=code, redirect_uri=redirect_uri),
                     "client_id": config.client_id,
                     "client_secret": config.client_secret,
                 },
             )
+            if getattr(response, "status_code", None) in {401, 403}:
+                response = await client.post(
+                    CLOUDFLARE_TOKEN_URL,
+                    data=_cloudflare_token_request_data(code=code, redirect_uri=redirect_uri),
+                    auth=httpx.BasicAuth(config.client_id, config.client_secret),
+                )
             response.raise_for_status()
             data = response.json()
     except (httpx.RequestError, httpx.HTTPStatusError, ValueError) as exc:

--- a/backend/app/services/mail_service_imports.py
+++ b/backend/app/services/mail_service_imports.py
@@ -12,6 +12,8 @@ from sqlalchemy.orm import Session
 from app.core.config import get_settings
 from app.core.credential_encryption import decrypt_secret
 from app.models.domain import Domain
+
+# Imported for model registration side effects when this service is loaded directly.
 from app.models.mail_source_import import MailSourceImport  # noqa: F401
 from app.models.setting import Setting
 from app.models.workspace import Workspace

--- a/backend/app/services/mail_service_imports.py
+++ b/backend/app/services/mail_service_imports.py
@@ -12,9 +12,7 @@ from sqlalchemy.orm import Session
 from app.core.config import get_settings
 from app.core.credential_encryption import decrypt_secret
 from app.models.domain import Domain
-
-# Imported for model registration side effects when this service is loaded directly.
-from app.models.mail_source_import import MailSourceImport  # noqa: F401
+from app.models.mail_source_import import MailSourceImport
 from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.services.organizations import require_organization_plan_limit
@@ -22,6 +20,7 @@ from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 
 POSTMARK_API_BASE = "https://api.postmarkapp.com"
 MAIL_SERVICE_DESCRIPTION_PREFIX = "Mail-service sender domain imported from "
+MODEL_REGISTRATION_IMPORTS = (MailSourceImport,)
 
 
 class MailServiceImportError(RuntimeError):

--- a/backend/app/services/mail_service_imports.py
+++ b/backend/app/services/mail_service_imports.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from app.core.config import get_settings
 from app.core.credential_encryption import decrypt_secret
 from app.models.domain import Domain
+from app.models.mail_source_import import MailSourceImport  # noqa: F401
 from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.services.organizations import require_organization_plan_limit

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -2138,6 +2138,7 @@ async def test_cloudflare_oauth_exchange_retries_with_basic_auth_after_forbidden
     )
 
     assert token_data["access_token"] == "provider-token"
+    assert len(requests) == 2
     assert requests[0]["data"]["client_id"] == "client-id"
     assert requests[0]["data"]["client_secret"] == "client-secret"
     assert requests[0]["auth"] is None

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -2036,6 +2036,8 @@ async def test_cloudflare_oauth_exchange_posts_token_request(
     monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_settings)
 
     class FakeTokenResponse:
+        status_code = 200
+
         def raise_for_status(self):
             return None
 
@@ -2052,8 +2054,8 @@ async def test_cloudflare_oauth_exchange_posts_token_request(
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-        async def post(self, url, *, data):
-            requests.append({"url": url, "data": data})
+        async def post(self, url, *, data, auth=None):
+            requests.append({"url": url, "data": data, "auth": auth})
             return FakeTokenResponse()
 
     monkeypatch.setattr(cloudflare_oauth.httpx, "AsyncClient", FakeAsyncClient)
@@ -2076,8 +2078,75 @@ async def test_cloudflare_oauth_exchange_posts_token_request(
                 "client_id": "client-id",
                 "client_secret": "client-secret",
             },
+            "auth": None,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_oauth_exchange_retries_with_basic_auth_after_forbidden(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    requests = []
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_settings)
+
+    class ForbiddenTokenResponse:
+        status_code = 403
+
+        def raise_for_status(self):
+            request = cloudflare_oauth.httpx.Request("POST", cloudflare_oauth.CLOUDFLARE_TOKEN_URL)
+            response = cloudflare_oauth.httpx.Response(403, request=request)
+            raise cloudflare_oauth.httpx.HTTPStatusError(
+                "Forbidden",
+                request=request,
+                response=response,
+            )
+
+        def json(self):
+            return {}
+
+    class SuccessfulTokenResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"access_token": "provider-token", "scope": "zone.read dns.read"}
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, *, data, auth=None):
+            requests.append({"url": url, "data": data, "auth": auth})
+            if len(requests) == 1:
+                return ForbiddenTokenResponse()
+            return SuccessfulTokenResponse()
+
+    monkeypatch.setattr(cloudflare_oauth.httpx, "AsyncClient", FakeAsyncClient)
+
+    token_data = await cloudflare_oauth.exchange_cloudflare_oauth_code(
+        code="oauth-code",
+        redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+    )
+
+    assert token_data["access_token"] == "provider-token"
+    assert requests[0]["data"]["client_id"] == "client-id"
+    assert requests[0]["data"]["client_secret"] == "client-secret"
+    assert requests[0]["auth"] is None
+    assert requests[1]["data"] == {
+        "grant_type": "authorization_code",
+        "code": "oauth-code",
+        "redirect_uri": "https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+    }
+    assert isinstance(requests[1]["auth"], cloudflare_oauth.httpx.BasicAuth)
 
 
 @pytest.mark.asyncio
@@ -2103,7 +2172,7 @@ async def test_cloudflare_oauth_exchange_rejects_missing_access_token(
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-        async def post(self, url, *, data):
+        async def post(self, url, *, data, auth=None):
             return FakeTokenResponse()
 
     monkeypatch.setattr(cloudflare_oauth.httpx, "AsyncClient", FakeAsyncClient)
@@ -2131,7 +2200,7 @@ async def test_cloudflare_oauth_exchange_wraps_http_errors(
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-        async def post(self, url, *, data):
+        async def post(self, url, *, data, auth=None):
             raise cloudflare_oauth.httpx.RequestError("network unavailable")
 
     monkeypatch.setattr(cloudflare_oauth.httpx, "AsyncClient", FakeAsyncClient)


### PR DESCRIPTION
## Summary
- Retry Cloudflare OAuth token exchange with HTTP Basic auth when Cloudflare rejects client_secret_post with 401/403.
- Keep the existing client_secret_post path for clients configured that way.
- Register MailSourceImport in the Postmark import service so read-only discovery works reliably from service entry points.

## Validation
- pytest backend/app/tests/test_cloudflare_dns.py -k 'cloudflare_oauth_exchange'
- pytest backend/app/tests/test_mail_service_imports.py
- black --check backend/app/services/cloudflare_oauth.py backend/app/services/mail_service_imports.py backend/app/tests/test_cloudflare_dns.py
- isort --check-only backend/app/services/cloudflare_oauth.py backend/app/services/mail_service_imports.py backend/app/tests/test_cloudflare_dns.py
- git diff --check

## Live checks
- Production logs showed Cloudflare callback reached DMARQ and Cloudflare returned 403 from /oauth2/token.
- Production Postmark setting exists, but live Postmark API returns 401 Unauthorized for /domains, so the stored token appears invalid for account-level discovery.