### PR TITLE
Show DNS provider repair readiness

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -23,10 +23,12 @@ from app.models.domain import Domain
 from app.models.report import DMARCReport
 from app.models.setting import Setting
 from app.models.workspace import Workspace
+from app.services.akamai_edgedns import get_akamai_edgedns_credentials
 from app.services.bimi import BIMIResult, check_bimi_cached
 from app.services.cloudflare_dns import (
     analyze_dns_records,
     discover_cloudflare_zones,
+    get_cloudflare_credentials,
     get_zone_for_domain,
     import_cloudflare_domains,
     list_dns_record_changes,
@@ -45,7 +47,10 @@ from app.services.dane import check_dane_cached
 from app.services.demo_data import DEMO_DAYS, build_demo_health_score_history
 from app.services.dns_cache import resolve_domain_dns_cached
 from app.services.dns_guidance import build_dns_guidance
-from app.services.dns_provider_connectors import provider_connector_registry
+from app.services.dns_provider_connectors import (
+    provider_connector_metadata,
+    provider_connector_registry,
+)
 from app.services.dns_provider_imports import (
     import_dns_provider_domains,
     preview_dns_provider_import,
@@ -75,6 +80,8 @@ from app.services.health_score_snapshots import (
     list_workspace_health_score_snapshots,
     upsert_health_score_snapshot,
 )
+from app.services.hetzner_dns import get_hetzner_dns_credentials
+from app.services.linode_dns import get_linode_dns_credentials
 from app.services.mail_service_imports import (
     MailServiceImportError,
     import_mail_service_domains,
@@ -95,6 +102,7 @@ from app.services.report_persistence import (
     hydrate_report_store_from_db,
 )
 from app.services.report_store import ReportStore
+from app.services.route53_dns import get_route53_dns_credentials
 from app.services.sender_intelligence import (
     build_source_intelligence,
     identify_sender,
@@ -409,6 +417,7 @@ class DNSRecordResponse(BaseModel):
     dmarcSuggestions: List[str] = []
     nameservers: List[str] = []
     dnsProvider: Optional[Dict[str, Any]] = None
+    providerContext: Optional[Dict[str, Any]] = None
 
 
 class DNSGuidanceRecordResponse(BaseModel):
@@ -550,6 +559,120 @@ def _detected_dns_provider_id(dns_provider: Optional[Dict[str, Any]]) -> Optiona
     if provider_id in {"", "custom", "unknown"}:
         return None
     return provider_id
+
+
+def _provider_credentials_configured(db: Session, provider_id: Optional[str]) -> bool:
+    """Return whether DMARQ has non-secret connection material for a DNS provider."""
+    normalized = _canonical_dns_provider_id(provider_id)
+    try:
+        if normalized == "cloudflare":
+            return get_cloudflare_credentials(db).configured
+        if normalized == "route53":
+            return get_route53_dns_credentials().configured
+        if normalized == "akamai-edgedns":
+            return get_akamai_edgedns_credentials().configured
+        if normalized == "hetzner":
+            return get_hetzner_dns_credentials().configured
+        if normalized == "linode":
+            return get_linode_dns_credentials().configured
+    except Exception as exc:  # pragma: no cover - defensive, no secret values are exposed.
+        logger.info("DNS provider credential readiness check failed for %s: %s", normalized, exc)
+    return False
+
+
+def _dns_provider_repair_context(
+    db: Session,
+    *,
+    dns_provider: Optional[Dict[str, Any]],
+    nameservers: List[str],
+) -> Dict[str, Any]:
+    """Build read-only provider connection and DNS repair readiness guidance."""
+    provider_id = _detected_dns_provider_id(dns_provider)
+    provider_name = (
+        dns_provider.get("provider_name") if dns_provider else "Unknown DNS provider"
+    ) or "Unknown DNS provider"
+    connector = provider_connector_metadata(provider_id or "") if provider_id else None
+    import_provider_ids = {provider["id"] for provider in supported_import_providers()}
+    write_provider_ids = set(_ready_dns_write_provider_ids())
+    connected = _provider_credentials_configured(db, provider_id)
+    confidence = (dns_provider or {}).get("confidence") or "unknown"
+    can_import = bool(provider_id and provider_id in import_provider_ids and connector)
+    write_connector_ready = bool(provider_id and provider_id in write_provider_ids and connector)
+    can_repair = bool(connected and write_connector_ready)
+
+    if not dns_provider or not nameservers:
+        status = "manual"
+        summary = "DMARQ has not seen authoritative nameserver evidence for this domain yet."
+        cta_label = "Refresh DNS"
+        cta_href = "#dns-records"
+        next_steps = [
+            "Refresh DNS after delegation is visible.",
+            "Use the manual DNS instructions until a provider can be detected.",
+        ]
+    elif not connector:
+        status = "manual"
+        summary = f"{provider_name} was detected, but DMARQ does not have a connector for it yet."
+        cta_label = "Use manual change plan"
+        cta_href = "#dns-guidance"
+        next_steps = [
+            "Review the DNS lint findings and manual change plan.",
+            "Apply changes in the provider console with a human approval step.",
+        ]
+    elif connected and can_repair:
+        status = "connected"
+        summary = (
+            f"{provider_name} is connected. DMARQ can import zones, verify ownership, "
+            "preview safe DNS repairs, and apply approved changes."
+        )
+        cta_label = "Open DNS change plan"
+        cta_href = "#dns-guidance"
+        next_steps = [
+            "Review the DNS lint findings and generated change plans.",
+            "Preview the provider mutation before applying any DNS change.",
+            "Approve only changes whose zone, record name, old value, and new value match intent.",
+        ]
+    elif connected:
+        status = "read_only"
+        summary = (
+            f"{provider_name} is connected for read/import context, but automatic repair is "
+            "not enabled for this provider yet."
+        )
+        cta_label = "Import provider zones"
+        cta_href = "/settings#provider-integrations"
+        next_steps = [
+            "Import visible provider zones to monitor DNS posture before reports arrive.",
+            "Use manual DNS changes until write support is available for this connector.",
+        ]
+    else:
+        status = "connect"
+        summary = (
+            f"{provider_name} appears authoritative for this domain. Connect it to verify "
+            "ownership, import zones, and unlock provider-aware repair previews."
+        )
+        cta_label = f"Connect {provider_name}"
+        cta_href = "/settings#provider-integrations"
+        next_steps = [
+            "Connect the provider with read-only zone and DNS permissions first.",
+            "Import the zone so DMARQ can confirm account-level ownership.",
+            "Add write scope only when you want human-approved one-click DNS repair.",
+        ]
+
+    return {
+        "status": status,
+        "detected_provider_id": provider_id,
+        "detected_provider_name": provider_name,
+        "confidence": confidence,
+        "connected": connected,
+        "can_import_zones": can_import,
+        "can_preview_repairs": write_connector_ready,
+        "can_apply_repairs": can_repair,
+        "connector": connector,
+        "summary": summary,
+        "cta_label": cta_label,
+        "cta_href": cta_href,
+        "next_steps": next_steps,
+        "nameservers": nameservers,
+    }
 
 
 def _ensure_dns_provider_selection_is_safe(
@@ -3860,6 +3983,11 @@ async def get_domain_dns_records(
         dmarcSuggestions=result.dmarc_suggestions,
         nameservers=result.nameservers,
         dnsProvider=asdict(result.dns_provider) if result.dns_provider else None,
+        providerContext=_dns_provider_repair_context(
+            db,
+            dns_provider=asdict(result.dns_provider) if result.dns_provider else None,
+            nameservers=result.nameservers,
+        ),
     )
 
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -969,6 +969,38 @@
                             </div>
                         </div>
                     </div>
+                    <div class="rounded-md border border-[#d8ebe8] bg-[#f2fbf9] p-4">
+                        <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                            <div class="min-w-0">
+                                <div class="flex flex-wrap items-center gap-2">
+                                    <p class="text-sm font-semibold text-[#07071f]">Provider repair readiness</p>
+                                    <span class="rounded-full px-2 py-1 text-xs font-semibold"
+                                          :class="providerContextBadgeClass"
+                                          x-text="providerContextStatusLabel"></span>
+                                </div>
+                                <p class="mt-1 text-sm text-[#45505f]" x-text="providerContextSummary"></p>
+                                <div class="mt-3 flex flex-wrap gap-2 text-xs">
+                                    <span class="rounded-full bg-white px-2 py-1 text-[#45505f] shadow-sm"
+                                          x-text="providerContext?.can_import_zones ? 'Zone import available' : 'Manual import only'"></span>
+                                    <span class="rounded-full bg-white px-2 py-1 text-[#45505f] shadow-sm"
+                                          x-text="providerContext?.can_preview_repairs ? 'Repair preview available' : 'Manual repair plan'"></span>
+                                    <span class="rounded-full bg-white px-2 py-1 text-[#45505f] shadow-sm"
+                                          x-text="providerContext?.can_apply_repairs ? 'Approved apply available' : 'No live writes'"></span>
+                                </div>
+                                <ol class="mt-3 space-y-1 text-sm text-[#45505f]">
+                                    <template x-for="step in providerContextSteps" :key="step">
+                                        <li class="flex gap-2">
+                                            <span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#2f9da5]"></span>
+                                            <span x-text="step"></span>
+                                        </li>
+                                    </template>
+                                </ol>
+                            </div>
+                            <a class="btn btn-sm btn-default shrink-0"
+                               :href="providerContextCtaHref"
+                               x-text="providerContextCtaLabel"></a>
+                        </div>
+                    </div>
                     <div>
                         <h3 class="font-semibold mb-1 flex items-center">
                             <span class="mr-2">DMARC Record</span>
@@ -1895,7 +1927,8 @@ function domainDetailsApp(domainId) {
             dkim: false,
             dkimSelectors: [],
             nameservers: [],
-            dnsProvider: null
+            dnsProvider: null,
+            providerContext: null
         },
         dnsRecordsLoading: true,
         dnsRecordsError: '',
@@ -2213,6 +2246,10 @@ function domainDetailsApp(domainId) {
             return this.dnsGuidance.dns_provider || this.dns.dnsProvider || null;
         },
 
+        get providerContext() {
+            return this.dns.providerContext || null;
+        },
+
         get dnsProviderName() {
             if (this.dnsRecordsLoading) return 'Checking DNS provider...';
             return this.detectedDnsProvider?.provider_name || 'Unknown provider';
@@ -2241,6 +2278,46 @@ function domainDetailsApp(domainId) {
             if (this.dnsRecordsLoading) return 'Checking nameservers...';
             const nameservers = this.dns.nameservers || this.detectedDnsProvider?.evidence || [];
             return nameservers.length ? nameservers.join(', ') : 'No NS evidence available yet';
+        },
+
+        get providerContextStatusLabel() {
+            if (this.dnsRecordsLoading) return 'checking';
+            return {
+                connected: 'connected',
+                read_only: 'read-only',
+                connect: 'connect provider',
+                manual: 'manual'
+            }[this.providerContext?.status] || 'manual';
+        },
+
+        get providerContextBadgeClass() {
+            if (this.dnsRecordsLoading) return 'bg-base-200 text-base-content/70';
+            return {
+                connected: 'bg-green-100 text-green-700',
+                read_only: 'bg-blue-100 text-blue-700',
+                connect: 'bg-yellow-100 text-yellow-800',
+                manual: 'bg-base-200 text-base-content/70'
+            }[this.providerContext?.status] || 'bg-base-200 text-base-content/70';
+        },
+
+        get providerContextSummary() {
+            if (this.dnsRecordsLoading) return 'Checking provider connection and safe DNS repair options.';
+            return this.providerContext?.summary || this.dnsProviderAction;
+        },
+
+        get providerContextSteps() {
+            if (this.dnsRecordsLoading) return ['Wait for DNS checks to complete.'];
+            const steps = this.providerContext?.next_steps || [];
+            return steps.length ? steps : ['Review the DNS lint findings and apply changes manually.'];
+        },
+
+        get providerContextCtaLabel() {
+            if (this.dnsRecordsLoading) return 'Checking...';
+            return this.providerContext?.cta_label || 'Review DNS guidance';
+        },
+
+        get providerContextCtaHref() {
+            return this.providerContext?.cta_href || '#dns-guidance';
         },
 
         syncDetectedDnsProvider() {

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -158,6 +158,7 @@
     {% endcall %}
 
     <!-- ── DNS Provider Connectors ────────────────────────────────────────── -->
+    <section id="provider-integrations">
     {% call card() %}
         {% call card_header() %}
             {% call card_title() %}DNS Provider Connectors{% endcall %}
@@ -320,6 +321,7 @@
             </form>
         {% endcall %}
     {% endcall %}
+    </section>
 
     <!-- ── Mail Service Imports ───────────────────────────────────────────── -->
     {% call card() %}

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -247,6 +247,7 @@ def test_settings_exposes_provider_agnostic_dns_import_without_html_injection():
     template = _settings_template()
 
     assert "DNS Provider Connectors" in template
+    assert 'id="provider-integrations"' in template
     assert "Provider Domain Discovery" in template
     assert "dns-provider-import-select" in template
     assert "loadDNSProviders" in template
@@ -341,6 +342,20 @@ def test_domain_details_exposes_ownership_and_delete_controls_without_html_injec
     assert "Type the domain name to confirm" in template
     assert "sourcesLoading" in template
     assert "sourceEvidenceCount" in template
+    assert "x-html" not in template
+
+
+def test_domain_details_exposes_dns_provider_repair_context_without_html_injection():
+    template = (
+        Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"
+    ).read_text()
+
+    assert "Provider repair readiness" in template
+    assert "providerContextStatusLabel" in template
+    assert "providerContextSummary" in template
+    assert "providerContextSteps" in template
+    assert "providerContextCtaHref" in template
+    assert "/settings#provider-integrations" not in template
     assert "x-html" not in template
 
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -329,7 +329,10 @@ def test_dns_endpoint_returns_real_data(authed_client: TestClient):
     assert data["checkedAt"] is not None
 
 
-def test_dns_endpoint_returns_dmarc_lint_findings(authed_client: TestClient):
+def test_dns_endpoint_returns_dmarc_lint_findings(
+    authed_client: TestClient,
+    monkeypatch,
+):
     result = DomainDNSResult(
         dmarc=True,
         dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@reports.example.net",
@@ -342,6 +345,12 @@ def test_dns_endpoint_returns_dmarc_lint_findings(authed_client: TestClient):
         dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
     )
 
+    monkeypatch.setattr(
+        domains_endpoint,
+        "get_cloudflare_credentials",
+        lambda db: SimpleNamespace(configured=False),
+    )
+
     with _mock_dns(result):
         response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns")
 
@@ -352,6 +361,44 @@ def test_dns_endpoint_returns_dmarc_lint_findings(authed_client: TestClient):
     assert data["nameservers"] == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
     assert data["dnsProvider"]["provider_id"] == "cloudflare"
     assert data["dnsProvider"]["connector_available"] is True
+    assert data["providerContext"]["status"] == "connect"
+    assert data["providerContext"]["detected_provider_id"] == "cloudflare"
+    assert data["providerContext"]["connected"] is False
+    assert data["providerContext"]["can_import_zones"] is True
+    assert data["providerContext"]["can_preview_repairs"] is True
+    assert data["providerContext"]["can_apply_repairs"] is False
+    assert data["providerContext"]["cta_href"] == "/settings#provider-integrations"
+
+
+def test_dns_endpoint_marks_connected_provider_repair_ready(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 include:_spf.example.com -all",
+        dkim=True,
+        dkim_selectors=["google"],
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+        dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
+    )
+    monkeypatch.setattr(
+        domains_endpoint,
+        "get_cloudflare_credentials",
+        lambda db: SimpleNamespace(configured=True),
+    )
+
+    with _mock_dns(result):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns")
+
+    assert response.status_code == 200
+    context = response.json()["providerContext"]
+    assert context["status"] == "connected"
+    assert context["connected"] is True
+    assert context["can_apply_repairs"] is True
+    assert context["cta_href"] == "#dns-guidance"
 
 
 def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: TestClient):


### PR DESCRIPTION
## Summary
- add read-only DNS provider repair context to the domain DNS response
- show provider connection/readiness, import availability, repair preview/apply status, and next steps on the domain detail DNS widget
- add a stable settings anchor for provider integrations

## Validation
- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_dns_endpoints.py::test_dns_endpoint_returns_dmarc_lint_findings backend/app/tests/test_dns_endpoints.py::test_dns_endpoint_marks_connected_provider_repair_ready backend/app/tests/test_dashboard_template_security.py::test_settings_exposes_provider_agnostic_dns_import_without_html_injection backend/app/tests/test_dashboard_template_security.py::test_domain_details_exposes_dns_provider_repair_context_without_html_injection backend/app/tests/test_dashboard_template_security.py::test_dashboard_trigger_poll_uses_post_action_not_get_link
- /tmp/dmarq-provider-connectors-423/.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-provider-connectors-423/.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py
- git diff --check

Closes part of #423.