### PR TITLE
Add structured remediation action plans

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1026,6 +1026,17 @@ class RemediationEvidence(BaseModel):
     value: str
 
 
+class RemediationActionPlan(BaseModel):
+    """Operator-facing action plan for one remediation queue item."""
+
+    owner: str
+    diagnosis: str
+    prerequisites: List[str] = Field(default_factory=list)
+    steps: List[str] = Field(default_factory=list)
+    completion_criteria: str
+    automation_path: str
+
+
 class RemediationNotification(BaseModel):
     """Read-only notification routing metadata for one remediation item."""
 
@@ -1055,6 +1066,7 @@ class RemediationQueueItem(BaseModel):
     blast_radius: str
     prerequisites: List[str] = Field(default_factory=list)
     expected_health_score_impact: str
+    action_plan: RemediationActionPlan
     automation: RemediationAutomation
     notification: RemediationNotification
 

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -205,7 +205,8 @@ def _dns_item(
     if recommended_provider:
         prerequisites.append(f"Use the detected provider path for {recommended_provider}.")
 
-    return {
+    next_steps = steps or [str(plan.get("rationale") or "Review the DNS finding.")]
+    item = {
         "id": f"dns:{plan.get('plan_id') or plan.get('finding_code')}",
         "source": "dns_lint",
         "state": "approval_ready" if automation_ready else "manual_action",
@@ -213,7 +214,7 @@ def _dns_item(
         "confidence": "high" if finding else "medium",
         "title": finding.get("title") if finding else f"Review {plan.get('finding_code')}",
         "detail": finding.get("detail") if finding else str(plan.get("rationale") or ""),
-        "next_steps": steps or [str(plan.get("rationale") or "Review the DNS finding.")],
+        "next_steps": next_steps,
         "evidence": evidence,
         "blast_radius": f"DNS record {plan.get('name')} ({plan.get('record_type')})",
         "prerequisites": prerequisites,
@@ -233,11 +234,13 @@ def _dns_item(
             ),
         },
     }
+    item["action_plan"] = _action_plan_for_item(item)
+    return item
 
 
 def _health_item(domain: str, action: Dict[str, Any]) -> Dict[str, Any]:
     state = "investigate" if action.get("type") == "low_compliance" else "manual_action"
-    return {
+    item = {
         "id": f"health:{action.get('type')}",
         "source": "health_score",
         "state": state,
@@ -261,6 +264,61 @@ def _health_item(domain: str, action: Dict[str, Any]) -> Dict[str, Any]:
             "apply_endpoint": None,
             "reason": "This item needs investigation before a provider change is safe.",
         },
+    }
+    item["action_plan"] = _action_plan_for_item(item)
+    return item
+
+
+def _action_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a compact operator action plan for one remediation queue item."""
+    automation = item.get("automation") or {}
+    source = str(item.get("source") or "remediation")
+    state = str(item.get("state") or "")
+    steps = [str(step) for step in item.get("next_steps") or [] if str(step).strip()]
+    prerequisites = [str(step) for step in item.get("prerequisites") or [] if str(step).strip()]
+
+    if automation.get("eligible"):
+        owner = "Domain DNS operator"
+        completion = "Provider preview is approved, applied, and verified by DMARQ."
+        steps = [
+            "Open the DNS change plan and preview the provider mutation.",
+            "Confirm the zone, record name, old value, new value, and TTL.",
+            "Approve the change, then refresh DNS posture after propagation.",
+        ]
+    elif state == "investigate":
+        owner = "Mail operations owner"
+        completion = "Sender legitimacy is confirmed and the item is resolved or converted into a DNS repair."
+        steps = steps or [
+            "Review the report evidence and sending-source history.",
+            "Confirm whether the sender is legitimate for this domain.",
+            "Authorize the sender with SPF/DKIM only after ownership is clear.",
+        ]
+    elif source == "dns_lint":
+        owner = "Domain DNS operator"
+        completion = "The DNS lint finding is no longer present after refresh."
+        steps = steps or [
+            "Open the DNS guidance section.",
+            "Apply the listed record change in the authoritative DNS provider.",
+            "Refresh DMARQ DNS checks after propagation.",
+        ]
+    else:
+        owner = "Mail operations owner"
+        completion = (
+            "The underlying domain health action no longer appears in the remediation queue."
+        )
+        steps = steps or ["Review the evidence and complete the recommended operator action."]
+
+    return {
+        "owner": owner,
+        "diagnosis": str(item.get("detail") or item.get("title") or "Review this finding."),
+        "prerequisites": prerequisites[:5],
+        "steps": steps[:6],
+        "completion_criteria": completion,
+        "automation_path": (
+            "provider_preview"
+            if automation.get("eligible")
+            else ("investigate" if state == "investigate" else "manual")
+        ),
     }
 
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -365,6 +365,28 @@
                                     <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next step</p>
                                     <p class="mt-1 text-sm text-[#120d36]" x-text="item.next_steps[0] || 'Review the evidence.'"></p>
                                 </div>
+                                <template x-if="item.action_plan">
+                                    <div class="mt-3 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-3">
+                                        <div class="flex flex-wrap items-center justify-between gap-2">
+                                            <p class="text-xs font-semibold uppercase text-[#5f5c78]">Action plan</p>
+                                            <span class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#1f7c83]"
+                                                  x-text="item.action_plan.owner"></span>
+                                        </div>
+                                        <p class="mt-2 text-sm text-[#120d36]" x-text="item.action_plan.diagnosis"></p>
+                                        <ol class="mt-3 space-y-1 text-sm text-[#45505f]">
+                                            <template x-for="step in (item.action_plan.steps || []).slice(0, 4)" :key="item.id + '-plan-' + step">
+                                                <li class="flex gap-2">
+                                                    <span class="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[#2f9da5]"></span>
+                                                    <span x-text="step"></span>
+                                                </li>
+                                            </template>
+                                        </ol>
+                                        <p class="mt-3 text-xs text-[#5f5c78]">
+                                            <span class="font-semibold">Done when: </span>
+                                            <span x-text="item.action_plan.completion_criteria"></span>
+                                        </p>
+                                    </div>
+                                </template>
                                 <template x-if="item.notification && item.notification.dispatch">
                                     <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3">
                                         <div class="flex flex-wrap items-center justify-between gap-2">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -384,6 +384,19 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
     assert "x-html" not in template
 
 
+def test_domain_details_exposes_remediation_action_plans_without_html_injection():
+    template = (
+        Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"
+    ).read_text()
+
+    assert "Remediation Queue" in template
+    assert "Action plan" in template
+    assert "item.action_plan.owner" in template
+    assert "item.action_plan.steps" in template
+    assert "item.action_plan.completion_criteria" in template
+    assert "x-html" not in template
+
+
 def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     template = (
         Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -1,4 +1,7 @@
-from app.services.remediation_queue import _remediation_notification_payload, build_remediation_queue
+from app.services.remediation_queue import (
+    _remediation_notification_payload,
+    build_remediation_queue,
+)
 
 
 def test_remediation_queue_prioritizes_provider_ready_dns_plan():
@@ -76,6 +79,13 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
     assert queue["items"][0]["automation"]["apply_endpoint"] == (
         "/api/v1/domains/example.com/dns/change-plan/apply"
     )
+    assert queue["items"][0]["action_plan"]["owner"] == "Domain DNS operator"
+    assert queue["items"][0]["action_plan"]["automation_path"] == "provider_preview"
+    assert (
+        "preview the provider mutation"
+        in " ".join(queue["items"][0]["action_plan"]["steps"]).lower()
+    )
+    assert queue["items"][0]["action_plan"]["completion_criteria"]
     notification = queue["items"][0]["notification"]
     assert notification == {
         "state": "approval_required",
@@ -162,6 +172,8 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
     assert queue["items"][0]["state"] == "manual_action"
     assert queue["items"][0]["automation"]["eligible"] is False
     assert queue["items"][0]["automation"]["apply_endpoint"] is None
+    assert queue["items"][0]["action_plan"]["automation_path"] == "manual"
+    assert queue["items"][0]["action_plan"]["completion_criteria"]
     assert queue["items"][0]["notification"]["state"] == "summary_only"
     assert queue["items"][0]["notification"]["event"] == "dmarq.remediation.summary"
     assert queue["items"][0]["notification"]["payload_preview"]["event_type"] == (
@@ -240,6 +252,8 @@ def test_remediation_queue_requires_recommended_provider_for_automation():
     assert queue["items"][0]["automation"]["eligible"] is False
     assert queue["items"][0]["automation"]["provider"] is None
     assert queue["items"][0]["automation"]["apply_endpoint"] is None
+    assert queue["items"][0]["action_plan"]["owner"] == "Domain DNS operator"
+    assert queue["items"][0]["action_plan"]["steps"]
     assert queue["items"][0]["notification"]["state"] == "action_required"
     assert queue["items"][0]["notification"]["event"] == (
         "dmarq.remediation.manual_action_required"


### PR DESCRIPTION
## Summary
- add structured operator action plans to remediation queue items
- expose owner, diagnosis, prerequisites, steps, completion criteria, and automation path in the API
- render the action plan in the domain Remediation Queue so operators see concrete next steps beyond a single line

## Validation
- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_remediation_queue.py backend/app/tests/test_dashboard_template_security.py::test_domain_details_exposes_remediation_action_plans_without_html_injection
- /tmp/dmarq-provider-connectors-423/.venv/bin/isort backend/app/api/api_v1/endpoints/domains.py backend/app/services/remediation_queue.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-provider-connectors-423/.venv/bin/black backend/app/api/api_v1/endpoints/domains.py backend/app/services/remediation_queue.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_dashboard_template_security.py
- git diff --check

Closes part of #384.