### PR TITLE
Harden dashboard poll summary behavior test runner

### DIFF
--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -5,6 +5,7 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+import pytest
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 
@@ -50,15 +51,16 @@ def _dashboard_script() -> str:
 
 def _run_dashboard_poll_summary(payload: dict[str, object]) -> str:
     node = shutil.which("node")
-    assert node, "node is required to execute dashboard-page.js behavior tests"
+    if not node:
+        pytest.skip("node is required to execute dashboard-page.js behavior tests")
 
     script_path = Path(__file__).resolve().parents[1] / "static" / "js" / "dashboard-page.js"
     runner = textwrap.dedent("""
         const fs = require('fs');
         const script = fs.readFileSync(process.argv[1], 'utf8');
         const payload = JSON.parse(process.argv[2]);
-        eval(script);
-        process.stdout.write(dashboardApp().summarizePollResults(payload));
+        const dashboardAppFactory = new Function(`${script}\\nreturn dashboardApp;`)();
+        process.stdout.write(dashboardAppFactory().summarizePollResults(payload));
         """)
     result = subprocess.run(
         [node, "-e", runner, str(script_path), json.dumps(payload)],


### PR DESCRIPTION
## Summary
- skip the JS behavior tests explicitly when Node is unavailable instead of relying on bare assert
- load dashboard-page.js via Function and return dashboardApp instead of direct eval

## Validation
- PYTHONPATH=backend .venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py::test_dashboard_poll_summary_reports_source_totals_and_outcomes backend/app/tests/test_dashboard_template_security.py::test_dashboard_poll_summary_uses_fallback_message_without_sources
- .venv/bin/isort --check-only backend/app/tests/test_dashboard_template_security.py
- .venv/bin/black --check backend/app/tests/test_dashboard_template_security.py
- git diff --check

Follow-up for Copilot comments on #505 after it merged.