### PR TITLE
Harden direct report intake webhook

### DIFF
--- a/backend/app/api/api_v1/endpoints/webhook.py
+++ b/backend/app/api/api_v1/endpoints/webhook.py
@@ -4,6 +4,7 @@ import base64
 import email
 import hmac
 import logging
+import math
 from email.header import decode_header
 from typing import Any, Dict, Optional
 
@@ -67,6 +68,42 @@ def _ensure_email_size(raw_email: bytes) -> None:
                 f"Maximum accepted size is {max_bytes} bytes."
             ),
         )
+
+
+def _ensure_base64_email_size(raw_email: str) -> None:
+    max_encoded_bytes = 4 * math.ceil(_max_webhook_email_bytes() / 3)
+    if len(raw_email) > max_encoded_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=(
+                "Webhook email payload is too large. "
+                f"Maximum accepted size is {_max_webhook_email_bytes()} bytes."
+            ),
+        )
+
+
+def _ensure_request_content_length(request: Request) -> None:
+    content_length = request.headers.get("content-length")
+    if not content_length:
+        return
+    try:
+        body_size = int(content_length)
+    except ValueError:
+        return
+    max_bytes = _max_webhook_email_bytes()
+    if body_size > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=(
+                "Webhook email payload is too large. "
+                f"Maximum accepted size is {max_bytes} bytes."
+            ),
+        )
+
+
+def _api_endpoint_path(path: str) -> str:
+    settings = get_settings()
+    return f"{settings.API_V1_STR.rstrip('/')}/webhook/{path.lstrip('/')}"
 
 
 def _require_webhook_secret(x_webhook_secret: Optional[str]) -> None:
@@ -164,12 +201,12 @@ async def webhook_status(_auth: dict = Depends(require_admin_auth)) -> Dict[str,
         "max_email_size_mb": max_bytes // (1024 * 1024),
         "endpoints": [
             {
-                "path": "/api/v1/webhook/email",
+                "path": _api_endpoint_path("email"),
                 "method": "POST",
                 "payload": "json_base64_rfc822",
             },
             {
-                "path": "/api/v1/webhook/email/raw",
+                "path": _api_endpoint_path("email/raw"),
                 "method": "POST",
                 "payload": "raw_rfc822",
             },
@@ -186,6 +223,7 @@ async def receive_email(
 ) -> Dict[str, Any]:
     """Receive a base64 encoded raw email from an email worker webhook."""
     _require_webhook_secret(x_webhook_secret)
+    _ensure_base64_email_size(payload.raw_email)
     try:
         raw_email = base64.b64decode(payload.raw_email, validate=True)
     except (ValueError, TypeError) as exc:
@@ -206,6 +244,7 @@ async def receive_raw_email(
 ) -> Dict[str, Any]:
     """Receive raw RFC 822 email bytes from an email worker webhook."""
     _require_webhook_secret(x_webhook_secret)
+    _ensure_request_content_length(request)
     raw_email = await request.body()
     _ensure_email_size(raw_email)
     return _handle_raw_email(raw_email, db)

--- a/backend/app/api/api_v1/endpoints/webhook.py
+++ b/backend/app/api/api_v1/endpoints/webhook.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.redaction import sanitize_for_log
+from app.core.security import require_admin_auth
 from app.services.dmarc_parser import DMARCParser
 from app.services.report_persistence import report_exists, save_parsed_report
 from app.services.report_store import ReportStore
@@ -48,6 +49,24 @@ def _decode_email_header(header: Optional[str]) -> str:
 def _is_dmarc_filename(filename: str) -> bool:
     lower = filename.lower()
     return lower.endswith((".xml", ".zip", ".gz", ".gzip"))
+
+
+def _max_webhook_email_bytes() -> int:
+    settings = get_settings()
+    max_mb = max(int(settings.WEBHOOK_MAX_EMAIL_SIZE_MB or 1), 1)
+    return max_mb * 1024 * 1024
+
+
+def _ensure_email_size(raw_email: bytes) -> None:
+    max_bytes = _max_webhook_email_bytes()
+    if len(raw_email) > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=(
+                "Webhook email payload is too large. "
+                f"Maximum accepted size is {max_bytes} bytes."
+            ),
+        )
 
 
 def _require_webhook_secret(x_webhook_secret: Optional[str]) -> None:
@@ -133,6 +152,32 @@ def _subject_from_message(msg: email.message.Message, fallback: Optional[str] = 
     return fallback or _decode_email_header(msg.get("Subject"))
 
 
+@router.get("/status")
+async def webhook_status(_auth: dict = Depends(require_admin_auth)) -> Dict[str, Any]:
+    """Return direct email webhook intake readiness without exposing the secret."""
+    settings = get_settings()
+    max_bytes = _max_webhook_email_bytes()
+    return {
+        "configured": bool(settings.WEBHOOK_SECRET),
+        "auth_header": "X-Webhook-Secret",
+        "max_email_size_bytes": max_bytes,
+        "max_email_size_mb": max_bytes // (1024 * 1024),
+        "endpoints": [
+            {
+                "path": "/api/v1/webhook/email",
+                "method": "POST",
+                "payload": "json_base64_rfc822",
+            },
+            {
+                "path": "/api/v1/webhook/email/raw",
+                "method": "POST",
+                "payload": "raw_rfc822",
+            },
+        ],
+        "accepted_attachment_extensions": [".xml", ".zip", ".gz", ".gzip"],
+    }
+
+
 @router.post("/email")
 async def receive_email(
     payload: EmailWebhookPayload,
@@ -149,6 +194,7 @@ async def receive_email(
             detail="raw_email must be valid base64.",
         ) from exc
 
+    _ensure_email_size(raw_email)
     return _handle_raw_email(raw_email, db, subject=payload.subject)
 
 
@@ -160,7 +206,9 @@ async def receive_raw_email(
 ) -> Dict[str, Any]:
     """Receive raw RFC 822 email bytes from an email worker webhook."""
     _require_webhook_secret(x_webhook_secret)
-    return _handle_raw_email(await request.body(), db)
+    raw_email = await request.body()
+    _ensure_email_size(raw_email)
+    return _handle_raw_email(raw_email, db)
 
 
 def _handle_raw_email(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -78,6 +78,7 @@ class Settings(BaseSettings):
     AKAMAI_ACCOUNT_KEY: Optional[str] = None
     POSTMARK_ACCOUNT_TOKEN: Optional[str] = None
     WEBHOOK_SECRET: Optional[str] = None
+    WEBHOOK_MAX_EMAIL_SIZE_MB: int = 25
 
     # Optional sender reputation feed lookups. Disabled by default because many
     # reputation providers require explicit terms, credentials, and volume limits.

--- a/backend/app/tests/test_webhook.py
+++ b/backend/app/tests/test_webhook.py
@@ -9,7 +9,9 @@ from unittest.mock import patch
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from starlette.requests import Request
 
+from app.api.api_v1.endpoints import webhook
 from app.core.config import get_settings
 from app.models.report import DMARCReport
 
@@ -195,6 +197,23 @@ def test_webhook_rejects_oversized_base64_before_decode(client: TestClient, monk
 
     assert response.status_code == 413
     decode.assert_not_called()
+
+
+def test_webhook_content_length_guard_allows_missing_header():
+    request = Request({"type": "http", "headers": []})
+
+    webhook._ensure_request_content_length(request)
+
+
+def test_webhook_content_length_guard_allows_invalid_header():
+    request = Request(
+        {
+            "type": "http",
+            "headers": [(b"content-length", b"not-a-number")],
+        }
+    )
+
+    webhook._ensure_request_content_length(request)
 
 
 def test_webhook_rejects_oversized_raw_email(client: TestClient, monkeypatch):

--- a/backend/app/tests/test_webhook.py
+++ b/backend/app/tests/test_webhook.py
@@ -114,6 +114,27 @@ def test_webhook_rejects_invalid_secret(client: TestClient, monkeypatch):
     assert response.status_code == 401
 
 
+def test_webhook_status_reports_readiness_without_secret(authed_client, monkeypatch):
+    _set_webhook_secret(monkeypatch)
+    monkeypatch.setenv("WEBHOOK_MAX_EMAIL_SIZE_MB", "3")
+    get_settings.cache_clear()
+
+    response = authed_client.get("/api/v1/webhook/status")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["configured"] is True
+    assert data["auth_header"] == "X-Webhook-Secret"
+    assert data["max_email_size_mb"] == 3
+    assert data["max_email_size_bytes"] == 3 * 1024 * 1024
+    assert {endpoint["path"] for endpoint in data["endpoints"]} == {
+        "/api/v1/webhook/email",
+        "/api/v1/webhook/email/raw",
+    }
+    assert ".xml" in data["accepted_attachment_extensions"]
+    assert "test-webhook-secret" not in response.text
+
+
 def test_webhook_imports_base64_email(client: TestClient, db_session, monkeypatch):
     secret = _set_webhook_secret(monkeypatch)
 
@@ -129,6 +150,36 @@ def test_webhook_imports_base64_email(client: TestClient, db_session, monkeypatc
     assert data["reports_found"] == 1
     assert data["imported"] == 1
     assert db_session.query(DMARCReport).count() == 1
+
+
+def test_webhook_rejects_oversized_base64_email(client: TestClient, monkeypatch):
+    secret = _set_webhook_secret(monkeypatch)
+    monkeypatch.setenv("WEBHOOK_MAX_EMAIL_SIZE_MB", "1")
+    get_settings.cache_clear()
+
+    response = client.post(
+        "/api/v1/webhook/email",
+        headers={"X-Webhook-Secret": secret},
+        json={"raw_email": base64.b64encode(b"x" * (1024 * 1024 + 1)).decode("ascii")},
+    )
+
+    assert response.status_code == 413
+    assert "too large" in response.json()["detail"]
+
+
+def test_webhook_rejects_oversized_raw_email(client: TestClient, monkeypatch):
+    secret = _set_webhook_secret(monkeypatch)
+    monkeypatch.setenv("WEBHOOK_MAX_EMAIL_SIZE_MB", "1")
+    get_settings.cache_clear()
+
+    response = client.post(
+        "/api/v1/webhook/email/raw",
+        headers={"X-Webhook-Secret": secret},
+        content=b"x" * (1024 * 1024 + 1),
+    )
+
+    assert response.status_code == 413
+    assert "Maximum accepted size" in response.json()["detail"]
 
 
 def test_webhook_raw_email_marks_duplicate(client: TestClient, monkeypatch):

--- a/backend/app/tests/test_webhook.py
+++ b/backend/app/tests/test_webhook.py
@@ -135,6 +135,20 @@ def test_webhook_status_reports_readiness_without_secret(authed_client, monkeypa
     assert "test-webhook-secret" not in response.text
 
 
+def test_webhook_status_uses_configured_api_prefix(authed_client, monkeypatch):
+    _set_webhook_secret(monkeypatch)
+    monkeypatch.setenv("API_V1_STR", "/internal/api")
+    get_settings.cache_clear()
+
+    response = authed_client.get("/api/v1/webhook/status")
+
+    assert response.status_code == 200
+    assert {endpoint["path"] for endpoint in response.json()["endpoints"]} == {
+        "/internal/api/webhook/email",
+        "/internal/api/webhook/email/raw",
+    }
+
+
 def test_webhook_imports_base64_email(client: TestClient, db_session, monkeypatch):
     secret = _set_webhook_secret(monkeypatch)
 
@@ -165,6 +179,22 @@ def test_webhook_rejects_oversized_base64_email(client: TestClient, monkeypatch)
 
     assert response.status_code == 413
     assert "too large" in response.json()["detail"]
+
+
+def test_webhook_rejects_oversized_base64_before_decode(client: TestClient, monkeypatch):
+    secret = _set_webhook_secret(monkeypatch)
+    monkeypatch.setenv("WEBHOOK_MAX_EMAIL_SIZE_MB", "1")
+    get_settings.cache_clear()
+
+    with patch("app.api.api_v1.endpoints.webhook.base64.b64decode") as decode:
+        response = client.post(
+            "/api/v1/webhook/email",
+            headers={"X-Webhook-Secret": secret},
+            json={"raw_email": "A" * (2 * 1024 * 1024)},
+        )
+
+    assert response.status_code == 413
+    decode.assert_not_called()
 
 
 def test_webhook_rejects_oversized_raw_email(client: TestClient, monkeypatch):

--- a/docs/cloudflare-email-worker-inbound-webhook.md
+++ b/docs/cloudflare-email-worker-inbound-webhook.md
@@ -43,6 +43,8 @@ manually outside this flow.
 - `WEBHOOK_SECRET` set in the DMARQ environment. See
   [Configuration](deployment/configuration.md#cloudflare-integration) and
   [Secret Handling with 1Password](deployment/secrets.md).
+- Optional: `WEBHOOK_MAX_EMAIL_SIZE_MB` if your report attachments require a
+  limit other than the 25 MB default.
 - A Cloudflare zone with Email Routing enabled.
 - An Email Worker bound to the DMARC report address.
 
@@ -63,6 +65,7 @@ Both routes require the `X-Webhook-Secret` header. The value must match
 
 | Route | Body | Purpose |
 |-------|------|---------|
+| `GET /api/v1/webhook/status` | Admin-authenticated JSON | Intake readiness, accepted endpoints, and payload limit without exposing the secret |
 | `POST /api/v1/webhook/email` | JSON | Base64-encoded RFC 822 message |
 | `POST /api/v1/webhook/email/raw` | Raw bytes | RFC 822 message as request body |
 
@@ -96,6 +99,7 @@ Send the RFC 822 bytes as the HTTP request body. No JSON wrapper.
 |-----------|-------------|--------|
 | `WEBHOOK_SECRET` unset in DMARQ | `503` | `Webhook ingestion is not configured.` |
 | Missing or wrong `X-Webhook-Secret` | `401` | `Invalid webhook secret.` |
+| Message body larger than `WEBHOOK_MAX_EMAIL_SIZE_MB` | `413` | `Webhook email payload is too large.` |
 | Invalid base64 in `raw_email` | `400` | `raw_email must be valid base64.` |
 | Unparseable email (raw path) | `400` | `Error processing email.` |
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -323,6 +323,7 @@ operational policy if long-term storage size matters.
 |----------|-------------|---------|---------|
 | `POSTMARK_ACCOUNT_TOKEN` | Optional Postmark account token for read-only sender-domain discovery | - | `your_postmark_account_token` |
 | `WEBHOOK_SECRET` | Required secret for inbound email worker webhooks | - | `openssl rand -hex 32` |
+| `WEBHOOK_MAX_EMAIL_SIZE_MB` | Maximum raw RFC 822 email size accepted by inbound report webhooks | `25` | `10`, `50` |
 
 Cloudflare credentials can also be stored from **Settings**. The API token is
 encrypted in the settings table and redacted when settings are read back. Leave


### PR DESCRIPTION
## Summary
- add an admin-only direct intake status endpoint that reports readiness, supported endpoint shapes, accepted extensions, and payload limit without exposing the webhook secret
- add WEBHOOK_MAX_EMAIL_SIZE_MB with a 25 MB default
- reject oversized JSON/base64 and raw RFC 822 webhook payloads with 413 before parsing
- document the status endpoint and payload limit for Cloudflare Email Worker deployments

## Validation
- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_webhook.py backend/app/tests/test_config.py
- /tmp/dmarq-provider-connectors-423/.venv/bin/isort --check-only backend/app/api/api_v1/endpoints/webhook.py backend/app/tests/test_webhook.py backend/app/core/config.py
- /tmp/dmarq-provider-connectors-423/.venv/bin/black --check backend/app/api/api_v1/endpoints/webhook.py backend/app/tests/test_webhook.py backend/app/core/config.py
- git diff --check

Part of #383.