### PR TITLE
Remove remaining shared inline template styles

### DIFF
--- a/backend/app/static/css/styles.css
+++ b/backend/app/static/css/styles.css
@@ -248,6 +248,10 @@ h1, h2, h3, h4, h5, h6 {
   @apply w-full;
 }
 
+.enforcement-gauge-bg {
+  background: conic-gradient(#2f9da5 0deg, #2f9da5 180deg, #e8e8e8 180deg, #e8e8e8 360deg);
+}
+
 /* Text status colors for compliance status */
 .text-success {
   color: #16a34a; /* Green color for compliant status */

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -202,8 +202,7 @@
                 <a href="/domains" class="mt-1 text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Review</a>
             </div>
             <div class="mt-7 flex justify-center">
-                <div id="enforcement-gauge" class="grid h-48 w-48 place-items-center rounded-full"
-                     style="background: conic-gradient(#2f9da5 0deg, #2f9da5 180deg, #e8e8e8 180deg, #e8e8e8 360deg);">
+                <div id="enforcement-gauge" class="enforcement-gauge-bg grid h-48 w-48 place-items-center rounded-full">
                     <div class="grid h-32 w-32 place-items-center rounded-full bg-white text-center">
                         <div>
                             <p id="enforcement-label" class="text-xl text-[#07071f]">mixed</p>

--- a/backend/app/templates/members.html
+++ b/backend/app/templates/members.html
@@ -181,7 +181,7 @@
                                         <div class="mt-3 h-2 overflow-hidden rounded-full bg-[#ebe9e6]">
                                             <div class="h-full rounded-full"
                                                  :class="limitTrackClass(limit)"
-                                                 :style="`width: ${Math.min(limit.usage_percent || 0, 100)}%`"></div>
+                                                 x-effect="$el.style.width = `${Math.min(limit.usage_percent || 0, 100)}%`"></div>
                                         </div>
                                         <p class="mt-2 text-xs text-[#7a4a12]" x-show="limit.message" x-text="limit.message"></p>
                                     </div>

--- a/backend/app/templates/tls_reports.html
+++ b/backend/app/templates/tls_reports.html
@@ -75,8 +75,8 @@
                         <div class="grid grid-cols-[6.5rem_1fr_7rem] gap-3 items-center">
                             <span class="text-sm text-base-content/70" x-text="day.date"></span>
                             <div class="h-3 rounded bg-base-300 overflow-hidden flex">
-                                <div class="bg-success" :style="`width: ${trendSuccessWidth(day)}%`"></div>
-                                <div class="bg-error" :style="`width: ${trendFailureWidth(day)}%`"></div>
+                                <div class="bg-success" x-effect="$el.style.width = `${trendSuccessWidth(day)}%`"></div>
+                                <div class="bg-error" x-effect="$el.style.width = `${trendFailureWidth(day)}%`"></div>
                             </div>
                             <span class="text-right text-sm font-medium" x-text="formatNumber(day.failed_sessions) + ' failed'"></span>
                         </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -647,6 +647,7 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert _has_inline_script('<script data-src="/static/js/members-page.js"></script>')
     assert not _has_inline_style('<div data-style="ok" x-effect="$el.style.width = width"></div>')
     assert _has_inline_style('<div data-style="ok" :style="bad"></div>')
+    assert _has_inline_style("<progress x-bind:style=\"{ width: progress + '%' }\" />")
     assert _has_inline_style("<div x-bind:style=\"{ width: progress + '%' }\"></div>")
 
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -36,6 +36,10 @@ def _has_inline_script(markup: str) -> bool:
     return bool(re.search(r"<script\b(?![^>]*\ssrc\s*=)[^>]*>", markup, re.IGNORECASE))
 
 
+def _has_inline_style(markup: str) -> bool:
+    return bool(re.search(r"\s:?style\s*=", markup, re.IGNORECASE))
+
+
 def _template_section_between_markers(template: str, start_marker: str, end_marker: str) -> str:
     start_match = re.search(rf"^[ \t]*{re.escape(start_marker)}", template, re.MULTILINE)
     assert start_match, f"{start_marker!r} marker missing from template"
@@ -214,9 +218,13 @@ def test_dashboard_clears_all_chart_instances():
 
 def test_dashboard_uses_external_page_script_for_csp_migration():
     template = _dashboard_template()
+    styles = _read_project_file("static", "css", "styles.css")
 
     assert 'src="/static/js/chart.umd.min.js"' in template
     assert 'src="/static/js/dashboard-page.js"' in template
+    assert "enforcement-gauge-bg" in template
+    assert ".enforcement-gauge-bg" in styles
+    assert not _has_inline_style(template)
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
@@ -360,6 +368,8 @@ def test_tls_reports_uses_external_page_script_for_csp_migration():
     assert "/api/v1/tls-reports/summary?" in script
     assert "/api/v1/tls-reports/upload" in script
     assert "Unable to load TLS report summary" in script
+    assert 'x-effect="$el.style.width' in template
+    assert not _has_inline_style(template)
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
@@ -616,7 +626,9 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert '@change="updateMembership(membership, true)"' not in template
     assert "x-html" not in template
     assert not _has_inline_script(template)
+    assert not _has_inline_style(template)
     assert _has_inline_script('<script data-src="/static/js/members-page.js"></script>')
+    assert _has_inline_style('<div data-style="ok" :style="bad"></div>')
 
 
 def test_base_template_propagates_selected_workspace_context():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -3,6 +3,7 @@ import re
 import shutil
 import subprocess
 import textwrap
+from html.parser import HTMLParser
 from pathlib import Path
 
 import pytest
@@ -36,8 +37,24 @@ def _has_inline_script(markup: str) -> bool:
     return bool(re.search(r"<script\b(?![^>]*\ssrc\s*=)[^>]*>", markup, re.IGNORECASE))
 
 
+class _InlineStyleDetector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.has_inline_style = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        inline_style_attrs = {"style", ":style", "x-bind:style"}
+        if any(name.lower() in inline_style_attrs for name, _value in attrs):
+            self.has_inline_style = True
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.handle_starttag(tag, attrs)
+
+
 def _has_inline_style(markup: str) -> bool:
-    return bool(re.search(r"\s:?style\s*=", markup, re.IGNORECASE))
+    parser = _InlineStyleDetector()
+    parser.feed(markup)
+    return parser.has_inline_style
 
 
 def _template_section_between_markers(template: str, start_marker: str, end_marker: str) -> str:
@@ -628,7 +645,9 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert not _has_inline_script(template)
     assert not _has_inline_style(template)
     assert _has_inline_script('<script data-src="/static/js/members-page.js"></script>')
+    assert not _has_inline_style('<div data-style="ok" x-effect="$el.style.width = width"></div>')
     assert _has_inline_style('<div data-style="ok" :style="bad"></div>')
+    assert _has_inline_style("<div x-bind:style=\"{ width: progress + '%' }\"></div>")
 
 
 def test_base_template_propagates_selected_workspace_context():


### PR DESCRIPTION
## Summary
- move the dashboard enforcement gauge's static conic-gradient into the shared stylesheet
- replace shared TLS and members inline style bindings with Alpine effects that set element widths at runtime
- add regression coverage so dashboard, TLS reports, and members templates reject inline style attributes

Part of #426.

## Local validation
- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py
- node --check backend/app/static/js/dashboard-page.js
- node --check backend/app/static/js/tls-reports-page.js
- node --check backend/app/static/js/members-page.js
- /tmp/dmarq-provider-connectors-423/.venv/bin/isort --check-only backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-provider-connectors-423/.venv/bin/black --check backend/app/tests/test_dashboard_template_security.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of the enforcement gauge, plan limits, and TLS failure trends with more consistent styling and layout.
  * Fixed stylesheet structure to ensure the new gauge background displays correctly.
* **Chores**
  * Strengthened template checks to better detect inline styling and keep the UI aligned with safer, more maintainable patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->