### PR TITLE
[codex] Use Cloudflare API OAuth token endpoint

### DIFF
--- a/backend/app/services/cloudflare_oauth.py
+++ b/backend/app/services/cloudflare_oauth.py
@@ -16,7 +16,7 @@ from app.core.credential_encryption import encrypt_secret
 from app.models.setting import Setting
 
 CLOUDFLARE_AUTHORIZATION_URL = "https://dash.cloudflare.com/oauth2/auth"
-CLOUDFLARE_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token"
+CLOUDFLARE_TOKEN_URL = "https://api.cloudflare.com/oauth2/token"
 CLOUDFLARE_DEFAULT_READ_SCOPES = "zone.read dns.read"
 _STATE_ALGORITHM = "HS256"
 _STATE_TTL = timedelta(minutes=10)

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -2014,6 +2014,10 @@ def test_cloudflare_oauth_config_requires_client_credentials(
         cloudflare_oauth.get_cloudflare_oauth_config()
 
 
+def test_cloudflare_oauth_token_exchange_uses_api_host():
+    assert cloudflare_oauth.CLOUDFLARE_TOKEN_URL == "https://api.cloudflare.com/oauth2/token"
+
+
 def test_cloudflare_oauth_decode_rejects_state_without_workspace(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
## Summary
- switch Cloudflare OAuth token exchange to the API-hosted token endpoint to avoid dashboard browser challenges from server runtimes
- add a regression assertion for the token endpoint host

## Validation
- python -m pytest backend/app/tests/test_cloudflare_dns.py -k 'cloudflare_oauth_exchange or cloudflare_oauth_token_exchange_uses_api_host or cloudflare_oauth_config'
- python -m py_compile backend/app/services/cloudflare_oauth.py backend/app/tests/test_cloudflare_dns.py
- git diff --check
- black --check backend/app/services/cloudflare_oauth.py backend/app/tests/test_cloudflare_dns.py
- isort --check-only backend/app/services/cloudflare_oauth.py backend/app/tests/test_cloudflare_dns.py