### PR TITLE
Add external IdP role claim mapping

### DIFF
--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -14,7 +14,11 @@ from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
 from app.core.config import Settings, get_settings
+from app.models.organization import Organization, OrganizationMembership
 from app.models.user import User
+from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
+from app.services.workspace_access import ORGANIZATION_ROLE_ALIASES, ROLE_PERMISSIONS
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +53,9 @@ class ExternalIdentityClaims:
     username: Optional[str] = None
     picture: Optional[str] = None
     email_verified: bool = False
+    groups: tuple[str, ...] = ()
+    workspace_roles: tuple[tuple[str, str], ...] = ()
+    organization_roles: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -517,7 +524,197 @@ def normalize_external_claims(
         username=payload.get("preferred_username") or payload.get("username"),
         picture=payload.get("picture"),
         email_verified=bool(payload.get("email_verified", False)),
+        groups=_normalize_string_claims(payload.get("groups") or payload.get("roles")),
+        workspace_roles=_normalize_role_claims(
+            payload.get("dmarq_workspace_roles") or payload.get("workspace_roles"),
+            allowed_roles=set(ROLE_PERMISSIONS),
+        ),
+        organization_roles=_normalize_role_claims(
+            payload.get("dmarq_organization_roles") or payload.get("organization_roles"),
+            allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
+        ),
     )
+
+
+def _normalize_string_claims(value: Any) -> tuple[str, ...]:
+    """Return a stable tuple from common IdP string/list claim shapes."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        values = value.split(",")
+    elif isinstance(value, (list, tuple, set)):
+        values = value
+    else:
+        return ()
+    normalized = []
+    seen = set()
+    for item in values:
+        text = str(item).strip()
+        key = text.lower()
+        if text and key not in seen:
+            normalized.append(text)
+            seen.add(key)
+    return tuple(normalized)
+
+
+def _normalize_role_value(role: Any, *, allowed_roles: set[str]) -> str:
+    normalized = str(role or "").strip().lower()
+    return normalized if normalized in allowed_roles else ""
+
+
+def _normalize_role_claims(
+    value: Any,
+    *,
+    allowed_roles: set[str],
+) -> tuple[tuple[str, str], ...]:
+    """Normalize provider role claims into ``(slug, role)`` pairs.
+
+    Accepted shapes:
+    - {"workspace-slug": "workspace_owner"}
+    - ["workspace-slug:workspace_owner"]
+    - [{"workspace": "workspace-slug", "role": "workspace_owner"}]
+    - [{"slug": "workspace-slug", "role": "workspace_owner"}]
+    """
+    if value is None:
+        return ()
+
+    raw_pairs: list[tuple[Any, Any]] = []
+    if isinstance(value, dict):
+        raw_pairs.extend(value.items())
+    elif isinstance(value, str):
+        raw_pairs.extend(_split_role_string(value))
+    elif isinstance(value, (list, tuple, set)):
+        for item in value:
+            if isinstance(item, dict):
+                slug = item.get("workspace") or item.get("organization") or item.get("slug")
+                raw_pairs.append((slug, item.get("role")))
+            elif isinstance(item, str):
+                raw_pairs.extend(_split_role_string(item))
+
+    normalized: list[tuple[str, str]] = []
+    seen = set()
+    for raw_slug, raw_role in raw_pairs:
+        slug = str(raw_slug or "").strip().lower()
+        role = _normalize_role_value(raw_role, allowed_roles=allowed_roles)
+        if not slug or not role:
+            continue
+        key = (slug, role)
+        if key in seen:
+            continue
+        normalized.append(key)
+        seen.add(key)
+    return tuple(normalized)
+
+
+def _split_role_string(value: str) -> list[tuple[str, str]]:
+    pairs = []
+    for item in value.split(","):
+        if ":" in item:
+            slug, role = item.split(":", 1)
+        elif "=" in item:
+            slug, role = item.split("=", 1)
+        else:
+            continue
+        pairs.append((slug, role))
+    return pairs
+
+
+def _upsert_workspace_membership(
+    db: Session,
+    *,
+    user: User,
+    workspace_slug: str,
+    role: str,
+) -> Optional[WorkspaceMembership]:
+    workspace = (
+        db.query(Workspace)
+        .filter(
+            Workspace.slug == workspace_slug,
+            Workspace.active.is_(True),
+        )
+        .first()
+    )
+    if workspace is None:
+        logger.info(
+            "Ignoring external workspace role for unknown workspace slug=%s user_id=%s",
+            workspace_slug,
+            user.id,
+        )
+        return None
+    membership = (
+        db.query(WorkspaceMembership)
+        .filter(
+            WorkspaceMembership.workspace_id == workspace.id,
+            WorkspaceMembership.user_id == user.id,
+        )
+        .first()
+    )
+    if membership is None:
+        membership = WorkspaceMembership(workspace_id=workspace.id, user_id=user.id, role=role)
+        db.add(membership)
+    else:
+        membership.role = role
+        membership.active = True
+        membership.updated_at = datetime.utcnow()
+    if user.workspace_id is None:
+        user.workspace_id = workspace.id
+    return membership
+
+
+def _upsert_organization_membership(
+    db: Session,
+    *,
+    user: User,
+    organization_slug: str,
+    role: str,
+) -> Optional[OrganizationMembership]:
+    organization = (
+        db.query(Organization)
+        .filter(
+            Organization.slug == organization_slug,
+            Organization.active.is_(True),
+        )
+        .first()
+    )
+    if organization is None:
+        logger.info(
+            "Ignoring external organization role for unknown organization slug=%s user_id=%s",
+            organization_slug,
+            user.id,
+        )
+        return None
+    membership = (
+        db.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.organization_id == organization.id,
+            OrganizationMembership.user_id == user.id,
+        )
+        .first()
+    )
+    if membership is None:
+        membership = OrganizationMembership(
+            organization_id=organization.id,
+            user_id=user.id,
+            role=role,
+        )
+        db.add(membership)
+    else:
+        membership.role = role
+        membership.active = True
+        membership.updated_at = datetime.utcnow()
+    return membership
+
+
+def _sync_external_memberships(claims: ExternalIdentityClaims, user: User, db: Session) -> None:
+    for workspace_slug, role in claims.workspace_roles:
+        _upsert_workspace_membership(db, user=user, workspace_slug=workspace_slug, role=role)
+    for organization_slug, role in claims.organization_roles:
+        _upsert_organization_membership(
+            db,
+            user=user,
+            organization_slug=organization_slug,
+            role=role,
+        )
 
 
 def sync_external_user(claims: ExternalIdentityClaims, db: Session) -> User:
@@ -534,7 +731,7 @@ def sync_external_user(claims: ExternalIdentityClaims, db: Session) -> User:
             logto_id=identity_id,
             email=claims.email,
             is_active=True,
-            is_superuser=True,
+            is_superuser=not bool(claims.workspace_roles or claims.organization_roles),
             is_verified=claims.email_verified,
         )
         db.add(user)
@@ -545,6 +742,7 @@ def sync_external_user(claims: ExternalIdentityClaims, db: Session) -> User:
     user.username = claims.username or user.username
     user.picture = claims.picture or user.picture
     user.updated_at = datetime.utcnow()
+    _sync_external_memberships(claims, user, db)
     db.commit()
     db.refresh(user)
     return user
@@ -576,6 +774,7 @@ def trusted_proxy_claims_from_request(
         name=request.headers.get(cfg.AUTH_TRUSTED_PROXY_NAME_HEADER),
         username=request.headers.get(cfg.AUTH_TRUSTED_PROXY_USERNAME_HEADER),
         email_verified=True,
+        groups=_normalize_string_claims(request.headers.get(cfg.AUTH_TRUSTED_PROXY_GROUPS_HEADER)),
     )
 
 

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -562,6 +562,15 @@ def _normalize_role_value(role: Any, *, allowed_roles: set[str]) -> str:
     return normalized if normalized in allowed_roles else ""
 
 
+def _extend_role_pairs_from_sequence(raw_pairs: list[tuple[Any, Any]], values: Any) -> None:
+    for item in values:
+        if isinstance(item, dict):
+            slug = item.get("workspace") or item.get("organization") or item.get("slug")
+            raw_pairs.append((slug, item.get("role")))
+        elif isinstance(item, str):
+            raw_pairs.extend(_split_role_string(item))
+
+
 def _normalize_role_claims(
     value: Any,
     *,
@@ -584,12 +593,7 @@ def _normalize_role_claims(
     elif isinstance(value, str):
         raw_pairs.extend(_split_role_string(value))
     elif isinstance(value, (list, tuple, set)):
-        for item in value:
-            if isinstance(item, dict):
-                slug = item.get("workspace") or item.get("organization") or item.get("slug")
-                raw_pairs.append((slug, item.get("role")))
-            elif isinstance(item, str):
-                raw_pairs.extend(_split_role_string(item))
+        _extend_role_pairs_from_sequence(raw_pairs, value)
 
     normalized: list[tuple[str, str]] = []
     seen = set()
@@ -741,6 +745,8 @@ def sync_external_user(claims: ExternalIdentityClaims, db: Session) -> User:
     user.full_name = claims.name or user.full_name
     user.username = claims.username or user.username
     user.picture = claims.picture or user.picture
+    if claims.workspace_roles or claims.organization_roles:
+        user.is_superuser = False
     user.updated_at = datetime.utcnow()
     _sync_external_memberships(claims, user, db)
     db.commit()

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -26,6 +26,7 @@ from app.api.api_v1.endpoints.auth import _create_next_cookie
 from app.core.auth_providers import (
     ExternalIdentityClaims,
     OIDCProviderConfig,
+    _normalize_role_claims,
     auth_provider_registry,
     configured_oidc_provider,
     create_oidc_state,
@@ -317,6 +318,35 @@ class TestExternalAuthProviders:
         assert claims.organization_roles == (
             ("customer-one", "organization_owner"),
             ("customer-two", "auditor"),
+        )
+
+    def test_normalize_role_claims_accepts_strings_and_deduplicates_pairs(self):
+        roles = _normalize_role_claims(
+            [
+                "primary:workspace_owner",
+                "primary=workspace_owner",
+                {"slug": "secondary", "role": "analyst"},
+                "missing-separator",
+                {"slug": "", "role": "analyst"},
+                {"slug": "ignored", "role": "root"},
+            ],
+            allowed_roles={"workspace_owner", "analyst"},
+        )
+
+        assert roles == (
+            ("primary", "workspace_owner"),
+            ("secondary", "analyst"),
+        )
+
+    def test_normalize_role_claims_accepts_single_string_claims(self):
+        roles = _normalize_role_claims(
+            "primary:workspace_owner,secondary=analyst,ignored=root",
+            allowed_roles={"workspace_owner", "analyst"},
+        )
+
+        assert roles == (
+            ("primary", "workspace_owner"),
+            ("secondary", "analyst"),
         )
 
     def test_sync_external_user_uses_provider_scoped_subject(self, db_session):

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -43,7 +43,10 @@ from app.core.logto import (
     decode_session_token,
     sync_logto_user,
 )
+from app.models.organization import Organization, OrganizationMembership
 from app.models.user import User
+from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceMembership
 
 # ── Session token helpers ─────────────────────────────────────────────────────
 
@@ -285,6 +288,37 @@ class TestExternalAuthProviders:
 
         assert exc.value.status_code == 403
 
+    def test_normalize_external_claims_extracts_idp_role_claims(self):
+        claims = normalize_external_claims(
+            "authentik",
+            {
+                "sub": "authentik-user-1",
+                "email": "owner@example.com",
+                "groups": ["dmarq-admins", "billing"],
+                "dmarq_workspace_roles": {
+                    "primary": "workspace_owner",
+                    "secondary": "analyst",
+                    "ignored": "root",
+                },
+                "dmarq_organization_roles": [
+                    {"organization": "customer-one", "role": "organization_owner"},
+                    "customer-two:auditor",
+                    "ignored:root",
+                ],
+            },
+            allowed_domains="example.com",
+        )
+
+        assert claims.groups == ("dmarq-admins", "billing")
+        assert claims.workspace_roles == (
+            ("primary", "workspace_owner"),
+            ("secondary", "analyst"),
+        )
+        assert claims.organization_roles == (
+            ("customer-one", "organization_owner"),
+            ("customer-two", "auditor"),
+        )
+
     def test_sync_external_user_uses_provider_scoped_subject(self, db_session):
         user = sync_external_user(
             ExternalIdentityClaims(
@@ -302,6 +336,58 @@ class TestExternalAuthProviders:
         assert user.logto_id == "authentik:authentik-user-1"
         assert user.email == "owner@example.com"
         assert user.full_name == "Owner"
+
+    def test_sync_external_user_applies_workspace_and_org_roles(self, db_session):
+        organization = Organization(slug="customer-one", name="Customer One")
+        workspace = Workspace(slug="primary", name="Primary", organization=organization)
+        db_session.add_all([organization, workspace])
+        db_session.commit()
+
+        user = sync_external_user(
+            ExternalIdentityClaims(
+                provider="authentik",
+                subject="authentik-user-1",
+                email="owner@example.com",
+                name="Owner",
+                workspace_roles=(("primary", "workspace_owner"),),
+                organization_roles=(("customer-one", "organization_owner"),),
+            ),
+            db_session,
+        )
+
+        workspace_membership = (
+            db_session.query(WorkspaceMembership)
+            .filter_by(workspace_id=workspace.id, user_id=user.id)
+            .one()
+        )
+        organization_membership = (
+            db_session.query(OrganizationMembership)
+            .filter_by(organization_id=organization.id, user_id=user.id)
+            .one()
+        )
+
+        assert user.is_superuser is False
+        assert user.workspace_id == workspace.id
+        assert workspace_membership.role == "workspace_owner"
+        assert workspace_membership.active is True
+        assert organization_membership.role == "organization_owner"
+        assert organization_membership.active is True
+
+    def test_sync_external_user_ignores_unknown_claim_targets(self, db_session):
+        user = sync_external_user(
+            ExternalIdentityClaims(
+                provider="authentik",
+                subject="authentik-user-1",
+                email="owner@example.com",
+                workspace_roles=(("missing", "workspace_owner"),),
+                organization_roles=(("missing-org", "organization_owner"),),
+            ),
+            db_session,
+        )
+
+        assert user.is_superuser is False
+        assert db_session.query(WorkspaceMembership).count() == 0
+        assert db_session.query(OrganizationMembership).count() == 0
 
     def test_trusted_proxy_auth_context_uses_authentik_headers(self):
         settings = Settings(

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -435,6 +435,62 @@ class TestExternalAuthProviders:
             == "workspace_owner"
         )
 
+    def test_sync_external_user_links_existing_email_and_updates_memberships(self, db_session):
+        organization = Organization(slug="customer-one", name="Customer One")
+        workspace = Workspace(slug="primary", name="Primary", organization=organization)
+        user = User(
+            email="owner@example.com",
+            is_active=True,
+            is_superuser=True,
+        )
+        db_session.add_all([organization, workspace, user])
+        db_session.flush()
+        db_session.add_all(
+            [
+                WorkspaceMembership(
+                    workspace_id=workspace.id,
+                    user_id=user.id,
+                    role="analyst",
+                    active=False,
+                ),
+                OrganizationMembership(
+                    organization_id=organization.id,
+                    user_id=user.id,
+                    role="auditor",
+                    active=False,
+                ),
+            ]
+        )
+        db_session.commit()
+
+        synced = sync_external_user(
+            ExternalIdentityClaims(
+                provider="authentik",
+                subject="authentik-user-1",
+                email="owner@example.com",
+                workspace_roles=(("primary", "workspace_owner"),),
+                organization_roles=(("customer-one", "organization_owner"),),
+            ),
+            db_session,
+        )
+
+        workspace_membership = (
+            db_session.query(WorkspaceMembership)
+            .filter_by(workspace_id=workspace.id, user_id=user.id)
+            .one()
+        )
+        organization_membership = (
+            db_session.query(OrganizationMembership)
+            .filter_by(organization_id=organization.id, user_id=user.id)
+            .one()
+        )
+        assert synced.id == user.id
+        assert synced.logto_id == "authentik:authentik-user-1"
+        assert workspace_membership.role == "workspace_owner"
+        assert workspace_membership.active is True
+        assert organization_membership.role == "organization_owner"
+        assert organization_membership.active is True
+
     def test_sync_external_user_ignores_unknown_claim_targets(self, db_session):
         user = sync_external_user(
             ExternalIdentityClaims(

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -373,6 +373,38 @@ class TestExternalAuthProviders:
         assert organization_membership.role == "organization_owner"
         assert organization_membership.active is True
 
+    def test_sync_external_user_demotes_fallback_superuser_with_role_claims(self, db_session):
+        organization = Organization(slug="customer-one", name="Customer One")
+        workspace = Workspace(slug="primary", name="Primary", organization=organization)
+        user = User(
+            logto_id="authentik:authentik-user-1",
+            email="owner@example.com",
+            is_active=True,
+            is_superuser=True,
+        )
+        db_session.add_all([organization, workspace, user])
+        db_session.commit()
+
+        synced = sync_external_user(
+            ExternalIdentityClaims(
+                provider="authentik",
+                subject="authentik-user-1",
+                email="owner@example.com",
+                workspace_roles=(("primary", "workspace_owner"),),
+            ),
+            db_session,
+        )
+
+        assert synced.id == user.id
+        assert synced.is_superuser is False
+        assert (
+            db_session.query(WorkspaceMembership)
+            .filter_by(workspace_id=workspace.id, user_id=user.id)
+            .one()
+            .role
+            == "workspace_owner"
+        )
+
     def test_sync_external_user_ignores_unknown_claim_targets(self, db_session):
         user = sync_external_user(
             ExternalIdentityClaims(


### PR DESCRIPTION
## Summary\n- normalize external IdP group, workspace role, and organization role claims\n- sync workspace and organization memberships on external login\n- keep single-user fallback behavior only when no explicit membership claims are present\n\n## Scope\nPart of #422. This does not close the full modular IdP roadmap; it adds the missing claim-to-membership bridge needed for Authentik/Keycloak/Entra-style deployments.\n\n## Validation\n- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_auth.py\n- /tmp/dmarq-provider-connectors-423/.venv/bin/black --check backend/app/core/auth_providers.py backend/app/tests/test_auth.py\n- /tmp/dmarq-provider-connectors-423/.venv/bin/isort --check-only backend/app/core/auth_providers.py backend/app/tests/test_auth.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External sign-in now recognizes additional identity details, including group memberships and workspace/organization roles.
  * Role information from supported identity providers is now normalized across several input formats for more reliable access handling.

* **Bug Fixes**
  * Improved syncing so existing workspace and organization memberships are created, reactivated, and updated correctly.
  * Unknown workspace or organization targets are now ignored safely.
  * User privilege levels now reflect incoming role assignments more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->