### PR TITLE
Fix sender provider recognition false positives

### DIFF
--- a/backend/app/services/sender_intelligence.py
+++ b/backend/app/services/sender_intelligence.py
@@ -722,7 +722,9 @@ def _owned_infrastructure(
         return None
     normalized_domain = domain.lower().strip(".")
     normalized_hostname = hostname.lower().strip(".")
-    if not normalized_hostname.endswith(normalized_domain):
+    if normalized_hostname != normalized_domain and not normalized_hostname.endswith(
+        f".{normalized_domain}"
+    ):
         return None
     return {
         "id": "owned-infrastructure",

--- a/backend/app/services/sender_intelligence.py
+++ b/backend/app/services/sender_intelligence.py
@@ -694,12 +694,12 @@ def _profile_score(
 
     host_matches = _contains_any(host_values, profile.hostname_tokens)
     if host_matches:
-        score += 45
+        score += 60
         evidence.append(f"PTR hostname matched {host_matches[0]}")
 
     domain_matches = _contains_any(domain_values, profile.domain_tokens)
     if domain_matches:
-        score += 30
+        score += 15
         evidence.append(f"Authentication domain matched {domain_matches[0]}")
 
     selector_matches = _contains_any(selector_values, profile.selector_tokens)
@@ -754,6 +754,13 @@ def identify_sender(
     senders are named, ambiguous matches are flagged, and unknown failing
     sources stay visibly distinct from legitimate but misconfigured services.
     """
+    suspicious_hostname = bool(
+        hostname and any(token in hostname.lower() for token in ("unknown", "forwarder"))
+    )
+    owned = None if suspicious_hostname else _owned_infrastructure(domain, hostname)
+    if owned:
+        return owned
+
     profile_matches = []
     for profile in SENDER_PROFILES:
         score, evidence = _profile_score(profile, hostname, source)
@@ -792,13 +799,6 @@ def identify_sender(
             "remediation_hint": best_profile.remediation_hint,
             "docs_url": best_profile.docs_url,
         }
-
-    suspicious_hostname = bool(
-        hostname and any(token in hostname.lower() for token in ("unknown", "forwarder"))
-    )
-    owned = None if suspicious_hostname else _owned_infrastructure(domain, hostname)
-    if owned:
-        return owned
 
     dmarc_failed = (
         int(source.get("dmarc_fail_count", 0) or 0) > 0 or source.get("dmarc_result") == "fail"

--- a/backend/app/tests/test_sender_intelligence.py
+++ b/backend/app/tests/test_sender_intelligence.py
@@ -84,6 +84,22 @@ def test_identify_sender_keeps_owned_infrastructure_ahead_of_auth_domain_hint():
     assert sender["provider"] == "cklnet.com"
 
 
+def test_identify_sender_requires_owned_infrastructure_label_boundary():
+    sender = identify_sender(
+        "203.0.113.21",
+        {
+            "dmarc_result": "fail",
+            "dmarc_fail_count": 4,
+        },
+        hostname="mx1.evilcklnet.com",
+        domain="cklnet.com",
+    )
+
+    assert sender["id"] == "unknown-sender"
+    assert sender["name"] == "Unknown sender"
+    assert sender["status"] == "unknown"
+
+
 def test_identify_sender_matches_major_email_service_domains():
     cases = [
         ("mailgun", "mailgun.org", "mxa.mailgun.org"),

--- a/backend/app/tests/test_sender_intelligence.py
+++ b/backend/app/tests/test_sender_intelligence.py
@@ -50,6 +50,40 @@ def test_identify_sender_matches_postmark_mtasv_domains():
     )
 
 
+def test_identify_sender_does_not_treat_auth_domain_only_as_postmark():
+    sender = identify_sender(
+        "74.6.131.41",
+        {
+            "spf_domains": ["pm.mtasv.net"],
+            "dmarc_result": "pass",
+            "dmarc_fail_count": 0,
+        },
+        hostname="sonic303-2.consmr.mail.bf2.yahoo.com",
+        domain="cklnet.com",
+    )
+
+    assert sender["id"] == "unknown-sender"
+    assert sender["name"] == "Unknown sender"
+    assert sender["status"] == "unknown"
+
+
+def test_identify_sender_keeps_owned_infrastructure_ahead_of_auth_domain_hint():
+    sender = identify_sender(
+        "2a01:4f8:c17:311b::1",
+        {
+            "dkim_domains": ["ab.mtasv.net"],
+            "dmarc_result": "mixed",
+            "dmarc_fail_count": 20,
+        },
+        hostname="mx1.cklnet.com",
+        domain="cklnet.com",
+    )
+
+    assert sender["id"] == "owned-infrastructure"
+    assert sender["name"] == "Owned infrastructure"
+    assert sender["provider"] == "cklnet.com"
+
+
 def test_identify_sender_matches_major_email_service_domains():
     cases = [
         ("mailgun", "mailgun.org", "mxa.mailgun.org"),
@@ -82,6 +116,7 @@ def test_identify_sender_matches_major_email_service_domains():
 def test_identify_sender_flags_ambiguous_provider_evidence():
     source = {
         "spf_domains": ["google.com", "stripe.com"],
+        "dkim_selectors": ["google", "stripe"],
         "dmarc_result": "pass",
     }
 


### PR DESCRIPTION
## Summary\n- require stronger hostname or network evidence before classifying a sender as a known provider\n- treat auth-domain-only matches as weak context instead of provider identity\n- prefer owned-infrastructure detection when PTR/header context belongs to the monitored domain\n\n## Fixes\nCloses #519. This addresses the production case where Yahoo and owned Hetzner sources were incorrectly labeled as Postmark because reports contained mtasv.net authentication domains.\n\n## Validation\n- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_sender_intelligence.py backend/app/tests/test_domain_detail_endpoints.py -k 'sender or source_intelligence or sources_includes_ip_intelligence'\n- /tmp/dmarq-provider-connectors-423/.venv/bin/black --check backend/app/services/sender_intelligence.py backend/app/tests/test_sender_intelligence.py\n- /tmp/dmarq-provider-connectors-423/.venv/bin/isort --check-only backend/app/services/sender_intelligence.py backend/app/tests/test_sender_intelligence.py