### PR TITLE
Record passive ARC metadata in forensic reports

### DIFF
--- a/backend/app/services/forensic_parser.py
+++ b/backend/app/services/forensic_parser.py
@@ -160,10 +160,22 @@ def _arc_detail_headers(
     if auth_headers:
         details["arc_authentication_results_present"] = True
         details["arc_authentication_results"] = _clean(
-            auth_headers[-1],
+            max(auth_headers, key=_arc_instance),
             redaction_policy=redaction_policy,
         )
     return details
+
+
+def _arc_instance(header_value: str) -> int:
+    for item in header_value.split(";"):
+        key, _, value = item.strip().partition("=")
+        if key.lower() != "i":
+            continue
+        try:
+            return int(value.strip())
+        except ValueError:
+            return -1
+    return -1
 
 
 class ForensicParser:

--- a/backend/app/services/forensic_parser.py
+++ b/backend/app/services/forensic_parser.py
@@ -13,7 +13,6 @@ from app.services.forensic_redaction import (
     redact_forensic_text,
 )
 
-
 MAX_FORENSIC_REPORT_SIZE = 10 * 1024 * 1024
 
 
@@ -140,6 +139,33 @@ def _feedback_detail_headers(
     return {key: value for key, value in details.items() if value}
 
 
+def _arc_detail_headers(
+    original_headers: Optional[Message],
+    *,
+    redaction_policy: Optional[ForensicRedactionPolicy] = None,
+) -> Dict[str, Any]:
+    """Return passive ARC metadata without treating ARC as DMARC evidence."""
+    if original_headers is None:
+        return {}
+
+    seal_headers = original_headers.get_all("ARC-Seal", [])
+    signature_headers = original_headers.get_all("ARC-Message-Signature", [])
+    auth_headers = original_headers.get_all("ARC-Authentication-Results", [])
+    details: Dict[str, Any] = {}
+    if seal_headers:
+        details["arc_seal_present"] = True
+        details["arc_set_count"] = len(seal_headers)
+    if signature_headers:
+        details["arc_message_signature_present"] = True
+    if auth_headers:
+        details["arc_authentication_results_present"] = True
+        details["arc_authentication_results"] = _clean(
+            auth_headers[-1],
+            redaction_policy=redaction_policy,
+        )
+    return details
+
+
 class ForensicParser:
     """Parse DMARC forensic/failure report emails without retaining message bodies."""
 
@@ -219,6 +245,7 @@ class ForensicParser:
         arrival_date = _parse_datetime(_header(feedback, "Arrival-Date", redact=False))
 
         details = _feedback_detail_headers(feedback, redaction_policy=redaction_policy)
+        details.update(_arc_detail_headers(original_headers, redaction_policy=redaction_policy))
 
         return {
             "report_id": report_id,

--- a/backend/app/tests/test_forensic_parser.py
+++ b/backend/app/tests/test_forensic_parser.py
@@ -8,6 +8,7 @@ from app.services import forensic_parser as forensic_parser_module
 from app.services.forensic_parser import (
     MAX_FORENSIC_REPORT_SIZE,
     ForensicParser,
+    _arc_detail_headers,
     _arc_instance,
     _coerce_text,
     _domain_from_address,
@@ -293,6 +294,14 @@ ARC-Authentication-Results: i=1; mx.forwarder.test; dmarc=fail header.from=forwa
 
 def test_arc_instance_ignores_malformed_instance_values():
     assert _arc_instance("i=not-a-number; mx.example.test; dmarc=pass") == -1
+
+
+def test_arc_instance_ignores_non_instance_segments_and_missing_instance():
+    assert _arc_instance("mx.example.test; dmarc=pass") == -1
+
+
+def test_arc_detail_headers_handles_missing_original_headers():
+    assert _arc_detail_headers(None) == {}
 
 
 def test_is_forensic_report_detects_headers_and_subject_fallbacks():

--- a/backend/app/tests/test_forensic_parser.py
+++ b/backend/app/tests/test_forensic_parser.py
@@ -270,8 +270,11 @@ From: Forwarded Sender <sender@forwarder.test>
 To: Receiver <receiver@example.net>
 Subject: Forwarded mail
 ARC-Seal: i=1; a=rsa-sha256; d=forwarder.test; cv=none
+ARC-Seal: i=2; a=rsa-sha256; d=forwarder.test; cv=pass
 ARC-Message-Signature: i=1; a=rsa-sha256; d=forwarder.test
-ARC-Authentication-Results: i=1; mx.forwarder.test; dmarc=fail header.from=forwarder.test smtp.mailfrom=sender@forwarder.test
+ARC-Message-Signature: i=2; a=rsa-sha256; d=forwarder.test
+ARC-Authentication-Results: i=2; mx.forwarder.test; dmarc=fail header.from=forwarder.test smtp.mailfrom=newest@forwarder.test
+ARC-Authentication-Results: i=1; mx.forwarder.test; dmarc=fail header.from=forwarder.test smtp.mailfrom=oldest@forwarder.test
 
 --ruf-boundary--
 """
@@ -282,8 +285,9 @@ ARC-Authentication-Results: i=1; mx.forwarder.test; dmarc=fail header.from=forwa
     assert details["arc_seal_present"] is True
     assert details["arc_message_signature_present"] is True
     assert details["arc_authentication_results_present"] is True
-    assert details["arc_set_count"] == 1
-    assert "se***@forwarder.test" in details["arc_authentication_results"]
+    assert details["arc_set_count"] == 2
+    assert "i=2" in details["arc_authentication_results"]
+    assert "ne***@forwarder.test" in details["arc_authentication_results"]
 
 
 def test_is_forensic_report_detects_headers_and_subject_fallbacks():

--- a/backend/app/tests/test_forensic_parser.py
+++ b/backend/app/tests/test_forensic_parser.py
@@ -8,6 +8,7 @@ from app.services import forensic_parser as forensic_parser_module
 from app.services.forensic_parser import (
     MAX_FORENSIC_REPORT_SIZE,
     ForensicParser,
+    _arc_instance,
     _coerce_text,
     _domain_from_address,
     _message_part_payload,
@@ -288,6 +289,10 @@ ARC-Authentication-Results: i=1; mx.forwarder.test; dmarc=fail header.from=forwa
     assert details["arc_set_count"] == 2
     assert "i=2" in details["arc_authentication_results"]
     assert "ne***@forwarder.test" in details["arc_authentication_results"]
+
+
+def test_arc_instance_ignores_malformed_instance_values():
+    assert _arc_instance("i=not-a-number; mx.example.test; dmarc=pass") == -1
 
 
 def test_is_forensic_report_detects_headers_and_subject_fallbacks():

--- a/backend/app/tests/test_forensic_parser.py
+++ b/backend/app/tests/test_forensic_parser.py
@@ -6,15 +6,14 @@ import pytest
 
 from app.services import forensic_parser as forensic_parser_module
 from app.services.forensic_parser import (
-    ForensicParser,
     MAX_FORENSIC_REPORT_SIZE,
+    ForensicParser,
     _coerce_text,
     _domain_from_address,
     _message_part_payload,
     _payload_text,
 )
 from app.services.forensic_redaction import ForensicRedactionPolicy
-
 
 SAMPLE_FORENSIC_EMAIL = b"""\
 From: DMARC Reporter <dmarc-reports@example.net>
@@ -248,9 +247,47 @@ body is ignored
     assert parsed["original_subject"] == "Forwarded failure sample"
 
 
+def test_parse_forensic_email_records_passive_arc_metadata():
+    content = b"""\
+From: DMARC Reporter <dmarc-reports@example.net>
+Subject: DMARC forensic report
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=feedback-report; boundary="ruf-boundary"
+
+--ruf-boundary
+Content-Type: message/feedback-report
+
+Feedback-Type: auth-failure
+Original-Mail-From: sender@forwarder.test
+Reported-Domain: forwarder.test
+Source-IP: 203.0.113.9
+Auth-Failure: dmarc
+
+--ruf-boundary
+Content-Type: text/rfc822-headers
+
+From: Forwarded Sender <sender@forwarder.test>
+To: Receiver <receiver@example.net>
+Subject: Forwarded mail
+ARC-Seal: i=1; a=rsa-sha256; d=forwarder.test; cv=none
+ARC-Message-Signature: i=1; a=rsa-sha256; d=forwarder.test
+ARC-Authentication-Results: i=1; mx.forwarder.test; dmarc=fail header.from=forwarder.test smtp.mailfrom=sender@forwarder.test
+
+--ruf-boundary--
+"""
+
+    parsed = ForensicParser.parse_bytes(content)
+    details = json.loads(parsed["feedback_headers"])
+
+    assert details["arc_seal_present"] is True
+    assert details["arc_message_signature_present"] is True
+    assert details["arc_authentication_results_present"] is True
+    assert details["arc_set_count"] == 1
+    assert "se***@forwarder.test" in details["arc_authentication_results"]
+
+
 def test_is_forensic_report_detects_headers_and_subject_fallbacks():
-    header_only = email.message_from_bytes(
-        b"""\
+    header_only = email.message_from_bytes(b"""\
 Subject: Delivery report
 MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="b"
@@ -261,8 +298,7 @@ Content-Type: text/rfc822-headers
 Authentication-Results: mx; dmarc=fail
 
 --b--
-"""
-    )
+""")
     subject_only = email.message_from_bytes(b"Subject: DMARC RUF failure\r\n\r\nbody")
 
     assert ForensicParser.is_forensic_report(header_only) is True
@@ -301,8 +337,7 @@ def test_forensic_parser_helper_fallbacks(monkeypatch):
 
 
 def test_is_forensic_report_detects_feedback_part_without_report_container():
-    msg = email.message_from_bytes(
-        b"""\
+    msg = email.message_from_bytes(b"""\
 Subject: Delivery notice
 MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="b"
@@ -313,15 +348,13 @@ Content-Type: message/feedback-report
 Feedback-Type: auth-failure
 
 --b--
-"""
-    )
+""")
 
     assert ForensicParser.is_forensic_report(msg) is True
 
 
 def test_is_forensic_report_ignores_non_dmarc_header_parts():
-    msg = email.message_from_bytes(
-        b"""\
+    msg = email.message_from_bytes(b"""\
 Subject: DMARC forensic notice
 MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="b"
@@ -332,7 +365,6 @@ Content-Type: text/rfc822-headers
 Authentication-Results: mx; spf=pass
 
 --b--
-"""
-    )
+""")
 
     assert ForensicParser.is_forensic_report(msg) is True

--- a/docs/development/dmarc-scope-open-items.md
+++ b/docs/development/dmarc-scope-open-items.md
@@ -9,9 +9,13 @@ DMARC message enforcement or outbound aggregate/failure report generation.
 - [x] Parse RFC 9989 policy records and discover effective DMARC policy with DNS Tree Walk.
 - [x] Parse RFC 9990 aggregate reports while preserving useful optional metadata.
 - [x] Parse inbound RFC 9991 failure reports without retaining message bodies.
+- [x] Preserve passive ARC metadata from inbound failure-report header samples
+      without using ARC as DMARC scoring evidence.
 - [x] Lint external `rua` / `ruf` destinations for required DNS authorization records.
 - [x] Add a first-class DNS lint endpoint with typed findings and stable machine-readable codes.
 - [x] Add DNS-setting generation helpers for DMARC, SPF include/all choices, DKIM selector checks, MTA-STS, TLS-RPT, and BIMI readiness.
+- [x] Add passive DANE/TLSA MX coverage checks and TLSA `3 1 1` suggestions
+      from reachable STARTTLS certificates.
 - [x] Add UI sections that show lint findings next to the current DNS records and suggested target records.
 - [x] Add bulk domain linting and export for managed-domain reviews.
 - [x] Expand aggregate fixture coverage for representative RFC 9990/DMARCbis variants and unknown-but-safe fields.
@@ -29,3 +33,4 @@ DMARC message enforcement or outbound aggregate/failure report generation.
 - Outbound DMARC aggregate report generation.
 - Outbound DMARC failure report generation.
 - Receiver-side failure-report rate limiting.
+- ARC chain validation as a source of DMARC policy override decisions.

--- a/docs/development/protocol-coverage.md
+++ b/docs/development/protocol-coverage.md
@@ -17,14 +17,16 @@ DMARQ supports passive DANE posture checks for SMTP delivery:
   hexadecimal association data.
 - show missing, partial, invalid, and syntactically valid coverage in DNS lint.
 - expose a read-only API endpoint at `GET /domains/{domain_id}/dns/dane`.
+- when MX STARTTLS is reachable, derive optional TLSA `3 1 1` SPKI SHA-256
+  suggestions from the presented certificate.
+- compare existing DANE-EE/SPKI/SHA-256 TLSA records with the live certificate
+  and flag stale data.
 - generate manual remediation steps and target-record shape without applying
   DNS writes.
 
 Boundaries:
 
 - DMARQ does not yet validate DNSSEC chains.
-- DMARQ does not yet connect to live SMTP hosts to compare TLSA hashes with the
-  presented certificate.
 - DMARQ does not automatically publish TLSA records.
 
 DANE is therefore a hygiene and readiness signal, not a delivery guarantee.
@@ -36,21 +38,27 @@ DMARQ already consumes DMARC forensic/RUF failure reports that arrive as
 redacted metadata needed for DMARC operations and avoids raw message-body
 storage.
 
+Supported metadata includes RFC 9991 failure fields, redacted original-message
+headers, canonicalized-DKIM presence flags, and passive ARC header presence from
+the redacted original header sample when receivers include it.
+
 Boundaries:
 
 - DMARQ consumes inbound reports; it does not generate outbound ARF reports for
   other receivers.
 - Generic abuse-desk ARF processing is out of scope unless the report contains
   DMARC/RUF-relevant evidence.
+- DMARQ records ARC metadata as diagnostic context only. ARC does not override
+  aggregate DMARC pass/fail evidence or change domain health scoring.
 
 ## Next Design Slices
 
 ### ARC
 
-ARC support should start as message/report metadata analysis, not DNS
-automation. Useful first slices:
+ARC support starts as message/report metadata analysis, not DNS automation.
+The shipped first slice records ARC header presence in RUF/forensic metadata.
+Useful follow-up slices:
 
-- detect ARC-related headers in forensic/RUF evidence when present.
 - explain when ARC may affect forwarded mail interpretation.
 - keep ARC separate from DMARC pass/fail scoring unless DMARQ has explicit
   receiver-side evidence.

--- a/docs/development/protocol-coverage.md
+++ b/docs/development/protocol-coverage.md
@@ -68,9 +68,8 @@ Useful follow-up slices:
 Future DANE work can add:
 
 - DNSSEC validation evidence.
-- live SMTP STARTTLS certificate retrieval.
-- TLSA hash comparison against the presented certificate or SPKI.
-- certificate rotation warnings.
+- certificate rotation warnings from repeated read-only checks.
+- richer explanation for stale or mismatched TLSA records.
 
 Those features require network-safety controls and should remain read-only until
 operators explicitly approve any DNS changes.

--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -20,6 +20,8 @@ DMARQ consumes inbound DMARC failure reports through its forensic/RUF pipeline. 
 - Original-message metadata supplied as `text/rfc822-headers` or `message/rfc822`; message bodies are not stored.
 - RFC 9991 DMARC failure metadata including `Auth-Failure: dmarc`, `Identity-Alignment`, `Delivery-Result`, `DKIM-Domain`, `DKIM-Identity`, `DKIM-Selector`, `SPF-DNS`, and `Reported-URI`.
 - Canonicalized DKIM header/body fields are treated as sensitive content. DMARQ records presence flags for diagnostics but does not persist their values.
+- ARC headers in the original-message header sample are recorded only as
+  redacted diagnostic metadata. They do not change DMARC pass/fail scoring.
 
 ## Forensic/RUF Privacy Model
 
@@ -38,6 +40,9 @@ DMARQ may persist:
 - RFC 9991 diagnostic metadata such as alignment, DKIM domain, DKIM selector,
   SPF DNS text, and `Reported-URI`.
 - boolean flags that canonicalized DKIM header/body fields were present.
+- passive ARC metadata such as whether ARC-Seal, ARC-Message-Signature, and
+  ARC-Authentication-Results were present, plus redacted ARC authentication
+  result text when available.
 
 DMARQ must not persist:
 
@@ -103,8 +108,10 @@ CSV exports include the most useful aggregate metadata for operators:
 - Unsupported attachments are skipped by IMAP and Gmail import paths and recorded in import details when stats are available.
 - For duplicate detection, DMARQ uses the domain and `report_id` pair. Fixture report IDs must remain unique within a single test import run.
 - RFC 9991 describes report generation duties such as outbound rate limiting and external `ruf` destination verification for Mail Receivers. DMARQ currently implements report-consumer parsing and analysis, not report generation.
-- ARC is tracked as a future message-analysis feature. DMARQ does not currently
-  score ARC chains or treat ARC as a replacement for DMARC alignment evidence.
+- ARC is tracked as message-analysis context. DMARQ records passive ARC
+  metadata from failure-report header samples when present, but does not
+  validate ARC chains or treat ARC as a replacement for DMARC alignment
+  evidence.
 - The product-scope backlog for parser, analyzer, DNS guidance, and DNS linting work is tracked in `docs/development/dmarc-scope-open-items.md`.
 
 ## Fixture Pack


### PR DESCRIPTION
## Summary\n- extract passive ARC metadata from RUF/forensic original-message samples\n- keep ARC as report context only, not as a DMARC scoring override\n- update protocol coverage docs for DANE/TLSA, ARC, and ARF boundaries\n\n## Scope\nPart of #310. This improves forensic protocol coverage without expanding DMARQ into outbound ARF generation or ARC trust-chain evaluation.\n\n## Validation\n- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_forensic_parser.py backend/app/tests/test_forensics_api.py\n- /tmp/dmarq-provider-connectors-423/.venv/bin/black --check backend/app/services/forensic_parser.py backend/app/tests/test_forensic_parser.py\n- /tmp/dmarq-provider-connectors-423/.venv/bin/isort --check-only backend/app/services/forensic_parser.py backend/app/tests/test_forensic_parser.py