### PR TITLE
Use database aggregates for domain summaries

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -100,6 +100,7 @@ from app.services.remediation_dispatch import attach_remediation_dispatch_previe
 from app.services.remediation_queue import build_remediation_queue
 from app.services.report_persistence import (
     domain_summaries_from_db,
+    hydrate_domain_report_store_from_db,
     hydrate_report_store_from_db,
 )
 from app.services.report_store import ReportStore
@@ -1910,6 +1911,41 @@ def _resolve_domain_name_for_read(
         status_code=status.HTTP_404_NOT_FOUND,
         detail="Domain not found",
     )
+
+
+def _single_domain_report_store_for_read(
+    db: Session,
+    domain_id: str,
+    workspace: Workspace,
+) -> tuple[str, ReportStore]:
+    """Return a ReportStore containing only the requested domain's persisted reports."""
+    store = ReportStore()
+    domain = workspace_domain_query(db, workspace).filter(Domain.name == domain_id).first()
+    if domain is None and domain_id.isdigit():
+        domain = workspace_domain_query(db, workspace).filter(Domain.id == int(domain_id)).first()
+    if domain is not None and not get_settings().DEMO_MODE:
+        domain_name = str(domain.name)
+        hydrate_domain_report_store_from_db(
+            db,
+            store,
+            domain_name,
+            workspace_id=workspace.id,
+        )
+        return domain_name, store
+
+    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    try:
+        domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
+    except HTTPException as exc:
+        if (
+            exc.status_code != status.HTTP_404_NOT_FOUND
+            or _stored_domain_exists(db, domain_id)
+            or not _allows_legacy_report_only_fallback(db)
+        ):
+            raise
+        hydrate_report_store_from_db(db, store)
+        domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
+    return domain_name, store
 
 
 def _record_evidence(
@@ -5936,19 +5972,12 @@ async def get_domain_sources(
     and SPF fix hints for sources that fail authentication.
     """
     workspace = _authorized_domain_read_workspace(_auth, db)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
+    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
-    if not _domain_exists(db, store, domain_id, workspace):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Domain not found",
-        )
-
-    sources = store.get_domain_sources(domain_id, days=days)
-    reports = store.get_domain_reports(domain_id)
+    sources = store.get_domain_sources(domain_name, days=days)
+    reports = store.get_domain_reports(domain_name)
     intelligence = build_source_intelligence(
-        domain_id,
+        domain_name,
         reports,
         sources,
         period_days=days,
@@ -5980,14 +6009,14 @@ async def get_domain_sources(
     source_context = []
     for source, hostname in zip(sources, hostnames):
         ip = source.get("source_ip", "unknown")
-        sender_by_ip[ip] = identify_sender(ip, source, hostname=hostname, domain=domain_id)
+        sender_by_ip[ip] = identify_sender(ip, source, hostname=hostname, domain=domain_name)
         source_context.append((source, hostname, sender_by_ip[ip]))
 
     reputations_by_ip = {}
     try:
         reputation_result, _, _ = await build_source_reputation_cached(
             db,
-            domain_id,
+            domain_name,
             reports,
             sources,
             senders_by_ip=sender_by_ip,
@@ -6060,19 +6089,12 @@ async def get_domain_source_reputation(
 ):
     """Return passive reputation evidence for observed sender IPs."""
     workspace = _authorized_domain_read_workspace(_auth, db)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
-    if not _domain_exists(db, store, domain_id, workspace):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Domain not found",
-        )
-
-    reports = store.get_domain_reports(domain_id)
-    sources = store.get_domain_sources(domain_id, days=days)
+    reports = store.get_domain_reports(domain_name)
+    sources = store.get_domain_sources(domain_name, days=days)
     intelligence = build_source_intelligence(
-        domain_id,
+        domain_name,
         reports,
         sources,
         period_days=days,
@@ -6088,7 +6110,7 @@ async def get_domain_source_reputation(
     }
     result, cached, _ = await build_source_reputation_cached(
         db,
-        domain_id,
+        domain_name,
         reports,
         sources,
         senders_by_ip=sender_by_ip,
@@ -6116,19 +6138,12 @@ async def get_domain_source_intelligence(
 ):
     """Return region summaries and source anomaly hints for a domain."""
     workspace = _authorized_domain_read_workspace(_auth, db)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
+    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
-    if not _domain_exists(db, store, domain_id, workspace):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Domain not found",
-        )
-
-    sources = store.get_domain_sources(domain_id, days=days)
+    sources = store.get_domain_sources(domain_name, days=days)
     intelligence = build_source_intelligence(
-        domain_id,
-        store.get_domain_reports(domain_id),
+        domain_name,
+        store.get_domain_reports(domain_name),
         sources,
         period_days=days,
     )

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1745,6 +1745,23 @@ def _get_domain_selectors_map_from_db(db: Session, domain_names: List[str]) -> D
     return selectors_by_domain
 
 
+def _selectors_from_dkim_auth_details(raw_details: str) -> List[str]:
+    try:
+        details = json.loads(raw_details or "[]")
+    except (TypeError, json.JSONDecodeError):
+        return []
+    if not isinstance(details, list):
+        return []
+    selectors: List[str] = []
+    for detail in details:
+        if not isinstance(detail, dict):
+            continue
+        selector = str(detail.get("selector") or "").strip()
+        if selector and selector not in selectors:
+            selectors.append(selector)
+    return selectors
+
+
 def _get_report_selectors_map_from_db(
     db: Session,
     domain_names: List[str],
@@ -1769,17 +1786,8 @@ def _get_report_selectors_map_from_db(
         if workspace_id is not None:
             query = query.filter(Domain.workspace_id == workspace_id)
         for domain_name, raw_details in query.all():
-            try:
-                details = json.loads(raw_details or "[]")
-            except (TypeError, json.JSONDecodeError):
-                continue
-            if not isinstance(details, list):
-                continue
             domain_selectors = selectors_by_domain.setdefault(domain_name, [])
-            for detail in details:
-                if not isinstance(detail, dict):
-                    continue
-                selector = str(detail.get("selector") or "").strip()
+            for selector in _selectors_from_dkim_auth_details(raw_details):
                 if selector and selector not in domain_selectors:
                     domain_selectors.append(selector)
     return selectors_by_domain
@@ -1943,6 +1951,10 @@ def _single_domain_report_store_for_read(
             or not _allows_legacy_report_only_fallback(db)
         ):
             raise
+        legacy_store = ReportStore.get_instance()
+        if _domain_exists(db, legacy_store, domain_id, workspace):
+            domain_name = _resolve_domain_name_for_read(db, legacy_store, domain_id, workspace)
+            return domain_name, legacy_store
         hydrate_report_store_from_db(db, store)
         domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
     return domain_name, store

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -20,7 +20,7 @@ from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
-from app.models.report import DMARCReport
+from app.models.report import DMARCReport, ReportRecord
 from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.services.akamai_edgedns import get_akamai_edgedns_credentials
@@ -99,6 +99,7 @@ from app.services.organizations import (
 from app.services.remediation_dispatch import attach_remediation_dispatch_previews
 from app.services.remediation_queue import build_remediation_queue
 from app.services.report_persistence import (
+    domain_summaries_from_db,
     hydrate_report_store_from_db,
 )
 from app.services.report_store import ReportStore
@@ -1743,6 +1744,46 @@ def _get_domain_selectors_map_from_db(db: Session, domain_names: List[str]) -> D
     return selectors_by_domain
 
 
+def _get_report_selectors_map_from_db(
+    db: Session,
+    domain_names: List[str],
+    *,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, List[str]]:
+    """Return DKIM selectors observed in persisted report records."""
+    if not domain_names:
+        return {}
+
+    unique_names = list(dict.fromkeys(domain_names))
+    selectors_by_domain: Dict[str, List[str]] = {}
+    for index in range(0, len(unique_names), DOMAIN_SELECTOR_LOOKUP_CHUNK_SIZE):
+        chunk = unique_names[index : index + DOMAIN_SELECTOR_LOOKUP_CHUNK_SIZE]
+        query = (
+            db.query(Domain.name, ReportRecord.dkim_auth_details)
+            .join(DMARCReport, DMARCReport.domain_id == Domain.id)
+            .join(ReportRecord, ReportRecord.report_id == DMARCReport.id)
+            .filter(Domain.name.in_(chunk))
+            .filter(ReportRecord.dkim_auth_details.isnot(None))
+        )
+        if workspace_id is not None:
+            query = query.filter(Domain.workspace_id == workspace_id)
+        for domain_name, raw_details in query.all():
+            try:
+                details = json.loads(raw_details or "[]")
+            except (TypeError, json.JSONDecodeError):
+                continue
+            if not isinstance(details, list):
+                continue
+            domain_selectors = selectors_by_domain.setdefault(domain_name, [])
+            for detail in details:
+                if not isinstance(detail, dict):
+                    continue
+                selector = str(detail.get("selector") or "").strip()
+                if selector and selector not in domain_selectors:
+                    domain_selectors.append(selector)
+    return selectors_by_domain
+
+
 def _policy_enforcement_suggestions(
     dmarc_policy: Optional[str],
     summary: Dict[str, Any],
@@ -2855,6 +2896,7 @@ def _record_health_snapshot_from_posture(
 
 @router.get("/summary", response_model=DomainSummaryResponse)
 async def get_domains_summary(
+    refresh: bool = Query(False, title="Refresh cached DNS results"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
@@ -2869,20 +2911,31 @@ async def get_domains_summary(
     """
     selected_workspace_id = parse_selected_workspace_id(selected_workspace)
     workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
-    store = ReportStore()
-    hydrate_report_store_from_db(
-        db,
-        store,
-        workspace_id=workspace.id,
-    )
     demo_mode = get_settings().DEMO_MODE
-    domains = _domain_names_for_summary(
-        db,
-        store,
-        workspace,
-        include_unscoped_report_domains=demo_mode,
-    )
-    summaries = store.get_all_domain_summaries()
+    store: Optional[ReportStore] = None
+    report_selectors_by_domain: Dict[str, List[str]] = {}
+    if demo_mode:
+        store = ReportStore()
+        hydrate_report_store_from_db(
+            db,
+            store,
+            workspace_id=workspace.id,
+        )
+        domains = _domain_names_for_summary(
+            db,
+            store,
+            workspace,
+            include_unscoped_report_domains=True,
+        )
+        summaries = store.get_all_domain_summaries()
+    else:
+        summaries = domain_summaries_from_db(db, workspace_id=workspace.id)
+        domains = list(summaries)
+        report_selectors_by_domain = _get_report_selectors_map_from_db(
+            db,
+            domains,
+            workspace_id=workspace.id,
+        )
 
     # Perform DNS checks for all domains, reusing fresh cached results.
     provider = get_default_provider(db)
@@ -2894,11 +2947,20 @@ async def get_domains_summary(
 
     async def _dns_for_domain(domain_name: str) -> DomainDNSResult:
         manual_selectors = manual_selectors_by_domain.get(domain_name, [])
-        report_selectors = _get_selectors_from_reports(store, domain_name)
+        if demo_mode and store is not None:
+            report_selectors = _get_selectors_from_reports(store, domain_name)
+        else:
+            report_selectors = report_selectors_by_domain.get(domain_name, [])
         combined = list(dict.fromkeys(manual_selectors + report_selectors))
         try:
             result, cached, checked_at = await asyncio.wait_for(
-                resolve_domain_dns_cached(db, provider, domain_name, selectors=combined),
+                resolve_domain_dns_cached(
+                    db,
+                    provider,
+                    domain_name,
+                    selectors=combined,
+                    refresh=refresh,
+                ),
                 timeout=10.0,
             )
             result.cached = cached  # type: ignore[attr-defined]
@@ -3092,15 +3154,19 @@ async def read_domains(
     """
     selected_workspace_id = parse_selected_workspace_id(selected_workspace)
     workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
-    store = ReportStore()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
-    domains = _domain_names_for_summary(
-        db,
-        store,
-        workspace,
-        include_unscoped_report_domains=False,
-    )
-    summaries = store.get_all_domain_summaries()
+    if get_settings().DEMO_MODE:
+        store = ReportStore()
+        hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+        domains = _domain_names_for_summary(
+            db,
+            store,
+            workspace,
+            include_unscoped_report_domains=False,
+        )
+        summaries = store.get_all_domain_summaries()
+    else:
+        summaries = domain_summaries_from_db(db, workspace_id=workspace.id)
+        domains = list(summaries)
     stored = {
         domain.name: domain
         for domain in workspace_domain_query(db, workspace).filter(Domain.name.in_(domains)).all()
@@ -5861,6 +5927,7 @@ async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Opti
 async def get_domain_sources(
     domain_id: str = Path(..., title="The domain ID or name"),
     days: int = Query(30, title="Number of days to look back"),
+    refresh: bool = Query(False, title="Refresh cached source reputation evidence"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -5926,6 +5993,7 @@ async def get_domain_sources(
             senders_by_ip=sender_by_ip,
             anomalies_by_ip=anomalies_by_ip,
             days=days,
+            refresh=refresh,
         )
         reputations_by_ip = source_reputation_by_ip(reputation_result)
     except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from sqlalchemy import case, distinct, func, or_
 from sqlalchemy.orm import Session, selectinload
 
 from app.core.config import get_settings
@@ -341,6 +342,58 @@ def hydrate_report_store_from_db(
     for report in reports:
         store.add_report(persisted_report_to_dict(report))
     return len(reports)
+
+
+def domain_summaries_from_db(
+    db: Session,
+    *,
+    workspace_id: Optional[int] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Return per-domain report aggregates without hydrating full report rows."""
+    passed_count = func.coalesce(
+        func.sum(
+            case(
+                (
+                    or_(ReportRecord.dkim == "pass", ReportRecord.spf == "pass"),
+                    ReportRecord.count,
+                ),
+                else_=0,
+            )
+        ),
+        0,
+    )
+    total_count = func.coalesce(func.sum(ReportRecord.count), 0)
+    query = (
+        db.query(
+            Domain.name.label("domain_name"),
+            Domain.dmarc_policy.label("policy"),
+            func.count(distinct(DMARCReport.id)).label("reports_processed"),
+            total_count.label("total_count"),
+            passed_count.label("passed_count"),
+        )
+        .outerjoin(DMARCReport, DMARCReport.domain_id == Domain.id)
+        .outerjoin(ReportRecord, ReportRecord.report_id == DMARCReport.id)
+        .filter(Domain.active == True)  # noqa: E712
+        .group_by(Domain.id, Domain.name, Domain.dmarc_policy)
+        .order_by(Domain.name)
+    )
+    if workspace_id is not None:
+        query = query.filter(Domain.workspace_id == workspace_id)
+
+    summaries: Dict[str, Dict[str, Any]] = {}
+    for row in query.all():
+        total = int(row.total_count or 0)
+        passed = int(row.passed_count or 0)
+        failed = max(0, total - passed)
+        summaries[row.domain_name] = {
+            "total_count": total,
+            "passed_count": passed,
+            "failed_count": failed,
+            "reports_processed": int(row.reports_processed or 0),
+            "compliance_rate": round((passed / total) * 100, 1) if total > 0 else 0.0,
+            "policy": row.policy,
+        }
+    return summaries
 
 
 def delete_persisted_report(

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -344,6 +344,33 @@ def hydrate_report_store_from_db(
     return len(reports)
 
 
+def hydrate_domain_report_store_from_db(
+    db: Session,
+    store: Optional[ReportStore],
+    domain_name: str,
+    *,
+    workspace_id: Optional[int] = None,
+) -> int:
+    """Load persisted reports for one domain into a fresh ReportStore."""
+    store = store or ReportStore()
+    store.clear()
+    query = (
+        db.query(DMARCReport)
+        .join(Domain, DMARCReport.domain_id == Domain.id)
+        .options(
+            selectinload(DMARCReport.domain),
+            selectinload(DMARCReport.records),
+        )
+        .filter(Domain.name == domain_name)
+    )
+    if workspace_id is not None:
+        query = query.filter(Domain.workspace_id == workspace_id)
+    reports = query.order_by(DMARCReport.end_date.desc()).all()
+    for report in reports:
+        store.add_report(persisted_report_to_dict(report))
+    return len(reports)
+
+
 def domain_summaries_from_db(
     db: Session,
     *,

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -188,6 +188,7 @@ function domainDetailsApp(domainId) {
         volumeScale: 'logarithmic',
         hasObservedVolume: false,
         lastComplianceTimeline: [],
+        refreshingPage: false,
 
         init() {
             const storedVolumeScale = this.loadStoredVolumeScale();
@@ -215,6 +216,29 @@ function domainDetailsApp(domainId) {
                 this.fetchSources();
                 this.fetchSourceIntelligence();
             });
+        },
+
+        async reloadPageData() {
+            this.refreshingPage = true;
+            try {
+                await Promise.all([
+                    this.fetchDomainStats(),
+                    this.fetchDNSRecords({ refresh: true }),
+                    this.fetchDNSHealth({ refresh: true }),
+                    this.fetchDNSGuidance({ refresh: true }),
+                    this.fetchPosture({ refresh: true }),
+                    this.fetchRemediationQueue(),
+                    this.fetchHealthHistory(),
+                    this.fetchMtaSts({ refresh: true }),
+                    this.fetchBimi({ refresh: true }),
+                    this.fetchSelectors(),
+                    this.fetchReports(),
+                    this.fetchSources({ refresh: true }),
+                    this.fetchSourceIntelligence()
+                ]);
+            } finally {
+                this.refreshingPage = false;
+            }
         },
 
         loadStoredVolumeScale() {
@@ -790,11 +814,13 @@ function domainDetailsApp(domainId) {
             }
         },
 
-        async fetchDNSRecords() {
+        async fetchDNSRecords(options = {}) {
             this.dnsRecordsLoading = true;
             this.dnsRecordsError = '';
             try {
-                const response = await fetch(`/api/v1/domains/${this.domainId}/dns`);
+                const response = await fetch(
+                    `/api/v1/domains/${this.domainId}/dns${options.refresh ? '?refresh=true' : ''}`
+                );
                 if (!response.ok) {
                     const data = await response.json().catch(() => ({}));
                     const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
@@ -811,9 +837,11 @@ function domainDetailsApp(domainId) {
             }
         },
 
-        async fetchDNSHealth() {
+        async fetchDNSHealth(options = {}) {
             try {
-                const response = await fetch(`/api/v1/domains/${this.domainId}/dns/health`);
+                const response = await fetch(
+                    `/api/v1/domains/${this.domainId}/dns/health${options.refresh ? '?refresh=true' : ''}`
+                );
                 if (response.ok) {
                     this.dnsHealth = await response.json();
                 }
@@ -822,9 +850,11 @@ function domainDetailsApp(domainId) {
             }
         },
 
-        async fetchDNSGuidance() {
+        async fetchDNSGuidance(options = {}) {
             try {
-                const response = await fetch(`/api/v1/domains/${this.domainId}/dns/lint`);
+                const response = await fetch(
+                    `/api/v1/domains/${this.domainId}/dns/lint${options.refresh ? '?refresh=true' : ''}`
+                );
                 if (response.ok) {
                     this.dnsGuidance = await response.json();
                     this.syncDetectedDnsProvider();
@@ -948,9 +978,11 @@ function domainDetailsApp(domainId) {
             return this.submitDNSChange(plan, true);
         },
 
-        async fetchPosture() {
+        async fetchPosture(options = {}) {
             try {
-                const response = await fetch(`/api/v1/domains/${this.domainId}/posture`);
+                const response = await fetch(
+                    `/api/v1/domains/${this.domainId}/posture${options.refresh ? '?refresh=true' : ''}`
+                );
                 if (response.ok) {
                     this.posture = await response.json();
                 }
@@ -1138,9 +1170,11 @@ function domainDetailsApp(domainId) {
             return this.fetchMigrationParity();
         },
 
-        async fetchMtaSts() {
+        async fetchMtaSts(options = {}) {
             try {
-                const response = await fetch(`/api/v1/domains/${this.domainId}/dns/mta-sts`);
+                const response = await fetch(
+                    `/api/v1/domains/${this.domainId}/dns/mta-sts${options.refresh ? '?refresh=true' : ''}`
+                );
                 if (response.ok) {
                     this.mtaSts = await response.json();
                 }
@@ -1149,9 +1183,11 @@ function domainDetailsApp(domainId) {
             }
         },
 
-        async fetchBimi() {
+        async fetchBimi(options = {}) {
             try {
-                const response = await fetch(`/api/v1/domains/${this.domainId}/dns/bimi`);
+                const response = await fetch(
+                    `/api/v1/domains/${this.domainId}/dns/bimi${options.refresh ? '?refresh=true' : ''}`
+                );
                 if (response.ok) {
                     this.bimi = await response.json();
                 }
@@ -1257,11 +1293,15 @@ function domainDetailsApp(domainId) {
             }
         },
         
-        async fetchSources() {
+        async fetchSources(options = {}) {
             this.sourcesLoading = true;
             this.sourcesError = '';
             try {
-                const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/sources?days=${this.sourceDateWindow()}`);
+                const params = new URLSearchParams({ days: this.sourceDateWindow() });
+                if (options.refresh) params.set('refresh', 'true');
+                const response = await fetch(
+                    `/api/v1/domains/${encodeURIComponent(this.domainId)}/sources?${params.toString()}`
+                );
                 if (!response.ok) {
                     const data = await response.json().catch(() => ({}));
                     const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -4,6 +4,7 @@ function domainsApp() {
         openCreate: false,
         openEdit: false,
         loading: true,
+        refreshing: false,
         loadError: '',
         saving: false,
         createError: '',
@@ -23,11 +24,15 @@ function domainsApp() {
             this.fetchDomains();
         },
 
-        async fetchDomains() {
-            this.loading = true;
+        async fetchDomains(options = {}) {
+            const refresh = Boolean(options.refresh);
+            this.loading = !refresh;
+            this.refreshing = refresh;
             this.loadError = '';
             try {
-                const response = await fetch('/api/v1/domains/summary');
+                const response = await fetch(
+                    `/api/v1/domains/summary${refresh ? '?refresh=true' : ''}`
+                );
                 if (!response.ok) {
                     throw new Error('Domains could not be loaded. Refresh the page or check the API service.');
                 }
@@ -53,6 +58,7 @@ function domainsApp() {
                 console.error('Error fetching domains:', error);
             } finally {
                 this.loading = false;
+                this.refreshing = false;
             }
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -48,6 +48,13 @@
                     </a>
                     <a href="#sending-sources" class="btn btn-sm border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f]">Review sources</a>
                     <button type="button"
+                            class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]"
+                            :disabled="refreshingPage"
+                            @click="reloadPageData()">
+                        <span x-show="refreshingPage" class="loading loading-spinner loading-xs"></span>
+                        <span x-text="refreshingPage ? 'Refreshing...' : 'Reload data'"></span>
+                    </button>
+                    <button type="button"
                             class="btn btn-outline btn-sm border-[#ff6f3c] text-[#b64218] hover:border-[#ff6f3c] hover:bg-[#fff2ec]"
                             @click="deleteDomain()">
                         Delete domain

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -21,9 +21,18 @@
             {% call card_header() %}
                 <div class="flex items-center justify-between">
                     {% call card_title() %}Monitored Domains{% endcall %}
-                    <button type="button" class="btn btn-outline btn-sm" @click="openCreate = true">
-                        <span class="mr-1">+</span> Add Domain
-                    </button>
+                    <div class="flex items-center gap-2">
+                        <button type="button"
+                                class="btn btn-outline btn-sm"
+                                @click="fetchDomains({ refresh: true })"
+                                :disabled="loading || refreshing">
+                            <span x-show="refreshing" class="loading loading-spinner loading-xs"></span>
+                            <span x-text="refreshing ? 'Refreshing...' : 'Reload'"></span>
+                        </button>
+                        <button type="button" class="btn btn-outline btn-sm" @click="openCreate = true">
+                            <span class="mr-1">+</span> Add Domain
+                        </button>
+                    </div>
                 </div>
                 {% call card_description() %}
                     Domains currently being monitored for DMARC compliance

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -1,4 +1,5 @@
 import asyncio
+from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
@@ -26,6 +27,59 @@ def test_domains_empty(authed_client: TestClient):
     assert response.status_code == 200
     data = response.json()
     assert data == []
+
+
+def test_domains_returns_demo_report_domains_in_demo_mode(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Demo mode keeps domain list reads on the demo ReportStore path."""
+    domain = Domain(name="demo-list.example", active=True)
+    db_session.add(domain)
+    db_session.commit()
+
+    def fake_hydrate(_db, store, workspace_id=None):
+        del workspace_id
+        store.add_report(
+            {
+                "domain": "demo-list.example",
+                "report_id": "demo-list-001",
+                "org_name": "Demo Reporter",
+                "policy": {"p": "none", "sp": "", "pct": "100"},
+                "records": [
+                    {
+                        "source_ip": "192.0.2.20",
+                        "count": 3,
+                        "disposition": "none",
+                        "dkim_result": "pass",
+                        "spf_result": "pass",
+                        "header_from": "demo-list.example",
+                    }
+                ],
+                "summary": {
+                    "total_count": 3,
+                    "passed_count": 3,
+                    "failed_count": 0,
+                    "pass_rate": 100.0,
+                },
+            }
+        )
+        return 1
+
+    monkeypatch.setattr(
+        "app.api.api_v1.endpoints.domains.get_settings",
+        lambda: SimpleNamespace(DEMO_MODE=True),
+    )
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
+
+    response = authed_client.get("/api/v1/domains/domains")
+
+    assert response.status_code == 200
+    row = next(item for item in response.json() if item["name"] == "demo-list.example")
+    assert row["reports_count"] == 1
+    assert row["emails_count"] == 3
+    assert row["compliance_rate"] == 100.0
 
 
 def test_create_domain_without_reports(authed_client: TestClient):

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -7,6 +7,8 @@ from starlette.requests import Request
 from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.main import app, members_page, settings
 from app.models.domain import Domain
+from app.models.report import DMARCReport, ReportRecord
+from app.services.workspaces import get_or_create_default_workspace
 
 
 def test_health_check(authed_client: TestClient):
@@ -39,6 +41,68 @@ def test_create_domain_without_reports(authed_client: TestClient):
     assert list_response.status_code == 200
     assert list_response.json()[0]["name"] == "example.com"
     assert list_response.json()[0]["reports_count"] == 0
+
+
+def test_read_domains_uses_database_aggregates_without_full_report_hydration(
+    authed_client: TestClient, db_session, monkeypatch
+):
+    """Domain list reads persisted aggregates without loading every report record into memory."""
+    workspace = get_or_create_default_workspace(db_session)
+    domain = Domain(
+        name="fast-list.example",
+        workspace_id=workspace.id,
+        active=True,
+        dmarc_policy="reject",
+    )
+    db_session.add(domain)
+    db_session.flush()
+    report = DMARCReport(
+        domain_id=domain.id,
+        report_id="fast-list-001",
+        org_name="Example Reporter",
+        begin_date=1_700_000_000,
+        end_date=1_700_086_399,
+        policy="reject",
+    )
+    db_session.add(report)
+    db_session.flush()
+    db_session.add_all(
+        [
+            ReportRecord(
+                report_id=report.id,
+                source_ip="203.0.113.10",
+                count=8,
+                disposition="none",
+                dkim="pass",
+                spf="fail",
+                header_from=domain.name,
+            ),
+            ReportRecord(
+                report_id=report.id,
+                source_ip="203.0.113.11",
+                count=2,
+                disposition="reject",
+                dkim="fail",
+                spf="fail",
+                header_from=domain.name,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    def fail_hydrate(*_args, **_kwargs):
+        raise AssertionError("read_domains should not hydrate the full ReportStore")
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fail_hydrate)
+
+    response = authed_client.get("/api/v1/domains/domains")
+
+    assert response.status_code == 200
+    row = next(item for item in response.json() if item["name"] == "fast-list.example")
+    assert row["policy"] == "reject"
+    assert row["reports_count"] == 1
+    assert row["emails_count"] == 10
+    assert row["compliance_rate"] == 80.0
 
 
 def test_update_domain_metadata_without_reports(authed_client: TestClient):

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1597,6 +1597,60 @@ def test_summary_endpoint_uses_manual_selectors(authed_client: TestClient, db_se
     assert "google" in captured_selectors
 
 
+def test_summary_endpoint_uses_database_aggregates_without_hydration(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Production summary reads persisted aggregates instead of rebuilding the report store."""
+    _persist_minimal_report(db_session)
+    captured_selectors = []
+
+    def fail_hydration(*args, **kwargs):
+        raise AssertionError("summary should not hydrate the full report store")
+
+    async def _fake_check_domain(domain, selectors=None):
+        captured_selectors.extend(selectors or [])
+        return MOCK_DNS_RESULT
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fail_hydration)
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.get_default_provider",
+        return_value=AsyncMock(check_domain=_fake_check_domain),
+    ):
+        response = authed_client.get("/api/v1/domains/summary")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_domains"] == 1
+    assert data["total_emails"] == 5
+    assert data["reports_processed"] == 1
+    assert data["domains"][0]["pass_rate"] == 100.0
+    assert "google" in captured_selectors
+
+
+def test_summary_endpoint_refresh_bypasses_dns_cache(authed_client: TestClient, db_session):
+    """The summary reload action forces DNS recomputation without report-store hydration."""
+    _persist_minimal_report(db_session)
+    provider = AsyncMock(check_domain=AsyncMock(return_value=MOCK_DNS_RESULT))
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.get_default_provider",
+        return_value=provider,
+    ):
+        first = authed_client.get("/api/v1/domains/summary")
+        second = authed_client.get("/api/v1/domains/summary")
+        refreshed = authed_client.get("/api/v1/domains/summary?refresh=true")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert refreshed.status_code == 200
+    assert provider.check_domain.await_count == 2
+    assert second.json()["domains"][0]["dns_cached"] is True
+    assert refreshed.json()["domains"][0]["dns_cached"] is False
+
+
 def test_summary_endpoint_returns_demo_domains_in_demo_mode(
     authed_client: TestClient,
     monkeypatch,

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1776,6 +1776,73 @@ def test_selector_map_lookup_chunks_domain_names(db_session, monkeypatch):
     }
 
 
+def test_report_selector_map_handles_empty_and_malformed_details(db_session):
+    """Report selector lookups tolerate malformed persisted DKIM auth details."""
+    assert domains_endpoint._get_report_selectors_map_from_db(db_session, []) == {}
+
+    domain = Domain(name="malformed-report-selectors.example", active=True)
+    db_session.add(domain)
+    db_session.flush()
+    report = DMARCReport(
+        domain_id=domain.id,
+        report_id="malformed-report-selectors",
+        org_name="Selector Org",
+        begin_date=1597449600,
+        end_date=1597535999,
+        policy="none",
+    )
+    db_session.add(report)
+    db_session.flush()
+    db_session.add_all(
+        [
+            ReportRecord(
+                report_id=report.id,
+                source_ip="203.0.113.201",
+                count=1,
+                disposition="none",
+                dkim="pass",
+                spf="pass",
+                dkim_auth_details=json.dumps(["bad", {"selector": "mail"}, {"selector": "mail"}]),
+            ),
+            ReportRecord(
+                report_id=report.id,
+                source_ip="203.0.113.202",
+                count=1,
+                disposition="none",
+                dkim="pass",
+                spf="pass",
+                dkim_auth_details="{",
+            ),
+            ReportRecord(
+                report_id=report.id,
+                source_ip="203.0.113.203",
+                count=1,
+                disposition="none",
+                dkim="pass",
+                spf="pass",
+                dkim_auth_details="{}",
+            ),
+            ReportRecord(
+                report_id=report.id,
+                source_ip="203.0.113.204",
+                count=1,
+                disposition="none",
+                dkim="pass",
+                spf="pass",
+                dkim_auth_details=json.dumps([{"selector": "zeta"}]),
+            ),
+        ]
+    )
+    db_session.commit()
+
+    selectors = domains_endpoint._get_report_selectors_map_from_db(
+        db_session,
+        ["malformed-report-selectors.example", "malformed-report-selectors.example"],
+    )
+
+    assert selectors == {"malformed-report-selectors.example": ["mail", "zeta"]}
+
+
 # ---------------------------------------------------------------------------
 # GET /api/v1/domains/{domain_id}/sources  (PTR + fix hints)
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2357,6 +2357,40 @@ def test_get_domain_sources_returns_sender_identity(
     assert "Google Workspace DKIM" in source["sender"]["remediation_hint"]
 
 
+def test_single_domain_report_store_resolves_numeric_domain_id(db_session):
+    """Single-domain report hydration accepts persisted numeric domain IDs."""
+    workspace = get_or_create_default_workspace(db_session)
+    domain = Domain(name="numeric-source.example", workspace_id=workspace.id, active=True)
+    db_session.add(domain)
+    db_session.commit()
+
+    domain_name, store = domains_endpoint._single_domain_report_store_for_read(
+        db_session,
+        str(domain.id),
+        workspace,
+    )
+
+    assert domain_name == "numeric-source.example"
+    assert store.get_domain_reports(domain_name) == []
+
+
+def test_single_domain_report_store_rejects_missing_domain_when_fallback_disabled(db_session):
+    """Multi-workspace setups must not fall back to legacy report-only global cache."""
+    alpha = Workspace(slug="source-alpha", name="Source Alpha", active=True)
+    beta = Workspace(slug="source-beta", name="Source Beta", active=True)
+    db_session.add_all([alpha, beta])
+    db_session.commit()
+
+    with pytest.raises(domains_endpoint.HTTPException) as exc_info:
+        domains_endpoint._single_domain_report_store_for_read(
+            db_session,
+            "missing-source.example",
+            alpha,
+        )
+
+    assert exc_info.value.status_code == 404
+
+
 def test_get_domain_source_intelligence_returns_regions_and_anomalies(
     seeded_client: TestClient,
 ):

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2531,6 +2531,72 @@ def test_get_domain_sources_refreshes_reputation_cache(
     assert captured_refresh == [True]
 
 
+def test_source_detail_endpoints_use_single_domain_persisted_reports(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Source detail endpoints avoid workspace-wide report-store hydration."""
+    workspace = get_or_create_default_workspace(db_session)
+    report_persistence.save_parsed_report(
+        db_session,
+        {
+            **REPORT_DICT_POLICY,
+            "domain": "fast-sources.example",
+            "report_id": "fast-sources-001",
+            "records": [
+                {
+                    "source_ip": "203.0.113.42",
+                    "count": 4,
+                    "disposition": "none",
+                    "dkim_result": "pass",
+                    "spf_result": "pass",
+                    "header_from": "fast-sources.example",
+                }
+            ],
+            "summary": {"total_count": 4, "passed_count": 4, "failed_count": 0},
+        },
+        workspace_id=workspace.id,
+    )
+    db_session.commit()
+
+    def fail_hydrate(*_args, **_kwargs):
+        raise AssertionError("source detail routes should not hydrate the full ReportStore")
+
+    async def fake_ptr_lookup(*_args, **_kwargs):
+        return "mail.fast-sources.example"
+
+    async def fake_reputation(*_args, **_kwargs):
+        return (
+            DomainReputation(
+                domain="fast-sources.example",
+                status="clean",
+                checked_at="2026-07-02T08:00:00Z",
+                summary={"listed": 0, "suspicious": 0, "clean": 1, "unknown": 0},
+                sources=[],
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fail_hydrate)
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
+
+    sources = authed_client.get("/api/v1/domains/fast-sources.example/sources?days=30")
+    intelligence = authed_client.get(
+        "/api/v1/domains/fast-sources.example/source-intelligence?days=30"
+    )
+    reputation = authed_client.get("/api/v1/domains/fast-sources.example/source-reputation?days=30")
+
+    assert sources.status_code == 200
+    assert sources.json()["sources"][0]["ip"] == "203.0.113.42"
+    assert intelligence.status_code == 200
+    assert intelligence.json()["summary"]["messages"] == 4
+    assert reputation.status_code == 200
+    assert reputation.json()["domain"] == "fast-sources.example"
+
+
 def test_source_recommendations_cover_common_cases():
     """Recommendation builder handles the milestone source patterns."""
     cases = [

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2502,6 +2502,35 @@ def test_get_domain_sources_includes_ip_intelligence_and_reputation(
     assert "source_reputation" in recommendation_types
 
 
+def test_get_domain_sources_refreshes_reputation_cache(
+    seeded_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The detail-page reload path forces reputation evidence refresh for sources."""
+    captured_refresh = []
+
+    async def fake_reputation(*_args, **kwargs):
+        captured_refresh.append(kwargs.get("refresh"))
+        return (
+            DomainReputation(
+                domain=DOMAIN,
+                status="clean",
+                checked_at="2026-07-02T08:00:00Z",
+                summary={"listed": 0, "suspicious": 0, "clean": 1, "unknown": 0},
+                sources=[],
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=30&refresh=true")
+
+    assert response.status_code == 200
+    assert captured_refresh == [True]
+
+
 def test_source_recommendations_cover_common_cases():
     """Recommendation builder handles the milestone source patterns."""
     cases = [


### PR DESCRIPTION
## Summary
- add a direct database aggregate path for domain list and domain summary endpoints
- avoid rebuilding the full in-memory report store for production domain summary/list pages
- add a Domain Management Reload action that forces cached DNS values to refresh with refresh=true
- add a Domain Detail Reload data action for DNS, posture, BIMI, MTA-STS, reports, sources, and reputation-backed source rows
- pass refresh=true from the source table to cached reputation evidence so blacklist/reputation data can be recomputed on demand
- load source detail, source intelligence, and source reputation reports through a single-domain persisted-report store instead of hydrating all workspace reports
- keep demo-mode behavior on the report-store path for generated demo data

Part of #523.

## Validation
- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_api.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_domain_detail_endpoints.py -k "domains or summary_endpoint or get_domain_sources_refreshes_reputation_cache or get_domain_sources_includes_ip_intelligence_and_reputation"
- PYTHONPATH=backend /tmp/dmarq-provider-connectors-423/.venv/bin/pytest -q backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_api.py -k "source_detail_endpoints_use_single_domain_persisted_reports or get_domain_sources_refreshes_reputation_cache or read_domains_uses_database_aggregates or summary_endpoint_uses_database_aggregates"
- /tmp/dmarq-provider-connectors-423/.venv/bin/black --check backend/app/services/report_persistence.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_api.py
- /tmp/dmarq-provider-connectors-423/.venv/bin/isort --check-only backend/app/services/report_persistence.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_api.py

## Follow-up kept in #523
- true materialized sender aggregates/precompute table can follow after the direct-query/single-domain-store slice proves stable
- page timing instrumentation and representative production-dataset benchmarks are still open
- broader cached detail payloads can follow for the highest-volume production pages