### PR TITLE
[codex] Show release info in product

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            DMARQ_BUILD_SHA=${{ github.sha }}
+            DMARQ_BUILD_REF=${{ github.ref_name }}
+            DMARQ_BUILD_IMAGE=${{ steps.release_ref.outputs.image }}
+            DMARQ_BUILD_DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,16 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
+ARG DMARQ_BUILD_SHA=""
+ARG DMARQ_BUILD_REF=""
+ARG DMARQ_BUILD_IMAGE=""
+ARG DMARQ_BUILD_DATE=""
+
+ENV DMARQ_BUILD_SHA="${DMARQ_BUILD_SHA}" \
+    DMARQ_BUILD_REF="${DMARQ_BUILD_REF}" \
+    DMARQ_BUILD_IMAGE="${DMARQ_BUILD_IMAGE}" \
+    DMARQ_BUILD_DATE="${DMARQ_BUILD_DATE}"
+
 # Install required system dependencies.
 # The backend does not need privileged mount helpers. Debian 13 currently has
 # no fixed util-linux package for the reported Snyk mount(8) CVEs, so remove

--- a/backend/app/api/api_v1/endpoints/health.py
+++ b/backend/app/api/api_v1/endpoints/health.py
@@ -3,12 +3,14 @@ from sqlalchemy import func, text
 from sqlalchemy.orm import Session
 
 from app.api.api_v1.endpoints.setup import setup_status
+from app.core.config import get_settings
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
 from app.models.report import DMARCReport
 from app.services.mailbox_recovery import import_row_diagnostic, not_configured_guidance
+from app.services.release_info import build_release_info
 from app.services.runtime_status import get_scheduler_status
 
 router = APIRouter()
@@ -22,10 +24,16 @@ async def health_check():
     """
     return {
         "status": "ok",
-        "version": "0.1.0",
+        "version": build_release_info(get_settings())["version"],
         "service": "dmarq",
         "is_setup_complete": setup_status["is_setup_complete"],
     }
+
+
+@router.get("/health/release", status_code=200)
+async def release_info():
+    """Return safe release/build metadata for support and the in-product changelog."""
+    return build_release_info(get_settings())
 
 
 def _iso(value):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -24,6 +24,11 @@ class Settings(BaseSettings):
     ENVIRONMENT: str = "development"
     DEMO_MODE: bool = False
     PUBLIC_BASE_URL: Optional[str] = None
+    DMARQ_RELEASE_VERSION: Optional[str] = None
+    DMARQ_BUILD_SHA: Optional[str] = None
+    DMARQ_BUILD_REF: Optional[str] = None
+    DMARQ_BUILD_IMAGE: Optional[str] = None
+    DMARQ_BUILD_DATE: Optional[str] = None
     # Self-hosted installs default to a single workspace. Enable this for SaaS,
     # ISP/MSP, or admin deployments that need explicit workspace switching.
     MULTI_WORKSPACE_UI_ENABLED: bool = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,7 @@ from app.services.mail_source_backfill_worker import run_due_mail_source_backfil
 from app.services.microsoft_graph_client import MicrosoftGraphClient
 from app.services.report_persistence import hydrate_report_store_from_db
 from app.services.report_store import ReportStore
+from app.services.release_info import build_release_info
 from app.services.runtime_status import (
     mark_scheduler_cycle_started,
     mark_scheduler_error,
@@ -573,6 +574,7 @@ app = create_app()  # noqa: F811 – intentional rebind; `app` package imported 
 templates_dir = os.path.join(os.path.dirname(__file__), "templates")
 templates = Jinja2Templates(directory=templates_dir)
 templates.env.globals["multi_workspace_ui_enabled"] = settings.MULTI_WORKSPACE_UI_ENABLED
+templates.env.globals["release_info"] = build_release_info(settings)
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/backend/app/services/release_info.py
+++ b/backend/app/services/release_info.py
@@ -1,0 +1,68 @@
+"""Runtime release metadata for support and in-product visibility."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from app import __version__
+
+
+def _clean(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    stripped = str(value).strip()
+    return stripped or None
+
+
+def _short_sha(value: Optional[str]) -> Optional[str]:
+    cleaned = _clean(value)
+    if not cleaned:
+        return None
+    return cleaned[:12]
+
+
+def build_release_info(settings: Any) -> Dict[str, Any]:
+    """Return safe build metadata and a short operator-facing changelog."""
+
+    sha = _clean(getattr(settings, "DMARQ_BUILD_SHA", None))
+    short_sha = _short_sha(sha)
+    version = _clean(getattr(settings, "DMARQ_RELEASE_VERSION", None)) or __version__
+    label = f"v{version}"
+    if short_sha:
+        label = f"{label} · {short_sha}"
+
+    return {
+        "service": "dmarq",
+        "version": version,
+        "label": label,
+        "build": {
+            "sha": sha,
+            "short_sha": short_sha,
+            "ref": _clean(getattr(settings, "DMARQ_BUILD_REF", None)),
+            "image": _clean(getattr(settings, "DMARQ_BUILD_IMAGE", None)),
+            "date": _clean(getattr(settings, "DMARQ_BUILD_DATE", None)),
+        },
+        "changes": [
+            {
+                "title": "Faster domain pages",
+                "description": (
+                    "Domain list and domain detail views use precomputed database "
+                    "aggregates so report-heavy installs load with less waiting."
+                ),
+            },
+            {
+                "title": "Sender intelligence",
+                "description": (
+                    "Sending sources now include provider detection, network context, "
+                    "first/last seen activity, and optional reputation feed checks."
+                ),
+            },
+            {
+                "title": "Self-hosted demo focus",
+                "description": (
+                    "The default demo and navigation emphasize the single-user, "
+                    "multiple-domain self-hosted story."
+                ),
+            },
+        ],
+    }

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -41,6 +41,12 @@
                 </span>
                 <span class="text-3xl font-bold tracking-normal">DMARQ</span>
             </a>
+            <button type="button"
+                    class="ml-4 hidden rounded-full border border-white/20 px-2.5 py-1 text-[11px] font-semibold text-white/70 transition hover:border-white/40 hover:bg-white/10 hover:text-white sm:inline-flex"
+                    title="Show release notes"
+                    onclick="document.getElementById('dmarq-release-modal')?.showModal()">
+                {{ release_info.label }}
+            </button>
         </div>
         <div class="flex items-center gap-3">
             {% if multi_workspace_ui_enabled %}
@@ -93,6 +99,14 @@
                             {% endif %}
                             <li><a href="/settings">Settings</a></li>
                             <li>
+                                <button type="button"
+                                        class="justify-between"
+                                        onclick="document.getElementById('dmarq-release-modal')?.showModal()">
+                                    Release
+                                    <span class="badge badge-ghost text-[10px]">{{ release_info.label }}</span>
+                                </button>
+                            </li>
+                            <li>
                                 <a href="/api/v1/auth/sign-out" class="text-error">
                                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
@@ -134,6 +148,12 @@
         <a href="/settings" aria-label="Settings" title="Settings" class="mt-auto rounded-lg p-3 text-white/55 hover:bg-white/10 hover:text-white">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.4 13.5a7.8 7.8 0 0 0 0-3l2-1.5-2-3.5-2.4 1a7.6 7.6 0 0 0-2.6-1.5L14 2h-4l-.4 3a7.6 7.6 0 0 0-2.6 1.5l-2.4-1-2 3.5 2 1.5a7.8 7.8 0 0 0 0 3l-2 1.5 2 3.5 2.4-1a7.6 7.6 0 0 0 2.6 1.5l.4 3h4l.4-3a7.6 7.6 0 0 0 2.6-1.5l2.4 1 2-3.5-2-1.5ZM12 15.5A3.5 3.5 0 1 1 12 8a3.5 3.5 0 0 1 0 7.5Z"/></svg>
         </a>
+        <button type="button"
+                class="max-w-20 truncate rounded-md px-2 py-1 text-[10px] font-semibold text-white/45 hover:bg-white/10 hover:text-white"
+                title="Show release notes"
+                onclick="document.getElementById('dmarq-release-modal')?.showModal()">
+            {{ release_info.label }}
+        </button>
     </aside>
 
     <main class="min-h-screen pt-24 md:ml-24">
@@ -141,6 +161,61 @@
         {% block content %}{% endblock %}
         </div>
     </main>
+
+    <dialog id="dmarq-release-modal" class="modal">
+        <div class="modal-box max-w-xl rounded-lg">
+            <form method="dialog">
+                <button class="btn btn-sm btn-circle btn-ghost absolute right-3 top-3" aria-label="Close">x</button>
+            </form>
+            <div class="space-y-5">
+                <div>
+                    <p class="text-xs font-semibold uppercase tracking-wide text-[#39a0aa]">Current release</p>
+                    <h2 class="mt-1 text-2xl font-bold text-[#07071f]">{{ release_info.label }}</h2>
+                    <dl class="mt-3 grid gap-2 text-sm text-base-content/70 sm:grid-cols-2">
+                        <div>
+                            <dt class="font-semibold text-base-content">Version</dt>
+                            <dd>{{ release_info.version }}</dd>
+                        </div>
+                        <div>
+                            <dt class="font-semibold text-base-content">Build</dt>
+                            <dd>{{ release_info.build.short_sha or 'local' }}</dd>
+                        </div>
+                        {% if release_info.build.ref %}
+                        <div>
+                            <dt class="font-semibold text-base-content">Ref</dt>
+                            <dd class="truncate">{{ release_info.build.ref }}</dd>
+                        </div>
+                        {% endif %}
+                        {% if release_info.build.date %}
+                        <div>
+                            <dt class="font-semibold text-base-content">Built</dt>
+                            <dd>{{ release_info.build.date }}</dd>
+                        </div>
+                        {% endif %}
+                    </dl>
+                </div>
+                <div>
+                    <h3 class="text-sm font-bold uppercase tracking-wide text-base-content/60">What's changed</h3>
+                    <div class="mt-3 space-y-3">
+                        {% for item in release_info.changes %}
+                        <div class="rounded-md border border-base-200 bg-base-100 p-3">
+                            <p class="font-semibold text-base-content">{{ item.title }}</p>
+                            <p class="mt-1 text-sm text-base-content/70">{{ item.description }}</p>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="modal-action">
+                    <form method="dialog">
+                        <button class="btn btn-primary">Close</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <form method="dialog" class="modal-backdrop">
+            <button>close</button>
+        </form>
+    </dialog>
 
     <!-- Scripts -->
     {% block scripts %}{% endblock %}

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 {% set multi_workspace_ui_enabled = multi_workspace_ui_enabled | default(false) %}
+{% set release_info = release_info | default({
+    'label': 'vlocal',
+    'version': 'local',
+    'build': {'short_sha': none, 'ref': none, 'date': none},
+    'changes': []
+}) %}
 <html lang="en" data-theme="dmarqlight" data-multi-workspace-ui="{{ 'true' if multi_workspace_ui_enabled else 'false' }}" class="dark:data-theme-dmarqdark">
 <head>
     <meta charset="UTF-8">

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -25,18 +25,22 @@ def test_release_info_endpoint_exposes_safe_build_metadata(
     authed_client: TestClient, monkeypatch
 ):
     """Release metadata is available for support without exposing secrets."""
-    monkeypatch.setenv("DMARQ_BUILD_SHA", "abcdef1234567890")
-    monkeypatch.setenv("DMARQ_BUILD_REF", "main")
-    monkeypatch.setenv("DMARQ_BUILD_IMAGE", "ghcr.io/christianlouis/dmarq:abcdef1")
-    monkeypatch.setenv("DMARQ_BUILD_DATE", "2026-07-03T12:00:00Z")
+    from app.api.api_v1.endpoints import health as health_endpoint  # pylint: disable=import-outside-toplevel
+    from app.core.config import Settings  # pylint: disable=import-outside-toplevel
 
-    from app.core.config import get_settings  # pylint: disable=import-outside-toplevel
+    monkeypatch.setattr(
+        health_endpoint,
+        "get_settings",
+        lambda: Settings(
+            SECRET_KEY="s" * 32,
+            DMARQ_BUILD_SHA="abcdef1234567890",
+            DMARQ_BUILD_REF="main",
+            DMARQ_BUILD_IMAGE="ghcr.io/christianlouis/dmarq:abcdef1",
+            DMARQ_BUILD_DATE="2026-07-03T12:00:00Z",
+        ),
+    )
 
-    get_settings.cache_clear()
-    try:
-        response = authed_client.get("/api/v1/health/release")
-    finally:
-        get_settings.cache_clear()
+    response = authed_client.get("/api/v1/health/release")
 
     assert response.status_code == 200
     data = response.json()

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -21,6 +21,34 @@ def test_health_check(authed_client: TestClient):
     assert "version" in data
 
 
+def test_release_info_endpoint_exposes_safe_build_metadata(
+    authed_client: TestClient, monkeypatch
+):
+    """Release metadata is available for support without exposing secrets."""
+    monkeypatch.setenv("DMARQ_BUILD_SHA", "abcdef1234567890")
+    monkeypatch.setenv("DMARQ_BUILD_REF", "main")
+    monkeypatch.setenv("DMARQ_BUILD_IMAGE", "ghcr.io/christianlouis/dmarq:abcdef1")
+    monkeypatch.setenv("DMARQ_BUILD_DATE", "2026-07-03T12:00:00Z")
+
+    from app.core.config import get_settings  # pylint: disable=import-outside-toplevel
+
+    get_settings.cache_clear()
+    try:
+        response = authed_client.get("/api/v1/health/release")
+    finally:
+        get_settings.cache_clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["service"] == "dmarq"
+    assert data["version"]
+    assert data["label"].startswith(f"v{data['version']}")
+    assert data["build"]["short_sha"] == "abcdef123456"
+    assert data["build"]["ref"] == "main"
+    assert data["build"]["image"] == "ghcr.io/christianlouis/dmarq:abcdef1"
+    assert data["changes"]
+
+
 def test_domains_empty(authed_client: TestClient):
     """Test that GET /api/v1/domains/domains returns empty list when no reports uploaded."""
     response = authed_client.get("/api/v1/domains/domains")


### PR DESCRIPTION
## What changed

- Adds safe runtime release metadata for DMARQ: semantic version, build SHA, ref, image, and build date.
- Shows the current release as a small clickable badge in the header, user menu, and sidebar footer.
- Adds an in-product release/changelog modal with the current build and short product-facing changes.
- Adds `/api/v1/health/release` so support and tests can read the same release metadata.
- Passes build metadata into the Docker image from the GitHub release build.

## Why

Operators need to see which deployed build they are using without leaving the product, especially when comparing demo/prod rollouts or validating fixes.

## Validation

- `.venv/bin/pytest backend/app/tests/test_api.py -q` -> 18 passed
- `.venv/bin/python -m compileall backend/app/services/release_info.py backend/app/api/api_v1/endpoints/health.py backend/app/main.py`
- `git diff --check`
