### PR TITLE
[codex] Add AI credential settings and Cloudflare scope profiles

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -39,8 +39,10 @@ from app.services.cloudflare_oauth import (
     build_cloudflare_authorization_url,
     build_cloudflare_oauth_state,
     cloudflare_oauth_configured,
+    cloudflare_scope_profile_metadata,
     decode_cloudflare_oauth_state,
     exchange_cloudflare_oauth_code,
+    normalize_cloudflare_scope_profile,
     persist_cloudflare_oauth_tokens,
 )
 from app.services.dane import check_dane_cached
@@ -1284,6 +1286,7 @@ class CloudflareOAuthAuthorizeResponse(BaseModel):
     authorization_url: str
     redirect_uri: str
     scopes: str
+    scope_profile: str
 
 
 class CloudflareOAuthStatusResponse(BaseModel):
@@ -1293,6 +1296,8 @@ class CloudflareOAuthStatusResponse(BaseModel):
     connected: bool
     auth_mode: Optional[str] = None
     scopes: Optional[str] = None
+    scope_profile: str = "read_only"
+    scope_profiles: List[Dict[str, Any]] = Field(default_factory=list)
     connected_at: Optional[str] = None
 
 
@@ -5067,6 +5072,10 @@ async def get_cloudflare_oauth_status(
         connected=bool(token_row and token_row.value),
         auth_mode=auth_mode,
         scopes=_setting_value(db, "cloudflare.oauth_scopes"),
+        scope_profile=normalize_cloudflare_scope_profile(
+            _setting_value(db, "cloudflare.oauth_scope_profile")
+        ),
+        scope_profiles=cloudflare_scope_profile_metadata(),
         connected_at=_setting_value(db, "cloudflare.oauth_connected_at"),
     )
 
@@ -5075,6 +5084,11 @@ async def get_cloudflare_oauth_status(
 async def get_cloudflare_oauth_authorize_url(
     request: Request,
     return_to: str = Query("/settings", title="Path to return to after OAuth"),
+    scope_profile: str = Query(
+        "read_only",
+        title="Cloudflare OAuth rights profile",
+        description="read_only, read_only_radar, or full_dns_repair",
+    ),
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
@@ -5086,10 +5100,16 @@ async def get_cloudflare_oauth_authorize_url(
         selected_workspace_id=parse_selected_workspace_id(selected_workspace),
     )
     redirect_uri = f"{_public_base_url(request, db)}/api/v1/domains/cloudflare/oauth/callback"
+    normalized_profile = normalize_cloudflare_scope_profile(scope_profile)
     try:
         payload = build_cloudflare_authorization_url(
             redirect_uri=redirect_uri,
-            state=build_cloudflare_oauth_state(workspace_id=workspace.id, return_to=return_to),
+            state=build_cloudflare_oauth_state(
+                workspace_id=workspace.id,
+                return_to=return_to,
+                scope_profile=normalized_profile,
+            ),
+            scope_profile=normalized_profile,
         )
     except LookupError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
@@ -5120,17 +5140,23 @@ async def cloudflare_oauth_callback(
     try:
         state_payload = decode_cloudflare_oauth_state(state_value)
         _authorized_domain_workspace(_auth, db, selected_workspace_id=state_payload["workspace_id"])
+        redirect_uri = f"{_public_base_url(request, db)}/api/v1/domains/cloudflare/oauth/callback"
         token_data = await exchange_cloudflare_oauth_code(
             code=code,
-            redirect_uri=f"{_public_base_url(request, db)}/api/v1/domains/cloudflare/oauth/callback",
+            redirect_uri=redirect_uri,
         )
-        persist_cloudflare_oauth_tokens(db, token_data)
+        persist_cloudflare_oauth_tokens(
+            db,
+            token_data,
+            scope_profile=state_payload.get("scope_profile"),
+        )
     except LookupError as exc:
         logger.info("Cloudflare OAuth callback failed: %s", exc)
         return HTMLResponse(
             content=(
                 "<html><body><p>Cloudflare connection failed. "
-                "Please close this window and retry after checking the connector settings.</p></body></html>"
+                "Please close this window and retry after checking the connector settings."
+                "</p></body></html>"
             ),
             status_code=400,
         )

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -13,9 +13,13 @@ in the ``settings`` database table.  Settings are organised into categories:
 - ``notifications`` - Future alerting/notification settings.
 """
 
+import ipaddress
 import logging
+import socket
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
+import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -24,6 +28,7 @@ from app.core.credential_encryption import decrypt_secret, encrypt_secret, is_en
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.setting import Setting
+from app.services.ai_assistance import AI_DEFAULTS
 from app.services.alert_history import (
     list_alert_config_audit,
     list_alert_history,
@@ -145,6 +150,13 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
         "key": "cloudflare.oauth_scopes",
         "value": "",
         "description": "Granted Cloudflare OAuth scopes",
+        "value_type": "string",
+        "category": "cloudflare",
+    },
+    {
+        "key": "cloudflare.oauth_scope_profile",
+        "value": "read_only",
+        "description": "Requested Cloudflare OAuth rights profile",
         "value_type": "string",
         "category": "cloudflare",
     },
@@ -362,6 +374,13 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
         "category": "ai",
     },
     {
+        "key": "ai.api_key",
+        "value": "",
+        "description": "Optional API key for OpenAI-compatible AI providers",
+        "value_type": "string",
+        "category": "ai",
+    },
+    {
         "key": "ai.remote_base_url",
         "value": "",
         "description": (
@@ -402,6 +421,7 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
 
 # Keys whose values should be redacted in GET responses (treated as secrets)
 _SECRET_KEYS = {
+    "ai.api_key",
     "cloudflare.api_token",
     "postmark.account_token",
     "notifications.apprise_urls",
@@ -603,6 +623,171 @@ class SummaryNotificationResponse(BaseModel):
     notification: Dict[str, Any]
 
 
+class AIProviderProfileResponse(BaseModel):
+    """AI provider profile metadata for the settings UI."""
+
+    id: str
+    name: str
+    description: str
+    default_base_url: str = ""
+    requires_base_url: bool = False
+    requires_api_key: bool = False
+    supports_model_discovery: bool = False
+    default_model: str = ""
+
+
+class AIConnectionTestRequest(BaseModel):
+    """Connection-test payload for an AI provider."""
+
+    provider: Optional[str] = None
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
+    model: Optional[str] = None
+
+
+class AIConnectionTestResponse(BaseModel):
+    """Sanitized AI provider connection-test response."""
+
+    success: bool
+    provider: str
+    message: str
+    models: List[str] = []
+    selected_model: Optional[str] = None
+
+
+AI_PROVIDER_PROFILES: List[Dict[str, Any]] = [
+    {
+        "id": "template",
+        "name": "Offline template",
+        "description": "Use deterministic local remediation templates. No token or network call.",
+        "default_base_url": "",
+        "requires_base_url": False,
+        "requires_api_key": False,
+        "supports_model_discovery": False,
+        "default_model": "",
+    },
+    {
+        "id": "openai",
+        "name": "OpenAI direct",
+        "description": "Use OpenAI's native OpenAI-compatible API.",
+        "default_base_url": "https://api.openai.com/v1",
+        "requires_base_url": False,
+        "requires_api_key": True,
+        "supports_model_discovery": True,
+        "default_model": "gpt-4.1-mini",
+    },
+    {
+        "id": "litellm",
+        "name": "LiteLLM proxy",
+        "description": "Use your LiteLLM gateway for OpenAI, Anthropic, Gemini, or local models.",
+        "default_base_url": "",
+        "requires_base_url": True,
+        "requires_api_key": True,
+        "supports_model_discovery": True,
+        "default_model": "",
+    },
+    {
+        "id": "openai_compatible",
+        "name": "OpenAI-compatible endpoint",
+        "description": "Use a self-hosted or vendor API that exposes /v1/models.",
+        "default_base_url": "",
+        "requires_base_url": True,
+        "requires_api_key": True,
+        "supports_model_discovery": True,
+        "default_model": "",
+    },
+]
+
+
+def _ai_provider_profile(provider: Optional[str]) -> Dict[str, Any]:
+    normalized = str(provider or "template").strip().lower().replace("-", "_")
+    return next(
+        (profile for profile in AI_PROVIDER_PROFILES if profile["id"] == normalized),
+        AI_PROVIDER_PROFILES[0],
+    )
+
+
+def _setting_plain_or_default(db: Session, key: str) -> str:
+    row = _get_setting(key, db)
+    if row is not None:
+        return _plain_value_for_setting(key, row.value) or ""
+    return str(AI_DEFAULTS.get(key, ""))
+
+
+def _normalize_ai_base_url(provider: str, base_url: str, profile: Dict[str, Any]) -> str:
+    value = (base_url or profile.get("default_base_url") or "").strip().rstrip("/")
+    if provider == "openai" and not value:
+        return "https://api.openai.com/v1"
+    return value
+
+
+def _is_public_address(host: str) -> bool:
+    """Return whether a hostname resolves only to public routable addresses."""
+    try:
+        literal = ipaddress.ip_address(host)
+        addresses = [literal]
+    except ValueError:
+        try:
+            addrinfo = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+        except socket.gaierror as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="AI base URL host could not be resolved.",
+            ) from exc
+        addresses = [ipaddress.ip_address(item[4][0]) for item in addrinfo]
+
+    return all(
+        not (
+            address.is_private
+            or address.is_loopback
+            or address.is_link_local
+            or address.is_multicast
+            or address.is_reserved
+            or address.is_unspecified
+        )
+        for address in addresses
+    )
+
+
+def _validated_ai_base_url(base_url: str) -> str:
+    normalized = base_url.strip().rstrip("/")
+    parsed = urlparse(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="AI base URL must be an absolute HTTP(S) URL.",
+        )
+    if parsed.username or parsed.password:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="AI base URL must not contain credentials.",
+        )
+    if not _is_public_address(parsed.hostname):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "AI base URL must resolve to public addresses. Private, localhost, "
+                "link-local, and reserved targets are blocked for connection tests."
+            ),
+        )
+    return normalized
+
+
+async def _fetch_openai_compatible_models(*, base_url: str, api_key: str) -> List[str]:
+    safe_base_url = _validated_ai_base_url(base_url)
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with httpx.AsyncClient(base_url=safe_base_url, timeout=10) as client:
+        response = await client.get("/models", headers=headers)
+        response.raise_for_status()
+        payload = response.json()
+    models = []
+    for item in payload.get("data", []):
+        model_id = str(item.get("id") or "").strip()
+        if model_id:
+            models.append(model_id)
+    return sorted(set(models))
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -739,6 +924,85 @@ async def send_notification_summary(
             detail=result,
         )
     return result
+
+
+@router.get("/ai/provider-profiles", response_model=List[AIProviderProfileResponse])
+async def list_ai_provider_profiles(
+    _auth: dict = Depends(require_admin_auth),
+) -> List[AIProviderProfileResponse]:
+    """Return supported AI provider presets without exposing credentials."""
+    return AI_PROVIDER_PROFILES
+
+
+@router.post("/ai/test", response_model=AIConnectionTestResponse)
+async def test_ai_connection(
+    payload: AIConnectionTestRequest,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+) -> AIConnectionTestResponse:
+    """Validate AI provider settings without returning secret material."""
+    _seed_defaults(db)
+    provider = str(payload.provider or _setting_plain_or_default(db, "ai.provider") or "template")
+    provider = provider.strip().lower().replace("-", "_")
+    profile = _ai_provider_profile(provider)
+    provider = profile["id"]
+
+    if provider == "template":
+        return AIConnectionTestResponse(
+            success=True,
+            provider=provider,
+            message="Offline template mode is available. No external AI connection is required.",
+            models=[],
+            selected_model=None,
+        )
+
+    stored_key = _setting_plain_or_default(db, "ai.api_key")
+    api_key = str(payload.api_key or "").strip()
+    if api_key == "**redacted**":
+        api_key = stored_key
+    if not api_key:
+        api_key = stored_key
+    if profile.get("requires_api_key") and not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Add an API key before testing this AI provider.",
+        )
+
+    base_url = _normalize_ai_base_url(
+        provider,
+        str(payload.base_url or _setting_plain_or_default(db, "ai.remote_base_url") or ""),
+        profile,
+    )
+    if profile.get("requires_base_url") and not base_url:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Add a provider base URL before testing this AI provider.",
+        )
+
+    selected_model = str(payload.model or _setting_plain_or_default(db, "ai.model") or "").strip()
+    try:
+        models = await _fetch_openai_compatible_models(base_url=base_url, api_key=api_key)
+    except httpx.HTTPStatusError as exc:
+        status_code = getattr(exc.response, "status_code", 0)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"AI provider rejected the connection test with HTTP {status_code}.",
+        ) from exc
+    except (httpx.RequestError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="AI provider connection test failed. Check the base URL and network path.",
+        ) from exc
+
+    if not selected_model and models:
+        selected_model = models[0]
+    return AIConnectionTestResponse(
+        success=True,
+        provider=provider,
+        message="AI provider connection succeeded.",
+        models=models,
+        selected_model=selected_model or None,
+    )
 
 
 @router.get("/{key:path}", response_model=SettingResponse)

--- a/backend/app/services/ai_assistance.py
+++ b/backend/app/services/ai_assistance.py
@@ -30,6 +30,7 @@ AI_DEFAULTS = {
     "ai.enabled": "false",
     "ai.provider": "template",
     "ai.model": "",
+    "ai.api_key": "",
     "ai.remote_base_url": "",
     "ai.redaction_mode": "strict",
     "ai.action_tools_enabled": "false",

--- a/backend/app/services/cloudflare_oauth.py
+++ b/backend/app/services/cloudflare_oauth.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
 import httpx
@@ -18,6 +18,7 @@ from app.models.setting import Setting
 CLOUDFLARE_AUTHORIZATION_URL = "https://dash.cloudflare.com/oauth2/auth"
 CLOUDFLARE_TOKEN_URL = "https://api.cloudflare.com/oauth2/token"
 CLOUDFLARE_DEFAULT_READ_SCOPES = "zone.read dns.read"
+CLOUDFLARE_DEFAULT_SCOPE_PROFILE = "read_only"
 _STATE_ALGORITHM = "HS256"
 _STATE_TTL = timedelta(minutes=10)
 
@@ -29,6 +30,69 @@ class CloudflareOAuthConfig:
     client_id: str
     client_secret: str
     scopes: str
+
+
+@dataclass(frozen=True)
+class CloudflareScopeProfile:
+    """User-selectable Cloudflare OAuth rights profile."""
+
+    id: str
+    name: str
+    description: str
+    scopes: str
+    dns_write_enabled: bool = False
+    radar_enabled: bool = False
+    radar_requires_api_token: bool = False
+    warning: Optional[str] = None
+
+
+CLOUDFLARE_SCOPE_PROFILES: Dict[str, CloudflareScopeProfile] = {
+    "read_only": CloudflareScopeProfile(
+        id="read_only",
+        name="Read-only discovery",
+        description="Verify ownership, import zones, and inspect DNS records.",
+        scopes="zone.read dns.read",
+    ),
+    "read_only_radar": CloudflareScopeProfile(
+        id="read_only_radar",
+        name="Read-only + Radar context",
+        description=(
+            "Read DNS zones and enable Cloudflare Radar enrichment when a Radar API token "
+            "is configured server-side."
+        ),
+        scopes="zone.read dns.read",
+        radar_enabled=True,
+        radar_requires_api_token=True,
+        warning=(
+            "Cloudflare Radar API access is not granted by this DNS OAuth scope; configure "
+            "a separate Radar-capable API token on the server for enrichment."
+        ),
+    ),
+    "full_dns_repair": CloudflareScopeProfile(
+        id="full_dns_repair",
+        name="Full DNS repair",
+        description="Read zones and allow human-approved DNS record changes.",
+        scopes="zone.read dns.read dns.write",
+        dns_write_enabled=True,
+        warning="Only use this when you want DMARQ to prepare and apply confirmed DNS repairs.",
+    ),
+}
+
+
+def normalize_cloudflare_scope_profile(profile: Optional[str]) -> str:
+    """Return a supported Cloudflare scope profile id."""
+    value = str(profile or "").strip().lower().replace("-", "_")
+    return value if value in CLOUDFLARE_SCOPE_PROFILES else CLOUDFLARE_DEFAULT_SCOPE_PROFILE
+
+
+def cloudflare_scope_profile_metadata() -> List[Dict[str, Any]]:
+    """Return serializable metadata for the settings UI."""
+    return [asdict(profile) for profile in CLOUDFLARE_SCOPE_PROFILES.values()]
+
+
+def cloudflare_scopes_for_profile(profile: Optional[str]) -> str:
+    """Resolve OAuth scopes for a supported profile."""
+    return CLOUDFLARE_SCOPE_PROFILES[normalize_cloudflare_scope_profile(profile)].scopes
 
 
 def cloudflare_oauth_configured() -> bool:
@@ -67,13 +131,16 @@ def build_cloudflare_oauth_state(
     *,
     workspace_id: int,
     return_to: str = "/settings",
+    scope_profile: Optional[str] = None,
 ) -> str:
     """Return a signed, short-lived state token for Cloudflare OAuth."""
     now = datetime.now(timezone.utc)
+    normalized_profile = normalize_cloudflare_scope_profile(scope_profile)
     token = jwt.encode(
         {
             "workspace_id": int(workspace_id),
             "return_to": _safe_return_to(return_to),
+            "scope_profile": normalized_profile,
             "iat": now,
             "exp": now + _STATE_TTL,
         },
@@ -98,6 +165,7 @@ def decode_cloudflare_oauth_state(state_value: str) -> Dict[str, Any]:
         return {
             "workspace_id": int(payload["workspace_id"]),
             "return_to": _safe_return_to(str(payload.get("return_to") or "/settings")),
+            "scope_profile": normalize_cloudflare_scope_profile(payload.get("scope_profile")),
         }
     except (JWTError, ValueError, KeyError, TypeError) as exc:
         raise LookupError("Invalid Cloudflare OAuth state.") from exc
@@ -107,20 +175,28 @@ def build_cloudflare_authorization_url(
     *,
     redirect_uri: str,
     state: str,
+    scope_profile: Optional[str] = None,
 ) -> Dict[str, str]:
     """Return the Cloudflare authorization URL and request metadata."""
     config = get_cloudflare_oauth_config()
+    normalized_profile = normalize_cloudflare_scope_profile(scope_profile)
+    scopes = (
+        config.scopes
+        if get_settings().CLOUDFLARE_OAUTH_SCOPES
+        else cloudflare_scopes_for_profile(normalized_profile)
+    )
     params = {
         "client_id": config.client_id,
         "response_type": "code",
         "redirect_uri": redirect_uri,
-        "scope": config.scopes,
+        "scope": scopes,
         "state": state,
     }
     return {
         "authorization_url": f"{CLOUDFLARE_AUTHORIZATION_URL}?{urlencode(params)}",
         "redirect_uri": redirect_uri,
-        "scopes": config.scopes,
+        "scopes": scopes,
+        "scope_profile": normalized_profile,
     }
 
 
@@ -196,12 +272,22 @@ def _upsert_setting(
 def persist_cloudflare_oauth_tokens(
     db: Session,
     token_data: Dict[str, Any],
+    *,
+    scope_profile: Optional[str] = None,
 ) -> None:
     """Persist the Cloudflare OAuth access token as the active provider token."""
     access_token = str(token_data.get("access_token") or "").strip()
     if not access_token:
         raise LookupError("Cloudflare OAuth did not return an access token.")
-    scope = str(token_data.get("scope") or get_cloudflare_oauth_config().scopes)
+    normalized_profile = normalize_cloudflare_scope_profile(scope_profile)
+    scope = str(
+        token_data.get("scope")
+        or (
+            get_cloudflare_oauth_config().scopes
+            if get_settings().CLOUDFLARE_OAUTH_SCOPES
+            else cloudflare_scopes_for_profile(normalized_profile)
+        )
+    )
     _upsert_setting(
         db,
         key="cloudflare.api_token",
@@ -219,6 +305,12 @@ def persist_cloudflare_oauth_tokens(
         key="cloudflare.oauth_scopes",
         value=scope,
         description="Granted Cloudflare OAuth scopes",
+    )
+    _upsert_setting(
+        db,
+        key="cloudflare.oauth_scope_profile",
+        value=normalized_profile,
+        description="Requested Cloudflare OAuth rights profile",
     )
     _upsert_setting(
         db,

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -30,6 +30,8 @@ function settingsApp() {
             connected: false,
             auth_mode: null,
             scopes: null,
+            scope_profile: 'read_only',
+            scope_profiles: [],
             connected_at: null,
         },
         cfZones: [],
@@ -44,6 +46,12 @@ function settingsApp() {
         disablingWebhookId: null,
         processingWebhooks: false,
         loadingWebhookDeliveries: false,
+        loadingAIProfiles: false,
+        testingAIConnection: false,
+        aiProviderProfiles: [],
+        aiConnectionResult: null,
+        aiModels: [],
+        showAIKey: false,
         webhooks: [],
         webhookDeliveries: [],
         webhookEventTypes: [],
@@ -91,6 +99,7 @@ function settingsApp() {
                 await this.loadWebhookDeliveries(false);
                 await this.loadCloudflareOAuthStatus(false);
                 await this.loadDNSProviders(false);
+                await this.loadAIProviderProfiles(false);
             } catch (err) {
                 this.showFlash('Error loading settings: ' + err.message, false);
             }
@@ -148,6 +157,98 @@ function settingsApp() {
                 this.showFlash('Error saving automation settings: ' + err.message, false);
             } finally {
                 this.saving = false;
+            }
+        },
+
+        aiProviderProfile(provider = null) {
+            const selected = String(provider || this.s['ai.provider'] || 'template').replaceAll('-', '_');
+            return (this.aiProviderProfiles || []).find(profile => profile.id === selected)
+                || this.aiProviderProfiles[0]
+                || { id: 'template', name: 'Offline template', description: '', requires_api_key: false, requires_base_url: false };
+        },
+
+        aiProviderNeedsApiKey() {
+            return Boolean(this.aiProviderProfile().requires_api_key);
+        },
+
+        aiProviderNeedsBaseUrl() {
+            return Boolean(this.aiProviderProfile().requires_base_url);
+        },
+
+        async loadAIProviderProfiles(showMessage = false) {
+            this.loadingAIProfiles = true;
+            try {
+                const res = await fetch('/api/v1/settings/ai/provider-profiles', {
+                    headers: this.apiHeaders(),
+                });
+                const data = await res.json().catch(() => ([]));
+                if (!res.ok) {
+                    if (showMessage) {
+                        this.showFlash('AI provider profiles failed: ' + (data.detail || res.statusText), false);
+                    }
+                    return;
+                }
+                this.aiProviderProfiles = Array.isArray(data) ? data : [];
+                const profile = this.aiProviderProfile();
+                if (!this.s['ai.provider']) {
+                    this.s['ai.provider'] = profile.id || 'template';
+                }
+                if (!this.s['ai.remote_base_url'] && profile.default_base_url) {
+                    this.s['ai.remote_base_url'] = profile.default_base_url;
+                }
+            } catch (err) {
+                if (showMessage) {
+                    this.showFlash('Error loading AI provider profiles: ' + err.message, false);
+                }
+            } finally {
+                this.loadingAIProfiles = false;
+            }
+        },
+
+        onAIProviderChanged() {
+            const profile = this.aiProviderProfile();
+            this.aiConnectionResult = null;
+            this.aiModels = [];
+            if (profile.default_base_url && !this.s['ai.remote_base_url']) {
+                this.s['ai.remote_base_url'] = profile.default_base_url;
+            }
+            if (profile.default_model && !this.s['ai.model']) {
+                this.s['ai.model'] = profile.default_model;
+            }
+        },
+
+        async testAIConnection() {
+            this.testingAIConnection = true;
+            this.aiConnectionResult = null;
+            try {
+                const res = await fetch('/api/v1/settings/ai/test', {
+                    method: 'POST',
+                    headers: this.apiHeaders(),
+                    body: JSON.stringify({
+                        provider: this.s['ai.provider'] || 'template',
+                        base_url: this.s['ai.remote_base_url'] || '',
+                        api_key: this.s['ai.api_key'] || '',
+                        model: this.s['ai.model'] || '',
+                    }),
+                });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok) {
+                    const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                    this.aiConnectionResult = { success: false, message: detail || res.statusText };
+                    this.showFlash('AI connection failed: ' + this.aiConnectionResult.message, false);
+                    return;
+                }
+                this.aiConnectionResult = data;
+                this.aiModels = data.models || [];
+                if (!this.s['ai.model'] && data.selected_model) {
+                    this.s['ai.model'] = data.selected_model;
+                }
+                this.showFlash(data.message || 'AI connection succeeded.', true);
+            } catch (err) {
+                this.aiConnectionResult = { success: false, message: err.message };
+                this.showFlash('Error testing AI connection: ' + err.message, false);
+            } finally {
+                this.testingAIConnection = false;
             }
         },
 
@@ -468,6 +569,9 @@ function settingsApp() {
                     return;
                 }
                 this.cfOAuthStatus = data;
+                if (!this.s['cloudflare.oauth_scope_profile']) {
+                    this.s['cloudflare.oauth_scope_profile'] = data.scope_profile || 'read_only';
+                }
             } catch (err) {
                 if (showMessage) {
                     this.showFlash('Error loading Cloudflare status: ' + err.message, false);
@@ -478,7 +582,8 @@ function settingsApp() {
         async connectCloudflare() {
             this.connectingCloudflare = true;
             try {
-                const res = await fetch('/api/v1/domains/cloudflare/oauth/authorize-url?return_to=/settings', {
+                const profile = encodeURIComponent(this.s['cloudflare.oauth_scope_profile'] || 'read_only');
+                const res = await fetch(`/api/v1/domains/cloudflare/oauth/authorize-url?return_to=/settings&scope_profile=${profile}`, {
                     headers: this.workspaceHeaders(),
                 });
                 const data = await res.json().catch(() => ({}));

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -179,6 +179,19 @@
                                 <span x-show="cfOAuthStatus.oauth_configured && !cfOAuthStatus.connected">Ready to connect with read-only zone and DNS access.</span>
                                 <span x-show="!cfOAuthStatus.oauth_configured">Configure Cloudflare OAuth client credentials on the server to enable one-click connect.</span>
                             </p>
+                            <div class="mt-3 grid gap-2 sm:grid-cols-[minmax(0,18rem)_minmax(0,1fr)] sm:items-start">
+                                <select x-model="s['cloudflare.oauth_scope_profile']"
+                                    class="select select-sm select-bordered w-full">
+                                    <template x-for="profile in cfOAuthStatus.scope_profiles || []" :key="profile.id">
+                                        <option :value="profile.id" x-text="profile.name"></option>
+                                    </template>
+                                </select>
+                                <div class="text-xs text-[#5f5c78]">
+                                    <p x-text="(cfOAuthStatus.scope_profiles || []).find(profile => profile.id === (s['cloudflare.oauth_scope_profile'] || cfOAuthStatus.scope_profile || 'read_only'))?.description || 'Choose how much Cloudflare access DMARQ should request.'"></p>
+                                    <p class="mt-1 text-warning" x-show="(cfOAuthStatus.scope_profiles || []).find(profile => profile.id === (s['cloudflare.oauth_scope_profile'] || cfOAuthStatus.scope_profile || 'read_only'))?.warning"
+                                        x-text="(cfOAuthStatus.scope_profiles || []).find(profile => profile.id === (s['cloudflare.oauth_scope_profile'] || cfOAuthStatus.scope_profile || 'read_only'))?.warning"></p>
+                                </div>
+                            </div>
                             <p class="mt-1 text-xs text-[#5f5c78]" x-show="cfOAuthStatus.scopes">
                                 Granted scopes: <span class="font-mono" x-text="cfOAuthStatus.scopes"></span>
                             </p>
@@ -1005,15 +1018,29 @@
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div class="form-control w-full">
                         <label class="label"><span class="label-text font-medium">Provider</span></label>
-                        <select x-model="s['ai.provider']" class="input input-bordered w-full">
-                            <option value="template">Template</option>
-                            <option value="local">Local</option>
-                            <option value="remote">Remote</option>
+                        <select x-model="s['ai.provider']"
+                            @change="onAIProviderChanged()"
+                            class="input input-bordered w-full">
+                            <template x-for="profile in aiProviderProfiles" :key="profile.id">
+                                <option :value="profile.id" x-text="profile.name"></option>
+                            </template>
                         </select>
+                        <label class="label">
+                            <span class="label-text-alt text-muted-foreground" x-text="aiProviderProfile().description"></span>
+                        </label>
                     </div>
                     <div class="form-control w-full">
                         <label class="label"><span class="label-text font-medium">Model</span></label>
-                        <input type="text" x-model="s['ai.model']" class="input input-bordered w-full" placeholder="Optional model name" />
+                        <template x-if="aiModels.length">
+                            <select x-model="s['ai.model']" class="input input-bordered w-full">
+                                <template x-for="model in aiModels" :key="model">
+                                    <option :value="model" x-text="model"></option>
+                                </template>
+                            </select>
+                        </template>
+                        <template x-if="!aiModels.length">
+                            <input type="text" x-model="s['ai.model']" class="input input-bordered w-full" placeholder="Optional model name" />
+                        </template>
                     </div>
                     <div class="form-control w-full">
                         <label class="label"><span class="label-text font-medium">Redaction</span></label>
@@ -1023,10 +1050,43 @@
                         </select>
                     </div>
                 </div>
-                <div class="form-control w-full">
-                    <label class="label"><span class="label-text font-medium">Remote Base URL</span></label>
-                    <input type="url" x-model="s['ai.remote_base_url']" class="input input-bordered w-full" placeholder="https://provider.example/v1" />
-                    <label class="label"><span class="label-text-alt text-muted-foreground">Credentials are not stored here; inject provider secrets through the deployment environment.</span></label>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="form-control w-full">
+                        <label class="label">
+                            <span class="label-text font-medium">Provider Base URL</span>
+                            <span class="label-text-alt" x-show="aiProviderNeedsBaseUrl()">Required</span>
+                        </label>
+                        <input type="url" x-model="s['ai.remote_base_url']" class="input input-bordered w-full" placeholder="https://provider.example/v1" />
+                    </div>
+                    <div class="form-control w-full">
+                        <label class="label">
+                            <span class="label-text font-medium">API Key</span>
+                            <span class="label-text-alt" x-show="aiProviderNeedsApiKey()">Required</span>
+                        </label>
+                        <div class="relative">
+                            <input :type="showAIKey ? 'text' : 'password'"
+                                x-model="s['ai.api_key']"
+                                class="input input-bordered w-full pr-10"
+                                placeholder="Stored encrypted; never shown again" />
+                            <button type="button"
+                                class="absolute right-2 top-3 text-muted-foreground hover:text-foreground"
+                                @click="showAIKey = !showAIKey">
+                                <svg x-show="!showAIKey" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>
+                                <svg x-show="showAIKey" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line></svg>
+                            </button>
+                        </div>
+                        <label class="label"><span class="label-text-alt text-muted-foreground">For self-hosting, environment-injected credentials still work; this field is for managed settings.</span></label>
+                    </div>
+                </div>
+                <div class="rounded-lg border border-border p-3" x-show="aiConnectionResult">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <p class="text-sm font-medium" x-text="aiConnectionResult?.success ? 'Connection OK' : 'Connection failed'"></p>
+                            <p class="text-sm text-muted-foreground" x-text="aiConnectionResult?.message"></p>
+                        </div>
+                        <span class="badge" :class="aiConnectionResult?.success ? 'badge-success' : 'badge-error'" x-text="aiConnectionResult?.provider || 'AI'"></span>
+                    </div>
+                    <p class="mt-2 text-xs text-muted-foreground" x-show="aiModels.length" x-text="`${aiModels.length} model${aiModels.length === 1 ? '' : 's'} discovered.`"></p>
                 </div>
                 <div class="form-control">
                     <label class="label cursor-pointer justify-start gap-3">
@@ -1037,7 +1097,14 @@
                         <span class="label-text font-medium">Allow human-confirmed action proposals</span>
                     </label>
                 </div>
-                <div class="flex justify-end">
+                <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                    <button type="button" class="btn btn-outline btn-md" :disabled="testingAIConnection"
+                        @click="testAIConnection()">
+                        <template x-if="!testingAIConnection">
+                            <span>Test Connection</span>
+                        </template>
+                        <template x-if="testingAIConnection"><span class="loading loading-spinner loading-xs mr-2"></span></template>
+                    </button>
                     <button type="submit" class="btn btn-default btn-md" :disabled="saving">
                         <template x-if="!saving">
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -5,6 +5,7 @@ import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -94,6 +95,11 @@ def test_ai_provider_profiles_are_exposed_to_settings(authed_client: TestClient)
     assert profiles["litellm"]["requires_base_url"] is True
 
 
+def test_ai_setting_helpers_use_safe_defaults(db_session: Session):
+    assert settings_endpoint._setting_plain_or_default(db_session, "missing.setting") == ""
+    assert settings_endpoint._normalize_ai_base_url("openai", "", {}) == "https://api.openai.com/v1"
+
+
 def test_ai_connection_template_profile_needs_no_secret(authed_client: TestClient):
     response = authed_client.post(
         "/api/v1/settings/ai/test",
@@ -115,6 +121,68 @@ def test_ai_connection_requires_key_for_remote_provider(authed_client: TestClien
     assert "API key" in response.json()["detail"]
 
 
+def test_ai_connection_uses_openai_default_base_url(authed_client: TestClient):
+    model_fetch = AsyncMock(return_value=["gpt-4.1-mini"])
+
+    with patch.object(settings_endpoint, "_fetch_openai_compatible_models", model_fetch):
+        response = authed_client.post(
+            "/api/v1/settings/ai/test",
+            json={"provider": "openai", "api_key": "sk-test"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["selected_model"] == "gpt-4.1-mini"
+    model_fetch.assert_awaited_once_with(
+        base_url="https://api.openai.com/v1",
+        api_key="sk-test",
+    )
+
+
+def test_ai_connection_requires_base_url_for_litellm(authed_client: TestClient):
+    response = authed_client.post(
+        "/api/v1/settings/ai/test",
+        json={"provider": "litellm", "api_key": "sk-test"},
+    )
+
+    assert response.status_code == 400
+    assert "base URL" in response.json()["detail"]
+
+
+def test_ai_connection_reports_provider_http_status(authed_client: TestClient):
+    request = httpx.Request("GET", "https://api.openai.com/v1/models")
+    response = httpx.Response(401, request=request)
+    model_fetch = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "unauthorized",
+            request=request,
+            response=response,
+        )
+    )
+
+    with patch.object(settings_endpoint, "_fetch_openai_compatible_models", model_fetch):
+        result = authed_client.post(
+            "/api/v1/settings/ai/test",
+            json={"provider": "openai", "api_key": "sk-test"},
+        )
+
+    assert result.status_code == 400
+    assert "HTTP 401" in result.json()["detail"]
+
+
+def test_ai_connection_reports_network_failure(authed_client: TestClient):
+    request = httpx.Request("GET", "https://api.openai.com/v1/models")
+    model_fetch = AsyncMock(side_effect=httpx.RequestError("timeout", request=request))
+
+    with patch.object(settings_endpoint, "_fetch_openai_compatible_models", model_fetch):
+        response = authed_client.post(
+            "/api/v1/settings/ai/test",
+            json={"provider": "openai", "api_key": "sk-test"},
+        )
+
+    assert response.status_code == 400
+    assert "connection test failed" in response.json()["detail"]
+
+
 @pytest.mark.parametrize(
     "base_url",
     [
@@ -134,6 +202,72 @@ def test_ai_connection_rejects_unsafe_model_discovery_urls(
 
     assert response.status_code == 400
     assert "AI base URL" in response.json()["detail"]
+
+
+def test_ai_connection_rejects_invalid_model_discovery_url():
+    with pytest.raises(Exception) as exc_info:
+        settings_endpoint._validated_ai_base_url("not-a-url")
+
+    assert "absolute HTTP(S) URL" in str(exc_info.value)
+
+
+def test_ai_connection_rejects_unresolvable_model_discovery_url(monkeypatch):
+    def fail_lookup(*_args, **_kwargs):
+        raise settings_endpoint.socket.gaierror("not found")
+
+    monkeypatch.setattr(settings_endpoint.socket, "getaddrinfo", fail_lookup)
+
+    with pytest.raises(Exception) as exc_info:
+        settings_endpoint._validated_ai_base_url("https://missing-ai.example/v1")
+
+    assert "could not be resolved" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_fetch_openai_compatible_models_sorts_unique_models(monkeypatch):
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "data": [
+                    {"id": "z-model"},
+                    {"id": ""},
+                    {"id": "a-model"},
+                    {"id": "z-model"},
+                ]
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, *, base_url: str, timeout: int):
+            assert base_url == "https://ai.example/v1"
+            assert timeout == 10
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, path: str, *, headers):
+            assert path == "/models"
+            assert headers == {"Authorization": "Bearer sk-test"}
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        settings_endpoint.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [(None, None, None, None, ("8.8.8.8", 443))],
+    )
+    monkeypatch.setattr(settings_endpoint.httpx, "AsyncClient", FakeAsyncClient)
+
+    models = await settings_endpoint._fetch_openai_compatible_models(
+        base_url="https://ai.example/v1/",
+        api_key="sk-test",
+    )
+
+    assert models == ["a-model", "z-model"]
 
 
 def test_ai_connection_uses_saved_redacted_secret_and_discovers_models(
@@ -230,6 +364,48 @@ def test_ai_summary_returns_not_found_for_unknown_domain(
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Domain not found"
+
+
+def test_ai_evidence_summary_handles_no_observed_volume(monkeypatch, db_session: Session):
+    context = {
+        "domain": DOMAIN,
+        "summary": {
+            "total_messages": 0,
+            "failed_messages": 0,
+            "compliance_rate": 0.0,
+        },
+        "evidence": [
+            {"label": "Domain", "value": DOMAIN, "href": f"/domains/{DOMAIN}"},
+        ],
+        "top_sources": [],
+        "config": {"provider": "template"},
+    }
+
+    monkeypatch.setattr(ai_assistance, "build_safe_context", lambda *_args, **_kwargs: context)
+
+    summary = ai_assistance.build_evidence_summary(db_session, DOMAIN)
+
+    assert summary["summary"]["headline"] == "No DMARC aggregate volume has been observed yet."
+    assert summary["recommendations"][0]["title"] == "Confirm report ingestion"
+
+
+def test_ai_headline_describes_healthy_and_mostly_healthy_posture():
+    healthy = {"summary": {"total_messages": 100, "failed_messages": 0, "compliance_rate": 100.0}}
+    mostly_healthy = {
+        "summary": {"total_messages": 100, "failed_messages": 5, "compliance_rate": 95.0}
+    }
+
+    assert (
+        ai_assistance._headline_for_context(healthy) == "Observed DMARC traffic is passing cleanly."
+    )
+    assert (
+        ai_assistance._headline_for_context(mostly_healthy)
+        == "DMARC posture is mostly healthy, with a small failure set to review."
+    )
+
+
+def test_ai_domain_selectors_from_db_returns_empty_for_unknown_domain(db_session: Session):
+    assert ai_assistance._domain_selectors_from_db(db_session, "missing.example") == []
 
 
 def test_ai_remediation_plan_uses_template_and_cache(

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -11,6 +11,8 @@ from sqlalchemy.orm import Session
 
 from app.api.api_v1.endpoints import ai as ai_endpoint
 from app.api.api_v1.endpoints import mcp as mcp_endpoint
+from app.api.api_v1.endpoints import settings as settings_endpoint
+from app.core.credential_encryption import decrypt_secret, is_encrypted_secret
 from app.models.alert import AlertHistory
 from app.models.domain import Domain
 from app.models.organization import Entitlement, Organization
@@ -77,8 +79,101 @@ def test_ai_settings_are_seeded(authed_client: TestClient):
     keys = {row["key"] for row in response.json()}
     assert "ai.enabled" in keys
     assert "ai.provider" in keys
+    assert "ai.api_key" in keys
     assert "ai.action_tools_enabled" in keys
     assert "mcp.enabled" in keys
+
+
+def test_ai_provider_profiles_are_exposed_to_settings(authed_client: TestClient):
+    response = authed_client.get("/api/v1/settings/ai/provider-profiles")
+
+    assert response.status_code == 200
+    profiles = {item["id"]: item for item in response.json()}
+    assert {"template", "openai", "litellm", "openai_compatible"}.issubset(profiles)
+    assert profiles["openai"]["requires_api_key"] is True
+    assert profiles["litellm"]["requires_base_url"] is True
+
+
+def test_ai_connection_template_profile_needs_no_secret(authed_client: TestClient):
+    response = authed_client.post(
+        "/api/v1/settings/ai/test",
+        json={"provider": "template"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert response.json()["provider"] == "template"
+
+
+def test_ai_connection_requires_key_for_remote_provider(authed_client: TestClient):
+    response = authed_client.post(
+        "/api/v1/settings/ai/test",
+        json={"provider": "openai", "base_url": "https://api.openai.com/v1"},
+    )
+
+    assert response.status_code == 400
+    assert "API key" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://127.0.0.1:4000/v1",
+        "http://localhost:4000/v1",
+        "http://user:pass@example.com/v1",
+    ],
+)
+def test_ai_connection_rejects_unsafe_model_discovery_urls(
+    authed_client: TestClient,
+    base_url: str,
+):
+    response = authed_client.post(
+        "/api/v1/settings/ai/test",
+        json={"provider": "litellm", "base_url": base_url, "api_key": "sk-test"},
+    )
+
+    assert response.status_code == 400
+    assert "AI base URL" in response.json()["detail"]
+
+
+def test_ai_connection_uses_saved_redacted_secret_and_discovers_models(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    save_response = authed_client.post(
+        "/api/v1/settings/bulk",
+        json={
+            "settings": {
+                "ai.provider": "openai",
+                "ai.remote_base_url": "https://api.openai.com/v1",
+                "ai.api_key": "sk-test",
+            }
+        },
+    )
+    assert save_response.status_code == 200
+    row = db_session.query(Setting).filter(Setting.key == "ai.api_key").one()
+    assert is_encrypted_secret(row.value)
+    assert decrypt_secret(row.value) == "sk-test"
+
+    model_fetch = AsyncMock(return_value=["gpt-4.1-mini", "gpt-4.1"])
+    with patch.object(settings_endpoint, "_fetch_openai_compatible_models", model_fetch):
+        response = authed_client.post(
+            "/api/v1/settings/ai/test",
+            json={
+                "provider": "openai",
+                "base_url": "https://api.openai.com/v1",
+                "api_key": "**redacted**",
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["models"] == ["gpt-4.1-mini", "gpt-4.1"]
+    assert data["selected_model"] == "gpt-4.1-mini"
+    model_fetch.assert_awaited_once_with(
+        base_url="https://api.openai.com/v1",
+        api_key="sk-test",
+    )
 
 
 def test_ai_summary_requires_explicit_opt_in(authed_client: TestClient):

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1962,10 +1962,12 @@ def test_cloudflare_oauth_state_round_trips_and_sanitizes_return_to(
     assert cloudflare_oauth.decode_cloudflare_oauth_state(state) == {
         "workspace_id": 42,
         "return_to": "/settings",
+        "scope_profile": "read_only",
     }
     assert cloudflare_oauth.decode_cloudflare_oauth_state(scheme_relative_state) == {
         "workspace_id": 42,
         "return_to": "/settings",
+        "scope_profile": "read_only",
     }
     with pytest.raises(LookupError, match="Invalid Cloudflare OAuth state"):
         cloudflare_oauth.decode_cloudflare_oauth_state("not-a-valid-token")
@@ -1987,6 +1989,22 @@ def test_cloudflare_oauth_authorization_url_uses_configured_scopes(
     assert "client_id=client-id" in result["authorization_url"]
     assert "scope=zone.read" in result["authorization_url"]
     assert "state=state-token" in result["authorization_url"]
+
+
+def test_cloudflare_oauth_authorization_url_uses_profile_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_empty_scope_settings)
+
+    result = cloudflare_oauth.build_cloudflare_authorization_url(
+        redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+        state="state-token",
+        scope_profile="full_dns_repair",
+    )
+
+    assert result["scope_profile"] == "full_dns_repair"
+    assert result["scopes"] == "zone.read dns.read dns.write"
+    assert "scope=zone.read+dns.read+dns.write" in result["authorization_url"]
 
 
 def test_cloudflare_oauth_config_defaults_to_read_scopes(
@@ -2237,6 +2255,7 @@ def test_persist_cloudflare_oauth_tokens_stores_encrypted_provider_token(
                     "cloudflare.api_token",
                     "cloudflare.auth_mode",
                     "cloudflare.oauth_scopes",
+                    "cloudflare.oauth_scope_profile",
                     "cloudflare.oauth_connected_at",
                 ]
             )
@@ -2247,6 +2266,7 @@ def test_persist_cloudflare_oauth_tokens_stores_encrypted_provider_token(
     assert settings["cloudflare.api_token"] != "provider-token"
     assert settings["cloudflare.auth_mode"] == "oauth"
     assert settings["cloudflare.oauth_scopes"] == "zone.read dns.read"
+    assert settings["cloudflare.oauth_scope_profile"] == "read_only"
     assert settings["cloudflare.oauth_connected_at"]
 
 
@@ -2292,6 +2312,7 @@ def test_persist_cloudflare_oauth_tokens_updates_existing_settings(
     cloudflare_oauth.persist_cloudflare_oauth_tokens(
         db_session,
         {"access_token": "provider-token", "scope": "zone.read"},
+        scope_profile="read_only_radar",
     )
 
     auth_mode = db_session.query(Setting).filter(Setting.key == "cloudflare.auth_mode").one()
@@ -2299,6 +2320,10 @@ def test_persist_cloudflare_oauth_tokens_updates_existing_settings(
     assert auth_mode.category == "cloudflare"
     assert auth_mode.value_type == "string"
     assert auth_mode.description == "Cloudflare connector authentication mode"
+    scope_profile = (
+        db_session.query(Setting).filter(Setting.key == "cloudflare.oauth_scope_profile").one()
+    )
+    assert scope_profile.value == "read_only_radar"
 
 
 def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(
@@ -2315,6 +2340,7 @@ def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(
                 "authorization_url": "https://dash.cloudflare.com/oauth2/auth?state=state-token",
                 "redirect_uri": "https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
                 "scopes": "zone.read dns.read",
+                "scope_profile": "read_only",
             },
         ) as authorize_mock,
     ):
@@ -2327,8 +2353,11 @@ def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(
     data = response.json()
     assert data["authorization_url"].startswith("https://dash.cloudflare.com/oauth2/auth")
     assert data["scopes"] == "zone.read dns.read"
+    assert data["scope_profile"] == "read_only"
     state_mock.assert_called_once()
     authorize_mock.assert_called_once()
+    assert state_mock.call_args.kwargs["scope_profile"] == "read_only"
+    assert authorize_mock.call_args.kwargs["scope_profile"] == "read_only"
     assert authorize_mock.call_args.kwargs["redirect_uri"] == (
         "https://app.example.test/api/v1/domains/cloudflare/oauth/callback"
     )
@@ -2381,7 +2410,11 @@ def test_cloudflare_oauth_callback_stores_token_and_redirects(
     with (
         patch(
             "app.api.api_v1.endpoints.domains.decode_cloudflare_oauth_state",
-            return_value={"workspace_id": workspace.id, "return_to": "/settings/cloudflare"},
+            return_value={
+                "workspace_id": workspace.id,
+                "return_to": "/settings/cloudflare",
+                "scope_profile": "full_dns_repair",
+            },
         ) as decode_mock,
         patch(
             "app.api.api_v1.endpoints.domains.exchange_cloudflare_oauth_code",
@@ -2402,7 +2435,11 @@ def test_cloudflare_oauth_callback_stores_token_and_redirects(
         code="oauth-code",
         redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
     )
-    persist_mock.assert_called_once_with(db_session, {"access_token": "provider-token"})
+    persist_mock.assert_called_once_with(
+        db_session,
+        {"access_token": "provider-token"},
+        scope_profile="full_dns_repair",
+    )
 
 
 def test_cloudflare_oauth_status_endpoint_reports_connected_token(
@@ -2433,6 +2470,14 @@ def test_cloudflare_oauth_status_endpoint_reports_connected_token(
             value_type="string",
         )
     )
+    db_session.add(
+        Setting(
+            key="cloudflare.oauth_scope_profile",
+            value="read_only_radar",
+            category="cloudflare",
+            value_type="string",
+        )
+    )
     db_session.commit()
 
     with patch("app.api.api_v1.endpoints.domains.cloudflare_oauth_configured", return_value=True):
@@ -2444,6 +2489,8 @@ def test_cloudflare_oauth_status_endpoint_reports_connected_token(
         "connected": True,
         "auth_mode": "oauth",
         "scopes": "zone.read dns.read",
+        "scope_profile": "read_only_radar",
+        "scope_profiles": cloudflare_oauth.cloudflare_scope_profile_metadata(),
         "connected_at": None,
     }
 

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1971,6 +1971,8 @@ def test_cloudflare_oauth_state_round_trips_and_sanitizes_return_to(
     }
     with pytest.raises(LookupError, match="Invalid Cloudflare OAuth state"):
         cloudflare_oauth.decode_cloudflare_oauth_state("not-a-valid-token")
+    with pytest.raises(LookupError, match="Invalid Cloudflare OAuth state"):
+        cloudflare_oauth.decode_cloudflare_oauth_state("")
 
 
 def test_cloudflare_oauth_authorization_url_uses_configured_scopes(


### PR DESCRIPTION
Closes #526.

## What changed
- Added settings-managed AI provider profiles for offline templates, OpenAI direct, LiteLLM, and OpenAI-compatible endpoints.
- Added encrypted `ai.api_key` storage, a safe connection-test endpoint, and model discovery through OpenAI-compatible `/models`.
- Added Cloudflare OAuth rights profiles for read-only discovery, read-only plus Radar context, and full DNS repair.
- Updated the settings UI with AI key entry, connection testing, model dropdowns, and Cloudflare scope selection.

## Validation
- `python -m compileall backend/app/services/cloudflare_oauth.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/settings.py backend/app/services/ai_assistance.py`
- `black --check`, `isort --check-only`, and `flake8` on touched Python files
- `node --check backend/app/static/js/settings-page.js`
- `pytest backend/app/tests/test_settings.py backend/app/tests/test_ai_mcp.py backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security_extra.py -q`
- `pytest backend/app/tests -q` -> 1640 passed locally before the final rebase; post-rebase focused suite passed again.