### PR TITLE
[codex] Improve domain page load performance

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2942,6 +2942,74 @@ def _record_health_snapshot_from_posture(
     )
 
 
+def _with_dns_summary_metadata(
+    result: DomainDNSResult,
+    *,
+    cached: bool,
+    checked_at: Optional[datetime],
+    pending: bool,
+) -> DomainDNSResult:
+    result.cached = cached  # type: ignore[attr-defined]
+    result.checked_at = checked_at  # type: ignore[attr-defined]
+    result.pending = pending  # type: ignore[attr-defined]
+    return result
+
+
+def _pending_dns_summary_result() -> DomainDNSResult:
+    return _with_dns_summary_metadata(
+        DomainDNSResult(),
+        cached=False,
+        checked_at=None,
+        pending=True,
+    )
+
+
+async def _resolve_summary_dns_result(
+    db: Session,
+    provider: Any,
+    domain_name: str,
+    selectors: List[str],
+    *,
+    refresh: bool,
+) -> DomainDNSResult:
+    if not refresh:
+        cached_result, cached, checked_at = get_cached_domain_dns_result(
+            db,
+            provider,
+            domain_name,
+            selectors=selectors,
+        )
+        if cached_result is not None:
+            return _with_dns_summary_metadata(
+                cached_result,
+                cached=cached,
+                checked_at=checked_at,
+                pending=False,
+            )
+        return _pending_dns_summary_result()
+
+    try:
+        result, cached, checked_at = await asyncio.wait_for(
+            resolve_domain_dns_cached(
+                db,
+                provider,
+                domain_name,
+                selectors=selectors,
+                refresh=refresh,
+            ),
+            timeout=10.0,
+        )
+        return _with_dns_summary_metadata(
+            result,
+            cached=cached,
+            checked_at=checked_at,
+            pending=False,
+        )
+    except (asyncio.TimeoutError, LookupError, OSError) as exc:
+        logger.warning("DNS check failed for %s: %s", domain_name, exc)
+        return DomainDNSResult()
+
+
 @router.get("/summary", response_model=DomainSummaryResponse)
 async def get_domains_summary(
     refresh: bool = Query(False, title="Refresh cached DNS results"),
@@ -2999,41 +3067,13 @@ async def get_domains_summary(
         else:
             report_selectors = report_selectors_by_domain.get(domain_name, [])
         combined = list(dict.fromkeys(manual_selectors + report_selectors))
-        if not refresh:
-            cached_result, cached, checked_at = get_cached_domain_dns_result(
-                db,
-                provider,
-                domain_name,
-                selectors=combined,
-            )
-            if cached_result is not None:
-                cached_result.cached = cached  # type: ignore[attr-defined]
-                cached_result.checked_at = checked_at  # type: ignore[attr-defined]
-                cached_result.pending = False  # type: ignore[attr-defined]
-                return cached_result
-            pending_result = DomainDNSResult()
-            pending_result.cached = False  # type: ignore[attr-defined]
-            pending_result.checked_at = None  # type: ignore[attr-defined]
-            pending_result.pending = True  # type: ignore[attr-defined]
-            return pending_result
-        try:
-            result, cached, checked_at = await asyncio.wait_for(
-                resolve_domain_dns_cached(
-                    db,
-                    provider,
-                    domain_name,
-                    selectors=combined,
-                    refresh=refresh,
-                ),
-                timeout=10.0,
-            )
-            result.cached = cached  # type: ignore[attr-defined]
-            result.checked_at = checked_at  # type: ignore[attr-defined]
-            result.pending = False  # type: ignore[attr-defined]
-            return result
-        except (asyncio.TimeoutError, LookupError, OSError) as exc:
-            logger.warning("DNS check failed for %s: %s", domain_name, exc)
-            return DomainDNSResult()
+        return await _resolve_summary_dns_result(
+            db,
+            provider,
+            domain_name,
+            combined,
+            refresh=refresh,
+        )
 
     dns_results = []
     for domain_name in domains:

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -45,7 +45,7 @@ from app.services.cloudflare_oauth import (
 )
 from app.services.dane import check_dane_cached
 from app.services.demo_data import DEMO_DAYS, build_demo_health_score_history
-from app.services.dns_cache import resolve_domain_dns_cached
+from app.services.dns_cache import get_cached_domain_dns_result, resolve_domain_dns_cached
 from app.services.dns_guidance import build_dns_guidance
 from app.services.dns_provider_connectors import (
     provider_connector_metadata,
@@ -2952,10 +2952,9 @@ async def get_domains_summary(
     """
     Get summary statistics for all domains, formatted for the dashboard.
 
-    Performs cached DNS lookups for each domain and includes the results
-    (DMARC/SPF/DKIM status and live DMARC policy) in the per-domain entries.
-    A per-domain timeout of 10 s prevents slow DNS responses from blocking the
-    page load.
+    Returns report and domain statistics quickly. By default DNS status is read
+    from cache only so the domain list is not blocked by live resolver calls.
+    Use refresh=true from the UI reload action to force live DNS recomputation.
     """
     selected_workspace_id = parse_selected_workspace_id(selected_workspace)
     workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
@@ -3000,6 +2999,23 @@ async def get_domains_summary(
         else:
             report_selectors = report_selectors_by_domain.get(domain_name, [])
         combined = list(dict.fromkeys(manual_selectors + report_selectors))
+        if not refresh:
+            cached_result, cached, checked_at = get_cached_domain_dns_result(
+                db,
+                provider,
+                domain_name,
+                selectors=combined,
+            )
+            if cached_result is not None:
+                cached_result.cached = cached  # type: ignore[attr-defined]
+                cached_result.checked_at = checked_at  # type: ignore[attr-defined]
+                cached_result.pending = False  # type: ignore[attr-defined]
+                return cached_result
+            pending_result = DomainDNSResult()
+            pending_result.cached = False  # type: ignore[attr-defined]
+            pending_result.checked_at = None  # type: ignore[attr-defined]
+            pending_result.pending = True  # type: ignore[attr-defined]
+            return pending_result
         try:
             result, cached, checked_at = await asyncio.wait_for(
                 resolve_domain_dns_cached(
@@ -3013,6 +3029,7 @@ async def get_domains_summary(
             )
             result.cached = cached  # type: ignore[attr-defined]
             result.checked_at = checked_at  # type: ignore[attr-defined]
+            result.pending = False  # type: ignore[attr-defined]
             return result
         except (asyncio.TimeoutError, LookupError, OSError) as exc:
             logger.warning("DNS check failed for %s: %s", domain_name, exc)
@@ -3041,6 +3058,7 @@ async def get_domains_summary(
         live_policy = extract_dmarc_policy(dns.dmarc_record)
         reported_policy = _normalize_reported_policy(summary.get("policy", {}))
         dmarc_policy = live_policy or reported_policy or "none"
+        dns_pending = bool(getattr(dns, "pending", False))
 
         # Format domain data for frontend
         domain_row = {
@@ -3058,6 +3076,7 @@ async def get_domains_summary(
             "dmarc_policy": dmarc_policy,
             "spf_status": dns.spf,
             "dkim_status": dns.dkim,
+            "dns_pending": dns_pending,
             "dns_cached": getattr(dns, "cached", False),
             "dns_checked_at": (
                 getattr(dns, "checked_at", None).isoformat()
@@ -3716,17 +3735,8 @@ async def get_domain_stats(
     Get detailed statistics for a specific domain
     """
     workspace = _authorized_domain_read_workspace(_auth, db)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
-    domains = _domain_names_for_summary(db, store, workspace)
-
-    if domain_id not in domains:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Domain not found",
-        )
-
-    summary = store.get_domain_summary(domain_id)
+    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
+    summary = store.get_domain_summary(domain_name)
     total_count = summary.get("total_count", 0)
     passed_count = summary.get("passed_count", 0)
     failed_count = total_count - passed_count
@@ -5182,17 +5192,10 @@ async def get_domain_reports(
     Get recent DMARC reports for a specific domain, along with compliance timeline
     """
     workspace = _authorized_domain_read_workspace(_auth, db)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
-
-    if not _domain_exists(db, store, domain_id, workspace):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Domain not found",
-        )
+    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
     # Get reports for this domain
-    reports = store.get_domain_reports(domain_id, limit=limit)
+    reports = store.get_domain_reports(domain_name, limit=limit)
 
     # Generate report entries
     report_entries = []
@@ -5214,7 +5217,7 @@ async def get_domain_reports(
         )
 
     # Build compliance timeline from actual report data
-    timeline = _build_compliance_timeline(store, domain_id)
+    timeline = _build_compliance_timeline(store, domain_name)
 
     return DomainReportsResponse(reports=report_entries, compliance_timeline=timeline)
 

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -8,7 +8,7 @@ import json
 import logging
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -156,7 +156,11 @@ async def resolve_domain_dns_cached(
             return cached_result, True, row.checked_at
 
     result = await _resolve_with_fallback(provider, domain, selectors=selectors)
-    if row and _has_dns_evidence(_result_from_json(row.result_json)) and not _has_dns_evidence(result):
+    if (
+        row
+        and _has_dns_evidence(_result_from_json(row.result_json))
+        and not _has_dns_evidence(result)
+    ):
         cached_result = _result_from_json(row.result_json)
         if _within_stale_evidence_grace(row, now):
             logger.warning(
@@ -200,3 +204,25 @@ async def resolve_domain_dns_cached(
 
     db.refresh(row)
     return result, False, row.checked_at
+
+
+def get_cached_domain_dns_result(
+    db: Session,
+    provider: BaseDNSProvider,
+    domain: str,
+    *,
+    selectors: List[str],
+) -> Tuple[Optional[DomainDNSResult], bool, Optional[datetime]]:
+    """Return the latest cached DNS result without performing network lookups."""
+    row = (
+        db.query(DNSCache)
+        .filter(
+            DNSCache.domain == domain,
+            DNSCache.provider == provider.__class__.__name__,
+            DNSCache.selectors_key == _selectors_key(selectors),
+        )
+        .first()
+    )
+    if row is None:
+        return None, False, None
+    return _result_from_json(row.result_json), True, row.checked_at

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -39,6 +39,8 @@ def _bounded(value: Any, *, lower: float = 0.0, upper: float = 100.0) -> float:
 
 def _effective_dmarc_policy(domain: Dict[str, Any]) -> str:
     """Return the DMARC policy used for scoring, distinct from endpoint fallbacks."""
+    if domain.get("dns_pending") and domain.get("dmarc_policy"):
+        return str(domain.get("dmarc_policy") or "none").lower()
     if not domain.get("dmarc_status"):
         return "missing"
     return str(domain.get("dmarc_policy") or "none").lower()
@@ -56,6 +58,8 @@ def _policy_factor(policy: Optional[str]) -> float:
 
 
 def _dns_factor(domain: Dict[str, Any]) -> float:
+    if domain.get("dns_pending"):
+        return 70.0
     checks = [
         bool(domain.get("dmarc_status")),
         bool(domain.get("spf_status")),
@@ -131,8 +135,21 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
     pass_rate = _bounded(domain.get("pass_rate"))
     policy = str(domain.get("dmarc_policy") or "missing").lower()
     actions: List[Dict[str, Any]] = []
+    dns_pending = bool(domain.get("dns_pending"))
 
-    if not domain.get("dmarc_status"):
+    if dns_pending:
+        actions.append(
+            _action(
+                action_type="dns_evidence_pending",
+                severity="info",
+                title="Refresh DNS evidence",
+                detail="DNS health has not been checked for this domain in the current cache.",
+                next_step="Open the domain or use Reload to fetch live DNS before making DNS decisions.",
+                score_impact=0,
+                domain=domain_name,
+            )
+        )
+    if not dns_pending and not domain.get("dmarc_status"):
         actions.append(
             _action(
                 action_type="missing_dmarc",
@@ -144,7 +161,7 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 domain=domain_name,
             )
         )
-    if not domain.get("spf_status"):
+    if not dns_pending and not domain.get("spf_status"):
         actions.append(
             _action(
                 action_type="missing_spf",
@@ -156,7 +173,7 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 domain=domain_name,
             )
         )
-    if not domain.get("dkim_status"):
+    if not dns_pending and not domain.get("dkim_status"):
         actions.append(
             _action(
                 action_type="missing_dkim",

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -44,6 +44,9 @@ function domainsApp() {
                     dmarc_policy: domain.dmarc_policy || 'Not configured',
                     spf_status: domain.spf_status ?? false,
                     dkim_status: domain.dkim_status ?? false,
+                    dns_pending: Boolean(domain.dns_pending),
+                    dns_cached: Boolean(domain.dns_cached),
+                    dns_checked_at: domain.dns_checked_at || null,
                     reports_count: domain.report_count,
                     emails_count: domain.total_emails,
                     compliance_rate: domain.pass_rate,
@@ -172,6 +175,21 @@ function domainsApp() {
             } finally {
                 this.saving = false;
             }
+        },
+
+        dnsStatusClass(domain, key) {
+            if (domain.dns_pending) return 'bg-gray-400';
+            return domain[key] ? 'bg-green-500' : 'bg-red-500';
+        },
+
+        dmarcStatusText(domain) {
+            if (domain.dns_pending) return 'Pending DNS refresh';
+            return domain.dmarc_policy || 'Not configured';
+        },
+
+        genericDnsStatusText(domain, key) {
+            if (domain.dns_pending) return 'Pending';
+            return domain[key] ? 'Configured' : 'Missing';
         },
     };
 }

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -82,22 +82,22 @@
                                 {% call td() %}
                                     <div class="flex items-center">
                                         <span class="w-2 h-2 rounded-full" 
-                                            :class="domain.dmarc_status ? 'bg-green-500' : 'bg-red-500'"></span>
-                                        <span class="ml-2" x-text="domain.dmarc_policy || 'Not configured'"></span>
+                                            :class="dnsStatusClass(domain, 'dmarc_status')"></span>
+                                        <span class="ml-2" x-text="dmarcStatusText(domain)"></span>
                                     </div>
                                 {% endcall %}
                                 {% call td() %}
                                     <div class="flex items-center">
                                         <span class="w-2 h-2 rounded-full"
-                                            :class="domain.spf_status ? 'bg-green-500' : 'bg-red-500'"></span>
-                                        <span class="ml-2" x-text="domain.spf_status ? 'Configured' : 'Missing'"></span>
+                                            :class="dnsStatusClass(domain, 'spf_status')"></span>
+                                        <span class="ml-2" x-text="genericDnsStatusText(domain, 'spf_status')"></span>
                                     </div>
                                 {% endcall %}
                                 {% call td() %}
                                     <div class="flex items-center">
                                         <span class="w-2 h-2 rounded-full"
-                                            :class="domain.dkim_status ? 'bg-green-500' : 'bg-red-500'"></span>
-                                        <span class="ml-2" x-text="domain.dkim_status ? 'Configured' : 'Missing'"></span>
+                                            :class="dnsStatusClass(domain, 'dkim_status')"></span>
+                                        <span class="ml-2" x-text="genericDnsStatusText(domain, 'dkim_status')"></span>
                                     </div>
                                 {% endcall %}
                                 {% call td("text-right") %}

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1576,6 +1576,24 @@ def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_sessio
     assert domain["dkim_status"] is False
 
 
+def test_summary_refresh_dns_exception_defaults_false(authed_client: TestClient, db_session):
+    """Resolver failures during explicit refresh should not block the summary."""
+    _persist_minimal_report(db_session)
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.resolve_domain_dns_cached",
+        new=AsyncMock(side_effect=LookupError("resolver unavailable")),
+    ):
+        response = authed_client.get("/api/v1/domains/summary?refresh=true")
+
+    assert response.status_code == 200
+    domain = response.json()["domains"][0]
+    assert domain["dmarc_status"] is False
+    assert domain["spf_status"] is False
+    assert domain["dkim_status"] is False
+    assert domain["dns_pending"] is False
+
+
 def test_summary_endpoint_uses_manual_selectors(authed_client: TestClient, db_session):
     """Manually configured selectors are forwarded by the summary endpoint."""
     _persist_minimal_report(db_session)

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1546,7 +1546,7 @@ def test_summary_includes_dns_fields(authed_client: TestClient, db_session):
     _persist_minimal_report(db_session)
 
     with _mock_dns():
-        response = authed_client.get("/api/v1/domains/summary")
+        response = authed_client.get("/api/v1/domains/summary?refresh=true")
 
     assert response.status_code == 200
     data = response.json()
@@ -1567,7 +1567,7 @@ def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_sessio
     empty_result = DomainDNSResult()
 
     with _mock_dns(result=empty_result):
-        response = authed_client.get("/api/v1/domains/summary")
+        response = authed_client.get("/api/v1/domains/summary?refresh=true")
 
     assert response.status_code == 200
     domain = response.json()["domains"][0]
@@ -1590,7 +1590,7 @@ def test_summary_endpoint_uses_manual_selectors(authed_client: TestClient, db_se
         "app.api.api_v1.endpoints.domains.get_default_provider",
         return_value=AsyncMock(check_domain=_fake_check_domain),
     ):
-        response = authed_client.get("/api/v1/domains/summary")
+        response = authed_client.get("/api/v1/domains/summary?refresh=true")
 
     assert response.status_code == 200
     assert "manualsel" in captured_selectors
@@ -1604,20 +1604,16 @@ def test_summary_endpoint_uses_database_aggregates_without_hydration(
 ):
     """Production summary reads persisted aggregates instead of rebuilding the report store."""
     _persist_minimal_report(db_session)
-    captured_selectors = []
 
     def fail_hydration(*args, **kwargs):
         raise AssertionError("summary should not hydrate the full report store")
 
-    async def _fake_check_domain(domain, selectors=None):
-        captured_selectors.extend(selectors or [])
-        return MOCK_DNS_RESULT
-
+    provider = AsyncMock(check_domain=AsyncMock(return_value=MOCK_DNS_RESULT))
     monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fail_hydration)
 
     with patch(
         "app.api.api_v1.endpoints.domains.get_default_provider",
-        return_value=AsyncMock(check_domain=_fake_check_domain),
+        return_value=provider,
     ):
         response = authed_client.get("/api/v1/domains/summary")
 
@@ -1627,7 +1623,8 @@ def test_summary_endpoint_uses_database_aggregates_without_hydration(
     assert data["total_emails"] == 5
     assert data["reports_processed"] == 1
     assert data["domains"][0]["pass_rate"] == 100.0
-    assert "google" in captured_selectors
+    assert data["domains"][0]["dns_pending"] is True
+    assert provider.check_domain.await_count == 0
 
 
 def test_summary_endpoint_refresh_bypasses_dns_cache(authed_client: TestClient, db_session):
@@ -1640,14 +1637,16 @@ def test_summary_endpoint_refresh_bypasses_dns_cache(authed_client: TestClient, 
         return_value=provider,
     ):
         first = authed_client.get("/api/v1/domains/summary")
-        second = authed_client.get("/api/v1/domains/summary")
         refreshed = authed_client.get("/api/v1/domains/summary?refresh=true")
+        second = authed_client.get("/api/v1/domains/summary")
 
     assert first.status_code == 200
     assert second.status_code == 200
     assert refreshed.status_code == 200
-    assert provider.check_domain.await_count == 2
+    assert first.json()["domains"][0]["dns_pending"] is True
+    assert provider.check_domain.await_count == 1
     assert second.json()["domains"][0]["dns_cached"] is True
+    assert second.json()["domains"][0]["dns_pending"] is False
     assert refreshed.json()["domains"][0]["dns_cached"] is False
 
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -182,6 +182,26 @@ def test_get_domain_reports_returns_200(seeded_client: TestClient):
     assert "compliance_timeline" in data
 
 
+def test_domain_stats_and_reports_use_single_domain_persisted_reports(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Stats and recent reports should not hydrate every workspace report."""
+
+    def fail_global_hydration(*args, **kwargs):
+        raise AssertionError("domain detail endpoints should not hydrate all reports")
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fail_global_hydration)
+
+    stats = seeded_client.get(f"/api/v1/domains/{DOMAIN}/stats")
+    reports = seeded_client.get(f"/api/v1/domains/{DOMAIN}/reports")
+
+    assert stats.status_code == 200
+    assert stats.json()["totalEmails"] == 10
+    assert reports.status_code == 200
+    assert reports.json()["reports"][0]["id"] == "rpt-dict-policy"
+
+
 def test_compliance_timeline_does_not_treat_no_volume_as_perfect_compliance():
     """Zero-volume report periods must not become 100% compliance points."""
     store = ReportStore()


### PR DESCRIPTION
## Summary
- make the domain summary endpoint cache-only by default for DNS evidence, with `refresh=true` preserving explicit live DNS reloads
- show pending DNS state in the domain list instead of treating missing cache as failing DNS
- avoid global report-store hydration for domain detail stats and recent-report timeline endpoints

## Why
Domain list and detail pages were doing too much synchronous work before rendering useful data. The domain list could block on live DNS checks for every domain, and detail stats/reports could rebuild workspace-wide report state for a single domain view.

## Validation
- `python3 -m compileall backend/app/api/api_v1/endpoints/domains.py backend/app/services/dns_cache.py backend/app/services/health_score.py`
- `node --check backend/app/static/js/domains-page.js`
- `pytest backend/app/tests/test_dns_endpoints.py::test_summary_includes_dns_fields backend/app/tests/test_dns_endpoints.py::test_summary_dns_failure_defaults_false backend/app/tests/test_dns_endpoints.py::test_summary_endpoint_uses_manual_selectors backend/app/tests/test_dns_endpoints.py::test_summary_endpoint_uses_database_aggregates_without_hydration backend/app/tests/test_dns_endpoints.py::test_summary_endpoint_refresh_bypasses_dns_cache backend/app/tests/test_domain_detail_endpoints.py::test_get_domain_reports_returns_200 backend/app/tests/test_domain_detail_endpoints.py::test_domain_stats_and_reports_use_single_domain_persisted_reports backend/app/tests/test_domain_detail_endpoints.py::test_domain_read_stats_selectors_and_search_use_workspace_auth backend/app/tests/test_domain_detail_endpoints.py::test_get_domain_reports_policy_dict_extracted backend/app/tests/test_domain_detail_endpoints.py::test_get_domain_reports_policy_string_preserved backend/app/tests/test_domain_detail_endpoints.py::test_get_domain_reports_timestamps_are_integers backend/app/tests/test_domain_detail_endpoints.py::test_get_domain_reports_uses_nested_summary_totals backend/app/tests/test_domain_detail_endpoints.py::test_get_domain_reports_unknown_domain_returns_404 backend/app/tests/test_health_score.py -q`
- `black --check` and `isort --check-only` on touched Python files

Closes #523


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer DNS status handling in domain summaries, including a visible “pending DNS refresh” state.
  * Domain detail views now use the correct saved data for stats and reports, improving consistency across screens.

* **Bug Fixes**
  * DNS checks now handle refresh timeouts and failures more gracefully.
  * Domain health scoring no longer shows missing-record warnings while DNS evidence is still pending.
  * Domain list statuses now display more accurate wording and colors when DNS data is not yet ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->