### PR TITLE
fix: prevent auth-domain sender misclassification

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -5712,6 +5712,19 @@ def _spf_fix_hint(ip: str, spf_result: str, failed_count: int = 0) -> Optional[s
         return None
 
 
+def _allow_direct_spf_ip_hint(sender: Optional[Dict[str, Any]]) -> bool:
+    """Return whether a raw ip4/ip6 SPF mechanism is safe to suggest.
+
+    Commercial senders and forwarders often use shared, rotating, or receiver-side
+    infrastructure. Suggesting a raw IP for those sources is misleading. Keep
+    copy-paste IP SPF hints for monitored-domain infrastructure where the PTR is
+    under the domain and the operator can reasonably own the host.
+    """
+    return bool(
+        sender and sender.get("status") == "known" and sender.get("id") == "owned-infrastructure"
+    )
+
+
 def _source_recommendations(
     ip: str,
     source: Dict[str, Any],
@@ -5720,6 +5733,9 @@ def _source_recommendations(
     sender: Optional[Dict[str, Any]] = None,
 ) -> List[SourceRecommendation]:
     """Build clear next steps for common DMARC source patterns."""
+    if not _allow_direct_spf_ip_hint(sender):
+        spf_fix_hint = None
+
     spf_result = source.get("spf_result", "unknown")
     dkim_result = source.get("dkim_result", "unknown")
     dmarc_result = source.get("dmarc_result") or (
@@ -6048,6 +6064,8 @@ async def get_domain_sources(
         spf_result = source.get("spf_result", "unknown")
         dkim_result = source.get("dkim_result", "unknown")
         spf_fix_hint = _spf_fix_hint(ip, spf_result, source.get("spf_fail_count", 0))
+        if not _allow_direct_spf_ip_hint(sender):
+            spf_fix_hint = None
         source_anomalies = anomalies_by_ip.get(ip, [])
         reputation = reputations_by_ip.get(ip)
         recommendations = _source_recommendations(ip, source, hostname, spf_fix_hint, sender)

--- a/backend/app/services/sender_intelligence.py
+++ b/backend/app/services/sender_intelligence.py
@@ -697,20 +697,28 @@ def _profile_score(
         score += 60
         evidence.append(f"PTR hostname matched {host_matches[0]}")
 
-    domain_matches = _contains_any(domain_values, profile.domain_tokens)
-    if domain_matches:
-        score += 15
-        evidence.append(f"Authentication domain matched {domain_matches[0]}")
-
-    selector_matches = _contains_any(selector_values, profile.selector_tokens)
-    if selector_matches:
-        score += 20
-        evidence.append(f"DKIM selector matched {selector_matches[0]}")
-
     extension_matches = _contains_any(extension_values, profile.extension_tokens)
     if extension_matches:
         score += 25
         evidence.append(f"Report metadata matched {extension_matches[0]}")
+
+    # Authentication domains and DKIM selectors describe how the message passed
+    # authentication, not necessarily which infrastructure originated it. A
+    # forwarder can preserve a provider DKIM signature while sending from Yahoo,
+    # Microsoft, or self-hosted infrastructure. When PTR exists and does not
+    # match the provider, keep auth-domain/selector matches as weak context only
+    # so they cannot rename the sending host by themselves.
+    allow_auth_evidence = not host_values or bool(host_matches) or bool(extension_matches)
+
+    domain_matches = _contains_any(domain_values, profile.domain_tokens)
+    if domain_matches and allow_auth_evidence:
+        score += 15
+        evidence.append(f"Authentication domain matched {domain_matches[0]}")
+
+    selector_matches = _contains_any(selector_values, profile.selector_tokens)
+    if selector_matches and allow_auth_evidence:
+        score += 20
+        evidence.append(f"DKIM selector matched {selector_matches[0]}")
 
     return min(score, 100), evidence
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1907,8 +1907,10 @@ def test_sources_endpoint_hostname_none_when_no_ptr(authed_client: TestClient):
         assert "hostname" in source
 
 
-def test_sources_endpoint_spf_fix_hint_for_failing_ip(authed_client: TestClient):
-    """A source with spf=fail should receive an spf_fix_hint containing its IP."""
+def test_sources_endpoint_omits_spf_fix_hint_for_unknown_failing_ip(
+    authed_client: TestClient,
+):
+    """Unknown failing sources should not receive copy-paste SPF IP changes."""
     store = ReportStore.get_instance()
     store.add_report(FAILING_SOURCE_REPORT)
 
@@ -1919,7 +1921,7 @@ def test_sources_endpoint_spf_fix_hint_for_failing_ip(authed_client: TestClient)
     sources = response.json()["sources"]
     failing = next((s for s in sources if s["ip"] == "10.0.0.1"), None)
     assert failing is not None
-    assert failing["spf_fix_hint"] == "ip4:10.0.0.1"
+    assert failing["spf_fix_hint"] is None
 
 
 def test_sources_endpoint_no_fix_hint_when_spf_passes(authed_client: TestClient):

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2313,7 +2313,7 @@ def test_get_domain_sources_returns_recommendations(
     assert {"unknown_sender", "full_fail", "policy_not_enforced"}.issubset(recommendation_types)
     assert source["sender"]["name"] == "Unknown sender"
     assert source["sender"]["status"] == "unknown"
-    assert source["spf_fix_hint"] == "ip4:192.0.2.10"
+    assert source["spf_fix_hint"] is None
 
 
 def test_get_domain_sources_returns_sender_identity(
@@ -2700,6 +2700,40 @@ def test_source_recommendations_cover_common_cases():
             )
         )
         assert {item.type for item in recommendations} == expected_types
+
+
+def test_source_recommendations_do_not_suggest_raw_spf_ip_for_unknown_forwarder():
+    """DKIM-preserving forwarders should not produce copy-paste SPF IP changes."""
+    source = {
+        "source_ip": "74.6.131.41",
+        "spf_result": "fail",
+        "dkim_result": "pass",
+        "dmarc_result": "pass",
+        "dmarc_pass_count": 1,
+        "dmarc_fail_count": 0,
+        "disposition": "none",
+    }
+    sender = {
+        "id": "unknown-sender",
+        "name": "Unknown sender",
+        "status": "unknown",
+        "reason": "No known provider profile matched this source.",
+        "remediation_hint": "Identify the business owner before authorizing it.",
+    }
+
+    recommendations = domains_endpoint._source_recommendations(  # pylint: disable=protected-access
+        "74.6.131.41",
+        source,
+        "sonic303-2.consmr.mail.bf2.yahoo.com",
+        "ip4:74.6.131.41",
+        sender,
+    )
+
+    dkim_only = next(item for item in recommendations if item.type == "dkim_only_pass")
+    assert "ip4:74.6.131.41" not in dkim_only.action
+    assert dkim_only.action == (
+        "Authorize this service in SPF, or confirm SPF is intentionally handled elsewhere."
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_sender_intelligence.py
+++ b/backend/app/tests/test_sender_intelligence.py
@@ -55,6 +55,8 @@ def test_identify_sender_does_not_treat_auth_domain_only_as_postmark():
         "74.6.131.41",
         {
             "spf_domains": ["pm.mtasv.net"],
+            "dkim_domains": ["pm.mtasv.net"],
+            "dkim_selectors": ["pm"],
             "dmarc_result": "pass",
             "dmarc_fail_count": 0,
         },


### PR DESCRIPTION
## Summary
- prevent authentication-domain and DKIM-selector evidence from naming a sender provider when PTR evidence points somewhere else
- keep Yahoo/forwarder-style hosts from being labeled as Postmark just because a preserved DKIM/SPF auth domain references `mtasv.net`
- suppress raw `ip4:`/`ip6:` SPF repair hints for unknown/commercial/forwarded sources; direct IP SPF hints now remain limited to owned infrastructure

## Validation
- `python -m compileall backend/app/services/sender_intelligence.py backend/app/api/api_v1/endpoints/domains.py`
- `pytest backend/app/tests/test_sender_intelligence.py backend/app/tests/test_domain_detail_endpoints.py -q`
- `black --check backend/app/services/sender_intelligence.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_sender_intelligence.py backend/app/tests/test_domain_detail_endpoints.py`
- `isort --check-only backend/app/services/sender_intelligence.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_sender_intelligence.py backend/app/tests/test_domain_detail_endpoints.py`
- `git diff --check`
