### PR TITLE
[codex] Expose DNS provider connection status

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -816,6 +816,9 @@ class DNSProviderCapabilityResponse(BaseModel):
     minimum_permissions: List[str] = Field(default_factory=list)
     setup_hint: Optional[str] = None
     docs_url: Optional[str] = None
+    credentials_configured: bool = False
+    connection_status: str = "not_configured"
+    connection_hint: str = "Configure provider credentials before discovery or repair."
 
 
 class DNSProviderCapabilitiesResponse(BaseModel):
@@ -3578,6 +3581,7 @@ async def export_all_domain_dns_lint(
 
 @router.get("/dns/providers", response_model=DNSProviderCapabilitiesResponse)
 async def get_dns_provider_capabilities(
+    db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
     """Return provider-backed DNS write capabilities."""
@@ -3600,11 +3604,31 @@ async def get_dns_provider_capabilities(
         "docs_url",
     }
     for provider in capabilities:
+        credentials_configured = _provider_credentials_configured(db, provider["id"])
+        import_available = provider["id"] in import_provider_ids
+        status = provider.get("status")
         seen_provider_ids.add(provider["id"])
         provider_rows.append(
             {
                 **provider,
-                "import_available": provider["id"] in import_provider_ids,
+                "import_available": import_available,
+                "credentials_configured": credentials_configured,
+                "connection_status": (
+                    "connected"
+                    if credentials_configured
+                    else (
+                        "needs_credentials" if import_available or status == "ready" else "planned"
+                    )
+                ),
+                "connection_hint": (
+                    "Credentials are configured. Discovery can run without exposing token material."
+                    if credentials_configured
+                    else (
+                        "Configure read-only provider credentials before running zone discovery."
+                        if import_available
+                        else "Provider is tracked for repair planning but is not import-ready yet."
+                    )
+                ),
                 **{
                     key: value
                     for key, value in connector_metadata.get(provider["id"], {}).items()
@@ -3615,6 +3639,8 @@ async def get_dns_provider_capabilities(
     for provider_id, metadata in connector_metadata.items():
         if provider_id in seen_provider_ids:
             continue
+        credentials_configured = _provider_credentials_configured(db, provider_id)
+        import_available = provider_id in import_provider_ids
         provider_rows.append(
             {
                 "id": provider_id,
@@ -3624,7 +3650,22 @@ async def get_dns_provider_capabilities(
                 "operations": [],
                 "credentials": ", ".join(metadata.get("auth_models") or ["provider credentials"]),
                 "status": "planned",
-                "import_available": provider_id in import_provider_ids,
+                "import_available": import_available,
+                "credentials_configured": credentials_configured,
+                "connection_status": (
+                    "connected"
+                    if credentials_configured
+                    else ("needs_credentials" if import_available else "planned")
+                ),
+                "connection_hint": (
+                    "Credentials are configured. Discovery can run without exposing token material."
+                    if credentials_configured
+                    else (
+                        "Configure read-only provider credentials before running zone discovery."
+                        if import_available
+                        else "Provider is tracked for repair planning but is not import-ready yet."
+                    )
+                ),
                 **{key: value for key, value in metadata.items() if key in metadata_keys},
             }
         )

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3606,7 +3606,6 @@ async def get_dns_provider_capabilities(
     for provider in capabilities:
         credentials_configured = _provider_credentials_configured(db, provider["id"])
         import_available = provider["id"] in import_provider_ids
-        status = provider.get("status")
         seen_provider_ids.add(provider["id"])
         provider_rows.append(
             {
@@ -3616,9 +3615,7 @@ async def get_dns_provider_capabilities(
                 "connection_status": (
                     "connected"
                     if credentials_configured
-                    else (
-                        "needs_credentials" if import_available or status == "ready" else "planned"
-                    )
+                    else ("needs_credentials" if import_available else "planned")
                 ),
                 "connection_hint": (
                     "Credentials are configured. Discovery can run without exposing token material."

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -465,6 +465,31 @@ function settingsApp() {
             return this.selectedDnsProviderMetadata().docs_url || '';
         },
 
+        selectedDnsProviderConnectionStatus() {
+            const provider = this.selectedDnsProviderMetadata();
+            return provider.connection_status || (provider.credentials_configured ? 'connected' : 'not_configured');
+        },
+
+        selectedDnsProviderConnectionLabel() {
+            const status = this.selectedDnsProviderConnectionStatus();
+            if (status === 'connected') return 'Connected';
+            if (status === 'needs_credentials') return 'Needs credentials';
+            if (status === 'planned') return 'Planned';
+            return 'Not configured';
+        },
+
+        selectedDnsProviderConnectionClass() {
+            const status = this.selectedDnsProviderConnectionStatus();
+            if (status === 'connected') return 'badge-success';
+            if (status === 'needs_credentials') return 'badge-warning';
+            if (status === 'planned') return 'badge-outline';
+            return 'badge-ghost';
+        },
+
+        selectedDnsProviderConnectionHint() {
+            return this.selectedDnsProviderMetadata().connection_hint || '';
+        },
+
         resetDnsProviderImportState() {
             this.cfZones = [];
             this.dnsProviderImportSummary = '';

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -276,10 +276,17 @@
                         </div>
                     </div>
                     <div class="rounded-md bg-base-200 px-3 py-2 text-xs text-base-content/70">
-                        <div>
-                            <span class="font-semibold" x-text="selectedDnsProviderName()"></span>
-                            <span x-text="selectedDnsProviderHint()"></span>
+                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                                <span class="font-semibold" x-text="selectedDnsProviderName()"></span>
+                                <span x-text="selectedDnsProviderHint()"></span>
+                            </div>
+                            <span class="badge badge-sm"
+                                  :class="selectedDnsProviderConnectionClass()"
+                                  x-text="selectedDnsProviderConnectionLabel()"></span>
                         </div>
+                        <div class="mt-1" x-show="selectedDnsProviderConnectionHint()"
+                             x-text="selectedDnsProviderConnectionHint()"></div>
                         <div class="mt-1" x-show="selectedDnsProviderAuthHint()">
                             Auth: <span class="font-medium" x-text="selectedDnsProviderAuthHint()"></span>
                         </div>

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1838,6 +1838,40 @@ def test_dns_provider_capabilities_mark_cloudflare_import_available(authed_clien
     assert "edgerc" in providers["akamai-edgedns"]["auth_models"]
 
 
+def test_dns_provider_capabilities_keep_write_only_provider_planned(
+    authed_client: TestClient,
+):
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains.provider_capabilities",
+            return_value=[
+                {
+                    "id": "digitalocean",
+                    "name": "DigitalOcean",
+                    "mode": "lexicon",
+                    "record_types": ["CNAME", "TXT"],
+                    "operations": ["create", "update"],
+                    "credentials": "environment",
+                    "status": "ready",
+                },
+            ],
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.supported_import_providers",
+            return_value=[],
+        ),
+    ):
+        response = authed_client.get("/api/v1/domains/dns/providers")
+
+    assert response.status_code == 200
+    provider = response.json()["providers"][0]
+    assert provider["id"] == "digitalocean"
+    assert provider["import_available"] is False
+    assert provider["credentials_configured"] is False
+    assert provider["connection_status"] == "planned"
+    assert "not import-ready yet" in provider["connection_hint"]
+
+
 def test_dns_provider_capabilities_report_configured_cloudflare_connection(
     authed_client: TestClient,
     db_session: Session,

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1817,6 +1817,9 @@ def test_dns_provider_capabilities_mark_cloudflare_import_available(authed_clien
     assert providers["cloudflare"]["record_read_status"] == "ready"
     assert providers["cloudflare"]["record_write_status"] == "ready"
     assert "Zone:Read" in providers["cloudflare"]["minimum_permissions"]
+    assert providers["cloudflare"]["credentials_configured"] is False
+    assert providers["cloudflare"]["connection_status"] == "needs_credentials"
+    assert "Configure read-only provider credentials" in providers["cloudflare"]["connection_hint"]
     assert providers["hetzner"]["import_available"] is True
     assert providers["hetzner"]["zone_import_status"] == "ready"
     assert providers["hetzner"]["record_read_status"] == "planned"
@@ -1833,6 +1836,28 @@ def test_dns_provider_capabilities_mark_cloudflare_import_available(authed_clien
     assert providers["akamai-edgedns"]["zone_import_status"] == "ready"
     assert providers["akamai-edgedns"]["record_write_status"] == "planned"
     assert "edgerc" in providers["akamai-edgedns"]["auth_models"]
+
+
+def test_dns_provider_capabilities_report_configured_cloudflare_connection(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    db_session.add(
+        Setting(
+            key="cloudflare.api_token",
+            value=encrypt_secret("cf-token"),
+            description="test token",
+        )
+    )
+    db_session.commit()
+
+    response = authed_client.get("/api/v1/domains/dns/providers")
+
+    assert response.status_code == 200
+    providers = {provider["id"]: provider for provider in response.json()["providers"]}
+    assert providers["cloudflare"]["credentials_configured"] is True
+    assert providers["cloudflare"]["connection_status"] == "connected"
+    assert "without exposing token material" in providers["cloudflare"]["connection_hint"]
 
 
 def test_dns_provider_import_preview_supports_akamai_alias(db_session, monkeypatch):

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -419,9 +419,15 @@ def test_settings_exposes_provider_agnostic_dns_import_without_html_injection():
     assert "selectedDnsProviderAuthHint" in script
     assert "selectedDnsProviderSetupHint" in script
     assert "selectedDnsProviderDocsUrl" in script
+    assert "selectedDnsProviderConnectionStatus" in script
+    assert "selectedDnsProviderConnectionLabel" in script
+    assert "selectedDnsProviderConnectionHint" in script
+    assert "selectedDnsProviderConnectionClass" in script
     assert "resetDnsProviderImportState" in script
     assert "dnsProviderImportError" in template
     assert "dnsProviderImportSummary" in template
+    assert "selectedDnsProviderConnectionLabel()" in template
+    assert "selectedDnsProviderConnectionHint()" in template
     assert "providerErrorDetail" in script
     assert "returned no importable zones" in template
     assert "discovery needs attention" in template

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -634,8 +634,11 @@ request.
 provider connector metadata. Each row includes the supported auth model,
 minimum permission hints, zone-import/read/write status, dry-run support,
 verification support, rollback guidance support, and whether DNS-zone import is
-actually available today. Use `GET /domains/dns/import/{provider}/preview` to
-list DNS zones visible to a connected provider without creating anything. Use
+actually available today. Rows also include non-secret connection state via
+`credentials_configured`, `connection_status`, and `connection_hint` so the UI
+can explain whether discovery can run or which credentials are still needed.
+Use `GET /domains/dns/import/{provider}/preview` to list DNS zones visible to a
+connected provider without creating anything. Use
 `POST /domains/dns/import/{provider}` with an optional `domains` array to import
 selected zones as monitored DMARQ domains before reports have arrived.
 Cloudflare, Route 53, Hetzner DNS, Linode DNS, and Akamai Edge DNS/FastDNS


### PR DESCRIPTION
## Summary

- adds non-secret DNS provider connection state to `GET /api/v1/domains/dns/providers`
- shows the selected provider's connection status and next step in Settings before discovery/import runs
- documents the new response fields for provider connector consumers

## Validation

- `.venv/bin/python -m pytest backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_dashboard_template_security.py` (177 passed)
- `.venv/bin/python -m black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

Refs #423


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer DNS provider connection indicators in Settings, including status badges and helpful hints.
  * DNS provider listings now show whether credentials are configured and what next step is needed.

* **Bug Fixes**
  * Improved provider availability messaging so connected, missing-credential, and not-yet-ready states are easier to understand.

* **Documentation**
  * Updated API docs to describe the new DNS provider connection status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->