### PR TITLE
[codex] Refactor stats source rollups

### DIFF
--- a/backend/app/utils/stats_summarizer.py
+++ b/backend/app/utils/stats_summarizer.py
@@ -589,6 +589,31 @@ class StatsSummarizer:
             return 0.0
         return round((compliant_emails / total_emails) * 100, 1)
 
+    @staticmethod
+    def _source_rollup_from_row(row) -> Dict[str, Any]:
+        """Return the API source rollup shape shared by global and domain stats."""
+        total_count = int(row.total_count or 0)
+        spf_pass_count = int(row.spf_pass_count or 0)
+        spf_fail_count = int(row.spf_fail_count or 0)
+        dkim_pass_count = int(row.dkim_pass_count or 0)
+        dkim_fail_count = int(row.dkim_fail_count or 0)
+        dmarc_pass_count = int(row.dmarc_pass_count or 0)
+        dmarc_fail_count = max(0, total_count - dmarc_pass_count)
+
+        return {
+            "ip": row.source_ip,
+            "count": total_count,
+            "spf_pass_count": spf_pass_count,
+            "spf_fail_count": spf_fail_count,
+            "dkim_pass_count": dkim_pass_count,
+            "dkim_fail_count": dkim_fail_count,
+            "dmarc_pass_count": dmarc_pass_count,
+            "dmarc_fail_count": dmarc_fail_count,
+            "spf": _auth_status_from_counts(spf_pass_count, spf_fail_count),
+            "dkim": _auth_status_from_counts(dkim_pass_count, dkim_fail_count),
+            "dmarc": _auth_status_from_counts(dmarc_pass_count, dmarc_fail_count),
+        }
+
     def _get_top_sources(
         self,
         db: Session,
@@ -636,29 +661,7 @@ class StatsSummarizer:
             .all()
         )
 
-        return [
-            {
-                "ip": row.source_ip,
-                "count": int(row.total_count),
-                "spf_pass_count": int(row.spf_pass_count or 0),
-                "spf_fail_count": int(row.spf_fail_count or 0),
-                "dkim_pass_count": int(row.dkim_pass_count or 0),
-                "dkim_fail_count": int(row.dkim_fail_count or 0),
-                "dmarc_pass_count": int(row.dmarc_pass_count or 0),
-                "dmarc_fail_count": int(row.total_count) - int(row.dmarc_pass_count or 0),
-                "spf": _auth_status_from_counts(
-                    int(row.spf_pass_count or 0), int(row.spf_fail_count or 0)
-                ),
-                "dkim": _auth_status_from_counts(
-                    int(row.dkim_pass_count or 0), int(row.dkim_fail_count or 0)
-                ),
-                "dmarc": _auth_status_from_counts(
-                    int(row.dmarc_pass_count or 0),
-                    int(row.total_count) - int(row.dmarc_pass_count or 0),
-                ),
-            }
-            for row in results
-        ]
+        return [self._source_rollup_from_row(row) for row in results]
 
     def _get_domain_sources(
         self,
@@ -707,29 +710,7 @@ class StatsSummarizer:
             .all()
         )
 
-        return [
-            {
-                "ip": row.source_ip,
-                "count": int(row.total_count),
-                "spf_pass_count": int(row.spf_pass_count or 0),
-                "spf_fail_count": int(row.spf_fail_count or 0),
-                "dkim_pass_count": int(row.dkim_pass_count or 0),
-                "dkim_fail_count": int(row.dkim_fail_count or 0),
-                "dmarc_pass_count": int(row.dmarc_pass_count or 0),
-                "dmarc_fail_count": int(row.total_count) - int(row.dmarc_pass_count or 0),
-                "spf": _auth_status_from_counts(
-                    int(row.spf_pass_count or 0), int(row.spf_fail_count or 0)
-                ),
-                "dkim": _auth_status_from_counts(
-                    int(row.dkim_pass_count or 0), int(row.dkim_fail_count or 0)
-                ),
-                "dmarc": _auth_status_from_counts(
-                    int(row.dmarc_pass_count or 0),
-                    int(row.total_count) - int(row.dmarc_pass_count or 0),
-                ),
-            }
-            for row in results
-        ]
+        return [self._source_rollup_from_row(row) for row in results]
 
     def _get_compliance_trend(
         self,


### PR DESCRIPTION
## Summary

- extracts the duplicated source rollup formatter shared by global and domain stats
- keeps the response shape stable for SPF/DKIM/DMARC pass/fail source summaries
- continues the #426 stats cleanup after the setup-script cleanup slice

## Validation

- `.venv/bin/python -m pytest backend/app/tests/test_stats_summarizer.py` (29 passed)
- `.venv/bin/python -m black --check backend/app/utils/stats_summarizer.py`
- `git diff --check`

Refs #426


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in source statistics reporting for both global and domain-level views.
  * Standardized counts and email authentication status values so results are calculated the same way across reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->