### PR TITLE
[codex] Add strict CSP enforcement switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ SECRET_KEY="CHANGE_THIS_TO_A_RANDOM_SECRET_IN_PRODUCTION"
 # Affects HSTS and other security settings
 ENVIRONMENT="development"
 
+# Optional CSP hardening.
+# First run with CSP_REPORT_ONLY=true and inspect browser/report logs. Only set
+# CSP_ENFORCE_STRICT=true after validating that your UI runtime works without
+# unsafe-inline or unsafe-eval.
+# CSP_REPORT_ONLY=false
+# CSP_ENFORCE_STRICT=false
+
 # Public URL used for OAuth callbacks when DMARQ is behind a proxy/ingress.
 # PUBLIC_BASE_URL="https://app.example.com"
 

--- a/backend/app/middleware/security.py
+++ b/backend/app/middleware/security.py
@@ -22,6 +22,42 @@ from starlette.responses import Response
 logger = logging.getLogger(__name__)
 
 
+def _strict_csp_directives() -> list[str]:
+    """Return the target CSP once templates and Alpine runtime are fully migrated."""
+    return [
+        "default-src 'self'",
+        "script-src 'self' https://cdn.tailwindcss.com https://cdn.jsdelivr.net",
+        "style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net",
+        "font-src 'self' https://fonts.gstatic.com",
+        "img-src 'self' data: https:",
+        "connect-src 'self'",
+        "frame-ancestors 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+    ]
+
+
+def _relaxed_csp_directives() -> list[str]:
+    """Return the compatibility CSP required by the current CDN Alpine runtime."""
+    return [
+        "default-src 'self'",
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+        " https://cdn.tailwindcss.com https://cdn.jsdelivr.net",
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com" " https://cdn.jsdelivr.net",
+        "font-src 'self' https://fonts.gstatic.com",
+        "img-src 'self' data: https:",
+        "connect-src 'self'",
+        "frame-ancestors 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+    ]
+
+
+def _truthy_env(name: str) -> bool:
+    """Return whether a boolean environment flag is enabled."""
+    return os.environ.get(name, "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """
     Middleware to add security headers to all HTTP responses.
@@ -51,58 +87,18 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         """
         response = await call_next(request)
 
-        # Content Security Policy (CSP)
-        # Restricts sources of content that can be loaded
-        #
-        # SECURITY TODO: Current CSP includes 'unsafe-inline' which weakens
-        # XSS protection. To remove it:
-        #
-        # For script-src 'unsafe-inline':
-        # 1. Move all inline <script> tags from templates to external .js files
-        # 2. OR implement CSP nonces for inline scripts (requires template changes)
-        # 3. Convert any inline event handlers (onclick, etc.) to addEventListener
-        #
-        # For style-src 'unsafe-inline':
-        # 1. Move inline styles to CSS files or use style tags with nonces
-        # 2. Replace style="" attributes with CSS classes
-        # 3. OR implement CSP nonces for inline styles
-        #
-        # Target secure CSP (no inline):
-        # "script-src 'self'"
-        # "style-src 'self' https://fonts.googleapis.com"
-        #
-        # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-        csp_directives = [
-            "default-src 'self'",
-            # TODO: Remove 'unsafe-inline' and 'unsafe-eval' - requires moving inline
-            # scripts to external files and replacing the standard Alpine CDN build
-            # with the CSP-compatible build.  # pylint: disable=fixme
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
-            " https://cdn.tailwindcss.com https://cdn.jsdelivr.net",
-            # TODO: Remove 'unsafe-inline' - requires moving inline styles to CSS or using nonces  # pylint: disable=fixme
-            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"
-            " https://cdn.jsdelivr.net",
-            "font-src 'self' https://fonts.gstatic.com",
-            "img-src 'self' data: https:",
-            "connect-src 'self'",
-            "frame-ancestors 'none'",  # Prevent framing
-            "base-uri 'self'",
-            "form-action 'self'",
-        ]
+        # Content Security Policy (CSP). Default remains compatibility mode for the
+        # current CDN Alpine runtime; operators can enable the strict target policy
+        # after validating their deployment with CSP_REPORT_ONLY=true.
+        csp_directives = (
+            _strict_csp_directives()
+            if _truthy_env("CSP_ENFORCE_STRICT")
+            else _relaxed_csp_directives()
+        )
         response.headers["Content-Security-Policy"] = "; ".join(csp_directives)
 
-        if os.environ.get("CSP_REPORT_ONLY", "false").lower() == "true":
-            report_only_directives = [
-                "default-src 'self'",
-                "script-src 'self' https://cdn.tailwindcss.com https://cdn.jsdelivr.net",
-                "style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net",
-                "font-src 'self' https://fonts.gstatic.com",
-                "img-src 'self' data: https:",
-                "connect-src 'self'",
-                "frame-ancestors 'none'",
-                "base-uri 'self'",
-                "form-action 'self'",
-            ]
+        if _truthy_env("CSP_REPORT_ONLY"):
+            report_only_directives = _strict_csp_directives()
             response.headers["Content-Security-Policy-Report-Only"] = "; ".join(
                 report_only_directives
             )

--- a/backend/app/middleware/security.py
+++ b/backend/app/middleware/security.py
@@ -41,9 +41,8 @@ def _relaxed_csp_directives() -> list[str]:
     """Return the compatibility CSP required by the current CDN Alpine runtime."""
     return [
         "default-src 'self'",
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
-        " https://cdn.tailwindcss.com https://cdn.jsdelivr.net",
-        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com" " https://cdn.jsdelivr.net",
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://cdn.jsdelivr.net",
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
         "font-src 'self' https://fonts.gstatic.com",
         "img-src 'self' data: https:",
         "connect-src 'self'",

--- a/backend/app/tests/test_security.py
+++ b/backend/app/tests/test_security.py
@@ -179,6 +179,20 @@ class TestSecurityHeaders:
         assert "'unsafe-eval'" not in csp_ro
         assert "script-src 'self'" in csp_ro
 
+    def test_strict_csp_can_be_enforced_after_runtime_migration(
+        self, client: TestClient, monkeypatch
+    ):
+        """Operators can enforce the strict target CSP once their UI is validated."""
+        monkeypatch.setenv("CSP_ENFORCE_STRICT", "true")
+
+        response = client.get("/mail-sources")
+
+        csp = response.headers["Content-Security-Policy"]
+        assert "'unsafe-inline'" not in csp
+        assert "'unsafe-eval'" not in csp
+        assert "script-src 'self'" in csp
+        assert "style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net" in csp
+
 
 class TestXMLParsingSecurity:
     """Test XML parsing security (defusedxml, XXE protection)."""

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -38,8 +38,8 @@ For deployment verification, upgrades, rollback, and routine checks, use the [Op
 | `DEBUG` | Enable debug mode | `false` | `true`, `false` |
 | `LOG_LEVEL` | Application logging level | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
 | `CORS_ORIGINS` | Allowed CORS origins | `http://localhost:8000` | `https://dmarq.example.com` |
-| `CSP_REPORT_ONLY` | Emit the strict target Content Security Policy as report-only while keeping the compatibility policy enforced. Use this first to validate browser behavior before enforcing strict CSP. | `false` | `true` |
-| `CSP_ENFORCE_STRICT` | Enforce the strict target CSP without `unsafe-inline` or `unsafe-eval`. Enable only after validating the UI runtime with report-only mode. | `false` | `true` |
+| `CSP_REPORT_ONLY` | Emit the strict target Content Security Policy as report-only while keeping the compatibility policy enforced. Use this first to validate browser behavior before enforcing strict CSP. | `false` | `true`, `false` |
+| `CSP_ENFORCE_STRICT` | Enforce the strict target CSP without `unsafe-inline` or `unsafe-eval`. Enable only after validating the UI runtime with report-only mode. | `false` | `true`, `false` |
 
 ### Logto Authentication Settings
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -38,6 +38,8 @@ For deployment verification, upgrades, rollback, and routine checks, use the [Op
 | `DEBUG` | Enable debug mode | `false` | `true`, `false` |
 | `LOG_LEVEL` | Application logging level | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
 | `CORS_ORIGINS` | Allowed CORS origins | `http://localhost:8000` | `https://dmarq.example.com` |
+| `CSP_REPORT_ONLY` | Emit the strict target Content Security Policy as report-only while keeping the compatibility policy enforced. Use this first to validate browser behavior before enforcing strict CSP. | `false` | `true` |
+| `CSP_ENFORCE_STRICT` | Enforce the strict target CSP without `unsafe-inline` or `unsafe-eval`. Enable only after validating the UI runtime with report-only mode. | `false` | `true` |
 
 ### Logto Authentication Settings
 


### PR DESCRIPTION
## Summary
- centralize relaxed and strict CSP directive builders
- keep compatibility CSP as the default while adding `CSP_ENFORCE_STRICT=true` for validated deployments
- document `CSP_REPORT_ONLY` and `CSP_ENFORCE_STRICT` in the env example and deployment configuration docs

## Validation
- `.venv/bin/python -m pytest -q backend/app/tests/test_security.py::TestSecurityHeaders`
- `.venv/bin/python -m black --check backend/app/middleware/security.py backend/app/tests/test_security.py`
- `git diff --check`

Refs #426