### PR TITLE
[codex] Document protocol coverage boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,23 @@ Included:
 - ✅ DNS linting, change plans, approved Cloudflare writes, and modular provider write adapters
 - ✅ Forensic/failure report ingestion with redacted metadata and grouped analysis
 - ✅ SMTP TLS report ingestion, trends, and top failure summaries
+- ✅ Passive DANE/TLSA MX coverage checks with read-only TLSA suggestions
 - ✅ Public demo mode with rolling synthetic `dmarq.org` and `dmarq.com` data
 - 🔭 Roadmap: domain mail-health scoring, human-approved repair loops, sender IP
   reputation checks, DNS/mail provider imports, direct report intake workers,
   ecosystem integrations, and localized remediation guidance
+
+Protocol boundary:
+
+- **Supported now:** DMARC aggregate reports, DMARC failure/RUF reports,
+  SMTP TLS reports, DMARC/SPF/DKIM DNS linting, MTA-STS, TLS-RPT, BIMI, and
+  passive DANE/TLSA guidance.
+- **Passive context only:** ARC headers found in failure-report samples are
+  retained as redacted diagnostics, but DMARQ does not validate ARC chains or
+  use ARC as a substitute for DMARC alignment.
+- **Out of scope today:** outbound ARF/RUF generation and receiver-side report
+  rate limiting. DMARQ consumes reports for domain operators; it is not a mail
+  receiver generating third-party reports.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Included:
 - ✅ DNS linting, change plans, approved Cloudflare writes, and modular provider write adapters
 - ✅ Forensic/failure report ingestion with redacted metadata and grouped analysis
 - ✅ SMTP TLS report ingestion, trends, and top failure summaries
-- ✅ Passive DANE/TLSA MX coverage checks with read-only TLSA suggestions
+- ✅ Best-effort passive DANE/TLSA MX checks with bounded live probing and read-only TLSA suggestions
 - ✅ Public demo mode with rolling synthetic `dmarq.org` and `dmarq.com` data
 - 🔭 Roadmap: domain mail-health scoring, human-approved repair loops, sender IP
   reputation checks, DNS/mail provider imports, direct report intake workers,
@@ -57,9 +57,9 @@ Included:
 
 Protocol boundary:
 
-- **Supported now:** DMARC aggregate reports, DMARC failure/RUF reports,
-  SMTP TLS reports, DMARC/SPF/DKIM DNS linting, MTA-STS, TLS-RPT, BIMI, and
-  passive DANE/TLSA guidance.
+- **Supported now:** DMARC aggregate reports, inbound DMARC failure/RUF reports,
+  SMTP TLS/TLS-RPT reports, DMARC/SPF/DKIM DNS linting, MTA-STS, BIMI, and
+  best-effort passive DANE/TLSA guidance with bounded live probing.
 - **Passive context only:** ARC headers found in failure-report samples are
   retained as redacted diagnostics, but DMARQ does not validate ARC chains or
   use ARC as a substitute for DMARC alignment.

--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -2,6 +2,24 @@
 
 DMARQ imports DMARC aggregate reports from direct uploads, IMAP attachments, Gmail API attachments, and the Cloudflare Email Worker webhook. Compatibility is locked by the fixture pack in `backend/app/tests/fixtures/dmarc_aggregate`.
 
+## Protocol Coverage Boundary
+
+DMARQ is a report consumer and DNS posture assistant. It parses standards-based
+reports, stores privacy-preserving evidence, and helps operators repair their
+own sending posture. It is not a mail receiver, outbound report generator, or
+mail gateway.
+
+| Protocol or signal | DMARQ support level | Boundary |
+| --- | --- | --- |
+| DMARC aggregate/RUA | Supported | Parse, persist, analyze, export, and visualize inbound aggregate reports. |
+| DMARC failure/RUF / ARF | Supported as inbound evidence | Parse inbound `multipart/report` and `message/feedback-report` metadata for operators who receive failure reports. DMARQ does not generate outbound ARF/RUF reports. |
+| SMTP TLS reports / TLS-RPT | Supported | Parse inbound TLS report data and surface posture/failure evidence. |
+| MTA-STS | Supported read-only posture | Check TXT and HTTPS policy presence, syntax, and enforcement mode. |
+| BIMI | Supported read-only posture | Check default selector and DMARC prerequisites. |
+| DANE/TLSA for MX hosts | Supported read-only guidance | Check TLSA coverage and syntax, and suggest `3 1 1` SPKI hashes when live SMTP STARTTLS evidence is reachable. DMARQ does not manage DNSSEC validation state. |
+| ARC | Passive diagnostic context only | Record redacted ARC header presence from failure-report samples when present. DMARQ does not validate ARC chains and does not use ARC to override DMARC alignment. |
+| DNS provider writes | Human-approved only | Low-risk TXT/CNAME changes can be previewed and applied through supported providers after explicit operator confirmation. |
+
 ## Supported Aggregate Inputs
 
 - Plain XML files with a `.xml` extension.

--- a/docs/reference/dmarc-compatibility.md
+++ b/docs/reference/dmarc-compatibility.md
@@ -12,11 +12,11 @@ mail gateway.
 | Protocol or signal | DMARQ support level | Boundary |
 | --- | --- | --- |
 | DMARC aggregate/RUA | Supported | Parse, persist, analyze, export, and visualize inbound aggregate reports. |
-| DMARC failure/RUF / ARF | Supported as inbound evidence | Parse inbound `multipart/report` and `message/feedback-report` metadata for operators who receive failure reports. DMARQ does not generate outbound ARF/RUF reports. |
+| DMARC failure reports via RUF using ARF | Supported as inbound evidence | Parse inbound `multipart/report` and `message/feedback-report` metadata for operators who receive RUF failure reports in ARF format. DMARQ does not generate outbound ARF/RUF reports. |
 | SMTP TLS reports / TLS-RPT | Supported | Parse inbound TLS report data and surface posture/failure evidence. |
 | MTA-STS | Supported read-only posture | Check TXT and HTTPS policy presence, syntax, and enforcement mode. |
 | BIMI | Supported read-only posture | Check default selector and DMARC prerequisites. |
-| DANE/TLSA for MX hosts | Supported read-only guidance | Check TLSA coverage and syntax, and suggest `3 1 1` SPKI hashes when live SMTP STARTTLS evidence is reachable. DMARQ does not manage DNSSEC validation state. |
+| DANE/TLSA for MX hosts | Best-effort read-only guidance | Check TLSA syntax and bounded MX coverage, and suggest `3 1 1` SPKI hashes when capped live SMTP STARTTLS probing can reach an MX host. DMARQ does not manage DNSSEC validation state. |
 | ARC | Passive diagnostic context only | Record redacted ARC header presence from failure-report samples when present. DMARQ does not validate ARC chains and does not use ARC to override DMARC alignment. |
 | DNS provider writes | Human-approved only | Low-risk TXT/CNAME changes can be previewed and applied through supported providers after explicit operator confirmation. |
 
@@ -96,10 +96,10 @@ Live DNS checks parse DMARC policy records according to RFC 9989:
 - Typed DNS guidance endpoints expose stable finding codes and target records
   for DMARC, SPF, DKIM, MTA-STS, TLS-RPT, BIMI, and passive DANE/TLSA
   readiness. Provider writes are never automatic; safe TXT/CNAME changes
-  require an explicit apply request. DANE/TLSA support is currently read-only
-  MX/TLSA syntax and coverage guidance with optional live SMTP STARTTLS SPKI
-  hash suggestions when the MX is reachable; DNSSEC chain validation remains
-  operator-confirmed.
+  require an explicit apply request. DANE/TLSA support is currently best-effort,
+  read-only MX/TLSA syntax and bounded coverage guidance with optional capped
+  live SMTP STARTTLS SPKI hash suggestions when an MX host is reachable; DNSSEC
+  chain validation remains operator-confirmed.
 
 ## Preserved Metadata
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -234,6 +234,18 @@ When `_mta-sts.<domain>` exists but `mta-sts.<domain>` does not resolve or the H
 
 MTA-STS posture uses the same cached DNS refresh behavior as the existing DNS health checks. Use the DNS refresh action when you publish or update a policy and need DMARQ to re-check immediately.
 
+### DANE/TLSA Posture
+
+When a domain has MX records, DMARQ can inspect passive DANE/TLSA readiness for
+the `_25._tcp.<mx-host>` names. The check is read-only: it reports whether TLSA
+records exist, whether their syntax is usable, and whether a reachable SMTP
+STARTTLS certificate can produce an operator-ready `3 1 1` SPKI SHA-256
+suggestion.
+
+Treat generated TLSA values as review evidence, not an automatic DNS change.
+The operator still needs to confirm DNSSEC posture, MX certificate rotation
+policy, and maintenance timing before publishing or replacing TLSA records.
+
 ### BIMI Readiness
 
 The domain detail page checks the default BIMI selector at

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -237,10 +237,10 @@ MTA-STS posture uses the same cached DNS refresh behavior as the existing DNS he
 ### DANE/TLSA Posture
 
 When a domain has MX records, DMARQ can inspect passive DANE/TLSA readiness for
-the `_25._tcp.<mx-host>` names. The check is read-only: it reports whether TLSA
-records exist, whether their syntax is usable, and whether a reachable SMTP
-STARTTLS certificate can produce an operator-ready `3 1 1` SPKI SHA-256
-suggestion.
+the `_25._tcp.<mx-host>` names on a best-effort basis. The check is read-only:
+it reports whether TLSA records exist, whether their syntax is usable, and
+whether capped live SMTP STARTTLS probing can reach an MX certificate that
+produces an operator-ready `3 1 1` SPKI SHA-256 suggestion.
 
 Treat generated TLSA values as review evidence, not an automatic DNS change.
 The operator still needs to confirm DNSSEC posture, MX certificate rotation


### PR DESCRIPTION
## Summary
- add a protocol boundary section to the README so current support versus parked scope is visible up front
- document the DMARC/DANE/ARC/ARF support matrix in the compatibility reference
- add user-guide DANE/TLSA posture guidance that makes the read-only/operator-review boundary explicit

## Validation
- `git diff --check`
- `.venv/bin/python -m mkdocs build`

Note: `mkdocs build --strict` is currently blocked by existing site-wide nav/link warnings unrelated to this diff. The pinned `docs/readthedocs/requirements.txt` set is also internally inconsistent on Markdown versions, so local validation used compatible current MkDocs packages without changing repo files.

Refs #310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README and reference docs with clearer coverage boundaries for supported and unsupported protocol/reporting behaviors.
  * Added guidance on passive DANE/TLSA readiness checks for MX hosts, including read-only TLSA suggestions and operator confirmation steps before publishing DNS changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->