### PR TITLE
[codex] Remove inline release modal handlers

### DIFF
--- a/backend/app/static/js/base-layout.js
+++ b/backend/app/static/js/base-layout.js
@@ -135,12 +135,16 @@ document.addEventListener('alpine:init', () => {
 
 (function bindReleaseModalTriggers() {
     document.addEventListener('click', (event) => {
-        const trigger = event.target.closest('[data-release-modal-trigger]');
+        const target = event.target;
+        if (!(target instanceof Element)) {
+            return;
+        }
+        const trigger = target.closest('[data-release-modal-trigger]');
         if (!trigger) {
             return;
         }
         const modal = document.getElementById('dmarq-release-modal');
-        if (modal && typeof modal.showModal === 'function') {
+        if (modal && typeof modal.showModal === 'function' && !modal.open) {
             modal.showModal();
         }
     });

--- a/backend/app/static/js/base-layout.js
+++ b/backend/app/static/js/base-layout.js
@@ -132,3 +132,16 @@ document.addEventListener('alpine:init', () => {
         document.documentElement.setAttribute('data-theme', 'dmarqlight');
     }
 })();
+
+(function bindReleaseModalTriggers() {
+    document.addEventListener('click', (event) => {
+        const trigger = event.target.closest('[data-release-modal-trigger]');
+        if (!trigger) {
+            return;
+        }
+        const modal = document.getElementById('dmarq-release-modal');
+        if (modal && typeof modal.showModal === 'function') {
+            modal.showModal();
+        }
+    });
+})();

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -50,7 +50,7 @@
             <button type="button"
                     class="ml-4 hidden rounded-full border border-white/20 px-2.5 py-1 text-[11px] font-semibold text-white/70 transition hover:border-white/40 hover:bg-white/10 hover:text-white sm:inline-flex"
                     title="Show release notes"
-                    onclick="document.getElementById('dmarq-release-modal')?.showModal()">
+                    data-release-modal-trigger>
                 {{ release_info.label }}
             </button>
         </div>
@@ -107,7 +107,7 @@
                             <li>
                                 <button type="button"
                                         class="justify-between"
-                                        onclick="document.getElementById('dmarq-release-modal')?.showModal()">
+                                        data-release-modal-trigger>
                                     Release
                                     <span class="badge badge-ghost text-[10px]">{{ release_info.label }}</span>
                                 </button>
@@ -157,7 +157,7 @@
         <button type="button"
                 class="max-w-20 truncate rounded-md px-2 py-1 text-[10px] font-semibold text-white/45 hover:bg-white/10 hover:text-white"
                 title="Show release notes"
-                onclick="document.getElementById('dmarq-release-modal')?.showModal()">
+                data-release-modal-trigger>
             {{ release_info.label }}
         </button>
     </aside>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -679,6 +679,9 @@ def test_base_template_propagates_selected_workspace_context():
     assert "data-release-modal-trigger" in template
     assert "bindReleaseModalTriggers" in script
     assert "dmarq-release-modal" in script
+    assert "event.target" in script
+    assert "target instanceof Element" in script
+    assert "!modal.open" in script
 
 
 def test_base_template_hides_workspace_controls_in_single_user_mode():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -675,6 +675,10 @@ def test_base_template_propagates_selected_workspace_context():
     assert "workspaces.length > 1" in template
     assert "localStorage.removeItem('dmarq.selectedWorkspaceId')" in script
     assert "input instanceof URL" in script
+    assert "onclick=" not in template
+    assert "data-release-modal-trigger" in template
+    assert "bindReleaseModalTriggers" in script
+    assert "dmarq-release-modal" in script
 
 
 def test_base_template_hides_workspace_controls_in_single_user_mode():


### PR DESCRIPTION
## Summary
- replace the base-layout release modal `onclick` handlers with `data-release-modal-trigger`
- bind the release modal opener from the external `base-layout.js` script
- add a regression assertion so inline `onclick=` handlers do not return to the base template

## Validation
- `.venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py`
- `node --check backend/app/static/js/base-layout.js`
- `.venv/bin/python -m black --check backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

Refs #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Show release notes” interaction so it opens the release modal through a safer client-side trigger instead of inline click handlers.
  * Added fallback behavior so clicking the trigger won’t break if the modal isn’t available or can’t be opened.
* **Tests**
  * Updated template coverage to verify the new release-notes trigger wiring is present and inline handlers are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->