### PR TITLE
[codex] Remove domain source inline style binding

### DIFF
--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1695,7 +1695,7 @@
                                             <template x-for="point in sourceVolumeBars(source)" :key="point.date">
                                                 <div class="tooltip flex-1 rounded-t"
                                                      :class="point.failed > 0 ? 'bg-[#ff6f3c]' : 'bg-[#2f9da5]'"
-                                                     :style="'height: ' + point.height + '%'"
+                                                     x-effect="$el.style.height = point.height + '%'"
                                                      :data-tip="point.label"></div>
                                             </template>
                                         </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -573,7 +573,9 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "source.reputation?.listings" in template
     assert "reputationStatusClass" in script
     assert 'colspan="9"' in template
+    assert "x-effect=\"$el.style.height = point.height + '%'" in template
     assert "x-html" not in template
+    assert not _has_inline_style(template)
 
 
 def test_domain_details_distinguishes_loading_error_and_empty_states():


### PR DESCRIPTION
## Summary
- replace the domain source volume-bar `:style` binding with an external Alpine `x-effect` style update
- add a regression assertion that domain details no longer carries inline style bindings
- keep the existing source intelligence volume history behavior unchanged

## Validation
- `.venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py::test_domain_details_exposes_source_ip_intelligence_without_html_injection`
- `.venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py`
- `.venv/bin/python -m black --check backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

Refs #426


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the rendering of volume bars in the Sending Sources table so their heights update reliably.
  * Strengthened template output to avoid inline style usage, helping keep the page safer and cleaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->