### PR TITLE
[codex] Move legacy login error style into CSS

### DIFF
--- a/backend/app/static/css/styles.css
+++ b/backend/app/static/css/styles.css
@@ -68,7 +68,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .login-error-message {
-  color: var(--color-accent);
+  color: red;
   margin-top: 0.625rem;
 }
 

--- a/backend/app/static/css/styles.css
+++ b/backend/app/static/css/styles.css
@@ -67,6 +67,11 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--color-neutral-light);
 }
 
+.login-error-message {
+  color: var(--color-accent);
+  margin-top: 0.625rem;
+}
+
 .card {
   background-color: var(--color-neutral-light);
   color: var(--color-neutral-dark);

--- a/backend/app/static/js/login.js
+++ b/backend/app/static/js/login.js
@@ -19,7 +19,7 @@ function renderLogin() {
                         <label for="password">Password</label>
                         <input type="password" id="password" name="password" required>
                     </div>
-                    <div id="login-error" class="hidden" style="color: red; margin-top: 10px;"></div>
+                    <div id="login-error" class="hidden login-error-message"></div>
                     <div>
                         <button type="submit" id="login-button">Login</button>
                     </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -112,6 +112,14 @@ def _reports_script() -> str:
     return _read_project_file("static", "js", "reports-page.js")
 
 
+def _legacy_login_script() -> str:
+    return _read_project_file("static", "js", "login.js")
+
+
+def _main_stylesheet() -> str:
+    return _read_project_file("static", "css", "styles.css")
+
+
 def _domains_template() -> str:
     return _read_project_file("templates", "domains.html")
 
@@ -657,6 +665,16 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert _has_inline_style('<div data-style="ok" :style="bad"></div>')
     assert _has_inline_style("<progress x-bind:style=\"{ width: progress + '%' }\" />")
     assert _has_inline_style("<div x-bind:style=\"{ width: progress + '%' }\"></div>")
+
+
+def test_legacy_login_script_uses_css_class_instead_of_inline_style():
+    script = _legacy_login_script()
+    stylesheet = _main_stylesheet()
+
+    assert "login-error-message" in script
+    assert ".login-error-message" in stylesheet
+    assert 'id="login-error" class="hidden login-error-message"' in script
+    assert "style=" not in script
 
 
 def test_base_template_propagates_selected_workspace_context():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -673,7 +673,11 @@ def test_legacy_login_script_uses_css_class_instead_of_inline_style():
 
     assert "login-error-message" in script
     assert ".login-error-message" in stylesheet
-    assert 'id="login-error" class="hidden login-error-message"' in script
+    assert re.search(
+        r'<div\b(?=[^>]*\bid="login-error")'
+        r'(?=[^>]*\bclass="[^"]*\bhidden\b[^"]*\blogin-error-message\b)[^>]*>',
+        script,
+    )
     assert "style=" not in script
 
 


### PR DESCRIPTION
## Summary
- move the legacy SPA login error styling out of inline HTML and into the shared stylesheet
- keep the rendered login error behavior unchanged while removing the remaining non-vendor `style=` hit
- add a regression assertion covering the legacy login script and CSS class

## Validation
- `.venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py`
- `node --check backend/app/static/js/login.js`
- `.venv/bin/python -m black --check backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`
- `rg -n "style=|:style|x-bind:style" backend/app/static/js backend/app/templates -g '!*.min.js'` returns no matches

Refs #426
