### PR TITLE
[codex] Fix Cloudflare OAuth scope profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,11 +60,14 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # Optional DNS provider integrations
 # CLOUDFLARE_API_TOKEN="your_cloudflare_api_token"
 # CLOUDFLARE_ZONE_ID="your_cloudflare_zone_id"
-# Optional one-click Cloudflare connector. Create a Cloudflare OAuth client with
-# read-only zone/DNS scopes first; keep DNS write scope separate until repair is enabled.
+# Optional one-click Cloudflare connector. The in-product rights profile controls
+# requested scopes: read-only asks for zone.read/dns.read, Radar profiles also
+# ask for radar.read and user.read, and full repair also asks for dns.write. Leave
+# CLOUDFLARE_OAUTH_SCOPES unset unless you intentionally need a legacy fixed
+# scope request when no profile is supplied.
 # CLOUDFLARE_OAUTH_CLIENT_ID="your_cloudflare_oauth_client_id"
 # CLOUDFLARE_OAUTH_CLIENT_SECRET="your_cloudflare_oauth_client_secret"
-# CLOUDFLARE_OAUTH_SCOPES="zone.read dns.read"
+# CLOUDFLARE_OAUTH_SCOPES=""
 # HETZNER_DNS_API_TOKEN="your_hetzner_read_only_api_token"
 # HETZNER_API_TOKEN="your_hetzner_read_only_api_token"
 # LINODE_API_TOKEN="your_linode_domains_read_only_token"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added in-product release metadata with version, image, git ref, build date, recent changes, and a link to the full changelog.
+- Added Cloudflare OAuth rights profiles for read-only zone import, read-only plus Radar enrichment, and full DNS repair.
+- Added source intelligence context for sending IPs, including provider recognition, network details, Radar links, and report activity history.
+- Added human-approved DNS repair groundwork for provider-connected domains.
+- Added self-hosted demo refinements focused on the single-user, multiple-domain workflow.
+
 ### Changed
+- Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.
+- The full Cloudflare DNS repair profile now requests DNS write access plus Radar read access so one-click repair and IP enrichment can work from the same consent flow.
+- Dashboard and domain detail pages now expose more actionable remediation context around DNS, DMARC, source authentication, and ownership state.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity
+
+### Fixed
+- Fixed the Cloudflare permissions picker so selecting the full DNS repair profile no longer falls back to read-only scopes.
+- Fixed the release modal coverage so recent operator-facing work is visible from inside the app.
+- Fixed several CSP-hardening regressions by moving legacy inline handlers and styles out of templates.
+
+### Security
+- Cloudflare DNS write capabilities remain tied to explicit full-repair selection and human-confirmed DNS changes.
+- Release metadata is sanitized for display and does not expose secrets.
 
 ## [0.3.0] - 2026-02-09
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -63,7 +63,7 @@ class Settings(BaseSettings):
     CLOUDFLARE_ZONE_ID: Optional[str] = None
     CLOUDFLARE_OAUTH_CLIENT_ID: Optional[str] = None
     CLOUDFLARE_OAUTH_CLIENT_SECRET: Optional[str] = None
-    CLOUDFLARE_OAUTH_SCOPES: str = "zone.read dns.read"
+    CLOUDFLARE_OAUTH_SCOPES: str = ""
     HETZNER_DNS_API_TOKEN: Optional[str] = None
     HETZNER_API_TOKEN: Optional[str] = None
     LINODE_API_TOKEN: Optional[str] = None

--- a/backend/app/services/cloudflare_oauth.py
+++ b/backend/app/services/cloudflare_oauth.py
@@ -56,25 +56,27 @@ CLOUDFLARE_SCOPE_PROFILES: Dict[str, CloudflareScopeProfile] = {
     "read_only_radar": CloudflareScopeProfile(
         id="read_only_radar",
         name="Read-only + Radar context",
-        description=(
-            "Read DNS zones and enable Cloudflare Radar enrichment when a Radar API token "
-            "is configured server-side."
-        ),
-        scopes="zone.read dns.read",
+        description=("Read DNS zones and request Cloudflare Radar read access for IP enrichment."),
+        scopes="zone.read dns.read radar.read user.read",
         radar_enabled=True,
-        radar_requires_api_token=True,
         warning=(
-            "Cloudflare Radar API access is not granted by this DNS OAuth scope; configure "
-            "a separate Radar-capable API token on the server for enrichment."
+            "Includes Account Radar Read plus User Details Read for Cloudflare Radar " "IP lookups."
         ),
     ),
     "full_dns_repair": CloudflareScopeProfile(
         id="full_dns_repair",
-        name="Full DNS repair",
-        description="Read zones and allow human-approved DNS record changes.",
-        scopes="zone.read dns.read dns.write",
+        name="Full DNS repair + Radar",
+        description=(
+            "Read zones, allow human-approved DNS record changes, and request "
+            "Cloudflare Radar IP enrichment access."
+        ),
+        scopes="zone.read dns.read dns.write radar.read user.read",
         dns_write_enabled=True,
-        warning="Only use this when you want DMARQ to prepare and apply confirmed DNS repairs.",
+        radar_enabled=True,
+        warning=(
+            "Only use this when you want DMARQ to prepare/apply confirmed DNS repairs "
+            "and enrich sending IPs with Cloudflare Radar."
+        ),
     ),
 }
 
@@ -179,12 +181,11 @@ def build_cloudflare_authorization_url(
 ) -> Dict[str, str]:
     """Return the Cloudflare authorization URL and request metadata."""
     config = get_cloudflare_oauth_config()
+    explicit_profile = scope_profile is not None
     normalized_profile = normalize_cloudflare_scope_profile(scope_profile)
-    scopes = (
-        config.scopes
-        if get_settings().CLOUDFLARE_OAUTH_SCOPES
-        else cloudflare_scopes_for_profile(normalized_profile)
-    )
+    scopes = cloudflare_scopes_for_profile(normalized_profile)
+    if not explicit_profile and get_settings().CLOUDFLARE_OAUTH_SCOPES:
+        scopes = config.scopes
     params = {
         "client_id": config.client_id,
         "response_type": "code",
@@ -280,14 +281,7 @@ def persist_cloudflare_oauth_tokens(
     if not access_token:
         raise LookupError("Cloudflare OAuth did not return an access token.")
     normalized_profile = normalize_cloudflare_scope_profile(scope_profile)
-    scope = str(
-        token_data.get("scope")
-        or (
-            get_cloudflare_oauth_config().scopes
-            if get_settings().CLOUDFLARE_OAUTH_SCOPES
-            else cloudflare_scopes_for_profile(normalized_profile)
-        )
-    )
+    scope = str(token_data.get("scope") or cloudflare_scopes_for_profile(normalized_profile))
     _upsert_setting(
         db,
         key="cloudflare.api_token",

--- a/backend/app/services/release_info.py
+++ b/backend/app/services/release_info.py
@@ -42,6 +42,7 @@ def build_release_info(settings: Any) -> Dict[str, Any]:
             "image": _clean(getattr(settings, "DMARQ_BUILD_IMAGE", None)),
             "date": _clean(getattr(settings, "DMARQ_BUILD_DATE", None)),
         },
+        "changelog_url": "https://github.com/christianlouis/dmarq/blob/main/CHANGELOG.md",
         "changes": [
             {
                 "title": "Faster domain pages",
@@ -62,6 +63,45 @@ def build_release_info(settings: Any) -> Dict[str, Any]:
                 "description": (
                     "The default demo and navigation emphasize the single-user, "
                     "multiple-domain self-hosted story."
+                ),
+            },
+            {
+                "title": "Cloudflare rights profiles",
+                "description": (
+                    "The Cloudflare connector exposes read-only, read-only plus Radar "
+                    "context, and full DNS repair profiles so operators can choose the "
+                    "least privilege needed for the next action."
+                ),
+            },
+            {
+                "title": "Safer DNS repair workflow",
+                "description": (
+                    "DNS changes remain human-approved, with provider imports, ownership "
+                    "verification, repair previews, and audit-friendly settings separated "
+                    "from automatic write actions."
+                ),
+            },
+            {
+                "title": "In-product release visibility",
+                "description": (
+                    "The current version, build image, git ref, build date, and recent "
+                    "operator-facing fixes are available from the small release label in "
+                    "the app shell."
+                ),
+            },
+            {
+                "title": "CSP hardening progress",
+                "description": (
+                    "Inline handlers and style bindings continue moving out of templates "
+                    "toward external scripts and CSS so strict CSP can become the default."
+                ),
+            },
+            {
+                "title": "Actionable remediation groundwork",
+                "description": (
+                    "Domain and report detail views include clearer next steps, DNS lint "
+                    "evidence, source intelligence, and safer repair context for DMARC "
+                    "operations."
                 ),
             },
         ],

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -201,7 +201,14 @@
                     </dl>
                 </div>
                 <div>
-                    <h3 class="text-sm font-bold uppercase tracking-wide text-base-content/60">What's changed</h3>
+                    <div class="flex items-center justify-between gap-3">
+                        <h3 class="text-sm font-bold uppercase tracking-wide text-base-content/60">What's changed</h3>
+                        {% if release_info.changelog_url %}
+                        <a class="link link-primary text-xs" href="{{ release_info.changelog_url }}" target="_blank" rel="noopener noreferrer">
+                            Full changelog
+                        </a>
+                        {% endif %}
+                    </div>
                     <div class="mt-3 space-y-3">
                         {% for item in release_info.changes %}
                         <div class="rounded-md border border-base-200 bg-base-100 p-3">

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -21,11 +21,11 @@ def test_health_check(authed_client: TestClient):
     assert "version" in data
 
 
-def test_release_info_endpoint_exposes_safe_build_metadata(
-    authed_client: TestClient, monkeypatch
-):
+def test_release_info_endpoint_exposes_safe_build_metadata(authed_client: TestClient, monkeypatch):
     """Release metadata is available for support without exposing secrets."""
-    from app.api.api_v1.endpoints import health as health_endpoint  # pylint: disable=import-outside-toplevel
+    from app.api.api_v1.endpoints import (
+        health as health_endpoint,
+    )  # pylint: disable=import-outside-toplevel
     from app.core.config import Settings  # pylint: disable=import-outside-toplevel
 
     monkeypatch.setattr(
@@ -50,7 +50,10 @@ def test_release_info_endpoint_exposes_safe_build_metadata(
     assert data["build"]["short_sha"] == "abcdef123456"
     assert data["build"]["ref"] == "main"
     assert data["build"]["image"] == "ghcr.io/christianlouis/dmarq:abcdef1"
-    assert data["changes"]
+    assert data["changelog_url"].endswith("/CHANGELOG.md")
+    assert len(data["changes"]) >= 8
+    assert "Cloudflare rights profiles" in {item["title"] for item in data["changes"]}
+    assert "CSP hardening progress" in {item["title"] for item in data["changes"]}
 
 
 def test_domains_empty(authed_client: TestClient):

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -2034,7 +2034,7 @@ def test_cloudflare_oauth_state_round_trips_and_sanitizes_return_to(
         cloudflare_oauth.decode_cloudflare_oauth_state("")
 
 
-def test_cloudflare_oauth_authorization_url_uses_configured_scopes(
+def test_cloudflare_oauth_authorization_url_uses_configured_scopes_without_profile(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_zone_read_settings)
@@ -2052,6 +2052,22 @@ def test_cloudflare_oauth_authorization_url_uses_configured_scopes(
     assert "state=state-token" in result["authorization_url"]
 
 
+def test_cloudflare_oauth_authorization_url_profile_overrides_configured_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(cloudflare_oauth, "get_settings", _cloudflare_oauth_zone_read_settings)
+
+    result = cloudflare_oauth.build_cloudflare_authorization_url(
+        redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+        state="state-token",
+        scope_profile="full_dns_repair",
+    )
+
+    assert result["scope_profile"] == "full_dns_repair"
+    assert result["scopes"] == "zone.read dns.read dns.write radar.read user.read"
+    assert "scope=zone.read+dns.read+dns.write+radar.read+user.read" in result["authorization_url"]
+
+
 def test_cloudflare_oauth_authorization_url_uses_profile_scopes(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2064,8 +2080,8 @@ def test_cloudflare_oauth_authorization_url_uses_profile_scopes(
     )
 
     assert result["scope_profile"] == "full_dns_repair"
-    assert result["scopes"] == "zone.read dns.read dns.write"
-    assert "scope=zone.read+dns.read+dns.write" in result["authorization_url"]
+    assert result["scopes"] == "zone.read dns.read dns.write radar.read user.read"
+    assert "scope=zone.read+dns.read+dns.write+radar.read+user.read" in result["authorization_url"]
 
 
 def test_cloudflare_oauth_config_defaults_to_read_scopes(
@@ -2077,6 +2093,22 @@ def test_cloudflare_oauth_config_defaults_to_read_scopes(
         cloudflare_oauth.get_cloudflare_oauth_config().scopes
         == cloudflare_oauth.CLOUDFLARE_DEFAULT_READ_SCOPES
     )
+
+
+def test_cloudflare_oauth_scope_profile_metadata_marks_full_dns_radar_enabled():
+    profiles = {
+        profile["id"]: profile for profile in cloudflare_oauth.cloudflare_scope_profile_metadata()
+    }
+
+    full_profile = profiles["full_dns_repair"]
+    assert full_profile["scopes"] == "zone.read dns.read dns.write radar.read user.read"
+    assert full_profile["dns_write_enabled"] is True
+    assert full_profile["radar_enabled"] is True
+
+    radar_profile = profiles["read_only_radar"]
+    assert radar_profile["scopes"] == "zone.read dns.read radar.read user.read"
+    assert radar_profile["dns_write_enabled"] is False
+    assert radar_profile["radar_enabled"] is True
 
 
 def test_cloudflare_oauth_config_requires_client_credentials(
@@ -2338,7 +2370,7 @@ def test_persist_cloudflare_oauth_tokens_requires_access_token(
         cloudflare_oauth.persist_cloudflare_oauth_tokens(db_session, {})
 
 
-def test_persist_cloudflare_oauth_tokens_defaults_to_configured_scopes(
+def test_persist_cloudflare_oauth_tokens_defaults_to_profile_scopes(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2348,10 +2380,11 @@ def test_persist_cloudflare_oauth_tokens_defaults_to_configured_scopes(
     cloudflare_oauth.persist_cloudflare_oauth_tokens(
         db_session,
         {"access_token": "provider-token"},
+        scope_profile="full_dns_repair",
     )
 
     scope = db_session.query(Setting).filter(Setting.key == "cloudflare.oauth_scopes").first()
-    assert scope.value == "zone.read"
+    assert scope.value == "zone.read dns.read dns.write radar.read user.read"
 
 
 def test_persist_cloudflare_oauth_tokens_updates_existing_settings(

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -701,6 +701,8 @@ def test_base_template_propagates_selected_workspace_context():
     assert "input instanceof URL" in script
     assert "onclick=" not in template
     assert "data-release-modal-trigger" in template
+    assert "Full changelog" in template
+    assert "release_info.changelog_url" in template
     assert "bindReleaseModalTriggers" in script
     assert "dmarq-release-modal" in script
     assert "event.target" in script

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -136,7 +136,7 @@ Live DNS writes stay behind the separate DNS repair approval flow.
 
 | Provider | Zone import | Configuration |
 |----------|-------------|---------------|
-| Cloudflare | Ready | OAuth client with `zone.read`/`dns.read`, or `CLOUDFLARE_API_TOKEN` with Zone/DNS read permissions |
+| Cloudflare | Ready | OAuth client with `zone.read`/`dns.read` for import, `radar.read`/`user.read` for Radar enrichment, and `dns.write` only for full repair; or `CLOUDFLARE_API_TOKEN` with matching permissions |
 | Amazon Route 53 | Ready | boto3/AWS credential chain, `DMARQ_ROUTE53_PROFILE`, or `DMARQ_ROUTE53_ROLE_ARN` with optional `DMARQ_ROUTE53_EXTERNAL_ID` |
 | Hetzner DNS | Ready | `HETZNER_DNS_API_TOKEN` or `HETZNER_API_TOKEN` with DNS zone read access |
 | Linode DNS | Ready | `LINODE_API_TOKEN` or `LINODE_TOKEN` with Domains read-only access |
@@ -310,7 +310,7 @@ operational policy if long-term storage size matters.
 | `CLOUDFLARE_ZONE_ID` | Optional default Cloudflare Zone ID | - | `your_cloudflare_zone_id` |
 | `CLOUDFLARE_OAUTH_CLIENT_ID` | Optional Cloudflare OAuth client ID for one-click provider connect | - | `your_cloudflare_oauth_client_id` |
 | `CLOUDFLARE_OAUTH_CLIENT_SECRET` | Optional Cloudflare OAuth client secret for one-click provider connect | - | `your_cloudflare_oauth_client_secret` |
-| `CLOUDFLARE_OAUTH_SCOPES` | Cloudflare OAuth scopes requested for read-only zone import and ownership checks | `zone.read dns.read` | `zone.read dns.read` |
+| `CLOUDFLARE_OAUTH_SCOPES` | Optional legacy fixed Cloudflare OAuth scope request used only when no in-product rights profile is supplied. Leave empty so the UI profiles can request `zone.read dns.read`, Radar-capable `zone.read dns.read radar.read user.read`, or full repair `zone.read dns.read dns.write radar.read user.read`. | - | `zone.read dns.read` |
 | `HETZNER_DNS_API_TOKEN` | Hetzner Console API token for read-only DNS zone import through `api.hetzner.cloud` | - | `your_hetzner_read_only_api_token` |
 | `HETZNER_API_TOKEN` | Fallback Hetzner token name if you already inject generic Hetzner Cloud credentials | - | `your_hetzner_read_only_api_token` |
 | `LINODE_API_TOKEN` | Linode API token for read-only DNS domain import through `api.linode.com/v4` | - | `your_linode_domains_read_only_token` |


### PR DESCRIPTION
## Summary
- make the Cloudflare OAuth rights profile drive the requested consent scopes instead of the legacy default forcing read-only
- add Radar permissions to the Radar and full DNS repair profiles, while full repair also requests DNS write
- expand the in-product release modal and root changelog so recent operator-facing work is visible
- document the Cloudflare scope profiles in `.env.example` and deployment configuration

## Root cause
`CLOUDFLARE_OAUTH_SCOPES` defaulted to `zone.read dns.read`, and the authorization URL preferred that setting over the selected UI profile. As a result, selecting `full_dns_repair` still produced a read-only consent URL.

## Validation
- `.venv/bin/python -m pytest -q backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_api.py::test_release_info_endpoint_exposes_safe_build_metadata backend/app/tests/test_dashboard_template_security.py::test_base_template_propagates_selected_workspace_context`
- `.venv/bin/python -m black --check backend/app/services/cloudflare_oauth.py backend/app/tests/test_cloudflare_dns.py backend/app/services/release_info.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

## Note
If Cloudflare still shows only two consent permissions after this release is deployed, the Cloudflare OAuth client registration itself likely still only allows the two read-only scopes. The OAuth client must also allow DNS Write, Radar Read, and User Details Read for the app to request them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-app release metadata, including a link to the full changelog.
  * Expanded Cloudflare setup options to better match read-only, import, and full DNS repair workflows.

* **Bug Fixes**
  * Fixed Cloudflare authorization so selected access profiles are respected consistently.
  * Improved fallback behavior when saved OAuth scope details are missing.

* **Documentation**
  * Updated Cloudflare configuration guidance to reflect the new recommended scope handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->