### PR TITLE
[codex] Map IdP groups to DMARQ roles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,9 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # AUTHENTIK_CLIENT_SECRET="your_authentik_client_secret"
 # AUTHENTIK_REDIRECT_URI="https://app.example.com/api/v1/auth/callback"
 # AUTHENTIK_ALLOWED_DOMAINS="example.com"
+# Optional group-to-role mappings. Syntax: group-name=target-slug:role
+# AUTHENTIK_GROUP_WORKSPACE_ROLE_MAP="dmarq-admins=primary:workspace_owner,dmarq-analysts=primary:analyst"
+# AUTHENTIK_GROUP_ORGANIZATION_ROLE_MAP="dmarq-admins=customer-one:organization_owner"
 
 # Authentik Outpost / trusted proxy mode.
 # Only enable when DMARQ is reachable exclusively through that proxy.
@@ -113,6 +116,8 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # AUTH_TRUSTED_PROXY_EMAIL_HEADER="X-Authentik-Email"
 # AUTH_TRUSTED_PROXY_SUBJECT_HEADER="X-Authentik-Uid"
 # AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS="example.com"
+# AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP="dmarq-admins=primary:workspace_owner"
+# AUTH_TRUSTED_PROXY_GROUP_ORGANIZATION_ROLE_MAP="dmarq-admins=customer-one:organization_owner"
 
 # Generic OIDC for Keycloak, Entra ID, Google Workspace, Okta, and similar.
 # AUTH_MODE="oidc"
@@ -121,6 +126,8 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # OIDC_CLIENT_ID="dmarq"
 # OIDC_CLIENT_SECRET="your_oidc_client_secret"
 # OIDC_ALLOWED_EMAILS="admin@example.com"
+# OIDC_GROUP_WORKSPACE_ROLE_MAP="dmarq-admins=primary:workspace_owner"
+# OIDC_GROUP_ORGANIZATION_ROLE_MAP="dmarq-admins=customer-one:organization_owner"
 
 # Optional mail service sender-domain discovery
 # POSTMARK_ACCOUNT_TOKEN="your_postmark_account_token"

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -599,11 +599,10 @@ def _merge_role_pairs(*role_sets: tuple[tuple[str, str], ...]) -> tuple[tuple[st
     seen = set()
     for role_set in role_sets:
         for slug, role in role_set:
-            key = (slug, role)
-            if key in seen:
+            if slug in seen:
                 continue
-            normalized.append(key)
-            seen.add(key)
+            normalized.append((slug, role))
+            seen.add(slug)
     return tuple(normalized)
 
 

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Optional
@@ -40,6 +41,8 @@ class OIDCProviderConfig:
     skip_ssl_verify: bool
     allowed_emails: Optional[str] = None
     allowed_domains: Optional[str] = None
+    group_workspace_role_map: Optional[str] = None
+    group_organization_role_map: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -349,6 +352,12 @@ def configured_oidc_provider(settings: Settings | None = None) -> Optional[OIDCP
             skip_ssl_verify=cfg.OIDC_SKIP_SSL_VERIFY,
             allowed_emails=cfg.AUTHENTIK_ALLOWED_EMAILS or cfg.OIDC_ALLOWED_EMAILS,
             allowed_domains=cfg.AUTHENTIK_ALLOWED_DOMAINS or cfg.OIDC_ALLOWED_DOMAINS,
+            group_workspace_role_map=(
+                cfg.AUTHENTIK_GROUP_WORKSPACE_ROLE_MAP or cfg.OIDC_GROUP_WORKSPACE_ROLE_MAP
+            ),
+            group_organization_role_map=(
+                cfg.AUTHENTIK_GROUP_ORGANIZATION_ROLE_MAP or cfg.OIDC_GROUP_ORGANIZATION_ROLE_MAP
+            ),
         )
     if provider == "oidc":
         if not cfg.OIDC_ISSUER_URL or not cfg.OIDC_CLIENT_ID or not cfg.OIDC_CLIENT_SECRET:
@@ -364,6 +373,8 @@ def configured_oidc_provider(settings: Settings | None = None) -> Optional[OIDCP
             skip_ssl_verify=cfg.OIDC_SKIP_SSL_VERIFY,
             allowed_emails=cfg.OIDC_ALLOWED_EMAILS,
             allowed_domains=cfg.OIDC_ALLOWED_DOMAINS,
+            group_workspace_role_map=cfg.OIDC_GROUP_WORKSPACE_ROLE_MAP,
+            group_organization_role_map=cfg.OIDC_GROUP_ORGANIZATION_ROLE_MAP,
         )
     return None
 
@@ -493,6 +504,8 @@ async def exchange_oidc_callback(
         claims_payload,
         allowed_emails=provider.allowed_emails,
         allowed_domains=provider.allowed_domains,
+        group_workspace_role_map=provider.group_workspace_role_map,
+        group_organization_role_map=provider.group_organization_role_map,
     )
 
 
@@ -502,6 +515,8 @@ def normalize_external_claims(
     *,
     allowed_emails: Optional[str] = None,
     allowed_domains: Optional[str] = None,
+    group_workspace_role_map: Optional[str] = None,
+    group_organization_role_map: Optional[str] = None,
 ) -> ExternalIdentityClaims:
     """Normalize provider-specific claim JSON into the DMARQ user shape."""
     subject = str(payload.get("sub") or payload.get("uid") or "").strip()
@@ -516,6 +531,29 @@ def normalize_external_claims(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Authenticated identity is not allowed to access this DMARQ instance.",
         )
+    groups = _normalize_string_claims(payload.get("groups") or payload.get("roles"))
+    workspace_roles = _merge_role_pairs(
+        _normalize_role_claims(
+            payload.get("dmarq_workspace_roles") or payload.get("workspace_roles"),
+            allowed_roles=set(ROLE_PERMISSIONS),
+        ),
+        _role_pairs_from_group_map(
+            groups,
+            group_workspace_role_map,
+            allowed_roles=set(ROLE_PERMISSIONS),
+        ),
+    )
+    organization_roles = _merge_role_pairs(
+        _normalize_role_claims(
+            payload.get("dmarq_organization_roles") or payload.get("organization_roles"),
+            allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
+        ),
+        _role_pairs_from_group_map(
+            groups,
+            group_organization_role_map,
+            allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
+        ),
+    )
     return ExternalIdentityClaims(
         provider=provider,
         subject=subject,
@@ -524,15 +562,9 @@ def normalize_external_claims(
         username=payload.get("preferred_username") or payload.get("username"),
         picture=payload.get("picture"),
         email_verified=bool(payload.get("email_verified", False)),
-        groups=_normalize_string_claims(payload.get("groups") or payload.get("roles")),
-        workspace_roles=_normalize_role_claims(
-            payload.get("dmarq_workspace_roles") or payload.get("workspace_roles"),
-            allowed_roles=set(ROLE_PERMISSIONS),
-        ),
-        organization_roles=_normalize_role_claims(
-            payload.get("dmarq_organization_roles") or payload.get("organization_roles"),
-            allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
-        ),
+        groups=groups,
+        workspace_roles=workspace_roles,
+        organization_roles=organization_roles,
     )
 
 
@@ -560,6 +592,63 @@ def _normalize_string_claims(value: Any) -> tuple[str, ...]:
 def _normalize_role_value(role: Any, *, allowed_roles: set[str]) -> str:
     normalized = str(role or "").strip().lower()
     return normalized if normalized in allowed_roles else ""
+
+
+def _merge_role_pairs(*role_sets: tuple[tuple[str, str], ...]) -> tuple[tuple[str, str], ...]:
+    normalized: list[tuple[str, str]] = []
+    seen = set()
+    for role_set in role_sets:
+        for slug, role in role_set:
+            key = (slug, role)
+            if key in seen:
+                continue
+            normalized.append(key)
+            seen.add(key)
+    return tuple(normalized)
+
+
+def _role_pairs_from_group_map(
+    groups: tuple[str, ...],
+    mapping: Optional[str],
+    *,
+    allowed_roles: set[str],
+) -> tuple[tuple[str, str], ...]:
+    """Return role pairs granted by configured IdP group mappings.
+
+    Mapping syntax is a comma- or semicolon-separated list of
+    ``group-name=target-slug:role`` entries. Repeating a group grants multiple
+    target roles.
+    """
+    if not groups or not mapping:
+        return ()
+
+    group_keys = {group.strip().lower() for group in groups if group.strip()}
+    mapped_pairs: list[tuple[str, str]] = []
+    for index, entry in enumerate(re.split(r"[,;]", mapping), start=1):
+        if "=" not in entry:
+            logger.warning("Ignoring malformed group-role mapping entry at position=%d", index)
+            continue
+        group, assignment = entry.split("=", 1)
+        if group.strip().lower() not in group_keys:
+            continue
+        parsed_any = False
+        for slug, role in _split_role_string(assignment):
+            parsed_any = True
+            normalized_role = _normalize_role_value(role, allowed_roles=allowed_roles)
+            normalized_slug = slug.strip().lower()
+            if normalized_slug and normalized_role:
+                mapped_pairs.append((normalized_slug, normalized_role))
+            else:
+                logger.warning(
+                    "Ignoring group-role mapping entry with invalid target at position=%d",
+                    index,
+                )
+        if not parsed_any:
+            logger.warning(
+                "Ignoring group-role mapping entry without a target at position=%d",
+                index,
+            )
+    return _merge_role_pairs(tuple(mapped_pairs))
 
 
 def _extend_role_pairs_from_sequence(raw_pairs: list[tuple[Any, Any]], values: Any) -> None:
@@ -640,8 +729,7 @@ def _upsert_workspace_membership(
     )
     if workspace is None:
         logger.info(
-            "Ignoring external workspace role for unknown workspace slug=%s user_id=%s",
-            workspace_slug,
+            "Ignoring external workspace role for unknown workspace user_id=%s",
             user.id,
         )
         return None
@@ -682,8 +770,7 @@ def _upsert_organization_membership(
     )
     if organization is None:
         logger.info(
-            "Ignoring external organization role for unknown organization slug=%s user_id=%s",
-            organization_slug,
+            "Ignoring external organization role for unknown organization user_id=%s",
             user.id,
         )
         return None
@@ -729,7 +816,7 @@ def sync_external_user(claims: ExternalIdentityClaims, db: Session) -> User:
         user = db.query(User).filter(User.email == claims.email).first()
         if user is not None:
             user.logto_id = identity_id
-            logger.info("Linked user id=%d (%s) to %s", user.id, claims.email, identity_id)
+            logger.info("Linked user id=%d to external provider=%s", user.id, claims.provider)
     if user is None:
         user = User(
             logto_id=identity_id,
@@ -740,7 +827,7 @@ def sync_external_user(claims: ExternalIdentityClaims, db: Session) -> User:
         )
         db.add(user)
         db.flush()
-        logger.info("Created user id=%d from %s", user.id, identity_id)
+        logger.info("Created user id=%d from external provider=%s", user.id, claims.provider)
 
     user.full_name = claims.name or user.full_name
     user.username = claims.username or user.username
@@ -773,6 +860,7 @@ def trusted_proxy_claims_from_request(
     ):
         return None
     provider = (cfg.AUTH_TRUSTED_PROXY_PROVIDER or "trusted_proxy").strip().lower()
+    groups = _normalize_string_claims(request.headers.get(cfg.AUTH_TRUSTED_PROXY_GROUPS_HEADER))
     return ExternalIdentityClaims(
         provider=provider,
         subject=subject or email,
@@ -780,7 +868,17 @@ def trusted_proxy_claims_from_request(
         name=request.headers.get(cfg.AUTH_TRUSTED_PROXY_NAME_HEADER),
         username=request.headers.get(cfg.AUTH_TRUSTED_PROXY_USERNAME_HEADER),
         email_verified=True,
-        groups=_normalize_string_claims(request.headers.get(cfg.AUTH_TRUSTED_PROXY_GROUPS_HEADER)),
+        groups=groups,
+        workspace_roles=_role_pairs_from_group_map(
+            groups,
+            cfg.AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP,
+            allowed_roles=set(ROLE_PERMISSIONS),
+        ),
+        organization_roles=_role_pairs_from_group_map(
+            groups,
+            cfg.AUTH_TRUSTED_PROXY_GROUP_ORGANIZATION_ROLE_MAP,
+            allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
+        ),
     )
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -146,6 +146,8 @@ class Settings(BaseSettings):
     ALLOW_OIDC_SKIP_SSL_VERIFY_IN_PRODUCTION: bool = False
     OIDC_ALLOWED_EMAILS: Optional[str] = None
     OIDC_ALLOWED_DOMAINS: Optional[str] = None
+    OIDC_GROUP_WORKSPACE_ROLE_MAP: Optional[str] = None
+    OIDC_GROUP_ORGANIZATION_ROLE_MAP: Optional[str] = None
 
     AUTHENTIK_ISSUER_URL: Optional[str] = None
     AUTHENTIK_CLIENT_ID: Optional[str] = None
@@ -154,6 +156,8 @@ class Settings(BaseSettings):
     AUTHENTIK_SCOPES: str = "openid email profile"
     AUTHENTIK_ALLOWED_EMAILS: Optional[str] = None
     AUTHENTIK_ALLOWED_DOMAINS: Optional[str] = None
+    AUTHENTIK_GROUP_WORKSPACE_ROLE_MAP: Optional[str] = None
+    AUTHENTIK_GROUP_ORGANIZATION_ROLE_MAP: Optional[str] = None
 
     # ── Trusted proxy / Authentik Outpost mode ───────────────────────────────
     # Use only when DMARQ is reachable exclusively through the trusted proxy.
@@ -166,6 +170,8 @@ class Settings(BaseSettings):
     AUTH_TRUSTED_PROXY_GROUPS_HEADER: str = "X-Authentik-Groups"
     AUTH_TRUSTED_PROXY_ALLOWED_EMAILS: Optional[str] = None
     AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS: Optional[str] = None
+    AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP: Optional[str] = None
+    AUTH_TRUSTED_PROXY_GROUP_ORGANIZATION_ROLE_MAP: Optional[str] = None
 
     # ── Logto OIDC ────────────────────────────────────────────────────────────
     # Set these to enable Logto-based authentication.

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -354,6 +354,36 @@ class TestExternalAuthProviders:
         )
         assert claims.organization_roles == (("customer-one", "organization_owner"),)
 
+    def test_normalize_external_claims_preserves_explicit_role_precedence(self):
+        claims = normalize_external_claims(
+            "authentik",
+            {
+                "sub": "authentik-user-1",
+                "email": "owner@example.com",
+                "groups": ["dmarq-admins", "auditors"],
+                "dmarq_workspace_roles": {"primary": "analyst"},
+                "dmarq_organization_roles": {"customer-one": "auditor"},
+            },
+            allowed_domains="example.com",
+            group_workspace_role_map=(
+                "dmarq-admins=primary:workspace_owner,"
+                "auditors=secondary:analyst"
+            ),
+            group_organization_role_map=(
+                "dmarq-admins=customer-one:organization_owner,"
+                "auditors=customer-two:auditor"
+            ),
+        )
+
+        assert claims.workspace_roles == (
+            ("primary", "analyst"),
+            ("secondary", "analyst"),
+        )
+        assert claims.organization_roles == (
+            ("customer-one", "auditor"),
+            ("customer-two", "auditor"),
+        )
+
     def test_normalize_external_claims_logs_invalid_group_role_mappings(self, caplog):
         with caplog.at_level(logging.WARNING, logger="app.core.auth_providers"):
             claims = normalize_external_claims(

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -366,12 +366,10 @@ class TestExternalAuthProviders:
             },
             allowed_domains="example.com",
             group_workspace_role_map=(
-                "dmarq-admins=primary:workspace_owner,"
-                "auditors=secondary:analyst"
+                "dmarq-admins=primary:workspace_owner," "auditors=secondary:analyst"
             ),
             group_organization_role_map=(
-                "dmarq-admins=customer-one:organization_owner,"
-                "auditors=customer-two:auditor"
+                "dmarq-admins=customer-one:organization_owner," "auditors=customer-two:auditor"
             ),
         )
 

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -16,6 +16,7 @@ Logto SDK calls are mocked so no live Logto instance is needed.
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -34,6 +35,7 @@ from app.core.auth_providers import (
     exchange_oidc_callback,
     normalize_external_claims,
     sync_external_user,
+    trusted_proxy_claims_from_request,
     trusted_proxy_auth_context,
 )
 from app.core.config import Settings, get_settings
@@ -210,6 +212,8 @@ class TestExternalAuthProviders:
             AUTHENTIK_ISSUER_URL="https://idp.example.test/application/o/dmarq",
             AUTHENTIK_CLIENT_ID="client-id",
             AUTHENTIK_CLIENT_SECRET="client-secret",
+            AUTHENTIK_GROUP_WORKSPACE_ROLE_MAP="dmarq-admins=primary:workspace_owner",
+            AUTHENTIK_GROUP_ORGANIZATION_ROLE_MAP="dmarq-admins=customer-one:organization_owner",
         )
 
         provider = configured_oidc_provider(settings)
@@ -219,6 +223,10 @@ class TestExternalAuthProviders:
         assert provider.provider == "authentik"
         assert provider.label == "Authentik"
         assert provider.issuer_url == "https://idp.example.test/application/o/dmarq"
+        assert provider.group_workspace_role_map == "dmarq-admins=primary:workspace_owner"
+        assert (
+            provider.group_organization_role_map == "dmarq-admins=customer-one:organization_owner"
+        )
 
     def test_generic_oidc_config_selects_provider_label(self):
         settings = Settings(
@@ -320,6 +328,54 @@ class TestExternalAuthProviders:
             ("customer-two", "auditor"),
         )
 
+    def test_normalize_external_claims_applies_group_role_mappings(self):
+        claims = normalize_external_claims(
+            "authentik",
+            {
+                "sub": "authentik-user-1",
+                "email": "owner@example.com",
+                "groups": ["DMARQ-Admins", "billing"],
+                "dmarq_workspace_roles": {"primary": "workspace_owner"},
+            },
+            allowed_domains="example.com",
+            group_workspace_role_map=(
+                "dmarq-admins=primary:workspace_owner,"
+                "billing=secondary:analyst,"
+                "ignored=primary:workspace_owner,"
+                "billing=bad:root"
+            ),
+            group_organization_role_map="dmarq-admins=customer-one:organization_owner",
+        )
+
+        assert claims.groups == ("DMARQ-Admins", "billing")
+        assert claims.workspace_roles == (
+            ("primary", "workspace_owner"),
+            ("secondary", "analyst"),
+        )
+        assert claims.organization_roles == (("customer-one", "organization_owner"),)
+
+    def test_normalize_external_claims_logs_invalid_group_role_mappings(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="app.core.auth_providers"):
+            claims = normalize_external_claims(
+                "authentik",
+                {
+                    "sub": "authentik-user-1",
+                    "email": "owner@example.com",
+                    "groups": ["dmarq-admins"],
+                },
+                allowed_domains="example.com",
+                group_workspace_role_map=(
+                    "malformed-entry," "dmarq-admins=primary:root," "dmarq-admins=missing-separator"
+                ),
+            )
+
+        assert claims.workspace_roles == ()
+        assert "malformed group-role mapping entry at position=1" in caplog.text
+        assert "invalid target at position=2" in caplog.text
+        assert "without a target at position=3" in caplog.text
+        assert "primary:root" not in caplog.text
+        assert "owner@example.com" not in caplog.text
+
     def test_normalize_role_claims_accepts_strings_and_deduplicates_pairs(self):
         roles = _normalize_role_claims(
             [
@@ -402,6 +458,39 @@ class TestExternalAuthProviders:
         assert workspace_membership.active is True
         assert organization_membership.role == "organization_owner"
         assert organization_membership.active is True
+
+    def test_sync_external_user_applies_group_mapped_roles(self, db_session):
+        organization = Organization(slug="customer-one", name="Customer One")
+        workspace = Workspace(slug="primary", name="Primary", organization=organization)
+        db_session.add_all([organization, workspace])
+        db_session.commit()
+
+        claims = normalize_external_claims(
+            "authentik",
+            {
+                "sub": "authentik-user-1",
+                "email": "owner@example.com",
+                "groups": ["dmarq-admins"],
+            },
+            group_workspace_role_map="dmarq-admins=primary:workspace_owner",
+            group_organization_role_map="dmarq-admins=customer-one:organization_owner",
+        )
+        user = sync_external_user(claims, db_session)
+
+        assert (
+            db_session.query(WorkspaceMembership)
+            .filter_by(workspace_id=workspace.id, user_id=user.id)
+            .one()
+            .role
+            == "workspace_owner"
+        )
+        assert (
+            db_session.query(OrganizationMembership)
+            .filter_by(organization_id=organization.id, user_id=user.id)
+            .one()
+            .role
+            == "organization_owner"
+        )
 
     def test_sync_external_user_demotes_fallback_superuser_with_role_claims(self, db_session):
         organization = Organization(slug="customer-one", name="Customer One")
@@ -530,6 +619,29 @@ class TestExternalAuthProviders:
             "name": "Owner",
             "username": "owner",
         }
+
+    def test_trusted_proxy_claims_apply_group_role_mappings(self):
+        settings = Settings(
+            AUTH_MODE="trusted_proxy",
+            AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS="example.com",
+            AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP="dmarq-admins=primary:workspace_owner",
+            AUTH_TRUSTED_PROXY_GROUP_ORGANIZATION_ROLE_MAP=(
+                "dmarq-admins=customer-one:organization_owner"
+            ),
+        )
+        request = MagicMock()
+        request.headers = {
+            "X-Authentik-Email": "owner@example.com",
+            "X-Authentik-Uid": "authentik-user-1",
+            "X-Authentik-Groups": "dmarq-admins,other",
+        }
+
+        claims = trusted_proxy_claims_from_request(request, settings)
+
+        assert claims is not None
+        assert claims.groups == ("dmarq-admins", "other")
+        assert claims.workspace_roles == (("primary", "workspace_owner"),)
+        assert claims.organization_roles == (("customer-one", "organization_owner"),)
 
     @pytest.mark.asyncio
     async def test_oidc_callback_rejects_unverified_id_token_without_userinfo(self):

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -81,6 +81,8 @@ Create an Authentik OAuth2/OpenID provider and register DMARQ's callback URL:
 | `AUTHENTIK_REDIRECT_URI` | Optional callback URL override | Auto-detected | `https://dmarq.example.com/api/v1/auth/callback` |
 | `AUTHENTIK_ALLOWED_EMAILS` | Optional comma-separated email allowlist | - | `admin@example.com` |
 | `AUTHENTIK_ALLOWED_DOMAINS` | Optional comma-separated email-domain allowlist | - | `example.com,example.org` |
+| `AUTHENTIK_GROUP_WORKSPACE_ROLE_MAP` | Optional Authentik group to DMARQ workspace role mapping. Use comma- or semicolon-separated `group=workspace-slug:role` entries. | - | `dmarq-admins=primary:workspace_owner` |
+| `AUTHENTIK_GROUP_ORGANIZATION_ROLE_MAP` | Optional Authentik group to DMARQ organization role mapping. Use comma- or semicolon-separated `group=organization-slug:role` entries. | - | `dmarq-admins=customer-one:organization_owner` |
 
 #### Generic OIDC
 
@@ -97,12 +99,21 @@ other OIDC-capable providers.
 | `OIDC_PROVIDER_LABEL` | UI label for the sign-in provider | `OpenID Connect` | `Keycloak` |
 | `OIDC_ALLOWED_EMAILS` | Optional comma-separated email allowlist | - | `admin@example.com` |
 | `OIDC_ALLOWED_DOMAINS` | Optional comma-separated email-domain allowlist | - | `example.com` |
+| `OIDC_GROUP_WORKSPACE_ROLE_MAP` | Optional IdP group to DMARQ workspace role mapping. Use comma- or semicolon-separated `group=workspace-slug:role` entries. | - | `dmarq-admins=primary:workspace_owner` |
+| `OIDC_GROUP_ORGANIZATION_ROLE_MAP` | Optional IdP group to DMARQ organization role mapping. Use comma- or semicolon-separated `group=organization-slug:role` entries. | - | `dmarq-admins=customer-one:organization_owner` |
 | `OIDC_SKIP_SSL_VERIFY` | Disable TLS verification for provider requests. Do not use in production unless explicitly allowed. | `false` | `true`, `false` |
 
 Presets such as Keycloak, Microsoft Entra ID, and Google Workspace do not need
 bespoke DMARQ code paths. Use `AUTH_MODE=oidc`, set `OIDC_PROVIDER_LABEL` to
 the provider name, and restrict single-user/self-hosted installs with
 `OIDC_ALLOWED_EMAILS` or `OIDC_ALLOWED_DOMAINS`.
+
+For team, ISP, or provider deployments, map IdP groups to existing local DMARQ
+workspace and organization slugs. DMARQ still keeps canonical users,
+workspaces, memberships, and audit logs locally; the IdP only proves identity
+and optionally grants roles through explicit mappings. Direct claims named
+`dmarq_workspace_roles` or `dmarq_organization_roles` can still be used when an
+IdP can emit them, and group mappings supplement those direct claims.
 
 #### Authentik Outpost / Trusted Proxy
 
@@ -121,6 +132,8 @@ owner.
 | `AUTH_TRUSTED_PROXY_USERNAME_HEADER` | Header containing username | `X-Authentik-Username` | `X-Authentik-Username` |
 | `AUTH_TRUSTED_PROXY_ALLOWED_EMAILS` | Optional comma-separated email allowlist | - | `admin@example.com` |
 | `AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS` | Optional comma-separated domain allowlist | - | `example.com` |
+| `AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP` | Optional trusted-proxy group to DMARQ workspace role mapping. Use comma- or semicolon-separated `group=workspace-slug:role` entries. | - | `dmarq-admins=primary:workspace_owner` |
+| `AUTH_TRUSTED_PROXY_GROUP_ORGANIZATION_ROLE_MAP` | Optional trusted-proxy group to DMARQ organization role mapping. Use comma- or semicolon-separated `group=organization-slug:role` entries. | - | `dmarq-admins=customer-one:organization_owner` |
 
 Cloudflare Access and Akamai EAA are tracked as trusted-proxy presets, not DNS
 provider account connectors. Use them only when they are the sole path to


### PR DESCRIPTION
## Summary
- add configurable group-to-workspace-role and group-to-organization-role mappings for Authentik, generic OIDC, and trusted-proxy auth
- merge group-derived roles with explicit OIDC role claims while preserving local DMARQ users, memberships, and audit boundaries
- document mapping syntax in .env.example and deployment configuration docs

## Validation
- /tmp/dmarq-ai-settings-526/.venv/bin/python -m pytest -q backend/app/tests/test_auth.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-ai-settings-526/.venv/bin/python -m black --check backend/app/core/auth_providers.py backend/app/core/config.py backend/app/tests/test_auth.py
- git diff --check

Refs #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional group-to-role mapping for sign-in, letting identity provider groups assign workspace and organization roles automatically.
  * Supported this across generic OIDC, Authentik direct OIDC, and trusted-proxy sign-in flows.

* **Documentation**
  * Updated configuration docs and example environment settings to show the new mapping options and how to format them.

* **Tests**
  * Expanded authentication coverage to verify group mapping, role assignment, and trusted-proxy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->