### PR TITLE
fix: remove Cloudflare OAuth user scope

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,7 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # CLOUDFLARE_ZONE_ID="your_cloudflare_zone_id"
 # Optional one-click Cloudflare connector. The in-product rights profile controls
 # requested scopes: read-only asks for zone.read/dns.read, Radar profiles also
-# ask for radar.read and user.read, and full repair also asks for dns.write. Leave
+# ask for radar.read, and full repair also asks for dns.write. Leave
 # CLOUDFLARE_OAUTH_SCOPES unset unless you intentionally need a legacy fixed
 # scope request when no profile is supplied.
 # CLOUDFLARE_OAUTH_CLIENT_ID="your_cloudflare_oauth_client_id"

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -5185,7 +5185,7 @@ async def cloudflare_oauth_callback(
         return HTMLResponse(
             content=(
                 "<html><body><p>Cloudflare connection failed. "
-                "Please close this window and try again from DMARQ settings.</p>"
+                "Please close this window or tab and try again from DMARQ settings.</p>"
                 f"{details}</body></html>"
             ),
             status_code=400,
@@ -5209,7 +5209,7 @@ async def cloudflare_oauth_callback(
         return HTMLResponse(
             content=(
                 "<html><body><p>Cloudflare connection failed. "
-                "Please close this window and retry after checking the connector settings."
+                "Please close this window or tab and retry after checking the connector settings."
                 "</p></body></html>"
             ),
             status_code=400,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1,6 +1,7 @@
 import asyncio
 import csv
 import hashlib
+import html
 import io
 import ipaddress
 import json
@@ -5164,13 +5165,28 @@ async def cloudflare_oauth_callback(
     from fastapi.responses import HTMLResponse, RedirectResponse
 
     error = request.query_params.get("error")
+    error_description = request.query_params.get("error_description")
     code = request.query_params.get("code")
     state_value = request.query_params.get("state")
     if error or not code or not state_value:
+        details = ""
+        if error:
+            safe_error = html.escape(error)
+            safe_description = html.escape(error_description or "")
+            details = f"<p><strong>Cloudflare error:</strong> {safe_error}</p>"
+            if safe_description:
+                details += f"<p>{safe_description}</p>"
+            if error == "invalid_scope":
+                details += (
+                    "<p>The selected rights profile requests a scope that this Cloudflare "
+                    "OAuth client is not allowed to request. Choose a lower rights profile "
+                    "or update the allowed scopes on the Cloudflare OAuth client.</p>"
+                )
         return HTMLResponse(
             content=(
                 "<html><body><p>Cloudflare connection failed. "
-                "Please close this window and try again from DMARQ settings.</p></body></html>"
+                "Please close this window and try again from DMARQ settings.</p>"
+                f"{details}</body></html>"
             ),
             status_code=400,
         )

--- a/backend/app/services/cloudflare_oauth.py
+++ b/backend/app/services/cloudflare_oauth.py
@@ -57,10 +57,11 @@ CLOUDFLARE_SCOPE_PROFILES: Dict[str, CloudflareScopeProfile] = {
         id="read_only_radar",
         name="Read-only + Radar context",
         description=("Read DNS zones and request Cloudflare Radar read access for IP enrichment."),
-        scopes="zone.read dns.read radar.read user.read",
+        scopes="zone.read dns.read radar.read",
         radar_enabled=True,
         warning=(
-            "Includes Account Radar Read plus User Details Read for Cloudflare Radar " "IP lookups."
+            "Includes Account Radar Read for Cloudflare Radar IP lookups. The Cloudflare "
+            "OAuth client must allow radar.read."
         ),
     ),
     "full_dns_repair": CloudflareScopeProfile(
@@ -70,12 +71,13 @@ CLOUDFLARE_SCOPE_PROFILES: Dict[str, CloudflareScopeProfile] = {
             "Read zones, allow human-approved DNS record changes, and request "
             "Cloudflare Radar IP enrichment access."
         ),
-        scopes="zone.read dns.read dns.write radar.read user.read",
+        scopes="zone.read dns.read dns.write radar.read",
         dns_write_enabled=True,
         radar_enabled=True,
         warning=(
             "Only use this when you want DMARQ to prepare/apply confirmed DNS repairs "
-            "and enrich sending IPs with Cloudflare Radar."
+            "and enrich sending IPs with Cloudflare Radar. The Cloudflare OAuth client "
+            "must allow dns.write and radar.read."
         ),
     ),
 }

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -617,7 +617,23 @@ function settingsApp() {
                     this.showFlash('Cloudflare connect failed: ' + (detail || res.statusText), false);
                     return;
                 }
-                window.location.href = data.authorization_url;
+                const popup = window.open(
+                    data.authorization_url,
+                    'dmarq-cloudflare-oauth',
+                    'width=760,height=840'
+                );
+                if (!popup) {
+                    window.location.href = data.authorization_url;
+                    return;
+                }
+                popup.opener = null;
+                const poll = window.setInterval(async () => {
+                    if (popup.closed) {
+                        window.clearInterval(poll);
+                        await this.loadCloudflareOAuthStatus(true);
+                        await this.loadDNSProviders(false);
+                    }
+                }, 1000);
             } catch (err) {
                 this.showFlash('Error starting Cloudflare connection: ' + err.message, false);
             } finally {

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -620,7 +620,7 @@ function settingsApp() {
                 const popup = window.open(
                     data.authorization_url,
                     'dmarq-cloudflare-oauth',
-                    'width=760,height=840'
+                    'width=760,height=840,noopener,noreferrer'
                 );
                 if (!popup) {
                     window.location.href = data.authorization_url;
@@ -630,8 +630,12 @@ function settingsApp() {
                 const poll = window.setInterval(async () => {
                     if (popup.closed) {
                         window.clearInterval(poll);
-                        await this.loadCloudflareOAuthStatus(true);
-                        await this.loadDNSProviders(false);
+                        try {
+                            await this.loadCloudflareOAuthStatus(true);
+                            await this.loadDNSProviders(false);
+                        } catch (err) {
+                            this.showFlash('Cloudflare status refresh failed: ' + err.message, false);
+                        }
                     }
                 }, 1000);
             } catch (err) {

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -2477,6 +2477,7 @@ def test_cloudflare_oauth_callback_requires_code_and_state(
 
     assert response.status_code == 400
     assert "Cloudflare connection failed" in response.text
+    assert "window or tab" in response.text
 
 
 def test_cloudflare_oauth_callback_explains_invalid_scope(
@@ -2494,6 +2495,7 @@ def test_cloudflare_oauth_callback_explains_invalid_scope(
     assert "invalid_scope" in response.text
     assert "cannot request radar.read" in response.text
     assert "Choose a lower rights profile" in response.text
+    assert "window or tab" in response.text
 
 
 def test_cloudflare_oauth_callback_returns_failure_for_invalid_state(
@@ -2509,6 +2511,7 @@ def test_cloudflare_oauth_callback_returns_failure_for_invalid_state(
 
     assert response.status_code == 400
     assert "retry after checking the connector settings" in response.text
+    assert "window or tab" in response.text
 
 
 def test_cloudflare_oauth_callback_stores_token_and_redirects(

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -2064,8 +2064,8 @@ def test_cloudflare_oauth_authorization_url_profile_overrides_configured_scopes(
     )
 
     assert result["scope_profile"] == "full_dns_repair"
-    assert result["scopes"] == "zone.read dns.read dns.write radar.read user.read"
-    assert "scope=zone.read+dns.read+dns.write+radar.read+user.read" in result["authorization_url"]
+    assert result["scopes"] == "zone.read dns.read dns.write radar.read"
+    assert "scope=zone.read+dns.read+dns.write+radar.read" in result["authorization_url"]
 
 
 def test_cloudflare_oauth_authorization_url_uses_profile_scopes(
@@ -2080,8 +2080,8 @@ def test_cloudflare_oauth_authorization_url_uses_profile_scopes(
     )
 
     assert result["scope_profile"] == "full_dns_repair"
-    assert result["scopes"] == "zone.read dns.read dns.write radar.read user.read"
-    assert "scope=zone.read+dns.read+dns.write+radar.read+user.read" in result["authorization_url"]
+    assert result["scopes"] == "zone.read dns.read dns.write radar.read"
+    assert "scope=zone.read+dns.read+dns.write+radar.read" in result["authorization_url"]
 
 
 def test_cloudflare_oauth_config_defaults_to_read_scopes(
@@ -2101,12 +2101,12 @@ def test_cloudflare_oauth_scope_profile_metadata_marks_full_dns_radar_enabled():
     }
 
     full_profile = profiles["full_dns_repair"]
-    assert full_profile["scopes"] == "zone.read dns.read dns.write radar.read user.read"
+    assert full_profile["scopes"] == "zone.read dns.read dns.write radar.read"
     assert full_profile["dns_write_enabled"] is True
     assert full_profile["radar_enabled"] is True
 
     radar_profile = profiles["read_only_radar"]
-    assert radar_profile["scopes"] == "zone.read dns.read radar.read user.read"
+    assert radar_profile["scopes"] == "zone.read dns.read radar.read"
     assert radar_profile["dns_write_enabled"] is False
     assert radar_profile["radar_enabled"] is True
 
@@ -2384,7 +2384,7 @@ def test_persist_cloudflare_oauth_tokens_defaults_to_profile_scopes(
     )
 
     scope = db_session.query(Setting).filter(Setting.key == "cloudflare.oauth_scopes").first()
-    assert scope.value == "zone.read dns.read dns.write radar.read user.read"
+    assert scope.value == "zone.read dns.read dns.write radar.read"
 
 
 def test_persist_cloudflare_oauth_tokens_updates_existing_settings(
@@ -2477,6 +2477,23 @@ def test_cloudflare_oauth_callback_requires_code_and_state(
 
     assert response.status_code == 400
     assert "Cloudflare connection failed" in response.text
+
+
+def test_cloudflare_oauth_callback_explains_invalid_scope(
+    authed_client: TestClient,
+):
+    response = authed_client.get(
+        "/api/v1/domains/cloudflare/oauth/callback"
+        "?error=invalid_scope"
+        "&error_description=The+OAuth+client+cannot+request+radar.read"
+        "&state=state-token"
+    )
+
+    assert response.status_code == 400
+    assert "Cloudflare error:" in response.text
+    assert "invalid_scope" in response.text
+    assert "cannot request radar.read" in response.text
+    assert "Choose a lower rights profile" in response.text
 
 
 def test_cloudflare_oauth_callback_returns_failure_for_invalid_state(

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -207,6 +207,15 @@ def _settings_script() -> str:
     return _read_project_file("static", "js", "settings-page.js")
 
 
+def test_settings_cloudflare_oauth_uses_popup_with_full_window_fallback():
+    script = _settings_script()
+
+    assert "window.open(" in script
+    assert "'dmarq-cloudflare-oauth'" in script
+    assert "window.location.href = data.authorization_url" in script
+    assert "loadCloudflareOAuthStatus(true)" in script
+
+
 def _domain_details_template() -> str:
     return _read_project_file("templates", "domain_details.html")
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -212,8 +212,10 @@ def test_settings_cloudflare_oauth_uses_popup_with_full_window_fallback():
 
     assert "window.open(" in script
     assert "'dmarq-cloudflare-oauth'" in script
+    assert "noopener,noreferrer" in script
     assert "window.location.href = data.authorization_url" in script
     assert "loadCloudflareOAuthStatus(true)" in script
+    assert "Cloudflare status refresh failed:" in script
 
 
 def _domain_details_template() -> str:

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -136,7 +136,7 @@ Live DNS writes stay behind the separate DNS repair approval flow.
 
 | Provider | Zone import | Configuration |
 |----------|-------------|---------------|
-| Cloudflare | Ready | OAuth client with `zone.read`/`dns.read` for import, `radar.read`/`user.read` for Radar enrichment, and `dns.write` only for full repair; or `CLOUDFLARE_API_TOKEN` with matching permissions |
+| Cloudflare | Ready | OAuth client with `zone.read`/`dns.read` for import, `radar.read` for Radar enrichment, and `dns.write` only for full repair; or `CLOUDFLARE_API_TOKEN` with matching permissions |
 | Amazon Route 53 | Ready | boto3/AWS credential chain, `DMARQ_ROUTE53_PROFILE`, or `DMARQ_ROUTE53_ROLE_ARN` with optional `DMARQ_ROUTE53_EXTERNAL_ID` |
 | Hetzner DNS | Ready | `HETZNER_DNS_API_TOKEN` or `HETZNER_API_TOKEN` with DNS zone read access |
 | Linode DNS | Ready | `LINODE_API_TOKEN` or `LINODE_TOKEN` with Domains read-only access |
@@ -310,7 +310,7 @@ operational policy if long-term storage size matters.
 | `CLOUDFLARE_ZONE_ID` | Optional default Cloudflare Zone ID | - | `your_cloudflare_zone_id` |
 | `CLOUDFLARE_OAUTH_CLIENT_ID` | Optional Cloudflare OAuth client ID for one-click provider connect | - | `your_cloudflare_oauth_client_id` |
 | `CLOUDFLARE_OAUTH_CLIENT_SECRET` | Optional Cloudflare OAuth client secret for one-click provider connect | - | `your_cloudflare_oauth_client_secret` |
-| `CLOUDFLARE_OAUTH_SCOPES` | Optional legacy fixed Cloudflare OAuth scope request used only when no in-product rights profile is supplied. Leave empty so the UI profiles can request `zone.read dns.read`, Radar-capable `zone.read dns.read radar.read user.read`, or full repair `zone.read dns.read dns.write radar.read user.read`. | - | `zone.read dns.read` |
+| `CLOUDFLARE_OAUTH_SCOPES` | Optional legacy fixed Cloudflare OAuth scope request used only when no in-product rights profile is supplied. Leave empty so the UI profiles can request `zone.read dns.read`, Radar-capable `zone.read dns.read radar.read`, or full repair `zone.read dns.read dns.write radar.read`. | - | `zone.read dns.read` |
 | `HETZNER_DNS_API_TOKEN` | Hetzner Console API token for read-only DNS zone import through `api.hetzner.cloud` | - | `your_hetzner_read_only_api_token` |
 | `HETZNER_API_TOKEN` | Fallback Hetzner token name if you already inject generic Hetzner Cloud credentials | - | `your_hetzner_read_only_api_token` |
 | `LINODE_API_TOKEN` | Linode API token for read-only DNS domain import through `api.linode.com/v4` | - | `your_linode_domains_read_only_token` |


### PR DESCRIPTION
## Summary
- remove unsupported user.read from Cloudflare OAuth rights profiles while keeping radar.read in Radar/full profiles
- show Cloudflare OAuth callback details for invalid_scope errors with actionable next steps
- open Cloudflare OAuth in a popup with full-window fallback and refresh status after close
- update docs/tests for the corrected Cloudflare scopes

## Local validation
- /tmp/dmarq-ai-settings-526/.venv/bin/python -m black --check backend/app/api/api_v1/endpoints/domains.py backend/app/services/cloudflare_oauth.py backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_dashboard_template_security.py
- /tmp/dmarq-ai-settings-526/.venv/bin/python -m pytest -q backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_dashboard_template_security.py