### PR TITLE
feat: localize DNS remediation guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,12 @@ ENVIRONMENT="development"
 # Public URL used for OAuth callbacks when DMARQ is behind a proxy/ingress.
 # PUBLIC_BASE_URL="https://app.example.com"
 
+# Default language for operator-facing guidance. English is the source and
+# fallback language; German remediation guidance is available for the highest
+# value DNS findings.
+# LANGUAGE="en"
+# DMARQ_DEFAULT_LOCALE="en"
+
 # Self-hosted installs default to a single visible workspace. Enable this for
 # SaaS, ISP/MSP, or operator deployments that need workspace switching and
 # member management in the UI.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2339,6 +2339,7 @@ async def _build_domain_dns_guidance(
     domain_id: str,
     *,
     refresh: bool = False,
+    locale: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build typed DNS lint findings and target records for a monitored domain."""
     manual_selectors = _get_domain_selectors_from_db(db, domain_id)
@@ -2382,6 +2383,7 @@ async def _build_domain_dns_guidance(
         monitored_selectors=combined_selectors,
         observed_selectors=report_selectors,
         mail_service_records=mail_service_records,
+        locale=locale or get_settings().default_locale,
     )
     return asdict(guidance)
 
@@ -3499,6 +3501,7 @@ async def update_domain(
 async def lint_all_domain_dns(
     refresh: bool = Query(False, title="Refresh cached DNS results"),
     limit: int = Query(100, ge=1, le=500, title="Maximum domains to lint"),
+    locale: Optional[str] = Query(None, title="Operator guidance locale"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -3510,7 +3513,9 @@ async def lint_all_domain_dns(
 
     items: List[DNSBulkGuidanceItem] = []
     for domain_name in domains:
-        guidance = await _build_domain_dns_guidance(db, store, domain_name, refresh=refresh)
+        guidance = await _build_domain_dns_guidance(
+            db, store, domain_name, refresh=refresh, locale=locale
+        )
         findings = guidance["findings"]
         items.append(
             DNSBulkGuidanceItem(
@@ -3529,6 +3534,7 @@ async def lint_all_domain_dns(
 async def export_all_domain_dns_lint(
     refresh: bool = Query(False, title="Refresh cached DNS results"),
     limit: int = Query(500, ge=1, le=1000, title="Maximum domains to export"),
+    locale: Optional[str] = Query(None, title="Operator guidance locale"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -3555,7 +3561,9 @@ async def export_all_domain_dns_lint(
         ]
     )
     for domain_name in domains:
-        guidance = await _build_domain_dns_guidance(db, store, domain_name, refresh=refresh)
+        guidance = await _build_domain_dns_guidance(
+            db, store, domain_name, refresh=refresh, locale=locale
+        )
         for finding in guidance["findings"]:
             target = finding.get("target_record") or {}
             writer.writerow(
@@ -4215,6 +4223,7 @@ async def get_domain_dns_records(
 async def get_domain_dns_lint(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached DNS result"),
+    locale: Optional[str] = Query(None, title="Operator guidance locale"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -4229,7 +4238,7 @@ async def get_domain_dns_lint(
             detail="Domain not found",
         )
 
-    return await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh)
+    return await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh, locale=locale)
 
 
 @router.get("/{domain_id}/dns/change-plan", response_model=DNSChangePlanResponse)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -24,6 +24,8 @@ class Settings(BaseSettings):
     ENVIRONMENT: str = "development"
     DEMO_MODE: bool = False
     PUBLIC_BASE_URL: Optional[str] = None
+    LANGUAGE: str = "en"
+    DMARQ_DEFAULT_LOCALE: Optional[str] = None
     DMARQ_RELEASE_VERSION: Optional[str] = None
     DMARQ_BUILD_SHA: Optional[str] = None
     DMARQ_BUILD_REF: Optional[str] = None
@@ -190,6 +192,15 @@ class Settings(BaseSettings):
     LOGTO_REDIRECT_URI: Optional[str] = None
     LOGTO_SKIP_SSL_VERIFY: bool = False
     ALLOW_LOGTO_SKIP_SSL_VERIFY_IN_PRODUCTION: bool = False
+
+    @property
+    def default_locale(self) -> str:
+        """Return the deployment default locale for operator-facing guidance."""
+        locale = self.DMARQ_DEFAULT_LOCALE or self.LANGUAGE or "en"
+        normalized = locale.strip().lower().replace("_", "-")
+        if normalized.startswith("de"):
+            return "de"
+        return "en"
 
     @property
     def logto_configured(self) -> bool:

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -205,7 +205,6 @@ def _finding(
     target_record: Optional[DNSGuidanceRecord] = None,
     evidence: Optional[List[str]] = None,
     remediation_steps: Optional[List[str]] = None,
-    locale: str = "en",
 ) -> DNSLintFinding:
     return DNSLintFinding(
         code=code,
@@ -217,9 +216,7 @@ def _finding(
         record_name=record_name,
         target_record=target_record,
         evidence=list(evidence or []),
-        remediation_steps=list(
-            remediation_steps or _default_remediation_steps(code, locale=locale)
-        ),
+        remediation_steps=list(remediation_steps or _default_remediation_steps(code)),
     )
 
 
@@ -228,6 +225,12 @@ _REMEDIATION_STEPS_EN: Dict[str, List[str]] = {
         "Open the DNS zone for the affected domain.",
         "Create one TXT record at _dmarc with a monitoring policy and rua mailbox.",
         "Wait for DNS propagation, then refresh DMARQ DNS lint.",
+    ],
+    "dmarc_monitoring_policy": [
+        "Review DMARQ report evidence to confirm which legitimate sources already pass "
+        "SPF or DKIM alignment.",
+        "Document or fix any active failures before tightening the DMARC policy.",
+        "Only then plan the move from p=none to quarantine or reject.",
     ],
     "spf_missing": [
         "List every platform currently allowed to send mail for this domain.",

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -81,6 +81,14 @@ def _today_id() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%d")
 
 
+def normalize_guidance_locale(locale: Optional[str]) -> str:
+    """Return the supported locale used for operator-facing DNS guidance."""
+    normalized = (locale or "en").strip().lower().replace("_", "-")
+    if normalized.startswith("de"):
+        return "de"
+    return "en"
+
+
 def _target_records(domain: str, result: DomainDNSResult) -> List[DNSGuidanceRecord]:
     dmarc_value = result.dmarc_record or (
         f"v=DMARC1; p=none; rua=mailto:dmarc@{domain}; adkim=r; aspf=r"
@@ -197,6 +205,7 @@ def _finding(
     target_record: Optional[DNSGuidanceRecord] = None,
     evidence: Optional[List[str]] = None,
     remediation_steps: Optional[List[str]] = None,
+    locale: str = "en",
 ) -> DNSLintFinding:
     return DNSLintFinding(
         code=code,
@@ -208,127 +217,220 @@ def _finding(
         record_name=record_name,
         target_record=target_record,
         evidence=list(evidence or []),
-        remediation_steps=list(remediation_steps or _default_remediation_steps(code)),
+        remediation_steps=list(
+            remediation_steps or _default_remediation_steps(code, locale=locale)
+        ),
     )
 
 
-def _default_remediation_steps(code: str) -> List[str]:
+_REMEDIATION_STEPS_EN: Dict[str, List[str]] = {
+    "dmarc_missing": [
+        "Open the DNS zone for the affected domain.",
+        "Create one TXT record at _dmarc with a monitoring policy and rua mailbox.",
+        "Wait for DNS propagation, then refresh DMARQ DNS lint.",
+    ],
+    "spf_missing": [
+        "List every platform currently allowed to send mail for this domain.",
+        "Publish exactly one root TXT record beginning with v=spf1.",
+        "Use ~all during rollout or -all after all senders are verified.",
+    ],
+    "spf_multiple_records": [
+        "Copy all current SPF mechanisms into one planned SPF record.",
+        "Remove duplicate or obsolete mechanisms while preserving active senders.",
+        "Publish one root SPF TXT record and remove the extra SPF TXT values.",
+    ],
+    "spf_all_too_permissive": [
+        "Confirm which senders are legitimate from DMARQ sending-source evidence.",
+        "Replace +all with ~all while validating, or -all after coverage is complete.",
+        "Refresh DNS lint and watch failure trends for at least one report cycle.",
+    ],
+    "spf_dns_lookup_limit_exceeded": [
+        "Count every include, a, mx, ptr, exists, and redirect mechanism.",
+        "Remove unused includes and flatten stable sender ranges with the provider.",
+        "Keep the final SPF path below 10 DNS lookups before enforcement.",
+    ],
+    "spf_dns_lookup_limit_risk": [
+        "Identify which SPF includes are still actively used.",
+        "Remove duplicate or retired sender includes before adding new senders.",
+        "Document the remaining lookup budget for future sender onboarding.",
+    ],
+    "spf_duplicate_include": [
+        "Find the repeated include values in the SPF TXT record.",
+        "Keep one copy of each include and remove the duplicates.",
+        "Refresh DNS lint to confirm the SPF lookup budget improved.",
+    ],
+    "spf_void_lookup": [
+        "Open each referenced include, exists, or redirect target.",
+        "Remove targets that no longer publish TXT records.",
+        "Ask the sender provider for the current SPF include when the sender is still active.",
+    ],
+    "dkim_selector_missing": [
+        "Identify the sending provider that owns the selector from report evidence.",
+        "Open that provider's domain authentication settings and copy the DKIM TXT or CNAME.",
+        "Publish the selector record, then refresh DNS lint and confirm it resolves.",
+    ],
+    "dkim_selector_cname_broken": [
+        "Open the DNS CNAME record shown in evidence.",
+        "Compare its target with the current value in the sending provider admin page.",
+        "Replace stale targets or complete provider-side domain authentication.",
+    ],
+    "dkim_selector_key_too_short": [
+        "Check whether the sending provider supports 2048-bit DKIM keys.",
+        "Generate a replacement selector instead of editing the existing key in place.",
+        "Publish and validate the new selector before retiring the old selector.",
+    ],
+    "dkim_selector_stale": [
+        "Confirm whether the selector belongs to a retired sender or old key rotation.",
+        "Keep it only if a valid provider still uses it for aligned mail.",
+        "Remove retired selector records after checking one or more report cycles.",
+    ],
+    "mta_sts_missing": [
+        "Publish _mta-sts TXT with a stable id value.",
+        "Host a valid HTTPS policy at the well-known mta-sts hostname.",
+        "Start in testing mode and rotate the TXT id whenever the policy changes.",
+    ],
+    "tls_rpt_missing": [
+        "Choose the TLS report mailbox or HTTPS collector endpoint.",
+        "Publish one TXT record at _smtp._tls with v=TLSRPTv1 and rua.",
+        "Confirm DMARQ imports TLS reports after receivers start sending them.",
+    ],
+    "tls_rpt_multiple_records": [
+        "Merge all TLS-RPT rua destinations into one TXT record.",
+        "Remove duplicate _smtp._tls TXT records.",
+        "Refresh DNS lint to confirm only one TLS-RPT record remains.",
+    ],
+    "tls_rpt_rua_missing": [
+        "Choose where SMTP TLS reports should be delivered.",
+        "Add rua=mailto:... or rua=https://... to the TLS-RPT TXT value.",
+        "Refresh DMARQ after DNS propagation.",
+    ],
+    "bimi_missing": [
+        "Complete DMARC enforcement first.",
+        "Publish a default._bimi TXT record with an HTTPS SVG logo URL.",
+        "Add a certificate URL if the mailbox providers you care about require it.",
+    ],
+    "dane_missing": [
+        "Confirm that the domain's DNS zone and every MX host zone you control are signed and validating with DNSSEC.",
+        "For each MX host, fetch the live SMTP STARTTLS certificate and compute the TLSA 3 1 1 SHA-256 SPKI value.",
+        "Publish one TLSA record under _25._tcp.<mx-host> per controlled MX host, or confirm your mail provider's DANE/TLSA support for third-party MX hosts, then refresh DMARQ DNS lint.",
+    ],
+    "dane_review": [
+        "Review every TLSA record shown in evidence for the affected MX hosts.",
+        "Compare the TLSA selector and hash with the current SMTP TLS certificate.",
+        "Rotate TLSA values in the same change window as certificate changes.",
+    ],
+    "mail_service_record_missing": [
+        "Open the sender-domain authentication page in the mail service.",
+        "Copy the required DNS record into the authoritative DNS provider.",
+        "Refresh DMARQ DNS lint and then re-check verification in the mail service.",
+    ],
+    "mail_service_record_conflict": [
+        "Compare the existing DNS value with the value required by the mail service.",
+        "Confirm no other active sender depends on the current value.",
+        "Update the record or split senders onto provider-supported hostnames.",
+    ],
+}
+
+
+_REMEDIATION_STEPS_DE: Dict[str, List[str]] = {
+    "dmarc_missing": [
+        "Oeffne die DNS-Zone der betroffenen Domain.",
+        "Lege genau einen TXT-Record unter _dmarc mit Monitoring-Policy und rua-Postfach an.",
+        "Warte die DNS-Verteilung ab und aktualisiere danach den DMARQ-DNS-Check.",
+    ],
+    "dmarc_monitoring_policy": [
+        "Pruefe in DMARQ, welche legitimen Versandquellen bereits SPF oder DKIM-aligned bestehen.",
+        "Dokumentiere oder behebe alle aktiven Fehlschlaege, bevor du die Policy verschaerfst.",
+        "Plane erst danach den Wechsel von p=none zu quarantine oder reject.",
+    ],
+    "spf_missing": [
+        "Liste alle Plattformen auf, die aktuell fuer diese Domain E-Mail senden duerfen.",
+        "Veroeffentliche genau einen TXT-Record an der Domain-Wurzel, der mit v=spf1 beginnt.",
+        "Nutze waehrend der Einfuehrung ~all oder nach verifizierten Sendern -all.",
+    ],
+    "spf_multiple_records": [
+        "Kopiere alle aktuellen SPF-Mechanismen in einen geplanten gemeinsamen SPF-Record.",
+        "Entferne doppelte oder veraltete Mechanismen, ohne aktive Sender zu verlieren.",
+        "Veroeffentliche genau einen SPF-TXT-Record und entferne die zusaetzlichen SPF-Werte.",
+    ],
+    "spf_all_too_permissive": [
+        "Pruefe anhand der DMARQ-Versandquellen, welche Sender legitim sind.",
+        "Ersetze +all waehrend der Validierung durch ~all oder nach vollstaendiger Abdeckung durch -all.",
+        "Aktualisiere den DNS-Check und beobachte die Fehlertrends mindestens einen Report-Zyklus lang.",
+    ],
+    "spf_dns_lookup_limit_exceeded": [
+        "Zaehle alle include-, a-, mx-, ptr-, exists- und redirect-Mechanismen.",
+        "Entferne ungenutzte Includes und ersetze stabile Senderbereiche gemeinsam mit dem Provider.",
+        "Halte den finalen SPF-Pfad vor DMARC-Enforcement unter zehn DNS-Lookups.",
+    ],
+    "spf_dns_lookup_limit_risk": [
+        "Identifiziere, welche SPF-Includes noch aktiv genutzt werden.",
+        "Entferne doppelte oder stillgelegte Sender-Includes, bevor neue Sender ergaenzt werden.",
+        "Dokumentiere das verbleibende Lookup-Budget fuer spaetere Sender-Onboardings.",
+    ],
+    "spf_duplicate_include": [
+        "Finde die wiederholten include-Werte im SPF-TXT-Record.",
+        "Behalte jeden include-Wert nur einmal und entferne die Duplikate.",
+        "Aktualisiere den DNS-Check, um das verbesserte SPF-Lookup-Budget zu bestaetigen.",
+    ],
+    "spf_void_lookup": [
+        "Oeffne jedes referenzierte include-, exists- oder redirect-Ziel.",
+        "Entferne Ziele, die keine TXT-Records mehr veroeffentlichen.",
+        "Frage beim Sender-Provider nach dem aktuellen SPF-Include, falls der Sender weiterhin aktiv ist.",
+    ],
+    "dkim_selector_missing": [
+        "Identifiziere anhand der Report-Evidenz den Versanddienst, dem dieser Selector gehoert.",
+        "Oeffne dort die Domain-Authentifizierung und kopiere den DKIM-TXT- oder CNAME-Record.",
+        "Veroeffentliche den Selector-Record, aktualisiere den DNS-Check und pruefe, ob er aufloest.",
+    ],
+    "dkim_selector_cname_broken": [
+        "Oeffne den in der Evidenz genannten DNS-CNAME-Record.",
+        "Vergleiche dessen Ziel mit dem aktuellen Wert im Administrationsbereich des Versanddienstes.",
+        "Ersetze veraltete Ziele oder schliesse die Domain-Authentifizierung beim Provider ab.",
+    ],
+    "dkim_selector_key_too_short": [
+        "Pruefe, ob der Versanddienst 2048-Bit-DKIM-Schluessel unterstuetzt.",
+        "Erzeuge einen neuen Selector, statt den bestehenden Schluessel direkt zu ersetzen.",
+        "Veroeffentliche und validiere den neuen Selector, bevor du den alten Selector entfernst.",
+    ],
+    "dkim_selector_stale": [
+        "Pruefe, ob der Selector zu einem stillgelegten Sender oder einer alten Schluesselrotation gehoert.",
+        "Behalte ihn nur, wenn ein gueltiger Provider ihn weiterhin fuer aligned Mail nutzt.",
+        "Entferne stillgelegte Selector-Records erst nach einem oder mehreren Report-Zyklen.",
+    ],
+}
+
+
+_FALLBACK_REMEDIATION_STEPS_EN = [
+    "Open the linked DNS or report evidence in DMARQ.",
+    "Make the smallest provider-side change that addresses the finding.",
+    "Refresh DNS lint and monitor the next aggregate report cycle.",
+]
+
+
+def _default_remediation_steps(code: str, *, locale: Optional[str] = None) -> List[str]:
     """Return deterministic operator steps for a lint finding."""
-    steps = {
-        "dmarc_missing": [
-            "Open the DNS zone for the affected domain.",
-            "Create one TXT record at _dmarc with a monitoring policy and rua mailbox.",
-            "Wait for DNS propagation, then refresh DMARQ DNS lint.",
-        ],
-        "spf_missing": [
-            "List every platform currently allowed to send mail for this domain.",
-            "Publish exactly one root TXT record beginning with v=spf1.",
-            "Use ~all during rollout or -all after all senders are verified.",
-        ],
-        "spf_multiple_records": [
-            "Copy all current SPF mechanisms into one planned SPF record.",
-            "Remove duplicate or obsolete mechanisms while preserving active senders.",
-            "Publish one root SPF TXT record and remove the extra SPF TXT values.",
-        ],
-        "spf_all_too_permissive": [
-            "Confirm which senders are legitimate from DMARQ sending-source evidence.",
-            "Replace +all with ~all while validating, or -all after coverage is complete.",
-            "Refresh DNS lint and watch failure trends for at least one report cycle.",
-        ],
-        "spf_dns_lookup_limit_exceeded": [
-            "Count every include, a, mx, ptr, exists, and redirect mechanism.",
-            "Remove unused includes and flatten stable sender ranges with the provider.",
-            "Keep the final SPF path below 10 DNS lookups before enforcement.",
-        ],
-        "spf_dns_lookup_limit_risk": [
-            "Identify which SPF includes are still actively used.",
-            "Remove duplicate or retired sender includes before adding new senders.",
-            "Document the remaining lookup budget for future sender onboarding.",
-        ],
-        "spf_duplicate_include": [
-            "Find the repeated include values in the SPF TXT record.",
-            "Keep one copy of each include and remove the duplicates.",
-            "Refresh DNS lint to confirm the SPF lookup budget improved.",
-        ],
-        "spf_void_lookup": [
-            "Open each referenced include, exists, or redirect target.",
-            "Remove targets that no longer publish TXT records.",
-            "Ask the sender provider for the current SPF include when the sender is still active.",
-        ],
-        "dkim_selector_missing": [
-            "Identify the sending provider that owns the selector from report evidence.",
-            "Open that provider's domain authentication settings and copy the DKIM TXT or CNAME.",
-            "Publish the selector record, then refresh DNS lint and confirm it resolves.",
-        ],
-        "dkim_selector_cname_broken": [
-            "Open the DNS CNAME record shown in evidence.",
-            "Compare its target with the current value in the sending provider admin page.",
-            "Replace stale targets or complete provider-side domain authentication.",
-        ],
-        "dkim_selector_key_too_short": [
-            "Check whether the sending provider supports 2048-bit DKIM keys.",
-            "Generate a replacement selector instead of editing the existing key in place.",
-            "Publish and validate the new selector before retiring the old selector.",
-        ],
-        "dkim_selector_stale": [
-            "Confirm whether the selector belongs to a retired sender or old key rotation.",
-            "Keep it only if a valid provider still uses it for aligned mail.",
-            "Remove retired selector records after checking one or more report cycles.",
-        ],
-        "mta_sts_missing": [
-            "Publish _mta-sts TXT with a stable id value.",
-            "Host a valid HTTPS policy at the well-known mta-sts hostname.",
-            "Start in testing mode and rotate the TXT id whenever the policy changes.",
-        ],
-        "tls_rpt_missing": [
-            "Choose the TLS report mailbox or HTTPS collector endpoint.",
-            "Publish one TXT record at _smtp._tls with v=TLSRPTv1 and rua.",
-            "Confirm DMARQ imports TLS reports after receivers start sending them.",
-        ],
-        "tls_rpt_multiple_records": [
-            "Merge all TLS-RPT rua destinations into one TXT record.",
-            "Remove duplicate _smtp._tls TXT records.",
-            "Refresh DNS lint to confirm only one TLS-RPT record remains.",
-        ],
-        "tls_rpt_rua_missing": [
-            "Choose where SMTP TLS reports should be delivered.",
-            "Add rua=mailto:... or rua=https://... to the TLS-RPT TXT value.",
-            "Refresh DMARQ after DNS propagation.",
-        ],
-        "bimi_missing": [
-            "Complete DMARC enforcement first.",
-            "Publish a default._bimi TXT record with an HTTPS SVG logo URL.",
-            "Add a certificate URL if the mailbox providers you care about require it.",
-        ],
-        "dane_missing": [
-            "Confirm that the domain's DNS zone and every MX host zone you control are signed and validating with DNSSEC.",
-            "For each MX host, fetch the live SMTP STARTTLS certificate and compute the TLSA 3 1 1 SHA-256 SPKI value.",
-            "Publish one TLSA record under _25._tcp.<mx-host> per controlled MX host, or confirm your mail provider's DANE/TLSA support for third-party MX hosts, then refresh DMARQ DNS lint.",
-        ],
-        "dane_review": [
-            "Review every TLSA record shown in evidence for the affected MX hosts.",
-            "Compare the TLSA selector and hash with the current SMTP TLS certificate.",
-            "Rotate TLSA values in the same change window as certificate changes.",
-        ],
-        "mail_service_record_missing": [
-            "Open the sender-domain authentication page in the mail service.",
-            "Copy the required DNS record into the authoritative DNS provider.",
-            "Refresh DMARQ DNS lint and then re-check verification in the mail service.",
-        ],
-        "mail_service_record_conflict": [
-            "Compare the existing DNS value with the value required by the mail service.",
-            "Confirm no other active sender depends on the current value.",
-            "Update the record or split senders onto provider-supported hostnames.",
-        ],
-    }
-    return steps.get(
-        code,
-        [
-            "Open the linked DNS or report evidence in DMARQ.",
-            "Make the smallest provider-side change that addresses the finding.",
-            "Refresh DNS lint and monitor the next aggregate report cycle.",
-        ],
-    )
+    if normalize_guidance_locale(locale) == "de":
+        return list(
+            _REMEDIATION_STEPS_DE.get(
+                code,
+                _REMEDIATION_STEPS_EN.get(code, _FALLBACK_REMEDIATION_STEPS_EN),
+            )
+        )
+    return list(_REMEDIATION_STEPS_EN.get(code, _FALLBACK_REMEDIATION_STEPS_EN))
+
+
+def _localize_default_remediation_steps(
+    findings: List[DNSLintFinding], *, locale: Optional[str]
+) -> None:
+    """Replace generated remediation steps with the requested locale."""
+    normalized_locale = normalize_guidance_locale(locale)
+    if normalized_locale == "en":
+        return
+    for finding in findings:
+        finding.remediation_steps = _default_remediation_steps(
+            finding.code, locale=normalized_locale
+        )
 
 
 def _classify_dmarc_warning(message: str) -> str:
@@ -1314,6 +1416,7 @@ async def build_dns_guidance(
     monitored_selectors: Optional[List[str]] = None,
     observed_selectors: Optional[List[str]] = None,
     mail_service_records: Optional[List[Dict[str, str]]] = None,
+    locale: Optional[str] = None,
 ) -> DNSGuidanceResult:
     """Build typed DNS lint findings and target records for a domain."""
     normalized_domain = domain.strip().strip(".").lower()
@@ -1338,6 +1441,7 @@ async def build_dns_guidance(
     findings.extend(_bimi_findings(bimi, extract_dmarc_policy(result.dmarc_record), targets))
     findings.extend(_dane_findings(dane_result, targets))
     findings.extend(await _mail_service_dns_findings(provider, mail_service_records or []))
+    _localize_default_remediation_steps(findings, locale=locale)
     return DNSGuidanceResult(
         domain=normalized_domain,
         status=_status(findings),

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -459,6 +459,39 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: Tes
     assert change_plan["manual_steps"]
 
 
+def test_dns_lint_endpoint_accepts_locale_for_operator_guidance(authed_client: TestClient):
+    result = DomainDNSResult(
+        dmarc=False,
+        spf=False,
+        dkim=False,
+        selectors_checked=["selector1"],
+        nameservers=["ns1.digitalocean.com", "ns2.digitalocean.com"],
+        dns_provider=detect_dns_provider(["ns1.digitalocean.com", "ns2.digitalocean.com"]),
+    )
+    mta_sts = MTAStsResult(status="pass")
+    bimi = BIMIResult(status="pass")
+
+    with (
+        _mock_dns(result),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(mta_sts, False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(bimi, False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/lint?locale=de")
+
+    assert response.status_code == 200
+    findings = {finding["code"]: finding for finding in response.json()["findings"]}
+    assert "Oeffne die DNS-Zone" in findings["dmarc_missing"]["remediation_steps"][0]
+    assert "Veroeffentliche genau einen TXT-Record" in (
+        findings["spf_missing"]["remediation_steps"][1]
+    )
+
+
 def test_dns_change_plan_endpoint_returns_apply_gated_plans(authed_client: TestClient):
     result = DomainDNSResult(
         dmarc=False,

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -288,9 +288,7 @@ async def test_build_dns_guidance_classifies_dmarc_warning_codes():
     assert "spf_all_neutral" in codes
     assert "bimi_dmarc_not_enforced" in codes
     monitoring = next(
-        finding
-        for finding in guidance.findings
-        if finding.code == "dmarc_monitoring_policy"
+        finding for finding in guidance.findings if finding.code == "dmarc_monitoring_policy"
     )
     assert monitoring.remediation_steps[0].startswith("Review DMARQ report evidence")
 

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -287,6 +287,12 @@ async def test_build_dns_guidance_classifies_dmarc_warning_codes():
     assert "dmarc_monitoring_policy" in codes
     assert "spf_all_neutral" in codes
     assert "bimi_dmarc_not_enforced" in codes
+    monitoring = next(
+        finding
+        for finding in guidance.findings
+        if finding.code == "dmarc_monitoring_policy"
+    )
+    assert monitoring.remediation_steps[0].startswith("Review DMARQ report evidence")
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -66,6 +66,65 @@ async def test_build_dns_guidance_returns_typed_findings_and_targets():
 
 
 @pytest.mark.asyncio
+async def test_build_dns_guidance_localizes_high_value_remediation_steps_to_german():
+    provider = FakeDNSProvider({})
+    dns = DomainDNSResult(
+        dmarc=False,
+        spf=False,
+        dkim=False,
+        selectors_checked=["selector1"],
+    )
+    mta_sts = MTAStsResult(status="pass")
+    bimi = BIMIResult(status="pass")
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        mta_sts,
+        bimi,
+        locale="de-DE",
+    )
+
+    findings = {finding.code: finding for finding in guidance.findings}
+    assert "Oeffne die DNS-Zone" in findings["dmarc_missing"].remediation_steps[0]
+    assert "Veroeffentliche genau einen TXT-Record" in findings["spf_missing"].remediation_steps[1]
+    assert "Domain-Authentifizierung" in " ".join(
+        findings["dkim_selector_missing"].remediation_steps
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_falls_back_to_english_for_missing_translation():
+    provider = FakeDNSProvider({"example.com": ["v=spf1 -all"]})
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+        dmarc_warnings=["Unsupported fo tag."],
+    )
+    mta_sts = MTAStsResult(status="pass")
+    bimi = BIMIResult(status="pass")
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        mta_sts,
+        bimi,
+        locale="de",
+    )
+
+    warning = next(
+        finding for finding in guidance.findings if finding.code == "dmarc_failure_option_invalid"
+    )
+    assert warning.remediation_steps[0] == "Open the linked DNS or report evidence in DMARQ."
+
+
+@pytest.mark.asyncio
 async def test_build_dns_guidance_lints_spf_and_tls_rpt_records():
     provider = FakeDNSProvider(
         {

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -195,7 +195,8 @@ against a delegated account.
 |----------|-------------|---------|---------|
 | `APP_NAME` | Custom instance name | `DMARQ` | `Company DMARC Monitor` |
 | `TIMEZONE` | Application timezone | `UTC` | `America/New_York`, `Europe/London` |
-| `LANGUAGE` | Default language | `en` | `en`, `fr`, `es` |
+| `LANGUAGE` | Default language for operator-facing guidance | `en` | `en`, `de` |
+| `DMARQ_DEFAULT_LOCALE` | Optional override for localized guidance; falls back to `LANGUAGE` | - | `de` |
 | `REPORTS_PER_PAGE` | Reports to show per page | `25` | `10`, `50`, `100` |
 | `MAX_UPLOAD_SIZE` | Maximum file upload size (MB) | `10` | `20`, `50` |
 | `SESSION_LIFETIME` | Session lifetime in minutes | `1440` (24h) | `60`, `720` |

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -16,6 +16,26 @@ There are many ways to contribute to DMARQ:
 - **Improving docs**: Help make our documentation more comprehensive
 - **Translation**: Help translate the interface into other languages
 
+## Translation Contributions
+
+DMARQ keeps English as the source and fallback language. German is the first
+non-English target for operator-facing remediation guidance; additional
+languages should start with high-value DMARC, SPF, and DKIM guidance before
+general UI copy.
+
+When contributing translations:
+
+- Translate operator-facing explanations, severity wording, next steps, and
+  remediation checklists.
+- Keep DNS record names, protocol tags, provider values, and examples such as
+  `v=DMARC1`, `v=spf1`, `rua=`, `DKIM`, `TXT`, `CNAME`, and hostnames unchanged.
+- Preserve safety wording around human approval, DNS propagation, and provider
+  verification.
+- Add or update tests that prove missing translations fall back to English and
+  that DNS/provider-specific values are interpolated unchanged.
+- Prefer short, direct language that an email or DNS operator can act on during
+  an incident.
+
 ## Development Environment Setup
 
 ### Prerequisites

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -620,6 +620,12 @@ selectors. The bulk endpoint returns the same payload shape per monitored
 domain, and the export endpoint returns the finding list as CSV for
 managed-domain reviews.
 
+Use `?locale=de` to request German operator-facing remediation steps. If a
+translation is missing, DMARQ falls back to the English source text and keeps
+DNS record values, hostnames, and protocol tags unchanged. Self-hosted
+instances can set `DMARQ_DEFAULT_LOCALE` or `LANGUAGE` to choose the default
+guidance language.
+
 The single-domain lint payload also includes `change_plans`. The dedicated
 `/dns/change-plan` endpoint returns the same operator-facing plans with
 proposed DNS records, captured current values, risk notes, rollback notes,


### PR DESCRIPTION
## Summary
- add locale-aware DNS remediation guidance with English fallback and initial German translations for high-value DMARC/SPF/DKIM findings
- expose locale selection on DNS lint endpoints and export flows while preserving DNS values/provider evidence unchanged
- document deployment defaults and contribution guidance for future translations

## Validation
- black --check backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/core/config.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py
- pytest -q backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py
- cd backend && pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=80
- git diff --check

Refs #387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized DNS lint guidance, with support for requesting remediation steps in German or English.
  * Added a default guidance language setting for deployments, including an override option for operator-facing localization.

* **Bug Fixes**
  * Improved fallback behavior so missing translations automatically use English instead of leaving guidance incomplete.

* **Documentation**
  * Updated deployment, API, and contributing docs to explain the new localization options and translation expectations.

* **Tests**
  * Added coverage for localized DNS guidance responses and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->