### PR TITLE
fix: keep Cloudflare OAuth popup handle

### DIFF
--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -627,6 +627,7 @@ function settingsApp() {
                     window.location.href = data.authorization_url;
                     return;
                 }
+                popup.opener = null;
                 const poll = window.setInterval(async () => {
                     if (popup.closed) {
                         window.clearInterval(poll);

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -620,13 +620,13 @@ function settingsApp() {
                 const popup = window.open(
                     data.authorization_url,
                     'dmarq-cloudflare-oauth',
-                    'width=760,height=840,noopener,noreferrer'
+                    // Keep a popup handle so Settings can refresh status after OAuth closes.
+                    'width=760,height=840,popup=yes'
                 );
                 if (!popup) {
                     window.location.href = data.authorization_url;
                     return;
                 }
-                popup.opener = null;
                 const poll = window.setInterval(async () => {
                     if (popup.closed) {
                         window.clearInterval(poll);

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -214,6 +214,7 @@ def test_settings_cloudflare_oauth_uses_popup_with_full_window_fallback():
     assert "'dmarq-cloudflare-oauth'" in script
     assert "popup=yes" in script
     assert "noopener,noreferrer" not in script
+    assert "popup.opener = null" in script
     assert "window.location.href = data.authorization_url" in script
     assert "loadCloudflareOAuthStatus(true)" in script
     assert "Cloudflare status refresh failed:" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -212,7 +212,8 @@ def test_settings_cloudflare_oauth_uses_popup_with_full_window_fallback():
 
     assert "window.open(" in script
     assert "'dmarq-cloudflare-oauth'" in script
-    assert "noopener,noreferrer" in script
+    assert "popup=yes" in script
+    assert "noopener,noreferrer" not in script
     assert "window.location.href = data.authorization_url" in script
     assert "loadCloudflareOAuthStatus(true)" in script
     assert "Cloudflare status refresh failed:" in script


### PR DESCRIPTION
## Summary
- keep the Cloudflare OAuth popup handle available in Settings
- remove the noopener/noreferrer window feature that makes some browsers return a null popup handle
- keep the full-window redirect fallback when popups are blocked

## Local validation
- node --check backend/app/static/js/settings-page.js
- black --check backend/app/tests/test_dashboard_template_security.py
- pytest -q backend/app/tests/test_dashboard_template_security.py

Fixes the Cloudflare Connect regression reported on app.dmarq.org settings.