### PR TITLE
fix: externalize operations refresh handling

### DIFF
--- a/backend/app/static/js/operations-page.js
+++ b/backend/app/static/js/operations-page.js
@@ -4,6 +4,23 @@ function operationsHealth() {
         error: '',
         health: {},
 
+        init() {
+            this.bindRefreshControl();
+            this.load();
+        },
+
+        bindRefreshControl() {
+            const root = this.$root || document.querySelector('[data-operations-health]');
+            const refreshButton = root?.querySelector('[data-operations-refresh]');
+            if (!refreshButton || refreshButton.dataset.operationsRefreshBound === 'true') {
+                return;
+            }
+            refreshButton.dataset.operationsRefreshBound = 'true';
+            refreshButton.addEventListener('click', () => {
+                this.load();
+            });
+        },
+
         async load() {
             this.loading = true;
             this.error = '';

--- a/backend/app/templates/operations.html
+++ b/backend/app/templates/operations.html
@@ -3,13 +3,13 @@
 {% block title %}DMARQ - Health{% endblock %}
 
 {% block content %}
-<div class="mx-auto max-w-6xl space-y-6" x-data="operationsHealth()" x-init="load()">
+<div class="mx-auto max-w-6xl space-y-6" x-data="operationsHealth()" data-operations-health>
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
             <h1 class="text-2xl font-bold">System Health</h1>
             <p class="mt-1 text-sm text-base-content/70">Operational status for imports, scheduler activity, and storage.</p>
         </div>
-        <button class="btn btn-outline btn-sm" @click="load" :disabled="loading">
+        <button class="btn btn-outline btn-sm" data-operations-refresh :disabled="loading">
             <span x-show="loading" class="loading loading-spinner loading-xs"></span>
             Refresh
         </button>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -287,6 +287,10 @@ def test_operations_uses_external_page_script_for_csp_migration():
 
     assert 'src="/static/js/operations-page.js"' in template
     assert "operationsHealth()" in template
+    assert 'x-init="load()"' not in template
+    assert '@click="load"' not in template
+    assert "data-operations-refresh" in template
+    assert "data-operations-refresh" in script
     assert "/api/v1/health/operations" in script
     assert "Health details could not be loaded." in script
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)


### PR DESCRIPTION
## Summary
- remove the Operations health page inline refresh handler and inline load initializer
- initialize the page from the external operations script instead
- extend the CSP migration regression test for the Operations page

## Validation
- node --check backend/app/static/js/operations-page.js
- black --check backend/app/tests/test_dashboard_template_security.py
- pytest -q backend/app/tests/test_dashboard_template_security.py

Part of #426.