### PR TITLE
fix: explain Cloudflare OAuth scope requirements

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -40,6 +40,7 @@ from app.services.cloudflare_oauth import (
     build_cloudflare_authorization_url,
     build_cloudflare_oauth_state,
     cloudflare_oauth_configured,
+    cloudflare_scopes_for_profile,
     cloudflare_scope_profile_metadata,
     decode_cloudflare_oauth_state,
     exchange_cloudflare_oauth_code,
@@ -5186,11 +5187,38 @@ async def cloudflare_oauth_callback(
             if safe_description:
                 details += f"<p>{safe_description}</p>"
             if error == "invalid_scope":
+                profile_id = "read_only"
+                try:
+                    profile_id = decode_cloudflare_oauth_state(state_value or "").get(
+                        "scope_profile", "read_only"
+                    )
+                except LookupError:
+                    profile_id = "read_only"
+                profile = next(
+                    (
+                        item
+                        for item in cloudflare_scope_profile_metadata()
+                        if item.get("id") == profile_id
+                    ),
+                    {},
+                )
+                permission_items = "".join(
+                    f"<li>{html.escape(str(permission))}</li>"
+                    for permission in profile.get("required_permissions", [])
+                )
+                requested_scopes = html.escape(cloudflare_scopes_for_profile(profile_id))
                 details += (
                     "<p>The selected rights profile requests a scope that this Cloudflare "
                     "OAuth client is not allowed to request. Choose a lower rights profile "
                     "or update the allowed scopes on the Cloudflare OAuth client.</p>"
+                    f"<p><strong>Selected profile:</strong> {html.escape(profile_id)}</p>"
+                    f"<p><strong>Requested scopes:</strong> <code>{requested_scopes}</code></p>"
                 )
+                if permission_items:
+                    details += (
+                        "<p>Allow these permissions on the Cloudflare OAuth client, then retry:</p>"
+                        f"<ul>{permission_items}</ul>"
+                    )
         return HTMLResponse(
             content=(
                 "<html><body><p>Cloudflare connection failed. "

--- a/backend/app/services/cloudflare_oauth.py
+++ b/backend/app/services/cloudflare_oauth.py
@@ -40,6 +40,7 @@ class CloudflareScopeProfile:
     name: str
     description: str
     scopes: str
+    required_permissions: tuple[str, ...] = ()
     dns_write_enabled: bool = False
     radar_enabled: bool = False
     radar_requires_api_token: bool = False
@@ -52,12 +53,14 @@ CLOUDFLARE_SCOPE_PROFILES: Dict[str, CloudflareScopeProfile] = {
         name="Read-only discovery",
         description="Verify ownership, import zones, and inspect DNS records.",
         scopes="zone.read dns.read",
+        required_permissions=("Zone Read", "DNS Read"),
     ),
     "read_only_radar": CloudflareScopeProfile(
         id="read_only_radar",
         name="Read-only + Radar context",
         description=("Read DNS zones and request Cloudflare Radar read access for IP enrichment."),
         scopes="zone.read dns.read radar.read",
+        required_permissions=("Zone Read", "DNS Read", "Account Radar Read"),
         radar_enabled=True,
         warning=(
             "Includes Account Radar Read for Cloudflare Radar IP lookups. The Cloudflare "
@@ -72,6 +75,7 @@ CLOUDFLARE_SCOPE_PROFILES: Dict[str, CloudflareScopeProfile] = {
             "Cloudflare Radar IP enrichment access."
         ),
         scopes="zone.read dns.read dns.write radar.read",
+        required_permissions=("Zone Read", "DNS Read", "DNS Write", "Account Radar Read"),
         dns_write_enabled=True,
         radar_enabled=True,
         warning=(
@@ -91,7 +95,12 @@ def normalize_cloudflare_scope_profile(profile: Optional[str]) -> str:
 
 def cloudflare_scope_profile_metadata() -> List[Dict[str, Any]]:
     """Return serializable metadata for the settings UI."""
-    return [asdict(profile) for profile in CLOUDFLARE_SCOPE_PROFILES.values()]
+    metadata: List[Dict[str, Any]] = []
+    for profile in CLOUDFLARE_SCOPE_PROFILES.values():
+        item = asdict(profile)
+        item["required_permissions"] = list(profile.required_permissions)
+        metadata.append(item)
+    return metadata
 
 
 def cloudflare_scopes_for_profile(profile: Optional[str]) -> str:

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -604,6 +604,17 @@ function settingsApp() {
             }
         },
 
+        selectedCloudflareOAuthProfile() {
+            const profileId = this.s['cloudflare.oauth_scope_profile']
+                || this.cfOAuthStatus.scope_profile
+                || 'read_only';
+            return (this.cfOAuthStatus.scope_profiles || []).find(profile => profile.id === profileId) || null;
+        },
+
+        selectedCloudflareOAuthPermissions() {
+            return this.selectedCloudflareOAuthProfile()?.required_permissions || [];
+        },
+
         async connectCloudflare() {
             this.connectingCloudflare = true;
             try {
@@ -616,6 +627,9 @@ function settingsApp() {
                     const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
                     this.showFlash('Cloudflare connect failed: ' + (detail || res.statusText), false);
                     return;
+                }
+                if (data.scopes) {
+                    this.showFlash(`Requesting Cloudflare OAuth scopes: ${data.scopes}`, true);
                 }
                 const popup = window.open(
                     data.authorization_url,

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -187,9 +187,17 @@
                                     </template>
                                 </select>
                                 <div class="text-xs text-[#5f5c78]">
-                                    <p x-text="(cfOAuthStatus.scope_profiles || []).find(profile => profile.id === (s['cloudflare.oauth_scope_profile'] || cfOAuthStatus.scope_profile || 'read_only'))?.description || 'Choose how much Cloudflare access DMARQ should request.'"></p>
-                                    <p class="mt-1 text-warning" x-show="(cfOAuthStatus.scope_profiles || []).find(profile => profile.id === (s['cloudflare.oauth_scope_profile'] || cfOAuthStatus.scope_profile || 'read_only'))?.warning"
-                                        x-text="(cfOAuthStatus.scope_profiles || []).find(profile => profile.id === (s['cloudflare.oauth_scope_profile'] || cfOAuthStatus.scope_profile || 'read_only'))?.warning"></p>
+                                    <p x-text="selectedCloudflareOAuthProfile()?.description || 'Choose how much Cloudflare access DMARQ should request.'"></p>
+                                    <p class="mt-1">
+                                        Request scopes:
+                                        <span class="font-mono" x-text="selectedCloudflareOAuthProfile()?.scopes || 'zone.read dns.read'"></span>
+                                    </p>
+                                    <p class="mt-1" x-show="selectedCloudflareOAuthPermissions().length">
+                                        Cloudflare client permissions:
+                                        <span x-text="selectedCloudflareOAuthPermissions().join(', ')"></span>
+                                    </p>
+                                    <p class="mt-1 text-warning" x-show="selectedCloudflareOAuthProfile()?.warning"
+                                        x-text="selectedCloudflareOAuthProfile()?.warning"></p>
                                 </div>
                             </div>
                             <p class="mt-1 text-xs text-[#5f5c78]" x-show="cfOAuthStatus.scopes">

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -2522,6 +2522,28 @@ def test_cloudflare_oauth_callback_explains_invalid_scope(
     assert "window or tab" in response.text
 
 
+def test_cloudflare_oauth_callback_explains_invalid_scope_with_bad_state(
+    authed_client: TestClient,
+):
+    with patch(
+        "app.api.api_v1.endpoints.domains.decode_cloudflare_oauth_state",
+        side_effect=LookupError("Invalid Cloudflare OAuth state."),
+    ):
+        response = authed_client.get(
+            "/api/v1/domains/cloudflare/oauth/callback"
+            "?error=invalid_scope"
+            "&error_description=The+OAuth+client+cannot+request+dns.write"
+            "&state=bad-state"
+        )
+
+    assert response.status_code == 400
+    assert "Selected profile:" in response.text
+    assert "read_only" in response.text
+    assert "zone.read dns.read" in response.text
+    assert "DNS Write" not in response.text
+    assert "window or tab" in response.text
+
+
 def test_cloudflare_oauth_callback_returns_failure_for_invalid_state(
     authed_client: TestClient,
 ):

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -2102,11 +2102,22 @@ def test_cloudflare_oauth_scope_profile_metadata_marks_full_dns_radar_enabled():
 
     full_profile = profiles["full_dns_repair"]
     assert full_profile["scopes"] == "zone.read dns.read dns.write radar.read"
+    assert full_profile["required_permissions"] == [
+        "Zone Read",
+        "DNS Read",
+        "DNS Write",
+        "Account Radar Read",
+    ]
     assert full_profile["dns_write_enabled"] is True
     assert full_profile["radar_enabled"] is True
 
     radar_profile = profiles["read_only_radar"]
     assert radar_profile["scopes"] == "zone.read dns.read radar.read"
+    assert radar_profile["required_permissions"] == [
+        "Zone Read",
+        "DNS Read",
+        "Account Radar Read",
+    ]
     assert radar_profile["dns_write_enabled"] is False
     assert radar_profile["radar_enabled"] is True
 
@@ -2483,18 +2494,31 @@ def test_cloudflare_oauth_callback_requires_code_and_state(
 def test_cloudflare_oauth_callback_explains_invalid_scope(
     authed_client: TestClient,
 ):
-    response = authed_client.get(
-        "/api/v1/domains/cloudflare/oauth/callback"
-        "?error=invalid_scope"
-        "&error_description=The+OAuth+client+cannot+request+radar.read"
-        "&state=state-token"
-    )
+    with patch(
+        "app.api.api_v1.endpoints.domains.decode_cloudflare_oauth_state",
+        return_value={
+            "workspace_id": 1,
+            "return_to": "/settings",
+            "scope_profile": "full_dns_repair",
+        },
+    ):
+        response = authed_client.get(
+            "/api/v1/domains/cloudflare/oauth/callback"
+            "?error=invalid_scope"
+            "&error_description=The+OAuth+client+cannot+request+radar.read"
+            "&state=state-token"
+        )
 
     assert response.status_code == 400
     assert "Cloudflare error:" in response.text
     assert "invalid_scope" in response.text
     assert "cannot request radar.read" in response.text
     assert "Choose a lower rights profile" in response.text
+    assert "Selected profile:" in response.text
+    assert "full_dns_repair" in response.text
+    assert "zone.read dns.read dns.write radar.read" in response.text
+    assert "DNS Write" in response.text
+    assert "Account Radar Read" in response.text
     assert "window or tab" in response.text
 
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -208,8 +208,16 @@ def _settings_script() -> str:
 
 
 def test_settings_cloudflare_oauth_uses_popup_with_full_window_fallback():
+    template = _settings_template()
     script = _settings_script()
 
+    assert "Request scopes:" in template
+    assert "Cloudflare client permissions:" in template
+    assert "selectedCloudflareOAuthProfile()" in template
+    assert "selectedCloudflareOAuthPermissions()" in template
+    assert "selectedCloudflareOAuthProfile()" in script
+    assert "selectedCloudflareOAuthPermissions()" in script
+    assert "Requesting Cloudflare OAuth scopes:" in script
     assert "window.open(" in script
     assert "'dmarq-cloudflare-oauth'" in script
     assert "popup=yes" in script


### PR DESCRIPTION
## Summary
- show the Cloudflare OAuth scopes and required client permissions for each rights profile in Settings
- include the selected profile, requested scopes, and required Cloudflare permissions in invalid_scope callback errors
- normalize scope profile metadata for JSON responses and cover the behavior with focused tests

## Validation
- node --check backend/app/static/js/settings-page.js
- black --check backend/app/services/cloudflare_oauth.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py backend/app/tests/test_dashboard_template_security.py
- pytest -q backend/app/tests/test_cloudflare_dns.py -k 'cloudflare_oauth'
- pytest -q backend/app/tests/test_dashboard_template_security.py -k 'settings_cloudflare_oauth'

Cloudflare documents that OAuth clients must allow the requested scope IDs, and Radar API tokens need Account > Radar > Read. This makes those requirements visible before redirect and actionable when Cloudflare returns invalid_scope.

Refs #426.