### PR TITLE
fix: externalize report delete handlers

### DIFF
--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -6,7 +6,29 @@ function reportDetailApp(reportId) {
         error: null,
 
         async init() {
+            this.bindDeleteControls();
             await this.fetchReport();
+        },
+
+        bindDeleteControls() {
+            const root = this.$root || document;
+            if (root.dataset?.reportDeleteBound === 'true') {
+                return;
+            }
+            if (root.dataset) {
+                root.dataset.reportDeleteBound = 'true';
+            }
+            root.addEventListener('click', (event) => {
+                const button = event.target.closest('[data-report-delete]');
+                if (!button || !root.contains(button)) {
+                    return;
+                }
+                const domain = button.dataset.reportDomain || '';
+                const reportId = button.dataset.reportId || '';
+                if (domain && reportId) {
+                    this.deleteReport(domain, reportId);
+                }
+            });
         },
 
         async fetchReport() {

--- a/backend/app/static/js/reports-page.js
+++ b/backend/app/static/js/reports-page.js
@@ -10,7 +10,29 @@ function reportsApp() {
         error: '',
 
         init() {
+            this.bindDeleteControls();
             this.fetchReports();
+        },
+
+        bindDeleteControls() {
+            const root = this.$root || document;
+            if (root.dataset?.reportDeleteBound === 'true') {
+                return;
+            }
+            if (root.dataset) {
+                root.dataset.reportDeleteBound = 'true';
+            }
+            root.addEventListener('click', (event) => {
+                const button = event.target.closest('[data-report-delete]');
+                if (!button || !root.contains(button)) {
+                    return;
+                }
+                const domain = button.dataset.reportDomain || '';
+                const reportId = button.dataset.reportId || '';
+                if (domain && reportId) {
+                    this.deleteReport(domain, reportId);
+                }
+            });
         },
 
         get filteredReports() {

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -57,7 +57,9 @@
                             All Reports
                         </a>
                         <button class="btn btn-error btn-sm"
-                                @click="deleteReport(report.domain, report.report_id)">
+                                data-report-delete
+                                :data-report-domain="report.domain"
+                                :data-report-id="report.report_id">
                             Delete Report
                         </button>
                     </div>

--- a/backend/app/templates/reports.html
+++ b/backend/app/templates/reports.html
@@ -128,7 +128,9 @@
                                             {% endcall %}
                                         </a>
                                         <button class="btn btn-error btn-sm"
-                                                @click="deleteReport(report.domain, report.report_id)">
+                                                data-report-delete
+                                                :data-report-domain="report.domain"
+                                                :data-report-id="report.report_id">
                                             Delete
                                         </button>
                                     </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -310,6 +310,10 @@ def test_reports_uses_external_page_script_for_csp_migration():
 
     assert 'src="/static/js/reports-page.js"' in template
     assert "reportsApp()" in template
+    assert '@click="deleteReport' not in template
+    assert "data-report-delete" in template
+    assert "data-report-delete" in script
+    assert "bindDeleteControls()" in script
     assert "/api/v1/reports" in script
     assert "deleteReport(domain, reportId)" in script
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
@@ -444,6 +448,10 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
 
     assert 'src="/static/js/report-detail-page.js"' in template
     assert "reportDetailApp" in template
+    assert '@click="deleteReport' not in template
+    assert "data-report-delete" in template
+    assert "data-report-delete" in script
+    assert "bindDeleteControls()" in script
     assert "/api/v1/reports/${encodeURIComponent(this.reportId)}" in script
     assert "deleteReport(domain, reportId)" in script
     assert "sourceLocation(record)" in script


### PR DESCRIPTION
## What changed
- Moved report-list delete button handling from inline Alpine `@click` markup to `/static/js/reports-page.js`.
- Moved report-detail delete button handling from inline Alpine `@click` markup to `/static/js/report-detail-page.js`.
- Added template security assertions so those delete handlers do not move back into templates.

## Why
This continues the CSP migration tracked in #426 by reducing inline event-handler usage on report surfaces without changing user-visible behavior.

## Validation
- `node --check backend/app/static/js/reports-page.js && node --check backend/app/static/js/report-detail-page.js`
- `black --check backend/app/tests/test_dashboard_template_security.py`
- `pytest -q backend/app/tests/test_dashboard_template_security.py -k 'reports_uses_external_page_script_for_csp_migration or reports_page_distinguishes_loading_error_and_empty_states or report_detail_uses_external_page_script_for_csp_migration'`
- `git diff --check origin/main..HEAD`

Refs #426


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the delete action on reports and report detail pages so it works reliably from the page itself.
  * Updated report deletion handling to use page-driven controls instead of inline click behavior, helping keep the interface more consistent and secure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->