### PR TITLE
fix: externalize report surface controls

### DIFF
--- a/backend/app/static/js/forensic-reports-page.js
+++ b/backend/app/static/js/forensic-reports-page.js
@@ -30,12 +30,18 @@ function forensicReportsApp() {
             }
 
             root.addEventListener('click', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 const resetButton = event.target.closest('[data-forensic-reset]');
                 if (resetButton && root.contains(resetButton)) {
                     this.resetFilters();
                 }
             });
             root.addEventListener('change', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 const domainFilter = event.target.closest('[data-forensic-domain-filter]');
                 if (domainFilter && root.contains(domainFilter)) {
                     this.filters.domain = domainFilter.value;
@@ -60,6 +66,9 @@ function forensicReportsApp() {
                 }
             });
             root.addEventListener('submit', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 const form = event.target.closest('[data-forensic-upload-form]');
                 if (form && root.contains(form)) {
                     event.preventDefault();

--- a/backend/app/static/js/forensic-reports-page.js
+++ b/backend/app/static/js/forensic-reports-page.js
@@ -17,7 +17,55 @@ function forensicReportsApp() {
             search: '',
         },
         init() {
+            this.bindControls();
             this.fetchReports();
+        },
+        bindControls() {
+            const root = this.$root || document;
+            if (root.dataset?.forensicControlsBound === 'true') {
+                return;
+            }
+            if (root.dataset) {
+                root.dataset.forensicControlsBound = 'true';
+            }
+
+            root.addEventListener('click', (event) => {
+                const resetButton = event.target.closest('[data-forensic-reset]');
+                if (resetButton && root.contains(resetButton)) {
+                    this.resetFilters();
+                }
+            });
+            root.addEventListener('change', (event) => {
+                const domainFilter = event.target.closest('[data-forensic-domain-filter]');
+                if (domainFilter && root.contains(domainFilter)) {
+                    this.filters.domain = domainFilter.value;
+                    this.fetchReports();
+                    return;
+                }
+                const authFilter = event.target.closest('[data-forensic-auth-filter]');
+                if (authFilter && root.contains(authFilter)) {
+                    this.filters.authFailure = authFilter.value;
+                    this.fetchReports();
+                    return;
+                }
+                const resultFilter = event.target.closest('[data-forensic-result-filter]');
+                if (resultFilter && root.contains(resultFilter)) {
+                    this.filters.deliveryResult = resultFilter.value;
+                    this.fetchReports();
+                    return;
+                }
+                const uploadFile = event.target.closest('[data-forensic-upload-file]');
+                if (uploadFile && root.contains(uploadFile)) {
+                    this.selectedFile = uploadFile.files?.[0] || null;
+                }
+            });
+            root.addEventListener('submit', (event) => {
+                const form = event.target.closest('[data-forensic-upload-form]');
+                if (form && root.contains(form)) {
+                    event.preventDefault();
+                    this.uploadReport();
+                }
+            });
         },
         get domains() {
             return this.domainOptions;

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -19,6 +19,9 @@ function reportDetailApp(reportId) {
                 root.dataset.reportDeleteBound = 'true';
             }
             root.addEventListener('click', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 const button = event.target.closest('[data-report-delete]');
                 if (!button || !root.contains(button)) {
                     return;

--- a/backend/app/static/js/reports-page.js
+++ b/backend/app/static/js/reports-page.js
@@ -23,6 +23,9 @@ function reportsApp() {
                 root.dataset.reportDeleteBound = 'true';
             }
             root.addEventListener('click', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 const button = event.target.closest('[data-report-delete]');
                 if (!button || !root.contains(button)) {
                     return;

--- a/backend/app/static/js/tls-reports-page.js
+++ b/backend/app/static/js/tls-reports-page.js
@@ -30,12 +30,18 @@ function tlsReportsApp() {
             }
 
             root.addEventListener('click', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 const refreshButton = event.target.closest('[data-tls-refresh]');
                 if (refreshButton && root.contains(refreshButton)) {
                     this.refresh();
                 }
             });
             root.addEventListener('change', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 const daysFilter = event.target.closest('[data-tls-days-filter]');
                 if (daysFilter && root.contains(daysFilter)) {
                     this.filters.days = daysFilter.value;
@@ -48,6 +54,9 @@ function tlsReportsApp() {
                 }
             });
             root.addEventListener('input', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 const domainFilter = event.target.closest('[data-tls-domain-filter]');
                 if (domainFilter && root.contains(domainFilter)) {
                     this.filters.domain = domainFilter.value;
@@ -56,6 +65,9 @@ function tlsReportsApp() {
                 }
             });
             root.addEventListener('submit', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 const form = event.target.closest('[data-tls-upload-form]');
                 if (form && root.contains(form)) {
                     event.preventDefault();

--- a/backend/app/static/js/tls-reports-page.js
+++ b/backend/app/static/js/tls-reports-page.js
@@ -1,4 +1,5 @@
 function tlsReportsApp() {
+    let domainRefreshTimer = null;
     const emptySummary = {
         totals: { reports: 0, successful_sessions: 0, failed_sessions: 0, failure_rate: 0 },
         trends: [],
@@ -16,7 +17,51 @@ function tlsReportsApp() {
         filters: { domain: '', days: '30' },
         summary: emptySummary,
         init() {
+            this.bindControls();
             this.refresh();
+        },
+        bindControls() {
+            const root = this.$root || document;
+            if (root.dataset?.tlsControlsBound === 'true') {
+                return;
+            }
+            if (root.dataset) {
+                root.dataset.tlsControlsBound = 'true';
+            }
+
+            root.addEventListener('click', (event) => {
+                const refreshButton = event.target.closest('[data-tls-refresh]');
+                if (refreshButton && root.contains(refreshButton)) {
+                    this.refresh();
+                }
+            });
+            root.addEventListener('change', (event) => {
+                const daysFilter = event.target.closest('[data-tls-days-filter]');
+                if (daysFilter && root.contains(daysFilter)) {
+                    this.filters.days = daysFilter.value;
+                    this.refresh();
+                    return;
+                }
+                const uploadFile = event.target.closest('[data-tls-upload-file]');
+                if (uploadFile && root.contains(uploadFile)) {
+                    this.selectedFile = uploadFile.files?.[0] || null;
+                }
+            });
+            root.addEventListener('input', (event) => {
+                const domainFilter = event.target.closest('[data-tls-domain-filter]');
+                if (domainFilter && root.contains(domainFilter)) {
+                    this.filters.domain = domainFilter.value;
+                    clearTimeout(domainRefreshTimer);
+                    domainRefreshTimer = setTimeout(() => this.refresh(), 250);
+                }
+            });
+            root.addEventListener('submit', (event) => {
+                const form = event.target.closest('[data-tls-upload-form]');
+                if (form && root.contains(form)) {
+                    event.preventDefault();
+                    this.uploadReport();
+                }
+            });
         },
         async refresh() {
             this.loading = true;

--- a/backend/app/templates/forensic_reports.html
+++ b/backend/app/templates/forensic_reports.html
@@ -50,7 +50,7 @@
                 <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
                     <label class="form-control">
                         <span class="label-text font-medium mb-1">Domain</span>
-                        <select class="select select-bordered w-full" x-model="filters.domain" @change="fetchReports()">
+                        <select class="select select-bordered w-full" x-model="filters.domain" data-forensic-domain-filter>
                             <option value="">All domains</option>
                             <template x-for="domain in domains" :key="domain">
                                 <option :value="domain" x-text="domain"></option>
@@ -59,7 +59,7 @@
                     </label>
                     <label class="form-control">
                         <span class="label-text font-medium mb-1">Failure</span>
-                        <select class="select select-bordered w-full" x-model="filters.authFailure" @change="fetchReports()">
+                        <select class="select select-bordered w-full" x-model="filters.authFailure" data-forensic-auth-filter>
                             <option value="">Any failure</option>
                             <option value="dkim">DKIM</option>
                             <option value="spf">SPF</option>
@@ -68,7 +68,7 @@
                     </label>
                     <label class="form-control">
                         <span class="label-text font-medium mb-1">Result</span>
-                        <select class="select select-bordered w-full" x-model="filters.deliveryResult" @change="fetchReports()">
+                        <select class="select select-bordered w-full" x-model="filters.deliveryResult" data-forensic-result-filter>
                             <option value="">Any result</option>
                             <option value="reject">Reject</option>
                             <option value="quarantine">Quarantine</option>
@@ -89,8 +89,8 @@
                 {% call card_description() %}Upload a forensic .eml or .txt file{% endcall %}
             {% endcall %}
             {% call card_content() %}
-                <form class="space-y-3" @submit.prevent="uploadReport()">
-                    <input type="file" class="file-input file-input-bordered w-full" accept=".eml,.txt,message/rfc822,text/plain" @change="selectedFile = $event.target.files[0] || null">
+                <form class="space-y-3" data-forensic-upload-form>
+                    <input type="file" class="file-input file-input-bordered w-full" accept=".eml,.txt,message/rfc822,text/plain" data-forensic-upload-file>
                     <button class="btn btn-primary w-full" type="submit" :disabled="uploading || !selectedFile">
                         <span x-show="!uploading">Upload Forensic Report</span>
                         <span x-show="uploading" class="loading loading-spinner loading-sm"></span>
@@ -153,7 +153,7 @@
                         Showing <span x-text="filteredReports.length"></span> of <span x-text="total"></span> reports
                     {% endcall %}
                 </div>
-                <button class="btn btn-outline btn-sm" @click="resetFilters()">Reset</button>
+                <button class="btn btn-outline btn-sm" data-forensic-reset>Reset</button>
             </div>
         {% endcall %}
         {% call card_content() %}

--- a/backend/app/templates/tls_reports.html
+++ b/backend/app/templates/tls_reports.html
@@ -12,13 +12,13 @@
             <p class="text-sm text-base-content/70 mt-1">SMTP TLS delivery trends and failure causes</p>
         </div>
         <div class="flex flex-wrap gap-2">
-            <select class="select select-bordered select-sm" x-model="filters.days" @change="refresh()">
+            <select class="select select-bordered select-sm" x-model="filters.days" data-tls-days-filter>
                 <option value="7">7 days</option>
                 <option value="30">30 days</option>
                 <option value="90">90 days</option>
                 <option value="365">365 days</option>
             </select>
-            <button class="btn btn-outline btn-sm" @click="refresh()">Refresh</button>
+            <button class="btn btn-outline btn-sm" data-tls-refresh>Refresh</button>
         </div>
     </div>
 
@@ -57,7 +57,7 @@
                         {% call card_title() %}Failure Trends{% endcall %}
                         {% call card_description() %}Daily TLS session results from imported TLS-RPT files{% endcall %}
                     </div>
-                    <input class="input input-bordered input-sm md:w-64" x-model.debounce.250ms="filters.domain" @input="refresh()" placeholder="Filter by domain">
+                    <input class="input input-bordered input-sm md:w-64" x-model.debounce.250ms="filters.domain" data-tls-domain-filter placeholder="Filter by domain">
                 </div>
             {% endcall %}
             {% call card_content() %}
@@ -91,8 +91,8 @@
                 {% call card_description() %}.json, .json.gz, or .zip{% endcall %}
             {% endcall %}
             {% call card_content() %}
-                <form class="space-y-3" @submit.prevent="uploadReport()">
-                    <input type="file" class="file-input file-input-bordered w-full" accept=".json,.gz,.gzip,.zip,application/json,application/zip" @change="selectedFile = $event.target.files[0] || null">
+                <form class="space-y-3" data-tls-upload-form>
+                    <input type="file" class="file-input file-input-bordered w-full" accept=".json,.gz,.gzip,.zip,application/json,application/zip" data-tls-upload-file>
                     <button class="btn btn-primary w-full" type="submit" :disabled="uploading || !selectedFile">
                         <span x-show="!uploading">Upload TLS Report</span>
                         <span x-show="uploading" class="loading loading-spinner loading-sm"></span>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -72,6 +72,15 @@ def _template_section_between_markers(template: str, start_marker: str, end_mark
     return section[: end_match.start()]
 
 
+def _has_alpine_handler_call(template: str, event: str, function_name: str) -> bool:
+    return bool(
+        re.search(
+            rf"@{re.escape(event)}(?:\.[\w:-]+)*\s*=\s*(['\"])\s*{re.escape(function_name)}\s*\(\s*\)\s*\1",
+            template,
+        )
+    )
+
+
 @pytest.mark.parametrize("template_name", ALL_TEMPLATE_NAMES)
 def test_templates_do_not_reintroduce_csp_blocking_inline_markup(template_name: str):
     template = _read_project_file("templates", *template_name.split("/"))
@@ -414,9 +423,9 @@ def test_forensic_reports_uses_external_page_script_for_csp_migration():
     assert "/api/v1/forensics/analysis?" in script
     assert "/api/v1/forensics/upload" in script
     assert "Unable to load forensic reports" in script
-    assert '@change="fetchReports()"' not in template
-    assert '@submit.prevent="uploadReport()"' not in template
-    assert '@click="resetFilters()"' not in template
+    assert not _has_alpine_handler_call(template, "change", "fetchReports")
+    assert not _has_alpine_handler_call(template, "submit", "uploadReport")
+    assert not _has_alpine_handler_call(template, "click", "resetFilters")
     assert "data-forensic-domain-filter" in template
     assert "data-forensic-auth-filter" in template
     assert "data-forensic-result-filter" in template
@@ -425,6 +434,7 @@ def test_forensic_reports_uses_external_page_script_for_csp_migration():
     assert "data-forensic-reset" in template
     assert "data-forensic-reset" in script
     assert "bindControls()" in script
+    assert "event.target instanceof Element" in script
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
@@ -449,10 +459,10 @@ def test_tls_reports_uses_external_page_script_for_csp_migration():
     assert "/api/v1/tls-reports/summary?" in script
     assert "/api/v1/tls-reports/upload" in script
     assert "Unable to load TLS report summary" in script
-    assert '@click="refresh()"' not in template
-    assert '@change="refresh()"' not in template
-    assert '@input="refresh()"' not in template
-    assert '@submit.prevent="uploadReport()"' not in template
+    assert not _has_alpine_handler_call(template, "click", "refresh")
+    assert not _has_alpine_handler_call(template, "change", "refresh")
+    assert not _has_alpine_handler_call(template, "input", "refresh")
+    assert not _has_alpine_handler_call(template, "submit", "uploadReport")
     assert "data-tls-refresh" in template
     assert "data-tls-days-filter" in template
     assert "data-tls-domain-filter" in template
@@ -460,6 +470,7 @@ def test_tls_reports_uses_external_page_script_for_csp_migration():
     assert "data-tls-upload-file" in template
     assert "data-tls-refresh" in script
     assert "bindControls()" in script
+    assert "event.target instanceof Element" in script
     assert 'x-effect="$el.style.width' in template
     assert not _has_inline_style(template)
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -314,6 +314,7 @@ def test_reports_uses_external_page_script_for_csp_migration():
     assert "data-report-delete" in template
     assert "data-report-delete" in script
     assert "bindDeleteControls()" in script
+    assert "event.target instanceof Element" in script
     assert "/api/v1/reports" in script
     assert "deleteReport(domain, reportId)" in script
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
@@ -474,6 +475,7 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "data-report-delete" in template
     assert "data-report-delete" in script
     assert "bindDeleteControls()" in script
+    assert "event.target instanceof Element" in script
     assert "/api/v1/reports/${encodeURIComponent(this.reportId)}" in script
     assert "deleteReport(domain, reportId)" in script
     assert "sourceLocation(record)" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -413,6 +413,17 @@ def test_forensic_reports_uses_external_page_script_for_csp_migration():
     assert "/api/v1/forensics/analysis?" in script
     assert "/api/v1/forensics/upload" in script
     assert "Unable to load forensic reports" in script
+    assert '@change="fetchReports()"' not in template
+    assert '@submit.prevent="uploadReport()"' not in template
+    assert '@click="resetFilters()"' not in template
+    assert "data-forensic-domain-filter" in template
+    assert "data-forensic-auth-filter" in template
+    assert "data-forensic-result-filter" in template
+    assert "data-forensic-upload-form" in template
+    assert "data-forensic-upload-file" in template
+    assert "data-forensic-reset" in template
+    assert "data-forensic-reset" in script
+    assert "bindControls()" in script
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
@@ -437,6 +448,17 @@ def test_tls_reports_uses_external_page_script_for_csp_migration():
     assert "/api/v1/tls-reports/summary?" in script
     assert "/api/v1/tls-reports/upload" in script
     assert "Unable to load TLS report summary" in script
+    assert '@click="refresh()"' not in template
+    assert '@change="refresh()"' not in template
+    assert '@input="refresh()"' not in template
+    assert '@submit.prevent="uploadReport()"' not in template
+    assert "data-tls-refresh" in template
+    assert "data-tls-days-filter" in template
+    assert "data-tls-domain-filter" in template
+    assert "data-tls-upload-form" in template
+    assert "data-tls-upload-file" in template
+    assert "data-tls-refresh" in script
+    assert "bindControls()" in script
     assert 'x-effect="$el.style.width' in template
     assert not _has_inline_style(template)
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)


### PR DESCRIPTION
## What changed
- Moved TLS report controls for refresh, day filter, domain filter, and upload file selection into `/static/js/tls-reports-page.js`.
- Moved forensic report controls for filters, upload file selection, upload submit, and reset into `/static/js/forensic-reports-page.js`.
- Added CSP regression assertions so these controls do not move back into inline Alpine event handlers.

## Why
This continues the #426 CSP hardening migration by reducing inline event-handler usage across report surfaces while keeping the existing Alpine data model and UI behavior intact.

## Validation
- `node --check backend/app/static/js/tls-reports-page.js && node --check backend/app/static/js/forensic-reports-page.js`
- `black --check backend/app/tests/test_dashboard_template_security.py`
- `pytest -q backend/app/tests/test_dashboard_template_security.py -k 'tls_reports_uses_external_page_script_for_csp_migration or forensic_reports_uses_external_page_script_for_csp_migration'`
- `git diff --check origin/main..HEAD`

Refs #426
