### PR TITLE
fix: externalize dashboard and layout controls

### DIFF
--- a/backend/app/static/js/base-layout.js
+++ b/backend/app/static/js/base-layout.js
@@ -14,6 +14,27 @@ document.addEventListener('alpine:init', () => {
             selectedWorkspaceId: enabled
                 ? localStorage.getItem('dmarq.selectedWorkspaceId') || ''
                 : '',
+            init() {
+                this.bindControls();
+                this.loadUser();
+            },
+            bindControls() {
+                if (typeof document === 'undefined') return;
+                const hasElement = typeof Element !== 'undefined';
+                const root = hasElement && this.$root instanceof Element
+                    ? this.$root
+                    : document.querySelector('[data-user-menu]');
+                if (!root || root.dataset.userMenuControlsBound === 'true') return;
+                root.dataset.userMenuControlsBound = 'true';
+
+                root.addEventListener('change', (event) => {
+                    if (!hasElement || !(event.target instanceof Element)) return;
+                    const switcher = event.target.closest('[data-workspace-switcher]');
+                    if (switcher && root.contains(switcher)) {
+                        this.selectWorkspace(switcher.value);
+                    }
+                });
+            },
             async loadUser() {
                 try {
                     const res = await fetch('/api/v1/auth/me');

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -69,12 +69,81 @@ function dashboardApp() {
         },
         
         init() {
+            this.bindControls();
+
             // Fetch domain summary on page load
             this.fetchDomainSummary();
             
             // Check report intake status
             this.getReportIntakeStatus();
             this.fetchForensicSummary();
+        },
+
+        bindControls() {
+            if (typeof document === 'undefined') return;
+            const hasElement = typeof Element !== 'undefined';
+            const root = hasElement && this.$root instanceof Element
+                ? this.$root
+                : document.querySelector('.dashboard-page');
+            if (!root || root.dataset.dashboardControlsBound === 'true') return;
+            root.dataset.dashboardControlsBound = 'true';
+
+            root.addEventListener('change', event => {
+                if (!hasElement || !(event.target instanceof Element)) return;
+
+                const dateInterval = event.target.closest('[data-dashboard-date-interval]');
+                if (dateInterval && root.contains(dateInterval)) {
+                    this.dateInterval = dateInterval.value;
+                    this.handleDateIntervalChange();
+                    return;
+                }
+
+                const dnsDomain = event.target.closest('[data-dashboard-dns-health-domain]');
+                if (dnsDomain && root.contains(dnsDomain)) {
+                    this.selectedDnsDomain = dnsDomain.value;
+                    this.updateDnsHealth();
+                }
+            });
+
+            root.addEventListener('click', event => {
+                if (!hasElement || !(event.target instanceof Element)) return;
+
+                const customApply = event.target.closest('[data-dashboard-custom-apply]');
+                if (customApply && root.contains(customApply)) {
+                    this.fetchDashboardStats();
+                    this.fetchWorkspaceHealthHistory();
+                    return;
+                }
+
+                const triggerPoll = event.target.closest('[data-dashboard-trigger-poll]');
+                if (triggerPoll && root.contains(triggerPoll)) {
+                    this.triggerPollNow();
+                    return;
+                }
+
+                const closeTour = event.target.closest('[data-dashboard-demo-tour-close]');
+                if (closeTour && root.contains(closeTour)) {
+                    this.closeDemoTour();
+                    return;
+                }
+
+                const previousTourStep = event.target.closest('[data-dashboard-demo-tour-previous]');
+                if (previousTourStep && root.contains(previousTourStep)) {
+                    this.previousDemoTourStep();
+                    return;
+                }
+
+                const nextTourStep = event.target.closest('[data-dashboard-demo-tour-next]');
+                if (nextTourStep && root.contains(nextTourStep)) {
+                    this.nextDemoTourStep();
+                }
+            });
+
+            document.addEventListener('keydown', event => {
+                if (event.key === 'Escape' && this.demoTourActive) {
+                    this.closeDemoTour();
+                }
+            });
         },
         
         formatSourceMethods(methods) {

--- a/backend/app/static/js/pages.js
+++ b/backend/app/static/js/pages.js
@@ -2,6 +2,24 @@ document.addEventListener('alpine:init', () => {
     // components/ui/alert.html
     Alpine.data('alertComponent', () => ({
         open: true,
+        init() {
+            this.bindControls();
+        },
+        bindControls() {
+            if (typeof document === 'undefined') return;
+            const hasElement = typeof Element !== 'undefined';
+            const root = hasElement && this.$root instanceof Element ? this.$root : null;
+            if (!root || root.dataset.alertControlsBound === 'true') return;
+            root.dataset.alertControlsBound = 'true';
+
+            root.addEventListener('click', (event) => {
+                if (!hasElement || !(event.target instanceof Element)) return;
+                const closeButton = event.target.closest('[data-alert-close]');
+                if (closeButton && root.contains(closeButton)) {
+                    this.close();
+                }
+            });
+        },
         close() {
             this.open = false;
         }

--- a/backend/app/templates/components/ui/alert.html
+++ b/backend/app/templates/components/ui/alert.html
@@ -22,7 +22,7 @@
     <button 
         type="button" 
         class="btn btn-ghost btn-sm btn-square"
-        x-on:click="close()"
+        data-alert-close
         aria-label="Close"
     >
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -42,7 +42,7 @@
                     <select id="dashboard-date-interval"
                             class="rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm font-semibold text-[#120d36]"
                             x-model="dateInterval"
-                            @change="handleDateIntervalChange()">
+                            data-dashboard-date-interval>
                         <template x-for="option in dateIntervalOptions" :key="option.value">
                             <option :value="option.value"
                                     :selected="option.value === dateInterval"
@@ -61,7 +61,7 @@
                                    x-model="customEndDate">
                             <button type="button"
                                     class="rounded-md bg-[#272a5f] px-3 py-2 text-sm font-semibold text-white hover:bg-[#171346]"
-                                    @click="fetchDashboardStats(); fetchWorkspaceHealthHistory()">
+                                    data-dashboard-custom-apply>
                                 Apply
                             </button>
                         </div>
@@ -221,7 +221,7 @@
                     <select id="dns-health-domain"
                             class="min-w-0 rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm font-semibold text-[#120d36]"
                             x-model="selectedDnsDomain"
-                            @change="updateDnsHealth()">
+                            data-dashboard-dns-health-domain>
                         <option value="">No report-backed domain selected</option>
                         <template x-for="domain in domains" :key="domain.domain_name || domain.id">
                             <option :value="domain.domain_name" x-text="domain.domain_name"></option>
@@ -375,7 +375,7 @@
                     <button type="button"
                             class="btn btn-outline btn-sm"
                             :disabled="triggerPollRunning"
-                            @click="triggerPollNow()">
+                            data-dashboard-trigger-poll>
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="m3 2 2 4h8L7 14h2l-4 8 1-6H4l2-8H3z"></path></svg>
                         <span x-text="triggerPollRunning ? 'Polling...' : 'Trigger Poll Now'"></span>
                     </button>
@@ -415,7 +415,7 @@
     <div x-show="demoTourActive"
          x-cloak
          class="fixed inset-0 z-50 pointer-events-none"
-         @keydown.escape.window="closeDemoTour()">
+         data-dashboard-demo-tour>
         <div class="absolute inset-0 bg-[#07071f]/45"></div>
         <div class="absolute left-1/2 top-28 w-[min(92vw,30rem)] -translate-x-1/2 rounded-lg bg-white p-5 shadow-xl pointer-events-auto md:left-auto md:right-8 md:translate-x-0">
             <div class="flex items-start justify-between gap-4">
@@ -427,17 +427,17 @@
                 <button type="button"
                         class="rounded-md px-2 py-1 text-lg text-[#5f5c78] hover:bg-[#f4f3f2]"
                         aria-label="Close guided demo"
-                        @click="closeDemoTour()">×</button>
+                        data-dashboard-demo-tour-close>×</button>
             </div>
             <p class="mt-3 text-sm text-[#5f5c78]" x-text="currentDemoTourStep()?.body"></p>
             <div class="mt-5 flex items-center justify-between gap-3">
                 <button type="button"
                         class="rounded-md border border-[#dfdfdf] px-3 py-2 text-sm font-semibold text-[#120d36] disabled:opacity-40"
                         :disabled="demoTourStepIndex === 0"
-                        @click="previousDemoTourStep()">Back</button>
+                        data-dashboard-demo-tour-previous>Back</button>
                 <button type="button"
                         class="rounded-md bg-[#272a5f] px-4 py-2 text-sm font-semibold text-white hover:bg-[#171346]"
-                        @click="nextDemoTourStep()"
+                        data-dashboard-demo-tour-next
                         x-text="demoTourStepIndex + 1 >= demoTourSteps.length ? 'Finish' : 'Next'"></button>
             </div>
         </div>

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -35,7 +35,8 @@
 </head>
 <body class="min-h-screen bg-[#f4f3f2] font-body antialiased text-[#07071f]">
     <header class="fixed inset-x-0 top-0 z-40 flex h-24 items-center bg-[#272a5f] px-5 text-white shadow-sm md:px-10"
-            x-data="userMenu({ multiWorkspaceUiEnabled: {{ multi_workspace_ui_enabled | tojson }} })" x-init="loadUser()">
+            x-data="userMenu({ multiWorkspaceUiEnabled: {{ multi_workspace_ui_enabled | tojson }} })"
+            data-user-menu>
         <div class="flex flex-1 items-center">
             <a href="/" class="inline-flex items-center gap-4" aria-label="DMARQ Dashboard">
                 <span class="grid h-12 w-12 place-items-center bg-[#272a5f]" aria-hidden="true">
@@ -61,7 +62,7 @@
                 <select id="workspace-switcher"
                         class="select select-sm w-full border-white/30 bg-white/95 text-[#272a5f]"
                         x-model="selectedWorkspaceId"
-                        @change="selectWorkspace($event.target.value)">
+                        data-workspace-switcher>
                     <template x-for="workspace in workspaces" :key="workspace.id">
                         <option :value="workspace.id"
                                 :disabled="!workspace.active"

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -804,6 +804,12 @@ def test_base_template_propagates_selected_workspace_context():
     assert "workspaces.length > 1" in template
     assert "localStorage.removeItem('dmarq.selectedWorkspaceId')" in script
     assert "input instanceof URL" in script
+    assert 'x-init="loadUser()"' not in template
+    assert '@change="selectWorkspace($event.target.value)"' not in template
+    assert "data-user-menu" in template
+    assert "data-workspace-switcher" in template
+    assert "bindControls()" in script
+    assert "data-workspace-switcher" in script
     assert "onclick=" not in template
     assert "data-release-modal-trigger" in template
     assert "Full changelog" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -335,6 +335,17 @@ def test_operations_uses_external_page_script_for_csp_migration():
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
+def test_alert_component_uses_external_close_control_for_csp_migration():
+    template = _read_project_file("templates", "components", "ui", "alert.html")
+    script = _read_project_file("static", "js", "pages.js")
+
+    assert 'x-on:click="close()"' not in template
+    assert "data-alert-close" in template
+    assert "data-alert-close" in script
+    assert "bindControls()" in script
+    assert "close()" in script
+
+
 def test_reports_uses_external_page_script_for_csp_migration():
     template = _reports_template()
     script = _reports_script()

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -288,12 +288,34 @@ def test_dashboard_clears_all_chart_instances():
 
 def test_dashboard_uses_external_page_script_for_csp_migration():
     template = _dashboard_template()
+    script = _dashboard_script()
     styles = _read_project_file("static", "css", "styles.css")
 
     assert 'src="/static/js/chart.umd.min.js"' in template
     assert 'src="/static/js/dashboard-page.js"' in template
     assert "enforcement-gauge-bg" in template
     assert ".enforcement-gauge-bg" in styles
+    assert '@change="handleDateIntervalChange()"' not in template
+    assert '@click="fetchDashboardStats(); fetchWorkspaceHealthHistory()"' not in template
+    assert '@change="updateDnsHealth()"' not in template
+    assert '@click="triggerPollNow()"' not in template
+    assert '@keydown.escape.window="closeDemoTour()"' not in template
+    assert '@click="closeDemoTour()"' not in template
+    assert '@click="previousDemoTourStep()"' not in template
+    assert '@click="nextDemoTourStep()"' not in template
+    assert "data-dashboard-date-interval" in template
+    assert "data-dashboard-custom-apply" in template
+    assert "data-dashboard-dns-health-domain" in template
+    assert "data-dashboard-trigger-poll" in template
+    assert "data-dashboard-demo-tour-close" in template
+    assert "data-dashboard-demo-tour-previous" in template
+    assert "data-dashboard-demo-tour-next" in template
+    assert "bindControls()" in script
+    assert "data-dashboard-date-interval" in script
+    assert "data-dashboard-custom-apply" in script
+    assert "data-dashboard-dns-health-domain" in script
+    assert "data-dashboard-trigger-poll" in script
+    assert "data-dashboard-demo-tour-close" in script
     assert not _has_inline_style(template)
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
@@ -879,7 +901,8 @@ def test_dashboard_trigger_poll_uses_post_action_not_get_link():
     script = _dashboard_script()
 
     assert 'href="/api/v1/admin/trigger-poll"' not in template
-    assert "triggerPollNow()" in template
+    assert "data-dashboard-trigger-poll" in template
+    assert "triggerPollNow()" in script
     assert "method: 'POST'" in script
     assert "Report Intake Status" in template
     assert "Gmail API" in script


### PR DESCRIPTION
## Summary
- move remaining dashboard date/DNS/poll/tour controls from inline Alpine handlers to dashboard-page.js
- move layout workspace switching from inline Alpine handlers into base-layout.js
- move dismissible alert close handling into pages.js
- extend template security coverage for the migrated controls

## Local validation
- node --check backend/app/static/js/pages.js
- node --check backend/app/static/js/base-layout.js
- node --check backend/app/static/js/dashboard-page.js
- python -m pytest -q backend/app/tests/test_dashboard_template_security.py

Part of #426.