### PR TITLE
fix: externalize setup wizard controls

### DIFF
--- a/backend/app/static/js/setup-page.js
+++ b/backend/app/static/js/setup-page.js
@@ -29,6 +29,7 @@ function setupWizard() {
             cloudflare_zone_id: '',
         },
         async init() {
+            this.bindControls();
             this.applyTheme();
             try {
                 const response = await fetch('/api/v1/setup/status');
@@ -48,6 +49,39 @@ function setupWizard() {
             } finally {
                 this.statusLoading = false;
             }
+        },
+        bindControls() {
+            if (typeof document === 'undefined') return;
+            const hasElement = typeof Element !== 'undefined';
+            const root = hasElement && this.$root instanceof Element
+                ? this.$root
+                : document.querySelector('[data-setup-wizard]');
+            if (!root || root.dataset.setupControlsBound === 'true') return;
+            root.dataset.setupControlsBound = 'true';
+
+            root.addEventListener('submit', (event) => {
+                if (!hasElement || !(event.target instanceof Element)) return;
+                const adminForm = event.target.closest('[data-setup-admin-form]');
+                if (adminForm && root.contains(adminForm)) {
+                    event.preventDefault();
+                    this.submitAdmin();
+                    return;
+                }
+
+                const systemForm = event.target.closest('[data-setup-system-form]');
+                if (systemForm && root.contains(systemForm)) {
+                    event.preventDefault();
+                    this.submitSystem();
+                }
+            });
+
+            root.addEventListener('click', (event) => {
+                if (!hasElement || !(event.target instanceof Element)) return;
+                const backButton = event.target.closest('[data-setup-back]');
+                if (backButton && root.contains(backButton)) {
+                    this.currentStep = 1;
+                }
+            });
         },
         applyTheme() {
             if (localStorage.getItem('darkMode') === 'true') {

--- a/backend/app/templates/setup.html
+++ b/backend/app/templates/setup.html
@@ -18,7 +18,7 @@
     <link href="/static/css/page-utilities.css" rel="stylesheet" type="text/css"/>
 </head>
 <body class="min-h-screen bg-base-200 font-sans antialiased">
-<div class="min-h-screen" x-data="setupWizard()" x-init="init()" x-cloak data-app-name="{{ app_name }}">
+<div class="min-h-screen" x-data="setupWizard()" x-cloak data-app-name="{{ app_name }}" data-setup-wizard>
     <header class="border-b border-base-300 bg-base-100">
         <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
             <a href="/" class="inline-flex items-center gap-3">
@@ -67,7 +67,7 @@
                         <span x-text="error"></span>
                     </div>
 
-                    <form x-show="!statusLoading && currentStep === 1" @submit.prevent="submitAdmin" class="space-y-5">
+                    <form x-show="!statusLoading && currentStep === 1" class="space-y-5" data-setup-admin-form>
                         <div>
                             <h2 class="text-xl font-semibold">Admin contact</h2>
                             <p class="mt-1 text-sm text-base-content/60">This contact is saved with the setup record.</p>
@@ -100,7 +100,7 @@
                         </div>
                     </form>
 
-                    <form x-show="!statusLoading && currentStep === 2" @submit.prevent="submitSystem" class="space-y-5">
+                    <form x-show="!statusLoading && currentStep === 2" class="space-y-5" data-setup-system-form>
                         <div>
                             <h2 class="text-xl font-semibold">System settings</h2>
                             <p class="mt-1 text-sm text-base-content/60">These values are stored in the application settings.</p>
@@ -142,7 +142,7 @@
                         </div>
 
                         <div class="flex justify-between gap-3">
-                            <button type="button" class="btn btn-ghost" @click="currentStep = 1" :disabled="saving">Back</button>
+                            <button type="button" class="btn btn-ghost" :disabled="saving" data-setup-back>Back</button>
                             <button type="submit" class="btn btn-primary" :disabled="saving">
                                 <span x-show="saving" class="loading loading-spinner loading-xs"></span>
                                 Finish setup

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -4,6 +4,8 @@ Tests for the /api/v1/setup endpoints.
 Covers initial setup status, admin user setup, and system configuration.
 """
 
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -90,13 +92,24 @@ class TestSetupPage:
 
         with TestClient(main_app) as test_client:
             response = test_client.get("/setup")
+        script = (
+            Path(__file__).resolve().parents[1] / "static" / "js" / "setup-page.js"
+        ).read_text()
 
         assert response.status_code == 200
         assert "First-run setup" in response.text
-        assert '@submit.prevent="submitAdmin"' in response.text
-        assert '@submit.prevent="submitSystem"' in response.text
+        assert '@submit.prevent="submitAdmin"' not in response.text
+        assert '@submit.prevent="submitSystem"' not in response.text
+        assert 'x-init="init()"' not in response.text
+        assert "data-setup-admin-form" in response.text
+        assert "data-setup-system-form" in response.text
+        assert "data-setup-back" in response.text
         assert 'data-app-name="DMARQ"' in response.text
         assert 'src="/static/js/setup-page.js"' in response.text
+        assert "bindControls()" in script
+        assert "data-setup-admin-form" in script
+        assert "data-setup-system-form" in script
+        assert "data-setup-back" in script
         assert "/static/js/setup.js" not in response.text
         assert "/onboarding" not in response.text
 


### PR DESCRIPTION
## Summary
- move first-run setup submit/back handlers from inline Alpine attributes into setup-page.js
- keep Cloudflare setup token handling on the existing backend settings path
- add setup page assertions for the CSP-safe data attributes and external handlers

## Local validation
- node --check backend/app/static/js/setup-page.js
- python -m pytest -q backend/app/tests/test_setup_endpoints.py

Part of #426.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The setup wizard now uses a more reliable client-side interaction flow for submitting forms and navigating back between steps.
  * Setup pages now include clearer built-in hooks for wizard behavior, improving first-run experience consistency.

* **Bug Fixes**
  * Prevented duplicate event handling in the setup flow.
  * Improved setup behavior when the page is loaded outside a browser context, reducing runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->