### PR TITLE
fix: address dashboard setup review followups

### DIFF
--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -139,11 +139,17 @@ function dashboardApp() {
                 }
             });
 
-            root.addEventListener('keydown', event => {
+            const ownerDocument = root.ownerDocument || document;
+            const keydownHandlerKey = '__dmarqDashboardKeydownHandler';
+            if (ownerDocument[keydownHandlerKey]) {
+                ownerDocument.removeEventListener('keydown', ownerDocument[keydownHandlerKey]);
+            }
+            ownerDocument[keydownHandlerKey] = event => {
                 if (event.key === 'Escape' && this.demoTourActive) {
                     this.closeDemoTour();
                 }
-            });
+            };
+            ownerDocument.addEventListener('keydown', ownerDocument[keydownHandlerKey]);
         },
         
         formatSourceMethods(methods) {

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -139,7 +139,7 @@ function dashboardApp() {
                 }
             });
 
-            document.addEventListener('keydown', event => {
+            root.addEventListener('keydown', event => {
                 if (event.key === 'Escape' && this.demoTourActive) {
                     this.closeDemoTour();
                 }

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -316,6 +316,8 @@ def test_dashboard_uses_external_page_script_for_csp_migration():
     assert "data-dashboard-dns-health-domain" in script
     assert "data-dashboard-trigger-poll" in script
     assert "data-dashboard-demo-tour-close" in script
+    assert "ownerDocument.addEventListener('keydown'" in script
+    assert "removeEventListener('keydown'" in script
     assert not _has_inline_style(template)
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -94,7 +94,7 @@ class TestSetupPage:
             response = test_client.get("/setup")
         script = (
             Path(__file__).resolve().parents[1] / "static" / "js" / "setup-page.js"
-        ).read_text()
+        ).read_text(encoding="utf-8")
 
         assert response.status_code == 200
         assert "First-run setup" in response.text


### PR DESCRIPTION
## Summary
- bind dashboard Escape handling to the dashboard root instead of document to avoid duplicate global listeners on reinitialization
- read setup-page.js with explicit UTF-8 encoding in the setup page test

## Validation
- git diff --check
- python3 -m compileall -q backend/app/tests/test_setup_endpoints.py backend/app/tests/test_dashboard_template_security.py
- node --check backend/app/static/js/dashboard-page.js

Follow-up for Copilot comments on #550 and #551.