### PR TITLE
Fix DNS evidence handling on lookup failures

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -424,6 +424,8 @@ class DNSRecordResponse(BaseModel):
     nameservers: List[str] = []
     dnsProvider: Optional[Dict[str, Any]] = None
     providerContext: Optional[Dict[str, Any]] = None
+    lookupStatus: str = "ok"
+    lookupError: Optional[str] = None
 
 
 class DNSGuidanceRecordResponse(BaseModel):
@@ -957,6 +959,8 @@ class DNSHealthResponse(BaseModel):
     compliance_rate: float
     total_emails: int
     failed_emails: int
+    dns_lookup_status: str = "ok"
+    dns_lookup_error: Optional[str] = None
     checks: List[DNSHealthCheck]
     recommendations: List[DNSHealthRecommendation]
 
@@ -2329,6 +2333,8 @@ async def _build_domain_dns_health(  # pylint: disable=too-many-locals
         compliance_rate=float(summary.get("compliance_rate", 0.0) or 0.0),
         total_emails=int(summary.get("total_count", 0) or 0),
         failed_emails=int(summary.get("failed_count", 0) or 0),
+        dns_lookup_status=result.lookup_status,
+        dns_lookup_error=result.lookup_error,
         checks=checks,
         recommendations=recommendations,
     )
@@ -2573,13 +2579,19 @@ async def _build_domain_health_grade(
     report_selectors = _get_selectors_from_reports(store, domain_id)
     combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
     provider = get_default_provider(db)
-    dns, _, _ = await resolve_domain_dns_cached(
-        db,
-        provider,
-        domain_id,
-        selectors=combined_selectors,
-        refresh=refresh,
-    )
+    try:
+        dns, _, _ = await resolve_domain_dns_cached(
+            db,
+            provider,
+            domain_id,
+            selectors=combined_selectors,
+            refresh=refresh,
+        )
+    except (asyncio.TimeoutError, LookupError, OSError) as exc:
+        dns = DomainDNSResult(
+            lookup_status="failed",
+            lookup_error=f"DNS lookup failed: {exc}",
+        )
     summary = store.get_domain_summary(domain_id)
     live_policy = extract_dmarc_policy(dns.dmarc_record)
     reported_policy = _normalize_reported_policy(summary.get("policy", {}))
@@ -2622,6 +2634,9 @@ async def _build_domain_health_grade(
         "dmarc_policy": live_policy or reported_policy or "none",
         "spf_status": dns.spf,
         "dkim_status": dns.dkim,
+        "dns_lookup_status": dns.lookup_status,
+        "dns_lookup_failed": dns.lookup_status == "failed",
+        "dns_lookup_error": dns.lookup_error,
         "dmarc_warnings": dns.dmarc_warnings,
         "dmarc_suggestions": dns.dmarc_suggestions,
         "source_reputation": asdict(reputation_result),
@@ -2969,10 +2984,19 @@ def _with_dns_summary_metadata(
 
 def _pending_dns_summary_result() -> DomainDNSResult:
     return _with_dns_summary_metadata(
-        DomainDNSResult(),
+        DomainDNSResult(lookup_status="pending"),
         cached=False,
         checked_at=None,
         pending=True,
+    )
+
+
+def _failed_dns_summary_result(error: str) -> DomainDNSResult:
+    return _with_dns_summary_metadata(
+        DomainDNSResult(lookup_status="failed", lookup_error=error),
+        cached=False,
+        checked_at=None,
+        pending=False,
     )
 
 
@@ -3019,7 +3043,7 @@ async def _resolve_summary_dns_result(
         )
     except (asyncio.TimeoutError, LookupError, OSError) as exc:
         logger.warning("DNS check failed for %s: %s", domain_name, exc)
-        return DomainDNSResult()
+        return _failed_dns_summary_result(f"DNS lookup failed: {exc}")
 
 
 @router.get("/summary", response_model=DomainSummaryResponse)
@@ -3111,6 +3135,8 @@ async def get_domains_summary(
         reported_policy = _normalize_reported_policy(summary.get("policy", {}))
         dmarc_policy = live_policy or reported_policy or "none"
         dns_pending = bool(getattr(dns, "pending", False))
+        dns_lookup_status = str(getattr(dns, "lookup_status", "ok") or "ok")
+        dns_lookup_failed = dns_lookup_status == "failed"
 
         # Format domain data for frontend
         domain_row = {
@@ -3129,6 +3155,9 @@ async def get_domains_summary(
             "spf_status": dns.spf,
             "dkim_status": dns.dkim,
             "dns_pending": dns_pending,
+            "dns_lookup_status": dns_lookup_status,
+            "dns_lookup_failed": dns_lookup_failed,
+            "dns_lookup_error": getattr(dns, "lookup_error", None),
             "dns_cached": getattr(dns, "cached", False),
             "dns_checked_at": (
                 getattr(dns, "checked_at", None).isoformat()
@@ -4217,6 +4246,8 @@ async def get_domain_dns_records(
             dns_provider=asdict(result.dns_provider) if result.dns_provider else None,
             nameservers=result.nameservers,
         ),
+        lookupStatus=result.lookup_status,
+        lookupError=result.lookup_error,
     )
 
 

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -124,6 +124,67 @@ def _lookup_failure_result(error_type: str, now: datetime) -> Tuple[DomainDNSRes
     )
 
 
+def _cache_row(
+    db: Session,
+    *,
+    domain: str,
+    provider_name: str,
+    selectors_key: str,
+) -> Optional[DNSCache]:
+    return (
+        db.query(DNSCache)
+        .filter(
+            DNSCache.domain == domain,
+            DNSCache.provider == provider_name,
+            DNSCache.selectors_key == selectors_key,
+        )
+        .first()
+    )
+
+
+def _store_cache_result(
+    db: Session,
+    row: Optional[DNSCache],
+    *,
+    domain: str,
+    provider_name: str,
+    selectors_key: str,
+    payload: str,
+    checked_at: datetime,
+) -> DNSCache:
+    if row is None:
+        row = DNSCache(
+            domain=domain,
+            provider=provider_name,
+            selectors_key=selectors_key,
+            result_json=payload,
+            checked_at=checked_at,
+        )
+        db.add(row)
+    else:
+        row.result_json = payload
+        row.checked_at = checked_at
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        row = _cache_row(
+            db,
+            domain=domain,
+            provider_name=provider_name,
+            selectors_key=selectors_key,
+        )
+        if row is None:
+            raise
+        row.result_json = payload
+        row.checked_at = checked_at
+        db.commit()
+
+    db.refresh(row)
+    return row
+
+
 async def _resolve_with_fallback(
     provider: BaseDNSProvider,
     domain: str,
@@ -203,14 +264,11 @@ async def resolve_domain_dns_cached(
     now = _utcnow_naive()
     provider_name = provider.__class__.__name__
     selectors_key = _selectors_key(selectors)
-    row = (
-        db.query(DNSCache)
-        .filter(
-            DNSCache.domain == domain,
-            DNSCache.provider == provider_name,
-            DNSCache.selectors_key == selectors_key,
-        )
-        .first()
+    row = _cache_row(
+        db,
+        domain=domain,
+        provider_name=provider_name,
+        selectors_key=selectors_key,
     )
 
     if row and not refresh:
@@ -257,40 +315,15 @@ async def resolve_domain_dns_cached(
             )
             return stale
 
-    payload = _result_to_json(result)
-    if row is None:
-        row = DNSCache(
-            domain=domain,
-            provider=provider_name,
-            selectors_key=selectors_key,
-            result_json=payload,
-            checked_at=now,
-        )
-        db.add(row)
-    else:
-        row.result_json = payload
-        row.checked_at = now
-
-    try:
-        db.commit()
-    except IntegrityError:
-        db.rollback()
-        row = (
-            db.query(DNSCache)
-            .filter(
-                DNSCache.domain == domain,
-                DNSCache.provider == provider_name,
-                DNSCache.selectors_key == selectors_key,
-            )
-            .first()
-        )
-        if row is None:
-            raise
-        row.result_json = payload
-        row.checked_at = now
-        db.commit()
-
-    db.refresh(row)
+    row = _store_cache_result(
+        db,
+        row,
+        domain=domain,
+        provider_name=provider_name,
+        selectors_key=selectors_key,
+        payload=_result_to_json(result),
+        checked_at=now,
+    )
     return result, False, row.checked_at
 
 
@@ -302,14 +335,11 @@ def get_cached_domain_dns_result(
     selectors: List[str],
 ) -> Tuple[Optional[DomainDNSResult], bool, Optional[datetime]]:
     """Return the latest cached DNS result without performing network lookups."""
-    row = (
-        db.query(DNSCache)
-        .filter(
-            DNSCache.domain == domain,
-            DNSCache.provider == provider.__class__.__name__,
-            DNSCache.selectors_key == _selectors_key(selectors),
-        )
-        .first()
+    row = _cache_row(
+        db,
+        domain=domain,
+        provider_name=provider.__class__.__name__,
+        selectors_key=_selectors_key(selectors),
     )
     if row is None:
         return None, False, None

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -96,6 +96,34 @@ def _within_stale_evidence_grace(row: DNSCache, now: datetime) -> bool:
     return row.checked_at >= now - timedelta(seconds=STALE_DNS_EVIDENCE_GRACE_SECONDS)
 
 
+def _stale_cached_evidence(
+    row: Optional[DNSCache],
+    *,
+    now: datetime,
+    lookup_error: str,
+) -> Optional[Tuple[DomainDNSResult, bool, datetime]]:
+    if not row:
+        return None
+    cached_result = _result_from_json(row.result_json)
+    if not _has_dns_evidence(cached_result) or not _within_stale_evidence_grace(row, now):
+        return None
+
+    cached_result.lookup_status = "stale_cache"
+    cached_result.lookup_error = lookup_error
+    return cached_result, True, row.checked_at
+
+
+def _lookup_failure_result(error_type: str, now: datetime) -> Tuple[DomainDNSResult, bool, datetime]:
+    return (
+        DomainDNSResult(
+            lookup_status="failed",
+            lookup_error=f"DNS lookup failed with {error_type}.",
+        ),
+        False,
+        now,
+    )
+
+
 async def _resolve_with_fallback(
     provider: BaseDNSProvider,
     domain: str,
@@ -196,47 +224,38 @@ async def resolve_domain_dns_cached(
     except asyncio.CancelledError:
         raise
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        if row and _has_dns_evidence(_result_from_json(row.result_json)):
-            cached_result = _result_from_json(row.result_json)
-            if _within_stale_evidence_grace(row, now):
-                cached_result.lookup_status = "stale_cache"
-                cached_result.lookup_error = (
-                    f"DNS lookup failed with {exc.__class__.__name__}; "
-                    "using the last known DNS evidence."
-                )
-                logger.warning(
-                    "DNS resolver failed; using last known DNS evidence for %s",
-                    provider_name,
-                )
-                return cached_result, True, row.checked_at
+        stale = _stale_cached_evidence(
+            row,
+            now=now,
+            lookup_error=(
+                f"DNS lookup failed with {exc.__class__.__name__}; "
+                "using the last known DNS evidence."
+            ),
+        )
+        if stale:
+            logger.warning(
+                "DNS resolver failed; using last known DNS evidence for %s",
+                provider_name,
+            )
+            return stale
         logger.warning(
             "DNS resolver failed with %s; returning lookup failure evidence",
             exc.__class__.__name__,
         )
-        return (
-            DomainDNSResult(
-                lookup_status="failed",
-                lookup_error=f"DNS lookup failed with {exc.__class__.__name__}.",
-            ),
-            False,
-            now,
+        return _lookup_failure_result(exc.__class__.__name__, now)
+
+    if not _has_dns_evidence(result):
+        stale = _stale_cached_evidence(
+            row,
+            now=now,
+            lookup_error="DNS resolver returned no DNS evidence; using the last known DNS cache.",
         )
-    if (
-        row
-        and _has_dns_evidence(_result_from_json(row.result_json))
-        and not _has_dns_evidence(result)
-    ):
-        cached_result = _result_from_json(row.result_json)
-        if _within_stale_evidence_grace(row, now):
-            cached_result.lookup_status = "stale_cache"
-            cached_result.lookup_error = (
-                "DNS resolver returned no DNS evidence; using the last known DNS cache."
-            )
+        if stale:
             logger.warning(
                 "DNS resolver returned no evidence; keeping last known DNS evidence for %s",
                 provider_name,
             )
-            return cached_result, True, row.checked_at
+            return stale
 
     payload = _result_to_json(result)
     if row is None:

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -19,6 +19,7 @@ from app.services.dns_resolver import (
     BaseDNSProvider,
     CloudflareDNSProvider,
     DomainDNSResult,
+    GoogleDNSProvider,
     SystemDNSProvider,
 )
 
@@ -60,6 +61,8 @@ def _result_from_json(value: str) -> DomainDNSResult:
         dmarc_suggestions=list(data.get("dmarc_suggestions") or []),
         nameservers=list(data.get("nameservers") or []),
         dns_provider=detection_from_json(data.get("dns_provider")),
+        lookup_status=str(data.get("lookup_status") or "ok"),
+        lookup_error=data.get("lookup_error"),
     )
 
 
@@ -99,31 +102,64 @@ async def _resolve_with_fallback(
     *,
     selectors: List[str],
 ) -> DomainDNSResult:
-    """Resolve DNS, using a public fallback when the primary result has no evidence."""
-    result = await provider.check_domain(domain, selectors=selectors)
-    if _has_dns_evidence(result):
-        return result
-    if not isinstance(provider, (CloudflareDNSProvider, SystemDNSProvider)):
-        return result
+    """Resolve DNS, walking independent resolvers before accepting an empty result."""
+    if not isinstance(
+        provider,
+        (SystemDNSProvider, CloudflareDNSProvider, GoogleDNSProvider),
+    ):
+        return await provider.check_domain(domain, selectors=selectors)
 
-    fallback: BaseDNSProvider
-    if isinstance(provider, CloudflareDNSProvider):
-        fallback = SystemDNSProvider()
-    else:
-        fallback = CloudflareDNSProvider()
+    fallback_types: List[type[BaseDNSProvider]] = [
+        SystemDNSProvider,
+        CloudflareDNSProvider,
+        GoogleDNSProvider,
+    ]
+    provider_types = [provider.__class__] + [
+        fallback_type
+        for fallback_type in fallback_types
+        if not isinstance(provider, fallback_type)
+    ]
+    last_result: Optional[DomainDNSResult] = None
+    resolver_errors: List[str] = []
 
-    try:
-        fallback_result = await fallback.check_domain(domain, selectors=selectors)
-    except asyncio.CancelledError:
-        raise
-    except Exception as exc:
-        logger.debug(
-            "Fallback DNS resolver failed with %s; returning primary DNS result",
-            exc.__class__.__name__,
-        )
-        return result
+    for index, provider_type in enumerate(provider_types):
+        candidate = provider if index == 0 else provider_type()
+        try:
+            result = await candidate.check_domain(domain, selectors=selectors)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            resolver_errors.append(f"{candidate.__class__.__name__}:{exc.__class__.__name__}")
+            logger.debug(
+                "DNS resolver %s failed with %s",
+                candidate.__class__.__name__,
+                exc.__class__.__name__,
+            )
+            continue
 
-    return fallback_result if _has_dns_evidence(fallback_result) else result
+        if _has_dns_evidence(result):
+            if index > 0:
+                result.lookup_status = "fallback"
+                result.lookup_error = (
+                    f"No DNS evidence from {provider.__class__.__name__}; "
+                    f"using {candidate.__class__.__name__}."
+                )
+            return result
+        last_result = result
+
+    if last_result is not None:
+        if resolver_errors:
+            last_result.lookup_status = "partial"
+            last_result.lookup_error = (
+                "No DNS evidence found after fallback resolver checks; "
+                f"{len(resolver_errors)} resolver error(s) occurred."
+            )
+        return last_result
+
+    raise LookupError(
+        "All DNS resolvers failed: "
+        + ", ".join(resolver_errors or ["no resolver attempted"])
+    )
 
 
 async def resolve_domain_dns_cached(
@@ -155,7 +191,36 @@ async def resolve_domain_dns_cached(
         if _is_fresh(row, cache_ttl, now):
             return cached_result, True, row.checked_at
 
-    result = await _resolve_with_fallback(provider, domain, selectors=selectors)
+    try:
+        result = await _resolve_with_fallback(provider, domain, selectors=selectors)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        if row and _has_dns_evidence(_result_from_json(row.result_json)):
+            cached_result = _result_from_json(row.result_json)
+            if _within_stale_evidence_grace(row, now):
+                cached_result.lookup_status = "stale_cache"
+                cached_result.lookup_error = (
+                    f"DNS lookup failed with {exc.__class__.__name__}; "
+                    "using the last known DNS evidence."
+                )
+                logger.warning(
+                    "DNS resolver failed; using last known DNS evidence for %s",
+                    provider_name,
+                )
+                return cached_result, True, row.checked_at
+        logger.warning(
+            "DNS resolver failed with %s; returning lookup failure evidence",
+            exc.__class__.__name__,
+        )
+        return (
+            DomainDNSResult(
+                lookup_status="failed",
+                lookup_error=f"DNS lookup failed with {exc.__class__.__name__}.",
+            ),
+            False,
+            now,
+        )
     if (
         row
         and _has_dns_evidence(_result_from_json(row.result_json))
@@ -163,6 +228,10 @@ async def resolve_domain_dns_cached(
     ):
         cached_result = _result_from_json(row.result_json)
         if _within_stale_evidence_grace(row, now):
+            cached_result.lookup_status = "stale_cache"
+            cached_result.lookup_error = (
+                "DNS resolver returned no DNS evidence; using the last known DNS cache."
+            )
             logger.warning(
                 "DNS resolver returned no evidence; keeping last known DNS evidence for %s",
                 provider_name,

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -101,6 +101,8 @@ class DomainDNSResult:
     dmarc_suggestions: List[str] = field(default_factory=list)
     nameservers: List[str] = field(default_factory=list)
     dns_provider: Optional[DNSProviderDetection] = None
+    lookup_status: str = "ok"
+    lookup_error: Optional[str] = None
 
 
 def _normalize_dns_name(domain: str) -> str:
@@ -971,6 +973,12 @@ class CloudflareDNSProvider(BaseDNSProvider):
         except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException):
             pass
         return []
+
+
+class GoogleDNSProvider(CloudflareDNSProvider):
+    """DNS provider using Google Public DNS-over-HTTPS as an independent fallback."""
+
+    CLOUDFLARE_DOH_URL: str = "https://dns.google/resolve"
 
 
 class DemoDNSProvider(BaseDNSProvider):

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -134,14 +134,14 @@ def _action(
     }
 
 
-def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
-    domain_name = str(domain.get("domain_name") or domain.get("id") or "domain")
-    pass_rate = _bounded(domain.get("pass_rate"))
-    policy = str(domain.get("dmarc_policy") or "missing").lower()
+def _dns_evidence_actions(
+    domain: Dict[str, Any],
+    *,
+    domain_name: str,
+    dns_pending: bool,
+    dns_lookup_failed: bool,
+) -> List[Dict[str, Any]]:
     actions: List[Dict[str, Any]] = []
-    dns_pending = bool(domain.get("dns_pending"))
-    dns_lookup_failed = bool(domain.get("dns_lookup_failed"))
-
     if dns_pending:
         actions.append(
             _action(
@@ -178,7 +178,21 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 ],
             )
         )
-    if not dns_pending and not dns_lookup_failed and not domain.get("dmarc_status"):
+    return actions
+
+
+def _missing_dns_actions(
+    domain: Dict[str, Any],
+    *,
+    domain_name: str,
+    dns_pending: bool,
+    dns_lookup_failed: bool,
+) -> List[Dict[str, Any]]:
+    if dns_pending or dns_lookup_failed:
+        return []
+
+    actions: List[Dict[str, Any]] = []
+    if not domain.get("dmarc_status"):
         actions.append(
             _action(
                 action_type="missing_dmarc",
@@ -190,7 +204,7 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 domain=domain_name,
             )
         )
-    if not dns_pending and not dns_lookup_failed and not domain.get("spf_status"):
+    if not domain.get("spf_status"):
         actions.append(
             _action(
                 action_type="missing_spf",
@@ -202,7 +216,7 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 domain=domain_name,
             )
         )
-    if not dns_pending and not dns_lookup_failed and not domain.get("dkim_status"):
+    if not domain.get("dkim_status"):
         actions.append(
             _action(
                 action_type="missing_dkim",
@@ -214,56 +228,68 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 domain=domain_name,
             )
         )
-    if pass_rate < 90 and int(domain.get("total_emails") or 0) > 0:
-        actions.append(
-            _action(
-                action_type="low_compliance",
-                severity="high" if pass_rate < 75 else "medium",
-                title="Investigate failing senders",
-                detail=f"DMARC pass rate is {pass_rate:.1f}%, below the 90% enforcement target.",
-                next_step="Open the domain detail page and fix the top failing sources before tightening policy.",
-                score_impact=18 if pass_rate < 75 else 10,
-                domain=domain_name,
-                evidence=[
-                    {"label": "pass_rate", "value": f"{pass_rate:.1f}%"},
-                    {"label": "failed", "value": str(domain.get("failed_count") or 0)},
-                ],
-            )
-        )
-    if policy == "none" and domain.get("dmarc_status"):
-        actions.append(
-            _action(
-                action_type="policy_none",
-                severity="medium",
-                title="Move out of monitoring mode",
-                detail="p=none keeps DMARQ in observation mode and caps the health grade.",
-                next_step="After known senders pass DMARC, stage p=quarantine and then p=reject.",
-                score_impact=14,
-                domain=domain_name,
-                evidence=[{"label": "policy", "value": "p=none"}],
-            )
-        )
-    if domain.get("dmarc_warnings"):
-        actions.append(
-            _action(
-                action_type="dmarc_lint",
-                severity="medium",
-                title="Resolve DMARC lint warnings",
-                detail="The DMARC record has lint warnings that reduce operator confidence.",
-                next_step="Review the DNS health details and publish a corrected DMARC record.",
-                score_impact=8,
-                domain=domain_name,
-                evidence=[
-                    {"label": "warnings", "value": str(len(domain.get("dmarc_warnings") or []))}
-                ],
-            )
-        )
+    return actions
+
+
+def _compliance_action(
+    domain: Dict[str, Any], *, domain_name: str, pass_rate: float
+) -> Optional[Dict[str, Any]]:
+    if pass_rate >= 90 or int(domain.get("total_emails") or 0) <= 0:
+        return None
+    return _action(
+        action_type="low_compliance",
+        severity="high" if pass_rate < 75 else "medium",
+        title="Investigate failing senders",
+        detail=f"DMARC pass rate is {pass_rate:.1f}%, below the 90% enforcement target.",
+        next_step="Open the domain detail page and fix the top failing sources before tightening policy.",
+        score_impact=18 if pass_rate < 75 else 10,
+        domain=domain_name,
+        evidence=[
+            {"label": "pass_rate", "value": f"{pass_rate:.1f}%"},
+            {"label": "failed", "value": str(domain.get("failed_count") or 0)},
+        ],
+    )
+
+
+def _policy_action(
+    domain: Dict[str, Any], *, domain_name: str, policy: str
+) -> Optional[Dict[str, Any]]:
+    if policy != "none" or not domain.get("dmarc_status"):
+        return None
+    return _action(
+        action_type="policy_none",
+        severity="medium",
+        title="Move out of monitoring mode",
+        detail="p=none keeps DMARQ in observation mode and caps the health grade.",
+        next_step="After known senders pass DMARC, stage p=quarantine and then p=reject.",
+        score_impact=14,
+        domain=domain_name,
+        evidence=[{"label": "policy", "value": "p=none"}],
+    )
+
+
+def _dmarc_lint_action(domain: Dict[str, Any], *, domain_name: str) -> Optional[Dict[str, Any]]:
+    if not domain.get("dmarc_warnings"):
+        return None
+    return _action(
+        action_type="dmarc_lint",
+        severity="medium",
+        title="Resolve DMARC lint warnings",
+        detail="The DMARC record has lint warnings that reduce operator confidence.",
+        next_step="Review the DNS health details and publish a corrected DMARC record.",
+        score_impact=8,
+        domain=domain_name,
+        evidence=[{"label": "warnings", "value": str(len(domain.get("dmarc_warnings") or []))}],
+    )
+
+
+def _reputation_actions(domain: Dict[str, Any], *, domain_name: str) -> List[Dict[str, Any]]:
     reputation = domain.get("source_reputation") or {}
     reputation_summary = reputation.get("summary") or {}
     listed = int(reputation_summary.get("listed") or 0)
     suspicious = int(reputation_summary.get("suspicious") or 0)
     if listed:
-        actions.append(
+        return [
             _action(
                 action_type="source_reputation_listed",
                 severity="critical",
@@ -277,9 +303,9 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 domain=domain_name,
                 evidence=[{"label": "listed_sources", "value": str(listed)}],
             )
-        )
-    elif suspicious:
-        actions.append(
+        ]
+    if suspicious:
+        return [
             _action(
                 action_type="source_reputation_review",
                 severity="high",
@@ -290,7 +316,37 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 domain=domain_name,
                 evidence=[{"label": "suspicious_sources", "value": str(suspicious)}],
             )
-        )
+        ]
+    return []
+
+
+def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
+    domain_name = str(domain.get("domain_name") or domain.get("id") or "domain")
+    pass_rate = _bounded(domain.get("pass_rate"))
+    policy = str(domain.get("dmarc_policy") or "missing").lower()
+    dns_pending = bool(domain.get("dns_pending"))
+    dns_lookup_failed = bool(domain.get("dns_lookup_failed"))
+    actions = [
+        *_dns_evidence_actions(
+            domain,
+            domain_name=domain_name,
+            dns_pending=dns_pending,
+            dns_lookup_failed=dns_lookup_failed,
+        ),
+        *_missing_dns_actions(
+            domain,
+            domain_name=domain_name,
+            dns_pending=dns_pending,
+            dns_lookup_failed=dns_lookup_failed,
+        ),
+        *_reputation_actions(domain, domain_name=domain_name),
+    ]
+    optional_actions = [
+        _compliance_action(domain, domain_name=domain_name, pass_rate=pass_rate),
+        _policy_action(domain, domain_name=domain_name, policy=policy),
+        _dmarc_lint_action(domain, domain_name=domain_name),
+    ]
+    actions.extend(action for action in optional_actions if action is not None)
 
     return sorted(actions, key=lambda item: item["score_impact"], reverse=True)
 

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -39,7 +39,9 @@ def _bounded(value: Any, *, lower: float = 0.0, upper: float = 100.0) -> float:
 
 def _effective_dmarc_policy(domain: Dict[str, Any]) -> str:
     """Return the DMARC policy used for scoring, distinct from endpoint fallbacks."""
-    if domain.get("dns_pending") and domain.get("dmarc_policy"):
+    if (domain.get("dns_pending") or domain.get("dns_lookup_failed")) and domain.get(
+        "dmarc_policy"
+    ):
         return str(domain.get("dmarc_policy") or "none").lower()
     if not domain.get("dmarc_status"):
         return "missing"
@@ -60,6 +62,8 @@ def _policy_factor(policy: Optional[str]) -> float:
 def _dns_factor(domain: Dict[str, Any]) -> float:
     if domain.get("dns_pending"):
         return 70.0
+    if domain.get("dns_lookup_failed"):
+        return 65.0
     checks = [
         bool(domain.get("dmarc_status")),
         bool(domain.get("spf_status")),
@@ -136,6 +140,7 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
     policy = str(domain.get("dmarc_policy") or "missing").lower()
     actions: List[Dict[str, Any]] = []
     dns_pending = bool(domain.get("dns_pending"))
+    dns_lookup_failed = bool(domain.get("dns_lookup_failed"))
 
     if dns_pending:
         actions.append(
@@ -149,7 +154,31 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 domain=domain_name,
             )
         )
-    if not dns_pending and not domain.get("dmarc_status"):
+    if dns_lookup_failed:
+        actions.append(
+            _action(
+                action_type="dns_evidence_unavailable",
+                severity="medium",
+                title="Refresh DNS evidence",
+                detail=(
+                    "DMARQ could not refresh live DNS evidence, so it is not treating "
+                    "missing lookup data as a missing record."
+                ),
+                next_step=(
+                    "Retry DNS refresh or check resolver/provider connectivity before "
+                    "changing DNS records."
+                ),
+                score_impact=0,
+                domain=domain_name,
+                evidence=[
+                    {
+                        "label": "dns_lookup",
+                        "value": str(domain.get("dns_lookup_error") or "lookup failed"),
+                    }
+                ],
+            )
+        )
+    if not dns_pending and not dns_lookup_failed and not domain.get("dmarc_status"):
         actions.append(
             _action(
                 action_type="missing_dmarc",
@@ -161,7 +190,7 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 domain=domain_name,
             )
         )
-    if not dns_pending and not domain.get("spf_status"):
+    if not dns_pending and not dns_lookup_failed and not domain.get("spf_status"):
         actions.append(
             _action(
                 action_type="missing_spf",
@@ -173,7 +202,7 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
                 domain=domain_name,
             )
         )
-    if not dns_pending and not domain.get("dkim_status"):
+    if not dns_pending and not dns_lookup_failed and not domain.get("dkim_status"):
         actions.append(
             _action(
                 action_type="missing_dkim",

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -16,7 +16,9 @@ function domainDetailsApp(domainId) {
             dkimSelectors: [],
             nameservers: [],
             dnsProvider: null,
-            providerContext: null
+            providerContext: null,
+            lookupStatus: 'ok',
+            lookupError: ''
         },
         dnsRecordsLoading: true,
         dnsRecordsError: '',
@@ -384,11 +386,55 @@ function domainDetailsApp(domainId) {
 
         get dkimLiveText() {
             if (this.dnsRecordsLoading) return 'Checking DKIM selectors...';
+            if (this.dnsLookupFailed) return this.dnsLookupFailureText;
             if (!this.dns.dkim) return 'No DKIM record found for configured selectors';
             if (this.dns.dkimSelectors && this.dns.dkimSelectors.length > 0) {
                 return 'selectors: ' + this.dns.dkimSelectors.join(', ');
             }
             return 'Verified';
+        },
+
+        get dnsLookupFailed() {
+            return this.dns.lookupStatus === 'failed';
+        },
+
+        get dnsLookupStaleCache() {
+            return this.dns.lookupStatus === 'stale_cache';
+        },
+
+        get dnsLookupFallback() {
+            return this.dns.lookupStatus === 'fallback';
+        },
+
+        get dnsLookupPartial() {
+            return this.dns.lookupStatus === 'partial';
+        },
+
+        get dnsLookupNoticeVisible() {
+            return this.dnsLookupFailed || this.dnsLookupStaleCache || this.dnsLookupFallback || this.dnsLookupPartial;
+        },
+
+        get dnsLookupNoticeClass() {
+            if (this.dnsLookupFailed) return 'border-red-200 bg-red-50 text-red-800';
+            return 'border-yellow-200 bg-yellow-50 text-yellow-800';
+        },
+
+        get dnsLookupNoticeText() {
+            if (this.dnsLookupFailed) return this.dnsLookupFailureText;
+            if (this.dnsLookupStaleCache) return this.dns.lookupError || 'Using last known DNS evidence because live DNS refresh returned no usable result.';
+            if (this.dnsLookupFallback) return this.dns.lookupError || 'DNS evidence was found through a fallback resolver.';
+            if (this.dnsLookupPartial) return this.dns.lookupError || 'DNS fallback completed with partial resolver errors.';
+            return '';
+        },
+
+        get dnsLookupFailureText() {
+            return this.dns.lookupError || 'DNS lookup failed; cached or report evidence may be incomplete.';
+        },
+
+        dnsRecordText(record, missingText, checkingText) {
+            if (this.dnsRecordsLoading) return checkingText;
+            if (this.dnsLookupFailed) return this.dnsLookupFailureText;
+            return record || missingText;
         },
 
         get detectedDnsProvider() {
@@ -401,17 +447,20 @@ function domainDetailsApp(domainId) {
 
         get dnsProviderName() {
             if (this.dnsRecordsLoading) return 'Checking DNS provider...';
+            if (this.dnsLookupFailed) return 'DNS lookup failed';
             return this.detectedDnsProvider?.provider_name || 'Unknown provider';
         },
 
         get dnsProviderConfidence() {
             if (this.dnsRecordsLoading) return 'checking';
+            if (this.dnsLookupFailed) return 'unavailable';
             return this.detectedDnsProvider?.confidence || 'unknown';
         },
 
         get dnsProviderAction() {
             if (this.dnsRecordsLoading) return 'Looking up authoritative nameservers and authentication records.';
             if (this.dnsRecordsError) return this.dnsRecordsError;
+            if (this.dnsLookupFailed) return this.dnsLookupFailureText;
             return this.detectedDnsProvider?.suggested_action || 'Review nameservers and select the DNS provider manually before making changes.';
         },
 
@@ -425,6 +474,7 @@ function domainDetailsApp(domainId) {
 
         get dnsNameserverText() {
             if (this.dnsRecordsLoading) return 'Checking nameservers...';
+            if (this.dnsLookupFailed) return this.dnsLookupFailureText;
             const nameservers = this.dns.nameservers || this.detectedDnsProvider?.evidence || [];
             return nameservers.length ? nameservers.join(', ') : 'No NS evidence available yet';
         },

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1030,23 +1030,30 @@
                                x-text="providerContextCtaLabel"></a>
                         </div>
                     </div>
+                    <div x-show="!dnsRecordsLoading && dnsLookupNoticeVisible"
+                         class="rounded border px-3 py-2 text-sm"
+                         :class="dnsLookupNoticeClass">
+                        <span x-text="dnsLookupNoticeText"></span>
+                    </div>
                     <div>
                         <h3 class="font-semibold mb-1 flex items-center">
                             <span class="mr-2">DMARC Record</span>
                             <span x-show="dnsRecordsLoading" class="loading loading-spinner loading-xs"></span>
                             <span x-show="!dnsRecordsLoading && dns.dmarc" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
-                            <span x-show="!dnsRecordsLoading && !dns.dmarc" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
+                            <span x-show="!dnsRecordsLoading && dnsLookupFailed" class="inline-flex h-2 w-2 rounded-full bg-yellow-500"></span>
+                            <span x-show="!dnsRecordsLoading && !dnsLookupFailed && !dns.dmarc" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
                         </h3>
-                        <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono" x-text="dnsRecordsLoading ? 'Checking DMARC record...' : (dns.dmarcRecord || 'No DMARC record found')">-</div>
+                        <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono" x-text="dnsRecordText(dns.dmarcRecord, 'No DMARC record found', 'Checking DMARC record...')">-</div>
                     </div>
                     <div>
                         <h3 class="font-semibold mb-1 flex items-center">
                             <span class="mr-2">SPF Record</span>
                             <span x-show="dnsRecordsLoading" class="loading loading-spinner loading-xs"></span>
                             <span x-show="!dnsRecordsLoading && dns.spf" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
-                            <span x-show="!dnsRecordsLoading && !dns.spf" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
+                            <span x-show="!dnsRecordsLoading && dnsLookupFailed" class="inline-flex h-2 w-2 rounded-full bg-yellow-500"></span>
+                            <span x-show="!dnsRecordsLoading && !dnsLookupFailed && !dns.spf" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
                         </h3>
-                        <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono" x-text="dnsRecordsLoading ? 'Checking SPF record...' : (dns.spfRecord || 'No SPF record found')">-</div>
+                        <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono" x-text="dnsRecordText(dns.spfRecord, 'No SPF record found', 'Checking SPF record...')">-</div>
                     </div>
                     <div id="mta-sts-posture">
                         <h3 class="font-semibold mb-1 flex items-center">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -716,6 +716,13 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "dnsRecordsLoading" in template
     assert "Checking DMARC record..." in template
     assert "DNS records could not be loaded." in script
+    assert "dnsLookupFailed" in template
+    assert "dnsLookupStaleCache" in script
+    assert "dnsLookupFallback" in script
+    assert "dnsLookupNoticeVisible" in template
+    assert "dnsLookupNoticeText" in template
+    assert "dnsRecordText" in template
+    assert "DNS lookup failed; cached or report evidence may be incomplete." in script
     assert "reportsLoading" in template
     assert "Loading recent reports..." in template
     assert "Recent reports could not be loaded." in script

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -329,6 +329,54 @@ def test_dns_endpoint_returns_real_data(authed_client: TestClient):
     assert data["checkedAt"] is not None
 
 
+def test_dns_endpoint_labels_lookup_failure_without_claiming_records_are_missing(
+    authed_client: TestClient,
+):
+    """A resolver exception should surface as lookup failure evidence."""
+    provider = AsyncMock()
+    provider.check_domain = AsyncMock(side_effect=LookupError("resolver unavailable"))
+    provider.lookup_txt = AsyncMock(side_effect=LookupError("resolver unavailable"))
+    provider.lookup_cname = AsyncMock(return_value=None)
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.get_default_provider",
+        return_value=provider,
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns?refresh=true")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dmarc"] is False
+    assert data["spf"] is False
+    assert data["dkim"] is False
+    assert data["lookupStatus"] == "failed"
+    assert "LookupError" in data["lookupError"]
+    assert data["dmarcRecord"] is None
+    assert data["spfRecord"] is None
+
+
+def test_dns_endpoint_labels_backend_fallback_evidence(authed_client: TestClient):
+    """The UI can surface that backend resolver fallback supplied DNS evidence."""
+    result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject",
+        spf=True,
+        spf_record="v=spf1 -all",
+        lookup_status="fallback",
+        lookup_error="No DNS evidence from SystemDNSProvider; using GoogleDNSProvider.",
+    )
+
+    with _mock_dns(result):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns?refresh=true")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["lookupStatus"] == "fallback"
+    assert "GoogleDNSProvider" in data["lookupError"]
+    assert data["dmarc"] is True
+    assert data["spf"] is True
+
+
 def test_dns_endpoint_returns_dmarc_lint_findings(
     authed_client: TestClient,
     monkeypatch,
@@ -852,6 +900,46 @@ async def test_dns_cache_keeps_recent_positive_evidence_when_lookup_turns_empty(
 
 
 @pytest.mark.asyncio
+async def test_dns_cache_uses_stale_positive_evidence_when_lookup_raises(db_session):
+    """Transient resolver exceptions should keep known-good evidence with an explicit label."""
+    healthy = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject",
+        spf=True,
+        spf_record="v=spf1 -all",
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+        dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
+    )
+    provider = AsyncMock()
+    provider.check_domain = AsyncMock(side_effect=TimeoutError("resolver timed out"))
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=provider.__class__.__name__,
+            selectors_key=_selectors_key([]),
+            result_json=json.dumps(asdict(healthy), sort_keys=True, separators=(",", ":")),
+            checked_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=30),
+        )
+    )
+    db_session.commit()
+
+    result, cached, _checked = await resolve_domain_dns_cached(
+        db_session,
+        provider,
+        DOMAIN,
+        selectors=[],
+    )
+
+    assert cached is True
+    assert result.lookup_status == "stale_cache"
+    assert "TimeoutError" in (result.lookup_error or "")
+    assert result.dmarc is True
+    assert result.spf is True
+    assert result.nameservers == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
+    assert provider.check_domain.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_dns_cache_allows_old_positive_evidence_to_expire(db_session):
     """Very old DNS evidence should not mask a persistently empty resolver result."""
     healthy = DomainDNSResult(
@@ -892,7 +980,12 @@ async def test_dns_cache_allows_old_positive_evidence_to_expire(db_session):
 async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_session):
     """A primary resolver with no evidence should not force a false F grade."""
     primary_provider = SystemDNSProvider()
-    primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
+    primary_check = AsyncMock(
+        return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
+    )
+    cloudflare_check = AsyncMock(
+        return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
+    )
     fallback_result = DomainDNSResult(
         dmarc=True,
         dmarc_record="v=DMARC1; p=reject",
@@ -906,8 +999,12 @@ async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_sessio
         patch.object(primary_provider, "check_domain", new=primary_check),
         patch(
             "app.services.dns_cache.CloudflareDNSProvider.check_domain",
+            new=cloudflare_check,
+        ),
+        patch(
+            "app.services.dns_cache.GoogleDNSProvider.check_domain",
             new=AsyncMock(return_value=fallback_result),
-        ) as fallback,
+        ) as google_fallback,
     ):
         result, cached, _checked = await resolve_domain_dns_cached(
             db_session,
@@ -920,21 +1017,30 @@ async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_sessio
     assert result.dmarc is True
     assert result.spf is True
     assert result.dns_provider is not None
+    assert result.lookup_status == "fallback"
+    assert "GoogleDNSProvider" in (result.lookup_error or "")
     primary_check.assert_awaited_once()
-    fallback.assert_awaited_once()
+    cloudflare_check.assert_awaited_once()
+    google_fallback.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_dns_cache_propagates_fallback_cancellation(db_session):
     """Request cancellation must not be swallowed by defensive fallback handling."""
     primary_provider = SystemDNSProvider()
-    primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
+    primary_check = AsyncMock(
+        return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
+    )
     fallback_check = AsyncMock(side_effect=asyncio.CancelledError())
 
     with (
         patch.object(primary_provider, "check_domain", new=primary_check),
         patch(
             "app.services.dns_cache.CloudflareDNSProvider.check_domain",
+            new=AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)),
+        ),
+        patch(
+            "app.services.dns_cache.GoogleDNSProvider.check_domain",
             new=fallback_check,
         ),
         pytest.raises(asyncio.CancelledError),
@@ -955,7 +1061,9 @@ async def test_dns_cache_fallback_failure_log_omits_user_values(db_session, capl
     """Fallback failure logging should not echo domains or exception messages."""
     domain = "bad.example\nforged-log-line"
     primary_provider = SystemDNSProvider()
-    primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
+    primary_check = AsyncMock(
+        return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
+    )
     fallback_check = AsyncMock(side_effect=RuntimeError(f"resolver failed for {domain}"))
     caplog.set_level(logging.DEBUG, logger="app.services.dns_cache")
 
@@ -964,6 +1072,10 @@ async def test_dns_cache_fallback_failure_log_omits_user_values(db_session, capl
         patch(
             "app.services.dns_cache.CloudflareDNSProvider.check_domain",
             new=fallback_check,
+        ),
+        patch(
+            "app.services.dns_cache.GoogleDNSProvider.check_domain",
+            new=AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)),
         ),
     ):
         result, cached, _checked = await resolve_domain_dns_cached(
@@ -975,6 +1087,7 @@ async def test_dns_cache_fallback_failure_log_omits_user_values(db_session, capl
 
     assert cached is False
     assert result.dmarc is False
+    assert result.lookup_status == "partial"
     assert "RuntimeError" in caplog.text
     assert domain not in caplog.text
     assert f"resolver failed for {domain}" not in caplog.text
@@ -1595,7 +1708,7 @@ def test_summary_includes_dns_fields(authed_client: TestClient, db_session):
 
 
 def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_session):
-    """If DNS check fails, status fields default to False rather than crashing."""
+    """Empty DNS results stay false without being labeled resolver failures."""
     _persist_minimal_report(db_session)
     empty_result = DomainDNSResult()
 
@@ -1607,10 +1720,12 @@ def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_sessio
     assert domain["dmarc_status"] is False
     assert domain["spf_status"] is False
     assert domain["dkim_status"] is False
+    assert domain["dns_lookup_status"] == "ok"
+    assert domain["dns_lookup_failed"] is False
 
 
-def test_summary_refresh_dns_exception_defaults_false(authed_client: TestClient, db_session):
-    """Resolver failures during explicit refresh should not block the summary."""
+def test_summary_refresh_dns_exception_marks_lookup_failed(authed_client: TestClient, db_session):
+    """Resolver failures should not become misleading missing-DNS recommendations."""
     _persist_minimal_report(db_session)
 
     with patch(
@@ -1625,6 +1740,14 @@ def test_summary_refresh_dns_exception_defaults_false(authed_client: TestClient,
     assert domain["spf_status"] is False
     assert domain["dkim_status"] is False
     assert domain["dns_pending"] is False
+    assert domain["dns_lookup_status"] == "failed"
+    assert domain["dns_lookup_failed"] is True
+    assert "resolver unavailable" in domain["dns_lookup_error"]
+    action_types = [action["type"] for action in domain["health"]["actions"]]
+    assert "dns_evidence_unavailable" in action_types
+    assert "missing_dmarc" not in action_types
+    assert "missing_spf" not in action_types
+    assert "missing_dkim" not in action_types
 
 
 def test_summary_endpoint_uses_manual_selectors(authed_client: TestClient, db_session):

--- a/backend/app/tests/test_health_score.py
+++ b/backend/app/tests/test_health_score.py
@@ -79,6 +79,36 @@ def test_missing_dmarc_scores_worse_than_policy_none():
     assert not any(action["type"] == "policy_none" for action in missing_record["actions"])
 
 
+def test_dns_lookup_failure_preserves_report_policy_and_avoids_missing_dns_actions():
+    """A resolver failure is not proof that DMARC/SPF/DKIM records are missing."""
+    health = score_domain_health(
+        {
+            "domain_name": "cklnet.com",
+            "total_emails": 20_000,
+            "failed_count": 0,
+            "pass_rate": 99.8,
+            "report_count": 30,
+            "dmarc_status": False,
+            "spf_status": False,
+            "dkim_status": False,
+            "dmarc_policy": "reject",
+            "dmarc_warnings": [],
+            "dns_lookup_failed": True,
+            "dns_lookup_error": "DNS lookup failed with TimeoutError.",
+        }
+    )
+
+    action_types = [action["type"] for action in health["actions"]]
+
+    assert health["factors"]["policy_strength"] == 100.0
+    assert health["factors"]["dns_posture"] == 65.0
+    assert health["grade"] != "F"
+    assert "dns_evidence_unavailable" in action_types
+    assert "missing_dmarc" not in action_types
+    assert "missing_spf" not in action_types
+    assert "missing_dkim" not in action_types
+
+
 def test_build_health_summary_weights_domain_scores_by_volume():
     domains = [
         {


### PR DESCRIPTION
## Summary
- add explicit DNS lookup status/error evidence to domain DNS APIs and summary rows
- use a resolver fallback chain before accepting empty DNS evidence, including Google Public DNS DoH after system/Cloudflare paths
- prevent health scoring/action plans from treating resolver failures as missing DMARC/SPF/DKIM records
- show fallback, stale-cache, partial, and failed DNS evidence states on the domain detail page

Fixes #554

## Local validation
- node --check backend/app/static/js/domain-details-page.js
- python -m py_compile backend/app/services/dns_cache.py backend/app/services/dns_resolver.py backend/app/api/api_v1/endpoints/domains.py backend/app/services/health_score.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_health_score.py backend/app/tests/test_dashboard_template_security.py
- git diff --check
- pytest -q backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_health_score.py backend/app/tests/test_dashboard_template_security.py::test_domain_details_distinguishes_loading_error_and_empty_states