### PR TITLE
Fix health action evidence precedence

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2622,6 +2622,8 @@ async def _build_domain_health_grade(
         days=30,
         refresh=refresh,
     )
+    dmarc_policy_source = "dns" if live_policy else "report" if reported_policy else "default"
+    dns_evidence_source = _dns_evidence_source(dns, has_live_policy=bool(live_policy))
     domain_row = {
         "id": domain_id,
         "domain_name": domain_id,
@@ -2632,6 +2634,8 @@ async def _build_domain_health_grade(
         "report_count": summary.get("reports_processed", 0),
         "dmarc_status": dns.dmarc,
         "dmarc_policy": live_policy or reported_policy or "none",
+        "dmarc_policy_source": dmarc_policy_source,
+        "dns_evidence_source": dns_evidence_source,
         "spf_status": dns.spf,
         "dkim_status": dns.dkim,
         "dns_lookup_status": dns.lookup_status,
@@ -2991,6 +2995,23 @@ def _pending_dns_summary_result() -> DomainDNSResult:
     )
 
 
+def _dns_evidence_source(dns: DomainDNSResult, *, has_live_policy: bool) -> str:
+    status = str(getattr(dns, "lookup_status", "ok") or "ok")
+    if status == "pending":
+        return "pending"
+    if status == "failed":
+        return "lookup_failed"
+    if status == "stale_cache":
+        return "stale_cache"
+    if status == "fallback":
+        return "fallback_dns"
+    if has_live_policy:
+        return "cached_dns" if getattr(dns, "cached", False) else "live_dns"
+    if status == "partial":
+        return "partial_dns"
+    return "empty_lookup"
+
+
 def _failed_dns_summary_result(error: str) -> DomainDNSResult:
     return _with_dns_summary_metadata(
         DomainDNSResult(lookup_status="failed", lookup_error=error),
@@ -3134,9 +3155,11 @@ async def get_domains_summary(
         live_policy = extract_dmarc_policy(dns.dmarc_record)
         reported_policy = _normalize_reported_policy(summary.get("policy", {}))
         dmarc_policy = live_policy or reported_policy or "none"
+        dmarc_policy_source = "dns" if live_policy else "report" if reported_policy else "default"
         dns_pending = bool(getattr(dns, "pending", False))
         dns_lookup_status = str(getattr(dns, "lookup_status", "ok") or "ok")
         dns_lookup_failed = dns_lookup_status == "failed"
+        dns_evidence_source = _dns_evidence_source(dns, has_live_policy=bool(live_policy))
 
         # Format domain data for frontend
         domain_row = {
@@ -3152,6 +3175,8 @@ async def get_domains_summary(
             # Real DNS status
             "dmarc_status": dns.dmarc,
             "dmarc_policy": dmarc_policy,
+            "dmarc_policy_source": dmarc_policy_source,
+            "dns_evidence_source": dns_evidence_source,
             "spf_status": dns.spf,
             "dkim_status": dns.dkim,
             "dns_pending": dns_pending,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2628,6 +2628,8 @@ async def _build_domain_health_grade(
         reported_policy=reported_policy,
     )
     dns_evidence_source = _dns_evidence_source(dns)
+    dns_pending = bool(getattr(dns, "pending", False))
+    dns_lookup_status = _dns_lookup_status(dns)
     domain_row = {
         "id": domain_id,
         "domain_name": domain_id,
@@ -2642,8 +2644,9 @@ async def _build_domain_health_grade(
         "dns_evidence_source": dns_evidence_source,
         "spf_status": dns.spf,
         "dkim_status": dns.dkim,
-        "dns_lookup_status": dns.lookup_status,
-        "dns_lookup_failed": dns.lookup_status == "failed",
+        "dns_pending": dns_pending,
+        "dns_lookup_status": dns_lookup_status,
+        "dns_lookup_failed": dns_lookup_status == "failed",
         "dns_lookup_error": dns.lookup_error,
         "dmarc_warnings": dns.dmarc_warnings,
         "dmarc_suggestions": dns.dmarc_suggestions,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -9,7 +9,7 @@ import logging
 import secrets
 from dataclasses import asdict
 from datetime import date, datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Request, status
 from fastapi.responses import JSONResponse, Response
@@ -2622,8 +2622,12 @@ async def _build_domain_health_grade(
         days=30,
         refresh=refresh,
     )
-    dmarc_policy_source = "dns" if live_policy else "report" if reported_policy else "default"
-    dns_evidence_source = _dns_evidence_source(dns, has_live_policy=bool(live_policy))
+    dmarc_policy, dmarc_policy_source = _dmarc_policy_with_source(
+        dns,
+        live_policy=live_policy,
+        reported_policy=reported_policy,
+    )
+    dns_evidence_source = _dns_evidence_source(dns)
     domain_row = {
         "id": domain_id,
         "domain_name": domain_id,
@@ -2633,7 +2637,7 @@ async def _build_domain_health_grade(
         "pass_rate": summary.get("compliance_rate", 0),
         "report_count": summary.get("reports_processed", 0),
         "dmarc_status": dns.dmarc,
-        "dmarc_policy": live_policy or reported_policy or "none",
+        "dmarc_policy": dmarc_policy,
         "dmarc_policy_source": dmarc_policy_source,
         "dns_evidence_source": dns_evidence_source,
         "spf_status": dns.spf,
@@ -2995,8 +2999,47 @@ def _pending_dns_summary_result() -> DomainDNSResult:
     )
 
 
-def _dns_evidence_source(dns: DomainDNSResult, *, has_live_policy: bool) -> str:
-    status = str(getattr(dns, "lookup_status", "ok") or "ok")
+_NON_LIVE_DNS_POLICY_STATUSES = {"pending", "failed", "stale_cache", "fallback"}
+
+
+def _dns_lookup_status(dns: DomainDNSResult) -> str:
+    return str(getattr(dns, "lookup_status", "ok") or "ok")
+
+
+def _dns_has_evidence(dns: DomainDNSResult) -> bool:
+    return any(
+        (
+            dns.dmarc,
+            dns.dmarc_record,
+            dns.spf,
+            dns.spf_record,
+            dns.dkim,
+            dns.dkim_record,
+            dns.dkim_selectors,
+            dns.nameservers,
+            dns.dmarc_policy_domain,
+        )
+    )
+
+
+def _dmarc_policy_with_source(
+    dns: DomainDNSResult,
+    *,
+    live_policy: Optional[str],
+    reported_policy: Optional[str],
+) -> Tuple[str, str]:
+    status = _dns_lookup_status(dns)
+    if status in _NON_LIVE_DNS_POLICY_STATUSES and reported_policy:
+        return reported_policy, "report"
+    if live_policy:
+        return live_policy, "dns"
+    if reported_policy:
+        return reported_policy, "report"
+    return "none", "default"
+
+
+def _dns_evidence_source(dns: DomainDNSResult) -> str:
+    status = _dns_lookup_status(dns)
     if status == "pending":
         return "pending"
     if status == "failed":
@@ -3005,10 +3048,10 @@ def _dns_evidence_source(dns: DomainDNSResult, *, has_live_policy: bool) -> str:
         return "stale_cache"
     if status == "fallback":
         return "fallback_dns"
-    if has_live_policy:
-        return "cached_dns" if getattr(dns, "cached", False) else "live_dns"
     if status == "partial":
         return "partial_dns"
+    if _dns_has_evidence(dns):
+        return "cached_dns" if getattr(dns, "cached", False) else "live_dns"
     return "empty_lookup"
 
 
@@ -3151,15 +3194,17 @@ async def get_domains_summary(
         total_passed += summary.get("passed_count", 0)
         total_reports += summary.get("reports_processed", 0)
 
-        # Prefer live DNS policy; fall back to policy seen in reports
         live_policy = extract_dmarc_policy(dns.dmarc_record)
         reported_policy = _normalize_reported_policy(summary.get("policy", {}))
-        dmarc_policy = live_policy or reported_policy or "none"
-        dmarc_policy_source = "dns" if live_policy else "report" if reported_policy else "default"
+        dmarc_policy, dmarc_policy_source = _dmarc_policy_with_source(
+            dns,
+            live_policy=live_policy,
+            reported_policy=reported_policy,
+        )
         dns_pending = bool(getattr(dns, "pending", False))
-        dns_lookup_status = str(getattr(dns, "lookup_status", "ok") or "ok")
+        dns_lookup_status = _dns_lookup_status(dns)
         dns_lookup_failed = dns_lookup_status == "failed"
-        dns_evidence_source = _dns_evidence_source(dns, has_live_policy=bool(live_policy))
+        dns_evidence_source = _dns_evidence_source(dns)
 
         # Format domain data for frontend
         domain_row = {

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -134,6 +134,38 @@ def _action(
     }
 
 
+def _evidence_label(value: Optional[str]) -> str:
+    labels = {
+        "live_dns": "Live DNS",
+        "cached_dns": "Cached DNS",
+        "fallback_dns": "Fallback DNS",
+        "stale_cache": "Stale DNS cache",
+        "partial_dns": "Partial DNS lookup",
+        "empty_lookup": "DNS lookup returned no evidence",
+        "lookup_failed": "DNS lookup failed",
+        "pending": "DNS lookup pending",
+        "dns": "DNS policy record",
+        "report": "DMARC report policy",
+        "default": "Default fallback",
+    }
+    return labels.get(str(value or ""), str(value or "unknown"))
+
+
+def _evidence_items(domain: Dict[str, Any]) -> List[Dict[str, str]]:
+    items: List[Dict[str, str]] = []
+    dns_source = domain.get("dns_evidence_source")
+    if dns_source:
+        items.append({"label": "dns_evidence", "value": _evidence_label(str(dns_source))})
+    policy_source = domain.get("dmarc_policy_source")
+    if policy_source:
+        items.append({"label": "policy_source", "value": _evidence_label(str(policy_source))})
+    if domain.get("dmarc_policy"):
+        items.append({"label": "policy", "value": f"p={domain.get('dmarc_policy')}"})
+    if domain.get("dns_lookup_status"):
+        items.append({"label": "dns_lookup", "value": str(domain.get("dns_lookup_status"))})
+    return items
+
+
 def _dns_evidence_actions(
     domain: Dict[str, Any],
     *,
@@ -141,6 +173,7 @@ def _dns_evidence_actions(
     dns_pending: bool,
     dns_lookup_failed: bool,
 ) -> List[Dict[str, Any]]:
+    provenance = _evidence_items(domain)
     actions: List[Dict[str, Any]] = []
     if dns_pending:
         actions.append(
@@ -152,9 +185,17 @@ def _dns_evidence_actions(
                 next_step="Open the domain or use Reload to fetch live DNS before making DNS decisions.",
                 score_impact=0,
                 domain=domain_name,
+                evidence=provenance,
             )
         )
     if dns_lookup_failed:
+        evidence = [
+            *provenance,
+            {
+                "label": "lookup_error",
+                "value": str(domain.get("dns_lookup_error") or "lookup failed"),
+            },
+        ]
         actions.append(
             _action(
                 action_type="dns_evidence_unavailable",
@@ -170,12 +211,7 @@ def _dns_evidence_actions(
                 ),
                 score_impact=0,
                 domain=domain_name,
-                evidence=[
-                    {
-                        "label": "dns_lookup",
-                        "value": str(domain.get("dns_lookup_error") or "lookup failed"),
-                    }
-                ],
+                evidence=evidence,
             )
         )
     return actions
@@ -191,6 +227,7 @@ def _missing_dns_actions(
     if dns_pending or dns_lookup_failed:
         return []
 
+    provenance = _evidence_items(domain)
     actions: List[Dict[str, Any]] = []
     if not domain.get("dmarc_status"):
         actions.append(
@@ -202,6 +239,7 @@ def _missing_dns_actions(
                 next_step="Publish a v=DMARC1 record with rua reporting and start in p=none if needed.",
                 score_impact=25,
                 domain=domain_name,
+                evidence=provenance,
             )
         )
     if not domain.get("spf_status"):
@@ -214,6 +252,7 @@ def _missing_dns_actions(
                 next_step="Publish or repair the SPF TXT record for legitimate sending infrastructure.",
                 score_impact=12,
                 domain=domain_name,
+                evidence=provenance,
             )
         )
     if not domain.get("dkim_status"):
@@ -226,6 +265,7 @@ def _missing_dns_actions(
                 next_step="Publish the missing selector or rotate the service DKIM configuration.",
                 score_impact=12,
                 domain=domain_name,
+                evidence=provenance,
             )
         )
     return actions
@@ -236,6 +276,7 @@ def _compliance_action(
 ) -> Optional[Dict[str, Any]]:
     if pass_rate >= 90 or int(domain.get("total_emails") or 0) <= 0:
         return None
+    provenance = _evidence_items(domain)
     return _action(
         action_type="low_compliance",
         severity="high" if pass_rate < 75 else "medium",
@@ -245,6 +286,7 @@ def _compliance_action(
         score_impact=18 if pass_rate < 75 else 10,
         domain=domain_name,
         evidence=[
+            *provenance,
             {"label": "pass_rate", "value": f"{pass_rate:.1f}%"},
             {"label": "failed", "value": str(domain.get("failed_count") or 0)},
         ],
@@ -256,6 +298,7 @@ def _policy_action(
 ) -> Optional[Dict[str, Any]]:
     if policy != "none" or not domain.get("dmarc_status"):
         return None
+    provenance = _evidence_items(domain)
     return _action(
         action_type="policy_none",
         severity="medium",
@@ -264,7 +307,7 @@ def _policy_action(
         next_step="After known senders pass DMARC, stage p=quarantine and then p=reject.",
         score_impact=14,
         domain=domain_name,
-        evidence=[{"label": "policy", "value": "p=none"}],
+        evidence=provenance or [{"label": "policy", "value": "p=none"}],
     )
 
 
@@ -279,7 +322,9 @@ def _dmarc_lint_action(domain: Dict[str, Any], *, domain_name: str) -> Optional[
         next_step="Review the DNS health details and publish a corrected DMARC record.",
         score_impact=8,
         domain=domain_name,
-        evidence=[{"label": "warnings", "value": str(len(domain.get("dmarc_warnings") or []))}],
+        evidence=[
+            {"label": "warnings", "value": str(len(domain.get("dmarc_warnings") or []))}
+        ],
     )
 
 

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -190,11 +190,11 @@ def _dns_evidence_actions(
         )
     if dns_lookup_failed:
         evidence = [
-            *provenance,
             {
                 "label": "lookup_error",
                 "value": str(domain.get("dns_lookup_error") or "lookup failed"),
             },
+            *provenance,
         ]
         actions.append(
             _action(
@@ -286,9 +286,9 @@ def _compliance_action(
         score_impact=18 if pass_rate < 75 else 10,
         domain=domain_name,
         evidence=[
-            *provenance,
             {"label": "pass_rate", "value": f"{pass_rate:.1f}%"},
             {"label": "failed", "value": str(domain.get("failed_count") or 0)},
+            *provenance,
         ],
     )
 

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -134,6 +134,17 @@
                                     </span>
                                 </div>
                                 <p class="mt-2 text-sm text-[#5f5c78]" x-text="action.detail"></p>
+                                <div x-show="(action.evidence || []).length"
+                                     class="mt-3 flex flex-wrap gap-1.5">
+                                    <template x-for="item in (action.evidence || []).slice(0, 4)"
+                                              :key="item.label + item.value">
+                                        <span class="rounded-full bg-[#f8f7f6] px-2 py-1 text-xs text-[#5f5c78]">
+                                            <span class="font-semibold" x-text="item.label.replaceAll('_', ' ')"></span>
+                                            <span>:</span>
+                                            <span x-text="item.value"></span>
+                                        </span>
+                                    </template>
+                                </div>
                                 <p class="mt-2 text-sm font-semibold text-[#272a5f]" x-text="action.next_step"></p>
                                 <p class="mt-2 text-xs text-[#5f5c78]" x-text="action.domain"></p>
                             </a>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -270,6 +270,8 @@ def test_dashboard_exposes_workspace_health_history():
 
     assert "Score Trend" in template
     assert "health-trend-chart" in template
+    assert "action.evidence" in template
+    assert "item.label.replaceAll('_', ' ')" in template
     assert "/api/v1/domains/summary/health/history" in script
     assert "fetchWorkspaceHealthHistory" in script
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1758,6 +1758,65 @@ def test_summary_refresh_dns_exception_marks_lookup_failed(authed_client: TestCl
     assert "missing_dkim" not in action_types
 
 
+def test_summary_prefers_report_policy_when_dns_cache_is_stale(
+    authed_client: TestClient,
+    db_session,
+):
+    """Stale DNS evidence should not override the policy observed in reports."""
+    save_parsed_report(
+        db_session,
+        {
+            **MINIMAL_REPORT,
+            "report_id": "stale-dns-policy-fixture",
+            "policy": {"p": "reject", "sp": "", "pct": "100"},
+        },
+    )
+    db_session.commit()
+    stale_dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 include:_spf.google.com ~all",
+        dkim=True,
+        dkim_selectors=["google"],
+        dkim_record="v=DKIM1; k=rsa; p=ABC",
+        lookup_status="stale_cache",
+    )
+
+    with _mock_dns(result=stale_dns):
+        response = authed_client.get("/api/v1/domains/summary?refresh=true")
+
+    assert response.status_code == 200
+    domain = response.json()["domains"][0]
+    assert domain["dmarc_policy"] == "reject"
+    assert domain["dmarc_policy_source"] == "report"
+    assert domain["dns_evidence_source"] == "stale_cache"
+
+
+def test_summary_dns_evidence_source_uses_any_live_dns_evidence(
+    authed_client: TestClient,
+    db_session,
+):
+    """SPF/DKIM evidence should not be reported as an empty DNS lookup."""
+    _persist_minimal_report(db_session)
+    partial_dns = DomainDNSResult(
+        dmarc=False,
+        spf=True,
+        spf_record="v=spf1 include:_spf.google.com ~all",
+        dkim=True,
+        dkim_selectors=["google"],
+        dkim_record="v=DKIM1; k=rsa; p=ABC",
+    )
+
+    with _mock_dns(result=partial_dns):
+        response = authed_client.get("/api/v1/domains/summary?refresh=true")
+
+    assert response.status_code == 200
+    domain = response.json()["domains"][0]
+    assert domain["dmarc_policy_source"] == "report"
+    assert domain["dns_evidence_source"] == "live_dns"
+
+
 def test_summary_endpoint_uses_manual_selectors(authed_client: TestClient, db_session):
     """Manually configured selectors are forwarded by the summary endpoint."""
     _persist_minimal_report(db_session)

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -35,6 +35,7 @@ from app.services.dns_resolver import DomainDNSResult, SystemDNSProvider
 from app.services.mta_sts import MTAStsResult
 from app.services.report_persistence import save_parsed_report
 from app.services.report_store import ReportStore
+from app.services.source_reputation import DomainReputation
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1815,6 +1816,42 @@ def test_summary_dns_evidence_source_uses_any_live_dns_evidence(
     domain = response.json()["domains"][0]
     assert domain["dmarc_policy_source"] == "report"
     assert domain["dns_evidence_source"] == "live_dns"
+
+
+@pytest.mark.asyncio
+async def test_domain_health_grade_treats_pending_dns_as_unavailable(db_session):
+    """Domain detail health should match summary behavior while DNS is pending."""
+    _persist_minimal_report(db_session)
+    pending_dns = DomainDNSResult(lookup_status="pending")
+    pending_dns.pending = True  # type: ignore[attr-defined]
+    reputation = DomainReputation(
+        domain=DOMAIN,
+        status="clean",
+        checked_at="2026-07-03T15:00:00Z",
+        summary={"total_sources": 0, "highest_risk_score": 0},
+    )
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains.resolve_domain_dns_cached",
+            new=AsyncMock(return_value=(pending_dns, False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.build_source_reputation_cached",
+            new=AsyncMock(return_value=(reputation, False, None)),
+        ),
+    ):
+        health = await domains_endpoint._build_domain_health_grade(  # pylint: disable=protected-access
+            db_session,
+            DOMAIN,
+            ReportStore.get_instance(),
+        )
+
+    action_types = [action["type"] for action in health["actions"]]
+    assert "dns_evidence_pending" in action_types
+    assert "missing_dmarc" not in action_types
+    assert "missing_spf" not in action_types
+    assert "missing_dkim" not in action_types
 
 
 def test_summary_endpoint_uses_manual_selectors(authed_client: TestClient, db_session):

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1743,8 +1743,16 @@ def test_summary_refresh_dns_exception_marks_lookup_failed(authed_client: TestCl
     assert domain["dns_lookup_status"] == "failed"
     assert domain["dns_lookup_failed"] is True
     assert "resolver unavailable" in domain["dns_lookup_error"]
+    assert domain["dmarc_policy_source"] == "report"
+    assert domain["dns_evidence_source"] == "lookup_failed"
     action_types = [action["type"] for action in domain["health"]["actions"]]
     assert "dns_evidence_unavailable" in action_types
+    dns_action = next(
+        action for action in domain["health"]["actions"] if action["type"] == "dns_evidence_unavailable"
+    )
+    evidence = {item["label"]: item["value"] for item in dns_action["evidence"]}
+    assert evidence["dns_evidence"] == "DNS lookup failed"
+    assert evidence["policy_source"] == "DMARC report policy"
     assert "missing_dmarc" not in action_types
     assert "missing_spf" not in action_types
     assert "missing_dkim" not in action_types

--- a/backend/app/tests/test_health_score.py
+++ b/backend/app/tests/test_health_score.py
@@ -92,6 +92,9 @@ def test_dns_lookup_failure_preserves_report_policy_and_avoids_missing_dns_actio
             "spf_status": False,
             "dkim_status": False,
             "dmarc_policy": "reject",
+            "dmarc_policy_source": "report",
+            "dns_evidence_source": "lookup_failed",
+            "dns_lookup_status": "failed",
             "dmarc_warnings": [],
             "dns_lookup_failed": True,
             "dns_lookup_error": "DNS lookup failed with TimeoutError.",
@@ -99,11 +102,16 @@ def test_dns_lookup_failure_preserves_report_policy_and_avoids_missing_dns_actio
     )
 
     action_types = [action["type"] for action in health["actions"]]
+    dns_action = next(action for action in health["actions"] if action["type"] == "dns_evidence_unavailable")
+    evidence = {item["label"]: item["value"] for item in dns_action["evidence"]}
 
     assert health["factors"]["policy_strength"] == 100.0
     assert health["factors"]["dns_posture"] == 65.0
     assert health["grade"] != "F"
     assert "dns_evidence_unavailable" in action_types
+    assert evidence["dns_evidence"] == "DNS lookup failed"
+    assert evidence["policy_source"] == "DMARC report policy"
+    assert evidence["policy"] == "p=reject"
     assert "missing_dmarc" not in action_types
     assert "missing_spf" not in action_types
     assert "missing_dkim" not in action_types

--- a/backend/app/tests/test_health_score.py
+++ b/backend/app/tests/test_health_score.py
@@ -44,14 +44,22 @@ def test_low_compliance_and_missing_dns_create_prioritized_actions():
             "spf_status": False,
             "dkim_status": True,
             "dmarc_policy": "missing",
+            "dmarc_policy_source": "default",
+            "dns_evidence_source": "live_dns",
+            "dns_lookup_status": "ok",
             "dmarc_warnings": [],
         }
     )
 
     action_types = [action["type"] for action in health["actions"]]
+    compliance_action = next(action for action in health["actions"] if action["type"] == "low_compliance")
 
     assert health["grade"] == "F"
     assert action_types[:2] == ["missing_dmarc", "low_compliance"]
+    assert [item["label"] for item in compliance_action["evidence"][:2]] == [
+        "pass_rate",
+        "failed",
+    ]
     assert "missing_spf" in action_types
 
 
@@ -109,6 +117,7 @@ def test_dns_lookup_failure_preserves_report_policy_and_avoids_missing_dns_actio
     assert health["factors"]["dns_posture"] == 65.0
     assert health["grade"] != "F"
     assert "dns_evidence_unavailable" in action_types
+    assert dns_action["evidence"][0]["label"] == "lookup_error"
     assert evidence["dns_evidence"] == "DNS lookup failed"
     assert evidence["policy_source"] == "DMARC report policy"
     assert evidence["policy"] == "p=reject"


### PR DESCRIPTION
## Summary\n- preserve report-policy evidence when live DNS is pending, failed, stale, or fallback-derived\n- expose DMARC policy source and DNS evidence source in summary payloads\n- show evidence chips on dashboard action-plan cards so operators can see why an action exists\n\nFixes #556\n\n## Local validation\n- /tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/services/dns_cache.py backend/app/services/health_score.py backend/app/services/source_reputation.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/reports.py\n- /tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_health_score.py backend/app/tests/test_dns_endpoints.py::test_summary_refresh_dns_exception_marks_lookup_failed backend/app/tests/test_dashboard_template_security.py::test_dashboard_exposes_workspace_health_history backend/app/tests/test_source_reputation.py backend/app/tests/test_domain_detail_endpoints.py::test_get_domain_sources_includes_ip_intelligence_and_reputation backend/app/tests/test_reports_api.py::test_get_report_by_id_includes_source_intelligence_and_reputation backend/app/tests/test_dashboard_template_security.py::test_domain_details_exposes_source_ip_intelligence_without_html_injection backend/app/tests/test_dashboard_template_security.py::test_report_detail_uses_external_page_script_for_csp_migration backend/app/tests/test_dashboard_template_security.py::test_reports_uses_external_page_script_for_csp_migration backend/app/tests/test_dashboard_template_security.py::test_reports_page_distinguishes_loading_error_and_empty_states backend/app/tests/test_dashboard_template_security.py::test_domains_uses_external_page_script_for_csp_migration backend/app/tests/test_dashboard_template_security.py::test_domains_page_distinguishes_loading_error_and_empty_states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more detailed provenance details to domain health summaries, showing where DMARC policy and DNS evidence came from.
  * Action items in the dashboard can now display supporting evidence with clearer labels.

* **Bug Fixes**
  * Improved DNS failure handling so health results better distinguish live DNS data, stored report data, and fallback values.
  * Enhanced visible action details when DNS lookup issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->