### PR TITLE
Externalize remaining report and domain action handlers

### DIFF
--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -21,7 +21,52 @@ function domainsApp() {
         },
 
         init() {
+            this.bindPageControls();
             this.fetchDomains();
+        },
+
+        bindPageControls() {
+            const root = this.$root || document;
+            if (root.dataset?.domainControlsBound === 'true') {
+                return;
+            }
+            if (root.dataset) {
+                root.dataset.domainControlsBound = 'true';
+            }
+
+            root.addEventListener('click', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
+
+                const refreshButton = event.target.closest('[data-domain-refresh]');
+                if (refreshButton && root.contains(refreshButton)) {
+                    this.fetchDomains({ refresh: true });
+                    return;
+                }
+
+                const createButton = event.target.closest('[data-domain-create-open]');
+                if (createButton && root.contains(createButton)) {
+                    this.openCreate = true;
+                    return;
+                }
+
+                const retryButton = event.target.closest('[data-domain-retry-load]');
+                if (retryButton && root.contains(retryButton)) {
+                    this.fetchDomains();
+                    return;
+                }
+
+                const editButton = event.target.closest('[data-domain-edit]');
+                if (!editButton || !root.contains(editButton)) {
+                    return;
+                }
+                const domainIndex = Number.parseInt(editButton.dataset.domainIndex || '', 10);
+                const domain = Number.isInteger(domainIndex) ? this.domains[domainIndex] : null;
+                if (domain) {
+                    this.openEditDialog(domain);
+                }
+            });
         },
 
         async fetchDomains(options = {}) {

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -6,22 +6,28 @@ function reportDetailApp(reportId) {
         error: null,
 
         async init() {
-            this.bindDeleteControls();
+            this.bindPageControls();
             await this.fetchReport();
         },
 
-        bindDeleteControls() {
+        bindPageControls() {
             const root = this.$root || document;
-            if (root.dataset?.reportDeleteBound === 'true') {
+            if (root.dataset?.reportControlsBound === 'true') {
                 return;
             }
             if (root.dataset) {
-                root.dataset.reportDeleteBound = 'true';
+                root.dataset.reportControlsBound = 'true';
             }
             root.addEventListener('click', (event) => {
                 if (!(event.target instanceof Element)) {
                     return;
                 }
+                const retryButton = event.target.closest('[data-report-retry-load]');
+                if (retryButton && root.contains(retryButton)) {
+                    this.fetchReport();
+                    return;
+                }
+
                 const button = event.target.closest('[data-report-delete]');
                 if (!button || !root.contains(button)) {
                     return;

--- a/backend/app/static/js/reports-page.js
+++ b/backend/app/static/js/reports-page.js
@@ -10,22 +10,34 @@ function reportsApp() {
         error: '',
 
         init() {
-            this.bindDeleteControls();
+            this.bindPageControls();
             this.fetchReports();
         },
 
-        bindDeleteControls() {
+        bindPageControls() {
             const root = this.$root || document;
-            if (root.dataset?.reportDeleteBound === 'true') {
+            if (root.dataset?.reportControlsBound === 'true') {
                 return;
             }
             if (root.dataset) {
-                root.dataset.reportDeleteBound = 'true';
+                root.dataset.reportControlsBound = 'true';
             }
             root.addEventListener('click', (event) => {
                 if (!(event.target instanceof Element)) {
                     return;
                 }
+                const resetButton = event.target.closest('[data-report-reset-filters]');
+                if (resetButton && root.contains(resetButton)) {
+                    this.resetFilters();
+                    return;
+                }
+
+                const retryButton = event.target.closest('[data-report-retry-load]');
+                if (retryButton && root.contains(retryButton)) {
+                    this.fetchReports();
+                    return;
+                }
+
                 const button = event.target.closest('[data-report-delete]');
                 if (!button || !root.contains(button)) {
                     return;

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -24,12 +24,12 @@
                     <div class="flex items-center gap-2">
                         <button type="button"
                                 class="btn btn-outline btn-sm"
-                                @click="fetchDomains({ refresh: true })"
+                                data-domain-refresh
                                 :disabled="loading || refreshing">
                             <span x-show="refreshing" class="loading loading-spinner loading-xs"></span>
                             <span x-text="refreshing ? 'Refreshing...' : 'Reload'"></span>
                         </button>
-                        <button type="button" class="btn btn-outline btn-sm" @click="openCreate = true">
+                        <button type="button" class="btn btn-outline btn-sm" data-domain-create-open>
                             <span class="mr-1">+</span> Add Domain
                         </button>
                     </div>
@@ -65,7 +65,7 @@
                                 {% call td(colspan="5", class="text-center") %}
                                     <div class="flex flex-col items-center gap-3 py-4">
                                         <p class="text-red-700" x-text="loadError"></p>
-                                        <button type="button" class="btn btn-outline btn-sm" @click="fetchDomains()">
+                                        <button type="button" class="btn btn-outline btn-sm" data-domain-retry-load>
                                             Retry loading domains
                                         </button>
                                     </div>
@@ -110,7 +110,10 @@
                                         <a :href="'/domains/' + domain.name" class="btn btn-sm btn-outline">
                                             Details
                                         </a>
-                                        <button type="button" class="btn btn-outline btn-sm" @click="openEditDialog(domain)">
+                                        <button type="button"
+                                                class="btn btn-outline btn-sm"
+                                                data-domain-edit
+                                                :data-domain-index="index">
                                             Edit
                                         </button>
                                     </div>

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -32,7 +32,7 @@
             </svg>
             <div class="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <span x-text="error"></span>
-                <button type="button" class="btn btn-outline btn-sm" @click="fetchReport()">
+                <button type="button" class="btn btn-outline btn-sm" data-report-retry-load>
                     Retry
                 </button>
             </div>

--- a/backend/app/templates/reports.html
+++ b/backend/app/templates/reports.html
@@ -34,7 +34,7 @@
                         </select>
                     </div>
                     <div class="w-full sm:w-auto flex items-end">
-                        <button type="button" class="btn btn-outline btn-md" @click="resetFilters()">
+                        <button type="button" class="btn btn-outline btn-md" data-report-reset-filters>
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>
                             Reset Filters
                         </button>
@@ -86,7 +86,7 @@
                                 {% call td(colspan="7", class="text-center") %}
                                     <div class="flex flex-col items-center gap-3 py-4">
                                         <p class="text-red-700" x-text="error"></p>
-                                        <button type="button" class="btn btn-outline btn-sm" @click="fetchReports()">
+                                        <button type="button" class="btn btn-outline btn-sm" data-report-retry-load>
                                             Retry loading reports
                                         </button>
                                     </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -399,7 +399,15 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert "/api/v1/domains/summary" in script
     assert "/api/v1/domains/domains" in script
     assert "createDomain()" in script
-    assert "openEditDialog(domain)" in template
+    assert "openEditDialog(domain)" not in template
+    assert "openEditDialog(domain)" in script
+    assert "bindPageControls()" in script
+    assert "data-domain-refresh" in template
+    assert "data-domain-refresh" in script
+    assert "data-domain-create-open" in template
+    assert "data-domain-create-open" in script
+    assert "data-domain-edit" in template
+    assert "data-domain-edit" in script
     assert "Edit monitored domain" in template
     assert "updateDomain()" in script
     assert "method: 'PATCH'" in script
@@ -416,7 +424,10 @@ def test_domains_page_distinguishes_loading_error_and_empty_states():
     assert "Domains could not be loaded." in script
     assert "No domains found. Add a domain to get started." in template
     assert "Retry loading domains" in template
-    assert '@click="fetchDomains()"' in template
+    assert '@click="fetchDomains()"' not in template
+    assert '@click="fetchDomains({ refresh: true })"' not in template
+    assert "data-domain-retry-load" in template
+    assert "data-domain-retry-load" in script
     assert 'x-if="!loading && loadError"' in template
     assert 'x-if="!loading && !loadError && domains.length === 0"' in template
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -360,12 +360,13 @@ def test_reports_uses_external_page_script_for_csp_migration():
     assert '@click="deleteReport' not in template
     assert "data-report-delete" in template
     assert "data-report-delete" in script
-    assert "bindDeleteControls()" in script
+    assert "bindPageControls()" in script
     assert "event.target instanceof Element" in script
     assert "/api/v1/reports" in script
     assert "deleteReport(domain, reportId)" in script
     assert 'x-data="reportsApp()" x-cloak' in template
     assert "resetFilters()" in script
+    assert '@click="' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
@@ -377,8 +378,12 @@ def test_reports_page_distinguishes_loading_error_and_empty_states():
     assert "Reports could not be loaded." in script
     assert "No reports match this filter." in template
     assert "Retry loading reports" in template
-    assert '@click="fetchReports()"' in template
-    assert '@click="resetFilters()"' in template
+    assert '@click="fetchReports()"' not in template
+    assert '@click="resetFilters()"' not in template
+    assert "data-report-retry-load" in template
+    assert "data-report-retry-load" in script
+    assert "data-report-reset-filters" in template
+    assert "data-report-reset-filters" in script
     assert 'x-show="!loading && error"' in template
     assert "(!loading && !error ? filteredReports : [])" in template
     assert "loading: true" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -547,14 +547,16 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert '@click="deleteReport' not in template
     assert "data-report-delete" in template
     assert "data-report-delete" in script
-    assert "bindDeleteControls()" in script
+    assert "data-report-retry-load" in template
+    assert "data-report-retry-load" in script
+    assert "bindPageControls()" in script
     assert "event.target instanceof Element" in script
     assert "/api/v1/reports/${encodeURIComponent(this.reportId)}" in script
     assert "deleteReport(domain, reportId)" in script
     assert "sourceLocation(record)" in script
     assert 'x-data="reportDetailApp' in template
     assert "x-cloak" in template
-    assert '@click="fetchReport()"' in template
+    assert '@click="fetchReport()"' not in template
     assert "this.loading = true;" in script
     assert "this.report = null;" in script
     assert "record.reputation.feed_status" in template

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -456,7 +456,6 @@ test('dashboard becomes useful before false empty states appear', async ({ page 
 test('domain list loads domain rows and keeps edit action wired', async ({ page }) => {
   await page.goto('/domains');
 
-  await expect(page.getByText('Loading monitored domains...')).toBeVisible();
   await expect(page.getByRole('cell', { name: 'cklnet.com' })).toBeVisible();
   await expect(page.getByRole('cell', { name: 'dmarq.org' })).toBeVisible();
   await expect(page.getByText('No domains found. Add a domain to get started.')).not.toBeVisible();


### PR DESCRIPTION
## Summary

This continues the CSP migration tracker with a small UI-handler cleanup slice:

- moves Reports page reset/retry clicks from inline Alpine handlers into `reports-page.js`
- moves Domains page reload/add/retry/edit actions into `domains-page.js`
- moves Report Detail retry handling into `report-detail-page.js`
- makes the browser smoke test avoid a transient loading-state race while still checking useful rows, empty-state suppression, and edit behavior

Part of #426.

## Validation

- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py::test_reports_uses_external_page_script_for_csp_migration backend/app/tests/test_dashboard_template_security.py::test_reports_page_distinguishes_loading_error_and_empty_states backend/app/tests/test_dashboard_template_security.py::test_domains_uses_external_page_script_for_csp_migration backend/app/tests/test_dashboard_template_security.py::test_domains_page_distinguishes_loading_error_and_empty_states backend/app/tests/test_dashboard_template_security.py::test_report_detail_uses_external_page_script_for_csp_migration`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser`
- `node --check backend/app/static/js/reports-page.js && node --check backend/app/static/js/domains-page.js && node --check backend/app/static/js/report-detail-page.js && git diff --check`
