### PR TITLE
Add remediation operator controls on domain detail

### DIFF
--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -80,6 +80,13 @@ function domainDetailsApp(domainId) {
             },
             items: []
         },
+        remediationAction: {
+            itemId: '',
+            action: '',
+            loading: false,
+            message: '',
+            error: ''
+        },
         mtaSts: {
             status: '',
             dns_record: '',
@@ -636,6 +643,24 @@ function domainDetailsApp(domainId) {
             return headers;
         },
 
+        apiErrorDetail(data, fallback) {
+            const detail = data?.detail;
+            if (typeof detail === 'string') {
+                return detail;
+            }
+            if (detail?.message) {
+                return detail.message;
+            }
+            if (Array.isArray(detail)) {
+                const message = detail
+                    .map(item => item?.msg || item?.message || item?.detail || '')
+                    .filter(Boolean)
+                    .join(', ');
+                return message || fallback;
+            }
+            return fallback;
+        },
+
         recommendationSeverityClass(severity) {
             if (severity === 'error') return 'bg-red-500';
             if (severity === 'warning') return 'bg-yellow-500';
@@ -694,6 +719,22 @@ function domainDetailsApp(domainId) {
             if (status === 'ready') return 'Review the payload preview and explicitly dispatch when the operator is ready.';
             const nextStep = (dispatch?.next_steps || [])[0];
             return nextStep || 'Review notification settings before dispatching this remediation item.';
+        },
+
+        remediationActionBusy(item, action = '') {
+            if (!this.remediationAction.loading) return false;
+            if (this.remediationAction.itemId !== item?.id) return false;
+            return !action || this.remediationAction.action === action;
+        },
+
+        remediationActionMessage(item) {
+            if (this.remediationAction.itemId !== item?.id) return '';
+            return this.remediationAction.message || this.remediationAction.error || '';
+        },
+
+        remediationActionMessageClass(item) {
+            if (this.remediationAction.itemId !== item?.id) return 'text-[#5f5c78]';
+            return this.remediationAction.error ? 'text-red-700' : 'text-green-700';
         },
 
         remediationHistoryDotClass(entry) {
@@ -1152,6 +1193,124 @@ function domainDetailsApp(domainId) {
             } catch (error) {
                 console.error('Error fetching remediation queue:', error);
                 this.resetRemediationQueue();
+            }
+        },
+
+        async recordRemediationLifecycle(item, lifecycleState) {
+            const notification = item?.notification || {};
+            if (!item?.id || !notification.event || !notification.dedupe_key) {
+                this.remediationAction = {
+                    itemId: item?.id || '',
+                    action: lifecycleState,
+                    loading: false,
+                    message: '',
+                    error: 'This remediation item does not have notification metadata.'
+                };
+                return;
+            }
+            this.remediationAction = {
+                itemId: item.id,
+                action: lifecycleState,
+                loading: true,
+                message: '',
+                error: ''
+            };
+            try {
+                const response = await fetch(
+                    `/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation/notifications/audit`,
+                    {
+                        method: 'POST',
+                        headers: this.workspaceHeaders(),
+                        body: JSON.stringify({
+                            item_id: item.id,
+                            lifecycle_state: lifecycleState,
+                            event: notification.event,
+                            dedupe_key: notification.dedupe_key
+                        })
+                    }
+                );
+                const data = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    throw new Error(this.apiErrorDetail(data, 'Remediation lifecycle marker could not be recorded.'));
+                }
+                this.remediationAction = {
+                    itemId: item.id,
+                    action: lifecycleState,
+                    loading: false,
+                    message: `Marked ${lifecycleState.replaceAll('_', ' ')}. No DNS changes were made.`,
+                    error: ''
+                };
+                await this.fetchRemediationQueue();
+            } catch (error) {
+                this.remediationAction = {
+                    itemId: item.id,
+                    action: lifecycleState,
+                    loading: false,
+                    message: '',
+                    error: error.message || 'Remediation lifecycle marker could not be recorded.'
+                };
+                console.error('Error recording remediation lifecycle marker:', error);
+            }
+        },
+
+        async dispatchRemediationNotification(item) {
+            const notification = item?.notification || {};
+            const dispatch = notification.dispatch || {};
+            if (!dispatch.eligible) {
+                this.remediationAction = {
+                    itemId: item?.id || '',
+                    action: 'dispatch',
+                    loading: false,
+                    message: '',
+                    error: this.remediationDispatchNextStep(dispatch)
+                };
+                return;
+            }
+            if (!window.confirm('Dispatch this remediation notification to the configured webhook route? This does not make DNS changes.')) {
+                return;
+            }
+            this.remediationAction = {
+                itemId: item.id,
+                action: 'dispatch',
+                loading: true,
+                message: '',
+                error: ''
+            };
+            try {
+                const response = await fetch(
+                    `/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation/notifications/dispatch`,
+                    {
+                        method: 'POST',
+                        headers: this.workspaceHeaders(),
+                        body: JSON.stringify({
+                            item_id: item.id,
+                            confirm: true,
+                            event: notification.event,
+                            dedupe_key: notification.dedupe_key
+                        })
+                    }
+                );
+                const data = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    throw new Error(this.apiErrorDetail(data, 'Remediation notification could not be dispatched.'));
+                }
+                this.remediationAction = {
+                    itemId: item.id,
+                    action: 'dispatch',
+                    loading: false,
+                    message: `Dispatch queued for ${data.delivery_count || 0} webhook route${data.delivery_count === 1 ? '' : 's'}. No DNS changes were made.`,
+                    error: ''
+                };
+                await this.fetchRemediationQueue();
+            } catch (error) {
+                this.remediationAction = {
+                    itemId: item.id,
+                    action: 'dispatch',
+                    loading: false,
+                    message: '',
+                    error: error.message || 'Remediation notification could not be dispatched.'
+                };
+                console.error('Error dispatching remediation notification:', error);
             }
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -406,6 +406,37 @@
                                         <template x-if="(item.notification.dispatch.blocked_reasons || []).length">
                                             <p class="mt-1 text-xs text-[#5f5c78]" x-text="item.notification.dispatch.blocked_reasons[0]"></p>
                                         </template>
+                                        <div class="mt-3 flex flex-wrap gap-2">
+                                            <button type="button"
+                                                    class="btn btn-xs btn-outline"
+                                                    :disabled="remediationActionBusy(item)"
+                                                    @click="recordRemediationLifecycle(item, 'previewed')">
+                                                Reviewed
+                                            </button>
+                                            <button type="button"
+                                                    class="btn btn-xs btn-outline"
+                                                    :disabled="remediationActionBusy(item)"
+                                                    @click="recordRemediationLifecycle(item, 'acknowledged')">
+                                                Acknowledge
+                                            </button>
+                                            <button type="button"
+                                                    class="btn btn-xs btn-outline"
+                                                    :disabled="remediationActionBusy(item)"
+                                                    @click="recordRemediationLifecycle(item, 'resolved')">
+                                                Resolve
+                                            </button>
+                                            <button type="button"
+                                                    class="btn btn-xs btn-primary"
+                                                    :disabled="remediationActionBusy(item) || !item.notification.dispatch.eligible"
+                                                    @click="dispatchRemediationNotification(item)">
+                                                <span x-show="remediationActionBusy(item, 'dispatch')" class="loading loading-spinner loading-xs"></span>
+                                                Dispatch
+                                            </button>
+                                        </div>
+                                        <p x-show="remediationActionMessage(item)"
+                                           class="mt-2 text-xs font-semibold"
+                                           :class="remediationActionMessageClass(item)"
+                                           x-text="remediationActionMessage(item)"></p>
                                         <template x-if="(item.notification.history || []).length">
                                             <div class="mt-3 border-t border-[#e6e3e1] pt-3">
                                                 <p class="text-xs font-semibold uppercase text-[#5f5c78]">Recent operator history</p>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -681,12 +681,25 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     template = (
         Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"
     ).read_text()
+    script = _domain_details_script()
 
     assert "Remediation Queue" in template
     assert "Action plan" in template
     assert "item.action_plan.owner" in template
     assert "item.action_plan.steps" in template
     assert "item.action_plan.completion_criteria" in template
+    assert "Notification dispatch" in template
+    assert "Reviewed" in template
+    assert "Acknowledge" in template
+    assert "Resolve" in template
+    assert "Dispatch" in template
+    assert "recordRemediationLifecycle(item, 'previewed')" in template
+    assert "recordRemediationLifecycle(item, 'acknowledged')" in template
+    assert "recordRemediationLifecycle(item, 'resolved')" in template
+    assert "dispatchRemediationNotification(item)" in template
+    assert "/remediation/notifications/audit" in script
+    assert "/remediation/notifications/dispatch" in script
+    assert "No DNS changes were made" in script
     assert "x-html" not in template
 
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -678,9 +678,7 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
 
 
 def test_domain_details_exposes_remediation_action_plans_without_html_injection():
-    template = (
-        Path(__file__).resolve().parents[1] / "templates" / "domain_details.html"
-    ).read_text()
+    template = _domain_details_template()
     script = _domain_details_script()
 
     assert "Remediation Queue" in template

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -322,6 +322,24 @@ async function installApiMocks(page) {
   await page.route('**/api/v1/**', async (route) => {
     const url = new URL(route.request().url());
     const path = url.pathname;
+    const method = route.request().method();
+
+    if (method === 'POST' && path === '/api/v1/domains/cklnet.com/remediation/notifications/audit') {
+      await route.fulfill(
+        json({
+          domain: 'cklnet.com',
+          item_id: 'manual-dkim-review',
+          event: 'dmarq.remediation.manual_action_required',
+          dedupe_key: 'dmarq:remediation:cklnet.com:manual-dkim-review',
+          lifecycle_state: 'previewed',
+          audit: {
+            action: 'remediation.notification_lifecycle_recorded',
+            details: { dns_write_attempted: false },
+          },
+        })
+      );
+      return;
+    }
 
     const responses = {
       '/api/v1/domains/summary': domainSummary,
@@ -389,8 +407,50 @@ async function installApiMocks(page) {
       },
       '/api/v1/domains/cklnet.com/remediation': {
         status: 'ready',
-        summary: { total: 1, approval_ready: 0, manual_action: 1, investigate: 0, informational: 0 },
-        items: [],
+        summary: {
+          total: 1,
+          approval_ready: 0,
+          manual_action: 1,
+          investigate: 0,
+          informational: 0,
+          dispatch_ready: 0,
+          dispatch_blocked: 1,
+          dispatch_disabled: 0,
+          dispatch_awaiting_acknowledgement: 1,
+          dispatch_webhook_routes: 0,
+        },
+        items: [
+          {
+            id: 'manual-dkim-review',
+            title: 'Review owned infrastructure DKIM',
+            detail: 'mx1.cklnet.com is passing through SPF but DKIM is not reliably aligned.',
+            state: 'manual_action',
+            severity: 'medium',
+            source: 'source_intelligence',
+            next_steps: ['Enable DKIM signing on the owned mail host.'],
+            blast_radius: 'single source',
+            expected_health_score_impact: '+5',
+            evidence: [{ label: 'source', value: 'mx1.cklnet.com' }],
+            action_plan: {
+              owner: 'mail operator',
+              diagnosis: 'Owned infrastructure needs DKIM signing review.',
+              steps: ['Check the selector', 'Publish DKIM DNS if needed'],
+              completion_criteria: 'DKIM passes on the next aggregate report.',
+            },
+            notification: {
+              state: 'action_required',
+              event: 'dmarq.remediation.manual_action_required',
+              dedupe_key: 'dmarq:remediation:cklnet.com:manual-dkim-review',
+              dispatch: {
+                enabled: true,
+                eligible: false,
+                blocked_reasons: ['Record a previewed or acknowledged remediation notification audit marker.'],
+                next_steps: ['Record a previewed or acknowledged remediation notification audit marker.'],
+              },
+              history: [],
+            },
+          },
+        ],
       },
       '/api/v1/domains/cklnet.com/posture/history': healthHistory,
       '/api/v1/domains/cklnet.com/dns/mta-sts': {
@@ -477,6 +537,9 @@ test('domain detail shows cached DNS evidence and sender reputation context', as
   await expect(page.getByText('Owned infrastructure').first()).toBeVisible();
   await expect(page.getByText('Reputation clean').first()).toBeVisible();
   await expect(page.getByText('Reputation not checked').first()).toBeVisible();
+  await expect(page.getByText('Review owned infrastructure DKIM')).toBeVisible();
+  await page.getByRole('button', { name: 'Reviewed' }).click();
+  await expect(page.getByText('Marked previewed. No DNS changes were made.')).toBeVisible();
   await expect(page.getByText('Sending sources could not be loaded.')).not.toBeVisible();
   await expect(page.getByText('No data available for this time period')).not.toBeVisible();
 });


### PR DESCRIPTION
## Summary

This adds the first visible operator controls to the remediation loop on the domain detail page:

- operators can mark a remediation notification as reviewed, acknowledged, or resolved
- operators can explicitly dispatch a remediation notification only when the existing readiness preview says it is eligible
- dispatch copy states that no DNS changes are made
- the queue refreshes after lifecycle or dispatch actions so recent operator history becomes visible
- browser smoke coverage now clicks the Reviewed control against a mocked audit endpoint

Part of #384.

## Safety boundary

- This does not perform DNS writes.
- Dispatch still requires the existing backend `confirm=true` path and readiness checks.
- Queue views remain read-only until an operator clicks an explicit control.

## Validation

- `node --check backend/app/static/js/domain-details-page.js`
- `node --check backend/tests/browser/live-dmarc-flows.spec.js`
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py::test_domain_details_exposes_remediation_action_plans_without_html_injection`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --grep "domain detail"`
- `git diff --check`
