### PR TITLE
Externalize upload and onboarding controls

### DIFF
--- a/backend/app/static/js/onboarding-page.js
+++ b/backend/app/static/js/onboarding-page.js
@@ -8,6 +8,7 @@ function workspaceOnboarding(options = {}) {
         plan: null,
         result: null,
         tasks: [],
+        initialized: false,
         form: {
             organizationName: '',
             workspaceName: '',
@@ -27,12 +28,30 @@ function workspaceOnboarding(options = {}) {
             return !this.multiWorkspaceUiEnabled;
         },
         init() {
+            if (this.initialized) return;
+            this.initialized = true;
             this.draftFields().forEach((field) => {
                 const storedValue = localStorage.getItem(`dmarq.onboarding.${field}`);
                 if (storedValue !== null) {
                     this.form[field] = storedValue;
                 }
                 this.$watch(`form.${field}`, () => this.persistDraft());
+            });
+            this.bindControls();
+        },
+        bindControls() {
+            const root = this.$root;
+            root?.querySelector('[data-onboarding-preview]')?.addEventListener('click', () => {
+                this.previewPlan();
+            });
+            root?.querySelector('[data-onboarding-apply]')?.addEventListener('click', () => {
+                this.applyPlan();
+            });
+            root?.addEventListener('click', (event) => {
+                if (!(event.target instanceof Element)) return;
+                const pathButton = event.target.closest('[data-onboarding-mail-path]');
+                if (!pathButton) return;
+                this.form.mailSourcePath = pathButton.getAttribute('data-onboarding-mail-path') || 'imap';
             });
         },
         draftFields() {

--- a/backend/app/static/js/upload-page.js
+++ b/backend/app/static/js/upload-page.js
@@ -24,6 +24,9 @@ function uploadForm() {
 
         bindControls() {
             const root = this.$root;
+            if (!root || root.dataset.uploadControlsBound === 'true') return;
+            root.dataset.uploadControlsBound = 'true';
+
             const dropzone = root?.querySelector('[data-upload-dropzone]');
             const fileInput = root?.querySelector('[data-upload-file-input]');
             const clearButton = root?.querySelector('[data-upload-clear]');

--- a/backend/app/static/js/upload-page.js
+++ b/backend/app/static/js/upload-page.js
@@ -6,6 +6,10 @@ function uploadForm() {
         isUploading: false,
         dragover: false,
 
+        init() {
+            this.bindControls();
+        },
+
         get pendingCount() {
             return this.files.filter((file) => file.status === 'pending').length;
         },
@@ -16,6 +20,41 @@ function uploadForm() {
 
         get errorCount() {
             return this.files.filter((file) => file.status === 'error').length;
+        },
+
+        bindControls() {
+            const root = this.$root;
+            const dropzone = root?.querySelector('[data-upload-dropzone]');
+            const fileInput = root?.querySelector('[data-upload-file-input]');
+            const clearButton = root?.querySelector('[data-upload-clear]');
+
+            dropzone?.addEventListener('dragover', (event) => {
+                event.preventDefault();
+                this.dragover = true;
+            });
+            dropzone?.addEventListener('dragleave', (event) => {
+                event.preventDefault();
+                this.dragover = false;
+            });
+            dropzone?.addEventListener('drop', (event) => {
+                event.preventDefault();
+                this.handleDrop(event);
+            });
+            fileInput?.addEventListener('change', (event) => {
+                this.handleFileSelect(event);
+            });
+            clearButton?.addEventListener('click', () => {
+                this.clearAll();
+            });
+            root?.addEventListener('click', (event) => {
+                if (!(event.target instanceof Element)) return;
+                const removeButton = event.target.closest('[data-upload-remove-index]');
+                if (!removeButton) return;
+                const index = Number(removeButton.getAttribute('data-upload-remove-index'));
+                if (Number.isInteger(index)) {
+                    this.removeFile(index);
+                }
+            });
         },
 
         handleFileSelect(event) {

--- a/backend/app/templates/onboarding.html
+++ b/backend/app/templates/onboarding.html
@@ -23,11 +23,11 @@
             </p>
         </div>
         <div class="flex flex-wrap gap-2">
-            <button type="button" class="btn btn-outline" @click="previewPlan" :disabled="saving">
+            <button type="button" class="btn btn-outline" :disabled="saving" data-onboarding-preview>
                 <span x-show="previewing" class="loading loading-spinner loading-xs"></span>
                 Preview tasks
             </button>
-            <button type="button" class="btn btn-primary" @click="applyPlan" :disabled="saving">
+            <button type="button" class="btn btn-primary" :disabled="saving" data-onboarding-apply>
                 <span x-show="applying" class="loading loading-spinner loading-xs"></span>
                 {{ "Create workspace" if multi_workspace_ui_enabled else "Apply setup" }}
             </button>
@@ -174,10 +174,10 @@
                     <div class="join">
                         <button type="button" class="btn join-item btn-sm"
                                 :class="form.mailSourcePath === 'imap' ? 'btn-primary' : 'btn-outline'"
-                                @click="form.mailSourcePath = 'imap'">IMAP</button>
+                                data-onboarding-mail-path="imap">IMAP</button>
                         <button type="button" class="btn join-item btn-sm"
                                 :class="form.mailSourcePath === 'dns_only' ? 'btn-primary' : 'btn-outline'"
-                                @click="form.mailSourcePath = 'dns_only'">DNS only</button>
+                                data-onboarding-mail-path="dns_only">DNS only</button>
                     </div>
                 </div>
 

--- a/backend/app/templates/upload.html
+++ b/backend/app/templates/upload.html
@@ -21,10 +21,8 @@
                 <!-- Drop Zone -->
                 <div
                     class="flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg p-8 text-center hover:bg-muted/50 transition-colors cursor-pointer relative"
-                    x-on:dragover.prevent="dragover = true"
-                    x-on:dragleave.prevent="dragover = false"
-                    x-on:drop.prevent="handleDrop($event)"
                     x-bind:class="{'border-primary/50 bg-primary/5': dragover}"
+                    data-upload-dropzone
                 >
                     <div class="mb-4 text-muted-foreground">
                         <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mx-auto"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" x2="12" y1="3" y2="15"></line></svg>
@@ -41,7 +39,7 @@
                         accept=".xml,.zip,.gz,.gzip"
                         multiple
                         class="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-                        x-on:change="handleFileSelect($event)"
+                        data-upload-file-input
                     />
                 </div>
 
@@ -54,7 +52,7 @@
                             type="button"
                             class="text-xs underline hover:text-foreground"
                             x-show="!isUploading"
-                            x-on:click="clearAll()"
+                            data-upload-clear
                         >Clear all</button>
                     </div>
 
@@ -93,7 +91,7 @@
                                 type="button"
                                 class="flex-shrink-0 ml-2 text-muted-foreground hover:text-foreground"
                                 x-show="entry.status !== 'uploading'"
-                                x-on:click="removeFile(index)"
+                                :data-upload-remove-index="index"
                                 aria-label="Remove file"
                             >
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -439,6 +439,21 @@ def test_upload_uses_external_page_script_for_csp_migration():
     assert 'src="/static/js/upload-page.js"' in template
     assert "uploadForm()" in template
     assert "/api/v1/reports/upload" in script
+    assert "bindControls()" in script
+    assert "data-upload-dropzone" in template
+    assert "data-upload-dropzone" in script
+    assert "data-upload-file-input" in template
+    assert "data-upload-file-input" in script
+    assert "data-upload-clear" in template
+    assert "data-upload-clear" in script
+    assert "data-upload-remove-index" in template
+    assert "data-upload-remove-index" in script
+    assert 'x-on:dragover.prevent="dragover = true"' not in template
+    assert 'x-on:dragleave.prevent="dragover = false"' not in template
+    assert 'x-on:drop.prevent="handleDrop($event)"' not in template
+    assert 'x-on:change="handleFileSelect($event)"' not in template
+    assert 'x-on:click="clearAll()"' not in template
+    assert 'x-on:click="removeFile(index)"' not in template
     assert "AbortController" in script
     assert "UPLOAD_TIMEOUT_MS" in script
     assert "this.isUploading = false" in script
@@ -947,6 +962,16 @@ def test_onboarding_template_uses_single_user_setup_story_by_default():
     assert "draftFields()" in script
     assert "normalizeDomain(value)" in script
     assert "dmarq.selectedWorkspaceId" in script
+    assert "bindControls()" in script
+    assert "data-onboarding-preview" in template
+    assert "data-onboarding-preview" in script
+    assert "data-onboarding-apply" in template
+    assert "data-onboarding-apply" in script
+    assert "data-onboarding-mail-path" in template
+    assert "data-onboarding-mail-path" in script
+    assert '@click="previewPlan"' not in template
+    assert '@click="applyPlan"' not in template
+    assert '@click="form.mailSourcePath = ' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
     assert "Account boundary" not in rendered
     assert "Owner ready" not in rendered

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -480,6 +480,32 @@ async function installApiMocks(page) {
         source_labels: ['Gmail API: dmarc-reports@example.com'],
         latest_source_check: '2026-07-03T12:00:00Z',
       },
+      '/api/v1/onboarding/preview': {
+        plan: {
+          tasks: [
+            {
+              id: 'dns-review',
+              title: 'Review DNS posture',
+              description: 'Check DMARC, SPF, DKIM, and ownership evidence.',
+              category: 'DNS',
+              href: '/domains/cklnet.com',
+            },
+          ],
+        },
+      },
+      '/api/v1/onboarding/apply': {
+        result: {
+          tasks: [
+            {
+              id: 'dns-review',
+              title: 'Review DNS posture',
+              description: 'Check DMARC, SPF, DKIM, and ownership evidence.',
+              category: 'DNS',
+              href: '/domains/cklnet.com',
+            },
+          ],
+        },
+      },
     };
 
     if (
@@ -523,6 +549,44 @@ test('domain list loads domain rows and keeps edit action wired', async ({ page 
   await page.getByRole('button', { name: 'Edit' }).first().click();
   await expect(page.getByRole('heading', { name: 'Edit monitored domain' })).toBeVisible();
   await expect(page.getByRole('dialog').getByText('cklnet.com')).toBeVisible();
+});
+
+test('upload page keeps queue controls wired without inline handlers', async ({ page }) => {
+  await page.goto('/upload');
+
+  const fileInput = page.locator('[data-upload-file-input]');
+  await fileInput.setInputFiles({
+    name: 'not-a-dmarc-report.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('not xml'),
+  });
+  await expect(page.getByText('Invalid file type. Only XML, ZIP, or GZIP files are supported.')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Remove file' }).click();
+  await expect(page.getByText('Select or drop files above to begin uploading automatically.')).toBeVisible();
+
+  await fileInput.setInputFiles({
+    name: 'report.xml',
+    mimeType: 'application/xml',
+    buffer: Buffer.from('<feedback></feedback>'),
+  });
+  await expect(page.getByText('0 records for unknown domain')).toBeVisible();
+
+  await page.getByText('Clear all').click();
+  await expect(page.getByText('Select or drop files above to begin uploading automatically.')).toBeVisible();
+});
+
+test('onboarding page keeps setup controls wired without inline handlers', async ({ page }) => {
+  await page.goto('/onboarding');
+
+  await expect(page.getByRole('heading', { name: 'Mail health setup' })).toBeVisible();
+  await page.getByRole('button', { name: 'DNS only' }).click();
+  await expect(page.getByText('without storing mailbox credentials')).toBeVisible();
+
+  await page.getByRole('textbox', { name: 'Domain' }).fill('cklnet.com');
+  await page.getByRole('button', { name: 'Preview tasks' }).click();
+  await expect(page.getByText('Preview is ready. Review the task list before applying setup.')).toBeVisible();
+  await expect(page.getByText('Review DNS posture')).toBeVisible();
 });
 
 test('domain detail shows cached DNS evidence and sender reputation context', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Move upload page queue controls from inline Alpine event attributes to external listeners in `upload-page.js`.
- Move onboarding preview/apply and mail-source path controls from inline Alpine click handlers to external listeners in `onboarding-page.js`.
- Add browser coverage for upload queue controls and onboarding DNS-only/preview controls.

## Why
This continues #426's CSP migration by reducing inline event handlers on user-facing setup and report-upload pages before strict CSP becomes the default.

## Validation
- `node --check backend/app/static/js/onboarding-page.js && node --check backend/app/static/js/upload-page.js && node --check backend/tests/browser/live-dmarc-flows.spec.js`
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py::test_upload_uses_external_page_script_for_csp_migration backend/app/tests/test_dashboard_template_security.py::test_onboarding_template_uses_single_user_setup_story_by_default backend/app/tests/test_dashboard_template_security.py::test_onboarding_template_keeps_workspace_story_for_multi_workspace_mode backend/app/tests/test_dashboard_template_security.py::test_templates_do_not_reintroduce_csp_blocking_inline_markup`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser`
- `git diff --check`

Part of #426.
