### PR TITLE
Externalize domains dialog controls

### DIFF
--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -67,6 +67,25 @@ function domainsApp() {
                     this.openEditDialog(domain);
                 }
             });
+
+            root.querySelectorAll('[data-domain-create-close]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    this.closeCreate();
+                });
+            });
+            root.querySelectorAll('[data-domain-edit-close]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    this.closeEdit();
+                });
+            });
+            root.querySelector('[data-domain-create-form]')?.addEventListener('submit', (event) => {
+                event.preventDefault();
+                this.createDomain();
+            });
+            root.querySelector('[data-domain-edit-form]')?.addEventListener('submit', (event) => {
+                event.preventDefault();
+                this.updateDomain();
+            });
         },
 
         async fetchDomains(options = {}) {

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -126,11 +126,11 @@
         {% endcall %}
     </div>
 
-    <dialog class="modal" :open="openCreate">
+    <dialog class="modal" :open="openCreate" data-domain-create-dialog>
         <div class="modal-box max-w-2xl">
             <h2 class="text-xl font-semibold">Add monitored domain</h2>
             <p class="mt-1 text-sm text-base-content/70">Track DNS health and future DMARC reports before the first report arrives.</p>
-            <form class="mt-5 space-y-4" @submit.prevent="createDomain">
+            <form class="mt-5 space-y-4" data-domain-create-form>
                 <label class="form-control">
                     <span class="label-text font-medium">Domain</span>
                     <input x-model.trim="newDomain.name" type="text" required placeholder="example.com" class="input input-bordered">
@@ -147,7 +147,7 @@
                     <span x-text="createError"></span>
                 </div>
                 <div class="modal-action">
-                    <button type="button" class="btn btn-ghost" @click="closeCreate" :disabled="saving">Cancel</button>
+                    <button type="button" class="btn btn-ghost" data-domain-create-close :disabled="saving">Cancel</button>
                     <button type="submit" class="btn btn-primary" :disabled="saving">
                         <span x-show="saving" class="loading loading-spinner loading-xs"></span>
                         Add domain
@@ -156,15 +156,15 @@
             </form>
         </div>
         <form method="dialog" class="modal-backdrop">
-            <button type="button" @click="closeCreate">close</button>
+            <button type="button" data-domain-create-close>close</button>
         </form>
     </dialog>
 
-    <dialog class="modal" :open="openEdit">
+    <dialog class="modal" :open="openEdit" data-domain-edit-dialog>
         <div class="modal-box max-w-2xl">
             <h2 class="text-xl font-semibold">Edit monitored domain</h2>
             <p class="mt-1 text-sm text-base-content/70" x-text="editDomain.name"></p>
-            <form class="mt-5 space-y-4" @submit.prevent="updateDomain">
+            <form class="mt-5 space-y-4" data-domain-edit-form>
                 <label class="form-control">
                     <span class="label-text font-medium">Description</span>
                     <textarea x-model.trim="editDomain.description" rows="3" class="textarea textarea-bordered" placeholder="Production mail domain"></textarea>
@@ -177,7 +177,7 @@
                     <span x-text="editError"></span>
                 </div>
                 <div class="modal-action">
-                    <button type="button" class="btn btn-ghost" @click="closeEdit" :disabled="saving">Cancel</button>
+                    <button type="button" class="btn btn-ghost" data-domain-edit-close :disabled="saving">Cancel</button>
                     <button type="submit" class="btn btn-primary" :disabled="saving">
                         <span x-show="saving" class="loading loading-spinner loading-xs"></span>
                         Save changes
@@ -186,7 +186,7 @@
             </form>
         </div>
         <form method="dialog" class="modal-backdrop">
-            <button type="button" @click="closeEdit">close</button>
+            <button type="button" data-domain-edit-close>close</button>
         </form>
     </dialog>
 </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -406,13 +406,27 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert "data-domain-refresh" in script
     assert "data-domain-create-open" in template
     assert "data-domain-create-open" in script
+    assert "data-domain-create-dialog" in template
+    assert "data-domain-create-form" in template
+    assert "data-domain-create-form" in script
+    assert "data-domain-create-close" in template
+    assert "data-domain-create-close" in script
     assert "data-domain-edit" in template
     assert "data-domain-edit" in script
+    assert "data-domain-edit-dialog" in template
+    assert "data-domain-edit-form" in template
+    assert "data-domain-edit-form" in script
+    assert "data-domain-edit-close" in template
+    assert "data-domain-edit-close" in script
     assert "Edit monitored domain" in template
     assert "updateDomain()" in script
     assert "method: 'PATCH'" in script
     assert "editError" in template
     assert 'x-data="domainsApp()" x-cloak' in template
+    assert '@submit.prevent="createDomain' not in template
+    assert '@submit.prevent="updateDomain' not in template
+    assert '@click="closeCreate' not in template
+    assert '@click="closeEdit' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -546,9 +546,18 @@ test('domain list loads domain rows and keeps edit action wired', async ({ page 
   await expect(page.getByRole('cell', { name: 'dmarq.org' })).toBeVisible();
   await expect(page.getByText('No domains found. Add a domain to get started.')).not.toBeVisible();
 
+  await page.getByRole('button', { name: '+ Add Domain' }).click();
+  await expect(page.getByRole('heading', { name: 'Add monitored domain' })).toBeVisible();
+  await expect(page.locator('[data-domain-create-dialog]')).toHaveJSProperty('open', true);
+  await page.locator('[data-domain-create-close]').first().click();
+  await expect(page.locator('[data-domain-create-dialog]')).toHaveJSProperty('open', false);
+
   await page.getByRole('button', { name: 'Edit' }).first().click();
   await expect(page.getByRole('heading', { name: 'Edit monitored domain' })).toBeVisible();
+  await expect(page.locator('[data-domain-edit-dialog]')).toHaveJSProperty('open', true);
   await expect(page.getByRole('dialog').getByText('cklnet.com')).toBeVisible();
+  await page.locator('[data-domain-edit-close]').first().click();
+  await expect(page.locator('[data-domain-edit-dialog]')).toHaveJSProperty('open', false);
 });
 
 test('upload page keeps queue controls wired without inline handlers', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Move the domains add/edit dialog submit and close controls from inline Alpine handlers to external listeners in `domains-page.js`.
- Add stable data markers for the create/edit dialogs so browser coverage can assert the actual dialog open state.
- Extend the browser smoke to cover add/edit dialog open and close behavior.

## Why
This continues #426's CSP migration by reducing inline event handlers on the domain management surface without changing domain CRUD API behavior.

## Validation
- `node --check backend/app/static/js/domains-page.js && node --check backend/tests/browser/live-dmarc-flows.spec.js`
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py::test_domains_uses_external_page_script_for_csp_migration backend/app/tests/test_dashboard_template_security.py::test_domains_page_distinguishes_loading_error_and_empty_states`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser`
- `git diff --check`

Part of #426.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Add monitored domain” and “Edit monitored domain” dialogs so their open/close actions work consistently.
  * Form submissions for creating and updating domains now behave correctly, with page controls handling submit actions directly.
  * Updated tests to verify the dialogs open, submit, and close as expected, helping prevent regressions in the domain management flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->