### PR TITLE
Externalize members page controls

### DIFF
--- a/backend/app/static/js/members-page.js
+++ b/backend/app/static/js/members-page.js
@@ -12,11 +12,87 @@ function membershipApp() {
         invite: { email: '', full_name: '', role: '' },
 
         async init() {
+            this.bindPageControls();
             await this.loadOrganizations();
         },
 
         apiHeaders() {
             return { 'Content-Type': 'application/json' };
+        },
+
+        bindPageControls() {
+            const root = this.$root || document.querySelector('[data-members-page]');
+            if (!root || root.dataset.membersControlsBound === 'true') {
+                return;
+            }
+            root.dataset.membersControlsBound = 'true';
+
+            root.addEventListener('click', (event) => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
+
+                const scopeButton = event.target.closest('[data-members-scope]');
+                if (scopeButton && root.contains(scopeButton)) {
+                    this.setScope(scopeButton.dataset.membersScope);
+                    return;
+                }
+
+                const refreshButton = event.target.closest('[data-members-refresh]');
+                if (refreshButton && root.contains(refreshButton)) {
+                    this.loadMemberships();
+                    return;
+                }
+
+                const deactivateButton = event.target.closest('[data-members-deactivate]');
+                if (deactivateButton && root.contains(deactivateButton)) {
+                    const membership = this.findMembershipByUserId(deactivateButton.dataset.membersUserId);
+                    if (membership) {
+                        this.deactivateMembership(membership);
+                    }
+                    return;
+                }
+
+                const restoreButton = event.target.closest('[data-members-restore]');
+                if (!restoreButton || !root.contains(restoreButton)) {
+                    return;
+                }
+                const membership = this.findMembershipByUserId(restoreButton.dataset.membersUserId);
+                if (membership) {
+                    this.updateMembership(membership, true);
+                }
+            });
+
+            root.addEventListener('change', (event) => {
+                if (!(event.target instanceof HTMLSelectElement)) {
+                    return;
+                }
+
+                if (event.target.matches('[data-members-organization-select]')) {
+                    this.selectOrganization(event.target.value);
+                    return;
+                }
+
+                if (event.target.matches('[data-members-workspace-select]')) {
+                    this.selectedWorkspaceId = event.target.value;
+                    this.loadMemberships();
+                    return;
+                }
+
+                if (!event.target.matches('[data-members-role-select]')) {
+                    return;
+                }
+                const membership = this.findMembershipByUserId(event.target.dataset.membersUserId);
+                if (membership) {
+                    membership.role = event.target.value;
+                    this.updateMembership(membership, membership.active);
+                }
+            });
+
+            root.querySelector('[data-members-invite-form]')?.addEventListener('submit', (event) => {
+                event.preventDefault();
+                this.inviteMember();
+            });
         },
 
         async loadOrganizations() {
@@ -151,6 +227,15 @@ function membershipApp() {
             } finally {
                 this.saving = false;
             }
+        },
+
+        findMembershipByUserId(userId) {
+            if (!userId) {
+                return null;
+            }
+            return this.memberships.find((membership) => {
+                return String(membership.user?.id) === String(userId);
+            }) || null;
         },
 
         setScope(scope) {

--- a/backend/app/templates/members.html
+++ b/backend/app/templates/members.html
@@ -4,7 +4,7 @@
 {% block title %}Members - DMARQ{% endblock %}
 
 {% block content %}
-<div x-data="membershipApp()" x-init="init()" class="mx-auto max-w-7xl space-y-6 py-4">
+<div x-data="membershipApp()" x-init="init()" class="mx-auto max-w-7xl space-y-6 py-4" data-members-page>
     <section class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
             <p class="text-sm font-semibold uppercase text-[#2c9aa3]">Access control</p>
@@ -48,13 +48,13 @@
                             <button type="button"
                                     class="btn join-item flex-1"
                                     :class="scope === 'workspace' ? 'btn-primary' : 'btn-outline'"
-                                    @click="setScope('workspace')">
+                                    data-members-scope="workspace">
                                 Workspace
                             </button>
                             <button type="button"
                                     class="btn join-item flex-1"
                                     :class="scope === 'organization' ? 'btn-primary' : 'btn-outline'"
-                                    @click="setScope('organization')">
+                                    data-members-scope="organization">
                                 Organization
                             </button>
                         </div>
@@ -63,7 +63,7 @@
                             <span class="label-text mb-2 font-semibold">Organization</span>
                             <select class="select select-bordered w-full"
                                     x-model="selectedOrgId"
-                                    @change="selectOrganization(selectedOrgId)">
+                                    data-members-organization-select>
                                 <template x-for="organization in organizations" :key="organization.id">
                                     <option :value="organization.id" x-text="organization.name"></option>
                                 </template>
@@ -75,7 +75,7 @@
                                 <span class="label-text mb-2 font-semibold">Workspace</span>
                                 <select class="select select-bordered w-full"
                                         x-model="selectedWorkspaceId"
-                                        @change="loadMemberships()">
+                                        data-members-workspace-select>
                                     <template x-for="workspace in currentWorkspaces()" :key="workspace.id">
                                         <option :value="workspace.id" x-text="workspace.name"></option>
                                     </template>
@@ -208,7 +208,7 @@
                 {% endcall %}
                 {% call card_content() %}
                     <form class="grid grid-cols-1 gap-3 lg:grid-cols-[1.2fr_1fr_1fr_auto]"
-                          @submit.prevent="inviteMember()">
+                          data-members-invite-form>
                         <label class="form-control">
                             <span class="label-text mb-2 font-semibold">Email</span>
                             <input class="input input-bordered w-full"
@@ -253,7 +253,7 @@
                                 Active and inactive assignments for the selected tenant boundary.
                             {% endcall %}
                         </div>
-                        <button type="button" class="btn btn-outline btn-sm" @click="loadMemberships()" :disabled="loading">
+                        <button type="button" class="btn btn-outline btn-sm" data-members-refresh :disabled="loading">
                             <span x-show="loading" class="loading loading-spinner loading-xs"></span>
                             Refresh
                         </button>
@@ -303,7 +303,8 @@
                                                 <select class="select select-bordered select-sm w-full"
                                                         :disabled="saving"
                                                         x-model="membership.role"
-                                                        @change="updateMembership(membership, membership.active)">
+                                                        :data-members-user-id="membership.user.id"
+                                                        data-members-role-select>
                                                     <template x-for="role in availableRoles" :key="role">
                                                         <option :value="role" x-text="roleLabel(role)"></option>
                                                     </template>
@@ -319,14 +320,16 @@
                                                         class="btn btn-outline btn-xs"
                                                         x-show="membership.active"
                                                         :disabled="saving"
-                                                        @click="deactivateMembership(membership)">
+                                                        :data-members-user-id="membership.user.id"
+                                                        data-members-deactivate>
                                                     Deactivate
                                                 </button>
                                                 <button type="button"
                                                         class="btn btn-primary btn-xs"
                                                         x-show="!membership.active"
                                                         :disabled="saving"
-                                                        @click="updateMembership(membership, true)">
+                                                        :data-members-user-id="membership.user.id"
+                                                        data-members-restore>
                                                     Restore
                                                 </button>
                                             </td>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -870,7 +870,16 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert "planLimitRows()" in template
     assert "invoice_delivery_label" in template
     assert 'x-text="membership.user.email"' in template
-    assert '@change="updateMembership(membership, membership.active)"' in template
+    assert '@click=' not in template
+    assert '@change=' not in template
+    assert '@submit' not in template
+    assert "data-members-page" in template
+    assert "data-members-scope" in template
+    assert "data-members-invite-form" in template
+    assert "data-members-role-select" in template
+    assert "bindPageControls()" in script
+    assert "findMembershipByUserId" in script
+    assert "data-members-role-select" in script
     assert '@change="updateMembership(membership, true)"' not in template
     assert "x-html" not in template
     assert not _has_inline_script(template)


### PR DESCRIPTION
## Summary
- move Members scope, refresh, invite, role update, deactivate, and restore actions out of inline Alpine event attributes
- bind those controls from `members-page.js` through stable data markers
- extend template security coverage to guard the Members page against inline event regressions

## Validation
- `node --check backend/app/static/js/members-page.js && node --check backend/tests/browser/live-dmarc-flows.spec.js && node --check backend/playwright.config.cjs`
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser` from `backend/`
- `git diff --check`

Part of #426.
