### PR TITLE
Externalize settings provider controls

### DIFF
--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -76,6 +76,9 @@ function settingsApp() {
             }
             this._providerControlsBound = true;
             this.$root.addEventListener('click', event => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 const button = event.target.closest('button');
                 if (!button || !this.$root.contains(button)) {
                     return;
@@ -104,6 +107,9 @@ function settingsApp() {
                 }
             });
             this.$root.addEventListener('change', event => {
+                if (!(event.target instanceof Element)) {
+                    return;
+                }
                 if (event.target.matches('[data-settings-dns-provider-select]')) {
                     this.resetDnsProviderImportState();
                 }

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -65,6 +65,51 @@ function settingsApp() {
 
         // Session cookie is sent automatically by the browser (httpOnly, same-origin).
         // No manual auth header needed for API calls from the UI.
+        initSettingsPage() {
+            this.bindProviderControls();
+            return this.loadSettings();
+        },
+
+        bindProviderControls() {
+            if (this._providerControlsBound || !this.$root) {
+                return;
+            }
+            this._providerControlsBound = true;
+            this.$root.addEventListener('click', event => {
+                const button = event.target.closest('button');
+                if (!button || !this.$root.contains(button)) {
+                    return;
+                }
+                if (button.matches('[data-settings-cloudflare-connect]')) {
+                    event.preventDefault();
+                    this.connectCloudflare();
+                } else if (button.matches('[data-settings-toggle-cf-token]')) {
+                    event.preventDefault();
+                    this.showCfToken = !this.showCfToken;
+                } else if (button.matches('[data-settings-discover-dns-zones]')) {
+                    event.preventDefault();
+                    this.discoverDNSProviderZones();
+                } else if (button.matches('[data-settings-import-dns-zones]')) {
+                    event.preventDefault();
+                    this.importDNSProviderZones();
+                } else if (button.matches('[data-settings-toggle-postmark-token]')) {
+                    event.preventDefault();
+                    this.showPostmarkToken = !this.showPostmarkToken;
+                } else if (button.matches('[data-settings-discover-mail-domains]')) {
+                    event.preventDefault();
+                    this.discoverMailServiceDomains();
+                } else if (button.matches('[data-settings-import-mail-domains]')) {
+                    event.preventDefault();
+                    this.importMailServiceDomains();
+                }
+            });
+            this.$root.addEventListener('change', event => {
+                if (event.target.matches('[data-settings-dns-provider-select]')) {
+                    this.resetDnsProviderImportState();
+                }
+            });
+        },
+
         apiHeaders() {
             return { 'Content-Type': 'application/json' };
         },

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -10,8 +10,9 @@
 
 {% block content %}
 <div
+    data-settings-page
     x-data="settingsApp()"
-    x-init="loadSettings()"
+    x-init="initSettingsPage()"
     class="space-y-6 py-4"
 >
 
@@ -206,7 +207,7 @@
                         </div>
                         <button type="button" class="btn btn-default btn-sm"
                             :disabled="connectingCloudflare || !cfOAuthStatus.oauth_configured"
-                            @click="connectCloudflare()">
+                            data-settings-cloudflare-connect>
                             <template x-if="!connectingCloudflare">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
                                     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
@@ -228,7 +229,7 @@
                             placeholder="Your Cloudflare API token" />
                         <button type="button"
                             class="absolute right-2 top-3 text-muted-foreground hover:text-foreground"
-                            @click="showCfToken = !showCfToken">
+                            data-settings-toggle-cf-token>
                             <svg x-show="!showCfToken" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>
                             <svg x-show="showCfToken" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line></svg>
                         </button>
@@ -252,14 +253,14 @@
                             <label class="sr-only" for="dns-provider-import-select">DNS provider</label>
                             <select id="dns-provider-import-select"
                                 x-model="selectedDnsProvider"
-                                @change="resetDnsProviderImportState()"
+                                data-settings-dns-provider-select
                                 class="select select-sm select-bordered min-w-44"
                                 :disabled="loadingDnsProviders || loadingCfZones || importingCfZones">
                                 <template x-for="provider in dnsImportProviders()" :key="provider.id">
                                     <option :value="provider.id" x-text="provider.name"></option>
                                 </template>
                             </select>
-                            <button type="button" class="btn btn-outline btn-sm" :disabled="saving || loadingCfZones || !selectedDnsProvider" @click="discoverDNSProviderZones()">
+                            <button type="button" class="btn btn-outline btn-sm" :disabled="saving || loadingCfZones || !selectedDnsProvider" data-settings-discover-dns-zones>
                                 <template x-if="!loadingCfZones">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
                                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
@@ -270,7 +271,7 @@
                                 <template x-if="loadingCfZones"><span class="loading loading-spinner loading-xs mr-2"></span></template>
                                 Discover
                             </button>
-                            <button type="button" class="btn btn-default btn-sm" :disabled="saving || importingCfZones || importableDnsProviderZoneCount() === 0" @click="importDNSProviderZones()">
+                            <button type="button" class="btn btn-default btn-sm" :disabled="saving || importingCfZones || importableDnsProviderZoneCount() === 0" data-settings-import-dns-zones>
                                 <template x-if="!importingCfZones">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
                                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
@@ -384,7 +385,7 @@
                             placeholder="Postmark account token" />
                         <button type="button"
                             class="absolute right-2 top-3 text-muted-foreground hover:text-foreground"
-                            @click="showPostmarkToken = !showPostmarkToken">
+                            data-settings-toggle-postmark-token>
                             <svg x-show="!showPostmarkToken" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
                                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg>
                             <svg x-show="showPostmarkToken" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
@@ -401,7 +402,7 @@
                             <p class="text-sm text-muted-foreground">Preview Postmark domains and import them into DMARQ for DNS linting and monitoring.</p>
                         </div>
                         <div class="flex flex-col gap-2 sm:flex-row">
-                            <button type="button" class="btn btn-outline btn-sm" :disabled="saving || loadingMailServiceDomains" @click="discoverMailServiceDomains()">
+                            <button type="button" class="btn btn-outline btn-sm" :disabled="saving || loadingMailServiceDomains" data-settings-discover-mail-domains>
                                 <template x-if="!loadingMailServiceDomains">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
                                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
@@ -412,7 +413,7 @@
                                 <template x-if="loadingMailServiceDomains"><span class="loading loading-spinner loading-xs mr-2"></span></template>
                                 Discover
                             </button>
-                            <button type="button" class="btn btn-default btn-sm" :disabled="saving || importingMailServiceDomains || mailServiceDomains.length === 0" @click="importMailServiceDomains()">
+                            <button type="button" class="btn btn-default btn-sm" :disabled="saving || importingMailServiceDomains || mailServiceDomains.length === 0" data-settings-import-mail-domains>
                                 <template x-if="!importingMailServiceDomains">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
                                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -600,6 +600,7 @@ def test_settings_exposes_provider_agnostic_dns_import_without_html_injection():
     template = _settings_template()
     script = _settings_script()
 
+    assert "data-settings-page" in template
     assert "DNS Provider Connectors" in template
     assert 'id="provider-integrations"' in template
     assert "Provider Domain Discovery" in template
@@ -618,6 +619,23 @@ def test_settings_exposes_provider_agnostic_dns_import_without_html_injection():
     assert "selectedDnsProviderConnectionHint" in script
     assert "selectedDnsProviderConnectionClass" in script
     assert "resetDnsProviderImportState" in script
+    assert "bindProviderControls" in script
+    assert "data-settings-cloudflare-connect" in template
+    assert "data-settings-toggle-cf-token" in template
+    assert "data-settings-dns-provider-select" in template
+    assert "data-settings-discover-dns-zones" in template
+    assert "data-settings-import-dns-zones" in template
+    assert "data-settings-toggle-postmark-token" in template
+    assert "data-settings-discover-mail-domains" in template
+    assert "data-settings-import-mail-domains" in template
+    assert '@click="connectCloudflare()"' not in template
+    assert '@click="showCfToken = !showCfToken"' not in template
+    assert '@change="resetDnsProviderImportState()"' not in template
+    assert '@click="discoverDNSProviderZones()"' not in template
+    assert '@click="importDNSProviderZones()"' not in template
+    assert '@click="showPostmarkToken = !showPostmarkToken"' not in template
+    assert '@click="discoverMailServiceDomains()"' not in template
+    assert '@click="importMailServiceDomains()"' not in template
     assert "dnsProviderImportError" in template
     assert "dnsProviderImportSummary" in template
     assert "selectedDnsProviderConnectionLabel()" in template


### PR DESCRIPTION
## Summary
- move Cloudflare OAuth, DNS zone import, and Postmark import buttons from inline Alpine click/change handlers to settings-page.js delegated controls
- keep the Settings template on stable data markers for provider actions
- extend the template security regression test so these provider controls do not regress back to inline handlers

## Validation
- node --check backend/app/static/js/settings-page.js
- /tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py
- DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser

Part of #426.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings controls now initialize through a more structured page setup, improving how provider-related actions are wired.
  * Cloudflare, DNS, and mail service actions on the Settings page now use consistent interaction hooks for connect, discover, import, and token visibility toggles.

* **Bug Fixes**
  * Provider changes now correctly reset DNS import state when switching DNS providers.
  * Updated Settings page rendering to avoid inline event handling, helping keep the page behavior more reliable and secure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->