### PR TITLE
Externalize mail source list controls

### DIFF
--- a/backend/app/static/js/mail-sources-page.js
+++ b/backend/app/static/js/mail-sources-page.js
@@ -48,7 +48,83 @@ function mailSourcesApp() {
         },
 
         async init() {
+            this.bindPageControls();
             await this.loadSources();
+        },
+
+        bindPageControls() {
+            if (this._pageControlsBound || !this.$root) {
+                return;
+            }
+            this._pageControlsBound = true;
+            this.$root.addEventListener('click', event => {
+                const target = event.target instanceof Element ? event.target : null;
+                const button = target ? target.closest('button') : null;
+                if (!button || !this.$root.contains(button)) {
+                    return;
+                }
+                const source = this.sourceById(button.dataset.sourceId);
+                const latestJob = source ? this.latestBackfill(source) : null;
+                if (button.matches('[data-mail-source-add]')) {
+                    event.preventDefault();
+                    this.openAddForm();
+                } else if (button.matches('[data-mail-source-edit]') && source) {
+                    event.preventDefault();
+                    this.openEditForm(source);
+                } else if (button.matches('[data-mail-source-test]') && source) {
+                    event.preventDefault();
+                    this.testSource(source.id);
+                } else if (button.matches('[data-mail-source-fetch]') && source) {
+                    event.preventDefault();
+                    this.fetchSource(source);
+                } else if (button.matches('[data-mail-source-backfill]') && source) {
+                    event.preventDefault();
+                    this.openBackfill(source);
+                } else if (button.matches('[data-mail-source-history]') && source) {
+                    event.preventDefault();
+                    this.loadImportHistory(source);
+                } else if (button.matches('[data-mail-source-delete]') && source) {
+                    event.preventDefault();
+                    this.confirmDelete(source);
+                } else if (button.matches('[data-mail-source-history-close]')) {
+                    event.preventDefault();
+                    this.closeHistory();
+                } else if (button.matches('[data-mail-source-backfill-refresh]') && source) {
+                    event.preventDefault();
+                    this.loadBackfills(source);
+                } else if (button.matches('[data-mail-source-backfill-cancel]') && source && latestJob) {
+                    event.preventDefault();
+                    this.cancelBackfill(source, latestJob);
+                } else if (button.matches('[data-mail-source-backfill-retry]') && source && latestJob) {
+                    event.preventDefault();
+                    this.retryBackfill(source, latestJob);
+                } else if (button.matches('[data-mail-source-backfill-close]')) {
+                    event.preventDefault();
+                    this.closeBackfill();
+                } else if (button.matches('[data-backfill-days]')) {
+                    event.preventDefault();
+                    this.backfillDays = Number(button.dataset.backfillDays);
+                } else if (button.matches('[data-mail-source-backfill-run]')) {
+                    event.preventDefault();
+                    this.runBackfill();
+                }
+            });
+            this.$root.addEventListener('change', event => {
+                const target = event.target instanceof Element ? event.target : null;
+                if (!target || !target.matches('[data-mail-source-toggle]')) {
+                    return;
+                }
+                const source = this.sourceById(target.dataset.sourceId);
+                if (source) {
+                    this.toggleSource(source.id);
+                }
+            });
+        },
+
+        sourceById(id) {
+            if (!id) return null;
+            const numericId = Number(id);
+            return this.sources.find(source => Number(source.id) === numericId) || null;
         },
 
         async loadSources() {

--- a/backend/app/static/js/mail-sources-page.js
+++ b/backend/app/static/js/mail-sources-page.js
@@ -119,6 +119,16 @@ function mailSourcesApp() {
                     this.toggleSource(source.id);
                 }
             });
+            window.addEventListener('keydown', event => {
+                if (event.key !== 'Escape' || !this.backfillSource) {
+                    return;
+                }
+                if (!this.$root.querySelector('[data-mail-source-backfill-modal]')) {
+                    return;
+                }
+                event.preventDefault();
+                this.closeBackfill();
+            });
         },
 
         sourceById(id) {

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -9,7 +9,7 @@
 {% block page_title %}Mail Sources{% endblock %}
 
 {% block content %}
-<div class="grid gap-4 md:gap-8 py-4" x-data="mailSourcesApp()">
+<div class="grid gap-4 md:gap-8 py-4" x-data="mailSourcesApp()" data-mail-sources-page>
 
     <!-- Page header -->
     <div class="flex items-center justify-between">
@@ -20,7 +20,7 @@
                 Multiple accounts and connection methods (IMAP, POP3, Gmail API, Microsoft 365) are supported.
             </p>
         </div>
-        <button class="btn btn-default btn-md" x-on:click="openAddForm()">
+        <button class="btn btn-default btn-md" data-mail-source-add>
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
                 <line x1="12" y1="5" x2="12" y2="19"></line>
@@ -102,7 +102,7 @@
                                         <template x-if="!backfillLoading[source.id] && !latestBackfill(source)">
                                             <div class="space-y-2">
                                                 <p class="text-xs text-muted-foreground">No queued backfills.</p>
-                                                <button class="btn btn-outline btn-xs" x-on:click.stop="openBackfill(source)">
+                                                <button class="btn btn-outline btn-xs" :data-source-id="source.id" data-mail-source-backfill>
                                                     Queue backfill
                                                 </button>
                                             </div>
@@ -131,23 +131,26 @@
                                                     x-text="latestBackfill(source).errors[0]"></p>
                                                 <div class="flex flex-wrap gap-1">
                                                     <button class="btn btn-outline btn-xs"
-                                                        x-on:click.stop="loadBackfills(source)"
+                                                        :data-source-id="source.id"
+                                                        data-mail-source-backfill-refresh
                                                         :disabled="backfillAction[source.id] === 'refresh'">
                                                         Refresh
                                                     </button>
                                                     <button class="btn btn-outline btn-xs"
                                                         x-show="canCancelBackfill(latestBackfill(source))"
-                                                        x-on:click.stop="cancelBackfill(source, latestBackfill(source))"
+                                                        :data-source-id="source.id"
+                                                        data-mail-source-backfill-cancel
                                                         :disabled="backfillAction[source.id] === 'cancel'">
                                                         Cancel
                                                     </button>
                                                     <button class="btn btn-outline btn-xs"
                                                         x-show="canRetryBackfill(latestBackfill(source))"
-                                                        x-on:click.stop="retryBackfill(source, latestBackfill(source))"
+                                                        :data-source-id="source.id"
+                                                        data-mail-source-backfill-retry
                                                         :disabled="backfillAction[source.id] === 'retry'">
                                                         Retry
                                                     </button>
-                                                    <button class="btn btn-ghost btn-xs" x-on:click.stop="openBackfill(source)">
+                                                    <button class="btn btn-ghost btn-xs" :data-source-id="source.id" data-mail-source-backfill>
                                                         New
                                                     </button>
                                                 </div>
@@ -159,12 +162,13 @@
                                             type="checkbox"
                                             class="toggle toggle-success toggle-sm"
                                             :checked="source.enabled"
-                                            x-on:change="toggleSource(source.id)"
+                                            :data-source-id="source.id"
+                                            data-mail-source-toggle
                                         />
                                     </td>
                                     <td>
                                         <div class="flex items-center gap-2">
-                                            <button class="btn btn-ghost btn-xs" x-on:click="openEditForm(source)" title="Edit">
+                                            <button class="btn btn-ghost btn-xs" :data-source-id="source.id" data-mail-source-edit title="Edit">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
                                                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                                     stroke-linejoin="round">
@@ -172,7 +176,7 @@
                                                     <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
                                                 </svg>
                                             </button>
-                                            <button class="btn btn-ghost btn-xs" x-on:click="testSource(source.id)" title="Test connection"
+                                            <button class="btn btn-ghost btn-xs" :data-source-id="source.id" data-mail-source-test title="Test connection"
                                                 :disabled="testing[source.id]">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
                                                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -181,7 +185,7 @@
                                                     <polyline points="22 4 12 14.01 9 11.01"></polyline>
                                                 </svg>
                                             </button>
-                                            <button class="btn btn-ghost btn-xs" x-on:click="fetchSource(source)" title="Run import now"
+                                            <button class="btn btn-ghost btn-xs" :data-source-id="source.id" data-mail-source-fetch title="Run import now"
                                                 :disabled="Boolean(fetching[source.id])">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
                                                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -190,7 +194,7 @@
                                                     <path d="M21 3v6h-6"></path>
                                                 </svg>
                                             </button>
-                                            <button class="btn btn-ghost btn-xs" x-on:click="openBackfill(source)" title="Backfill date range"
+                                            <button class="btn btn-ghost btn-xs" :data-source-id="source.id" data-mail-source-backfill title="Backfill date range"
                                                 :disabled="Boolean(fetching[source.id])">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
                                                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -201,7 +205,7 @@
                                                     <line x1="3" y1="10" x2="21" y2="10"></line>
                                                 </svg>
                                             </button>
-                                            <button class="btn btn-ghost btn-xs" x-on:click="loadImportHistory(source)" title="Import history">
+                                            <button class="btn btn-ghost btn-xs" :data-source-id="source.id" data-mail-source-history title="Import history">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
                                                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                                     stroke-linejoin="round">
@@ -209,7 +213,7 @@
                                                     <polyline points="12 6 12 12 16 14"></polyline>
                                                 </svg>
                                             </button>
-                                            <button class="btn btn-ghost btn-xs text-error" x-on:click="confirmDelete(source)" title="Delete">
+                                            <button class="btn btn-ghost btn-xs text-error" :data-source-id="source.id" data-mail-source-delete title="Delete">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
                                                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                                     stroke-linejoin="round">
@@ -242,7 +246,7 @@
                             <span x-text="historySource ? `${historySource.name} • ${sourceTargetLabel(historySource)}` : ''"></span>
                         {% endcall %}
                     </div>
-                    <button class="btn btn-ghost btn-sm" x-on:click="closeHistory()">Close</button>
+                    <button class="btn btn-ghost btn-sm" data-mail-source-history-close>Close</button>
                 </div>
             {% endcall %}
             {% call card_content() %}
@@ -685,7 +689,7 @@
         <div class="bg-base-100 rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4">
             <div class="flex items-center justify-between">
                 <h2 class="text-lg font-semibold">Backfill Mail Source</h2>
-                <button class="btn btn-ghost btn-sm btn-circle" x-on:click="closeBackfill()">✕</button>
+                <button class="btn btn-ghost btn-sm btn-circle" data-mail-source-backfill-close>✕</button>
             </div>
             <div class="space-y-3">
                 <p class="text-sm text-muted-foreground" x-text="backfillSource ? backfillSource.name : ''"></p>
@@ -693,9 +697,9 @@
                     Queues a resumable mailbox search. Progress appears in the Backfill column.
                 </p>
                 <div class="join w-full">
-                    <button type="button" class="btn btn-sm join-item flex-1" x-on:click="backfillDays = 7">7 days</button>
-                    <button type="button" class="btn btn-sm join-item flex-1" x-on:click="backfillDays = 30">30 days</button>
-                    <button type="button" class="btn btn-sm join-item flex-1" x-on:click="backfillDays = 90">90 days</button>
+                    <button type="button" class="btn btn-sm join-item flex-1" data-backfill-days="7">7 days</button>
+                    <button type="button" class="btn btn-sm join-item flex-1" data-backfill-days="30">30 days</button>
+                    <button type="button" class="btn btn-sm join-item flex-1" data-backfill-days="90">90 days</button>
                 </div>
                 <label class="form-control">
                     <span class="label-text">Days to search</span>
@@ -703,8 +707,8 @@
                 </label>
             </div>
             <div class="flex justify-end gap-2">
-                <button class="btn btn-ghost btn-sm" x-on:click="closeBackfill()">Cancel</button>
-                <button class="btn btn-primary btn-sm" x-on:click="runBackfill()"
+                <button class="btn btn-ghost btn-sm" data-mail-source-backfill-close>Cancel</button>
+                <button class="btn btn-primary btn-sm" data-mail-source-backfill-run
                     :disabled="!validBackfillDays() || Boolean(backfillAction[backfillSource && backfillSource.id])">
                     Queue Backfill
                 </button>

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -685,7 +685,7 @@
     <!-- Backfill modal -->
     <div x-show="backfillSource" x-cloak
         class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-        x-on:keydown.escape.window="closeBackfill()">
+        data-mail-source-backfill-modal>
         <div class="bg-base-100 rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4">
             <div class="flex items-center justify-between">
                 <h2 class="text-lg font-semibold">Backfill Mail Source</h2>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -98,6 +98,14 @@ def _dashboard_script() -> str:
     return _read_project_file("static", "js", "dashboard-page.js")
 
 
+def _mail_sources_template() -> str:
+    return _read_project_file("templates", "mail_sources.html")
+
+
+def _mail_sources_script() -> str:
+    return _read_project_file("static", "js", "mail-sources-page.js")
+
+
 def _run_dashboard_poll_summary(payload: dict[str, object]) -> str:
     node = shutil.which("node")
     if not node:
@@ -648,6 +656,49 @@ def test_settings_exposes_provider_agnostic_dns_import_without_html_injection():
     assert "/api/v1/domains/dns/import/${encodeURIComponent(providerId)}" in script
     assert "discoverCloudflareZones()" in script
     assert "importCloudflareZones()" in script
+    assert "x-html" not in template
+    assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
+
+
+def test_mail_sources_list_actions_are_bound_from_external_script():
+    template = _mail_sources_template()
+    script = _mail_sources_script()
+
+    assert 'src="/static/js/mail-sources-page.js"' in template
+    assert "data-mail-sources-page" in template
+    assert "data-mail-source-add" in template
+    assert "data-mail-source-toggle" in template
+    assert "data-mail-source-edit" in template
+    assert "data-mail-source-test" in template
+    assert "data-mail-source-fetch" in template
+    assert "data-mail-source-backfill" in template
+    assert "data-mail-source-history" in template
+    assert "data-mail-source-delete" in template
+    assert "data-mail-source-history-close" in template
+    assert "data-mail-source-backfill-refresh" in template
+    assert "data-mail-source-backfill-cancel" in template
+    assert "data-mail-source-backfill-retry" in template
+    assert "data-mail-source-backfill-close" in template
+    assert "data-mail-source-backfill-run" in template
+    assert "data-backfill-days" in template
+    assert "bindPageControls" in script
+    assert "sourceById" in script
+    assert "data-mail-source-toggle" in script
+    assert 'x-on:click="openAddForm()"' not in template
+    assert 'x-on:change="toggleSource(source.id)"' not in template
+    assert 'x-on:click="openEditForm(source)"' not in template
+    assert 'x-on:click="testSource(source.id)"' not in template
+    assert 'x-on:click="fetchSource(source)"' not in template
+    assert 'x-on:click="loadImportHistory(source)"' not in template
+    assert 'x-on:click="confirmDelete(source)"' not in template
+    assert 'x-on:click.stop="openBackfill(source)"' not in template
+    assert 'x-on:click.stop="loadBackfills(source)"' not in template
+    assert 'x-on:click.stop="cancelBackfill(source, latestBackfill(source))"' not in template
+    assert 'x-on:click.stop="retryBackfill(source, latestBackfill(source))"' not in template
+    assert 'x-on:click="backfillDays = 7"' not in template
+    assert 'x-on:click="backfillDays = 30"' not in template
+    assert 'x-on:click="backfillDays = 90"' not in template
+    assert 'x-on:click="runBackfill()"' not in template
     assert "x-html" not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -664,7 +664,7 @@ def test_mail_sources_list_actions_are_bound_from_external_script():
     template = _mail_sources_template()
     script = _mail_sources_script()
 
-    assert 'src="/static/js/mail-sources-page.js"' in template
+    assert _has_script_src(template, "/static/js/mail-sources-page.js")
     assert "data-mail-sources-page" in template
     assert "data-mail-source-add" in template
     assert "data-mail-source-toggle" in template
@@ -680,10 +680,13 @@ def test_mail_sources_list_actions_are_bound_from_external_script():
     assert "data-mail-source-backfill-retry" in template
     assert "data-mail-source-backfill-close" in template
     assert "data-mail-source-backfill-run" in template
+    assert "data-mail-source-backfill-modal" in template
     assert "data-backfill-days" in template
     assert "bindPageControls" in script
     assert "sourceById" in script
     assert "data-mail-source-toggle" in script
+    assert "event.key !== 'Escape'" in script
+    assert "data-mail-source-backfill-modal" in script
     assert 'x-on:click="openAddForm()"' not in template
     assert 'x-on:change="toggleSource(source.id)"' not in template
     assert 'x-on:click="openEditForm(source)"' not in template
@@ -699,6 +702,7 @@ def test_mail_sources_list_actions_are_bound_from_external_script():
     assert 'x-on:click="backfillDays = 30"' not in template
     assert 'x-on:click="backfillDays = 90"' not in template
     assert 'x-on:click="runBackfill()"' not in template
+    assert 'x-on:keydown.escape.window="closeBackfill()"' not in template
     assert "x-html" not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 


### PR DESCRIPTION
## Summary
- move Mail Sources list actions for add/edit/test/fetch/backfill/history/delete from inline Alpine handlers to mail-sources-page.js delegated controls
- move backfill modal quick-range, close, and queue actions to stable data markers
- add a template security regression test so these list and backfill controls do not regress to inline handlers

## Validation
- node --check backend/app/static/js/mail-sources-page.js
- /tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py
- PATH=/tmp/dmarq-dns-evidence-554/backend/node_modules/.bin:$PATH NODE_PATH=/tmp/dmarq-dns-evidence-554/backend/node_modules DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser

Part of #426.