### PR TITLE
Externalize mail source form controls

### DIFF
--- a/backend/app/static/js/mail-sources-page.js
+++ b/backend/app/static/js/mail-sources-page.js
@@ -107,27 +107,73 @@ function mailSourcesApp() {
                 } else if (button.matches('[data-mail-source-backfill-run]')) {
                     event.preventDefault();
                     this.runBackfill();
+                } else if (button.matches('[data-mail-source-form-close]')) {
+                    event.preventDefault();
+                    this.closeForm();
+                } else if (button.matches('[data-mail-source-password-toggle]')) {
+                    event.preventDefault();
+                    this.showPassword = !this.showPassword;
+                } else if (button.matches('[data-mail-source-m365-load-folders]')) {
+                    event.preventDefault();
+                    this.loadM365Folders();
+                } else if (button.matches('[data-mail-source-test-adhoc]')) {
+                    event.preventDefault();
+                    this.testAdHoc();
+                } else if (button.matches('[data-mail-source-connect-gmail]')) {
+                    event.preventDefault();
+                    this.connectGmail();
+                } else if (button.matches('[data-mail-source-connect-m365]')) {
+                    event.preventDefault();
+                    this.connectM365();
+                } else if (button.matches('[data-mail-source-delete-cancel]')) {
+                    event.preventDefault();
+                    this.deleteTarget = null;
+                } else if (button.matches('[data-mail-source-delete-confirm]')) {
+                    event.preventDefault();
+                    this.deleteSource();
                 }
             });
             this.$root.addEventListener('change', event => {
                 const target = event.target instanceof Element ? event.target : null;
-                if (!target || !target.matches('[data-mail-source-toggle]')) {
+                if (!target) {
                     return;
                 }
-                const source = this.sourceById(target.dataset.sourceId);
-                if (source) {
-                    this.toggleSource(source.id);
+                if (target.matches('[data-mail-source-toggle]')) {
+                    const source = this.sourceById(target.dataset.sourceId);
+                    if (source) {
+                        this.toggleSource(source.id);
+                    }
+                } else if (target.matches('[data-mail-source-m365-folder-select]')) {
+                    this.applyM365FolderSelection(target.value);
+                }
+            });
+            this.$root.addEventListener('input', event => {
+                const target = event.target instanceof Element ? event.target : null;
+                if (target && target.matches('[data-mail-source-m365-manual-folder]')) {
+                    this.form.m365_folder_id = '';
+                }
+            });
+            this.$root.addEventListener('submit', event => {
+                const form = event.target instanceof Element ? event.target : null;
+                if (form && form.matches('[data-mail-source-form]')) {
+                    event.preventDefault();
+                    this.saveSource();
                 }
             });
             window.addEventListener('keydown', event => {
-                if (event.key !== 'Escape' || !this.backfillSource) {
+                if (event.key !== 'Escape') {
                     return;
                 }
-                if (!this.$root.querySelector('[data-mail-source-backfill-modal]')) {
-                    return;
+                if (this.deleteTarget && this.$root.querySelector('[data-mail-source-delete-modal]')) {
+                    event.preventDefault();
+                    this.deleteTarget = null;
+                } else if (this.backfillSource && this.$root.querySelector('[data-mail-source-backfill-modal]')) {
+                    event.preventDefault();
+                    this.closeBackfill();
+                } else if (this.showForm && this.$root.querySelector('[data-mail-source-form-modal]')) {
+                    event.preventDefault();
+                    this.closeForm();
                 }
-                event.preventDefault();
-                this.closeBackfill();
             });
         },
 

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -340,15 +340,15 @@
     <!-- Add / Edit modal -->
     <div x-show="showForm" x-cloak
         class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-        x-on:keydown.escape.window="closeForm()">
+        data-mail-source-form-modal>
         <div class="bg-base-100 rounded-lg shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
             <div class="p-6 space-y-4">
                 <div class="flex items-center justify-between">
                     <h2 class="text-lg font-semibold" x-text="editingId ? 'Edit Mail Source' : 'Add Mail Source'"></h2>
-                    <button class="btn btn-ghost btn-sm btn-circle" x-on:click="closeForm()">✕</button>
+                    <button class="btn btn-ghost btn-sm btn-circle" data-mail-source-form-close>✕</button>
                 </div>
 
-                <form id="source-form" x-on:submit.prevent="saveSource()" class="space-y-4">
+                <form id="source-form" data-mail-source-form class="space-y-4">
 
                     <!-- Name -->
                     <div>
@@ -403,7 +403,7 @@
                                 <input :type="showPassword ? 'text' : 'password'" x-model="form.password"
                                     class="input input-bordered w-full pr-10" />
                                 <button type="button" class="absolute right-2 top-3 text-muted-foreground hover:text-foreground"
-                                    x-on:click="showPassword = !showPassword">
+                                    data-mail-source-password-toggle>
                                     <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                         viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                         stroke-linecap="round" stroke-linejoin="round">
@@ -474,7 +474,7 @@
                                         placeholder="GOCSPX-…" />
                                     <button type="button"
                                         class="absolute right-2 top-3 text-muted-foreground hover:text-foreground"
-                                        x-on:click="showPassword = !showPassword">
+                                        data-mail-source-password-toggle>
                                         <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                             viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                             stroke-linecap="round" stroke-linejoin="round">
@@ -541,7 +541,7 @@
                                         class="input input-bordered w-full pr-10" />
                                     <button type="button"
                                         class="absolute right-2 top-3 text-muted-foreground hover:text-foreground"
-                                        x-on:click="showPassword = !showPassword">
+                                        data-mail-source-password-toggle>
                                         <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" width="16" height="16"
                                             viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                             stroke-linecap="round" stroke-linejoin="round">
@@ -571,20 +571,20 @@
                                 <div class="flex flex-col gap-2 md:flex-row">
                                     <select class="select select-bordered w-full md:flex-1"
                                         x-model="form.m365_folder_id"
-                                        x-on:change="applyM365FolderSelection($event.target.value)">
+                                        data-mail-source-m365-folder-select>
                                         <option value="">Use folder name below</option>
                                         <template x-for="folder in m365Folders" :key="folder.id">
                                             <option :value="folder.id" x-text="folder.path || folder.display_name"></option>
                                         </template>
                                     </select>
                                     <button type="button" class="btn btn-outline"
-                                        x-on:click="loadM365Folders()"
+                                        data-mail-source-m365-load-folders
                                         :disabled="!editingId || !m365Connected || m365FoldersLoading">
                                         <span x-text="m365FoldersLoading ? 'Loading…' : 'Load folders'"></span>
                                     </button>
                                 </div>
                                 <input type="text" x-model="form.folder" placeholder="INBOX"
-                                    x-on:input="form.m365_folder_id = ''"
+                                    data-mail-source-m365-manual-folder
                                     class="input input-bordered w-full mt-2" />
                                 <p class="text-xs text-muted-foreground mt-1">Use a listed folder when available; otherwise enter a well-known folder such as INBOX.</p>
                                 <p class="text-xs text-error mt-1" x-show="m365FoldersError" x-text="m365FoldersError"></p>
@@ -638,7 +638,7 @@
                         <div class="flex gap-2">
                             <template x-if="form.method !== 'GMAIL_API' && form.method !== 'M365_GRAPH'">
                                 <button type="button" class="btn btn-outline btn-sm"
-                                    x-on:click="testAdHoc()"
+                                    data-mail-source-test-adhoc
                                     :disabled="isTesting || isSaving">
                                     <span x-show="!isTesting">Test Connection</span>
                                     <span x-show="isTesting" class="flex items-center" x-cloak>
@@ -652,7 +652,7 @@
                             </template>
                             <template x-if="form.method === 'GMAIL_API' && editingId">
                                 <button type="button" class="btn btn-outline btn-sm"
-                                    x-on:click="connectGmail()"
+                                    data-mail-source-connect-gmail
                                     :disabled="isTesting || isSaving">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
                                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-1">
@@ -663,14 +663,14 @@
                             </template>
                             <template x-if="form.method === 'M365_GRAPH' && editingId">
                                 <button type="button" class="btn btn-outline btn-sm"
-                                    x-on:click="connectM365()"
+                                    data-mail-source-connect-m365
                                     :disabled="isTesting || isSaving">
                                     Connect Microsoft 365
                                 </button>
                             </template>
                         </div>
                         <div class="flex gap-2">
-                            <button type="button" class="btn btn-ghost btn-sm" x-on:click="closeForm()">Cancel</button>
+                            <button type="button" class="btn btn-ghost btn-sm" data-mail-source-form-close>Cancel</button>
                             <button type="submit" class="btn btn-default btn-sm" :disabled="isSaving">
                                 <span x-show="!isSaving" x-text="editingId ? 'Update' : 'Save'"></span>
                                 <span x-show="isSaving" x-cloak>Saving…</span>
@@ -718,7 +718,8 @@
 
     <!-- Delete confirmation modal -->
     <div x-show="deleteTarget" x-cloak
-        class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+        data-mail-source-delete-modal>
         <div class="bg-base-100 rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4">
             <h2 class="text-lg font-semibold">Delete Mail Source</h2>
             <p class="text-sm text-muted-foreground">
@@ -726,8 +727,8 @@
                 This action cannot be undone.
             </p>
             <div class="flex justify-end gap-2">
-                <button class="btn btn-ghost btn-sm" x-on:click="deleteTarget = null">Cancel</button>
-                <button class="btn btn-error btn-sm" x-on:click="deleteSource()">Delete</button>
+                <button class="btn btn-ghost btn-sm" data-mail-source-delete-cancel>Cancel</button>
+                <button class="btn btn-error btn-sm" data-mail-source-delete-confirm>Delete</button>
             </div>
         </div>
     </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -707,6 +707,46 @@ def test_mail_sources_list_actions_are_bound_from_external_script():
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
+def test_mail_sources_form_actions_are_bound_from_external_script():
+    template = _mail_sources_template()
+    script = _mail_sources_script()
+
+    assert "data-mail-source-form-modal" in template
+    assert "data-mail-source-form" in template
+    assert "data-mail-source-form-close" in template
+    assert "data-mail-source-password-toggle" in template
+    assert "data-mail-source-m365-folder-select" in template
+    assert "data-mail-source-m365-load-folders" in template
+    assert "data-mail-source-m365-manual-folder" in template
+    assert "data-mail-source-test-adhoc" in template
+    assert "data-mail-source-connect-gmail" in template
+    assert "data-mail-source-connect-m365" in template
+    assert "data-mail-source-delete-modal" in template
+    assert "data-mail-source-delete-cancel" in template
+    assert "data-mail-source-delete-confirm" in template
+    assert "data-mail-source-form" in script
+    assert "data-mail-source-m365-folder-select" in script
+    assert "data-mail-source-m365-manual-folder" in script
+    assert "data-mail-source-connect-gmail" in script
+    assert "data-mail-source-delete-confirm" in script
+    assert "data-mail-source-form-modal" in script
+    assert "data-mail-source-delete-modal" in script
+    assert 'x-on:keydown.escape.window="closeForm()"' not in template
+    assert 'x-on:click="closeForm()"' not in template
+    assert 'x-on:submit.prevent="saveSource()"' not in template
+    assert 'x-on:click="showPassword = !showPassword"' not in template
+    assert 'x-on:change="applyM365FolderSelection($event.target.value)"' not in template
+    assert 'x-on:click="loadM365Folders()"' not in template
+    assert 'x-on:input="form.m365_folder_id = \'\'"' not in template
+    assert 'x-on:click="testAdHoc()"' not in template
+    assert 'x-on:click="connectGmail()"' not in template
+    assert 'x-on:click="connectM365()"' not in template
+    assert 'x-on:click="deleteTarget = null"' not in template
+    assert 'x-on:click="deleteSource()"' not in template
+    assert "x-html" not in template
+    assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
+
+
 def test_domain_details_exposes_health_history_without_html_injection():
     template = _domain_details_template()
     script = _domain_details_script()

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -725,9 +725,15 @@ def test_mail_sources_form_actions_are_bound_from_external_script():
     assert "data-mail-source-delete-cancel" in template
     assert "data-mail-source-delete-confirm" in template
     assert "data-mail-source-form" in script
+    assert "data-mail-source-form-close" in script
+    assert "data-mail-source-password-toggle" in script
     assert "data-mail-source-m365-folder-select" in script
+    assert "data-mail-source-m365-load-folders" in script
     assert "data-mail-source-m365-manual-folder" in script
+    assert "data-mail-source-test-adhoc" in script
     assert "data-mail-source-connect-gmail" in script
+    assert "data-mail-source-connect-m365" in script
+    assert "data-mail-source-delete-cancel" in script
     assert "data-mail-source-delete-confirm" in script
     assert "data-mail-source-form-modal" in script
     assert "data-mail-source-delete-modal" in script


### PR DESCRIPTION
## Summary
- move Mail Sources add/edit form submit, close, password reveal, OAuth connect, Microsoft 365 folder, and delete modal actions from inline Alpine handlers to mail-sources-page.js delegated controls
- keep the Mail Sources template on stable data markers so the page can move closer to strict CSP
- add regression assertions for the remaining Mail Sources form and modal controls

## Validation
- node --check backend/app/static/js/mail-sources-page.js
- /tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py
- PATH=/tmp/dmarq-dns-evidence-554/backend/node_modules/.bin:$PATH NODE_PATH=/tmp/dmarq-dns-evidence-554/backend/node_modules DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser

Part of #426.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mail sources screen so form actions, password visibility, folder loading, connection testing, and connect/cancel/delete controls work more reliably.
  * Enhanced keyboard behavior so Escape now closes the active dialog or clears delete confirmation in the expected order.
  * Added support for selecting Microsoft 365 folders and using manual folder entry more smoothly.
* **Chores**
  * Updated the mail sources UI to use more consistent client-side control hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->