### PR TITLE
Externalize domain detail top controls

### DIFF
--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -200,6 +200,7 @@ function domainDetailsApp(domainId) {
         refreshingPage: false,
 
         init() {
+            this.bindPageControls();
             const storedVolumeScale = this.loadStoredVolumeScale();
             if (storedVolumeScale === 'linear' || storedVolumeScale === 'logarithmic') {
                 this.volumeScale = storedVolumeScale;
@@ -211,6 +212,110 @@ function domainDetailsApp(domainId) {
                 this.fetchSources();
                 this.fetchSourceIntelligence();
             });
+        },
+
+        bindPageControls() {
+            if (this._pageControlsBound || !this.$root) {
+                return;
+            }
+            this._pageControlsBound = true;
+            this.$root.addEventListener('click', event => {
+                const target = event.target instanceof Element ? event.target : null;
+                const button = target ? target.closest('button') : null;
+                if (!button || !this.$root.contains(button)) {
+                    return;
+                }
+                if (button.matches('[data-domain-detail-reload]')) {
+                    event.preventDefault();
+                    this.reloadPageData();
+                } else if (button.matches('[data-domain-detail-delete]')) {
+                    event.preventDefault();
+                    this.deleteDomain();
+                } else if (button.matches('[data-domain-detail-verify-ownership]')) {
+                    event.preventDefault();
+                    this.verifyDomainOwnership();
+                } else if (button.matches('[data-domain-detail-verify-cloudflare]')) {
+                    event.preventDefault();
+                    this.verifyDomainOwnershipCloudflare();
+                } else if (button.matches('[data-domain-detail-volume-scale]')) {
+                    event.preventDefault();
+                    this.setVolumeScale(button.dataset.domainDetailVolumeScale);
+                } else if (button.matches('[data-domain-detail-remediation-action]')) {
+                    event.preventDefault();
+                    this.handleRemediationAction(button);
+                } else if (button.matches('[data-domain-detail-migration-action]')) {
+                    event.preventDefault();
+                    this.handleMigrationAction(button.dataset.domainDetailMigrationAction);
+                } else if (button.matches('[data-domain-detail-selector-add]')) {
+                    event.preventDefault();
+                    this.addSelector();
+                } else if (button.matches('[data-domain-detail-selector-delete]')) {
+                    event.preventDefault();
+                    this.deleteSelector(button.dataset.selectorValue || '');
+                } else if (button.matches('[data-domain-detail-copy-value]')) {
+                    event.preventDefault();
+                    this.copyValue(button.dataset.domainDetailCopyValue || '');
+                } else if (button.matches('[data-domain-detail-dns-action]')) {
+                    event.preventDefault();
+                    this.handleDnsPlanAction(
+                        button.dataset.domainDetailDnsAction,
+                        button.dataset.dnsPlanId
+                    );
+                }
+            });
+            this.$root.addEventListener('keydown', event => {
+                const target = event.target instanceof Element ? event.target : null;
+                if (!target || !target.matches('[data-domain-detail-selector-input]') || event.key !== 'Enter') {
+                    return;
+                }
+                event.preventDefault();
+                this.addSelector();
+            });
+        },
+
+        findRemediationItem(itemId) {
+            return (this.remediationQueue.items || []).find(item => String(item.id) === String(itemId));
+        },
+
+        findDnsPlan(planId) {
+            return (this.dnsGuidance.change_plans || []).find(plan => String(plan.plan_id) === String(planId));
+        },
+
+        handleRemediationAction(button) {
+            const item = this.findRemediationItem(button.dataset.remediationItemId);
+            if (!item) return;
+            const action = button.dataset.domainDetailRemediationAction;
+            if (action === 'dispatch') {
+                this.dispatchRemediationNotification(item);
+                return;
+            }
+            this.recordRemediationLifecycle(item, action);
+        },
+
+        handleMigrationAction(action) {
+            const handlers = {
+                enable: () => this.enableMigrationTools(),
+                preview_import: () => this.previewMigrationImport(),
+                load_sample: () => this.loadMigrationImportSample(),
+                apply_preview_baseline: () => this.applyMigrationPreviewBaseline(),
+                compare_baseline: () => this.compareMigrationBaseline()
+            };
+            handlers[action]?.();
+        },
+
+        handleDnsPlanAction(action, planId) {
+            const plan = this.findDnsPlan(planId);
+            if (!plan) return;
+            if (action === 'preview') {
+                this.previewDNSChange(plan);
+            } else if (action === 'apply') {
+                this.applyDNSChange(plan);
+            }
+        },
+
+        copyValue(value) {
+            if (!value || !navigator.clipboard) return;
+            navigator.clipboard.writeText(value);
         },
 
         async loadInitialData() {

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -6,7 +6,7 @@
 {% block title %}DMARQ - {{ domain.name }} Details{% endblock %}
 
 {% block content %}
-<div class="space-y-6" x-data="domainDetailsApp('{{ domain_id }}')">
+<div class="space-y-6" x-data="domainDetailsApp('{{ domain_id }}')" data-domain-detail-page>
     <nav class="text-sm text-[#5f5c78]">
         <ol class="flex items-center space-x-2">
             <li><a href="/" class="font-semibold hover:text-[#2f9da5]">Dashboard</a></li>
@@ -50,13 +50,13 @@
                     <button type="button"
                             class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]"
                             :disabled="refreshingPage"
-                            @click="reloadPageData()">
+                            data-domain-detail-reload>
                         <span x-show="refreshingPage" class="loading loading-spinner loading-xs"></span>
                         <span x-text="refreshingPage ? 'Refreshing...' : 'Reload data'"></span>
                     </button>
                     <button type="button"
                             class="btn btn-outline btn-sm border-[#ff6f3c] text-[#b64218] hover:border-[#ff6f3c] hover:bg-[#fff2ec]"
-                            @click="deleteDomain()">
+                            data-domain-detail-delete>
                         Delete domain
                     </button>
                 </div>
@@ -94,13 +94,13 @@
                         <button type="button"
                                 class="btn btn-sm bg-[#2f9da5] text-white hover:bg-[#272a5f]"
                                 :disabled="ownership.loading"
-                                @click="verifyDomainOwnership()">
+                                data-domain-detail-verify-ownership>
                             <span x-text="ownership.loading ? 'Checking...' : 'Check ownership'"></span>
                         </button>
                         <button type="button"
                                 class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5]"
                                 :disabled="ownership.loading"
-                                @click="verifyDomainOwnershipCloudflare()">
+                                data-domain-detail-verify-cloudflare>
                             <span x-text="ownership.loading ? 'Checking...' : 'Verify via Cloudflare'"></span>
                         </button>
                     </div>
@@ -211,14 +211,14 @@
                                     :class="effectiveVolumeScale() === 'logarithmic' ? 'btn-primary' : 'btn-outline'"
                                     :aria-pressed="effectiveVolumeScale() === 'logarithmic'"
                                     :disabled="!hasObservedVolume"
-                                    @click="setVolumeScale('logarithmic')">
+                                    data-domain-detail-volume-scale="logarithmic">
                                 Log
                             </button>
                             <button type="button"
                                     class="btn btn-xs join-item"
                                     :class="effectiveVolumeScale() === 'linear' ? 'btn-primary' : 'btn-outline'"
                                     :aria-pressed="effectiveVolumeScale() === 'linear'"
-                                    @click="setVolumeScale('linear')">
+                                    data-domain-detail-volume-scale="linear">
                                 Linear
                             </button>
                         </div>
@@ -410,25 +410,29 @@
                                             <button type="button"
                                                     class="btn btn-xs btn-outline"
                                                     :disabled="remediationActionBusy(item)"
-                                                    @click="recordRemediationLifecycle(item, 'previewed')">
+                                                    :data-remediation-item-id="item.id"
+                                                    data-domain-detail-remediation-action="previewed">
                                                 Reviewed
                                             </button>
                                             <button type="button"
                                                     class="btn btn-xs btn-outline"
                                                     :disabled="remediationActionBusy(item)"
-                                                    @click="recordRemediationLifecycle(item, 'acknowledged')">
+                                                    :data-remediation-item-id="item.id"
+                                                    data-domain-detail-remediation-action="acknowledged">
                                                 Acknowledge
                                             </button>
                                             <button type="button"
                                                     class="btn btn-xs btn-outline"
                                                     :disabled="remediationActionBusy(item)"
-                                                    @click="recordRemediationLifecycle(item, 'resolved')">
+                                                    :data-remediation-item-id="item.id"
+                                                    data-domain-detail-remediation-action="resolved">
                                                 Resolve
                                             </button>
                                             <button type="button"
                                                     class="btn btn-xs btn-primary"
                                                     :disabled="remediationActionBusy(item) || !item.notification.dispatch.eligible"
-                                                    @click="dispatchRemediationNotification(item)">
+                                                    :data-remediation-item-id="item.id"
+                                                    data-domain-detail-remediation-action="dispatch">
                                                 <span x-show="remediationActionBusy(item, 'dispatch')" class="loading loading-spinner loading-xs"></span>
                                                 Dispatch
                                             </button>
@@ -696,7 +700,7 @@
                         </div>
                         <button type="button"
                                 class="btn btn-sm bg-[#272a5f] text-white hover:bg-[#2f9da5]"
-                                @click="enableMigrationTools()">
+                                data-domain-detail-migration-action="enable">
                             I am migrating data
                         </button>
                     </div>
@@ -735,16 +739,16 @@
                     </div>
                     <div class="mt-3 flex flex-wrap items-center gap-2">
                         <button class="btn btn-sm bg-[#2f9da5] text-white hover:bg-[#272a5f]"
-                                @click="previewMigrationImport"
+                                data-domain-detail-migration-action="preview_import"
                                 :disabled="migrationImport.loading || !migrationImport.content.trim()">
                             <span x-text="migrationImport.loading ? 'Previewing...' : 'Preview export'"></span>
                         </button>
-                        <button class="btn btn-sm btn-outline" @click="loadMigrationImportSample">
+                        <button class="btn btn-sm btn-outline" data-domain-detail-migration-action="load_sample">
                             Load sample
                         </button>
                         <button class="btn btn-sm btn-outline"
                                 x-show="migrationImport.preview?.baseline"
-                                @click="applyMigrationPreviewBaseline">
+                                data-domain-detail-migration-action="apply_preview_baseline">
                             Use suggested baseline
                         </button>
                     </div>
@@ -855,7 +859,7 @@
                         </label>
                     </div>
                     <div class="mt-3 flex flex-wrap items-center gap-2">
-                        <button class="btn btn-sm bg-[#2f9da5] text-white hover:bg-[#272a5f]" @click="compareMigrationBaseline">
+                        <button class="btn btn-sm bg-[#2f9da5] text-white hover:bg-[#272a5f]" data-domain-detail-migration-action="compare_baseline">
                             Compare baseline
                         </button>
                         <span class="text-xs text-[#5f5c78]">Use values from the same legacy-platform export window.</span>
@@ -1165,7 +1169,8 @@
                                 <div class="flex items-center justify-between py-1 px-2 rounded bg-muted mb-1">
                                     <span class="font-mono text-sm" x-text="sel"></span>
                                     <button
-                                        @click="deleteSelector(sel)"
+                                        :data-selector-value="sel"
+                                        data-domain-detail-selector-delete
                                         class="text-red-500 hover:text-red-700 text-xs ml-4"
                                         title="Remove selector"
                                     >✕</button>
@@ -1188,13 +1193,13 @@
                         <div class="flex items-center gap-2">
                             <input
                                 x-model="newSelector"
-                                @keydown.enter.prevent="addSelector()"
+                                data-domain-detail-selector-input
                                 type="text"
                                 placeholder="e.g. google, selector1, mail"
                                 class="input input-sm input-bordered flex-1 font-mono"
                             />
                             <button
-                                @click="addSelector()"
+                                data-domain-detail-selector-add
                                 :disabled="!newSelector.trim()"
                                 class="btn btn-sm btn-primary"
                             >Add</button>
@@ -1240,7 +1245,7 @@
                                                     <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
                                                         <code class="flex-1 break-all text-xs" x-text="finding.target_record.name + ' ' + finding.target_record.record_type + ' ' + finding.target_record.value"></code>
                                                         <button
-                                                            @click="navigator.clipboard.writeText(finding.target_record.value)"
+                                                            :data-domain-detail-copy-value="finding.target_record.value"
                                                             class="btn btn-xs btn-ghost"
                                                             title="Copy DNS value"
                                                         >
@@ -1270,7 +1275,7 @@
                                                 <p class="mt-1 text-xs text-base-content/60" x-text="record.purpose"></p>
                                             </div>
                                             <button
-                                                @click="navigator.clipboard.writeText(record.value)"
+                                                :data-domain-detail-copy-value="record.value"
                                                 class="btn btn-xs btn-ghost"
                                                 title="Copy DNS value"
                                             >
@@ -1345,7 +1350,7 @@
                                                     <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
                                                         <code class="flex-1 break-all text-xs" x-text="plan.name + ' ' + plan.record_type + ' ' + plan.proposed_value"></code>
                                                         <button
-                                                            @click="navigator.clipboard.writeText(plan.name + ' ' + plan.record_type + ' ' + plan.proposed_value)"
+                                                            :data-domain-detail-copy-value="plan.name + ' ' + plan.record_type + ' ' + plan.proposed_value"
                                                             class="btn btn-xs btn-ghost"
                                                             title="Copy planned DNS record"
                                                         >
@@ -1377,14 +1382,16 @@
                                                     <button
                                                         class="btn btn-xs btn-outline"
                                                         :disabled="dnsWrite.loading || !plan.provider_write_available"
-                                                        @click="previewDNSChange(plan)"
+                                                        :data-dns-plan-id="plan.plan_id"
+                                                        data-domain-detail-dns-action="preview"
                                                     >
                                                         Preview
                                                     </button>
                                                     <button
                                                         class="btn btn-xs bg-[#2f9da5] text-white hover:bg-[#272a5f]"
                                                         :disabled="dnsWrite.loading || !plan.provider_write_available"
-                                                        @click="applyDNSChange(plan)"
+                                                        :data-dns-plan-id="plan.plan_id"
+                                                        data-domain-detail-dns-action="apply"
                                                     >
                                                         Apply
                                                     </button>
@@ -1865,7 +1872,7 @@
                                                                 <div class="mt-2 flex items-center gap-2 rounded bg-base-200 px-2 py-1">
                                                                     <code class="flex-1 font-mono text-xs" x-text="source.spf_fix_hint"></code>
                                                                     <button
-                                                                        @click="navigator.clipboard.writeText(source.spf_fix_hint)"
+                                                                        :data-domain-detail-copy-value="source.spf_fix_hint"
                                                                         class="btn btn-xs btn-ghost"
                                                                         title="Copy SPF mechanism"
                                                                     >

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -773,8 +773,13 @@ def test_domain_details_exposes_volume_scale_controls_without_html_injection():
 
     assert "Volume scale" in template
     assert 'role="group" aria-label="Volume scale"' in template
-    assert "setVolumeScale('logarithmic')" in template
-    assert "setVolumeScale('linear')" in template
+    assert "data-domain-detail-page" in template
+    assert 'data-domain-detail-volume-scale="logarithmic"' in template
+    assert 'data-domain-detail-volume-scale="linear"' in template
+    assert "data-domain-detail-volume-scale" in script
+    assert "bindPageControls()" in script
+    assert "setVolumeScale('logarithmic')" not in template
+    assert "setVolumeScale('linear')" not in template
     assert ":aria-pressed=\"effectiveVolumeScale() === 'logarithmic'\"" in template
     assert ":aria-pressed=\"effectiveVolumeScale() === 'linear'\"" in template
     assert ':disabled="!hasObservedVolume"' in template
@@ -812,6 +817,13 @@ def test_domain_details_exposes_migration_readiness_without_html_injection():
     assert "migrationImport.preview?.sample_rows" in template
     assert "migrationToolsEnabled" in template
     assert "I am migrating data" in template
+    assert "data-domain-detail-migration-action" in template
+    assert "handleMigrationAction" in script
+    assert "@click=\"enableMigrationTools()\"" not in template
+    assert '@click="previewMigrationImport"' not in template
+    assert "@click=\"loadMigrationImportSample\"" not in template
+    assert "@click=\"applyMigrationPreviewBaseline\"" not in template
+    assert "@click=\"compareMigrationBaseline\"" not in template
     assert "x-html" not in template
 
 
@@ -820,12 +832,45 @@ def test_domain_details_exposes_ownership_and_delete_controls_without_html_injec
     script = _domain_details_script()
 
     assert "Domain Ownership" in template
+    assert "data-domain-detail-reload" in template
+    assert "data-domain-detail-delete" in template
+    assert "data-domain-detail-verify-ownership" in template
+    assert "data-domain-detail-verify-cloudflare" in template
+    assert "data-domain-detail-reload" in script
+    assert "data-domain-detail-delete" in script
+    assert "data-domain-detail-verify-ownership" in script
+    assert "data-domain-detail-verify-cloudflare" in script
     assert "/ownership" in script
     assert "/ownership/verify" in script
     assert "Report mailbox access is enough" not in template
     assert "deleteDomain()" in script
+    assert '@click="reloadPageData()"' not in template
+    assert '@click="deleteDomain()"' not in template
+    assert '@click="verifyDomainOwnership()"' not in template
+    assert '@click="verifyDomainOwnershipCloudflare()"' not in template
     assert "Type the domain name to confirm" in script
     assert "sourcesLoading" in template
+
+
+def test_domain_details_externalizes_detail_actions_without_inline_handlers():
+    template = _domain_details_template()
+    script = _domain_details_script()
+
+    assert "data-domain-detail-remediation-action" in template
+    assert "handleRemediationAction" in script
+    assert "findRemediationItem" in script
+    assert "data-domain-detail-selector-add" in template
+    assert "data-domain-detail-selector-delete" in template
+    assert "data-domain-detail-selector-input" in template
+    assert "data-domain-detail-copy-value" in template
+    assert "data-domain-detail-dns-action" in template
+    assert "handleDnsPlanAction" in script
+    assert "findDnsPlan" in script
+    assert "copyValue" in script
+    assert "@click=" not in template
+    assert "@keydown" not in template
+    assert "navigator.clipboard.writeText" not in template
+    assert "x-html" not in template
     assert "sourceEvidenceCount" in template
     assert "x-html" not in template
 
@@ -857,10 +902,15 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "Acknowledge" in template
     assert "Resolve" in template
     assert "Dispatch" in template
-    assert "recordRemediationLifecycle(item, 'previewed')" in template
-    assert "recordRemediationLifecycle(item, 'acknowledged')" in template
-    assert "recordRemediationLifecycle(item, 'resolved')" in template
-    assert "dispatchRemediationNotification(item)" in template
+    assert 'data-domain-detail-remediation-action="previewed"' in template
+    assert 'data-domain-detail-remediation-action="acknowledged"' in template
+    assert 'data-domain-detail-remediation-action="resolved"' in template
+    assert 'data-domain-detail-remediation-action="dispatch"' in template
+    assert "recordRemediationLifecycle(item, 'previewed')" not in template
+    assert "recordRemediationLifecycle(item, 'acknowledged')" not in template
+    assert "recordRemediationLifecycle(item, 'resolved')" not in template
+    assert "dispatchRemediationNotification(item)" not in template
+    assert "handleRemediationAction" in script
     assert "/remediation/notifications/audit" in script
     assert "/remediation/notifications/dispatch" in script
     assert "No DNS changes were made" in script


### PR DESCRIPTION
## Summary
- moves domain detail header, ownership, Cloudflare verification, delete, and volume-scale actions behind external page controls
- externalizes remaining domain detail remediation, migration, DKIM selector, DNS plan, and copy actions from inline handlers into `domain-details-page.js`
- adds regression coverage so the domain detail template cannot reintroduce `@click`, `@keydown`, inline clipboard calls, or page-owned inline scripts

## Local validation
- `node --check backend/app/static/js/domain-details-page.js`
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py`
- `PATH=/tmp/dmarq-dns-evidence-554/backend/node_modules/.bin:$PATH NODE_PATH=/tmp/dmarq-dns-evidence-554/backend/node_modules DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser`
- `git diff --check`

Part of #426.