### PR TITLE
fix: surface report reputation and parallelize DNS fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up root directory for clarity
 
 ### Fixed
+- Fixed report detail views so sender-IP reputation appears as a dedicated score and assessment column instead of being buried in source metadata.
+- Fixed DNS fallback behavior so independent public resolvers are checked in parallel before a transient timeout can make records appear missing.
+- Fixed domain sending-source loading so PTR and network enrichment run in parallel instead of pushing report-backed source rows past the UI timeout.
 - Fixed the Cloudflare permissions picker so selecting the full DNS repair profile no longer falls back to read-only scopes.
 - Fixed the release modal coverage so recent operator-facing work is visible from inside the app.
 - Fixed several CSP-hardening regressions by moving legacy inline handlers and styles out of templates.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -6363,8 +6363,9 @@ async def get_domain_sources(
     settings = get_settings()
 
     ips = [s.get("source_ip", "unknown") for s in sources]
-    hostnames = await asyncio.gather(*[_safe_ptr_lookup(provider, ip) for ip in ips])
-    networks_by_ip = await _source_networks_by_ip(db, provider, ips, settings)
+    ptr_task = asyncio.gather(*[_safe_ptr_lookup(provider, ip) for ip in ips])
+    network_task = asyncio.create_task(_source_networks_by_ip(db, provider, ips, settings))
+    hostnames, networks_by_ip = await asyncio.gather(ptr_task, network_task)
 
     source_entries = []
     sender_by_ip: Dict[str, Dict[str, Any]] = {}

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -185,19 +185,10 @@ def _store_cache_result(
     return row
 
 
-async def _resolve_with_fallback(
-    provider: BaseDNSProvider,
-    domain: str,
-    *,
-    selectors: List[str],
-) -> DomainDNSResult:
-    """Resolve DNS, walking independent resolvers before accepting an empty result."""
-    if not isinstance(
-        provider,
-        (SystemDNSProvider, CloudflareDNSProvider, GoogleDNSProvider),
-    ):
-        return await provider.check_domain(domain, selectors=selectors)
+DNSCandidateResult = Tuple[str, Optional[DomainDNSResult], Optional[Exception]]
 
+
+def _fallback_candidates(provider: BaseDNSProvider) -> List[BaseDNSProvider]:
     fallback_types: List[type[BaseDNSProvider]] = [
         SystemDNSProvider,
         CloudflareDNSProvider,
@@ -208,42 +199,117 @@ async def _resolve_with_fallback(
         for fallback_type in fallback_types
         if not isinstance(provider, fallback_type)
     ]
-    last_result: Optional[DomainDNSResult] = None
+    return [
+        provider if index == 0 else provider_type()
+        for index, provider_type in enumerate(provider_types)
+    ]
+
+
+async def _run_dns_candidate(
+    candidate: BaseDNSProvider,
+    domain: str,
+    *,
+    selectors: List[str],
+) -> DNSCandidateResult:
+    name = candidate.__class__.__name__
+    try:
+        return name, await candidate.check_domain(domain, selectors=selectors), None
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return name, None, exc
+
+
+def _cancel_pending_dns_tasks(tasks: List[asyncio.Task[DNSCandidateResult]]) -> None:
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+
+
+def _fallback_result(
+    result: DomainDNSResult,
+    *,
+    task_name: str,
+    primary_name: str,
+) -> DomainDNSResult:
+    if task_name != primary_name:
+        result.lookup_status = "fallback"
+        result.lookup_error = f"No DNS evidence from {primary_name}; using {task_name}."
+    return result
+
+
+def _empty_fallback_result(
+    first_empty_result: Optional[DomainDNSResult],
+    resolver_errors: List[str],
+) -> Optional[DomainDNSResult]:
+    if first_empty_result is None:
+        return None
+    if resolver_errors:
+        first_empty_result.lookup_status = "partial"
+        first_empty_result.lookup_error = (
+            "No DNS evidence found after fallback resolver checks; "
+            f"{len(resolver_errors)} resolver error(s) occurred."
+        )
+    return first_empty_result
+
+
+async def _resolve_with_fallback(  # noqa: C901
+    provider: BaseDNSProvider,
+    domain: str,
+    *,
+    selectors: List[str],
+) -> DomainDNSResult:
+    """Resolve DNS, checking independent resolvers before accepting an empty result."""
+    if not isinstance(
+        provider,
+        (SystemDNSProvider, CloudflareDNSProvider, GoogleDNSProvider),
+    ):
+        return await provider.check_domain(domain, selectors=selectors)
+
+    first_empty_result: Optional[DomainDNSResult] = None
     resolver_errors: List[str] = []
+    candidates = _fallback_candidates(provider)
+    tasks = [
+        asyncio.create_task(_run_dns_candidate(candidate, domain, selectors=selectors))
+        for candidate in candidates
+    ]
 
-    for index, provider_type in enumerate(provider_types):
-        candidate = provider if index == 0 else provider_type()
-        try:
-            result = await candidate.check_domain(domain, selectors=selectors)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            resolver_errors.append(f"{candidate.__class__.__name__}:{exc.__class__.__name__}")
-            logger.debug(
-                "DNS resolver %s failed with %s",
-                candidate.__class__.__name__,
-                exc.__class__.__name__,
-            )
-            continue
+    try:
+        for completed in asyncio.as_completed(tasks):
+            try:
+                task_name, result, error = await completed
+            except asyncio.CancelledError:
+                for task in tasks:
+                    task.cancel()
+                raise
 
-        if _has_dns_evidence(result):
-            if index > 0:
-                result.lookup_status = "fallback"
-                result.lookup_error = (
-                    f"No DNS evidence from {provider.__class__.__name__}; "
-                    f"using {candidate.__class__.__name__}."
+            if error is not None:
+                resolver_errors.append(f"{task_name}:{error.__class__.__name__}")
+                logger.debug(
+                    "DNS resolver %s failed with %s",
+                    task_name,
+                    error.__class__.__name__,
                 )
-            return result
-        last_result = result
+                continue
 
-    if last_result is not None:
-        if resolver_errors:
-            last_result.lookup_status = "partial"
-            last_result.lookup_error = (
-                "No DNS evidence found after fallback resolver checks; "
-                f"{len(resolver_errors)} resolver error(s) occurred."
-            )
-        return last_result
+            if result is None:
+                continue
+
+            if _has_dns_evidence(result):
+                return _fallback_result(
+                    result,
+                    task_name=task_name,
+                    primary_name=provider.__class__.__name__,
+                )
+
+            if first_empty_result is None:
+                first_empty_result = result
+    finally:
+        _cancel_pending_dns_tasks(tasks)
+
+    empty_result = _empty_fallback_result(first_empty_result, resolver_errors)
+    if empty_result is not None:
+        return empty_result
 
     raise LookupError(
         "All DNS resolvers failed: "

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -149,6 +149,22 @@ function reportDetailApp(reportId) {
             return reputation?.status_label || reputation?.status || 'Reputation unavailable';
         },
 
+        reputationScoreLabel(reputation) {
+            if (typeof reputation?.risk_score === 'number') {
+                return `risk ${reputation.risk_score}/100`;
+            }
+            return 'risk unknown';
+        },
+
+        reputationDetail(reputation) {
+            return (
+                reputation?.status_detail ||
+                reputation?.summary ||
+                reputation?.evidence_summary ||
+                'No reputation assessment is available for this IP yet.'
+            );
+        },
+
         reputationCheckedLabel(reputation) {
             if (!reputation?.checked_at) return 'not checked yet';
             const date = new Date(reputation.checked_at);

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -186,6 +186,7 @@
                             {% call tr() %}
                                 {% call th() %}Source IP{% endcall %}
                                 {% call th() %}Source intelligence{% endcall %}
+                                {% call th() %}Reputation{% endcall %}
                                 {% call th() %}Count{% endcall %}
                                 {% call th() %}Disposition{% endcall %}
                                 {% call th() %}DKIM{% endcall %}
@@ -197,7 +198,7 @@
                         {% call tbody() %}
                             <template x-if="report.records.length === 0">
                                 <tr>
-                                    <td colspan="8" class="text-center py-4">
+                                    <td colspan="9" class="text-center py-4">
                                         <div class="text-muted-foreground">No records in this report</div>
                                     </td>
                                 </tr>
@@ -250,17 +251,25 @@
                                                class="inline-flex text-primary hover:underline">Open in Cloudflare Radar</a>
                                             <div x-show="record.source_details?.network_error && !record.source_details?.asn && !record.source_details?.network"
                                                  x-text="record.source_details.network_error"></div>
+                                        </div>
+                                    {% endcall %}
+                                    {% call td() %}
+                                        <div class="min-w-56 max-w-xs space-y-2 text-xs text-[#5f5c78]">
                                             <template x-if="record.reputation">
-                                                <div class="space-y-1 pt-1">
+                                                <div class="space-y-2">
                                                     <div class="flex flex-wrap gap-1">
-                                                        <span class="inline-flex items-center px-2 py-1 rounded text-xs"
+                                                        <span class="inline-flex items-center rounded px-2 py-1 text-xs font-semibold"
                                                               :class="reputationClass(record.reputation.status)"
-                                                              x-text="`${reputationLabel(record.reputation)} · risk ${record.reputation.risk_score}/100`"></span>
-                                                        <span class="inline-flex items-center px-2 py-1 rounded text-xs"
+                                                              x-text="reputationLabel(record.reputation)"></span>
+                                                        <span class="inline-flex items-center rounded bg-base-200 px-2 py-1 font-mono text-xs text-base-content/80"
+                                                              x-text="reputationScoreLabel(record.reputation)"></span>
+                                                    </div>
+                                                    <div class="flex flex-wrap gap-1">
+                                                        <span class="inline-flex items-center rounded px-2 py-1 text-xs"
                                                               :class="reputationFeedClass(record.reputation.feed_status)"
                                                               x-text="record.reputation.feed_summary || 'Local reputation evidence only'"></span>
                                                     </div>
-                                                    <div x-text="record.reputation.status_detail || record.reputation.summary"></div>
+                                                    <div class="leading-relaxed" x-text="reputationDetail(record.reputation)"></div>
                                                     <div class="text-muted-foreground" x-text="reputationCheckedLabel(record.reputation)"></div>
                                                     <template x-if="record.reputation.listings?.length">
                                                         <div class="font-semibold text-[#ff6f3c]">
@@ -276,6 +285,14 @@
                                                             </span>
                                                         </template>
                                                     </div>
+                                                </div>
+                                            </template>
+                                            <template x-if="!record.reputation">
+                                                <div class="space-y-1">
+                                                    <span class="inline-flex items-center rounded bg-base-200 px-2 py-1 text-xs font-semibold text-base-content/70">
+                                                        Reputation not calculated
+                                                    </span>
+                                                    <p>Reload source intelligence to refresh reputation evidence for this IP.</p>
                                                 </div>
                                             </template>
                                         </div>

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -629,7 +629,12 @@ test('reports list and aggregate detail keep source evidence actionable', async 
   await expect(page.getByText('mta203-ab1.mtasv.net')).toBeVisible();
   await expect(page.getByText('AS23352').first()).toBeVisible();
   await expect(page.getByText('SERVERCENTRAL - DEFT.COM, US').first()).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'Reputation' })).toBeVisible();
   await expect(page.getByText('Reputation clean').first()).toBeVisible();
+  await expect(page.getByText('risk 0/100').first()).toBeVisible();
+  await expect(page.getByText('No blacklist listings found.').first()).toBeVisible();
+  await expect(page.getByText('Reputation not checked').first()).toBeVisible();
+  await expect(page.getByText('Reputation feeds are disabled.').first()).toBeVisible();
   await expect(page.getByText('DKIM did not pass for this source.')).toBeVisible();
   await expect(page.getByText('Failed to load report')).not.toBeVisible();
 });


### PR DESCRIPTION
## Summary
- show sender-IP reputation as a dedicated score and assessment column on aggregate report detail pages
- run System, Cloudflare, and Google DNS fallback resolvers in parallel before accepting empty DNS evidence
- add changelog coverage and browser smoke assertions for report reputation visibility

## Local validation
- node --check backend/app/static/js/report-detail-page.js
- git diff --check
- python -m pytest backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_reports_api.py -q
- npm run test:browser
- live DNS resolver probe for cklnet.com, dmarq.org, docuelevate.org, christianlouis.de