### PR TITLE
fix: keep domain detail enrichment from timing out

### DIFF
--- a/backend/app/services/source_reputation_feeds.py
+++ b/backend/app/services/source_reputation_feeds.py
@@ -119,7 +119,10 @@ class DNSBLFeedProvider:
         if skipped:
             return self._evidence("skipped", checked_at=checked_at, detail=skipped)
 
-        query_name = f"{_reverse_ip(ip)}.{self.config.query_zone.strip('.')}"
+        try:
+            query_name = f"{_reverse_ip(ip)}.{self.config.query_zone.strip('.')}"
+        except ValueError as exc:
+            return self._evidence("skipped", checked_at=checked_at, detail=str(exc))
         try:
             answers = await asyncio.to_thread(self._resolver.resolve, query_name, "A")
         except dns.exception.DNSException as exc:

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1087,7 +1087,7 @@ function domainDetailsApp(domainId) {
                 const response = await this.fetchWithTimeout(
                     `/api/v1/domains/${this.domainId}/dns${options.refresh ? '?refresh=true' : ''}`,
                     {},
-                    options.refresh ? 20000 : 10000
+                    options.refresh ? 60000 : 45000
                 );
                 if (!response.ok) {
                     const data = await response.json().catch(() => ({}));
@@ -1692,7 +1692,7 @@ function domainDetailsApp(domainId) {
                 const response = await this.fetchWithTimeout(
                     `/api/v1/domains/${encodeURIComponent(this.domainId)}/sources?${params.toString()}`,
                     {},
-                    options.refresh ? 25000 : 12000
+                    options.refresh ? 60000 : 45000
                 );
                 if (!response.ok) {
                     const data = await response.json().catch(() => ({}));

--- a/backend/app/tests/test_source_reputation_feeds.py
+++ b/backend/app/tests/test_source_reputation_feeds.py
@@ -151,7 +151,8 @@ async def test_dnsbl_ipv6_sources_are_skipped_without_exception():
             display_name="Demo Reputation Feed",
             enabled=True,
             query_zone="example.test",
-        )
+        ),
+        resolver=NoNameserversResolver(),
     )
 
     evidence = await provider.lookup_ip("2a01:4f8:c17:311b::1")

--- a/backend/app/tests/test_source_reputation_feeds.py
+++ b/backend/app/tests/test_source_reputation_feeds.py
@@ -144,6 +144,23 @@ async def test_dnsbl_no_nameservers_reports_provider_error():
 
 
 @pytest.mark.asyncio
+async def test_dnsbl_ipv6_sources_are_skipped_without_exception():
+    provider = DNSBLFeedProvider(
+        FeedProviderConfig(
+            provider_id="demo_feed",
+            display_name="Demo Reputation Feed",
+            enabled=True,
+            query_zone="example.test",
+        )
+    )
+
+    evidence = await provider.lookup_ip("2a01:4f8:c17:311b::1")
+
+    assert evidence.status == "skipped"
+    assert "IPv4 sources only" in (evidence.detail or "")
+
+
+@pytest.mark.asyncio
 async def test_abuseipdb_high_score_returns_listing():
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.params["ipAddress"] == "8.8.8.8"


### PR DESCRIPTION
## Summary
- skip IPv6 sources in DNSBL feed lookups instead of raising a server error
- give live DNS and sending-source enrichment requests enough time to complete on heavy domains
- cover the IPv6 DNSBL skip path with a focused regression test

## Why
The live `cklnet.com` domain detail page was returning 500s from posture/source enrichment when an IPv6 sending source reached the DNSBL registry. The frontend then displayed DNS and sending-source timeouts, which made the product look like DNS was broken even when the backing lookups were partially succeeding.

## Validation
- `python -m pytest backend/app/tests/test_source_reputation_feeds.py backend/app/tests/test_domain_detail_endpoints.py::test_get_domain_sources_continues_when_enrichment_times_out -q`
- `python -m pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dns_resolver.py -q`
- `python -m flake8 backend/app/services/source_reputation_feeds.py backend/app/tests/test_source_reputation_feeds.py`
- `node --check backend/app/static/js/domain-details-page.js`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS reputation lookups so unsupported IP formats are handled gracefully and reported as skipped instead of causing an error.
  * Increased timeout limits for domain details requests, helping DNS records and source data load more reliably under slower conditions.
* **Tests**
  * Added coverage for skipped DNSBL lookups when IPv6 addresses are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->