### PR TITLE
feat: add mail authentication wizard defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a DMARC aggregate-report mailbox default so generated DNS guidance can use a central `rua=mailto:` address instead of always defaulting to `dmarc@<domain>`.
 - Added in-product release metadata with version, image, git ref, build date, recent changes, and a link to the full changelog.
 - Added Cloudflare OAuth rights profiles for read-only zone import, read-only plus Radar enrichment, and full DNS repair.
 - Added source intelligence context for sending IPs, including provider recognition, network details, Radar links, and report activity history.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2346,6 +2346,12 @@ async def _build_domain_dns_health(  # pylint: disable=too-many-locals
     )
 
 
+def _plain_setting_value(db: Session, key: str) -> Optional[str]:
+    row = db.query(Setting).filter(Setting.key == key).first()
+    value = row.value if row else None
+    return value.strip() if value else None
+
+
 async def _build_domain_dns_guidance(
     db: Session,
     store: ReportStore,
@@ -2397,6 +2403,7 @@ async def _build_domain_dns_guidance(
         observed_selectors=report_selectors,
         mail_service_records=mail_service_records,
         locale=locale or get_settings().default_locale,
+        dmarc_report_mailbox=_plain_setting_value(db, "dmarc.aggregate_report_mailbox"),
     )
     return asdict(guidance)
 

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -116,6 +116,16 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
         "value_type": "string",
         "category": "dmarc",
     },
+    {
+        "key": "dmarc.aggregate_report_mailbox",
+        "value": "",
+        "description": (
+            "Default aggregate-report mailbox used in generated DMARC rua records "
+            "(for example dmarc-reports@example.com)"
+        ),
+        "value_type": "string",
+        "category": "dmarc",
+    },
     # ── DNS ──────────────────────────────────────────────────────────────────
     {
         "key": "dns.resolver",

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -89,9 +89,16 @@ def normalize_guidance_locale(locale: Optional[str]) -> str:
     return "en"
 
 
-def _target_records(domain: str, result: DomainDNSResult) -> List[DNSGuidanceRecord]:
+def _target_records(
+    domain: str,
+    result: DomainDNSResult,
+    *,
+    dmarc_report_mailbox: Optional[str] = None,
+) -> List[DNSGuidanceRecord]:
+    report_mailbox = (dmarc_report_mailbox or "").strip()
+    rua_mailbox = report_mailbox or f"dmarc@{domain}"
     dmarc_value = result.dmarc_record or (
-        f"v=DMARC1; p=none; rua=mailto:dmarc@{domain}; adkim=r; aspf=r"
+        f"v=DMARC1; p=none; rua=mailto:{rua_mailbox}; adkim=r; aspf=r"
     )
     spf_value = result.spf_record or "v=spf1 -all"
     dkim_selector = (result.dkim_selectors or result.selectors_checked or ["selector1"])[0]
@@ -1420,11 +1427,16 @@ async def build_dns_guidance(
     observed_selectors: Optional[List[str]] = None,
     mail_service_records: Optional[List[Dict[str, str]]] = None,
     locale: Optional[str] = None,
+    dmarc_report_mailbox: Optional[str] = None,
 ) -> DNSGuidanceResult:
     """Build typed DNS lint findings and target records for a domain."""
     normalized_domain = domain.strip().strip(".").lower()
     dane_result = dane or DANEResult(errors=["No DANE/TLSA context was evaluated."])
-    targets = _target_records(normalized_domain, result)
+    targets = _target_records(
+        normalized_domain,
+        result,
+        dmarc_report_mailbox=dmarc_report_mailbox,
+    )
     targets.append(_dane_target_record(normalized_domain, dane_result))
     findings: List[DNSLintFinding] = []
     findings.extend(_dmarc_findings(normalized_domain, result, targets))

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -284,6 +284,61 @@ function domainDetailsApp(domainId) {
             return (this.dnsGuidance.change_plans || []).find(plan => String(plan.plan_id) === String(planId));
         },
 
+        get mailAuthSetupRecords() {
+            const records = this.dnsGuidance.target_records || [];
+            const wantedCodes = ['target_dmarc', 'target_spf', 'target_dkim'];
+            return wantedCodes
+                .map(code => records.find(record => record.code === code))
+                .filter(Boolean);
+        },
+
+        get mailAuthSetupSummary() {
+            const records = this.mailAuthSetupRecords;
+            if (!records.length) {
+                return 'Load DNS guidance to generate the DMARC, SPF, and DKIM records for this domain.';
+            }
+            const dmarc = records.find(record => record.code === 'target_dmarc');
+            const rua = this.extractDmarcRua(dmarc?.value || '');
+            if (rua) {
+                return `Generated setup records are ready. Aggregate reports are directed to ${rua}.`;
+            }
+            return 'Generated setup records are ready. Review the DMARC rua mailbox before publishing.';
+        },
+
+        mailAuthRecordLabel(record) {
+            const labels = {
+                target_dmarc: 'DMARC monitoring',
+                target_spf: 'SPF sender policy',
+                target_dkim: 'DKIM selector'
+            };
+            return labels[record?.code] || 'Mail authentication record';
+        },
+
+        mailAuthRecordStatus(record) {
+            if (!record) return 'missing';
+            if (record.code === 'target_dmarc') return this.dns.dmarc ? 'published' : 'ready to publish';
+            if (record.code === 'target_spf') return this.dns.spf ? 'published' : 'ready to publish';
+            if (record.code === 'target_dkim') return this.dns.dkim ? 'published' : 'needs provider key';
+            return record.priority || 'recommended';
+        },
+
+        mailAuthRecordStatusClass(record) {
+            const status = this.mailAuthRecordStatus(record);
+            if (status === 'published') return 'bg-green-100 text-green-700';
+            if (status === 'needs provider key') return 'bg-yellow-100 text-yellow-800';
+            return 'bg-[#e9f6f4] text-[#176b73]';
+        },
+
+        dnsRecordLine(record) {
+            if (!record) return '';
+            return `${record.name} ${record.record_type} ${record.value}`;
+        },
+
+        extractDmarcRua(value) {
+            const match = String(value || '').match(/(?:^|;\s*)rua=mailto:([^;\s]+)/i);
+            return match ? match[1] : '';
+        },
+
         handleRemediationAction(button) {
             const item = this.findRemediationItem(button.dataset.remediationItemId);
             if (!item) return;

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1274,6 +1274,23 @@
                                 </div>
                             </template>
                         </div>
+                        <div class="mt-4 rounded-md border border-[#d8ebe8] bg-white p-3">
+                            <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                                <div>
+                                    <p class="text-sm font-semibold text-[#07071f]">Report intake path</p>
+                                    <p class="mt-1 text-sm text-[#45505f]">
+                                        Use the generated DMARC rua mailbox with IMAP/Gmail import, or route the same
+                                        mailbox through Cloudflare Email Routing and an Email Worker when the zone lives
+                                        in Cloudflare.
+                                    </p>
+                                </div>
+                                <a href="https://github.com/christianlouis/dmarq/blob/main/docs/cloudflare-email-worker-inbound-webhook.md"
+                                   class="btn btn-sm btn-outline"
+                                   title="Open Cloudflare Email Worker setup guide">
+                                    Cloudflare Worker guide
+                                </a>
+                            </div>
+                        </div>
                     </div>
                     <div id="dns-guidance" class="border rounded-lg p-4">
                         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1217,6 +1217,64 @@
                         </div>
                         <p x-show="selectorError" x-text="selectorError" class="text-red-500 text-xs mt-1"></p>
                     </div>
+                    <div id="mail-auth-setup" class="rounded-lg border border-[#d8ebe8] bg-[#f2fbf9] p-4">
+                        <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]">Mail authentication setup</p>
+                                <h3 class="mt-1 text-lg font-semibold text-[#07071f]">DMARC, SPF, and DKIM wizard</h3>
+                                <p class="mt-1 text-sm text-[#45505f]" x-text="mailAuthSetupSummary"></p>
+                            </div>
+                            <a href="/settings#dmarc-defaults" class="btn btn-sm btn-outline">
+                                Configure report mailbox
+                            </a>
+                        </div>
+                        <div class="mt-4 grid gap-3 lg:grid-cols-3">
+                            <template x-if="!mailAuthSetupRecords.length">
+                                <div class="rounded-md border border-[#e6e3e1] bg-white p-3 text-sm text-[#5f5c78] lg:col-span-3">
+                                    DNS guidance is still loading. Refresh this section if no records appear.
+                                </div>
+                            </template>
+                            <template x-for="record in mailAuthSetupRecords" :key="'mail-auth-' + record.code">
+                                <div class="rounded-md border border-[#d8ebe8] bg-white p-3 shadow-sm">
+                                    <div class="flex items-start justify-between gap-2">
+                                        <div>
+                                            <p class="font-semibold text-[#07071f]" x-text="mailAuthRecordLabel(record)"></p>
+                                            <p class="mt-1 text-xs text-[#5f5c78]" x-text="record.purpose"></p>
+                                        </div>
+                                        <span class="shrink-0 rounded-full px-2 py-1 text-xs font-semibold"
+                                              :class="mailAuthRecordStatusClass(record)"
+                                              x-text="mailAuthRecordStatus(record)"></span>
+                                    </div>
+                                    <div class="mt-3 space-y-2">
+                                        <div>
+                                            <p class="text-xs font-semibold uppercase text-[#5f5c78]">Name</p>
+                                            <code class="mt-1 block break-all rounded bg-[#f4f3f2] p-2 text-xs" x-text="record.name"></code>
+                                        </div>
+                                        <div>
+                                            <p class="text-xs font-semibold uppercase text-[#5f5c78]">Value</p>
+                                            <code class="mt-1 block break-all rounded bg-[#f4f3f2] p-2 text-xs" x-text="record.value"></code>
+                                        </div>
+                                    </div>
+                                    <div class="mt-3 flex flex-wrap gap-2">
+                                        <button
+                                            :data-domain-detail-copy-value="record.value"
+                                            class="btn btn-xs btn-default"
+                                            title="Copy DNS value"
+                                        >
+                                            Copy value
+                                        </button>
+                                        <button
+                                            :data-domain-detail-copy-value="dnsRecordLine(record)"
+                                            class="btn btn-xs btn-ghost"
+                                            title="Copy full DNS record"
+                                        >
+                                            Copy full record
+                                        </button>
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
                     <div id="dns-guidance" class="border rounded-lg p-4">
                         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                             <div>

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -73,6 +73,7 @@
     {% endcall %}
 
     <!-- ── DMARC Policy Defaults ─────────────────────────────────────────── -->
+    <section id="dmarc-defaults">
     {% call card() %}
         {% call card_header() %}
             {% call card_title() %}DMARC Policy Defaults{% endcall %}
@@ -116,6 +117,17 @@
                         </select>
                     </div>
                 </div>
+                <div class="form-control w-full">
+                    <label class="label"><span class="label-text font-medium">Aggregate report mailbox</span></label>
+                    <input x-model.trim="s['dmarc.aggregate_report_mailbox']" type="email"
+                        class="input input-bordered w-full"
+                        placeholder="dmarc-reports@example.com">
+                    <label class="label">
+                        <span class="label-text-alt text-muted-foreground">
+                            Used for generated rua=mailto: DNS guidance. Leave blank to use dmarc@ each domain.
+                        </span>
+                    </label>
+                </div>
                 <div class="flex justify-end">
                     <button type="submit" class="btn btn-default btn-md" :disabled="saving">
                         <template x-if="!saving">
@@ -128,6 +140,7 @@
             </form>
         {% endcall %}
     {% endcall %}
+    </section>
 
     <!-- ── DNS Resolver ──────────────────────────────────────────────────── -->
     {% call card() %}

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -26,6 +26,7 @@ from app.models.dns_cache import DNSCache, DNSRecordChange
 from app.models.domain import Domain
 from app.models.organization import Entitlement, Organization
 from app.models.report import DMARCReport, ReportRecord
+from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.services.bimi import BIMIResult
 from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
@@ -539,6 +540,38 @@ def test_dns_lint_endpoint_accepts_locale_for_operator_guidance(authed_client: T
     assert "Veroeffentliche genau einen TXT-Record" in (
         findings["spf_missing"]["remediation_steps"][1]
     )
+
+
+def test_dns_lint_endpoint_uses_configured_aggregate_report_mailbox(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(
+        Setting(
+            key="dmarc.aggregate_report_mailbox",
+            value="dmarc-reports@example.net",
+            value_type="string",
+            category="dmarc",
+        )
+    )
+    db_session.commit()
+    result = DomainDNSResult(
+        dmarc=False,
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        selectors_checked=["selector1"],
+    )
+
+    with _mock_dns(result):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/lint")
+
+    assert response.status_code == 200
+    data = response.json()
+    target = next(record for record in data["target_records"] if record["code"] == "target_dmarc")
+    assert "rua=mailto:dmarc-reports@example.net" in target["value"]
+    plan = next(plan for plan in data["change_plans"] if plan["finding_code"] == "dmarc_missing")
+    assert "rua=mailto:dmarc-reports@example.net" in plan["proposed_value"]
 
 
 def test_dns_change_plan_endpoint_returns_apply_gated_plans(authed_client: TestClient):

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -66,6 +66,32 @@ async def test_build_dns_guidance_returns_typed_findings_and_targets():
 
 
 @pytest.mark.asyncio
+async def test_build_dns_guidance_uses_configured_aggregate_report_mailbox():
+    provider = FakeDNSProvider({})
+    dns = DomainDNSResult(
+        dmarc=False,
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        selectors_checked=["selector1"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        dmarc_report_mailbox="dmarc-reports@example.net",
+    )
+
+    target = next(record for record in guidance.target_records if record.code == "target_dmarc")
+    assert "rua=mailto:dmarc-reports@example.net" in target.value
+    plan = next(plan for plan in guidance.change_plans if plan.finding_code == "dmarc_missing")
+    assert "rua=mailto:dmarc-reports@example.net" in plan.proposed_value
+
+
+@pytest.mark.asyncio
 async def test_build_dns_guidance_localizes_high_value_remediation_steps_to_german():
     provider = FakeDNSProvider({})
     dns = DomainDNSResult(

--- a/docs/cloudflare-email-worker-inbound-webhook.md
+++ b/docs/cloudflare-email-worker-inbound-webhook.md
@@ -36,6 +36,14 @@ records, including Cloudflare-managed DMARC, SPF, or DKIM records. Cloudflare
 DNS integration in DMARQ remains read-only unless an operator changes records
 manually outside this flow.
 
+When Cloudflare manages the reporting domain, this intake path pairs well with
+the central report mailbox in **Settings** > **DMARC Policy Defaults**. Publish
+the generated DMARC `rua=mailto:` value for each domain, route that address
+through Cloudflare Email Routing, and let the Worker forward received reports to
+DMARQ. The current guide documents the manual setup; one-click Cloudflare Email
+Routing and Worker provisioning is tracked separately because it requires
+broader Cloudflare permissions than read-only zone/DNS discovery.
+
 ## Prerequisites
 
 - DMARQ deployed with a reachable HTTPS URL (for example

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -49,6 +49,27 @@ Configure where and how DMARC reports are delivered:
 - **RUF Email**: The email address receiving forensic reports
 - **Report Frequency**: How often you want to receive reports
 
+The generated DMARC record on each domain detail page uses the central
+aggregate-report mailbox from **Settings** > **DMARC Policy Defaults**. This is
+useful for self-hosted deployments that collect all reports in one inbox, for
+example `dmarc-reports@example.com`. If no default is configured, DMARQ suggests
+`dmarc@<domain>`.
+
+### DMARC, SPF, and DKIM Wizard
+
+Each domain detail page includes a DMARC, SPF, and DKIM wizard next to the DNS
+health evidence. The wizard converts the current DNS posture into copyable
+target records:
+
+- **DMARC** shows the starter policy and report mailbox DMARQ would publish.
+- **SPF** shows the proposed SPF TXT record when no usable SPF record exists.
+- **DKIM** lists configured or discovered selectors and shows whether a
+  provider key is still needed.
+
+Use the wizard as a guided starting point. DMARQ still keeps DNS writes
+human-in-the-loop: copy records manually or review a provider-backed change plan
+before approving any DNS update.
+
 ## Domain Health Check
 
 DMARQ provides a health check feature for each domain:

--- a/docs/user_guide/settings.md
+++ b/docs/user_guide/settings.md
@@ -128,6 +128,23 @@ your DNS provider even if no DMARC reports have arrived yet.
 The import flow only creates monitored domains in DMARQ. It does not change DNS
 records. DNS repair remains a separate preview-and-approve action.
 
+## DMARC Policy Defaults
+
+Use **Settings** > **DMARC Policy Defaults** to define the starter policy and
+aggregate-report destination used by generated DNS guidance.
+
+- **Default policy** controls the policy DMARQ suggests for new DMARC records.
+- **DMARC aggregate report mailbox** controls the `rua=mailto:` address in
+  generated DMARC records. Set this to a central mailbox such as
+  `dmarc-reports@example.com` when all domains should send reports to one
+  monitored inbox.
+- If the aggregate report mailbox is empty, DMARQ falls back to
+  `dmarc@<domain>` for each domain.
+
+Changing these defaults does not modify DNS automatically. Domain detail pages
+and DNS lint guidance use the saved values when showing copyable records and
+provider-backed change plans.
+
 ## API Access
 
 DMARQ provides an API for integration with other systems:


### PR DESCRIPTION
## Summary

- adds a configurable default DMARC aggregate-report mailbox in Settings
- threads that value into generated DMARC DNS guidance and domain-detail target records
- adds a domain-detail DMARC/SPF/DKIM wizard with copyable record lines
- documents the central report-mailbox workflow and Cloudflare Email Worker intake path

Closes #574.

## Validation

- `/tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py -q`
- `node --check backend/app/static/js/domain-details-page.js`
- `git diff --check`
