### PR TITLE
fix: recover stale DNS evidence on refresh

### DIFF
--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -113,6 +113,60 @@ def _stale_cached_evidence(
     return cached_result, True, row.checked_at
 
 
+def _latest_stale_evidence_row(
+    db: Session,
+    *,
+    domain: str,
+    provider_name: str,
+    now: datetime,
+    excluded_selectors_key: str,
+) -> Optional[DNSCache]:
+    rows = (
+        db.query(DNSCache)
+        .filter(
+            DNSCache.domain == domain,
+            DNSCache.provider == provider_name,
+            DNSCache.selectors_key != excluded_selectors_key,
+        )
+        .order_by(DNSCache.checked_at.desc())
+        .limit(25)
+        .all()
+    )
+    for candidate in rows:
+        if not _within_stale_evidence_grace(candidate, now):
+            continue
+        try:
+            if _has_dns_evidence(_result_from_json(candidate.result_json)):
+                return candidate
+        except (TypeError, ValueError, json.JSONDecodeError):
+            logger.debug("Ignoring unreadable DNS cache row for %s", domain)
+    return None
+
+
+def _best_stale_cached_evidence(
+    db: Session,
+    row: Optional[DNSCache],
+    *,
+    domain: str,
+    provider_name: str,
+    selectors_key: str,
+    now: datetime,
+    lookup_error: str,
+) -> Optional[Tuple[DomainDNSResult, bool, datetime]]:
+    stale = _stale_cached_evidence(row, now=now, lookup_error=lookup_error)
+    if stale:
+        return stale
+
+    fallback_row = _latest_stale_evidence_row(
+        db,
+        domain=domain,
+        provider_name=provider_name,
+        now=now,
+        excluded_selectors_key=selectors_key,
+    )
+    return _stale_cached_evidence(fallback_row, now=now, lookup_error=lookup_error)
+
+
 def _lookup_failure_result(error_type: str, now: datetime) -> Tuple[DomainDNSResult, bool, datetime]:
     return (
         DomainDNSResult(
@@ -348,8 +402,12 @@ async def resolve_domain_dns_cached(
     except asyncio.CancelledError:
         raise
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        stale = _stale_cached_evidence(
+        stale = _best_stale_cached_evidence(
+            db,
             row,
+            domain=domain,
+            provider_name=provider_name,
+            selectors_key=selectors_key,
             now=now,
             lookup_error=(
                 f"DNS lookup failed with {exc.__class__.__name__}; "
@@ -369,8 +427,12 @@ async def resolve_domain_dns_cached(
         return _lookup_failure_result(exc.__class__.__name__, now)
 
     if not _has_dns_evidence(result):
-        stale = _stale_cached_evidence(
+        stale = _best_stale_cached_evidence(
+            db,
             row,
+            domain=domain,
+            provider_name=provider_name,
+            selectors_key=selectors_key,
             now=now,
             lookup_error="DNS resolver returned no DNS evidence; using the last known DNS cache.",
         )

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -121,20 +121,20 @@ def _latest_stale_evidence_row(
     now: datetime,
     excluded_selectors_key: str,
 ) -> Optional[DNSCache]:
+    grace_cutoff = now - timedelta(seconds=STALE_DNS_EVIDENCE_GRACE_SECONDS)
     rows = (
         db.query(DNSCache)
         .filter(
             DNSCache.domain == domain,
             DNSCache.provider == provider_name,
             DNSCache.selectors_key != excluded_selectors_key,
+            DNSCache.checked_at >= grace_cutoff,
         )
         .order_by(DNSCache.checked_at.desc())
         .limit(25)
         .all()
     )
     for candidate in rows:
-        if not _within_stale_evidence_grace(candidate, now):
-            continue
         try:
             if _has_dns_evidence(_result_from_json(candidate.result_json)):
                 return candidate
@@ -167,7 +167,9 @@ def _best_stale_cached_evidence(
     return _stale_cached_evidence(fallback_row, now=now, lookup_error=lookup_error)
 
 
-def _lookup_failure_result(error_type: str, now: datetime) -> Tuple[DomainDNSResult, bool, datetime]:
+def _lookup_failure_result(
+    error_type: str, now: datetime
+) -> Tuple[DomainDNSResult, bool, datetime]:
     return (
         DomainDNSResult(
             lookup_status="failed",
@@ -249,9 +251,7 @@ def _fallback_candidates(provider: BaseDNSProvider) -> List[BaseDNSProvider]:
         GoogleDNSProvider,
     ]
     provider_types = [provider.__class__] + [
-        fallback_type
-        for fallback_type in fallback_types
-        if not isinstance(provider, fallback_type)
+        fallback_type for fallback_type in fallback_types if not isinstance(provider, fallback_type)
     ]
     return [
         provider if index == 0 else provider_type()
@@ -366,8 +366,7 @@ async def _resolve_with_fallback(  # noqa: C901
         return empty_result
 
     raise LookupError(
-        "All DNS resolvers failed: "
-        + ", ".join(resolver_errors or ["no resolver attempted"])
+        "All DNS resolvers failed: " + ", ".join(resolver_errors or ["no resolver attempted"])
     )
 
 

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -139,7 +139,7 @@ def _latest_stale_evidence_row(
             if _has_dns_evidence(_result_from_json(candidate.result_json)):
                 return candidate
         except (TypeError, ValueError, json.JSONDecodeError):
-            logger.debug("Ignoring unreadable DNS cache row for %s", domain)
+            logger.debug("Ignoring unreadable stale DNS cache row")
     return None
 
 

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -228,6 +228,9 @@ function domainDetailsApp(domainId) {
                 if (button.matches('[data-domain-detail-reload]')) {
                     event.preventDefault();
                     this.reloadPageData();
+                } else if (button.matches('[data-domain-detail-refresh-dns]')) {
+                    event.preventDefault();
+                    this.refreshDNSData();
                 } else if (button.matches('[data-domain-detail-delete]')) {
                     event.preventDefault();
                     this.deleteDomain();
@@ -392,6 +395,19 @@ function domainDetailsApp(domainId) {
             }
         },
 
+        async refreshDNSData() {
+            await Promise.allSettled([
+                this.fetchDNSRecords({ refresh: true, preserveEvidenceOnFailure: true }),
+                this.fetchDNSHealth({ refresh: true }),
+                this.fetchDNSGuidance({ refresh: true }),
+                this.fetchPosture({ refresh: true }),
+                this.fetchRemediationQueue(),
+                this.fetchMtaSts({ refresh: true }),
+                this.fetchBimi({ refresh: true }),
+                this.fetchSelectors()
+            ]);
+        },
+
         loadStoredVolumeScale() {
             try {
                 return window.localStorage?.getItem('dmarq:domain-volume-scale') || null;
@@ -541,6 +557,28 @@ function domainDetailsApp(domainId) {
 
         get dnsLookupFailureText() {
             return this.dns.lookupError || 'DNS lookup failed; cached or report evidence may be incomplete.';
+        },
+
+        dnsResponseHasEvidence(dns) {
+            if (!dns) return false;
+            return Boolean(
+                dns.dmarc ||
+                dns.dmarcRecord ||
+                dns.spf ||
+                dns.spfRecord ||
+                dns.dkim ||
+                dns.dkimRecord ||
+                (Array.isArray(dns.dkimSelectors) && dns.dkimSelectors.length > 0) ||
+                (Array.isArray(dns.nameservers) && dns.nameservers.length > 0)
+            );
+        },
+
+        shouldPreserveCurrentDNS(responseDns, options = {}) {
+            if (!options.preserveEvidenceOnFailure) return false;
+            if (!this.dnsResponseHasEvidence(this.dns)) return false;
+            if (this.dnsResponseHasEvidence(responseDns)) return false;
+            const status = responseDns?.lookupStatus || 'ok';
+            return status === 'failed' || status === 'partial';
         },
 
         dnsRecordText(record, missingText, checkingText) {
@@ -1095,6 +1133,10 @@ function domainDetailsApp(domainId) {
                     throw new Error(detail || 'DNS records could not be loaded.');
                 }
                 const data = await response.json();
+                if (this.shouldPreserveCurrentDNS(data, options)) {
+                    this.dnsRecordsError = data.lookupError || 'Live DNS refresh did not return usable evidence. Keeping the last known DNS records on screen.';
+                    return;
+                }
                 this.dns = data;
                 this.syncDetectedDnsProvider();
             } catch (error) {
@@ -1206,11 +1248,7 @@ function domainDetailsApp(domainId) {
                         : 'DNS change submitted, but provider verification is not complete. Review the verification details before treating it as repaired.')
                     : 'Preview ready. Review the provider mutation before applying.';
                 if (apply) {
-                    await this.fetchDNSRecords();
-                    await this.fetchDNSHealth();
-                    await this.fetchDNSGuidance();
-                    await this.fetchPosture();
-                    await this.fetchRemediationQueue();
+                    await this.refreshDNSData();
                 }
                 return data;
             } catch (error) {
@@ -1607,13 +1645,7 @@ function domainDetailsApp(domainId) {
                 });
                 if (response.ok) {
                     this.newSelector = '';
-                    // Refresh selectors (both manual and report) and DNS check
-                    this.fetchSelectors();
-                    this.fetchDNSRecords();
-                    this.fetchDNSHealth();
-                    this.fetchDNSGuidance();
-                    this.fetchPosture();
-                    this.fetchMtaSts();
+                    await this.refreshDNSData();
                 } else {
                     const err = await response.json();
                     this.selectorError = err.detail || 'Failed to add selector';
@@ -1631,13 +1663,7 @@ function domainDetailsApp(domainId) {
                     { method: 'DELETE' }
                 );
                 if (response.ok) {
-                    // Refresh selectors (both manual and report) and DNS check
-                    this.fetchSelectors();
-                    this.fetchDNSRecords();
-                    this.fetchDNSHealth();
-                    this.fetchDNSGuidance();
-                    this.fetchPosture();
-                    this.fetchMtaSts();
+                    await this.refreshDNSData();
                 } else {
                     console.error('Error deleting selector:', response.status);
                 }

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -400,11 +400,7 @@ function domainDetailsApp(domainId) {
                 this.fetchDNSRecords({ refresh: true, preserveEvidenceOnFailure: true }),
                 this.fetchDNSHealth({ refresh: true }),
                 this.fetchDNSGuidance({ refresh: true }),
-                this.fetchPosture({ refresh: true }),
-                this.fetchRemediationQueue(),
-                this.fetchMtaSts({ refresh: true }),
-                this.fetchBimi({ refresh: true }),
-                this.fetchSelectors()
+                this.fetchPosture({ refresh: true })
             ]);
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1008,10 +1008,21 @@
         <section id="dns-records">
         {% call card() %}
             {% call card_header() %}
-                {% call card_title() %}DNS Records{% endcall %}
-                {% call card_description() %}
-                    Email authentication DNS records for this domain
-                {% endcall %}
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                        {% call card_title() %}DNS Records{% endcall %}
+                        {% call card_description() %}
+                            Email authentication DNS records for this domain
+                        {% endcall %}
+                    </div>
+                    <button type="button"
+                            class="btn btn-sm btn-default shrink-0"
+                            data-domain-detail-refresh-dns
+                            :disabled="dnsRecordsLoading">
+                        <span x-show="dnsRecordsLoading" class="loading loading-spinner loading-xs"></span>
+                        <span x-text="dnsRecordsLoading ? 'Refreshing DNS...' : 'Refresh DNS'"></span>
+                    </button>
+                </div>
             {% endcall %}
             {% call card_content() %}
                 <div class="grid gap-4">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -863,10 +863,13 @@ def test_domain_details_exposes_ownership_and_delete_controls_without_html_injec
 
     assert "Domain Ownership" in template
     assert "data-domain-detail-reload" in template
+    assert "data-domain-detail-refresh-dns" in template
     assert "data-domain-detail-delete" in template
     assert "data-domain-detail-verify-ownership" in template
     assert "data-domain-detail-verify-cloudflare" in template
     assert "data-domain-detail-reload" in script
+    assert "data-domain-detail-refresh-dns" in script
+    assert "refreshDNSData" in script
     assert "data-domain-detail-delete" in script
     assert "data-domain-detail-verify-ownership" in script
     assert "data-domain-detail-verify-cloudflare" in script
@@ -875,6 +878,7 @@ def test_domain_details_exposes_ownership_and_delete_controls_without_html_injec
     assert "Report mailbox access is enough" not in template
     assert "deleteDomain()" in script
     assert '@click="reloadPageData()"' not in template
+    assert '@click="refreshDNSData()"' not in template
     assert '@click="deleteDomain()"' not in template
     assert '@click="verifyDomainOwnership()"' not in template
     assert '@click="verifyDomainOwnershipCloudflare()"' not in template

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -901,6 +901,55 @@ async def test_dns_cache_keeps_recent_positive_evidence_when_lookup_turns_empty(
 
 
 @pytest.mark.asyncio
+async def test_dns_cache_uses_positive_evidence_from_previous_selector_set(db_session):
+    """Selector changes should not let a transient empty lookup hide known DNS records."""
+    healthy = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject",
+        spf=True,
+        spf_record="v=spf1 -all",
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+        dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
+    )
+    empty = DomainDNSResult(dmarc=False, spf=False, dkim=False)
+    provider = AsyncMock(check_domain=AsyncMock(return_value=empty))
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=provider.__class__.__name__,
+            selectors_key=_selectors_key(["pm20250806"]),
+            result_json=json.dumps(asdict(healthy), sort_keys=True, separators=(",", ":")),
+            checked_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=30),
+        )
+    )
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=provider.__class__.__name__,
+            selectors_key=_selectors_key(["pm20250806", "ab20250324"]),
+            result_json=json.dumps(asdict(empty), sort_keys=True, separators=(",", ":")),
+            checked_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=30),
+        )
+    )
+    db_session.commit()
+
+    result, cached, _checked = await resolve_domain_dns_cached(
+        db_session,
+        provider,
+        DOMAIN,
+        selectors=["pm20250806", "ab20250324"],
+        refresh=True,
+    )
+
+    assert cached is True
+    assert result.lookup_status == "stale_cache"
+    assert result.dmarc is True
+    assert result.spf is True
+    assert result.nameservers == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
+    assert provider.check_domain.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_dns_cache_uses_stale_positive_evidence_when_lookup_raises(db_session):
     """Transient resolver exceptions should keep known-good evidence with an explicit label."""
     healthy = DomainDNSResult(


### PR DESCRIPTION
## Summary\n- add a real DNS refresh control on domain detail pages\n- keep last known good DNS evidence on screen when a live refresh returns no usable data\n- reuse recent positive DNS cache evidence across selector-key changes so transient resolver misses do not drop domains to F\n- refresh DNS-dependent posture after DNS changes and selector edits\n\nFixes #577.\n\n## Local validation\n- /tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py::test_dns_cache_refreshes_stale_empty_dns_result backend/app/tests/test_dns_endpoints.py::test_dns_cache_keeps_recent_positive_evidence_when_lookup_turns_empty backend/app/tests/test_dns_endpoints.py::test_dns_cache_uses_positive_evidence_from_previous_selector_set backend/app/tests/test_dns_endpoints.py::test_dns_endpoint_refresh_bypasses_cache backend/app/tests/test_dashboard_template_security.py::test_domain_details_exposes_ownership_and_delete_controls_without_html_injection backend/app/tests/test_dashboard_template_security.py::test_domain_details_externalizes_detail_actions_without_inline_handlers backend/app/tests/test_dashboard_template_security.py::test_domain_details_distinguishes_loading_error_and_empty_states -q\n- /tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_mta_sts.py backend/app/tests/test_bimi.py backend/app/tests/test_dane.py -q\n- /tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/services/dns_cache.py backend/app/tests/test_dns_endpoints.py\n- node --check backend/app/static/js/domain-details-page.js\n- git diff --check