### PR TITLE
feat: add report reputation refresh control

### DIFF
--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -3,7 +3,7 @@ import ipaddress
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, File, Header, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Header, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -808,6 +808,7 @@ def _source_details(
 @router.get("/{report_id}", response_model=ReportDetail)
 async def get_report_by_id(
     report_id: str,
+    refresh_reputation: bool = Query(False, title="Refresh cached source reputation evidence"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
@@ -881,6 +882,7 @@ async def get_report_by_id(
             senders_by_ip=sender_by_ip,
             anomalies_by_ip={},
             days=1,
+            refresh=refresh_reputation,
         )
         reputations_by_ip = source_reputation_by_ip(reputation_result)
     except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/backend/app/services/source_reputation.py
+++ b/backend/app/services/source_reputation.py
@@ -581,13 +581,14 @@ def source_reputation_cache_key(
         if feed_providers is not None
         else _feed_fingerprint(feed_results_by_ip)
     )
-    return (
+    payload = (
         f"source-reputation:{int(days)}:"
         f"{_source_fingerprint(sources)}:"
         f"{_report_fingerprint(reports)}:"
         f"{_context_fingerprint(senders_by_ip, anomalies_by_ip)}:"
         f"{feed_fingerprint}"
     )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _feed_fingerprint(feed_results_by_ip: Optional[Dict[str, IPFeedReputation]]) -> str:

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -116,6 +116,8 @@ function domainDetailsApp(domainId) {
         sources: [],
         sourcesLoading: false,
         sourcesError: '',
+        sourceReputationRefreshing: false,
+        sourceReputationRefreshError: '',
         sourceIntelligence: {
             regions: [],
             anomalies: [],
@@ -231,6 +233,9 @@ function domainDetailsApp(domainId) {
                 } else if (button.matches('[data-domain-detail-refresh-dns]')) {
                     event.preventDefault();
                     this.refreshDNSData();
+                } else if (button.matches('[data-domain-detail-refresh-reputation]')) {
+                    event.preventDefault();
+                    this.refreshSourceReputation();
                 } else if (button.matches('[data-domain-detail-delete]')) {
                     event.preventDefault();
                     this.deleteDomain();
@@ -402,6 +407,18 @@ function domainDetailsApp(domainId) {
                 this.fetchDNSGuidance({ refresh: true }),
                 this.fetchPosture({ refresh: true })
             ]);
+        },
+
+        async refreshSourceReputation() {
+            this.sourceReputationRefreshing = true;
+            this.sourceReputationRefreshError = '';
+            try {
+                await this.fetchSources({ refresh: true, preserveOnFailure: true });
+            } catch (error) {
+                this.sourceReputationRefreshError = error.message || 'Source reputation could not be refreshed.';
+            } finally {
+                this.sourceReputationRefreshing = false;
+            }
         },
 
         loadStoredVolumeScale() {
@@ -1724,7 +1741,12 @@ function domainDetailsApp(domainId) {
                 const data = await response.json();
                 this.sources = data.sources || [];
             } catch (error) {
-                this.sources = [];
+                if (!options.preserveOnFailure) {
+                    this.sources = [];
+                }
+                if (options.preserveOnFailure) {
+                    this.sourceReputationRefreshError = error.message || 'Source reputation could not be refreshed.';
+                }
                 this.sourcesError = error.message || 'Sending sources could not be loaded.';
                 console.error('Error fetching sources:', error);
             } finally {

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -4,6 +4,8 @@ function reportDetailApp(reportId) {
         report: null,
         loading: true,
         error: null,
+        reputationRefreshing: false,
+        reputationRefreshError: '',
 
         async init() {
             this.bindPageControls();
@@ -28,6 +30,12 @@ function reportDetailApp(reportId) {
                     return;
                 }
 
+                const refreshReputationButton = event.target.closest('[data-report-refresh-reputation]');
+                if (refreshReputationButton && root.contains(refreshReputationButton)) {
+                    this.fetchReport({ refreshReputation: true });
+                    return;
+                }
+
                 const button = event.target.closest('[data-report-delete]');
                 if (!button || !root.contains(button)) {
                     return;
@@ -40,26 +48,49 @@ function reportDetailApp(reportId) {
             });
         },
 
-        async fetchReport() {
-            this.loading = true;
-            this.error = null;
+        async fetchReport(options = {}) {
+            const refreshReputation = Boolean(options.refreshReputation);
+            if (refreshReputation) {
+                this.reputationRefreshing = true;
+                this.reputationRefreshError = '';
+            } else {
+                this.loading = true;
+                this.error = null;
+            }
             try {
-                const response = await fetch(`/api/v1/reports/${encodeURIComponent(this.reportId)}`);
+                const query = refreshReputation ? '?refresh_reputation=true' : '';
+                const response = await fetch(`/api/v1/reports/${encodeURIComponent(this.reportId)}${query}`);
                 if (response.ok) {
                     this.report = await response.json();
                 } else if (response.status === 404) {
-                    this.report = null;
-                    this.error = `Report '${this.reportId}' was not found. It may have been deleted or may not exist.`;
+                    if (!refreshReputation) {
+                        this.report = null;
+                        this.error = `Report '${this.reportId}' was not found. It may have been deleted or may not exist.`;
+                    } else {
+                        this.reputationRefreshError = `Report '${this.reportId}' was not found.`;
+                    }
                 } else {
-                    this.report = null;
-                    this.error = 'Failed to load report. Please try again later.';
+                    if (!refreshReputation) {
+                        this.report = null;
+                        this.error = 'Failed to load report. Please try again later.';
+                    } else {
+                        this.reputationRefreshError = 'Reputation could not be refreshed. Please try again later.';
+                    }
                 }
             } catch (err) {
-                this.report = null;
-                this.error = 'Network error — could not load report.';
+                if (!refreshReputation) {
+                    this.report = null;
+                    this.error = 'Network error — could not load report.';
+                } else {
+                    this.reputationRefreshError = 'Network error — reputation could not be refreshed.';
+                }
                 console.error('Error fetching report:', err);
             } finally {
-                this.loading = false;
+                if (refreshReputation) {
+                    this.reputationRefreshing = false;
+                } else {
+                    this.loading = false;
+                }
             }
         },
 

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -62,6 +62,9 @@ function reportDetailApp(reportId) {
                 const response = await fetch(`/api/v1/reports/${encodeURIComponent(this.reportId)}${query}`);
                 if (response.ok) {
                     this.report = await response.json();
+                    if (!refreshReputation) {
+                        this.reputationRefreshError = '';
+                    }
                 } else if (response.status === 404) {
                     if (!refreshReputation) {
                         this.report = null;

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1555,9 +1555,14 @@
         <section id="sending-sources">
         {% call card() %}
             {% call card_header() %}
-                <div class="flex items-center justify-between">
-                    {% call card_title() %}Sending Sources{% endcall %}
-                    <div class="space-x-2">
+                <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                        {% call card_title() %}Sending Sources{% endcall %}
+                        {% call card_description() %}
+                            IP addresses and servers sending email as this domain
+                        {% endcall %}
+                    </div>
+                    <div class="flex flex-wrap gap-2">
                         <select x-model="filters.dateRange" class="select select-sm select-bordered">
                             <option value="7">Last 7 days</option>
                             <option value="30">Last 30 days</option>
@@ -1570,13 +1575,21 @@
                             placeholder="Filter sources..." 
                             class="input input-sm input-bordered max-w-xs"
                         >
+                        <button type="button"
+                                class="btn btn-sm btn-default"
+                                data-domain-detail-refresh-reputation
+                                :disabled="sourceReputationRefreshing || sourcesLoading">
+                            <span x-show="sourceReputationRefreshing" class="loading loading-spinner loading-xs"></span>
+                            <span x-text="sourceReputationRefreshing ? 'Refreshing reputation...' : 'Refresh reputation'"></span>
+                        </button>
                     </div>
                 </div>
-                {% call card_description() %}
-                    IP addresses and servers sending email as this domain
-                {% endcall %}
             {% endcall %}
             {% call card_content() %}
+                <p x-show="sourceReputationRefreshError"
+                   x-cloak
+                   class="mb-4 rounded-md border border-[#ffcfbd] bg-[#fff2ec] px-3 py-2 text-sm text-[#8a2d0d]"
+                   x-text="sourceReputationRefreshError"></p>
                 {% call table() %}
                     {% call thead() %}
                         {% call tr() %}
@@ -1740,7 +1753,7 @@
                                             </div>
                                         </template>
                                         <template x-if="!source.reputation">
-                                            <p class="text-muted-foreground">Reputation has not been calculated for this source yet.</p>
+                                            <p class="text-muted-foreground">Reputation has not been calculated for this source yet. Use Refresh reputation to recalculate cached IP evidence.</p>
                                         </template>
                                         <template x-if="!source.geo?.asn && !source.geo?.network && !source.reputation">
                                             <p class="text-muted-foreground">No ASN or reputation evidence available yet.</p>

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -61,6 +61,13 @@
                         <a href="/reports" class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]">
                             All Reports
                         </a>
+                        <button type="button"
+                                class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]"
+                                data-report-refresh-reputation
+                                :disabled="reputationRefreshing">
+                            <span x-show="reputationRefreshing" class="loading loading-spinner loading-xs"></span>
+                            <span x-text="reputationRefreshing ? 'Refreshing reputation...' : 'Recalculate reputation'"></span>
+                        </button>
                         <button class="btn btn-error btn-sm"
                                 data-report-delete
                                 :data-report-domain="report.domain"
@@ -181,6 +188,10 @@
                     {% endcall %}
                 {% endcall %}
                 {% call card_content() %}
+                    <p x-show="reputationRefreshError"
+                       x-cloak
+                       class="mb-4 rounded-md border border-[#ffcfbd] bg-[#fff2ec] px-3 py-2 text-sm text-[#8a2d0d]"
+                       x-text="reputationRefreshError"></p>
                     {% call table() %}
                         {% call thead() %}
                             {% call tr() %}
@@ -292,7 +303,7 @@
                                                     <span class="inline-flex items-center rounded bg-base-200 px-2 py-1 text-xs font-semibold text-base-content/70">
                                                         Reputation not calculated
                                                     </span>
-                                                    <p>Reload source intelligence to refresh reputation evidence for this IP.</p>
+                                                    <p>Use Recalculate reputation to refresh reputation feeds and cached IP evidence for this report.</p>
                                                 </div>
                                             </template>
                                         </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -591,6 +591,7 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "refresh_reputation=true" in script
     assert "reputationRefreshing" in template
     assert "reputationRefreshError" in template
+    assert "if (!refreshReputation) {\n                        this.reputationRefreshError = '';" in script
     assert "bindPageControls()" in script
     assert "event.target instanceof Element" in script
     assert "/api/v1/reports/${encodeURIComponent(this.reportId)}" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -586,6 +586,11 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "data-report-delete" in script
     assert "data-report-retry-load" in template
     assert "data-report-retry-load" in script
+    assert "data-report-refresh-reputation" in template
+    assert "data-report-refresh-reputation" in script
+    assert "refresh_reputation=true" in script
+    assert "reputationRefreshing" in template
+    assert "reputationRefreshError" in template
     assert "bindPageControls()" in script
     assert "event.target instanceof Element" in script
     assert "/api/v1/reports/${encodeURIComponent(this.reportId)}" in script
@@ -598,6 +603,7 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "this.report = null;" in script
     assert "record.reputation.feed_status" in template
     assert "record.reputation.feed_summary" in template
+    assert "Use Recalculate reputation" in template
     assert "reputationFeedClass" in script
     assert "reputationLabel" in script
     assert "reputationEvidencePreview" in script
@@ -974,6 +980,11 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "source.active_days" in template
     assert "source.report_count" in template
     assert "source.volume_history" in template
+    assert "data-domain-detail-refresh-reputation" in template
+    assert "data-domain-detail-refresh-reputation" in script
+    assert "refreshSourceReputation" in script
+    assert "sourceReputationRefreshing" in template
+    assert "sourceReputationRefreshError" in template
     assert "sourceSeenLabel" in script
     assert "sourceVolumeBars" in script
     assert "source.reputation.status" in template
@@ -985,7 +996,7 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "reputationFeedClass" in script
     assert "reputationLabel" in script
     assert "reputationEvidencePreview" in script
-    assert "Reputation has not been calculated for this source yet." in template
+    assert "Use Refresh reputation" in template
     assert 'colspan="9"' in template
     assert "x-effect=\"$el.style.height = point.height + '%'" in template
     assert "x-html" not in template

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -958,6 +958,55 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
     assert record["reputation"]["listings"] == ["Example DNSBL"]
 
 
+def test_get_report_by_id_refreshes_reputation_cache(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Report detail refresh should force cached reputation evidence to recalculate."""
+    workspace = get_or_create_default_workspace(db_session)
+    _persist_parsed_report(
+        db_session,
+        _parsed_report(domain="example.com", report_id="source-intel-refresh-report"),
+        workspace_id=workspace.id,
+    )
+    captured_refresh = []
+
+    async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
+        return "mail.example-sender.net"
+
+    async def fake_reputation(*_args, **kwargs):
+        captured_refresh.append(kwargs.get("refresh"))
+        return (
+            DomainReputation(
+                domain="example.com",
+                status="clean",
+                checked_at="2026-07-01T00:00:00Z",
+                sources=[
+                    SourceReputation(
+                        ip="192.0.2.55",
+                        status="clean",
+                        risk_score=4,
+                        summary="No external reputation listing observed.",
+                        checked_at="2026-07-01T00:00:00Z",
+                    )
+                ],
+                summary={"total_sources": 1, "clean": 1},
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+
+    response = authed_client.get("/api/v1/reports/source-intel-refresh-report?refresh_reputation=true")
+
+    assert response.status_code == 200
+    assert captured_refresh == [True]
+    assert response.json()["records"][0]["reputation"]["status"] == "clean"
+
+
 def test_get_report_by_id_continues_when_reputation_enrichment_fails(
     authed_client: TestClient,
     db_session,

--- a/backend/app/tests/test_source_reputation.py
+++ b/backend/app/tests/test_source_reputation.py
@@ -6,6 +6,7 @@ from app.services.source_reputation import (
     build_source_reputation,
     build_source_reputation_cached,
     reputation_presentation,
+    source_reputation_cache_key,
     source_reputation_by_ip,
 )
 from app.services.source_reputation_feeds import FeedLookupEvidence, IPFeedReputation
@@ -373,6 +374,48 @@ async def test_build_source_reputation_cached_includes_reports_in_cache_key(db_s
     assert second_cached is False
     assert source_reputation_by_ip(first)["203.0.113.10"].first_seen == 1_700_000_000
     assert source_reputation_by_ip(second)["203.0.113.10"].first_seen == 1_800_000_000
+
+
+def test_source_reputation_cache_key_fits_dns_cache_selector_column():
+    """Real source context still fits the shared DNS cache selector column."""
+    sources = [
+        {
+            "source_ip": f"203.0.113.{index}",
+            "count": index + 1,
+            "dmarc_fail_count": index % 3,
+            "extensions": {"demo:source": f"sender-{index}", "demo:reputation": "clean"},
+        }
+        for index in range(20)
+    ]
+    reports = [
+        {
+            "domain": "example.com",
+            "begin_date": 1_800_000_000 + index * 86_400,
+            "end_date": 1_800_086_400 + index * 86_400,
+            "records": [{"source_ip": source["source_ip"]} for source in sources],
+        }
+        for index in range(4)
+    ]
+
+    key = source_reputation_cache_key(
+        sources,
+        reports,
+        senders_by_ip={
+            source["source_ip"]: {
+                "id": "provider-with-a-long-name",
+                "name": "Provider With Long Name",
+                "confidence": 95,
+            }
+            for source in sources
+        },
+        anomalies_by_ip={
+            source["source_ip"]: [{"type": "volume_spike", "severity": "medium"}]
+            for source in sources
+        },
+        days=90,
+    )
+
+    assert len(key) == 64
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- adds report-detail and domain-detail controls to refresh cached sender reputation evidence without losing the currently visible rows
- wires `refresh_reputation=true` through the report endpoint so operators can force a fresh feed/cache calculation
- fixes the live PostgreSQL cache failure by hashing source-reputation cache keys to fit the existing 64-character selector column

## Validation
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_reports_api.py backend/app/tests/test_dashboard_template_security.py -q`
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_source_reputation.py backend/app/tests/test_source_reputation_feeds.py backend/app/tests/test_reports_api.py::test_get_report_by_id_includes_source_intelligence_and_reputation backend/app/tests/test_reports_api.py::test_get_report_by_id_refreshes_reputation_cache backend/app/tests/test_reports_api.py::test_get_report_by_id_continues_when_reputation_enrichment_fails -q`
- `node --check backend/app/static/js/report-detail-page.js && node --check backend/app/static/js/domain-details-page.js`
- `/tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/services/source_reputation.py backend/app/tests/test_source_reputation.py backend/app/api/api_v1/endpoints/reports.py`
- `git diff --check`

Closes #578


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “refresh reputation” action on report and domain detail pages to recalculate cached reputation data on demand.
  * Report details now support a refresh option in the API, letting users reload reputation-related results without redoing the entire report.

* **Bug Fixes**
  * Improved error handling so failed refreshes keep existing results visible and show a clear message.
  * Updated cache key handling to use a consistent fixed-length value for reputation lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->