### PR TITLE
fix: parallelize DKIM selector DNS checks

### DIFF
--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -409,6 +409,24 @@ class BaseDNSProvider(ABC):
         """Return TLSA record strings for *name* when available."""
         return []
 
+    async def _check_one_dkim_selector(
+        self, domain: str, selector: str
+    ) -> Tuple[str, Optional[str]]:
+        """Return the selector and first valid DKIM record for one selector."""
+        try:
+            records = await self.lookup_txt(f"{selector}._domainkey.{domain}")
+            for record in records:
+                if "v=dkim1" in record.lower() or "p=" in record.lower():
+                    return selector, record
+        except LookupError as exc:
+            logger.debug(
+                "DKIM lookup failed for selector=%s domain=%s: %s",
+                selector,
+                _sanitize_for_log(domain),
+                exc,
+            )
+        return selector, None
+
     async def check_dkim(
         self, domain: str, selectors: List[str]
     ) -> Tuple[bool, List[str], Optional[str]]:
@@ -418,25 +436,21 @@ class BaseDNSProvider(ABC):
         a valid DKIM TXT record is collected.  The boolean is ``True`` when at
         least one selector resolved.  *first_record_string* is the record text
         for the first matching selector (useful for display purposes).
+
+        Selector lookups are parallel so slow common-selector guesses do not
+        block otherwise valid DMARC/SPF/nameserver evidence.  ``gather`` keeps
+        input order, preserving manual selector priority in the response.
         """
-        matching_selectors: List[str] = []
-        first_record: Optional[str] = None
-        for selector in selectors:
-            try:
-                records = await self.lookup_txt(f"{selector}._domainkey.{domain}")
-                for record in records:
-                    if "v=dkim1" in record.lower() or "p=" in record.lower():
-                        matching_selectors.append(selector)
-                        if first_record is None:
-                            first_record = record
-                        break
-            except LookupError as exc:
-                logger.debug(
-                    "DKIM lookup failed for selector=%s domain=%s: %s",
-                    selector,
-                    _sanitize_for_log(domain),
-                    exc,
-                )
+        selector_results = await asyncio.gather(
+            *(self._check_one_dkim_selector(domain, selector) for selector in selectors)
+        )
+        matching_selectors = [
+            selector for selector, record in selector_results if record is not None
+        ]
+        first_record = next(
+            (record for _selector, record in selector_results if record is not None),
+            None,
+        )
         return bool(matching_selectors), matching_selectors, first_record
 
     async def check_domain(

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -537,6 +537,10 @@ function domainDetailsApp(domainId) {
             return this.dns.lookupStatus === 'failed';
         },
 
+        get dnsEvidenceUnavailable() {
+            return Boolean(this.dnsRecordsError) || this.dnsLookupFailed;
+        },
+
         get dnsLookupStaleCache() {
             return this.dns.lookupStatus === 'stale_cache';
         },
@@ -594,6 +598,7 @@ function domainDetailsApp(domainId) {
 
         dnsRecordText(record, missingText, checkingText) {
             if (this.dnsRecordsLoading) return checkingText;
+            if (this.dnsRecordsError) return 'DNS evidence unavailable. Reload DNS to retry the live lookup.';
             if (this.dnsLookupFailed) return this.dnsLookupFailureText;
             return record || missingText;
         },
@@ -608,12 +613,14 @@ function domainDetailsApp(domainId) {
 
         get dnsProviderName() {
             if (this.dnsRecordsLoading) return 'Checking DNS provider...';
+            if (this.dnsRecordsError) return 'DNS evidence unavailable';
             if (this.dnsLookupFailed) return 'DNS lookup failed';
             return this.detectedDnsProvider?.provider_name || 'Unknown provider';
         },
 
         get dnsProviderConfidence() {
             if (this.dnsRecordsLoading) return 'checking';
+            if (this.dnsRecordsError) return 'unavailable';
             if (this.dnsLookupFailed) return 'unavailable';
             return this.detectedDnsProvider?.confidence || 'unknown';
         },
@@ -635,6 +642,7 @@ function domainDetailsApp(domainId) {
 
         get dnsNameserverText() {
             if (this.dnsRecordsLoading) return 'Checking nameservers...';
+            if (this.dnsRecordsError) return 'DNS evidence unavailable. Reload DNS to retry.';
             if (this.dnsLookupFailed) return this.dnsLookupFailureText;
             const nameservers = this.dns.nameservers || this.detectedDnsProvider?.evidence || [];
             return nameservers.length ? nameservers.join(', ') : 'No NS evidence available yet';
@@ -642,6 +650,7 @@ function domainDetailsApp(domainId) {
 
         get providerContextStatusLabel() {
             if (this.dnsRecordsLoading) return 'checking';
+            if (this.dnsRecordsError) return 'unavailable';
             return {
                 connected: 'connected',
                 read_only: 'read-only',
@@ -662,17 +671,20 @@ function domainDetailsApp(domainId) {
 
         get providerContextSummary() {
             if (this.dnsRecordsLoading) return 'Checking provider connection and safe DNS repair options.';
+            if (this.dnsRecordsError) return 'Live DNS evidence is not available yet, so DMARQ is not making repair assumptions.';
             return this.providerContext?.summary || this.dnsProviderAction;
         },
 
         get providerContextSteps() {
             if (this.dnsRecordsLoading) return ['Wait for DNS checks to complete.'];
+            if (this.dnsRecordsError) return ['Reload DNS after the resolver finishes or network timeouts clear.'];
             const steps = this.providerContext?.next_steps || [];
             return steps.length ? steps : ['Review the DNS lint findings and apply changes manually.'];
         },
 
         get providerContextCtaLabel() {
             if (this.dnsRecordsLoading) return 'Checking...';
+            if (this.dnsRecordsError) return 'Reload DNS';
             return this.providerContext?.cta_label || 'Review DNS guidance';
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1086,8 +1086,8 @@
                             <span class="mr-2">DMARC Record</span>
                             <span x-show="dnsRecordsLoading" class="loading loading-spinner loading-xs"></span>
                             <span x-show="!dnsRecordsLoading && dns.dmarc" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
-                            <span x-show="!dnsRecordsLoading && dnsLookupFailed" class="inline-flex h-2 w-2 rounded-full bg-yellow-500"></span>
-                            <span x-show="!dnsRecordsLoading && !dnsLookupFailed && !dns.dmarc" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
+                            <span x-show="!dnsRecordsLoading && dnsEvidenceUnavailable" class="inline-flex h-2 w-2 rounded-full bg-yellow-500"></span>
+                            <span x-show="!dnsRecordsLoading && !dnsEvidenceUnavailable && !dns.dmarc" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
                         </h3>
                         <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono" x-text="dnsRecordText(dns.dmarcRecord, 'No DMARC record found', 'Checking DMARC record...')">-</div>
                     </div>
@@ -1096,8 +1096,8 @@
                             <span class="mr-2">SPF Record</span>
                             <span x-show="dnsRecordsLoading" class="loading loading-spinner loading-xs"></span>
                             <span x-show="!dnsRecordsLoading && dns.spf" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
-                            <span x-show="!dnsRecordsLoading && dnsLookupFailed" class="inline-flex h-2 w-2 rounded-full bg-yellow-500"></span>
-                            <span x-show="!dnsRecordsLoading && !dnsLookupFailed && !dns.spf" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
+                            <span x-show="!dnsRecordsLoading && dnsEvidenceUnavailable" class="inline-flex h-2 w-2 rounded-full bg-yellow-500"></span>
+                            <span x-show="!dnsRecordsLoading && !dnsEvidenceUnavailable && !dns.spf" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
                         </h3>
                         <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono" x-text="dnsRecordText(dns.spfRecord, 'No SPF record found', 'Checking SPF record...')">-</div>
                     </div>
@@ -1155,7 +1155,8 @@
                             <span class="mr-2">DKIM (live check)</span>
                             <span x-show="dnsRecordsLoading" class="loading loading-spinner loading-xs"></span>
                             <span x-show="!dnsRecordsLoading && dns.dkim" class="inline-flex h-2 w-2 rounded-full bg-green-500"></span>
-                            <span x-show="!dnsRecordsLoading && !dns.dkim" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
+                            <span x-show="!dnsRecordsLoading && dnsEvidenceUnavailable" class="inline-flex h-2 w-2 rounded-full bg-yellow-500"></span>
+                            <span x-show="!dnsRecordsLoading && !dnsEvidenceUnavailable && !dns.dkim" class="inline-flex h-2 w-2 rounded-full bg-red-500"></span>
                         </h3>
                         <div class="bg-muted p-2 rounded text-sm overflow-x-auto font-mono"
                              x-text="dkimLiveText">-</div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1020,7 +1020,8 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "dnsRecordsLoading" in template
     assert "Checking DMARC record..." in template
     assert "DNS records could not be loaded." in script
-    assert "dnsLookupFailed" in template
+    assert "dnsEvidenceUnavailable" in template
+    assert "DNS evidence unavailable. Reload DNS to retry the live lookup." in script
     assert "dnsLookupStaleCache" in script
     assert "dnsLookupFallback" in script
     assert "dnsLookupNoticeVisible" in template

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -463,15 +463,20 @@ async def test_check_dkim_queries_selectors_in_parallel_and_preserves_priority()
     provider = SlowSelectorProvider()
     task = asyncio.create_task(provider.check_dkim("example.com", ["manual", "common"]))
 
-    for _attempt in range(20):
-        if provider.started == 2:
-            break
-        await asyncio.sleep(0)
+    try:
+        for _attempt in range(20):
+            if provider.started == 2:
+                break
+            await asyncio.sleep(0)
 
-    assert provider.started == 2
-    provider.release.set()
+        assert provider.started == 2
+        provider.release.set()
 
-    found, selectors, record = await task
+        found, selectors, record = await task
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
     assert found is True
     assert selectors == ["manual", "common"]

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -5,6 +5,7 @@ DNS network I/O is mocked at the ``lookup_txt`` level so no real DNS queries
 are made during testing.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -439,6 +440,42 @@ async def test_check_dkim_found_multiple_selectors():
     assert "mail" in selectors
     assert len(selectors) == 2
     assert record is not None  # record of the first match
+
+
+@pytest.mark.asyncio
+async def test_check_dkim_queries_selectors_in_parallel_and_preserves_priority():
+    """Slow selector guesses should not serialize the whole DNS refresh."""
+
+    class SlowSelectorProvider(BaseDNSProvider):
+        def __init__(self):
+            self.started = 0
+            self.release = asyncio.Event()
+
+        async def lookup_txt(self, name: str):
+            self.started += 1
+            await self.release.wait()
+            if name == "manual._domainkey.example.com":
+                return ["v=DKIM1; k=rsa; p=MANUAL"]
+            if name == "common._domainkey.example.com":
+                return ["v=DKIM1; k=rsa; p=COMMON"]
+            raise LookupError("NXDOMAIN")
+
+    provider = SlowSelectorProvider()
+    task = asyncio.create_task(provider.check_dkim("example.com", ["manual", "common"]))
+
+    for _attempt in range(20):
+        if provider.started == 2:
+            break
+        await asyncio.sleep(0)
+
+    assert provider.started == 2
+    provider.release.set()
+
+    found, selectors, record = await task
+
+    assert found is True
+    assert selectors == ["manual", "common"]
+    assert record == "v=DKIM1; k=rsa; p=MANUAL"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- parallelize DKIM selector TXT lookups so slow common-selector guesses do not block domain DNS refreshes
- preserve manual selector priority and existing DKIM response order
- add a regression test proving parallel selector startup and stable first-record selection

## Validation
- /tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_dns_resolver.py backend/app/tests/test_dns_endpoints.py -q
- /tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/services/dns_resolver.py backend/app/tests/test_dns_resolver.py
- git diff --check

Follow-up for #577.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNS status messages now better distinguish between missing records and DNS data that could not be retrieved.
  * DKIM checks are faster and preserve selector priority while handling multiple selectors more reliably.
  * Status indicators for DMARC, SPF, and DKIM now show clearer unavailable/error states.

* **Tests**
  * Updated coverage for DNS failure messaging and DKIM lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->