### PR TITLE
fix: harden reputation refresh errors

### DIFF
--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -722,6 +722,15 @@ async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Opti
         return None
 
 
+def _raise_refresh_reputation_failure(refresh_reputation: bool, exc: Exception) -> None:
+    if not refresh_reputation:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Source reputation could not be refreshed.",
+    ) from exc
+
+
 def _source_row_from_report_record(record: Dict[str, Any]) -> Dict[str, Any]:
     """Convert one report record into the source-row shape used by reputation scoring."""
     count = int(record.get("count") or 0)
@@ -890,6 +899,7 @@ async def get_report_by_id(
             "Report source reputation enrichment failed for report detail: %s",
             type(exc).__name__,
         )
+        _raise_refresh_reputation_failure(refresh_reputation, exc)
 
     # Normalize records
     record_details = []

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -414,8 +414,6 @@ function domainDetailsApp(domainId) {
             this.sourceReputationRefreshError = '';
             try {
                 await this.fetchSources({ refresh: true, preserveOnFailure: true });
-            } catch (error) {
-                this.sourceReputationRefreshError = error.message || 'Source reputation could not be refreshed.';
             } finally {
                 this.sourceReputationRefreshing = false;
             }
@@ -1740,14 +1738,15 @@ function domainDetailsApp(domainId) {
                 }
                 const data = await response.json();
                 this.sources = data.sources || [];
+                this.sourceReputationRefreshError = '';
             } catch (error) {
                 if (!options.preserveOnFailure) {
                     this.sources = [];
+                    this.sourcesError = error.message || 'Sending sources could not be loaded.';
                 }
                 if (options.preserveOnFailure) {
                     this.sourceReputationRefreshError = error.message || 'Source reputation could not be refreshed.';
                 }
-                this.sourcesError = error.message || 'Sending sources could not be loaded.';
                 console.error('Error fetching sources:', error);
             } finally {
                 this.sourcesLoading = false;

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -59,7 +59,19 @@ function reportDetailApp(reportId) {
             }
             try {
                 const query = refreshReputation ? '?refresh_reputation=true' : '';
-                const response = await fetch(`/api/v1/reports/${encodeURIComponent(this.reportId)}${query}`);
+                const requestUrl = `/api/v1/reports/${encodeURIComponent(this.reportId)}${query}`;
+                let response;
+                if (refreshReputation) {
+                    const controller = new AbortController();
+                    const timeout = window.setTimeout(() => controller.abort(), 30000);
+                    try {
+                        response = await fetch(requestUrl, { signal: controller.signal });
+                    } finally {
+                        window.clearTimeout(timeout);
+                    }
+                } else {
+                    response = await fetch(requestUrl);
+                }
                 if (response.ok) {
                     this.report = await response.json();
                     if (!refreshReputation) {
@@ -73,17 +85,21 @@ function reportDetailApp(reportId) {
                         this.reputationRefreshError = `Report '${this.reportId}' was not found.`;
                     }
                 } else {
+                    const data = await response.json().catch(() => ({}));
+                    const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
                     if (!refreshReputation) {
                         this.report = null;
-                        this.error = 'Failed to load report. Please try again later.';
+                        this.error = detail || 'Failed to load report. Please try again later.';
                     } else {
-                        this.reputationRefreshError = 'Reputation could not be refreshed. Please try again later.';
+                        this.reputationRefreshError = detail || 'Reputation could not be refreshed. Please try again later.';
                     }
                 }
             } catch (err) {
                 if (!refreshReputation) {
                     this.report = null;
                     this.error = 'Network error — could not load report.';
+                } else if (err?.name === 'AbortError') {
+                    this.reputationRefreshError = 'Reputation refresh timed out. Please try again in a moment.';
                 } else {
                     this.reputationRefreshError = 'Network error — reputation could not be refreshed.';
                 }

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -592,6 +592,8 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "reputationRefreshing" in template
     assert "reputationRefreshError" in template
     assert "if (!refreshReputation) {\n                        this.reputationRefreshError = '';" in script
+    assert "Reputation refresh timed out. Please try again in a moment." in script
+    assert "const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;" in script
     assert "bindPageControls()" in script
     assert "event.target instanceof Element" in script
     assert "/api/v1/reports/${encodeURIComponent(this.reportId)}" in script
@@ -986,6 +988,8 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "refreshSourceReputation" in script
     assert "sourceReputationRefreshing" in template
     assert "sourceReputationRefreshError" in template
+    assert "this.sourceReputationRefreshError = '';" in script
+    assert "if (!options.preserveOnFailure) {\n                    this.sources = [];" in script
     assert "sourceSeenLabel" in script
     assert "sourceVolumeBars" in script
     assert "source.reputation.status" in template

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -1036,6 +1036,33 @@ def test_get_report_by_id_continues_when_reputation_enrichment_fails(
     assert record["reputation"] is None
 
 
+def test_get_report_by_id_surfaces_refresh_reputation_failure(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    workspace = get_or_create_default_workspace(db_session)
+    _persist_parsed_report(
+        db_session,
+        _parsed_report(domain="example.com", report_id="source-intel-refresh-failure"),
+        workspace_id=workspace.id,
+    )
+
+    async def failing_reputation(*_args, **_kwargs):
+        raise RuntimeError("provider unavailable")
+
+    async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
+        return None
+
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", failing_reputation)
+
+    response = authed_client.get("/api/v1/reports/source-intel-refresh-failure?refresh_reputation=true")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Source reputation could not be refreshed."
+
+
 def test_safe_ptr_lookup_returns_none_for_invalid_or_failed_lookup():
     class FailingProvider:
         async def lookup_ptr(self, _ip):


### PR DESCRIPTION
## Summary
- surface refresh-specific reputation failures from the report detail API
- clear stale source/report reputation refresh errors after successful reloads
- add refresh timeout handling and backend detail display for report refreshes

## Validation
- git diff --check origin/main...HEAD
- node --check backend/app/static/js/report-detail-page.js
- node --check backend/app/static/js/domain-details-page.js
- flake8 backend/app/api/api_v1/endpoints/reports.py backend/app/tests/test_reports_api.py backend/app/tests/test_dashboard_template_security.py
- pytest backend/app/tests/test_dashboard_template_security.py -k 'report_detail_uses_external_page_script_for_csp_migration or source_ip_intelligence' -q
- pytest backend/app/tests/test_reports_api.py -k 'refresh_reputation or reputation_enrichment_fails' -q