### PR TITLE
Fix optional posture score weighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up root directory for clarity
 
 ### Fixed
+- Fixed domain posture scoring so optional MTA-STS/BIMI gaps stay visible as actions without collapsing otherwise healthy DMARC/SPF/DKIM domains to an F-grade impression.
 - Fixed report detail views so sender-IP reputation appears as a dedicated score and assessment column instead of being buried in source metadata.
 - Fixed DNS fallback behavior so independent public resolvers are checked in parallel before a transient timeout can make records appear missing.
 - Fixed domain sending-source loading so PTR and network enrichment run in parallel instead of pushing report-backed source rows past the UI timeout.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2667,8 +2667,7 @@ def _build_posture_dashboard(
     domain_health: Dict[str, Any],
     changes: List[Dict[str, Any]],
 ) -> PostureDashboardResponse:
-    passing = sum(1 for check in health.checks if check.status == "pass")
-    score = round((passing / len(health.checks)) * 100) if health.checks else 0
+    score = _posture_score(health.checks)
     coverage = [
         PostureCoverageItem(
             key=check.key,
@@ -2691,6 +2690,26 @@ def _build_posture_dashboard(
         changes=_change_summaries(changes),
         playbooks=_operator_playbooks(health.recommendations),
     )
+
+
+def _posture_score(checks: List[DNSHealthCheck]) -> int:
+    """Score posture with DMARC/SPF/DKIM as core controls and optional controls as light weight."""
+    if not checks:
+        return 0
+    weights = {
+        "dmarc": 35,
+        "spf": 25,
+        "dkim": 25,
+        "mta_sts": 10,
+        "bimi": 5,
+    }
+    total_weight = sum(weights.get(check.key, 0) for check in checks)
+    if total_weight <= 0:
+        return 0
+    passing_weight = sum(
+        weights.get(check.key, 0) for check in checks if check.status == "pass"
+    )
+    return round((passing_weight / total_weight) * 100)
 
 
 def _history_response_from_points(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1541,7 +1541,7 @@ def test_posture_dashboard_links_recommendations_changes_and_playbooks(
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "degraded"
-    assert data["score"] == 80
+    assert data["score"] == 75
     assert data["health"]["domain"] == DOMAIN
     assert data["health"]["grade"] in {"A+", "A", "A-", "B+", "B", "B-", "C", "D", "F"}
     assert isinstance(data["health"]["score"], int)
@@ -1595,6 +1595,37 @@ def test_posture_dashboard_distinguishes_mta_sts_policy_hosting_failure(
     assert "Rotate the TXT id" in recommendation["action"]
     assert any(playbook["key"] == "mta_sts_policy_unreachable" for playbook in data["playbooks"])
     assert all(item["type"] != "missing_mta_sts" for item in data["recommendations"])
+    assert data["score"] == 85
+    assert data["health"]["grade"] != "F"
+
+
+def test_posture_dashboard_weights_optional_controls_below_core_authentication(
+    authed_client: TestClient,
+):
+    """Missing optional posture checks should not collapse a core-authenticated domain."""
+    mta_sts = MTAStsResult(errors=["No _mta-sts TXT record was found."])
+    bimi = BIMIResult(errors=["No BIMI TXT record was found at the selector."])
+
+    with (
+        _mock_dns(result=MOCK_DNS_RESULT),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(mta_sts, False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(bimi, False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/posture")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "degraded"
+    assert data["score"] == 85
+    assert data["health"]["grade"] != "F"
+    recommendation_types = {item["type"] for item in data["recommendations"]}
+    assert {"missing_mta_sts", "missing_bimi"}.issubset(recommendation_types)
 
 
 def test_posture_dashboard_refreshes_health_grade_dns(


### PR DESCRIPTION
## Summary
- weight posture scoring around core DMARC/SPF/DKIM controls instead of treating optional controls equally
- keep MTA-STS/BIMI gaps visible as recommendations without collapsing otherwise healthy domains
- add regression coverage for core-authenticated domains with optional posture gaps
- update changelog

Closes #586

## Local validation
- /tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py backend/app/tests/test_health_score.py -q
- /tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_health_score.py
- git diff --check