### PR TITLE
Align release metadata with built image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,9 +235,15 @@ jobs:
         env:
           IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
         run: |
+          FULL_SHA=$(git rev-parse HEAD)
           SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          BUILD_REF=$(git symbolic-ref --short HEAD 2>/dev/null || git describe --tags --exact-match HEAD 2>/dev/null || git rev-parse --short=12 HEAD)
+          BUILD_DATE=$(git show -s --format=%cI HEAD)
           echo "image=${IMAGE_REPOSITORY}:${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "full_sha=${FULL_SHA}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "build_ref=${BUILD_REF}" >> "$GITHUB_OUTPUT"
+          echo "build_date=${BUILD_DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -272,10 +278,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            DMARQ_BUILD_SHA=${{ github.sha }}
-            DMARQ_BUILD_REF=${{ github.ref_name }}
+            DMARQ_BUILD_SHA=${{ steps.release_ref.outputs.full_sha }}
+            DMARQ_BUILD_REF=${{ steps.release_ref.outputs.build_ref }}
             DMARQ_BUILD_IMAGE=${{ steps.release_ref.outputs.image }}
-            DMARQ_BUILD_DATE=${{ github.event.head_commit.timestamp }}
+            DMARQ_BUILD_DATE=${{ steps.release_ref.outputs.build_date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed domain posture scoring so optional MTA-STS/BIMI gaps stay visible as actions without collapsing otherwise healthy DMARC/SPF/DKIM domains to an F-grade impression.
+- Fixed Docker release metadata so the in-product build SHA, ref, and date come from the checked-out image source instead of the workflow trigger commit.
 - Fixed report detail views so sender-IP reputation appears as a dedicated score and assessment column instead of being buried in source metadata.
 - Fixed DNS fallback behavior so independent public resolvers are checked in parallel before a transient timeout can make records appear missing.
 - Fixed domain sending-source loading so PTR and network enrichment run in parallel instead of pushing report-backed source rows past the UI timeout.

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -2,8 +2,11 @@ import importlib.util
 from pathlib import Path
 
 
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
 def _load_script_module():
-    script_path = Path(__file__).resolve().parents[3] / "scripts" / "check_release_rollout.py"
+    script_path = REPO_ROOT / "scripts" / "check_release_rollout.py"
     spec = importlib.util.spec_from_file_location("check_release_rollout", script_path)
     module = importlib.util.module_from_spec(spec)
     assert spec and spec.loader
@@ -55,3 +58,21 @@ def test_release_rollout_compare_reports_drift():
     assert any("environment expected demo" in failure for failure in failures)
     assert any("build SHA expected prefix deadbee" in failure for failure in failures)
     assert any("image expected ghcr.io/christianlouis/dmarq:deadbee" in failure for failure in failures)
+
+
+def test_release_workflow_build_metadata_uses_checked_out_ref():
+    """Docker build metadata must describe the commit used to build the image."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "FULL_SHA=$(git rev-parse HEAD)" in workflow
+    assert "DMARQ_BUILD_SHA=${{ steps.release_ref.outputs.full_sha }}" in workflow
+    assert "DMARQ_BUILD_REF=${{ steps.release_ref.outputs.build_ref }}" in workflow
+    assert "DMARQ_BUILD_DATE=${{ steps.release_ref.outputs.build_date }}" in workflow
+    build_args = workflow.split("build-args: |", maxsplit=1)[1].split(
+        "cache-from:", maxsplit=1
+    )[0]
+    assert "github.sha" not in build_args
+    assert "github.ref_name" not in build_args
+    assert "github.event.head_commit.timestamp" not in build_args


### PR DESCRIPTION
## Summary
- derive Docker build SHA, ref, and date from the checked-out image source
- keep the short-SHA image tag and release endpoint metadata tied to the same commit
- add workflow regression coverage so build args do not drift back to trigger metadata
- update changelog

Closes #583

## Local validation
- /tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_release_rollout_script.py backend/app/tests/test_api.py::test_release_info_endpoint_exposes_safe_build_metadata backend/app/tests/test_api.py::test_api_health_includes_release_summary backend/app/tests/test_api.py::test_root_healthz_includes_release_summary -q
- /tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/tests/test_release_rollout_script.py
- git diff --check