### PR TITLE
Fix Cloudflare OAuth invalid-scope recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed domain posture scoring so optional MTA-STS/BIMI gaps stay visible as actions without collapsing otherwise healthy DMARC/SPF/DKIM domains to an F-grade impression.
 - Fixed Docker release metadata so the in-product build SHA, ref, and date come from the checked-out image source instead of the workflow trigger commit.
+- Fixed Cloudflare OAuth recovery so invalid-scope callbacks offer a read-only retry path and stale legacy scopes such as `user.read` are filtered from DMARQ-generated requests.
 - Fixed report detail views so sender-IP reputation appears as a dedicated score and assessment column instead of being buried in source metadata.
 - Fixed DNS fallback behavior so independent public resolvers are checked in parallel before a transient timeout can make records appear missing.
 - Fixed domain sending-source loading so PTR and network enrichment run in parallel instead of pushing report-backed source rows past the UI timeout.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -5336,12 +5336,16 @@ async def cloudflare_oauth_callback(
                     for permission in profile.get("required_permissions", [])
                 )
                 requested_scopes = html.escape(cloudflare_scopes_for_profile(profile_id))
+                retry_href = "/settings?cloudflare_scope_profile=read_only&cloudflare_retry=1"
                 details += (
                     "<p>The selected rights profile requests a scope that this Cloudflare "
                     "OAuth client is not allowed to request. Choose a lower rights profile "
                     "or update the allowed scopes on the Cloudflare OAuth client.</p>"
                     f"<p><strong>Selected profile:</strong> {html.escape(profile_id)}</p>"
                     f"<p><strong>Requested scopes:</strong> <code>{requested_scopes}</code></p>"
+                    "<p><a href=\""
+                    f"{html.escape(retry_href)}"
+                    "\">Retry with read-only Cloudflare access</a></p>"
                 )
                 if permission_items:
                     details += (

--- a/backend/app/services/cloudflare_oauth.py
+++ b/backend/app/services/cloudflare_oauth.py
@@ -19,6 +19,7 @@ CLOUDFLARE_AUTHORIZATION_URL = "https://dash.cloudflare.com/oauth2/auth"
 CLOUDFLARE_TOKEN_URL = "https://api.cloudflare.com/oauth2/token"
 CLOUDFLARE_DEFAULT_READ_SCOPES = "zone.read dns.read"
 CLOUDFLARE_DEFAULT_SCOPE_PROFILE = "read_only"
+CLOUDFLARE_ALLOWED_SCOPES = frozenset({"zone.read", "dns.read", "dns.write", "radar.read"})
 _STATE_ALGORITHM = "HS256"
 _STATE_TTL = timedelta(minutes=10)
 
@@ -44,6 +45,7 @@ class CloudflareScopeProfile:
     dns_write_enabled: bool = False
     radar_enabled: bool = False
     radar_requires_api_token: bool = False
+    requires_client_allowlisting: bool = False
     warning: Optional[str] = None
 
 
@@ -62,6 +64,7 @@ CLOUDFLARE_SCOPE_PROFILES: Dict[str, CloudflareScopeProfile] = {
         scopes="zone.read dns.read radar.read",
         required_permissions=("Zone Read", "DNS Read", "Account Radar Read"),
         radar_enabled=True,
+        requires_client_allowlisting=True,
         warning=(
             "Includes Account Radar Read for Cloudflare Radar IP lookups. The Cloudflare "
             "OAuth client must allow radar.read."
@@ -78,6 +81,7 @@ CLOUDFLARE_SCOPE_PROFILES: Dict[str, CloudflareScopeProfile] = {
         required_permissions=("Zone Read", "DNS Read", "DNS Write", "Account Radar Read"),
         dns_write_enabled=True,
         radar_enabled=True,
+        requires_client_allowlisting=True,
         warning=(
             "Only use this when you want DMARQ to prepare/apply confirmed DNS repairs "
             "and enrich sending IPs with Cloudflare Radar. The Cloudflare OAuth client "
@@ -108,6 +112,12 @@ def cloudflare_scopes_for_profile(profile: Optional[str]) -> str:
     return CLOUDFLARE_SCOPE_PROFILES[normalize_cloudflare_scope_profile(profile)].scopes
 
 
+def _sanitize_cloudflare_scopes(scopes: Optional[str]) -> str:
+    requested = str(scopes or "").replace(",", " ").split()
+    allowed = [scope for scope in requested if scope in CLOUDFLARE_ALLOWED_SCOPES]
+    return " ".join(dict.fromkeys(allowed)) or CLOUDFLARE_DEFAULT_READ_SCOPES
+
+
 def cloudflare_oauth_configured() -> bool:
     """Return whether a Cloudflare OAuth client can be used."""
     settings = get_settings()
@@ -125,7 +135,7 @@ def get_cloudflare_oauth_config() -> CloudflareOAuthConfig:
     return CloudflareOAuthConfig(
         client_id=settings.CLOUDFLARE_OAUTH_CLIENT_ID,
         client_secret=settings.CLOUDFLARE_OAUTH_CLIENT_SECRET,
-        scopes=settings.CLOUDFLARE_OAUTH_SCOPES or CLOUDFLARE_DEFAULT_READ_SCOPES,
+        scopes=_sanitize_cloudflare_scopes(settings.CLOUDFLARE_OAUTH_SCOPES),
     )
 
 

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -217,19 +217,34 @@ function settingsApp() {
             if (params.get('cloudflare_retry') === '1') {
                 this.s['cloudflare.oauth_scope_profile'] = 'read_only';
                 this.showFlash('Cloudflare retry is set to the read-only profile. Click Connect Cloudflare to continue.', true);
+                this.clearCloudflareOAuthQueryState(params);
                 return;
             }
             const profile = params.get('cloudflare_scope_profile');
             if (profile && this.isKnownCloudflareOAuthProfile(profile)) {
                 this.s['cloudflare.oauth_scope_profile'] = profile;
             }
+            if (profile) {
+                this.clearCloudflareOAuthQueryState(params);
+            }
+        },
+
+        clearCloudflareOAuthQueryState(params) {
+            params.delete('cloudflare_scope_profile');
+            params.delete('cloudflare_retry');
+            const query = params.toString();
+            window.history.replaceState(
+                {},
+                '',
+                window.location.pathname + (query ? `?${query}` : '')
+            );
         },
 
         isKnownCloudflareOAuthProfile(profileId) {
             const knownProfiles = new Set(
                 (this.cfOAuthStatus.scope_profiles || []).map(profile => profile.id)
             );
-            ['read_only', 'read_only_radar', 'full_dns_radar'].forEach(profile => knownProfiles.add(profile));
+            ['read_only', 'read_only_radar', 'full_dns_repair'].forEach(profile => knownProfiles.add(profile));
             return knownProfiles.has(profileId);
         },
 

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -199,6 +199,7 @@ function settingsApp() {
                 const map = {};
                 rows.forEach(r => { map[r.key] = r.value ?? ''; });
                 this.s = map;
+                this.applyCloudflareOAuthQueryState();
                 await this.loadAlertHistory(false);
                 await this.loadConfigAudit(false);
                 await this.loadWebhooks(false);
@@ -208,6 +209,17 @@ function settingsApp() {
                 await this.loadAIProviderProfiles(false);
             } catch (err) {
                 this.showFlash('Error loading settings: ' + err.message, false);
+            }
+        },
+
+        applyCloudflareOAuthQueryState() {
+            const params = new URLSearchParams(window.location.search);
+            const profile = params.get('cloudflare_scope_profile');
+            if (profile) {
+                this.s['cloudflare.oauth_scope_profile'] = profile;
+            }
+            if (params.get('cloudflare_retry') === '1') {
+                this.showFlash('Cloudflare retry is set to the read-only profile. Click Connect Cloudflare to continue.', true);
             }
         },
 
@@ -719,6 +731,10 @@ function settingsApp() {
 
         selectedCloudflareOAuthPermissions() {
             return this.selectedCloudflareOAuthProfile()?.required_permissions || [];
+        },
+
+        selectedCloudflareOAuthRequiresAllowlisting() {
+            return Boolean(this.selectedCloudflareOAuthProfile()?.requires_client_allowlisting);
         },
 
         async connectCloudflare() {

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -214,13 +214,23 @@ function settingsApp() {
 
         applyCloudflareOAuthQueryState() {
             const params = new URLSearchParams(window.location.search);
+            if (params.get('cloudflare_retry') === '1') {
+                this.s['cloudflare.oauth_scope_profile'] = 'read_only';
+                this.showFlash('Cloudflare retry is set to the read-only profile. Click Connect Cloudflare to continue.', true);
+                return;
+            }
             const profile = params.get('cloudflare_scope_profile');
-            if (profile) {
+            if (profile && this.isKnownCloudflareOAuthProfile(profile)) {
                 this.s['cloudflare.oauth_scope_profile'] = profile;
             }
-            if (params.get('cloudflare_retry') === '1') {
-                this.showFlash('Cloudflare retry is set to the read-only profile. Click Connect Cloudflare to continue.', true);
-            }
+        },
+
+        isKnownCloudflareOAuthProfile(profileId) {
+            const knownProfiles = new Set(
+                (this.cfOAuthStatus.scope_profiles || []).map(profile => profile.id)
+            );
+            ['read_only', 'read_only_radar', 'full_dns_radar'].forEach(profile => knownProfiles.add(profile));
+            return knownProfiles.has(profileId);
         },
 
         async saveCategory(category) {
@@ -712,7 +722,10 @@ function settingsApp() {
                     return;
                 }
                 this.cfOAuthStatus = data;
-                if (!this.s['cloudflare.oauth_scope_profile']) {
+                if (
+                    !this.s['cloudflare.oauth_scope_profile']
+                    || !this.isKnownCloudflareOAuthProfile(this.s['cloudflare.oauth_scope_profile'])
+                ) {
                     this.s['cloudflare.oauth_scope_profile'] = data.scope_profile || 'read_only';
                 }
             } catch (err) {

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -197,9 +197,6 @@
                                         Cloudflare client permissions:
                                         <span x-text="selectedCloudflareOAuthPermissions().join(', ')"></span>
                                     </p>
-                                    <p class="mt-1 text-warning" x-show="selectedCloudflareOAuthRequiresAllowlisting()">
-                                        This profile must be enabled in the Cloudflare OAuth client's allowed permissions before Cloudflare will approve the request.
-                                    </p>
                                     <p class="mt-1 text-warning" x-show="selectedCloudflareOAuthProfile()?.warning"
                                         x-text="selectedCloudflareOAuthProfile()?.warning"></p>
                                 </div>

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -197,6 +197,9 @@
                                         Cloudflare client permissions:
                                         <span x-text="selectedCloudflareOAuthPermissions().join(', ')"></span>
                                     </p>
+                                    <p class="mt-1 text-warning" x-show="selectedCloudflareOAuthRequiresAllowlisting()">
+                                        This profile must be enabled in the Cloudflare OAuth client's allowed permissions before Cloudflare will approve the request.
+                                    </p>
                                     <p class="mt-1 text-warning" x-show="selectedCloudflareOAuthProfile()?.warning"
                                         x-text="selectedCloudflareOAuthProfile()?.warning"></p>
                                 </div>

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -2552,6 +2552,33 @@ def test_cloudflare_oauth_callback_explains_invalid_scope(
     assert "window or tab" in response.text
 
 
+def test_cloudflare_oauth_callback_explains_legacy_user_read_invalid_scope(
+    authed_client: TestClient,
+):
+    with patch(
+        "app.api.api_v1.endpoints.domains.decode_cloudflare_oauth_state",
+        return_value={
+            "workspace_id": 1,
+            "return_to": "/settings",
+            "scope_profile": "read_only",
+        },
+    ):
+        response = authed_client.get(
+            "/api/v1/domains/cloudflare/oauth/callback"
+            "?error=invalid_scope"
+            "&error_description=The+OAuth+client+cannot+request+user.read"
+            "&state=state-token"
+        )
+
+    assert response.status_code == 400
+    assert "cannot request user.read" in response.text
+    assert "Selected profile:" in response.text
+    assert "read_only" in response.text
+    assert "zone.read dns.read" in response.text
+    assert "cloudflare_scope_profile=read_only" in response.text
+    assert "cloudflare_retry=1" in response.text
+
+
 def test_cloudflare_oauth_callback_explains_invalid_scope_with_bad_state(
     authed_client: TestClient,
 ):

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1981,6 +1981,10 @@ def _cloudflare_oauth_zone_read_settings():
     return _cloudflare_oauth_settings(CLOUDFLARE_OAUTH_SCOPES="zone.read")
 
 
+def _cloudflare_oauth_legacy_user_scope_settings():
+    return _cloudflare_oauth_settings(CLOUDFLARE_OAUTH_SCOPES="zone.read user.read dns.read")
+
+
 def _cloudflare_oauth_empty_scope_settings():
     return _cloudflare_oauth_settings(CLOUDFLARE_OAUTH_SCOPES="")
 
@@ -2052,6 +2056,24 @@ def test_cloudflare_oauth_authorization_url_uses_configured_scopes_without_profi
     assert "state=state-token" in result["authorization_url"]
 
 
+def test_cloudflare_oauth_authorization_url_drops_legacy_user_read_scope(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        cloudflare_oauth,
+        "get_settings",
+        _cloudflare_oauth_legacy_user_scope_settings,
+    )
+
+    result = cloudflare_oauth.build_cloudflare_authorization_url(
+        redirect_uri="https://app.example.test/api/v1/domains/cloudflare/oauth/callback",
+        state="state-token",
+    )
+
+    assert result["scopes"] == "zone.read dns.read"
+    assert "user.read" not in result["authorization_url"]
+
+
 def test_cloudflare_oauth_authorization_url_profile_overrides_configured_scopes(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2110,6 +2132,7 @@ def test_cloudflare_oauth_scope_profile_metadata_marks_full_dns_radar_enabled():
     ]
     assert full_profile["dns_write_enabled"] is True
     assert full_profile["radar_enabled"] is True
+    assert full_profile["requires_client_allowlisting"] is True
 
     radar_profile = profiles["read_only_radar"]
     assert radar_profile["scopes"] == "zone.read dns.read radar.read"
@@ -2120,6 +2143,10 @@ def test_cloudflare_oauth_scope_profile_metadata_marks_full_dns_radar_enabled():
     ]
     assert radar_profile["dns_write_enabled"] is False
     assert radar_profile["radar_enabled"] is True
+    assert radar_profile["requires_client_allowlisting"] is True
+
+    read_only_profile = profiles["read_only"]
+    assert read_only_profile["requires_client_allowlisting"] is False
 
 
 def test_cloudflare_oauth_config_requires_client_credentials(
@@ -2519,6 +2546,9 @@ def test_cloudflare_oauth_callback_explains_invalid_scope(
     assert "zone.read dns.read dns.write radar.read" in response.text
     assert "DNS Write" in response.text
     assert "Account Radar Read" in response.text
+    assert "Retry with read-only Cloudflare access" in response.text
+    assert "cloudflare_scope_profile=read_only" in response.text
+    assert "cloudflare_retry=1" in response.text
     assert "window or tab" in response.text
 
 
@@ -2541,6 +2571,7 @@ def test_cloudflare_oauth_callback_explains_invalid_scope_with_bad_state(
     assert "read_only" in response.text
     assert "zone.read dns.read" in response.text
     assert "DNS Write" not in response.text
+    assert "Retry with read-only Cloudflare access" in response.text
     assert "window or tab" in response.text
 
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -155,6 +155,21 @@ Live DNS writes stay behind the separate DNS repair approval flow.
 | Linode DNS | Ready | `LINODE_API_TOKEN` or `LINODE_TOKEN` with Domains read-only access |
 | Akamai Edge DNS/FastDNS | Ready | EdgeGrid DNS credentials via `.edgerc` or `AKAMAI_*` variables, separate from Akamai EAA login |
 
+Cloudflare OAuth clients must explicitly allow every scope DMARQ can request.
+Configure the Cloudflare OAuth application with the profile you want operators
+to use:
+
+| DMARQ profile | OAuth scopes | Cloudflare client permissions |
+|---------------|--------------|-------------------------------|
+| Read-only discovery | `zone.read dns.read` | Zone Read, DNS Read |
+| Read-only + Radar context | `zone.read dns.read radar.read` | Zone Read, DNS Read, Account Radar Read |
+| Full DNS repair + Radar | `zone.read dns.read dns.write radar.read` | Zone Read, DNS Read, DNS Write, Account Radar Read |
+
+If Cloudflare returns `invalid_scope`, retry with the read-only profile first.
+Then update the Cloudflare OAuth application's allowed permissions before
+requesting Radar or DNS Write access again. DMARQ filters legacy unsupported
+scopes such as `user.read` from its own OAuth requests.
+
 For Route 53 self-hosted installs, use a local AWS profile or environment
 credentials with `route53:ListHostedZones`. Hosted/provider deployments should
 prefer role assumption with an external ID. Add `route53:ListResourceRecordSets`


### PR DESCRIPTION
## Summary
- filter unsupported legacy Cloudflare OAuth scopes such as user.read from DMARQ-generated requests
- mark Radar/write profiles as requiring Cloudflare OAuth client allowlisting in Settings metadata and UI
- add a safe read-only retry path on invalid-scope callback pages for popup and full-window flows
- document exact Cloudflare profile scopes and required client permissions
- update changelog

Closes #581

## Local validation
- /tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_cloudflare_dns.py -q
- /tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py::test_settings_exposes_provider_agnostic_dns_import_without_html_injection backend/app/tests/test_dashboard_template_security.py::test_settings_controls_are_bound_from_external_script -q
- /tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/services/cloudflare_oauth.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloudflare OAuth sign-in now offers a read-only retry path when an `invalid_scope` error occurs.
  * Unsupported or legacy Cloudflare scopes are now filtered out of authorization requests, reducing connection failures.

* **New Features**
  * Added clearer guidance in Settings for profiles that require Cloudflare client allowlisting.
  * The OAuth settings page now reacts to retry and profile details in the link, helping users continue setup smoothly.

* **Documentation**
  * Updated deployment guidance with Cloudflare permission profiles and troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->