### PR TITLE
feat: add configurable mail-auth setup defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added in-product release metadata with version, image, git ref, build date, recent changes, and a link to the full changelog.
 - Added Cloudflare OAuth rights profiles for read-only zone import, read-only plus Radar enrichment, and full DNS repair.
+- Added configurable mail-authentication setup defaults so generated DMARC/TLS-RPT guidance can use central report mailboxes.
 - Added source intelligence context for sending IPs, including provider recognition, network details, Radar links, and report activity history.
 - Added human-approved DNS repair groundwork for provider-connected domains.
 - Added self-hosted demo refinements focused on the single-user, multiple-domain workflow.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -196,7 +196,7 @@ def _setting_value(db: Session, key: str) -> Optional[str]:
 def _int_setting_value(db: Session, key: str, default: int) -> int:
     value = _setting_value(db, key)
     try:
-        return int(value or default)
+        return default if value in {None, ""} else int(value)
     except (TypeError, ValueError):
         return default
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -50,7 +50,7 @@ from app.services.cloudflare_oauth import (
 from app.services.dane import check_dane_cached
 from app.services.demo_data import DEMO_DAYS, build_demo_health_score_history
 from app.services.dns_cache import get_cached_domain_dns_result, resolve_domain_dns_cached
-from app.services.dns_guidance import build_dns_guidance
+from app.services.dns_guidance import MailAuthSetupDefaults, build_dns_guidance
 from app.services.dns_provider_connectors import (
     provider_connector_metadata,
     provider_connector_registry,
@@ -191,6 +191,25 @@ def _raise_plan_limit_error(exc: OrganizationPlanLimitError) -> None:
 def _setting_value(db: Session, key: str) -> Optional[str]:
     row = db.query(Setting).filter(Setting.key == key).first()
     return row.value if row and row.value else None
+
+
+def _int_setting_value(db: Session, key: str, default: int) -> int:
+    value = _setting_value(db, key)
+    try:
+        return int(value or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _mail_auth_setup_defaults(db: Session) -> MailAuthSetupDefaults:
+    return MailAuthSetupDefaults(
+        report_mailbox=_setting_value(db, "dmarc.report_mailbox"),
+        tls_report_mailbox=_setting_value(db, "dmarc.tls_report_mailbox"),
+        policy=_setting_value(db, "dmarc.default_policy") or "none",
+        percentage=_int_setting_value(db, "dmarc.default_percentage", 100),
+        adkim=_setting_value(db, "dmarc.default_adkim") or "r",
+        aspf=_setting_value(db, "dmarc.default_aspf") or "r",
+    )
 
 
 def _public_base_url(request: Request, db: Session) -> str:
@@ -2396,6 +2415,7 @@ async def _build_domain_dns_guidance(
         monitored_selectors=combined_selectors,
         observed_selectors=report_selectors,
         mail_service_records=mail_service_records,
+        setup_defaults=_mail_auth_setup_defaults(db),
         locale=locale or get_settings().default_locale,
     )
     return asdict(guidance)

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -116,6 +116,20 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
         "value_type": "string",
         "category": "dmarc",
     },
+    {
+        "key": "dmarc.report_mailbox",
+        "value": "",
+        "description": "Central mailbox for DMARC aggregate reports used in generated rua records",
+        "value_type": "string",
+        "category": "dmarc",
+    },
+    {
+        "key": "dmarc.tls_report_mailbox",
+        "value": "",
+        "description": "Central mailbox for SMTP TLS reports used in generated TLS-RPT records",
+        "value_type": "string",
+        "category": "dmarc",
+    },
     # ── DNS ──────────────────────────────────────────────────────────────────
     {
         "key": "dns.resolver",

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -27,6 +27,18 @@ class DNSGuidanceRecord:
 
 
 @dataclass
+class MailAuthSetupDefaults:
+    """Operator-selected defaults for generated mail-authentication records."""
+
+    report_mailbox: Optional[str] = None
+    tls_report_mailbox: Optional[str] = None
+    policy: str = "none"
+    percentage: int = 100
+    adkim: str = "r"
+    aspf: str = "r"
+
+
+@dataclass
 class DNSLintFinding:
     """Stable machine-readable lint finding."""
 
@@ -89,12 +101,38 @@ def normalize_guidance_locale(locale: Optional[str]) -> str:
     return "en"
 
 
-def _target_records(domain: str, result: DomainDNSResult) -> List[DNSGuidanceRecord]:
+def _mailbox(default_value: Optional[str], fallback_local_part: str, domain: str) -> str:
+    value = (default_value or "").strip()
+    if value:
+        return value
+    return f"{fallback_local_part}@{domain}"
+
+
+def _dmarc_record_value(domain: str, defaults: MailAuthSetupDefaults) -> str:
+    policy = defaults.policy if defaults.policy in {"none", "quarantine", "reject"} else "none"
+    adkim = defaults.adkim if defaults.adkim in {"r", "s"} else "r"
+    aspf = defaults.aspf if defaults.aspf in {"r", "s"} else "r"
+    percentage = max(0, min(100, int(defaults.percentage or 100)))
+    report_mailbox = _mailbox(defaults.report_mailbox, "dmarc", domain)
+    return (
+        f"v=DMARC1; p={policy}; rua=mailto:{report_mailbox}; "
+        f"pct={percentage}; adkim={adkim}; aspf={aspf}"
+    )
+
+
+def _target_records(
+    domain: str,
+    result: DomainDNSResult,
+    *,
+    setup_defaults: Optional[MailAuthSetupDefaults] = None,
+) -> List[DNSGuidanceRecord]:
+    defaults = setup_defaults or MailAuthSetupDefaults()
     dmarc_value = result.dmarc_record or (
-        f"v=DMARC1; p=none; rua=mailto:dmarc@{domain}; adkim=r; aspf=r"
+        _dmarc_record_value(domain, defaults)
     )
     spf_value = result.spf_record or "v=spf1 -all"
     dkim_selector = (result.dkim_selectors or result.selectors_checked or ["selector1"])[0]
+    tls_report_mailbox = _mailbox(defaults.tls_report_mailbox, "tlsrpt", domain)
     return [
         DNSGuidanceRecord(
             code="target_dmarc",
@@ -134,7 +172,7 @@ def _target_records(domain: str, result: DomainDNSResult) -> List[DNSGuidanceRec
             code="target_tls_rpt",
             record_type="TXT",
             name=f"_smtp._tls.{domain}",
-            value=f"v=TLSRPTv1; rua=mailto:tlsrpt@{domain}",
+            value=f"v=TLSRPTv1; rua=mailto:{tls_report_mailbox}",
             purpose="SMTP TLS Reporting aggregate delivery.",
         ),
         DNSGuidanceRecord(
@@ -1419,12 +1457,13 @@ async def build_dns_guidance(
     monitored_selectors: Optional[List[str]] = None,
     observed_selectors: Optional[List[str]] = None,
     mail_service_records: Optional[List[Dict[str, str]]] = None,
+    setup_defaults: Optional[MailAuthSetupDefaults] = None,
     locale: Optional[str] = None,
 ) -> DNSGuidanceResult:
     """Build typed DNS lint findings and target records for a domain."""
     normalized_domain = domain.strip().strip(".").lower()
     dane_result = dane or DANEResult(errors=["No DANE/TLSA context was evaluated."])
-    targets = _target_records(normalized_domain, result)
+    targets = _target_records(normalized_domain, result, setup_defaults=setup_defaults)
     targets.append(_dane_target_record(normalized_domain, dane_result))
     findings: List[DNSLintFinding] = []
     findings.extend(_dmarc_findings(normalized_domain, result, targets))

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -112,7 +112,7 @@ def _dmarc_record_value(domain: str, defaults: MailAuthSetupDefaults) -> str:
     policy = defaults.policy if defaults.policy in {"none", "quarantine", "reject"} else "none"
     adkim = defaults.adkim if defaults.adkim in {"r", "s"} else "r"
     aspf = defaults.aspf if defaults.aspf in {"r", "s"} else "r"
-    percentage = max(0, min(100, int(defaults.percentage or 100)))
+    percentage = max(0, min(100, int(defaults.percentage)))
     report_mailbox = _mailbox(defaults.report_mailbox, "dmarc", domain)
     return (
         f"v=DMARC1; p={policy}; rua=mailto:{report_mailbox}; "

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -755,6 +755,16 @@ function domainDetailsApp(domainId) {
             return 'bg-base-200 text-base-content/70';
         },
 
+        get mailAuthTargetRecords() {
+            const codes = new Set(['target_dmarc', 'target_spf', 'target_dkim']);
+            return (this.dnsGuidance.target_records || []).filter(record => codes.has(record.code));
+        },
+
+        get optionalTransportTargetRecords() {
+            const codes = new Set(['target_dmarc', 'target_spf', 'target_dkim']);
+            return (this.dnsGuidance.target_records || []).filter(record => !codes.has(record.code));
+        },
+
         get migrationStatusClass() {
             if (this.migration.error) return 'bg-red-100 text-red-700';
             if (this.migration.status === 'ready') return 'bg-green-100 text-green-700';

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1272,9 +1272,44 @@
                             </template>
                         </div>
                         <div class="mt-4">
-                            <h4 class="text-sm font-semibold">Target Records</h4>
+                            <div class="rounded-lg border border-[#d8ebe8] bg-[#f2fbf9] p-4">
+                                <div class="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+                                    <div>
+                                        <h4 class="text-sm font-semibold text-[#07071f]">Mail authentication setup</h4>
+                                        <p class="text-xs text-[#45505f]">Publish or verify these core DMARC, SPF, and DKIM records first.</p>
+                                    </div>
+                                    <a href="/settings#dmarc-defaults" class="btn btn-xs btn-outline">Edit defaults</a>
+                                </div>
+                                <div class="mt-3 grid gap-2">
+                                    <template x-for="record in mailAuthTargetRecords" :key="record.code">
+                                        <div class="rounded border border-[#c7e3df] bg-white p-3">
+                                            <div class="flex flex-col gap-2 lg:flex-row lg:items-center">
+                                                <div class="min-w-0 flex-1">
+                                                    <div class="flex flex-wrap items-center gap-2">
+                                                        <code class="text-xs font-semibold" x-text="record.name"></code>
+                                                        <span class="badge badge-outline" x-text="record.record_type"></span>
+                                                        <span class="badge badge-ghost" x-text="record.priority"></span>
+                                                    </div>
+                                                    <code class="mt-2 block break-all rounded bg-base-200 p-2 text-xs" x-text="record.value"></code>
+                                                    <p class="mt-1 text-xs text-base-content/60" x-text="record.purpose"></p>
+                                                </div>
+                                                <button
+                                                    :data-domain-detail-copy-value="record.value"
+                                                    class="btn btn-xs btn-ghost"
+                                                    title="Copy DNS value"
+                                                >
+                                                    Copy
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mt-4">
+                            <h4 class="text-sm font-semibold">Optional transport and branding records</h4>
                             <div class="mt-2 grid gap-2">
-                                <template x-for="record in dnsGuidance.target_records" :key="record.code">
+                                <template x-for="record in optionalTransportTargetRecords" :key="record.code">
                                     <div class="rounded border border-base-300 p-3">
                                         <div class="flex flex-col gap-2 lg:flex-row lg:items-center">
                                             <div class="min-w-0 flex-1">

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -79,7 +79,7 @@
             {% call card_description() %}Default values applied when adding a new domain{% endcall %}
         {% endcall %}
         {% call card_content() %}
-            <form data-settings-save-category="dmarc" class="space-y-4">
+            <form id="dmarc-defaults" data-settings-save-category="dmarc" class="space-y-4">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div class="form-control w-full">
                         <label class="label"><span class="label-text font-medium">Default Policy</span></label>
@@ -114,6 +114,26 @@
                             <option value="r">Relaxed</option>
                             <option value="s">Strict</option>
                         </select>
+                    </div>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="form-control w-full">
+                        <label class="label"><span class="label-text font-medium">Aggregate report mailbox</span></label>
+                        <input
+                            x-model="s['dmarc.report_mailbox']"
+                            type="email"
+                            placeholder="dmarc-reports@example.com"
+                            class="input input-bordered w-full" />
+                        <label class="label"><span class="label-text-alt text-muted-foreground">Used in generated DMARC rua records. Leave empty to use dmarc@domain.</span></label>
+                    </div>
+                    <div class="form-control w-full">
+                        <label class="label"><span class="label-text font-medium">TLS report mailbox</span></label>
+                        <input
+                            x-model="s['dmarc.tls_report_mailbox']"
+                            type="email"
+                            placeholder="tlsrpt@example.com"
+                            class="input input-bordered w-full" />
+                        <label class="label"><span class="label-text-alt text-muted-foreground">Used in generated SMTP TLS-RPT records. Leave empty to use tlsrpt@domain.</span></label>
                     </div>
                 </div>
                 <div class="flex justify-end">

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -26,6 +26,7 @@ from app.models.dns_cache import DNSCache, DNSRecordChange
 from app.models.domain import Domain
 from app.models.organization import Entitlement, Organization
 from app.models.report import DMARCReport, ReportRecord
+from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.services.bimi import BIMIResult
 from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
@@ -506,6 +507,74 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: Tes
     assert change_plan["provider_write_available"] is False
     assert change_plan["provider_value_required"] is True
     assert change_plan["manual_steps"]
+
+
+def test_dns_lint_endpoint_uses_configured_mail_auth_defaults(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add_all(
+        [
+            Setting(
+                key="dmarc.report_mailbox",
+                value="dmarc-reports@cklnet.com",
+                description="Central DMARC report mailbox",
+                value_type="string",
+                category="dmarc",
+            ),
+            Setting(
+                key="dmarc.tls_report_mailbox",
+                value="tls-reports@cklnet.com",
+                description="Central TLS report mailbox",
+                value_type="string",
+                category="dmarc",
+            ),
+            Setting(
+                key="dmarc.default_policy",
+                value="quarantine",
+                description="Default DMARC policy",
+                value_type="string",
+                category="dmarc",
+            ),
+            Setting(
+                key="dmarc.default_percentage",
+                value="25",
+                description="Default DMARC percentage",
+                value_type="integer",
+                category="dmarc",
+            ),
+        ]
+    )
+    db_session.commit()
+    result = DomainDNSResult(
+        dmarc=False,
+        spf=False,
+        dkim=False,
+        selectors_checked=["selector1"],
+        nameservers=["ns1.digitalocean.com", "ns2.digitalocean.com"],
+        dns_provider=detect_dns_provider(["ns1.digitalocean.com", "ns2.digitalocean.com"]),
+    )
+
+    with (
+        _mock_dns(result),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(MTAStsResult(status="pass"), False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(BIMIResult(status="pass"), False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/lint")
+
+    assert response.status_code == 200
+    targets = {record["code"]: record for record in response.json()["target_records"]}
+    assert targets["target_dmarc"]["value"] == (
+        "v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@cklnet.com; "
+        "pct=25; adkim=r; aspf=r"
+    )
+    assert targets["target_tls_rpt"]["value"] == "v=TLSRPTv1; rua=mailto:tls-reports@cklnet.com"
 
 
 def test_dns_lint_endpoint_accepts_locale_for_operator_guidance(authed_client: TestClient):

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -577,6 +577,44 @@ def test_dns_lint_endpoint_uses_configured_mail_auth_defaults(
     assert targets["target_tls_rpt"]["value"] == "v=TLSRPTv1; rua=mailto:tls-reports@cklnet.com"
 
 
+def test_int_setting_value_preserves_zero_and_falls_back(db_session):
+    db_session.add_all(
+        [
+            Setting(
+                key="dmarc.default_percentage_zero",
+                value="0",
+                description="Zero percentage",
+                value_type="integer",
+                category="dmarc",
+            ),
+            Setting(
+                key="dmarc.default_percentage_invalid",
+                value="not-an-int",
+                description="Invalid percentage",
+                value_type="integer",
+                category="dmarc",
+            ),
+        ]
+    )
+    db_session.commit()
+
+    assert domains_endpoint._int_setting_value(
+        db_session,
+        "dmarc.default_percentage_zero",
+        100,
+    ) == 0
+    assert domains_endpoint._int_setting_value(
+        db_session,
+        "dmarc.default_percentage_invalid",
+        100,
+    ) == 100
+    assert domains_endpoint._int_setting_value(
+        db_session,
+        "dmarc.default_percentage_missing",
+        100,
+    ) == 100
+
+
 def test_dns_lint_endpoint_accepts_locale_for_operator_guidance(authed_client: TestClient):
     result = DomainDNSResult(
         dmarc=False,

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -100,6 +100,30 @@ async def test_build_dns_guidance_uses_configured_mail_auth_defaults():
 
 
 @pytest.mark.asyncio
+async def test_build_dns_guidance_preserves_zero_dmarc_percentage():
+    provider = FakeDNSProvider({})
+    dns = DomainDNSResult(
+        dmarc=False,
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(percentage=0),
+    )
+
+    targets = {record.code: record for record in guidance.target_records}
+    assert "pct=0" in targets["target_dmarc"].value
+
+
+@pytest.mark.asyncio
 async def test_build_dns_guidance_localizes_high_value_remediation_steps_to_german():
     provider = FakeDNSProvider({})
     dns = DomainDNSResult(

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -2,7 +2,7 @@ import pytest
 
 from app.services.bimi import BIMIResult
 from app.services.dane import DANEResult, TLSASuggestion
-from app.services.dns_guidance import build_dns_guidance
+from app.services.dns_guidance import MailAuthSetupDefaults, build_dns_guidance
 from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult
 from app.services.mta_sts import MTAStsResult
 
@@ -63,6 +63,40 @@ async def test_build_dns_guidance_returns_typed_findings_and_targets():
     assert plan.applies_automatically is False
     assert plan.provider_write_available is False
     assert plan.rollback.startswith("Delete the newly created")
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_uses_configured_mail_auth_defaults():
+    provider = FakeDNSProvider({})
+    dns = DomainDNSResult(
+        dmarc=False,
+        spf=False,
+        dkim=False,
+        selectors_checked=["selector1"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(
+            report_mailbox="dmarc-reports@central.example",
+            tls_report_mailbox="tls-reports@central.example",
+            policy="quarantine",
+            percentage=50,
+            adkim="s",
+            aspf="s",
+        ),
+    )
+
+    targets = {record.code: record for record in guidance.target_records}
+    assert targets["target_dmarc"].value == (
+        "v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@central.example; "
+        "pct=50; adkim=s; aspf=s"
+    )
+    assert targets["target_tls_rpt"].value == "v=TLSRPTv1; rua=mailto:tls-reports@central.example"
 
 
 @pytest.mark.asyncio

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -173,6 +173,23 @@ possible, or inject `AKAMAI_HOST`, `AKAMAI_CLIENT_TOKEN`,
 Use `AKAMAI_ACCOUNT_SWITCH_KEY` only when your Akamai client needs to operate
 against a delegated account.
 
+### Mail Authentication Defaults
+
+The Settings page includes DMARC defaults used by domain-level DNS guidance and
+change plans. Set a central aggregate-report mailbox, for example
+`dmarc-reports@example.com`, when reports should flow to one monitored inbox
+instead of `dmarc@<each-domain>`. DMARQ uses that value in generated
+`rua=mailto:...` records for domains that do not already publish DMARC.
+
+The same section controls the default DMARC policy, `pct`, `adkim`, and `aspf`
+values used by generated setup records. Keep `p=none` for initial monitoring,
+then tighten per domain once legitimate senders pass consistently. The optional
+TLS report mailbox is used for generated `_smtp._tls` TLS-RPT records.
+
+Cloudflare Email Routing or a Cloudflare Email Worker can be used as a future
+managed intake path for reports, but live Cloudflare changes should remain
+explicitly reviewed through the DNS provider repair flow.
+
 ### IMAP Settings
 
 | Variable | Description | Default | Example |


### PR DESCRIPTION
## Summary
- add DMARC settings for a central aggregate-report mailbox and TLS report mailbox
- use those defaults when generating DMARC and TLS-RPT target records for DNS guidance
- split domain detail target records into a core mail-auth setup block and optional transport/branding records
- document central report mailbox guidance for self-hosted operators

Refs #574

## Local validation
- /tmp/dmarq-live-audit-venv/bin/python -m pytest backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py::test_dns_lint_endpoint_uses_configured_mail_auth_defaults backend/app/tests/test_dns_endpoints.py::test_dns_lint_endpoint_returns_typed_findings_and_targets backend/app/tests/test_dashboard_template_security.py::test_settings_exposes_provider_agnostic_dns_import_without_html_injection backend/app/tests/test_dashboard_template_security.py::test_settings_controls_are_bound_from_external_script -q
- /tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/services/dns_guidance.py backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/settings.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py
- git diff --check