### PR TITLE
refactor: remove explicit page init handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed domain sending-source loading so PTR and network enrichment run in parallel instead of pushing report-backed source rows past the UI timeout.
 - Fixed the Cloudflare permissions picker so selecting the full DNS repair profile no longer falls back to read-only scopes.
 - Fixed the release modal coverage so recent operator-facing work is visible from inside the app.
-- Fixed several CSP-hardening regressions by moving legacy inline handlers and styles out of templates.
+- Fixed several CSP-hardening regressions by moving legacy inline handlers, explicit page initialization, and styles out of templates.
 
 ### Security
 - Cloudflare DNS write capabilities remain tied to explicit full-repair selection and human-confirmed DNS changes.

--- a/backend/app/templates/forensic_report_detail.html
+++ b/backend/app/templates/forensic_report_detail.html
@@ -4,7 +4,7 @@
 {% block title %}DMARQ - Forensic Report Detail{% endblock %}
 
 {% block content %}
-<div class="space-y-6" x-data="forensicReportDetailApp({{ report_id }})" x-init="init()">
+<div class="space-y-6" x-data="forensicReportDetailApp({{ report_id }})" data-forensic-report-detail-page>
     <nav class="text-sm text-[#5f5c78]">
         <ol class="flex items-center space-x-2">
             <li><a href="/" class="font-semibold hover:text-[#2f9da5]">Dashboard</a></li>

--- a/backend/app/templates/forensic_reports.html
+++ b/backend/app/templates/forensic_reports.html
@@ -5,7 +5,7 @@
 {% block title %}DMARQ - Forensic Reports{% endblock %}
 
 {% block content %}
-<div class="container mx-auto py-4" x-data="forensicReportsApp()" x-init="init()">
+<div class="container mx-auto py-4" x-data="forensicReportsApp()" data-forensic-reports-page>
     <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between mb-6">
         <div>
             <h1 class="text-2xl font-bold">Forensic Reports</h1>

--- a/backend/app/templates/members.html
+++ b/backend/app/templates/members.html
@@ -4,7 +4,7 @@
 {% block title %}Members - DMARQ{% endblock %}
 
 {% block content %}
-<div x-data="membershipApp()" x-init="init()" class="mx-auto max-w-7xl space-y-6 py-4" data-members-page>
+<div x-data="membershipApp()" class="mx-auto max-w-7xl space-y-6 py-4" data-members-page>
     <section class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
             <p class="text-sm font-semibold uppercase text-[#2c9aa3]">Access control</p>

--- a/backend/app/templates/onboarding.html
+++ b/backend/app/templates/onboarding.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="mx-auto max-w-7xl space-y-6"
      x-data="workspaceOnboarding({ multiWorkspaceUiEnabled: {{ multi_workspace_ui_enabled | tojson }} })"
-     x-init="init()" x-cloak>
+     data-onboarding-page x-cloak>
     <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
             <p class="text-sm font-semibold uppercase tracking-wide text-[#2f9da6]">Guided setup</p>

--- a/backend/app/templates/profile.html
+++ b/backend/app/templates/profile.html
@@ -5,7 +5,7 @@
 {% block title %}My Profile – {{ app_name }}{% endblock %}
 
 {% block content %}
-<div x-data="profileApp()" x-init="init()" class="max-w-2xl mx-auto space-y-6 py-4">
+<div x-data="profileApp()" class="max-w-2xl mx-auto space-y-6 py-4" data-profile-page>
 
     <!-- Profile info card -->
     {% call card() %}

--- a/backend/app/templates/tls_reports.html
+++ b/backend/app/templates/tls_reports.html
@@ -5,7 +5,7 @@
 {% block title %}DMARQ - TLS Reports{% endblock %}
 
 {% block content %}
-<div class="container mx-auto py-4" x-data="tlsReportsApp()" x-init="init()">
+<div class="container mx-auto py-4" x-data="tlsReportsApp()" data-tls-reports-page>
     <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between mb-6">
         <div>
             <h1 class="text-2xl font-bold">TLS Reports</h1>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -489,8 +489,10 @@ def test_profile_uses_external_page_script_for_csp_migration():
 
     assert 'src="/static/js/profile-page.js"' in template
     assert "profileApp()" in template
+    assert "data-profile-page" in template
     assert "/api/v1/auth/me" in script
     assert "Failed to load user profile" in script
+    assert 'x-init="init()"' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
@@ -531,9 +533,11 @@ def test_forensic_reports_uses_external_page_script_for_csp_migration():
     assert "data-forensic-upload-form" in template
     assert "data-forensic-upload-file" in template
     assert "data-forensic-reset" in template
+    assert "data-forensic-reports-page" in template
     assert "data-forensic-reset" in script
     assert "bindControls()" in script
     assert "event.target instanceof Element" in script
+    assert 'x-init="init()"' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
@@ -546,6 +550,8 @@ def test_forensic_report_detail_uses_external_page_script_for_csp_migration():
     assert "/api/v1/forensics/${this.reportId}" in script
     assert "Forensic report not found" in script
     assert "feedbackHeaderEntries" in script
+    assert "data-forensic-report-detail-page" in template
+    assert 'x-init="init()"' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
@@ -567,9 +573,11 @@ def test_tls_reports_uses_external_page_script_for_csp_migration():
     assert "data-tls-domain-filter" in template
     assert "data-tls-upload-form" in template
     assert "data-tls-upload-file" in template
+    assert "data-tls-reports-page" in template
     assert "data-tls-refresh" in script
     assert "bindControls()" in script
     assert "event.target instanceof Element" in script
+    assert 'x-init="init()"' not in template
     assert 'x-effect="$el.style.width' in template
     assert not _has_inline_style(template)
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
@@ -1079,6 +1087,7 @@ def test_members_template_uses_membership_api_without_html_injection():
 
     assert _has_script_src(template, "/static/js/members-page.js")
     assert "membershipApp()" in template
+    assert 'x-init="init()"' not in template
     assert "/api/v1/organizations" in script
     assert "/api/v1/memberships/organizations/" in script
     assert "/api/v1/memberships/workspaces/" in script
@@ -1200,6 +1209,7 @@ def test_onboarding_template_uses_single_user_setup_story_by_default():
     assert "One monitored domain with DMARC report and DNS setup tasks." in rendered
     assert "multiWorkspaceUiEnabled: false" in rendered
     assert 'src="/static/js/onboarding-page.js"' in template
+    assert "data-onboarding-page" in template
     assert "/api/v1/onboarding/preview" in script
     assert "/api/v1/onboarding/apply" in script
     assert "draftFields()" in script
@@ -1215,6 +1225,7 @@ def test_onboarding_template_uses_single_user_setup_story_by_default():
     assert '@click="previewPlan"' not in template
     assert '@click="applyPlan"' not in template
     assert '@click="form.mailSourcePath = ' not in template
+    assert 'x-init="init()"' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
     assert "Account boundary" not in rendered
     assert "Owner ready" not in rendered


### PR DESCRIPTION
## Summary
- remove explicit `x-init="init()"` calls from profile, onboarding, forensic, TLS-RPT, and members templates where Alpine already invokes the controller `init()` lifecycle
- add stable page markers and regression assertions so those templates stay on the CSP migration path
- keep the remaining special Settings initializer untouched

Refs #426.

## Validation
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py`
- `node --check backend/app/static/js/onboarding-page.js`
- `node --check backend/app/static/js/profile-page.js`
- `node --check backend/app/static/js/forensic-reports-page.js`
- `node --check backend/app/static/js/forensic-report-detail-page.js`
- `node --check backend/app/static/js/tls-reports-page.js`
- `node --check backend/app/static/js/members-page.js`
- `git diff --check`
