### PR TITLE
refactor: externalize settings page init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed domain sending-source loading so PTR and network enrichment run in parallel instead of pushing report-backed source rows past the UI timeout.
 - Fixed the Cloudflare permissions picker so selecting the full DNS repair profile no longer falls back to read-only scopes.
 - Fixed the release modal coverage so recent operator-facing work is visible from inside the app.
+- Fixed the remaining Settings page startup hook so CSP hardening no longer depends on template-level page initialization.
 - Fixed several CSP-hardening regressions by moving legacy inline handlers, explicit page initialization, and styles out of templates.
 
 ### Security

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -65,6 +65,10 @@ function settingsApp() {
 
         // Session cookie is sent automatically by the browser (httpOnly, same-origin).
         // No manual auth header needed for API calls from the UI.
+        init() {
+            return this.initSettingsPage();
+        },
+
         initSettingsPage() {
             this.bindProviderControls();
             return this.loadSettings();

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -12,7 +12,6 @@
 <div
     data-settings-page
     x-data="settingsApp()"
-    x-init="initSettingsPage()"
     class="space-y-6 py-4"
 >
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -645,9 +645,12 @@ def test_settings_exposes_provider_agnostic_dns_import_without_html_injection():
     assert "selectedDnsProviderConnectionClass" in script
     assert "resetDnsProviderImportState" in script
     assert "bindProviderControls" in script
-    assert 'x-init="initSettingsPage()"' not in template
-    assert "init() {" in script
-    assert "return this.initSettingsPage()" in script
+    assert re.search(r"\bx-init\s*=", template) is None
+    assert re.search(
+        r"\binit\s*\(\s*\)\s*\{[^}]*\breturn\s+this\.initSettingsPage\s*\(\s*\)",
+        script,
+        re.DOTALL,
+    )
     assert "data-settings-cloudflare-connect" in template
     assert "data-settings-toggle-cf-token" in template
     assert "data-settings-dns-provider-select" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -645,6 +645,9 @@ def test_settings_exposes_provider_agnostic_dns_import_without_html_injection():
     assert "selectedDnsProviderConnectionClass" in script
     assert "resetDnsProviderImportState" in script
     assert "bindProviderControls" in script
+    assert 'x-init="initSettingsPage()"' not in template
+    assert "init() {" in script
+    assert "return this.initSettingsPage()" in script
     assert "data-settings-cloudflare-connect" in template
     assert "data-settings-toggle-cf-token" in template
     assert "data-settings-dns-provider-select" in template


### PR DESCRIPTION
## What changed
- Removed the remaining Settings page `x-init` startup hook from the template.
- Added an Alpine `init()` lifecycle wrapper in the external Settings page script.
- Added a template-security regression assertion so Settings cannot reintroduce this CSP-sensitive startup pattern.
- Updated the changelog with the operator-facing CSP-hardening fix.

## Why
Issue #426 tracks CSP hardening cleanup. After #591 removed explicit init handlers from the other page shells, Settings was the remaining page-level `x-init` hook. Keeping startup logic in the external script moves the app closer to strict CSP without changing visible Settings behavior.

## Validation
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py`
- `node --check backend/app/static/js/settings-page.js`
- `rg -n 'x-init=' backend/app/templates` returned no template matches
- `git diff --check`

Refs #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Settings page startup flow so it loads without relying on inline page initialization.
  * Continued CSP hardening by moving initialization to a safer external script path.
  * Updated checks to ensure the Settings page still initializes as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->