### PR TITLE
feat: add domain mail-auth wizard steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added in-product release metadata with version, image, git ref, build date, recent changes, and a link to the full changelog.
+- Added a domain-level DMARC/SPF/DKIM mail-authentication wizard entry point that renders generated target records as ordered setup steps.
 - Added Cloudflare OAuth rights profiles for read-only zone import, read-only plus Radar enrichment, and full DNS repair.
 - Added configurable mail-authentication setup defaults so generated DMARC/TLS-RPT guidance can use central report mailboxes.
 - Added source intelligence context for sending IPs, including provider recognition, network details, Radar links, and report activity history.

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -760,6 +760,40 @@ function domainDetailsApp(domainId) {
             return (this.dnsGuidance.target_records || []).filter(record => codes.has(record.code));
         },
 
+        targetRecordByCode(code) {
+            return (this.dnsGuidance.target_records || []).find(record => record.code === code) || null;
+        },
+
+        get mailAuthWizardSteps() {
+            const stepDefinitions = [
+                {
+                    code: 'target_dmarc',
+                    label: 'DMARC reporting',
+                    action: 'Publish or verify the DMARC policy and aggregate-report mailbox.',
+                    reason: 'This tells receivers where to send DMARC aggregate reports and defines the current enforcement mode.',
+                },
+                {
+                    code: 'target_spf',
+                    label: 'SPF sender authorization',
+                    action: 'Publish exactly one SPF record that matches the legitimate sending services.',
+                    reason: 'This lets receivers verify whether the connecting sender is allowed to send for this domain.',
+                },
+                {
+                    code: 'target_dkim',
+                    label: 'DKIM signing',
+                    action: 'Publish each provider selector and confirm active senders sign with aligned DKIM.',
+                    reason: 'This keeps DMARC passing even when SPF alignment changes or mail is forwarded.',
+                },
+            ];
+            return stepDefinitions
+                .map((definition, index) => ({
+                    ...definition,
+                    index: index + 1,
+                    record: this.targetRecordByCode(definition.code),
+                }))
+                .filter(step => step.record);
+        },
+
         get optionalTransportTargetRecords() {
             const codes = new Set(['target_dmarc', 'target_spf', 'target_dkim']);
             return (this.dnsGuidance.target_records || []).filter(record => !codes.has(record.code));

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -755,11 +755,6 @@ function domainDetailsApp(domainId) {
             return 'bg-base-200 text-base-content/70';
         },
 
-        get mailAuthTargetRecords() {
-            const codes = new Set(['target_dmarc', 'target_spf', 'target_dkim']);
-            return (this.dnsGuidance.target_records || []).filter(record => codes.has(record.code));
-        },
-
         targetRecordByCode(code) {
             return (this.dnsGuidance.target_records || []).find(record => record.code === code) || null;
         },
@@ -786,12 +781,15 @@ function domainDetailsApp(domainId) {
                 },
             ];
             return stepDefinitions
-                .map((definition, index) => ({
+                .map(definition => ({
                     ...definition,
-                    index: index + 1,
                     record: this.targetRecordByCode(definition.code),
                 }))
-                .filter(step => step.record);
+                .filter(step => step.record)
+                .map((step, index) => ({
+                    ...step,
+                    index: index + 1,
+                }));
         },
 
         get optionalTransportTargetRecords() {

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1271,31 +1271,37 @@
                                 </div>
                             </template>
                         </div>
-                        <div class="mt-4">
+                        <div id="mail-auth-wizard" class="mt-4">
                             <div class="rounded-lg border border-[#d8ebe8] bg-[#f2fbf9] p-4">
                                 <div class="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
                                     <div>
-                                        <h4 class="text-sm font-semibold text-[#07071f]">Mail authentication setup</h4>
-                                        <p class="text-xs text-[#45505f]">Publish or verify these core DMARC, SPF, and DKIM records first.</p>
+                                        <h4 class="text-sm font-semibold text-[#07071f]">Mail authentication wizard</h4>
+                                        <p class="text-xs text-[#45505f]">Work through DMARC, SPF, and DKIM in this order before tightening enforcement.</p>
                                     </div>
                                     <a href="/settings#dmarc-defaults" class="btn btn-xs btn-outline">Edit defaults</a>
                                 </div>
-                                <div class="mt-3 grid gap-2">
-                                    <template x-for="record in mailAuthTargetRecords" :key="record.code">
+                                <div class="mt-3 grid gap-3">
+                                    <template x-for="step in mailAuthWizardSteps" :key="step.code">
                                         <div class="rounded border border-[#c7e3df] bg-white p-3">
-                                            <div class="flex flex-col gap-2 lg:flex-row lg:items-center">
+                                            <div class="flex flex-col gap-3 lg:flex-row lg:items-start">
+                                                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#0f766e] text-sm font-semibold text-white"
+                                                     x-text="step.index"></div>
                                                 <div class="min-w-0 flex-1">
                                                     <div class="flex flex-wrap items-center gap-2">
-                                                        <code class="text-xs font-semibold" x-text="record.name"></code>
-                                                        <span class="badge badge-outline" x-text="record.record_type"></span>
-                                                        <span class="badge badge-ghost" x-text="record.priority"></span>
+                                                        <span class="text-sm font-semibold text-[#07071f]" x-text="step.label"></span>
+                                                        <span class="badge badge-outline" x-text="step.record.record_type"></span>
+                                                        <span class="badge badge-ghost" x-text="step.record.priority"></span>
                                                     </div>
-                                                    <code class="mt-2 block break-all rounded bg-base-200 p-2 text-xs" x-text="record.value"></code>
-                                                    <p class="mt-1 text-xs text-base-content/60" x-text="record.purpose"></p>
+                                                    <p class="mt-1 text-xs text-[#45505f]" x-text="step.action"></p>
+                                                    <p class="mt-1 text-xs text-base-content/60" x-text="step.reason"></p>
+                                                    <div class="mt-2 rounded bg-base-200 p-2">
+                                                        <code class="block break-all text-xs font-semibold" x-text="step.record.name"></code>
+                                                        <code class="mt-1 block break-all text-xs" x-text="step.record.value"></code>
+                                                    </div>
                                                 </div>
                                                 <button
-                                                    :data-domain-detail-copy-value="record.value"
-                                                    class="btn btn-xs btn-ghost"
+                                                    :data-domain-detail-copy-value="step.record.value"
+                                                    class="btn btn-xs btn-ghost lg:mt-1"
                                                     title="Copy DNS value"
                                                 >
                                                     Copy

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -936,6 +936,13 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
     template = _domain_details_template()
     script = _domain_details_script()
 
+    assert 'id="mail-auth-wizard"' in template
+    assert "Mail authentication wizard" in template
+    assert "mailAuthWizardSteps" in template
+    assert "targetRecordByCode" in script
+    assert "target_dmarc" in script
+    assert "target_spf" in script
+    assert "target_dkim" in script
     assert "Provider repair readiness" in template
     assert "providerContextStatusLabel" in script
     assert "providerContextSummary" in script


### PR DESCRIPTION
## What changed
- Turned the domain-detail mail-authentication setup card into an ordered DMARC/SPF/DKIM wizard entry point.
- Reuses the existing DNS guidance target records, so the wizard stays aligned with configured DMARC defaults and generated DNS plans.
- Adds step-level operator guidance for what each record does before tightening DMARC enforcement.
- Adds regression coverage so the domain detail template keeps exposing the wizard without unsafe HTML injection patterns.

## Why
Issue #574 asks for a per-domain mail-auth wizard that makes DMARC, SPF, and DKIM setup more actionable. The first backend/defaults slice already made generated records use configurable report mailboxes. This slice makes that guidance visible as a guided flow on the domain detail page without adding live DNS writes.

## Validation
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py`
- `node --check backend/app/static/js/domain-details-page.js`
- `git diff --check`
- Rebased on current `origin/main` after #592 merged.

Refs #574