### PR TITLE
feat: add domain DMARC mailbox overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Cloudflare DNS write capabilities remain tied to explicit full-repair selection and human-confirmed DNS changes.
 - Release metadata is sanitized for display and does not expose secrets.
+- Domain-specific DMARC aggregate-report mailbox overrides now feed DNS lint and
+  the mail-authentication wizard before falling back to the workspace default.
 
 ## [0.3.0] - 2026-02-09
 

--- a/backend/alembic/versions/c8d9e0f1a2b3_add_domain_dmarc_report_mailbox.py
+++ b/backend/alembic/versions/c8d9e0f1a2b3_add_domain_dmarc_report_mailbox.py
@@ -1,0 +1,32 @@
+"""add domain dmarc report mailbox
+
+Revision ID: c8d9e0f1a2b3
+Revises: b1c2d3e4f5a6, 6a7b8c9d0e1f, 1b2c3d4e5f6a
+Create Date: 2026-07-04 05:25:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d9e0f1a2b3"
+down_revision: Union[str, Sequence[str], None] = (
+    "b1c2d3e4f5a6",
+    "6a7b8c9d0e1f",
+    "1b2c3d4e5f6a",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Store optional domain-specific DMARC aggregate-report mailbox overrides."""
+    op.add_column("domains", sa.Column("dmarc_report_mailbox", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove domain-specific DMARC aggregate-report mailbox overrides."""
+    op.drop_column("domains", "dmarc_report_mailbox")

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -201,9 +201,34 @@ def _int_setting_value(db: Session, key: str, default: int) -> int:
         return default
 
 
-def _mail_auth_setup_defaults(db: Session) -> MailAuthSetupDefaults:
+def _normalize_optional_mailbox(value: Optional[str]) -> Optional[str]:
+    """Return a trimmed mailbox override or None when the operator cleared it."""
+    mailbox = (value or "").strip()
+    if not mailbox:
+        return None
+    if "@" not in mailbox or mailbox.startswith("@") or mailbox.endswith("@"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="DMARC report mailbox must be a valid email address",
+        )
+    if any(character.isspace() for character in mailbox):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="DMARC report mailbox must not contain whitespace",
+        )
+    return mailbox
+
+
+def _mail_auth_setup_defaults(
+    db: Session, domain: Optional[Domain] = None
+) -> MailAuthSetupDefaults:
+    report_mailbox = (
+        domain.dmarc_report_mailbox
+        if domain is not None and domain.dmarc_report_mailbox
+        else _setting_value(db, "dmarc.report_mailbox")
+    )
     return MailAuthSetupDefaults(
-        report_mailbox=_setting_value(db, "dmarc.report_mailbox"),
+        report_mailbox=report_mailbox,
         tls_report_mailbox=_setting_value(db, "dmarc.tls_report_mailbox"),
         policy=_setting_value(db, "dmarc.default_policy") or "none",
         percentage=_int_setting_value(db, "dmarc.default_percentage", 100),
@@ -250,6 +275,7 @@ class DomainResponse(DomainBase):
     emails_count: int = 0
     compliance_rate: float = 0.0
     dkim_selectors: List[str] = Field(default_factory=list)
+    dmarc_report_mailbox: Optional[str] = None
     mail_service_context: List[Dict[str, Any]] = Field(default_factory=list)
 
 
@@ -259,6 +285,7 @@ class DomainCreate(BaseModel):
     name: str
     description: Optional[str] = None
     dkim_selectors: Optional[List[str]] = None
+    dmarc_report_mailbox: Optional[str] = None
 
 
 class DomainUpdate(BaseModel):
@@ -266,6 +293,7 @@ class DomainUpdate(BaseModel):
 
     description: Optional[str] = None
     dkim_selectors: Optional[List[str]] = None
+    dmarc_report_mailbox: Optional[str] = None
 
 
 class DomainStatsResponse(BaseModel):
@@ -2405,6 +2433,7 @@ async def _build_domain_dns_guidance(
         refresh=refresh,
     )
     mail_service_records = await mail_service_dns_records_for_domain(db, domain_id)
+    stored_domain = db.query(Domain).filter(Domain.name == domain_id).first()
     guidance = await build_dns_guidance(
         domain_id,
         provider,
@@ -2415,7 +2444,7 @@ async def _build_domain_dns_guidance(
         monitored_selectors=combined_selectors,
         observed_selectors=report_selectors,
         mail_service_records=mail_service_records,
-        setup_defaults=_mail_auth_setup_defaults(db),
+        setup_defaults=_mail_auth_setup_defaults(db, stored_domain),
         locale=locale or get_settings().default_locale,
     )
     return asdict(guidance)
@@ -3456,6 +3485,7 @@ async def read_domains(
             dkim_selectors=_normalize_domain_selectors(
                 (stored_domain.dkim_selectors or "").split(",") if stored_domain else []
             ),
+            dmarc_report_mailbox=stored_domain.dmarc_report_mailbox if stored_domain else None,
             mail_service_context=mail_service_context_from_domain(stored_domain),
         )
         result.append(domain_response)
@@ -3495,11 +3525,13 @@ async def create_domain(
             _raise_plan_limit_error(exc)
 
     selectors = ",".join(_normalize_domain_selectors(payload.dkim_selectors))
+    report_mailbox = _normalize_optional_mailbox(payload.dmarc_report_mailbox)
     domain = Domain(
         workspace_id=workspace.id,
         name=name,
         description=payload.description,
         dkim_selectors=selectors or None,
+        dmarc_report_mailbox=report_mailbox,
         active=True,
         verified=False,
     )
@@ -3518,6 +3550,7 @@ async def create_domain(
         description=domain.description,
         policy=domain.dmarc_policy or "unknown",
         dkim_selectors=_normalize_domain_selectors((domain.dkim_selectors or "").split(",")),
+        dmarc_report_mailbox=domain.dmarc_report_mailbox,
         mail_service_context=mail_service_context_from_domain(domain),
     )
 
@@ -3556,6 +3589,7 @@ async def read_domain(
         dkim_selectors=_normalize_domain_selectors(
             (stored_domain.dkim_selectors or "").split(",") if stored_domain else []
         ),
+        dmarc_report_mailbox=stored_domain.dmarc_report_mailbox if stored_domain else None,
         mail_service_context=mail_service_context_from_domain(stored_domain),
     )
 
@@ -3603,6 +3637,8 @@ async def update_domain(
     if "dkim_selectors" in fields:
         selectors = _normalize_domain_selectors(payload.dkim_selectors)
         domain.dkim_selectors = ",".join(selectors) if selectors else None
+    if "dmarc_report_mailbox" in fields:
+        domain.dmarc_report_mailbox = _normalize_optional_mailbox(payload.dmarc_report_mailbox)
 
     try:
         db.commit()
@@ -3625,6 +3661,7 @@ async def update_domain(
             "dkim_selector_count": len(
                 _normalize_domain_selectors((domain.dkim_selectors or "").split(","))
             ),
+            "has_dmarc_report_mailbox_override": bool(domain.dmarc_report_mailbox),
         },
         auth_context=_auth,
         request=request,
@@ -3641,6 +3678,7 @@ async def update_domain(
         emails_count=summary.get("total_count", 0),
         compliance_rate=summary.get("compliance_rate", 0.0),
         dkim_selectors=_normalize_domain_selectors((domain.dkim_selectors or "").split(",")),
+        dmarc_report_mailbox=domain.dmarc_report_mailbox,
         mail_service_context=mail_service_context_from_domain(domain),
     )
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -206,7 +206,14 @@ def _normalize_optional_mailbox(value: Optional[str]) -> Optional[str]:
     mailbox = (value or "").strip()
     if not mailbox:
         return None
-    if "@" not in mailbox or mailbox.startswith("@") or mailbox.endswith("@"):
+    if mailbox.lower().startswith("mailto:"):
+        mailbox = mailbox[7:].strip()
+    if any(character in mailbox for character in (";", ",")):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="DMARC report mailbox must be a single email address",
+        )
+    if mailbox.count("@") != 1 or mailbox.startswith("@") or mailbox.endswith("@"):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="DMARC report mailbox must be a valid email address",

--- a/backend/app/models/domain.py
+++ b/backend/app/models/domain.py
@@ -19,6 +19,7 @@ class Domain(Base):
 
     # DMARC policy information
     dmarc_policy = Column(String, nullable=True)
+    dmarc_report_mailbox = Column(String, nullable=True)
     spf_record = Column(String, nullable=True)
     dkim_selectors = Column(String, nullable=True)  # Comma-separated list of DKIM selectors
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -577,6 +577,85 @@ def test_dns_lint_endpoint_uses_configured_mail_auth_defaults(
     assert targets["target_tls_rpt"]["value"] == "v=TLSRPTv1; rua=mailto:tls-reports@cklnet.com"
 
 
+def test_dns_lint_endpoint_prefers_domain_dmarc_mailbox_override(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add_all(
+        [
+            Setting(
+                key="dmarc.report_mailbox",
+                value="dmarc-reports@central.example",
+                description="Central DMARC report mailbox",
+                value_type="string",
+                category="dmarc",
+            ),
+            Domain(
+                name=DOMAIN,
+                active=True,
+                dmarc_report_mailbox="dmarc-example@tenant.example",
+            ),
+        ]
+    )
+    db_session.commit()
+    result = DomainDNSResult(
+        dmarc=False,
+        spf=False,
+        dkim=False,
+        selectors_checked=["selector1"],
+    )
+
+    with (
+        _mock_dns(result),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(MTAStsResult(status="pass"), False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(BIMIResult(status="pass"), False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/lint")
+
+    assert response.status_code == 200
+    targets = {record["code"]: record for record in response.json()["target_records"]}
+    assert targets["target_dmarc"]["value"] == (
+        "v=DMARC1; p=none; rua=mailto:dmarc-example@tenant.example; "
+        "pct=100; adkim=r; aspf=r"
+    )
+
+
+def test_update_domain_persists_dmarc_report_mailbox_override(authed_client: TestClient):
+    create_response = authed_client.post("/api/v1/domains/domains", json={"name": DOMAIN})
+    assert create_response.status_code == 201
+
+    response = authed_client.patch(
+        f"/api/v1/domains/domains/{DOMAIN}",
+        json={"dmarc_report_mailbox": "dmarc-example@tenant.example"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["dmarc_report_mailbox"] == "dmarc-example@tenant.example"
+
+    read_response = authed_client.get(f"/api/v1/domains/domains/{DOMAIN}")
+    assert read_response.status_code == 200
+    assert read_response.json()["dmarc_report_mailbox"] == "dmarc-example@tenant.example"
+
+
+def test_update_domain_rejects_invalid_dmarc_report_mailbox(authed_client: TestClient):
+    create_response = authed_client.post("/api/v1/domains/domains", json={"name": DOMAIN})
+    assert create_response.status_code == 201
+
+    response = authed_client.patch(
+        f"/api/v1/domains/domains/{DOMAIN}",
+        json={"dmarc_report_mailbox": "not a mailbox"},
+    )
+
+    assert response.status_code == 422
+    assert "valid email address" in response.json()["detail"]
+
+
 def test_int_setting_value_preserves_zero_and_falls_back(db_session):
     db_session.add_all(
         [

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -632,7 +632,7 @@ def test_update_domain_persists_dmarc_report_mailbox_override(authed_client: Tes
 
     response = authed_client.patch(
         f"/api/v1/domains/domains/{DOMAIN}",
-        json={"dmarc_report_mailbox": "dmarc-example@tenant.example"},
+        json={"dmarc_report_mailbox": "mailto:dmarc-example@tenant.example"},
     )
 
     assert response.status_code == 200
@@ -642,18 +642,38 @@ def test_update_domain_persists_dmarc_report_mailbox_override(authed_client: Tes
     assert read_response.status_code == 200
     assert read_response.json()["dmarc_report_mailbox"] == "dmarc-example@tenant.example"
 
+    response = authed_client.patch(
+        f"/api/v1/domains/domains/{DOMAIN}",
+        json={"dmarc_report_mailbox": ""},
+    )
+    assert response.status_code == 200
+    assert response.json()["dmarc_report_mailbox"] is None
+
+    response = authed_client.patch(
+        f"/api/v1/domains/domains/{DOMAIN}",
+        json={"dmarc_report_mailbox": "dmarc-example@tenant.example"},
+    )
+    assert response.status_code == 200
+
+    response = authed_client.patch(
+        f"/api/v1/domains/domains/{DOMAIN}",
+        json={"dmarc_report_mailbox": None},
+    )
+    assert response.status_code == 200
+    assert response.json()["dmarc_report_mailbox"] is None
+
 
 def test_update_domain_rejects_invalid_dmarc_report_mailbox(authed_client: TestClient):
     create_response = authed_client.post("/api/v1/domains/domains", json={"name": DOMAIN})
     assert create_response.status_code == 201
 
-    response = authed_client.patch(
-        f"/api/v1/domains/domains/{DOMAIN}",
-        json={"dmarc_report_mailbox": "not a mailbox"},
-    )
+    for mailbox in ("not a mailbox", "dmarc@example.com; pct=0", "a@example.com,b@example.com"):
+        response = authed_client.patch(
+            f"/api/v1/domains/domains/{DOMAIN}",
+            json={"dmarc_report_mailbox": mailbox},
+        )
 
-    assert response.status_code == 422
-    assert "valid email address" in response.json()["detail"]
+        assert response.status_code == 422
 
 
 def test_int_setting_value_preserves_zero_and_falls_back(db_session):

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -557,6 +557,7 @@ Returns details for a specific domain.
 {
   "id": "1",
   "name": "example.com",
+  "dmarc_report_mailbox": "dmarc-reports@example.net",
   "added_at": "2025-01-15T14:30:00Z",
   "status": "active",
   "compliance_rate": 87.5,
@@ -569,6 +570,21 @@ Returns details for a specific domain.
   }
 }
 ```
+
+`dmarc_report_mailbox` is optional. When present, generated DMARC target
+records and DNS lint guidance use it as the aggregate-report `rua` destination
+for this domain. When omitted, DMARQ uses the workspace-wide
+`dmarc.report_mailbox` setting and then falls back to `dmarc@<domain>`.
+
+#### Update Domain Metadata
+
+```
+PATCH /domains/{domain_id}
+```
+
+Editable fields include `description`, `dkim_selectors`, and
+`dmarc_report_mailbox`. Send an empty string or `null` for
+`dmarc_report_mailbox` to clear the domain-specific override.
 
 #### Get BIMI Posture
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -45,9 +45,16 @@ To update a record:
 
 Configure where and how DMARC reports are delivered:
 
-- **RUA Email**: The email address receiving aggregate reports
+- **Default RUA Email**: The central workspace mailbox that should receive
+  aggregate reports, such as `dmarc-reports@example.net`
+- **Domain RUA Override**: An optional per-domain mailbox when one domain needs
+  a different aggregate-report destination
 - **RUF Email**: The email address receiving forensic reports
 - **Report Frequency**: How often you want to receive reports
+
+DNS guidance and the mail authentication wizard use the domain override first,
+then the workspace default, and only fall back to `dmarc@<domain>` when neither
+is configured.
 
 ## Domain Health Check
 


### PR DESCRIPTION
Refs #574

## Summary
- add an optional per-domain DMARC aggregate-report mailbox override
- use the domain override ahead of the workspace default in DNS lint and mail-auth wizard target records
- expose the field in domain create/read/update responses and document the fallback order

## Local validation
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dns_guidance.py backend/app/tests/test_dns_endpoints.py` -> 103 passed
- `git diff --check` -> passed
- `py_compile` for changed backend/migration files -> passed

## Notes
Black/isort are not installed in the local validation venv, so GitHub lint remains the final formatting gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Domains can now store an optional DMARC report mailbox override.
  * Domain details and update requests now support viewing and editing this setting.
  * DNS linting and mail-auth setup now use the domain-specific mailbox when available, with fallback behavior preserved.

* **Bug Fixes**
  * Improved validation for mailbox values to reject invalid or malformed email addresses.
  * Clearing the override is now supported through domain updates.

* **Documentation**
  * Updated API and user guides to explain report destination precedence and the new domain override field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->