### PR TITLE
security: remove inline script CSP allowance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release metadata is sanitized for display and does not expose secrets.
 - Domain-specific DMARC aggregate-report mailbox overrides now feed DNS lint and
   the mail-authentication wizard before falling back to the workspace default.
+- The default browser policy no longer allows inline scripts; Alpine expression
+  compatibility still keeps `unsafe-eval` until the CSP runtime migration is
+  complete.
 
 ## [0.3.0] - 2026-02-09
 

--- a/backend/app/middleware/security.py
+++ b/backend/app/middleware/security.py
@@ -41,7 +41,7 @@ def _relaxed_csp_directives() -> list[str]:
     """Return the compatibility CSP required by current Alpine expressions."""
     return [
         "default-src 'self'",
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+        "script-src 'self' 'unsafe-eval'",
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
         "font-src 'self' https://fonts.gstatic.com",
         "img-src 'self' data: https:",

--- a/backend/app/tests/test_security.py
+++ b/backend/app/tests/test_security.py
@@ -140,6 +140,10 @@ class TestSecurityHeaders:
         csp = response.headers["Content-Security-Policy"]
 
         assert "'unsafe-eval'" in csp
+        script_src = next(part.strip() for part in csp.split(";") if "script-src" in part)
+        assert "'unsafe-inline'" not in script_src
+        assert script_src == "script-src 'self' 'unsafe-eval'"
+        assert "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com" in csp
         assert "https://cdn.jsdelivr.net" not in csp
         assert "https://cdn.tailwindcss.com" not in csp
 

--- a/backend/app/tests/test_security.py
+++ b/backend/app/tests/test_security.py
@@ -140,7 +140,11 @@ class TestSecurityHeaders:
         csp = response.headers["Content-Security-Policy"]
 
         assert "'unsafe-eval'" in csp
-        script_src = next(part.strip() for part in csp.split(";") if "script-src" in part)
+        script_src = next(
+            part.strip()
+            for part in csp.split(";")
+            if part.strip().startswith("script-src ")
+        )
         assert "'unsafe-inline'" not in script_src
         assert script_src == "script-src 'self' 'unsafe-eval'"
         assert "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com" in csp


### PR DESCRIPTION
Refs #426

## Summary
- remove `unsafe-inline` from the default `script-src` CSP directive
- keep `unsafe-eval` for the current Alpine expression runtime
- keep `style-src unsafe-inline` for the remaining style compatibility boundary
- update regression coverage and changelog

## Local validation
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_security.py backend/app/tests/test_dashboard_template_security.py` -> 107 passed
- `py_compile` for changed backend/test files -> passed
- `git diff --check` -> passed

## Notes
This is the next conservative CSP step after page scripts were externalized. It does not yet remove `unsafe-eval`; that remains tied to the Alpine CSP runtime migration.