### PR TITLE
fix: merge alembic migration heads

### DIFF
--- a/backend/alembic/versions/d9e0f1a2b3c4_merge_mail_auth_and_backfill_heads.py
+++ b/backend/alembic/versions/d9e0f1a2b3c4_merge_mail_auth_and_backfill_heads.py
@@ -1,4 +1,4 @@
-"""merge mail auth and backfill migration heads
+"""merge backfill checkpoints and dmarc mailbox migration heads
 
 Revision ID: d9e0f1a2b3c4
 Revises: c1d2e3f4a5b6, c8d9e0f1a2b3

--- a/backend/alembic/versions/d9e0f1a2b3c4_merge_mail_auth_and_backfill_heads.py
+++ b/backend/alembic/versions/d9e0f1a2b3c4_merge_mail_auth_and_backfill_heads.py
@@ -1,0 +1,26 @@
+"""merge mail auth and backfill migration heads
+
+Revision ID: d9e0f1a2b3c4
+Revises: c1d2e3f4a5b6, c8d9e0f1a2b3
+Create Date: 2026-07-04 06:35:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "d9e0f1a2b3c4"
+down_revision: Union[str, Sequence[str], None] = (
+    "c1d2e3f4a5b6",
+    "c8d9e0f1a2b3",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Merge parallel migration branches without changing schema."""
+
+
+def downgrade() -> None:
+    """Unmerge only the Alembic revision marker."""

--- a/backend/app/tests/test_alembic_migrations.py
+++ b/backend/app/tests/test_alembic_migrations.py
@@ -9,5 +9,6 @@ def test_alembic_revision_graph_has_single_head():
     backend_dir = Path(__file__).resolve().parents[2]
     config = Config(str(backend_dir / "alembic.ini"))
     script = ScriptDirectory.from_config(config)
+    heads = script.get_heads()
 
-    assert script.get_heads() == ["d9e0f1a2b3c4"]
+    assert len(heads) == 1, f"Expected a single Alembic head, got {heads}"

--- a/backend/app/tests/test_alembic_migrations.py
+++ b/backend/app/tests/test_alembic_migrations.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def test_alembic_revision_graph_has_single_head():
+    """Production deploys run `alembic upgrade head`, so multiple heads block rollout."""
+    backend_dir = Path(__file__).resolve().parents[2]
+    config = Config(str(backend_dir / "alembic.ini"))
+    script = ScriptDirectory.from_config(config)
+
+    assert script.get_heads() == ["d9e0f1a2b3c4"]


### PR DESCRIPTION
## Summary

- adds an Alembic merge migration for the parallel `c1d2e3f4a5b6` and `c8d9e0f1a2b3` heads
- adds a regression test so the migration graph must keep a single head

## Why

Prod rollout of the v1.120.0 image is currently blocked in the `dmarq-migrate` hook because `alembic upgrade head` refuses to run with multiple heads:

```text
Multiple head revisions are present for given argument 'head'
```

The existing app pods remain healthy, but the GitOps sync cannot complete until the migration graph has one head again.

## Validation

- `/tmp/dmarq-live-audit-venv/bin/alembic -c backend/alembic.ini heads`
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_alembic_migrations.py`
- `/tmp/dmarq-live-audit-venv/bin/python -m py_compile backend/alembic/versions/d9e0f1a2b3c4_merge_mail_auth_and_backfill_heads.py backend/app/tests/test_alembic_migrations.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a migration branch split so the database history now has a single clear path.
  * Kept the schema unchanged while aligning the migration record for smoother future upgrades.

* **Tests**
  * Added a check to ensure the migration history remains on one head revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->