### PR TITLE
test: audit strict CSP in browser smoke

### DIFF
--- a/backend/playwright.config.cjs
+++ b/backend/playwright.config.cjs
@@ -31,6 +31,7 @@ if (!useExternalServer) {
     env: {
       ...process.env,
       DMARQ_BROWSER_SMOKE_PORT: port,
+      CSP_REPORT_ONLY: process.env.CSP_REPORT_ONLY || 'true',
     },
   };
 }

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -522,10 +522,14 @@ async function installApiMocks(page) {
 }
 
 async function installCspViolationRecorder(page) {
+  page.__dmarqCspViolations = [];
+  await page.exposeFunction('__recordDmarqCspViolation', (violation) => {
+    page.__dmarqCspViolations.push(violation);
+  });
+
   await page.addInitScript(() => {
-    window.__dmarqCspViolations = [];
     document.addEventListener('securitypolicyviolation', (event) => {
-      window.__dmarqCspViolations.push({
+      window.__recordDmarqCspViolation({
         blockedURI: event.blockedURI,
         disposition: event.disposition,
         effectiveDirective: event.effectiveDirective,
@@ -539,6 +543,10 @@ async function installCspViolationRecorder(page) {
   });
 }
 
+function directiveMatches(effectiveDirective, directive) {
+  return effectiveDirective === directive || effectiveDirective.startsWith(`${directive}-`);
+}
+
 function isKnownStrictCspMigrationBlocker(violation) {
   const sourceFile = violation.sourceFile || '';
   const blockedURI = violation.blockedURI || '';
@@ -550,8 +558,8 @@ function isKnownStrictCspMigrationBlocker(violation) {
 
   if (sourceFile.endsWith('/static/js/vendor/alpine.min.js')) {
     return (
-      (effectiveDirective === 'script-src' && blockedURI === 'eval') ||
-      (effectiveDirective === 'style-src' && blockedURI === 'inline')
+      (directiveMatches(effectiveDirective, 'script-src') && blockedURI === 'eval') ||
+      (directiveMatches(effectiveDirective, 'style-src') && blockedURI === 'inline')
     );
   }
 
@@ -564,18 +572,22 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.afterEach(async ({ page }) => {
-  const violations = await page.evaluate(() => window.__dmarqCspViolations || []);
+  const violations = page.__dmarqCspViolations || [];
   const unexpectedViolations = violations.filter(
     (violation) => !isKnownStrictCspMigrationBlocker(violation)
   );
 
-  expect(unexpectedViolations).toEqual([]);
+  expect(unexpectedViolations, 'unexpected CSP report-only violations').toEqual([]);
 });
 
 test('dashboard becomes useful before false empty states appear', async ({ page }) => {
   const started = Date.now();
   const response = await page.goto('/dashboard');
-  expect(response.headers()['content-security-policy-report-only']).toContain("script-src 'self'");
+  expect(response, 'dashboard navigation should return a response').not.toBeNull();
+  const cspReportOnly = response.headers()['content-security-policy-report-only'];
+  expect(cspReportOnly, 'dashboard should send a CSP report-only header').toContain(
+    "script-src 'self'"
+  );
 
   await expect(page.getByText('Fix DKIM alignment for owned infrastructure')).toBeVisible();
   await expect(page.getByText('cklnet.com').first()).toBeVisible();

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -521,13 +521,61 @@ async function installApiMocks(page) {
   });
 }
 
+async function installCspViolationRecorder(page) {
+  await page.addInitScript(() => {
+    window.__dmarqCspViolations = [];
+    document.addEventListener('securitypolicyviolation', (event) => {
+      window.__dmarqCspViolations.push({
+        blockedURI: event.blockedURI,
+        disposition: event.disposition,
+        effectiveDirective: event.effectiveDirective,
+        lineNumber: event.lineNumber,
+        originalPolicy: event.originalPolicy,
+        sample: event.sample,
+        sourceFile: event.sourceFile,
+        violatedDirective: event.violatedDirective,
+      });
+    });
+  });
+}
+
+function isKnownStrictCspMigrationBlocker(violation) {
+  const sourceFile = violation.sourceFile || '';
+  const blockedURI = violation.blockedURI || '';
+  const effectiveDirective = violation.effectiveDirective || violation.violatedDirective || '';
+
+  if (violation.disposition !== 'report') {
+    return false;
+  }
+
+  if (sourceFile.endsWith('/static/js/vendor/alpine.min.js')) {
+    return (
+      (effectiveDirective === 'script-src' && blockedURI === 'eval') ||
+      (effectiveDirective === 'style-src' && blockedURI === 'inline')
+    );
+  }
+
+  return false;
+}
+
 test.beforeEach(async ({ page }) => {
+  await installCspViolationRecorder(page);
   await installApiMocks(page);
+});
+
+test.afterEach(async ({ page }) => {
+  const violations = await page.evaluate(() => window.__dmarqCspViolations || []);
+  const unexpectedViolations = violations.filter(
+    (violation) => !isKnownStrictCspMigrationBlocker(violation)
+  );
+
+  expect(unexpectedViolations).toEqual([]);
 });
 
 test('dashboard becomes useful before false empty states appear', async ({ page }) => {
   const started = Date.now();
-  await page.goto('/dashboard');
+  const response = await page.goto('/dashboard');
+  expect(response.headers()['content-security-policy-report-only']).toContain("script-src 'self'");
 
   await expect(page.getByText('Fix DKIM alignment for owned infrastructure')).toBeVisible();
   await expect(page.getByText('cklnet.com').first()).toBeVisible();

--- a/backend/tests/browser/smoke_server.py
+++ b/backend/tests/browser/smoke_server.py
@@ -1,5 +1,6 @@
 """Local browser-smoke server with deterministic DMARC report evidence."""
 
+import atexit
 import os
 import sys
 from pathlib import Path
@@ -11,10 +12,12 @@ os.environ.setdefault("ENVIRONMENT", "test")
 os.environ.setdefault("AUTH_DISABLED", "true")
 os.environ.setdefault("ALLOW_AUTH_DISABLED_IN_PRODUCTION", "true")
 os.environ.setdefault("SECRET_KEY", "browser-smoke-secret-key-change-me")
+SMOKE_DB_PATH = Path(f"/tmp/dmarq-browser-smoke-{os.getpid()}.sqlite")
 os.environ.setdefault(
     "DATABASE_URL",
-    f"sqlite:///{Path(f'/tmp/dmarq-browser-smoke-{os.getpid()}.sqlite').as_posix()}",
+    f"sqlite:///{SMOKE_DB_PATH.as_posix()}",
 )
+atexit.register(lambda: SMOKE_DB_PATH.unlink(missing_ok=True))
 os.environ.setdefault("SOURCE_NETWORK_ENRICHMENT_ENABLED", "false")
 os.environ.setdefault("SOURCE_REPUTATION_FEEDS_ENABLED", "false")
 

--- a/backend/tests/browser/smoke_server.py
+++ b/backend/tests/browser/smoke_server.py
@@ -13,7 +13,7 @@ os.environ.setdefault("ALLOW_AUTH_DISABLED_IN_PRODUCTION", "true")
 os.environ.setdefault("SECRET_KEY", "browser-smoke-secret-key-change-me")
 os.environ.setdefault(
     "DATABASE_URL",
-    f"sqlite:///{Path('/tmp/dmarq-browser-smoke.sqlite').as_posix()}",
+    f"sqlite:///{Path(f'/tmp/dmarq-browser-smoke-{os.getpid()}.sqlite').as_posix()}",
 )
 os.environ.setdefault("SOURCE_NETWORK_ENRICHMENT_ENABLED", "false")
 os.environ.setdefault("SOURCE_REPUTATION_FEEDS_ENABLED", "false")


### PR DESCRIPTION
## Summary
- run browser smoke tests with strict CSP report-only enabled by default
- record browser `securitypolicyviolation` events and fail on unexpected CSP regressions
- keep the current known Alpine runtime blockers explicit while issue #598 tracks the final strict-default migration
- isolate the browser-smoke SQLite database per server process so stale local schemas do not mask UI results

## Validation
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_security.py backend/app/tests/test_dashboard_template_security.py`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium`

Refs #598


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser session handling for content security policy reporting, helping surface unexpected script policy issues more reliably.
  * Reduced flaky browser smoke runs by isolating each process’s temporary database file.
* **Tests**
  * Added checks to catch unexpected security policy violations during end-to-end browser testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->