### PR TITLE
refactor: make upload form alpine csp ready

### DIFF
--- a/backend/app/static/js/upload-page.js
+++ b/backend/app/static/js/upload-page.js
@@ -22,6 +22,26 @@ function uploadForm() {
             return this.files.filter((file) => file.status === 'error').length;
         },
 
+        get dropzoneClass() {
+            return this.dragover ? 'border-primary/50 bg-primary/5' : '';
+        },
+
+        get queuedFileLabel() {
+            return `${this.files.length} file${this.files.length !== 1 ? 's' : ''} queued`;
+        },
+
+        get allSuccessMessage() {
+            return `Successfully processed ${this.successCount} file${this.successCount !== 1 ? 's' : ''}.`;
+        },
+
+        get allErrorMessage() {
+            return `Failed to process ${this.errorCount} file${this.errorCount !== 1 ? 's' : ''}.`;
+        },
+
+        get mixedUploadMessage() {
+            return `${this.successCount} succeeded, ${this.errorCount} failed. See details above.`;
+        },
+
         bindControls() {
             const root = this.$root;
             if (!root || root.dataset.uploadControlsBound === 'true') return;
@@ -149,3 +169,7 @@ function uploadForm() {
         },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('uploadForm', uploadForm);
+});

--- a/backend/app/templates/upload.html
+++ b/backend/app/templates/upload.html
@@ -21,7 +21,7 @@
                 <!-- Drop Zone -->
                 <div
                     class="flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg p-8 text-center hover:bg-muted/50 transition-colors cursor-pointer relative"
-                    x-bind:class="{'border-primary/50 bg-primary/5': dragover}"
+                    x-bind:class="dropzoneClass"
                     data-upload-dropzone
                 >
                     <div class="mb-4 text-muted-foreground">
@@ -47,7 +47,7 @@
                 <div x-show="files.length > 0" x-cloak class="space-y-2">
                     <!-- Queue header -->
                     <div class="flex items-center justify-between text-sm text-muted-foreground">
-                        <span x-text="`${files.length} file${files.length !== 1 ? 's' : ''} queued`"></span>
+                        <span x-text="queuedFileLabel"></span>
                         <button
                             type="button"
                             class="text-xs underline hover:text-foreground"
@@ -105,7 +105,7 @@
                             {% call alert(variant="success") %}
                                 {% call alert_title() %}All uploads complete{% endcall %}
                                 {% call alert_description() %}
-                                    <p x-text="`Successfully processed ${successCount} file${successCount !== 1 ? 's' : ''}.`"></p>
+                                    <p x-text="allSuccessMessage"></p>
                                 {% endcall %}
                             {% endcall %}
                         </template>
@@ -113,7 +113,7 @@
                             {% call alert(variant="error") %}
                                 {% call alert_title() %}Upload failed{% endcall %}
                                 {% call alert_description() %}
-                                    <p x-text="`Failed to process ${errorCount} file${errorCount !== 1 ? 's' : ''}.`"></p>
+                                    <p x-text="allErrorMessage"></p>
                                 {% endcall %}
                             {% endcall %}
                         </template>
@@ -121,7 +121,7 @@
                             {% call alert(variant="warning") %}
                                 {% call alert_title() %}Upload complete with errors{% endcall %}
                                 {% call alert_description() %}
-                                    <p x-text="`${successCount} succeeded, ${errorCount} failed. See details above.`"></p>
+                                    <p x-text="mixedUploadMessage"></p>
                                 {% endcall %}
                             {% endcall %}
                         </template>


### PR DESCRIPTION
## Summary
- register the upload form through `Alpine.data('uploadForm', ...)` so it works with the Alpine CSP runtime
- move upload-page template literals and object class bindings out of inline Alpine expressions and into component getters
- keep the existing standard Alpine behavior unchanged while making this page pass under strict CSP with the CSP runtime

## Validation
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_security.py`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium`
- local strict-CSP POC for upload only: temporarily swapped in `@alpinejs/csp@3.15.12`, then ran `CSP_ENFORCE_STRICT=true CSP_REPORT_ONLY=false DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium -g "upload page"`

Refs #598
