### PR TITLE
feat: surface remediation activity on dashboard

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -100,7 +100,10 @@ from app.services.organizations import (
     OrganizationPlanLimitError,
     require_organization_plan_limit,
 )
-from app.services.remediation_dispatch import attach_remediation_dispatch_previews
+from app.services.remediation_dispatch import (
+    attach_remediation_dispatch_previews,
+    summarize_remediation_activity,
+)
 from app.services.remediation_queue import build_remediation_queue
 from app.services.report_persistence import (
     domain_summaries_from_db,
@@ -3243,6 +3246,12 @@ async def get_domains_summary(
         domain.name: domain
         for domain in workspace_domain_query(db, workspace).filter(Domain.name.in_(domains)).all()
     }
+    remediation_activity = summarize_remediation_activity(
+        db,
+        workspace=workspace,
+        domains=domains,
+    )
+    remediation_by_domain = remediation_activity["domains"]
 
     async def _dns_for_domain(domain_name: str) -> DomainDNSResult:
         manual_selectors = manual_selectors_by_domain.get(domain_name, [])
@@ -3320,6 +3329,7 @@ async def get_domains_summary(
             ),
             "dmarc_warnings": dns.dmarc_warnings,
             "dmarc_suggestions": dns.dmarc_suggestions,
+            "remediation": remediation_by_domain.get(domain_name, {}),
         }
         domain_row["health"] = score_domain_health(domain_row)
         domains_list.append(domain_row)
@@ -3331,13 +3341,16 @@ async def get_domains_summary(
     if total_emails > 0:
         overall_pass_rate = round((total_passed / total_emails) * 100, 1)
 
+    health_summary = build_health_summary(domains_list, domain_health)
+    health_summary["remediation"] = remediation_activity["summary"]
+
     return DomainSummaryResponse(
         total_domains=total_domains,
         total_emails=total_emails,
         overall_pass_rate=overall_pass_rate,
         reports_processed=total_reports,
         domains=domains_list,
-        health_summary=build_health_summary(domains_list, domain_health),
+        health_summary=health_summary,
     )
 
 

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -6,6 +6,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.models.setting import Setting
@@ -272,18 +273,22 @@ def summarize_remediation_activity(
             "domains": summaries,
         }
 
-    effective_row_limit = max(row_limit, len(domain_names) * 15)
-    rows = (
-        db.query(WorkspaceAuditLog)
-        .filter(
-            WorkspaceAuditLog.workspace_id == workspace.id,
-            WorkspaceAuditLog.entity_type == "remediation_notification",
-            WorkspaceAuditLog.action.in_(HISTORY_ACTIONS),
+    normalized_entity_name = func.lower(func.rtrim(func.trim(WorkspaceAuditLog.entity_name), "."))
+    rows: List[WorkspaceAuditLog] = []
+    per_domain_limit = max(row_limit, 1)
+    for domain in domain_names:
+        rows.extend(
+            db.query(WorkspaceAuditLog)
+            .filter(
+                WorkspaceAuditLog.workspace_id == workspace.id,
+                WorkspaceAuditLog.entity_type == "remediation_notification",
+                normalized_entity_name == domain,
+                WorkspaceAuditLog.action.in_(HISTORY_ACTIONS),
+            )
+            .order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
+            .limit(per_domain_limit)
+            .all()
         )
-        .order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
-        .limit(effective_row_limit)
-        .all()
-    )
 
     for row in rows:
         domain = normalize_domain_name(str(row.entity_name or ""))

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -163,6 +163,129 @@ def _history_entry(row: WorkspaceAuditLog) -> Optional[Dict[str, Any]]:
     }
 
 
+def _empty_domain_activity(domain: str) -> Dict[str, Any]:
+    return {
+        "domain": domain,
+        "status": "none",
+        "latest_state": None,
+        "latest_label": "No operator activity",
+        "latest_at": None,
+        "previewed": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "rejected": 0,
+        "snoozed": 0,
+        "dispatch_enqueued": 0,
+        "delivery_count": 0,
+        "needs_operator_follow_up": False,
+    }
+
+
+def _apply_activity_entry(summary: Dict[str, Any], entry: Dict[str, Any]) -> None:
+    state = str(entry.get("state") or "")
+    if summary["latest_state"] is None:
+        summary["latest_state"] = state
+        summary["latest_label"] = str(entry.get("label") or state.replace("_", " ").title())
+        summary["latest_at"] = entry.get("created_at")
+    if state in {"previewed", "acknowledged", "resolved", "rejected", "snoozed"}:
+        summary[state] += 1
+    if state == "delivery_enqueued":
+        summary["dispatch_enqueued"] += 1
+        summary["delivery_count"] += _safe_int(entry.get("delivery_count"))
+
+
+def _activity_status(summary: Dict[str, Any]) -> str:
+    latest_state = summary["latest_state"]
+    if latest_state == "resolved":
+        return "resolved"
+    if latest_state in {"rejected", "snoozed"}:
+        return "operator_hold"
+    if summary["dispatch_enqueued"]:
+        return "dispatched"
+    if latest_state in {"previewed", "acknowledged"}:
+        return "reviewed"
+    if latest_state:
+        return "activity"
+    return "none"
+
+
+def _finalize_activity_summary(summary: Dict[str, Any]) -> None:
+    summary["status"] = _activity_status(summary)
+    summary["needs_operator_follow_up"] = summary["status"] in {
+        "dispatched",
+        "reviewed",
+        "operator_hold",
+    }
+
+
+def _remediation_activity_totals(summaries: Dict[str, Dict[str, Any]]) -> Dict[str, int]:
+    return {
+        "domains_with_activity": sum(
+            1 for summary in summaries.values() if summary["latest_state"] is not None
+        ),
+        "dispatch_enqueued": sum(summary["dispatch_enqueued"] for summary in summaries.values()),
+        "resolved": sum(summary["resolved"] for summary in summaries.values()),
+        "operator_holds": sum(
+            summary["rejected"] + summary["snoozed"] for summary in summaries.values()
+        ),
+        "needs_operator_follow_up": sum(
+            1 for summary in summaries.values() if summary["needs_operator_follow_up"]
+        ),
+        "delivery_count": sum(summary["delivery_count"] for summary in summaries.values()),
+    }
+
+
+def summarize_remediation_activity(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domains: Iterable[str],
+    row_limit: int = 500,
+) -> Dict[str, Any]:
+    """Summarize remediation audit activity without rebuilding domain queues."""
+    domain_names = [str(domain or "").strip() for domain in domains if str(domain or "").strip()]
+    summaries = {domain: _empty_domain_activity(domain) for domain in domain_names}
+    if not domain_names:
+        return {
+            "summary": {
+                "domains_with_activity": 0,
+                "dispatch_enqueued": 0,
+                "resolved": 0,
+                "operator_holds": 0,
+                "needs_operator_follow_up": 0,
+                "delivery_count": 0,
+            },
+            "domains": summaries,
+        }
+
+    rows = (
+        db.query(WorkspaceAuditLog)
+        .filter(
+            WorkspaceAuditLog.workspace_id == workspace.id,
+            WorkspaceAuditLog.entity_type == "remediation_notification",
+            WorkspaceAuditLog.entity_name.in_(domain_names),
+            WorkspaceAuditLog.action.in_(HISTORY_ACTIONS),
+        )
+        .order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
+        .limit(row_limit)
+        .all()
+    )
+
+    for row in rows:
+        domain = str(row.entity_name or "")
+        if domain not in summaries:
+            continue
+        entry = _history_entry(row)
+        if entry is None:
+            continue
+        _apply_activity_entry(summaries[domain], entry)
+
+    for summary in summaries.values():
+        _finalize_activity_summary(summary)
+
+    return {"summary": _remediation_activity_totals(summaries), "domains": summaries}
+
+
 def _notification_histories(
     db: Session,
     *,

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
 from sqlalchemy.orm import Session
@@ -13,6 +13,7 @@ from app.models.webhook import WebhookEndpoint
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services.webhook_events import SUPPORTED_EVENT_TYPES, endpoint_matches_event
+from app.utils.domain_validator import normalize_domain_name
 
 DISPATCH_ENABLED_KEY = "notifications.remediation_dispatch_enabled"
 DISPATCH_CHANNEL_KEY = "notifications.remediation_dispatch_channel"
@@ -116,7 +117,7 @@ def _latest_lifecycle_marker(
         details = json.loads(row.details or "{}")
     except (json.JSONDecodeError, TypeError):
         details = {}
-    recorded_at = row.created_at.isoformat() if isinstance(row.created_at, datetime) else None
+    recorded_at = _audit_timestamp(row.created_at)
     return {"state": details.get("lifecycle_state"), "recorded_at": recorded_at}
 
 
@@ -135,9 +136,17 @@ def _safe_int(value: Any) -> int:
         return 0
 
 
+def _audit_timestamp(value: Any) -> Optional[str]:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
+
+
 def _history_entry(row: WorkspaceAuditLog) -> Optional[Dict[str, Any]]:
     details = _audit_details(row)
-    created_at = row.created_at.isoformat() if isinstance(row.created_at, datetime) else None
+    created_at = _audit_timestamp(row.created_at)
     action = str(row.action or "")
     if action == "remediation.notification_dispatch_enqueued":
         state = "delivery_enqueued" if details.get("delivery_enqueued") else "dispatch_requested"
@@ -243,7 +252,12 @@ def summarize_remediation_activity(
     row_limit: int = 500,
 ) -> Dict[str, Any]:
     """Summarize remediation audit activity without rebuilding domain queues."""
-    domain_names = [str(domain or "").strip() for domain in domains if str(domain or "").strip()]
+    domain_names = []
+    for domain in domains:
+        domain_name = normalize_domain_name(str(domain or ""))
+        if domain_name:
+            domain_names.append(domain_name)
+    domain_names = list(dict.fromkeys(domain_names))
     summaries = {domain: _empty_domain_activity(domain) for domain in domain_names}
     if not domain_names:
         return {
@@ -258,21 +272,21 @@ def summarize_remediation_activity(
             "domains": summaries,
         }
 
+    effective_row_limit = max(row_limit, len(domain_names) * 15)
     rows = (
         db.query(WorkspaceAuditLog)
         .filter(
             WorkspaceAuditLog.workspace_id == workspace.id,
             WorkspaceAuditLog.entity_type == "remediation_notification",
-            WorkspaceAuditLog.entity_name.in_(domain_names),
             WorkspaceAuditLog.action.in_(HISTORY_ACTIONS),
         )
         .order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
-        .limit(row_limit)
+        .limit(effective_row_limit)
         .all()
     )
 
     for row in rows:
-        domain = str(row.entity_name or "")
+        domain = normalize_domain_name(str(row.entity_name or ""))
         if domain not in summaries:
             continue
         entry = _history_entry(row)

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -801,6 +801,36 @@ function dashboardApp() {
             return this.healthSummary?.domains || [];
         },
 
+        remediationTotals() {
+            return this.healthSummary?.remediation || {};
+        },
+
+        domainRemediation(domainName) {
+            return this.domainByName(domainName)?.remediation || {};
+        },
+
+        remediationStatusLabel(status) {
+            return {
+                resolved: 'Resolved',
+                dispatched: 'Dispatched',
+                reviewed: 'Reviewed',
+                operator_hold: 'Operator hold',
+                activity: 'Activity',
+                none: 'No activity'
+            }[String(status || 'none')] || 'Activity';
+        },
+
+        remediationStatusClass(status) {
+            return {
+                resolved: 'text-[#247982]',
+                dispatched: 'text-[#8a6418]',
+                reviewed: 'text-[#272a5f]',
+                operator_hold: 'text-[#b8431d]',
+                activity: 'text-[#5f5c78]',
+                none: 'text-[#5f5c78]'
+            }[String(status || 'none')] || 'text-[#5f5c78]';
+        },
+
         gradeClass(grade) {
             const value = String(grade || 'F');
             if (value.startsWith('A')) return 'bg-[#dff3e8] text-[#1f6f45]';
@@ -1371,6 +1401,7 @@ function dashboardApp() {
                 row.appendChild(this.createDomainNameCell(domain.domain_name));
                 row.appendChild(this.createTextCell(this.formatLargeNumber(domain.total_emails || 0)));
                 row.appendChild(this.createGradeCell(domain.health));
+                row.appendChild(this.createRemediationCell(domain.remediation));
                 row.appendChild(this.createPassRateCell(domain.pass_rate || 0));
                 row.appendChild(this.createTextCell(this.formatLargeNumber(domain.failed_count || 0)));
                 row.appendChild(this.createTextCell(this.formatLargeNumber(domain.report_count || 0)));
@@ -1408,6 +1439,32 @@ function dashboardApp() {
             score.className = 'text-xs text-muted-foreground whitespace-nowrap';
             score.textContent = `${health?.score ?? 0}/100`;
             wrapper.appendChild(score);
+
+            cell.appendChild(wrapper);
+            return cell;
+        },
+
+        createRemediationCell(remediation) {
+            const cell = document.createElement('td');
+            cell.className = 'table-cell';
+
+            const wrapper = document.createElement('div');
+            wrapper.className = 'flex flex-col gap-1';
+
+            const status = remediation?.status || 'none';
+            const badge = document.createElement('span');
+            badge.className = `inline-flex w-fit rounded-md bg-[#f8f7f6] px-2 py-1 text-xs font-semibold ${this.remediationStatusClass(status)}`;
+            badge.textContent = this.remediationStatusLabel(status);
+            wrapper.appendChild(badge);
+
+            const latest = document.createElement('span');
+            latest.className = 'text-xs text-muted-foreground whitespace-nowrap';
+            if (remediation?.latest_at) {
+                latest.textContent = new Date(remediation.latest_at).toLocaleString();
+            } else {
+                latest.textContent = 'No operator action';
+            }
+            wrapper.appendChild(latest);
 
             cell.appendChild(wrapper);
             return cell;

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -91,6 +91,25 @@
                     <span x-text="healthSummary?.domain_count || 0"></span>
                     <span> domains need attention.</span>
                 </p>
+                <div class="mt-5 grid gap-2 border-t border-[#dfdfdf] pt-4 text-sm">
+                    <div class="flex items-center justify-between gap-3">
+                        <span class="text-[#5f5c78]">Remediation activity</span>
+                        <span class="font-semibold text-[#120d36]">
+                            <span x-text="remediationTotals().domains_with_activity || 0"></span>
+                            <span> domains</span>
+                        </span>
+                    </div>
+                    <div class="flex items-center justify-between gap-3">
+                        <span class="text-[#5f5c78]">Operator follow-up</span>
+                        <span class="font-semibold text-[#b8431d]"
+                              x-text="remediationTotals().needs_operator_follow_up || 0"></span>
+                    </div>
+                    <div class="flex items-center justify-between gap-3">
+                        <span class="text-[#5f5c78]">Resolved markers</span>
+                        <span class="font-semibold text-[#247982]"
+                              x-text="remediationTotals().resolved || 0"></span>
+                    </div>
+                </div>
                 <div class="mt-5 border-t border-[#dfdfdf] pt-4" x-show="healthHistory?.points?.length">
                     <div class="mb-3 flex items-center justify-between gap-3">
                         <p class="text-sm font-semibold text-[#120d36]">Score Trend</p>
@@ -160,6 +179,11 @@
                                 <div class="min-w-0">
                                     <p class="truncate font-semibold text-[#120d36]" x-text="domainHealth.domain"></p>
                                     <p class="mt-1 text-xs capitalize text-[#5f5c78]" x-text="domainHealth.status"></p>
+                                    <template x-if="domainRemediation(domainHealth.domain)?.status && domainRemediation(domainHealth.domain).status !== 'none'">
+                                        <p class="mt-1 text-xs font-semibold"
+                                           :class="remediationStatusClass(domainRemediation(domainHealth.domain).status)"
+                                           x-text="remediationStatusLabel(domainRemediation(domainHealth.domain).status)"></p>
+                                    </template>
                                 </div>
                                 <div class="text-right">
                                     <div class="inline-flex min-w-12 justify-center rounded-md px-2 py-1 text-lg font-bold"
@@ -336,6 +360,7 @@
                             {% call th() %}Domain{% endcall %}
                             {% call th() %}Emails{% endcall %}
                             {% call th() %}Grade{% endcall %}
+                            {% call th() %}Remediation{% endcall %}
                             {% call th() %}Pass Rate{% endcall %}
                             {% call th() %}Failed{% endcall %}
                             {% call th() %}Reports{% endcall %}

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2009,7 +2009,7 @@ def test_summary_includes_remediation_activity(authed_client: TestClient, db_ses
                 action="remediation.notification_dispatch_enqueued",
                 entity_type="remediation_notification",
                 entity_id="dns:dmarc-missing",
-                entity_name=DOMAIN,
+                entity_name=f" {DOMAIN.upper()}. ",
                 details=json.dumps(
                     {
                         "delivery_enqueued": True,
@@ -2026,7 +2026,7 @@ def test_summary_includes_remediation_activity(authed_client: TestClient, db_ses
                 action="remediation.notification_lifecycle_recorded",
                 entity_type="remediation_notification",
                 entity_id="dns:dmarc-missing",
-                entity_name=DOMAIN,
+                entity_name=f" {DOMAIN.upper()}. ",
                 details=json.dumps({"lifecycle_state": "resolved"}),
                 created_at=now + timedelta(seconds=1),
             ),
@@ -2042,6 +2042,7 @@ def test_summary_includes_remediation_activity(authed_client: TestClient, db_ses
     domain = data["domains"][0]
     assert domain["remediation"]["status"] == "resolved"
     assert domain["remediation"]["latest_state"] == "resolved"
+    assert domain["remediation"]["latest_at"].endswith("Z")
     assert domain["remediation"]["resolved"] == 1
     assert domain["remediation"]["dispatch_enqueued"] == 1
     assert data["health_summary"]["remediation"]["domains_with_activity"] == 1

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -35,6 +35,7 @@ from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
 from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import DomainDNSResult, SystemDNSProvider
 from app.services.mta_sts import MTAStsResult
+from app.services.remediation_dispatch import summarize_remediation_activity
 from app.services.report_persistence import save_parsed_report
 from app.services.report_store import ReportStore
 from app.services.source_reputation import DomainReputation
@@ -2030,6 +2031,16 @@ def test_summary_includes_remediation_activity(authed_client: TestClient, db_ses
                 details=json.dumps({"lifecycle_state": "resolved"}),
                 created_at=now + timedelta(seconds=1),
             ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:quiet-domain",
+                entity_name=" Quiet.Example. ",
+                details=json.dumps({"lifecycle_state": "acknowledged"}),
+                created_at=now - timedelta(days=1),
+            ),
         ]
     )
     db_session.commit()
@@ -2048,6 +2059,14 @@ def test_summary_includes_remediation_activity(authed_client: TestClient, db_ses
     assert data["health_summary"]["remediation"]["domains_with_activity"] == 1
     assert data["health_summary"]["remediation"]["resolved"] == 1
     assert data["health_summary"]["remediation"]["delivery_count"] == 1
+
+    activity = summarize_remediation_activity(
+        db_session,
+        workspace=workspace,
+        domains=[DOMAIN, "quiet.example"],
+        row_limit=1,
+    )
+    assert activity["domains"]["quiet.example"]["latest_state"] == "acknowledged"
 
 
 def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_session):

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -28,6 +28,7 @@ from app.models.organization import Entitlement, Organization
 from app.models.report import DMARCReport, ReportRecord
 from app.models.setting import Setting
 from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceAuditLog
 from app.services.bimi import BIMIResult
 from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
 from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
@@ -37,6 +38,7 @@ from app.services.mta_sts import MTAStsResult
 from app.services.report_persistence import save_parsed_report
 from app.services.report_store import ReportStore
 from app.services.source_reputation import DomainReputation
+from app.services.workspaces import get_or_create_default_workspace
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1992,6 +1994,59 @@ def test_summary_includes_dns_fields(authed_client: TestClient, db_session):
     assert domain["spf_status"] is True
     assert domain["dkim_status"] is True
     assert domain["dmarc_policy"] == "none"
+
+
+def test_summary_includes_remediation_activity(authed_client: TestClient, db_session):
+    """Dashboard summaries include remediation-loop audit state without rebuilding queues."""
+    _persist_minimal_report(db_session)
+    workspace = get_or_create_default_workspace(db_session)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    db_session.add_all(
+        [
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_dispatch_enqueued",
+                entity_type="remediation_notification",
+                entity_id="dns:dmarc-missing",
+                entity_name=DOMAIN,
+                details=json.dumps(
+                    {
+                        "delivery_enqueued": True,
+                        "delivery_count": 1,
+                        "dns_write_attempted": False,
+                        "sent": False,
+                    }
+                ),
+                created_at=now,
+            ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:dmarc-missing",
+                entity_name=DOMAIN,
+                details=json.dumps({"lifecycle_state": "resolved"}),
+                created_at=now + timedelta(seconds=1),
+            ),
+        ]
+    )
+    db_session.commit()
+
+    with _mock_dns():
+        response = authed_client.get("/api/v1/domains/summary?refresh=true")
+
+    assert response.status_code == 200
+    data = response.json()
+    domain = data["domains"][0]
+    assert domain["remediation"]["status"] == "resolved"
+    assert domain["remediation"]["latest_state"] == "resolved"
+    assert domain["remediation"]["resolved"] == 1
+    assert domain["remediation"]["dispatch_enqueued"] == 1
+    assert data["health_summary"]["remediation"]["domains_with_activity"] == 1
+    assert data["health_summary"]["remediation"]["resolved"] == 1
+    assert data["health_summary"]["remediation"]["delivery_count"] == 1
 
 
 def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_session):

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 from app.models.workspace_access import WorkspaceAuditLog
@@ -318,6 +318,96 @@ def test_notification_histories_return_sanitized_recent_audit_events(db_session)
     assert "actor_id" not in history[0]
     assert history[1]["state"] == "acknowledged"
     assert history[1]["operator_note"] == "Reviewed with DNS owner"
+
+
+def test_summarize_remediation_activity_handles_empty_domain_inputs(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+
+    activity = remediation_dispatch.summarize_remediation_activity(
+        db_session,
+        workspace=workspace,
+        domains=["", " . "],
+        row_limit=0,
+    )
+
+    assert activity == {
+        "summary": {
+            "domains_with_activity": 0,
+            "dispatch_enqueued": 0,
+            "resolved": 0,
+            "operator_holds": 0,
+            "needs_operator_follow_up": 0,
+            "delivery_count": 0,
+        },
+        "domains": {},
+    }
+    assert remediation_dispatch._audit_timestamp("not-a-datetime") is None
+
+
+def test_summarize_remediation_activity_reports_status_variants(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add_all(
+        [
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:reviewed",
+                entity_name=" Reviewed.Example. ",
+                details=json.dumps({"lifecycle_state": "previewed"}),
+                created_at=datetime(2026, 7, 1, 8, 0, 0, tzinfo=timezone.utc),
+            ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:hold",
+                entity_name="Hold.Example.",
+                details=json.dumps({"lifecycle_state": "rejected"}),
+                created_at=datetime(2026, 7, 1, 9, 0, 0),
+            ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_dispatch_enqueued",
+                entity_type="remediation_notification",
+                entity_id="dns:dispatch-requested",
+                entity_name="dispatch.example",
+                details=json.dumps({"delivery_enqueued": False}),
+                created_at=datetime(2026, 7, 1, 10, 0, 0),
+            ),
+        ]
+    )
+    db_session.commit()
+
+    activity = remediation_dispatch.summarize_remediation_activity(
+        db_session,
+        workspace=workspace,
+        domains=["reviewed.example", "hold.example", "dispatch.example"],
+        row_limit=1,
+    )
+
+    reviewed = activity["domains"]["reviewed.example"]
+    assert reviewed["status"] == "reviewed"
+    assert reviewed["latest_state"] == "previewed"
+    assert reviewed["latest_at"] == "2026-07-01T08:00:00Z"
+    assert reviewed["needs_operator_follow_up"] is True
+
+    hold = activity["domains"]["hold.example"]
+    assert hold["status"] == "operator_hold"
+    assert hold["latest_state"] == "rejected"
+    assert hold["rejected"] == 1
+    assert hold["needs_operator_follow_up"] is True
+
+    dispatch_requested = activity["domains"]["dispatch.example"]
+    assert dispatch_requested["status"] == "activity"
+    assert dispatch_requested["latest_state"] == "dispatch_requested"
+    assert dispatch_requested["latest_label"] == "Dispatch requested"
+    assert activity["summary"]["domains_with_activity"] == 3
+    assert activity["summary"]["operator_holds"] == 1
+    assert activity["summary"]["needs_operator_follow_up"] == 2
 
 
 def test_build_remediation_dispatch_preview_fetches_context_when_not_preloaded(monkeypatch):


### PR DESCRIPTION
## What changed

- Adds a fast remediation activity summary from existing workspace audit events without rebuilding per-domain queues.
- Includes each domain's latest remediation operator state in `/api/v1/domains/summary`.
- Adds workspace remediation counters to the dashboard health panel and a per-domain remediation status column in the dashboard table.
- Keeps the flow read-only and human-in-the-loop: no DNS writes, no automatic dispatch, no outbound sends.

## Why

Issue #384 already had domain-level remediation queue, dispatch readiness, and audit history. The dashboard still lacked a compact answer to what has been reviewed, dispatched, resolved, or held by an operator across domains.

## Validation

- `/tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/services/remediation_dispatch.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dns_endpoints.py::test_summary_includes_remediation_activity backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_dashboard_template_security.py`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium -g "dashboard"` from `backend/`

Refs #384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remediation activity details to domain summary responses and dashboard views.
  * Introduced new remediation metrics in the System Health area, including activity, follow-up, and resolution counts.
  * Added a remediation status column/label to domain tables and cards for clearer at-a-glance status.
* **Bug Fixes**
  * Domain summary pages now show the latest remediation state and timestamp, including cases with no operator action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->