### PR TITLE
feat: flag unresolved remediation markers

### DIFF
--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -430,6 +430,7 @@ def build_remediation_dispatch_preview(
     else:
         webhook_count = webhook_event_counts.get(event_type, 0)
     blocked_reasons: List[str] = []
+    verification = _verification_state(lifecycle_state, lifecycle.get("recorded_at"))
 
     operator_hold = lifecycle_state in OPERATOR_HELD_LIFECYCLE_STATES
     if operator_hold:
@@ -457,11 +458,52 @@ def build_remediation_dispatch_preview(
         "lifecycle_state": lifecycle_state,
         "lifecycle_recorded_at": lifecycle.get("recorded_at"),
         "operator_hold": operator_hold,
+        "verification": verification,
         "webhook_endpoint_count": webhook_count,
         "blocked_reasons": blocked_reasons,
         "would_enqueue": enabled and not blocked_reasons,
         "delivery_enqueued": False,
         "next_steps": _next_steps(blocked_reasons),
+    }
+
+
+def _verification_state(
+    lifecycle_state: Optional[str],
+    lifecycle_recorded_at: Optional[str],
+) -> Dict[str, Any]:
+    if lifecycle_state == "resolved":
+        return {
+            "state": "still_observed",
+            "verified": False,
+            "label": "Still observed",
+            "detail": (
+                "An operator marked this remediation item resolved, but current "
+                "domain evidence still produces the same finding."
+            ),
+            "recorded_at": lifecycle_recorded_at,
+        }
+    if lifecycle_state in {"rejected", "snoozed"}:
+        return {
+            "state": f"operator_{lifecycle_state}",
+            "verified": False,
+            "label": lifecycle_state.replace("_", " ").title(),
+            "detail": "Operator hold is active; DMARQ will keep showing current evidence.",
+            "recorded_at": lifecycle_recorded_at,
+        }
+    if lifecycle_state in ACKNOWLEDGED_LIFECYCLE_STATES:
+        return {
+            "state": "pending_operator_action",
+            "verified": False,
+            "label": "Pending action",
+            "detail": "Operator reviewed this item; current evidence still needs remediation.",
+            "recorded_at": lifecycle_recorded_at,
+        }
+    return {
+        "state": "not_started",
+        "verified": False,
+        "label": "Not started",
+        "detail": "No verification marker exists for this current remediation item.",
+        "recorded_at": lifecycle_recorded_at,
     }
 
 

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -949,7 +949,7 @@ function domainDetailsApp(domainId) {
             if (!verification) return '';
             const detail = verification.detail || '';
             if (!verification.recorded_at) return detail;
-            return `${detail} Last marker: ${this.formatDate(verification.recorded_at)}.`;
+            return `${detail} Last marker: ${this.formatIsoDate(verification.recorded_at)}.`;
         },
 
         remediationActionBusy(item, action = '') {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -934,6 +934,24 @@ function domainDetailsApp(domainId) {
             return nextStep || 'Review notification settings before dispatching this remediation item.';
         },
 
+        remediationVerificationClass(verification) {
+            const state = verification?.state || 'not_started';
+            return {
+                still_observed: 'bg-red-100 text-red-700',
+                pending_operator_action: 'bg-yellow-100 text-yellow-800',
+                operator_rejected: 'bg-base-200 text-base-content/70',
+                operator_snoozed: 'bg-base-200 text-base-content/70',
+                not_started: 'bg-base-200 text-base-content/70'
+            }[state] || 'bg-base-200 text-base-content/70';
+        },
+
+        remediationVerificationText(verification) {
+            if (!verification) return '';
+            const detail = verification.detail || '';
+            if (!verification.recorded_at) return detail;
+            return `${detail} Last marker: ${this.formatDate(verification.recorded_at)}.`;
+        },
+
         remediationActionBusy(item, action = '') {
             if (!this.remediationAction.loading) return false;
             if (this.remediationAction.itemId !== item?.id) return false;

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -406,6 +406,18 @@
                                         <template x-if="(item.notification.dispatch.blocked_reasons || []).length">
                                             <p class="mt-1 text-xs text-[#5f5c78]" x-text="item.notification.dispatch.blocked_reasons[0]"></p>
                                         </template>
+                                        <template x-if="item.notification.dispatch.verification">
+                                            <div class="mt-3 rounded border border-[#e6e3e1] bg-white px-3 py-2 text-xs">
+                                                <div class="flex flex-wrap items-center justify-between gap-2">
+                                                    <span class="font-semibold text-[#5f5c78]">Verification</span>
+                                                    <span class="rounded px-2 py-1 font-semibold"
+                                                          :class="remediationVerificationClass(item.notification.dispatch.verification)"
+                                                          x-text="item.notification.dispatch.verification.label"></span>
+                                                </div>
+                                                <p class="mt-2 text-[#120d36]"
+                                                   x-text="remediationVerificationText(item.notification.dispatch.verification)"></p>
+                                            </div>
+                                        </template>
                                         <div class="mt-3 flex flex-wrap gap-2">
                                             <button type="button"
                                                     class="btn btn-xs btn-outline"

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -221,6 +221,56 @@ def test_attach_remediation_dispatch_previews_counts_operator_held_items(monkeyp
     assert result["summary"]["dispatch_snoozed"] == 0
 
 
+def test_verification_state_covers_lifecycle_branches():
+    recorded_at = "2026-07-01T08:00:00"
+
+    assert remediation_dispatch._verification_state("resolved", recorded_at) == {
+        "state": "still_observed",
+        "verified": False,
+        "label": "Still observed",
+        "detail": (
+            "An operator marked this remediation item resolved, but current "
+            "domain evidence still produces the same finding."
+        ),
+        "recorded_at": recorded_at,
+    }
+    assert remediation_dispatch._verification_state("rejected", recorded_at) == {
+        "state": "operator_rejected",
+        "verified": False,
+        "label": "Rejected",
+        "detail": "Operator hold is active; DMARQ will keep showing current evidence.",
+        "recorded_at": recorded_at,
+    }
+    assert remediation_dispatch._verification_state("snoozed", recorded_at) == {
+        "state": "operator_snoozed",
+        "verified": False,
+        "label": "Snoozed",
+        "detail": "Operator hold is active; DMARQ will keep showing current evidence.",
+        "recorded_at": recorded_at,
+    }
+    assert remediation_dispatch._verification_state("previewed", recorded_at) == {
+        "state": "pending_operator_action",
+        "verified": False,
+        "label": "Pending action",
+        "detail": "Operator reviewed this item; current evidence still needs remediation.",
+        "recorded_at": recorded_at,
+    }
+    assert remediation_dispatch._verification_state("acknowledged", recorded_at) == {
+        "state": "pending_operator_action",
+        "verified": False,
+        "label": "Pending action",
+        "detail": "Operator reviewed this item; current evidence still needs remediation.",
+        "recorded_at": recorded_at,
+    }
+    assert remediation_dispatch._verification_state(None, None) == {
+        "state": "not_started",
+        "verified": False,
+        "label": "Not started",
+        "detail": "No verification marker exists for this current remediation item.",
+        "recorded_at": None,
+    }
+
+
 def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):
     def fail_if_called(*_args, **_kwargs):
         raise AssertionError("empty queues should not fetch dispatch context")

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -200,6 +200,16 @@ def test_attach_remediation_dispatch_previews_counts_operator_held_items(monkeyp
     dispatch = result["items"][0]["notification"]["dispatch"]
     assert dispatch["operator_hold"] is True
     assert dispatch["eligible"] is False
+    assert dispatch["verification"] == {
+        "state": "still_observed",
+        "verified": False,
+        "label": "Still observed",
+        "detail": (
+            "An operator marked this remediation item resolved, but current "
+            "domain evidence still produces the same finding."
+        ),
+        "recorded_at": "2026-07-01T08:00:00",
+    }
     assert dispatch["blocked_reasons"] == ["Operator marked this remediation item resolved."]
     assert dispatch["next_steps"] == [
         "Keep monitoring new reports; reopen the item only if the finding returns."


### PR DESCRIPTION
## Summary
- add remediation verification metadata to dispatch previews so current findings marked resolved are shown as still observed
- surface the verification state on domain remediation cards
- cover the resolved-but-still-present case in remediation dispatch tests

## Validation
- /tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/services/remediation_dispatch.py backend/app/tests/test_remediation_dispatch.py
- /tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_remediation_dispatch.py
- /tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_domain_detail_endpoints.py::test_domain_remediation_dispatch_preview_becomes_eligible_without_enqueuing backend/app/tests/test_domain_detail_endpoints.py::test_domain_remediation_notification_dispatch_enqueues_webhook_delivery
- DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium -g "domain detail"

Refs #384