### PR TITLE
feat: surface verified remediation fixes

### DIFF
--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -357,15 +357,20 @@ def _verified_fixed_items(
     """Return resolved remediation markers whose items no longer appear in current evidence."""
     if not hasattr(db, "query"):
         return []
+    normalized_domain = normalize_domain_name(domain)
+    if not normalized_domain:
+        return []
     active_ids = {str(item_id or "") for item_id in current_item_ids if str(item_id or "")}
-    normalized_entity_name = func.lower(func.rtrim(func.trim(WorkspaceAuditLog.entity_name), "."))
+    normalized_entity_name = func.lower(
+        func.rtrim(func.ltrim(func.trim(WorkspaceAuditLog.entity_name), "."), ".")
+    )
     rows = (
         db.query(WorkspaceAuditLog)
         .filter(
             WorkspaceAuditLog.workspace_id == workspace.id,
             WorkspaceAuditLog.action == "remediation.notification_lifecycle_recorded",
             WorkspaceAuditLog.entity_type == "remediation_notification",
-            normalized_entity_name == normalize_domain_name(domain),
+            normalized_entity_name == normalized_domain,
         )
         .order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
         .limit(max(limit * 4, limit))
@@ -377,10 +382,10 @@ def _verified_fixed_items(
         item_id = str(row.entity_id or "")
         if not item_id or item_id in active_ids or item_id in seen:
             continue
+        seen.add(item_id)
         details = _audit_details(row)
         if details.get("lifecycle_state") != "resolved":
             continue
-        seen.add(item_id)
         verified.append(
             {
                 "item_id": item_id,

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -346,6 +346,61 @@ def _notification_histories(
     return histories
 
 
+def _verified_fixed_items(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domain: str,
+    current_item_ids: Iterable[str],
+    limit: int = 5,
+) -> List[Dict[str, Any]]:
+    """Return resolved remediation markers whose items no longer appear in current evidence."""
+    if not hasattr(db, "query"):
+        return []
+    active_ids = {str(item_id or "") for item_id in current_item_ids if str(item_id or "")}
+    normalized_entity_name = func.lower(func.rtrim(func.trim(WorkspaceAuditLog.entity_name), "."))
+    rows = (
+        db.query(WorkspaceAuditLog)
+        .filter(
+            WorkspaceAuditLog.workspace_id == workspace.id,
+            WorkspaceAuditLog.action == "remediation.notification_lifecycle_recorded",
+            WorkspaceAuditLog.entity_type == "remediation_notification",
+            normalized_entity_name == normalize_domain_name(domain),
+        )
+        .order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
+        .limit(max(limit * 4, limit))
+        .all()
+    )
+    verified: List[Dict[str, Any]] = []
+    seen: Set[str] = set()
+    for row in rows:
+        item_id = str(row.entity_id or "")
+        if not item_id or item_id in active_ids or item_id in seen:
+            continue
+        details = _audit_details(row)
+        if details.get("lifecycle_state") != "resolved":
+            continue
+        seen.add(item_id)
+        verified.append(
+            {
+                "item_id": item_id,
+                "state": "verified_fixed",
+                "verified": True,
+                "label": "Verified fixed",
+                "detail": (
+                    "This remediation item was marked resolved and no longer appears "
+                    "in the current remediation queue."
+                ),
+                "recorded_at": _audit_timestamp(row.created_at),
+                "operator_note": details.get("operator_note"),
+                "actor_type": row.actor_type,
+            }
+        )
+        if len(verified) >= limit:
+            break
+    return verified
+
+
 def _latest_lifecycle_marker_from_history(
     history: Sequence[Dict[str, Any]],
 ) -> Dict[str, Optional[str]]:
@@ -527,8 +582,16 @@ def attach_remediation_dispatch_previews(
     """Attach read-only dispatch readiness to every queue item notification."""
     domain = str(queue.get("domain") or "")
     items = list(queue.get("items", []))
+    item_ids = [str(item.get("id") or "") for item in items]
+    verified_fixed_items = _verified_fixed_items(
+        db,
+        workspace=workspace,
+        domain=domain,
+        current_item_ids=item_ids,
+    )
+    queue["verified_items"] = verified_fixed_items
     if not items:
-        _attach_dispatch_summary(queue, items)
+        _attach_dispatch_summary(queue, items, verified_fixed_items=verified_fixed_items)
         return queue
     settings = _settings(db)
     configured_events = _configured_events(settings.get(DISPATCH_EVENTS_KEY, ""))
@@ -538,7 +601,7 @@ def attach_remediation_dispatch_previews(
         db,
         workspace=workspace,
         domain=domain,
-        item_ids=[str(item.get("id") or "") for item in items],
+        item_ids=item_ids,
     )
     webhook_event_counts = _webhook_event_counts(
         endpoints,
@@ -565,6 +628,7 @@ def attach_remediation_dispatch_previews(
         queue,
         items,
         webhook_event_route_keys=webhook_event_route_keys,
+        verified_fixed_items=verified_fixed_items,
     )
     return queue
 
@@ -574,6 +638,7 @@ def _attach_dispatch_summary(
     items: Sequence[Dict[str, Any]],
     *,
     webhook_event_route_keys: Optional[Dict[str, Set[str]]] = None,
+    verified_fixed_items: Optional[Sequence[Dict[str, Any]]] = None,
 ) -> None:
     """Expose queue-level dispatch readiness counters for dashboards."""
     summary = dict(queue.get("summary") or {})
@@ -612,6 +677,7 @@ def _attach_dispatch_summary(
             "dispatch_snoozed": sum(
                 1 for dispatch in dispatches if dispatch.get("lifecycle_state") == "snoozed"
             ),
+            "dispatch_verified_fixed": len(verified_fixed_items or []),
         }
     )
     queue["summary"] = summary

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -76,9 +76,11 @@ function domainDetailsApp(domainId) {
                 dispatch_blocked: 0,
                 dispatch_disabled: 0,
                 dispatch_awaiting_acknowledgement: 0,
-                dispatch_webhook_routes: 0
+                dispatch_webhook_routes: 0,
+                dispatch_verified_fixed: 0
             },
-            items: []
+            items: [],
+            verified_items: []
         },
         remediationAction: {
             itemId: '',
@@ -1402,9 +1404,11 @@ function domainDetailsApp(domainId) {
                     dispatch_blocked: 0,
                     dispatch_disabled: 0,
                     dispatch_awaiting_acknowledgement: 0,
-                    dispatch_webhook_routes: 0
+                    dispatch_webhook_routes: 0,
+                    dispatch_verified_fixed: 0
                 },
-                items: []
+                items: [],
+                verified_items: []
             };
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -317,8 +317,39 @@
                             <span class="rounded bg-red-100 px-2 py-1 font-semibold text-red-700">
                                 <span x-text="remediationQueue.summary.dispatch_blocked || 0"></span><span> blocked</span>
                             </span>
+                            <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700">
+                                <span x-text="remediationQueue.summary.dispatch_verified_fixed || 0"></span><span> verified fixed</span>
+                            </span>
                         </div>
                     </div>
+                    <template x-if="(remediationQueue.verified_items || []).length > 0">
+                        <div class="mt-4 rounded-lg border border-[#d8ebe8] bg-[#f2fbf9] p-3">
+                            <div class="flex flex-wrap items-center justify-between gap-2">
+                                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Verified fixes</p>
+                                <span class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#1f7c83]">
+                                    <span x-text="remediationQueue.verified_items.length"></span><span> no longer observed</span>
+                                </span>
+                            </div>
+                            <div class="mt-2 grid gap-2 md:grid-cols-2">
+                                <template x-for="verified in remediationQueue.verified_items.slice(0, 4)"
+                                          :key="'verified-' + verified.item_id">
+                                    <div class="rounded border border-[#d8ebe8] bg-white px-3 py-2 text-xs">
+                                        <div class="flex flex-wrap items-center justify-between gap-2">
+                                            <span class="font-mono text-[#120d36]" x-text="verified.item_id"></span>
+                                            <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700"
+                                                  x-text="verified.label"></span>
+                                        </div>
+                                        <p class="mt-2 text-[#45505f]" x-text="verified.detail"></p>
+                                        <p class="mt-1 text-[#5f5c78]">
+                                            <span x-text="formatIsoDate(verified.recorded_at)"></span>
+                                            <span x-show="verified.actor_type"> · </span>
+                                            <span x-show="verified.actor_type" x-text="verified.actor_type"></span>
+                                        </p>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
                     <template x-if="remediationQueue.items.length > 0">
                         <div class="mt-4 grid gap-3 md:grid-cols-3">
                             <div class="rounded-lg bg-white p-3">

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -340,6 +340,9 @@
                                                   x-text="verified.label"></span>
                                         </div>
                                         <p class="mt-2 text-[#45505f]" x-text="verified.detail"></p>
+                                        <p class="mt-2 rounded bg-[#f6f8fb] px-2 py-1 text-[#45505f]"
+                                           x-show="verified.operator_note"
+                                           x-text="verified.operator_note"></p>
                                         <p class="mt-1 text-[#5f5c78]">
                                             <span x-text="formatIsoDate(verified.recorded_at)"></span>
                                             <span x-show="verified.actor_type"> · </span>

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -143,6 +143,7 @@ def test_attach_remediation_dispatch_previews_adds_dashboard_summary(monkeypatch
     assert summary["dispatch_disabled"] == 0
     assert summary["dispatch_awaiting_acknowledgement"] == 1
     assert summary["dispatch_webhook_routes"] == 1
+    assert summary["dispatch_verified_fixed"] == 0
 
 
 def test_attach_remediation_dispatch_previews_counts_operator_held_items(monkeypatch):
@@ -219,6 +220,7 @@ def test_attach_remediation_dispatch_previews_counts_operator_held_items(monkeyp
     assert result["summary"]["dispatch_resolved"] == 1
     assert result["summary"]["dispatch_rejected"] == 0
     assert result["summary"]["dispatch_snoozed"] == 0
+    assert result["summary"]["dispatch_verified_fixed"] == 0
 
 
 def test_verification_state_covers_lifecycle_branches():
@@ -296,7 +298,76 @@ def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):
         "dispatch_resolved": 0,
         "dispatch_rejected": 0,
         "dispatch_snoozed": 0,
+        "dispatch_verified_fixed": 0,
     }
+    assert result["verified_items"] == []
+
+
+def test_attach_remediation_dispatch_previews_reports_verified_fixed_items(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add_all(
+        [
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:dmarc-missing",
+                entity_name=" Example.COM. ",
+                details=json.dumps(
+                    {
+                        "lifecycle_state": "resolved",
+                        "operator_note": "Record is now visible after propagation.",
+                    }
+                ),
+                created_at=datetime(2026, 7, 1, 8, 0, 0),
+            ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:still-present",
+                entity_name="example.com",
+                details=json.dumps({"lifecycle_state": "resolved"}),
+                created_at=datetime(2026, 7, 1, 9, 0, 0),
+            ),
+        ]
+    )
+    db_session.commit()
+    queue = {
+        "domain": "example.com",
+        "summary": {"total": 1},
+        "items": [
+            {
+                "id": "dns:still-present",
+                "notification": {"event": EVENT_REMEDIATION_APPROVAL_REQUIRED},
+            }
+        ],
+    }
+
+    result = remediation_dispatch.attach_remediation_dispatch_previews(
+        db_session,
+        workspace=workspace,
+        queue=queue,
+    )
+
+    assert result["summary"]["dispatch_verified_fixed"] == 1
+    assert result["verified_items"] == [
+        {
+            "item_id": "dns:dmarc-missing",
+            "state": "verified_fixed",
+            "verified": True,
+            "label": "Verified fixed",
+            "detail": (
+                "This remediation item was marked resolved and no longer appears "
+                "in the current remediation queue."
+            ),
+            "recorded_at": "2026-07-01T08:00:00Z",
+            "operator_note": "Record is now visible after propagation.",
+            "actor_type": "operator",
+        }
+    ]
 
 
 def test_notification_histories_return_sanitized_recent_audit_events(db_session):

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -313,7 +313,7 @@ def test_attach_remediation_dispatch_previews_reports_verified_fixed_items(db_se
                 action="remediation.notification_lifecycle_recorded",
                 entity_type="remediation_notification",
                 entity_id="dns:dmarc-missing",
-                entity_name=" Example.COM. ",
+                entity_name=" .Example.COM. ",
                 details=json.dumps(
                     {
                         "lifecycle_state": "resolved",
@@ -331,6 +331,26 @@ def test_attach_remediation_dispatch_previews_reports_verified_fixed_items(db_se
                 entity_name="example.com",
                 details=json.dumps({"lifecycle_state": "resolved"}),
                 created_at=datetime(2026, 7, 1, 9, 0, 0),
+            ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:changed-after-resolved",
+                entity_name="example.com",
+                details=json.dumps({"lifecycle_state": "resolved"}),
+                created_at=datetime(2026, 7, 1, 7, 0, 0),
+            ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="dns:changed-after-resolved",
+                entity_name="example.com",
+                details=json.dumps({"lifecycle_state": "snoozed"}),
+                created_at=datetime(2026, 7, 1, 10, 0, 0),
             ),
         ]
     )


### PR DESCRIPTION
## What changed
- Adds a verified-fixed remediation state for lifecycle items that were marked resolved and no longer appear in the current remediation queue.
- Surfaces verified fixes on the domain detail remediation panel with a counter, timestamp, operator note context, and actor type.
- Keeps the slice read-only: no DNS/provider writes and no provider-side changes.

## Why
Operators need feedback that a previously resolved remediation item stayed fixed after the next analysis pass. Before this, those items simply disappeared from the queue, which made it hard to tell whether the product had verified the fix or lost the context.

Refs #384.

## Validation
- `flake8 backend/app/services/remediation_dispatch.py backend/app/tests/test_remediation_dispatch.py`
- `pytest -q backend/app/tests/test_remediation_dispatch.py`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium -g "domain detail"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Verified fixes” section in the Remediation Queue to show recently resolved items that are no longer present in the active queue.
  * Displayed a new summary count for verified fixed items alongside existing queue metrics.

* **Bug Fixes**
  * Improved queue summaries to keep the verified fixed count accurate across page updates and resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->