### PR TITLE
fix: prepare upload page for Alpine CSP runtime

### DIFF
--- a/backend/app/static/js/upload-page.js
+++ b/backend/app/static/js/upload-page.js
@@ -22,6 +22,34 @@ function uploadForm() {
             return this.files.filter((file) => file.status === 'error').length;
         },
 
+        get hasFiles() {
+            return this.files.length > 0;
+        },
+
+        get isEmpty() {
+            return this.files.length === 0;
+        },
+
+        get canClear() {
+            return !this.isUploading;
+        },
+
+        get isProcessed() {
+            return !this.isUploading && this.hasFiles && this.pendingCount === 0;
+        },
+
+        get isAllSuccess() {
+            return this.errorCount === 0 && this.successCount > 0;
+        },
+
+        get isAllError() {
+            return this.successCount === 0 && this.errorCount > 0;
+        },
+
+        get isMixedResult() {
+            return this.successCount > 0 && this.errorCount > 0;
+        },
+
         get dropzoneClass() {
             return this.dragover ? 'border-primary/50 bg-primary/5' : '';
         },

--- a/backend/app/templates/upload.html
+++ b/backend/app/templates/upload.html
@@ -17,7 +17,7 @@
             {% endcall %}
         {% endcall %}
         {% call card_content() %}
-            <div class="space-y-6" x-data="uploadForm()">
+            <div class="space-y-6" x-data="uploadForm">
                 <!-- Drop Zone -->
                 <div
                     class="flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg p-8 text-center hover:bg-muted/50 transition-colors cursor-pointer relative"
@@ -44,14 +44,14 @@
                 </div>
 
                 <!-- File queue -->
-                <div x-show="files.length > 0" x-cloak class="space-y-2">
+                <div x-show="hasFiles" x-cloak class="space-y-2">
                     <!-- Queue header -->
                     <div class="flex items-center justify-between text-sm text-muted-foreground">
                         <span x-text="queuedFileLabel"></span>
                         <button
                             type="button"
                             class="text-xs underline hover:text-foreground"
-                            x-show="!isUploading"
+                            x-show="canClear"
                             data-upload-clear
                         >Clear all</button>
                     </div>
@@ -100,8 +100,8 @@
                     </template>
 
                     <!-- Summary alert shown when all files have been processed -->
-                    <div x-show="!isUploading && files.length > 0 && pendingCount === 0" class="mt-4">
-                        <template x-if="errorCount === 0 && successCount > 0">
+                    <div x-show="isProcessed" class="mt-4">
+                        <template x-if="isAllSuccess">
                             {% call alert(variant="success") %}
                                 {% call alert_title() %}All uploads complete{% endcall %}
                                 {% call alert_description() %}
@@ -109,7 +109,7 @@
                                 {% endcall %}
                             {% endcall %}
                         </template>
-                        <template x-if="successCount === 0 && errorCount > 0">
+                        <template x-if="isAllError">
                             {% call alert(variant="error") %}
                                 {% call alert_title() %}Upload failed{% endcall %}
                                 {% call alert_description() %}
@@ -117,7 +117,7 @@
                                 {% endcall %}
                             {% endcall %}
                         </template>
-                        <template x-if="successCount > 0 && errorCount > 0">
+                        <template x-if="isMixedResult">
                             {% call alert(variant="warning") %}
                                 {% call alert_title() %}Upload complete with errors{% endcall %}
                                 {% call alert_description() %}
@@ -129,7 +129,7 @@
                 </div>
 
                 <!-- Hint shown when the queue is empty -->
-                <p x-show="files.length === 0" class="text-center text-sm text-muted-foreground">
+                <p x-show="isEmpty" class="text-center text-sm text-muted-foreground">
                     Select or drop files above to begin uploading automatically.
                 </p>
             </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -459,9 +459,17 @@ def test_upload_uses_external_page_script_for_csp_migration():
     script = _upload_script()
 
     assert 'src="/static/js/upload-page.js"' in template
-    assert "uploadForm()" in template
+    assert 'x-data="uploadForm"' in template
+    assert "uploadForm()" not in template
+    assert "Alpine.data('uploadForm', uploadForm)" in script
     assert "/api/v1/reports/upload" in script
     assert "bindControls()" in script
+    assert "get hasFiles()" in script
+    assert "get isProcessed()" in script
+    assert "get isAllSuccess()" in script
+    assert 'x-show="hasFiles"' in template
+    assert 'x-show="isProcessed"' in template
+    assert 'x-if="isAllSuccess"' in template
     assert "data-upload-dropzone" in template
     assert "data-upload-dropzone" in script
     assert "data-upload-file-input" in template


### PR DESCRIPTION
## What changed
- Prepares the upload page for the Alpine CSP runtime by using the registered `uploadForm` component instead of a global `uploadForm()` expression.
- Moves queue and result display predicates into named component getters so the template has simpler CSP-friendly expressions.
- Extends the upload CSP regression test to guard against reintroducing the global initializer.

## Why
Issue #598 needs the app migrated page by page before the strict Alpine CSP runtime can become the default. Upload is a small, isolated page and already used external event binding, so this is a low-risk first migration slice.

Refs #598.

## Validation
- `/tmp/dmarq-live-audit-venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py -k upload`
- `/tmp/dmarq-live-audit-venv/bin/flake8 backend/app/tests/test_dashboard_template_security.py`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium -g "upload page keeps queue controls"`
