### PR TITLE
fix: prepare profile and login for Alpine CSP runtime

### DIFF
--- a/backend/app/static/js/login-page.js
+++ b/backend/app/static/js/login-page.js
@@ -1,6 +1,20 @@
 document.addEventListener('alpine:init', () => {
     Alpine.data('loginErrorBanner', () => ({
         error: new URLSearchParams(window.location.search).get('error'),
+
+        get hasError() {
+            return Boolean(this.error);
+        },
+
+        get errorMessage() {
+            if (this.error === 'callback_failed') {
+                return 'The authentication callback failed. Please try again.';
+            }
+            if (this.error === 'token_error') {
+                return 'Could not read authentication token. Please try again.';
+            }
+            return 'An unexpected error occurred. Please try again.';
+        },
     }));
 });
 

--- a/backend/app/static/js/profile-page.js
+++ b/backend/app/static/js/profile-page.js
@@ -1,6 +1,65 @@
 function profileApp() {
     return {
         user: null,
+
+        get hasPicture() {
+            return Boolean(this.user && this.user.picture);
+        },
+
+        get showPlaceholderAvatar() {
+            return Boolean(this.user && !this.user.picture);
+        },
+
+        get avatarAlt() {
+            if (!this.user) return 'User avatar';
+            return this.user.full_name || this.user.email || 'User avatar';
+        },
+
+        get avatarInitial() {
+            if (!this.user) return '?';
+            const source = this.user.full_name || this.user.email || '?';
+            return source.charAt(0).toUpperCase();
+        },
+
+        get displayName() {
+            if (!this.user) return '...';
+            return this.user.full_name || '-';
+        },
+
+        get emailText() {
+            return this.user && this.user.email ? this.user.email : '';
+        },
+
+        get usernameText() {
+            return this.user && this.user.username ? this.user.username : '-';
+        },
+
+        get isAdmin() {
+            return Boolean(this.user && this.user.is_superuser);
+        },
+
+        get isRegularUser() {
+            return Boolean(this.user && !this.user.is_superuser);
+        },
+
+        get externalIdText() {
+            return this.user && this.user.logto_id ? this.user.logto_id : '-';
+        },
+
+        get authDisabled() {
+            return Boolean(this.user && this.user.auth_disabled);
+        },
+
+        get externalAuthEnabled() {
+            return Boolean(this.user && !this.user.auth_disabled);
+        },
+
+        get authProviderText() {
+            return this.user && this.user.auth_provider_label
+                ? this.user.auth_provider_label
+                : 'External auth';
+        },
+
         async init() {
             try {
                 const response = await fetch('/api/v1/auth/me');
@@ -13,3 +72,7 @@ function profileApp() {
         },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('profileApp', profileApp);
+});

--- a/backend/app/templates/login.html
+++ b/backend/app/templates/login.html
@@ -60,19 +60,15 @@
             {% else %}
 
             <!-- Error banner (shown when ?error= is present) -->
-            <div x-data="loginErrorBanner()"
-                 x-show="error" x-cloak>
+            <div x-data="loginErrorBanner"
+                 x-show="hasError" x-cloak>
                 <div role="alert" class="alert alert-error">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
                     </svg>
                     <div>
                         <p class="font-semibold">Sign-in failed</p>
-                        <p class="text-sm" x-text="error === 'callback_failed'
-                            ? 'The authentication callback failed. Please try again.'
-                            : error === 'token_error'
-                            ? 'Could not read authentication token. Please try again.'
-                            : 'An unexpected error occurred. Please try again.'">
+                        <p class="text-sm" x-text="errorMessage">
                         </p>
                     </div>
                 </div>

--- a/backend/app/templates/profile.html
+++ b/backend/app/templates/profile.html
@@ -5,7 +5,7 @@
 {% block title %}My Profile – {{ app_name }}{% endblock %}
 
 {% block content %}
-<div x-data="profileApp()" class="max-w-2xl mx-auto space-y-6 py-4" data-profile-page>
+<div x-data="profileApp" class="max-w-2xl mx-auto space-y-6 py-4" data-profile-page>
 
     <!-- Profile info card -->
     {% call card() %}
@@ -16,36 +16,36 @@
         {% call card_content() %}
             <div class="flex items-center gap-4 mb-6">
                 <!-- Avatar -->
-                <template x-if="user && user.picture">
-                    <img :src="user.picture" :alt="user.full_name || user.email"
+                <template x-if="hasPicture">
+                    <img :src="user.picture" :alt="avatarAlt"
                          class="w-16 h-16 rounded-full object-cover ring-2 ring-primary/20">
                 </template>
-                <template x-if="user && !user.picture">
+                <template x-if="showPlaceholderAvatar">
                     <div class="avatar placeholder">
                         <div class="bg-primary text-primary-content rounded-full w-16">
                             <span class="text-2xl font-semibold"
-                                  x-text="user ? (user.full_name || user.email || '?')[0].toUpperCase() : '?'"></span>
+                                  x-text="avatarInitial"></span>
                         </div>
                     </div>
                 </template>
                 <div>
-                    <p class="text-lg font-semibold" x-text="user ? (user.full_name || '—') : '…'"></p>
-                    <p class="text-sm text-base-content/60" x-text="user ? user.email : ''"></p>
+                    <p class="text-lg font-semibold" x-text="displayName"></p>
+                    <p class="text-sm text-base-content/60" x-text="emailText"></p>
                 </div>
             </div>
 
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
                 <div>
                     <span class="font-medium text-base-content/70">Username</span>
-                    <p class="mt-0.5" x-text="user && user.username ? user.username : '—'"></p>
+                    <p class="mt-0.5" x-text="usernameText"></p>
                 </div>
                 <div>
                     <span class="font-medium text-base-content/70">Role</span>
                     <p class="mt-0.5">
-                        <template x-if="user && user.is_superuser">
+                        <template x-if="isAdmin">
                             <span class="badge badge-primary badge-sm">Admin</span>
                         </template>
-                        <template x-if="user && !user.is_superuser">
+                        <template x-if="isRegularUser">
                             <span class="badge badge-ghost badge-sm">User</span>
                         </template>
                     </p>
@@ -53,16 +53,16 @@
                 <div>
                     <span class="font-medium text-base-content/70">External ID</span>
                     <p class="mt-0.5 font-mono text-xs truncate"
-                       x-text="user && user.logto_id ? user.logto_id : '—'"></p>
+                       x-text="externalIdText"></p>
                 </div>
                 <div>
                     <span class="font-medium text-base-content/70">Auth mode</span>
                     <p class="mt-0.5">
-                        <template x-if="user && user.auth_disabled">
+                        <template x-if="authDisabled">
                             <span class="badge badge-warning badge-sm">Auth disabled</span>
                         </template>
-                        <template x-if="user && !user.auth_disabled">
-                            <span class="badge badge-success badge-sm" x-text="user.auth_provider_label || 'External auth'"></span>
+                        <template x-if="externalAuthEnabled">
+                            <span class="badge badge-success badge-sm" x-text="authProviderText"></span>
                         </template>
                     </p>
                 </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -496,11 +496,33 @@ def test_profile_uses_external_page_script_for_csp_migration():
     script = _profile_script()
 
     assert 'src="/static/js/profile-page.js"' in template
-    assert "profileApp()" in template
+    assert 'x-data="profileApp"' in template
+    assert "profileApp()" not in template
+    assert "Alpine.data('profileApp', profileApp)" in script
     assert "data-profile-page" in template
     assert "/api/v1/auth/me" in script
     assert "Failed to load user profile" in script
+    assert "get avatarInitial()" in script
+    assert "get authProviderText()" in script
+    assert 'x-text="avatarInitial"' in template
+    assert 'x-text="authProviderText"' in template
     assert 'x-init="init()"' not in template
+    assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
+
+
+def test_login_error_banner_uses_registered_component_for_csp_migration():
+    template = _read_project_file("templates", "login.html")
+    script = _read_project_file("static", "js", "login-page.js")
+
+    assert 'src="/static/js/login-page.js"' in template
+    assert 'x-data="loginErrorBanner"' in template
+    assert "loginErrorBanner()" not in template
+    assert "Alpine.data('loginErrorBanner'" in script
+    assert "get hasError()" in script
+    assert "get errorMessage()" in script
+    assert 'x-show="hasError"' in template
+    assert 'x-text="errorMessage"' in template
+    assert "error === 'callback_failed'" not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -480,6 +480,15 @@ async function installApiMocks(page) {
         source_labels: ['Gmail API: dmarc-reports@example.com'],
         latest_source_check: '2026-07-03T12:00:00Z',
       },
+      '/api/v1/auth/me': {
+        email: 'operator@example.com',
+        full_name: 'Demo Operator',
+        username: 'operator',
+        logto_id: 'auth-disabled-local',
+        is_superuser: true,
+        auth_disabled: true,
+        auth_provider_label: 'Auth disabled',
+      },
       '/api/v1/onboarding/preview': {
         plan: {
           tasks: [
@@ -643,6 +652,20 @@ test('upload page keeps queue controls wired without inline handlers', async ({ 
 
   await page.getByText('Clear all').click();
   await expect(page.getByText('Select or drop files above to begin uploading automatically.')).toBeVisible();
+});
+
+test('profile page renders the registered Alpine component', async ({ page }) => {
+  await page.goto('/profile');
+
+  const main = page.getByRole('main');
+  await expect(page.getByRole('heading', { name: 'My Profile' })).toBeVisible();
+  await expect(main.getByText('Demo Operator')).toBeVisible();
+  await expect(main.getByText('operator@example.com')).toBeVisible();
+  await expect(main.getByText('Username')).toBeVisible();
+  await expect(main.getByText('operator', { exact: true })).toBeVisible();
+  await expect(main.getByText('Auth mode')).toBeVisible();
+  await expect(main.getByText('Auth disabled')).toBeVisible();
+  await expect(page.getByText('Failed to load user profile')).not.toBeVisible();
 });
 
 test('onboarding page keeps setup controls wired without inline handlers', async ({ page }) => {


### PR DESCRIPTION
## What changed
- Prepares the profile page for the Alpine CSP runtime by using the registered `profileApp` component name instead of a global initializer expression.
- Moves profile display predicates and labels into component getters so the template is simpler and CSP-parser friendly.
- Prepares the login error banner the same way, using `loginErrorBanner` plus `hasError` and `errorMessage` getters.
- Adds static CSP regression coverage and a browser smoke for the profile page component wiring.

## Why
Issue #598 is tracking the move to a strict default CSP after the Alpine runtime migration. Profile and login are small, isolated pages and are good follow-up slices after the upload page migration.

Refs #598.

## Validation
- `/tmp/dmarq-live-audit-venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py -k 'profile or login_error_banner'`
- `/tmp/dmarq-live-audit-venv/bin/flake8 backend/app/tests/test_dashboard_template_security.py`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium -g "profile page renders"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the login page’s error banner with clearer, user-friendly messages for common sign-in problems.
  * Updated the profile page to show richer account details, including avatar fallback, display name, email, username, role, and authentication status.

* **Bug Fixes**
  * Made the login and profile pages render their dynamic content more reliably using the app’s standard page initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->