### PR TITLE
fix: prepare reports list for Alpine CSP runtime

### DIFF
--- a/backend/app/static/js/reports-page.js
+++ b/backend/app/static/js/reports-page.js
@@ -50,6 +50,33 @@ function reportsApp() {
             });
         },
 
+        get showLoading() {
+            return this.loading;
+        },
+
+        get showError() {
+            return !this.loading && Boolean(this.error);
+        },
+
+        get showReportCount() {
+            return !this.loading && !this.error;
+        },
+
+        get showEmpty() {
+            return !this.loading && !this.error && this.filteredReports.length === 0;
+        },
+
+        get filteredReportCount() {
+            return this.filteredReports.length;
+        },
+
+        get visibleReports() {
+            if (this.loading || this.error) {
+                return [];
+            }
+            return this.filteredReports;
+        },
+
         get filteredReports() {
             return this.reports.filter((report) => {
                 if (this.filters.domain && report.domain !== this.filters.domain) {
@@ -76,6 +103,20 @@ function reportsApp() {
             return date.toLocaleDateString();
         },
 
+        normalizeReport(report) {
+            const passRate = Number(report.pass_rate || 0);
+            const reportId = String(report.report_id || '');
+
+            return {
+                ...report,
+                pass_rate: passRate,
+                pass_rate_class: this.getPassRateColor(passRate),
+                pass_rate_label: `${passRate}%`,
+                end_date_label: this.formatDate(report.end_date),
+                detail_url: `/reports/${encodeURIComponent(reportId)}`,
+            };
+        },
+
         resetFilters() {
             this.filters = {
                 domain: '',
@@ -97,7 +138,8 @@ function reportsApp() {
                 if (!response.ok) {
                     throw new Error('Reports could not be loaded. Refresh the page or check the import service.');
                 }
-                this.reports = await response.json();
+                const reports = await response.json();
+                this.reports = reports.map((report) => this.normalizeReport(report));
                 this.domains = [...new Set(this.reports.map((report) => report.domain))].sort();
             } catch (error) {
                 this.reports = [];
@@ -142,3 +184,7 @@ function reportsApp() {
         },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('reportsApp', reportsApp);
+});

--- a/backend/app/static/js/reports-page.js
+++ b/backend/app/static/js/reports-page.js
@@ -99,7 +99,13 @@ function reportsApp() {
         },
 
         formatDate(dateStr) {
+            if (!dateStr) {
+                return '';
+            }
             const date = new Date(dateStr);
+            if (Number.isNaN(date.getTime())) {
+                return '';
+            }
             return date.toLocaleDateString();
         },
 

--- a/backend/app/templates/reports.html
+++ b/backend/app/templates/reports.html
@@ -6,7 +6,7 @@
 {% block title %}DMARQ - Reports{% endblock %}
 
 {% block content %}
-<div class="container mx-auto py-4" x-data="reportsApp()" x-cloak>
+<div class="container mx-auto py-4" x-data="reportsApp" x-cloak>
     <h1 class="text-2xl font-bold mb-6">DMARC Reports</h1>
 
     <!-- Report Filters -->
@@ -52,9 +52,9 @@
                     {% call card_title() %}DMARC Reports{% endcall %}
                 </div>
                 {% call card_description() %}
-                    <span x-show="loading">Loading reports...</span>
-                    <span x-show="!loading && !error">Showing <span x-text="filteredReports.length"></span> reports</span>
-                    <span x-show="!loading && error">Reports unavailable</span>
+                    <span x-show="showLoading">Loading reports...</span>
+                    <span x-show="showReportCount">Showing <span x-text="filteredReportCount"></span> reports</span>
+                    <span x-show="showError">Reports unavailable</span>
                 {% endcall %}
             {% endcall %}
             {% call card_content() %}
@@ -71,7 +71,7 @@
                         {% endcall %}
                     {% endcall %}
                     {% call tbody() %}
-                        <template x-if="loading">
+                        <template x-if="showLoading">
                             {% call tr() %}
                                 {% call td(colspan="7", class="text-center") %}
                                     <div class="flex items-center justify-center gap-2 py-4 text-muted-foreground" role="status">
@@ -81,7 +81,7 @@
                                 {% endcall %}
                             {% endcall %}
                         </template>
-                        <template x-if="!loading && error">
+                        <template x-if="showError">
                             {% call tr() %}
                                 {% call td(colspan="7", class="text-center") %}
                                     <div class="flex flex-col items-center gap-3 py-4">
@@ -93,17 +93,17 @@
                                 {% endcall %}
                             {% endcall %}
                         </template>
-                        <template x-if="!loading && !error && filteredReports.length === 0">
+                        <template x-if="showEmpty">
                             {% call tr() %}
                                 {% call td(colspan="7", class="text-center") %}
                                     <p class="py-4 text-muted-foreground">No reports match this filter.</p>
                                 {% endcall %}
                             {% endcall %}
                         </template>
-                        <template x-for="(report, index) in (!loading && !error ? filteredReports : [])" :key="index">
+                        <template x-for="report in visibleReports" :key="report.report_id">
                             {% call tr() %}
                                 {% call td() %}
-                                    <div x-text="formatDate(report.end_date)"></div>
+                                    <div x-text="report.end_date_label"></div>
                                 {% endcall %}
                                 {% call td() %}
                                     <div class="inline-flex items-center px-2 py-1 rounded text-xs bg-blue-100 text-blue-800">
@@ -121,13 +121,13 @@
                                 {% endcall %}
                                 {% call td() %}
                                     <div class="inline-flex items-center px-2 py-1 rounded" 
-                                         :class="getPassRateColor(report.pass_rate)">
-                                        <span x-text="report.pass_rate + '%'"></span>
+                                         :class="report.pass_rate_class">
+                                        <span x-text="report.pass_rate_label"></span>
                                     </div>
                                 {% endcall %}
                                 {% call td("text-right") %}
                                     <div class="inline-flex gap-2 justify-end">
-                                        <a :href="`/reports/${report.report_id}`">
+                                        <a :href="report.detail_url">
                                             {% call button(variant="outline", size="sm") %}
                                                 View Details
                                             {% endcall %}

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -364,7 +364,8 @@ def test_reports_uses_external_page_script_for_csp_migration():
     script = _reports_script()
 
     assert 'src="/static/js/reports-page.js"' in template
-    assert "reportsApp()" in template
+    assert 'x-data="reportsApp" x-cloak' in template
+    assert "Alpine.data('reportsApp', reportsApp)" in script
     assert '@click="deleteReport' not in template
     assert "data-report-delete" in template
     assert "data-report-delete" in script
@@ -372,7 +373,6 @@ def test_reports_uses_external_page_script_for_csp_migration():
     assert "event.target instanceof Element" in script
     assert "/api/v1/reports" in script
     assert "deleteReport(domain, reportId)" in script
-    assert 'x-data="reportsApp()" x-cloak' in template
     assert "resetFilters()" in script
     assert '@click="' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
@@ -392,8 +392,10 @@ def test_reports_page_distinguishes_loading_error_and_empty_states():
     assert "data-report-retry-load" in script
     assert "data-report-reset-filters" in template
     assert "data-report-reset-filters" in script
-    assert 'x-show="!loading && error"' in template
-    assert "(!loading && !error ? filteredReports : [])" in template
+    assert 'x-show="showError"' in template
+    assert 'x-show="loading"' not in template
+    assert "visibleReports" in template
+    assert "filteredReportCount" in template
     assert "loading: true" in script
     assert "throw new Error('Reports could not be loaded." in script
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -371,6 +371,7 @@ def test_reports_uses_external_page_script_for_csp_migration():
     assert "data-report-delete" in script
     assert "bindPageControls()" in script
     assert "event.target instanceof Element" in script
+    assert "Number.isNaN(date.getTime())" in script
     assert "/api/v1/reports" in script
     assert "deleteReport(domain, reportId)" in script
     assert "resetFilters()" in script


### PR DESCRIPTION
## Summary
- registers the reports list Alpine component by name for the strict CSP runtime
- moves report count, loading/error/empty state checks, pass-rate labels/classes, formatted dates, and detail URLs into the external reports page script
- keeps the existing delete/retry/reset controls on delegated data attributes

## Validation
- `/tmp/dmarq-live-audit-venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py`
- `/tmp/dmarq-live-audit-venv/bin/flake8 backend/app/tests/test_dashboard_template_security.py`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium -g "reports list"` from `backend/`
- `git diff --check`

Part of #598.
