### PR TITLE
fix: prepare operations page for Alpine CSP runtime

### DIFF
--- a/backend/app/static/js/operations-page.js
+++ b/backend/app/static/js/operations-page.js
@@ -9,6 +9,98 @@ function operationsHealth() {
             this.load();
         },
 
+        get hasError() {
+            return Boolean(this.error);
+        },
+
+        get scheduler() {
+            return this.health.scheduler || {};
+        },
+
+        get database() {
+            return this.health.database || {};
+        },
+
+        get imports() {
+            return this.health.imports || {};
+        },
+
+        get reports() {
+            return this.health.reports || {};
+        },
+
+        get statusLabel() {
+            return this.health.status || 'loading';
+        },
+
+        get statusClass() {
+            return this.health.status === 'ok' ? 'text-success' : 'text-warning';
+        },
+
+        get databaseLabel() {
+            return this.database.ok ? 'Connected' : 'Failed';
+        },
+
+        get databaseClass() {
+            return this.database.ok ? 'text-success' : 'text-error';
+        },
+
+        get mailSourcesLabel() {
+            return `${this.scheduler.enabled_sources || 0}/${this.scheduler.total_sources || 0}`;
+        },
+
+        get reportsCountLabel() {
+            return this.reports.count || 0;
+        },
+
+        get schedulerStateLabel() {
+            return this.scheduler.running ? 'Running' : 'Stopped';
+        },
+
+        get lastCycleLabel() {
+            return this.formatDate(this.scheduler.last_cycle_started_at);
+        },
+
+        get lastSuccessLabel() {
+            return this.formatDate(this.scheduler.last_success_at);
+        },
+
+        get schedulerLastErrorLabel() {
+            return this.scheduler.last_error || 'None';
+        },
+
+        get latestImportLabel() {
+            return this.formatImport(this.imports.latest);
+        },
+
+        get latestSuccessfulImportLabel() {
+            return this.formatImport(this.imports.latest_successful);
+        },
+
+        get latestReportLabel() {
+            return this.formatDate(this.reports.latest_processed_at);
+        },
+
+        get databaseDetailLabel() {
+            return this.database.detail || 'Unknown';
+        },
+
+        get checks() {
+            return this.health.checks || [];
+        },
+
+        get hasChecks() {
+            return this.checks.length > 0;
+        },
+
+        get mailboxRecovery() {
+            return this.health.mailbox_recovery || [];
+        },
+
+        get hasMailboxRecovery() {
+            return this.mailboxRecovery.length > 0;
+        },
+
         bindRefreshControl() {
             const root = this.$root || document.querySelector('[data-operations-health]');
             const refreshButton = root?.querySelector('[data-operations-refresh]');
@@ -29,7 +121,7 @@ function operationsHealth() {
                 if (!response.ok) {
                     throw new Error('Health details could not be loaded.');
                 }
-                this.health = await response.json();
+                this.health = this.normalizeHealth(await response.json());
             } catch (error) {
                 this.error = error.message || 'Health details could not be loaded.';
             } finally {
@@ -51,5 +143,32 @@ function operationsHealth() {
             if (!value) return 'Mailbox';
             return value.replaceAll('_', ' ');
         },
+
+        normalizeHealth(payload) {
+            const health = payload || {};
+            const mailboxRecovery = (health.mailbox_recovery || []).map((item, index) => {
+                const recoverySteps = item.recovery_steps || [];
+                const summary = item.summary || '';
+                const category = item.category || '';
+
+                return {
+                    ...item,
+                    key: `${category}-${summary}-${index}`,
+                    category_label: this.categoryLabel(category),
+                    recovery_steps: recoverySteps,
+                    has_recovery_steps: recoverySteps.length > 0,
+                };
+            });
+
+            return {
+                ...health,
+                checks: health.checks || [],
+                mailbox_recovery: mailboxRecovery,
+            };
+        },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('operationsHealth', operationsHealth);
+});

--- a/backend/app/templates/operations.html
+++ b/backend/app/templates/operations.html
@@ -3,7 +3,7 @@
 {% block title %}DMARQ - Health{% endblock %}
 
 {% block content %}
-<div class="mx-auto max-w-6xl space-y-6" x-data="operationsHealth()" data-operations-health>
+<div class="mx-auto max-w-6xl space-y-6" x-data="operationsHealth" data-operations-health>
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
             <h1 class="text-2xl font-bold">System Health</h1>
@@ -15,7 +15,7 @@
         </button>
     </div>
 
-    <div x-show="error" role="alert" class="alert alert-error">
+    <div x-show="hasError" role="alert" class="alert alert-error">
         <span x-text="error"></span>
     </div>
 
@@ -23,25 +23,25 @@
         <div class="card bg-base-100 shadow">
             <div class="card-body">
                 <div class="text-sm text-base-content/60">Overall</div>
-                <div class="text-2xl font-semibold capitalize" :class="health.status === 'ok' ? 'text-success' : 'text-warning'" x-text="health.status || 'loading'"></div>
+                <div class="text-2xl font-semibold capitalize" :class="statusClass" x-text="statusLabel"></div>
             </div>
         </div>
         <div class="card bg-base-100 shadow">
             <div class="card-body">
                 <div class="text-sm text-base-content/60">Database</div>
-                <div class="text-2xl font-semibold" :class="health.database?.ok ? 'text-success' : 'text-error'" x-text="health.database?.ok ? 'Connected' : 'Failed'"></div>
+                <div class="text-2xl font-semibold" :class="databaseClass" x-text="databaseLabel"></div>
             </div>
         </div>
         <div class="card bg-base-100 shadow">
             <div class="card-body">
                 <div class="text-sm text-base-content/60">Mail Sources</div>
-                <div class="text-2xl font-semibold" x-text="`${health.scheduler?.enabled_sources || 0}/${health.scheduler?.total_sources || 0}`"></div>
+                <div class="text-2xl font-semibold" x-text="mailSourcesLabel"></div>
             </div>
         </div>
         <div class="card bg-base-100 shadow">
             <div class="card-body">
                 <div class="text-sm text-base-content/60">Reports</div>
-                <div class="text-2xl font-semibold" x-text="health.reports?.count || 0"></div>
+                <div class="text-2xl font-semibold" x-text="reportsCountLabel"></div>
             </div>
         </div>
     </div>
@@ -53,19 +53,19 @@
                 <dl class="grid gap-3 text-sm sm:grid-cols-2">
                     <div>
                         <dt class="text-base-content/60">State</dt>
-                        <dd class="font-medium" x-text="health.scheduler?.running ? 'Running' : 'Stopped'"></dd>
+                        <dd class="font-medium" x-text="schedulerStateLabel"></dd>
                     </div>
                     <div>
                         <dt class="text-base-content/60">Last cycle</dt>
-                        <dd class="font-medium" x-text="formatDate(health.scheduler?.last_cycle_started_at)"></dd>
+                        <dd class="font-medium" x-text="lastCycleLabel"></dd>
                     </div>
                     <div>
                         <dt class="text-base-content/60">Last successful cycle</dt>
-                        <dd class="font-medium" x-text="formatDate(health.scheduler?.last_success_at)"></dd>
+                        <dd class="font-medium" x-text="lastSuccessLabel"></dd>
                     </div>
                     <div>
                         <dt class="text-base-content/60">Last error</dt>
-                        <dd class="font-medium" x-text="health.scheduler?.last_error || 'None'"></dd>
+                        <dd class="font-medium" x-text="schedulerLastErrorLabel"></dd>
                     </div>
                 </dl>
             </div>
@@ -77,48 +77,48 @@
                 <dl class="grid gap-3 text-sm sm:grid-cols-2">
                     <div>
                         <dt class="text-base-content/60">Last completed</dt>
-                        <dd class="font-medium" x-text="formatImport(health.imports?.latest)"></dd>
+                        <dd class="font-medium" x-text="latestImportLabel"></dd>
                     </div>
                     <div>
                         <dt class="text-base-content/60">Last successful</dt>
-                        <dd class="font-medium" x-text="formatImport(health.imports?.latest_successful)"></dd>
+                        <dd class="font-medium" x-text="latestSuccessfulImportLabel"></dd>
                     </div>
                     <div>
                         <dt class="text-base-content/60">Latest report</dt>
-                        <dd class="font-medium" x-text="formatDate(health.reports?.latest_processed_at)"></dd>
+                        <dd class="font-medium" x-text="latestReportLabel"></dd>
                     </div>
                     <div>
                         <dt class="text-base-content/60">Database detail</dt>
-                        <dd class="font-medium" x-text="health.database?.detail || 'Unknown'"></dd>
+                        <dd class="font-medium" x-text="databaseDetailLabel"></dd>
                     </div>
                 </dl>
             </div>
         </section>
     </div>
 
-    <section class="card bg-base-100 shadow" x-show="health.checks?.length">
+    <section class="card bg-base-100 shadow" x-show="hasChecks">
         <div class="card-body">
             <h2 class="card-title">Attention</h2>
             <ul class="list-disc space-y-2 pl-5 text-sm">
-                <template x-for="check in health.checks" :key="check">
+                <template x-for="check in checks" :key="check">
                     <li x-text="check"></li>
                 </template>
             </ul>
         </div>
     </section>
 
-    <section class="card bg-base-100 shadow" x-show="health.mailbox_recovery?.length">
+    <section class="card bg-base-100 shadow" x-show="hasMailboxRecovery">
         <div class="card-body">
             <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <h2 class="card-title">Mailbox Recovery</h2>
                 <a href="/mail-sources" class="btn btn-outline btn-sm">Open Mail Sources</a>
             </div>
             <div class="grid gap-3 md:grid-cols-2">
-                <template x-for="item in health.mailbox_recovery" :key="item.category + item.summary">
+                <template x-for="item in mailboxRecovery" :key="item.key">
                     <div class="rounded-lg border border-base-300 bg-base-200/60 p-4">
-                        <div class="text-xs font-semibold uppercase tracking-wide text-base-content/60" x-text="categoryLabel(item.category)"></div>
+                        <div class="text-xs font-semibold uppercase tracking-wide text-base-content/60" x-text="item.category_label"></div>
                         <p class="mt-1 text-sm font-medium" x-text="item.summary"></p>
-                        <ul class="mt-3 list-disc space-y-1 pl-5 text-sm text-base-content/70" x-show="item.recovery_steps?.length">
+                        <ul class="mt-3 list-disc space-y-1 pl-5 text-sm text-base-content/70" x-show="item.has_recovery_steps">
                             <template x-for="step in item.recovery_steps" :key="step">
                                 <li x-text="step"></li>
                             </template>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -338,13 +338,19 @@ def test_operations_uses_external_page_script_for_csp_migration():
     script = _operations_script()
 
     assert 'src="/static/js/operations-page.js"' in template
-    assert "operationsHealth()" in template
+    assert 'x-data="operationsHealth"' in template
+    assert "Alpine.data('operationsHealth', operationsHealth)" in script
     assert 'x-init="load()"' not in template
     assert '@click="load"' not in template
     assert "data-operations-refresh" in template
     assert "data-operations-refresh" in script
     assert "/api/v1/health/operations" in script
     assert "Health details could not be loaded." in script
+    assert "statusClass" in template
+    assert "databaseClass" in template
+    assert "mailSourcesLabel" in template
+    assert "hasMailboxRecovery" in template
+    assert "normalizeHealth" in script
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -66,6 +66,43 @@ const reputationUnknown = {
   recommendations: [],
 };
 
+const operationsHealth = {
+  status: 'ok',
+  database: { ok: true, detail: 'SQLite ready' },
+  scheduler: {
+    running: true,
+    enabled_sources: 2,
+    total_sources: 3,
+    last_cycle_started_at: '2026-07-04T08:20:00Z',
+    last_success_at: '2026-07-04T08:21:00Z',
+    last_error: '',
+  },
+  imports: {
+    latest: {
+      status: 'completed',
+      reports_found: 4,
+      finished_at: '2026-07-04T08:22:00Z',
+    },
+    latest_successful: {
+      status: 'completed',
+      reports_found: 4,
+      finished_at: '2026-07-04T08:22:00Z',
+    },
+  },
+  reports: {
+    count: 151,
+    latest_processed_at: '2026-07-04T08:22:30Z',
+  },
+  checks: ['DNS cache refresh queue is healthy'],
+  mailbox_recovery: [
+    {
+      category: 'gmail_backfill',
+      summary: 'Gmail backfill can resume from the saved cursor.',
+      recovery_steps: ['Open Mail Sources', 'Run backfill from cursor'],
+    },
+  ],
+};
+
 const domainSummary = {
   total_domains: 2,
   total_emails: 2873,
@@ -346,6 +383,7 @@ async function installApiMocks(page) {
       '/api/v1/stats/dashboard': dashboardStats,
       '/api/v1/domains/summary/health/history': healthHistory,
       '/api/v1/reports': reports,
+      '/api/v1/health/operations': operationsHealth,
       '/api/v1/reports/browser-smoke-cklnet': reportDetail,
       '/api/v1/domains/cklnet.com/stats': {
         complianceRate: 92.1,
@@ -720,4 +758,19 @@ test('reports list and aggregate detail keep source evidence actionable', async 
   await expect(page.getByText('Reputation feeds are disabled.').first()).toBeVisible();
   await expect(page.getByText('DKIM did not pass for this source.')).toBeVisible();
   await expect(page.getByText('Failed to load report')).not.toBeVisible();
+});
+
+test('operations health page renders the registered Alpine component', async ({ page }) => {
+  await page.goto('/operations');
+
+  await expect(page.getByRole('heading', { name: 'System Health' })).toBeVisible();
+  await expect(page.getByText('ok')).toBeVisible();
+  await expect(page.getByText('Connected')).toBeVisible();
+  await expect(page.getByText('2/3')).toBeVisible();
+  await expect(page.getByText('151')).toBeVisible();
+  await expect(page.getByText('Running')).toBeVisible();
+  await expect(page.getByText('completed (4 reports)')).toHaveCount(2);
+  await expect(page.getByText('DNS cache refresh queue is healthy')).toBeVisible();
+  await expect(page.getByText('gmail backfill', { exact: true })).toBeVisible();
+  await expect(page.getByText('Gmail backfill can resume from the saved cursor.')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- registers the Operations/System Health Alpine page by name for the strict CSP runtime
- moves status labels, classes, scheduler/import/report summaries, checks, and mailbox-recovery display fields into the external page script
- adds a browser smoke payload and assertion for the operations page so the registered component is exercised under Playwright

## Validation
- `/tmp/dmarq-live-audit-venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py -k 'operations or reports'`
- `node --check backend/app/static/js/operations-page.js`
- `node --check backend/tests/browser/live-dmarc-flows.spec.js`
- `/tmp/dmarq-live-audit-venv/bin/flake8 backend/app/tests/test_dashboard_template_security.py`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium -g "operations health"` from `backend/`
- `git diff --check`

Part of #598.
