### PR TITLE
[codex] Prepare domains and setup pages for Alpine CSP runtime

### DIFF
--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -102,23 +102,7 @@ function domainsApp() {
                 }
                 const data = await response.json();
 
-                this.domains = data.domains.map((domain) => ({
-                    name: domain.domain_name,
-                    dmarc_status: domain.dmarc_status ?? false,
-                    dmarc_policy: domain.dmarc_policy || 'Not configured',
-                    spf_status: domain.spf_status ?? false,
-                    dkim_status: domain.dkim_status ?? false,
-                    dns_pending: Boolean(domain.dns_pending),
-                    dns_cached: Boolean(domain.dns_cached),
-                    dns_checked_at: domain.dns_checked_at || null,
-                    reports_count: domain.report_count,
-                    emails_count: domain.total_emails,
-                    compliance_rate: domain.pass_rate,
-                    description: domain.description || '',
-                    dkim_selectors: Array.isArray(domain.dkim_selectors)
-                        ? domain.dkim_selectors
-                        : [],
-                }));
+                this.domains = data.domains.map((domain) => this.normalizeDomain(domain));
             } catch (error) {
                 this.domains = [];
                 this.loadError = error.message || 'Domains could not be loaded.';
@@ -241,6 +225,32 @@ function domainsApp() {
             }
         },
 
+        normalizeDomain(domain) {
+            const normalized = {
+                name: domain.domain_name,
+                dmarc_status: domain.dmarc_status ?? false,
+                dmarc_policy: domain.dmarc_policy || 'Not configured',
+                spf_status: domain.spf_status ?? false,
+                dkim_status: domain.dkim_status ?? false,
+                dns_pending: Boolean(domain.dns_pending),
+                dns_cached: Boolean(domain.dns_cached),
+                dns_checked_at: domain.dns_checked_at || null,
+                reports_count: domain.report_count,
+                emails_count: domain.total_emails,
+                compliance_rate: domain.pass_rate,
+                description: domain.description || '',
+                dkim_selectors: Array.isArray(domain.dkim_selectors) ? domain.dkim_selectors : [],
+            };
+
+            return {
+                ...normalized,
+                detail_url: `/domains/${encodeURIComponent(normalized.name)}`,
+                dmarc_status_class: this.dnsStatusClass(normalized, 'dmarc_status'),
+                spf_status_class: this.dnsStatusClass(normalized, 'spf_status'),
+                dkim_status_class: this.dnsStatusClass(normalized, 'dkim_status'),
+            };
+        },
+
         dnsStatusClass(domain, key) {
             if (domain.dns_pending) return 'bg-gray-400';
             return domain[key] ? 'bg-green-500' : 'bg-red-500';
@@ -257,3 +267,7 @@ function domainsApp() {
         },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('domainsApp', domainsApp);
+});

--- a/backend/app/static/js/setup-page.js
+++ b/backend/app/static/js/setup-page.js
@@ -150,5 +150,30 @@ function setupWizard() {
                 this.saving = false;
             }
         },
+        get renderedSteps() {
+            return this.steps.map((step) => ({
+                ...step,
+                className: this.stepClass(step.id),
+                badgeClass: this.stepBadgeClass(step.id),
+            }));
+        },
+        get domainsConfiguredLabel() {
+            return `(${this.totalDomains} configured)`;
+        },
+        get mailSourcesEnabledLabel() {
+            return `(${this.enabledMailSources}/${this.totalMailSources} enabled)`;
+        },
+        get mailboxRecoverySteps() {
+            return Array.isArray(this.mailboxRecoveryHint?.recovery_steps)
+                ? this.mailboxRecoveryHint.recovery_steps
+                : [];
+        },
+        get hasMailboxRecoverySteps() {
+            return this.mailboxRecoverySteps.length > 0;
+        },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('setupWizard', setupWizard);
+});

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -6,7 +6,7 @@
 {% block title %}DMARQ - Domains{% endblock %}
 
 {% block content %}
-<div class="container mx-auto py-4" x-data="domainsApp()" x-cloak>
+<div class="container mx-auto py-4" x-data="domainsApp" x-cloak data-domains-page>
     <h1 class="text-2xl font-bold mb-6">Domain Management</h1>
     
     {% if error %}
@@ -87,27 +87,27 @@
                                 {% call td() %}
                                     <div class="flex items-center">
                                         <span class="w-2 h-2 rounded-full" 
-                                            :class="dnsStatusClass(domain, 'dmarc_status')"></span>
+                                            :class="domain.dmarc_status_class"></span>
                                         <span class="ml-2" x-text="dmarcStatusText(domain)"></span>
                                     </div>
                                 {% endcall %}
                                 {% call td() %}
                                     <div class="flex items-center">
                                         <span class="w-2 h-2 rounded-full"
-                                            :class="dnsStatusClass(domain, 'spf_status')"></span>
+                                            :class="domain.spf_status_class"></span>
                                         <span class="ml-2" x-text="genericDnsStatusText(domain, 'spf_status')"></span>
                                     </div>
                                 {% endcall %}
                                 {% call td() %}
                                     <div class="flex items-center">
                                         <span class="w-2 h-2 rounded-full"
-                                            :class="dnsStatusClass(domain, 'dkim_status')"></span>
+                                            :class="domain.dkim_status_class"></span>
                                         <span class="ml-2" x-text="genericDnsStatusText(domain, 'dkim_status')"></span>
                                     </div>
                                 {% endcall %}
                                 {% call td("text-right") %}
                                     <div class="flex justify-end space-x-2">
-                                        <a :href="'/domains/' + domain.name" class="btn btn-sm btn-outline">
+                                        <a :href="domain.detail_url" class="btn btn-sm btn-outline">
                                             Details
                                         </a>
                                         <button type="button"

--- a/backend/app/templates/setup.html
+++ b/backend/app/templates/setup.html
@@ -17,7 +17,7 @@
     <link href="/static/css/page-utilities.css" rel="stylesheet" type="text/css"/>
 </head>
 <body class="min-h-screen bg-base-200 font-sans antialiased">
-<div class="min-h-screen" x-data="setupWizard()" x-cloak data-app-name="{{ app_name }}" data-setup-wizard>
+<div class="min-h-screen" x-data="setupWizard" x-cloak data-app-name="{{ app_name }}" data-setup-wizard>
     <header class="border-b border-base-300 bg-base-100">
         <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
             <a href="/" class="inline-flex items-center gap-3">
@@ -40,11 +40,11 @@
             <div class="card bg-base-100 shadow">
                 <div class="card-body gap-6">
                     <ol class="grid gap-3 sm:grid-cols-3" aria-label="Setup progress">
-                        <template x-for="step in steps" :key="step.id">
+                        <template x-for="step in renderedSteps" :key="step.id">
                             <li class="flex items-center gap-3 rounded-lg border border-base-300 p-3"
-                                :class="stepClass(step.id)">
+                                :class="step.className">
                                 <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-semibold"
-                                      :class="stepBadgeClass(step.id)"
+                                      :class="step.badgeClass"
                                       x-text="step.id"></span>
                                 <span class="min-w-0">
                                     <span class="block text-sm font-semibold" x-text="step.title"></span>
@@ -219,14 +219,14 @@
                             <span class="mt-1 h-2 w-2 rounded-full bg-primary"></span>
                             <span>
                                 <a href="/domains" class="link link-primary font-medium">Add monitored domains</a>
-                                <span class="ml-1" x-text="`(${totalDomains} configured)`"></span>
+                                <span class="ml-1" x-text="domainsConfiguredLabel"></span>
                             </span>
                         </li>
                         <li class="flex gap-2">
                             <span class="mt-1 h-2 w-2 rounded-full bg-secondary"></span>
                             <span>
                                 <a href="/mail-sources" class="link link-primary font-medium">Connect a mailbox</a>
-                                <span class="ml-1" x-text="`(${enabledMailSources}/${totalMailSources} enabled)`"></span>
+                                <span class="ml-1" x-text="mailSourcesEnabledLabel"></span>
                             </span>
                         </li>
                         <li class="flex gap-2">
@@ -238,8 +238,8 @@
                     </ul>
                     <div x-show="mailboxRecoveryHint" class="mt-4 rounded-lg border border-warning/30 bg-warning/10 p-4 text-sm">
                         <div class="font-semibold text-base-content" x-text="mailboxRecoveryHint?.summary"></div>
-                        <ul class="mt-2 list-disc space-y-1 pl-5 text-base-content/70" x-show="mailboxRecoveryHint?.recovery_steps?.length">
-                            <template x-for="step in mailboxRecoveryHint.recovery_steps" :key="step">
+                        <ul class="mt-2 list-disc space-y-1 pl-5 text-base-content/70" x-show="hasMailboxRecoverySteps">
+                            <template x-for="step in mailboxRecoverySteps" :key="step">
                                 <li x-text="step"></li>
                             </template>
                         </ul>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -412,10 +412,18 @@ def test_domains_uses_external_page_script_for_csp_migration():
     script = _domains_script()
 
     assert 'src="/static/js/domains-page.js"' in template
-    assert "domainsApp()" in template
+    assert 'x-data="domainsApp" x-cloak' in template
+    assert "Alpine.data('domainsApp', domainsApp)" in script
     assert "/api/v1/domains/summary" in script
     assert "/api/v1/domains/domains" in script
     assert "createDomain()" in script
+    assert "normalizeDomain(domain)" in script
+    assert "detail_url" in script
+    assert "encodeURIComponent(normalized.name)" in script
+    assert "domain.detail_url" in template
+    assert "domain.dmarc_status_class" in template
+    assert "domain.spf_status_class" in template
+    assert "domain.dkim_status_class" in template
     assert "openEditDialog(domain)" not in template
     assert "openEditDialog(domain)" in script
     assert "bindPageControls()" in script
@@ -439,7 +447,9 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert "updateDomain()" in script
     assert "method: 'PATCH'" in script
     assert "editError" in template
-    assert 'x-data="domainsApp()" x-cloak' in template
+    assert "data-domains-page" in template
+    assert "dnsStatusClass(domain" not in template
+    assert "'/domains/' + domain.name" not in template
     assert '@submit.prevent="createDomain' not in template
     assert '@submit.prevent="updateDomain' not in template
     assert '@click="closeCreate' not in template

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -98,6 +98,19 @@ class TestSetupPage:
 
         assert response.status_code == 200
         assert "First-run setup" in response.text
+        assert 'x-data="setupWizard" x-cloak' in response.text
+        assert "setupWizard()" not in response.text
+        assert "renderedSteps" in response.text
+        assert "step.className" in response.text
+        assert "step.badgeClass" in response.text
+        assert "domainsConfiguredLabel" in response.text
+        assert "mailSourcesEnabledLabel" in response.text
+        assert "hasMailboxRecoverySteps" in response.text
+        assert "mailboxRecoverySteps" in response.text
+        assert "stepClass(step.id)" not in response.text
+        assert "stepBadgeClass(step.id)" not in response.text
+        assert "`(${totalDomains} configured)`" not in response.text
+        assert "`(${enabledMailSources}/${totalMailSources} enabled)`" not in response.text
         assert '@submit.prevent="submitAdmin"' not in response.text
         assert '@submit.prevent="submitSystem"' not in response.text
         assert 'x-init="init()"' not in response.text
@@ -107,6 +120,12 @@ class TestSetupPage:
         assert 'data-app-name="DMARQ"' in response.text
         assert 'src="/static/js/setup-page.js"' in response.text
         assert "bindControls()" in script
+        assert "Alpine.data('setupWizard', setupWizard)" in script
+        assert "renderedSteps()" in script
+        assert "domainsConfiguredLabel()" in script
+        assert "mailSourcesEnabledLabel()" in script
+        assert "mailboxRecoverySteps()" in script
+        assert "hasMailboxRecoverySteps()" in script
         assert "data-setup-admin-form" in script
         assert "data-setup-system-form" in script
         assert "data-setup-back" in script


### PR DESCRIPTION
## Summary
- moves the Domains page to the registered Alpine component pattern and script-derived status/detail fields
- URL-encodes domain detail links from the domains list
- moves setup progress classes, checklist labels, and mailbox recovery steps into the setup page script
- keeps this as a bounded follow-up slice for #598

## Validation
- `/tmp/dmarq-live-audit-venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py -k domains backend/app/tests/test_setup_endpoints.py::TestSetupPage backend/app/tests/test_security.py::TestSecurityHeaders::test_auth_templates_use_external_page_scripts`
- `/tmp/dmarq-live-audit-venv/bin/pytest -q backend/app/tests/test_setup_endpoints.py::TestSetupPage backend/app/tests/test_security.py::TestSecurityHeaders::test_auth_templates_use_external_page_scripts`
- `node --check backend/app/static/js/domains-page.js && node --check backend/app/static/js/setup-page.js`
- `/tmp/dmarq-live-audit-venv/bin/flake8 backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_setup_endpoints.py backend/app/tests/test_security.py`
- `git diff --check HEAD~2..HEAD`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium -g "domain list"`

Refs #598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The setup page now shows a clearer step-by-step progress view with improved labels for configured domains, mail sources, and mailbox recovery guidance.
  * The domains page now uses cleaner, precomputed status indicators and detail links for each monitored domain.

* **Bug Fixes**
  * Improved page rendering consistency for the setup and domains screens, including better handling of status display and recovery steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->