### PR TITLE
[codex] Prepare forensic reports page for Alpine CSP runtime

### DIFF
--- a/backend/app/static/js/forensic-reports-page.js
+++ b/backend/app/static/js/forensic-reports-page.js
@@ -93,6 +93,9 @@ function forensicReportsApp() {
                 ].some((value) => String(value || '').toLowerCase().includes(search))
             );
         },
+        get filteredReportsCount() {
+            return this.filteredReports.length;
+        },
         get summary() {
             return {
                 total: this.total,
@@ -100,6 +103,24 @@ function forensicReportsApp() {
                 spf: this.reports.filter((report) => report.auth_failure === 'spf').length,
                 rejected: this.reports.filter((report) => report.delivery_result === 'reject').length,
             };
+        },
+        get uploadIdle() {
+            return !this.uploading;
+        },
+        get uploadDisabled() {
+            return this.uploading || !this.selectedFile;
+        },
+        get uploadMessageClass() {
+            return this.uploadError ? 'text-error' : 'text-success';
+        },
+        get hasAnalysisGroups() {
+            return this.analysis.groups.length > 0;
+        },
+        get analysisEmpty() {
+            return !this.hasAnalysisGroups;
+        },
+        get visibleAnalysisGroups() {
+            return this.analysis.groups.slice(0, 3);
         },
         async fetchReports() {
             this.loading = true;
@@ -112,7 +133,7 @@ function forensicReportsApp() {
                 const response = await fetch(`/api/v1/forensics?${params.toString()}`);
                 if (!response.ok) throw new Error('Unable to load forensic reports');
                 const data = await response.json();
-                this.reports = data.reports || [];
+                this.reports = (data.reports || []).map((report) => this.normalizeReport(report));
                 this.total = data.total || 0;
                 await this.fetchAnalysis(params);
                 if (!this.filters.domain) {
@@ -133,7 +154,11 @@ function forensicReportsApp() {
         async fetchAnalysis(params) {
             const response = await fetch(`/api/v1/forensics/analysis?${params.toString()}`);
             if (!response.ok) throw new Error('Unable to analyze forensic reports');
-            this.analysis = await response.json();
+            const analysis = await response.json();
+            this.analysis = {
+                ...analysis,
+                groups: (analysis.groups || []).map((group) => this.normalizeAnalysisGroup(group)),
+            };
         },
         async uploadReport() {
             if (!this.selectedFile) return;
@@ -168,6 +193,24 @@ function forensicReportsApp() {
             const date = new Date(value);
             return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
         },
+        normalizeReport(report) {
+            const domain = report.domain || report.reported_domain || 'unknown';
+            return {
+                ...report,
+                arrival_label: this.formatDate(report.arrival_date || report.processed_at),
+                domain_label: domain,
+                domain_url: `/domains/${encodeURIComponent(domain)}`,
+                detail_url: `/forensics/${encodeURIComponent(report.id)}`,
+            };
+        },
+        normalizeAnalysisGroup(group) {
+            return {
+                ...group,
+                priority_class: this.priorityClass(group.priority),
+                visible_recommendations: (group.recommendations || []).slice(0, 2),
+                sample_count_label: `${group.count || 0} samples`,
+            };
+        },
         priorityClass(priority) {
             if (priority === 'high') return 'badge-error';
             if (priority === 'medium') return 'badge-warning';
@@ -175,3 +218,7 @@ function forensicReportsApp() {
         },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('forensicReportsApp', forensicReportsApp);
+});

--- a/backend/app/templates/forensic_reports.html
+++ b/backend/app/templates/forensic_reports.html
@@ -5,7 +5,7 @@
 {% block title %}DMARQ - Forensic Reports{% endblock %}
 
 {% block content %}
-<div class="container mx-auto py-4" x-data="forensicReportsApp()" data-forensic-reports-page>
+<div class="container mx-auto py-4" x-data="forensicReportsApp" data-forensic-reports-page>
     <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between mb-6">
         <div>
             <h1 class="text-2xl font-bold">Forensic Reports</h1>
@@ -91,11 +91,11 @@
             {% call card_content() %}
                 <form class="space-y-3" data-forensic-upload-form>
                     <input type="file" class="file-input file-input-bordered w-full" accept=".eml,.txt,message/rfc822,text/plain" data-forensic-upload-file>
-                    <button class="btn btn-primary w-full" type="submit" :disabled="uploading || !selectedFile">
-                        <span x-show="!uploading">Upload Forensic Report</span>
+                    <button class="btn btn-primary w-full" type="submit" :disabled="uploadDisabled">
+                        <span x-show="uploadIdle">Upload Forensic Report</span>
                         <span x-show="uploading" class="loading loading-spinner loading-sm"></span>
                     </button>
-                    <p class="text-sm" :class="uploadError ? 'text-error' : 'text-success'" x-show="uploadMessage" x-text="uploadMessage"></p>
+                    <p class="text-sm" :class="uploadMessageClass" x-show="uploadMessage" x-text="uploadMessage"></p>
                 </form>
             {% endcall %}
         {% endcall %}
@@ -115,27 +115,27 @@
             </div>
         {% endcall %}
         {% call card_content() %}
-            <template x-if="analysis.groups.length === 0">
+            <template x-if="analysisEmpty">
                 <p class="text-base-content/60">No failure samples are available for analysis.</p>
             </template>
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4" x-show="analysis.groups.length > 0">
-                <template x-for="group in analysis.groups.slice(0, 3)" :key="group.key">
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4" x-show="hasAnalysisGroups">
+                <template x-for="group in visibleAnalysisGroups" :key="group.key">
                     <div class="border border-base-300 rounded-md p-4 space-y-3">
                         <div class="flex items-start justify-between gap-3">
                             <div class="min-w-0">
                                 <p class="font-semibold break-words" x-text="group.domain"></p>
                                 <p class="text-sm font-mono text-base-content/70" x-text="group.source_ip"></p>
                             </div>
-                            <span class="badge uppercase" :class="priorityClass(group.priority)" x-text="group.priority"></span>
+                            <span class="badge uppercase" :class="group.priority_class" x-text="group.priority"></span>
                         </div>
                         <p class="text-sm" x-text="group.diagnosis"></p>
                         <ul class="text-sm space-y-1 list-disc pl-4">
-                            <template x-for="action in group.recommendations.slice(0, 2)" :key="action">
+                            <template x-for="action in group.visible_recommendations" :key="action">
                                 <li x-text="action"></li>
                             </template>
                         </ul>
                         <div class="flex items-center justify-between text-xs text-base-content/60">
-                            <span><span x-text="group.count"></span> samples</span>
+                            <span x-text="group.sample_count_label"></span>
                             <span class="uppercase" x-text="group.auth_failure"></span>
                         </div>
                     </div>
@@ -150,7 +150,7 @@
                 <div>
                     {% call card_title() %}Authentication Failures{% endcall %}
                     {% call card_description() %}
-                        Showing <span x-text="filteredReports.length"></span> of <span x-text="total"></span> reports
+                        Showing <span x-text="filteredReportsCount"></span> of <span x-text="total"></span> reports
                     {% endcall %}
                 </div>
                 <button class="btn btn-outline btn-sm" data-forensic-reset>Reset</button>
@@ -185,15 +185,15 @@
                         </template>
                         <template x-for="report in filteredReports" :key="report.id">
                             {% call tr() %}
-                                {% call td() %}<span x-text="formatDate(report.arrival_date || report.processed_at)"></span>{% endcall %}
-                                {% call td() %}<a class="link link-hover font-medium" :href="'/domains/' + encodeURIComponent(report.domain || report.reported_domain)" x-text="report.domain || report.reported_domain || 'unknown'"></a>{% endcall %}
+                                {% call td() %}<span x-text="report.arrival_label"></span>{% endcall %}
+                                {% call td() %}<a class="link link-hover font-medium" :href="report.domain_url" x-text="report.domain_label"></a>{% endcall %}
                                 {% call td() %}<span class="font-mono text-sm" x-text="report.source_ip || '-'"></span>{% endcall %}
                                 {% call td() %}<span class="badge badge-error badge-outline uppercase" x-text="report.auth_failure || 'unknown'"></span>{% endcall %}
                                 {% call td() %}<span class="badge badge-ghost uppercase" x-text="report.delivery_result || 'unknown'"></span>{% endcall %}
                                 {% call td() %}<span class="block max-w-48 truncate" x-text="report.original_from || report.original_mail_from || '-'"></span>{% endcall %}
                                 {% call td() %}<span class="block max-w-64 truncate" x-text="report.original_subject || '-'"></span>{% endcall %}
                                 {% call td("text-right") %}
-                                    <a class="btn btn-outline btn-sm" :href="'/forensics/' + report.id">Investigate</a>
+                                    <a class="btn btn-outline btn-sm" :href="report.detail_url">Investigate</a>
                                 {% endcall %}
                             {% endcall %}
                         </template>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -568,11 +568,39 @@ def test_forensic_reports_uses_external_page_script_for_csp_migration():
     script = _forensic_reports_script()
 
     assert 'src="/static/js/forensic-reports-page.js"' in template
-    assert "forensicReportsApp()" in template
+    assert 'x-data="forensicReportsApp"' in template
+    assert "Alpine.data('forensicReportsApp', forensicReportsApp)" in script
     assert "/api/v1/forensics?" in script
     assert "/api/v1/forensics/analysis?" in script
     assert "/api/v1/forensics/upload" in script
     assert "Unable to load forensic reports" in script
+    assert "normalizeReport(report)" in script
+    assert "normalizeAnalysisGroup(group)" in script
+    assert "domain_url" in script
+    assert "detail_url" in script
+    assert "encodeURIComponent(domain)" in script
+    assert "encodeURIComponent(report.id)" in script
+    assert "uploadDisabled" in template
+    assert "uploadIdle" in template
+    assert "uploadMessageClass" in template
+    assert "analysisEmpty" in template
+    assert "hasAnalysisGroups" in template
+    assert "visibleAnalysisGroups" in template
+    assert "group.priority_class" in template
+    assert "group.visible_recommendations" in template
+    assert "group.sample_count_label" in template
+    assert "filteredReportsCount" in template
+    assert "report.arrival_label" in template
+    assert "report.domain_url" in template
+    assert "report.domain_label" in template
+    assert "report.detail_url" in template
+    assert "forensicReportsApp()" not in template
+    assert "priorityClass(group.priority)" not in template
+    assert "analysis.groups.slice(0, 3)" not in template
+    assert "group.recommendations.slice(0, 2)" not in template
+    assert "formatDate(report.arrival_date" not in template
+    assert "'/domains/' + encodeURIComponent" not in template
+    assert "'/forensics/' + report.id" not in template
     assert not _has_alpine_handler_call(template, "change", "fetchReports")
     assert not _has_alpine_handler_call(template, "submit", "uploadReport")
     assert not _has_alpine_handler_call(template, "click", "resetFilters")

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -511,7 +511,43 @@ async function installApiMocks(page) {
         warnings: [],
       },
       '/api/v1/domains/cklnet.com/selectors': [{ selector: 'pm' }, { selector: 'mail' }],
-      '/api/v1/forensics/analysis': { total: 0, failure_counts: {} },
+      '/api/v1/forensics': {
+        reports: [
+          {
+            id: 'forensic-1',
+            report_id: 'forensic-1',
+            arrival_date: '2026-07-04T08:10:00Z',
+            processed_at: '2026-07-04T08:12:00Z',
+            domain: 'cklnet.com',
+            reported_domain: 'cklnet.com',
+            source_ip: '193.138.195.141',
+            auth_failure: 'dkim',
+            delivery_result: 'reject',
+            original_from: 'alerts@cklnet.com',
+            original_subject: 'Authentication failed',
+            authentication_results: 'dkim=fail spf=pass dmarc=fail',
+          },
+        ],
+        total: 1,
+      },
+      '/api/v1/forensics/analysis': {
+        total: 1,
+        priority_counts: { high: 1, medium: 0 },
+        failure_counts: { dkim: 1 },
+        result_counts: { reject: 1 },
+        groups: [
+          {
+            key: 'cklnet.com:193.138.195.141:dkim',
+            domain: 'cklnet.com',
+            source_ip: '193.138.195.141',
+            priority: 'high',
+            diagnosis: 'DKIM failed for a source that still sends mail.',
+            recommendations: ['Check selector DNS', 'Confirm signing in the mail service'],
+            count: 1,
+            auth_failure: 'dkim',
+          },
+        ],
+      },
       '/api/v1/poll-status': {
         is_running: true,
         enabled_sources: 1,
@@ -665,6 +701,21 @@ test('domain list loads domain rows and keeps edit action wired', async ({ page 
   await expect(page.getByRole('dialog').getByText('cklnet.com')).toBeVisible();
   await page.locator('[data-domain-edit-close]').first().click();
   await expect(page.locator('[data-domain-edit-dialog]')).toHaveJSProperty('open', false);
+});
+
+test('forensic reports page renders normalized links and analysis cards', async ({ page }) => {
+  await page.goto('/forensics');
+
+  await expect(page.getByRole('heading', { name: 'Forensic Reports' })).toBeVisible();
+  await expect(page.getByText('DKIM failed for a source that still sends mail.')).toBeVisible();
+  await expect(page.getByText('1 samples')).toBeVisible();
+
+  const domainLink = page.getByRole('link', { name: 'cklnet.com' }).first();
+  await expect(domainLink).toHaveAttribute('href', '/domains/cklnet.com');
+  await expect(page.getByRole('link', { name: 'Investigate' })).toHaveAttribute(
+    'href',
+    '/forensics/forensic-1'
+  );
 });
 
 test('upload page keeps queue controls wired without inline handlers', async ({ page }) => {


### PR DESCRIPTION
## Summary
- moves the Forensic Reports page to the registered Alpine component pattern
- moves analysis card classes, upload state, report dates, and detail/domain URLs into the external page script
- URL-encodes forensic detail and domain links from normalized row data
- adds a browser smoke for the forensic reports page

## Validation
- `/tmp/dmarq-live-audit-venv/bin/pytest -q backend/app/tests/test_dashboard_template_security.py -k forensic_reports`
- `node --check backend/app/static/js/forensic-reports-page.js && node --check backend/tests/browser/live-dmarc-flows.spec.js`
- `/tmp/dmarq-live-audit-venv/bin/flake8 backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`
- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python npm run test:browser -- --project=chromium -g "forensic reports"`

Refs #598