### PR TITLE
[codex] Use public DNS resolvers for domain evidence

### DIFF
--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -133,8 +133,8 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
     # ── DNS ──────────────────────────────────────────────────────────────────
     {
         "key": "dns.resolver",
-        "value": "system",
-        "description": "DNS resolver to use: system or cloudflare",
+        "value": "public",
+        "description": "DNS resolver to use: public or cloudflare",
         "value_type": "string",
         "category": "dns",
     },

--- a/backend/app/api/api_v1/endpoints/setup.py
+++ b/backend/app/api/api_v1/endpoints/setup.py
@@ -263,7 +263,7 @@ async def setup_system(
             db,
             DNS_RESOLVER_KEY,
             "cloudflare",
-            description="DNS resolver to use: system or cloudflare",
+            description="DNS resolver to use: public or cloudflare",
             category="dns",
         )
     db.commit()

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -19,7 +19,7 @@ from app.services.dns_resolver import (
     BaseDNSProvider,
     CloudflareDNSProvider,
     DomainDNSResult,
-    GoogleDNSProvider,
+    PublicRecursiveDNSProvider,
     SystemDNSProvider,
 )
 
@@ -246,9 +246,8 @@ DNSCandidateResult = Tuple[str, Optional[DomainDNSResult], Optional[Exception]]
 
 def _fallback_candidates(provider: BaseDNSProvider) -> List[BaseDNSProvider]:
     fallback_types: List[type[BaseDNSProvider]] = [
-        SystemDNSProvider,
+        PublicRecursiveDNSProvider,
         CloudflareDNSProvider,
-        GoogleDNSProvider,
     ]
     provider_types = [provider.__class__] + [
         fallback_type for fallback_type in fallback_types if not isinstance(provider, fallback_type)
@@ -316,7 +315,7 @@ async def _resolve_with_fallback(  # noqa: C901
     """Resolve DNS, checking independent resolvers before accepting an empty result."""
     if not isinstance(
         provider,
-        (SystemDNSProvider, CloudflareDNSProvider, GoogleDNSProvider),
+        (SystemDNSProvider, PublicRecursiveDNSProvider, CloudflareDNSProvider),
     ):
         return await provider.check_domain(domain, selectors=selectors)
 

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -2,13 +2,14 @@
 DNS resolver service for DMARC, SPF, DKIM, and PTR record lookups.
 
 Provides an extensible provider architecture so that DNS data can be fetched
-either via the system resolver (dnspython) or via the Cloudflare DNS API for
-future Cloudflare integration.
+through public recursive resolvers or via the Cloudflare DNS API for future
+Cloudflare integration.
 """
 
 import asyncio
 import ipaddress
 import logging
+import shlex
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
@@ -22,6 +23,20 @@ logger = logging.getLogger(__name__)
 def _sanitize_for_log(value: str) -> str:
     """Remove newline and carriage-return characters to prevent log injection."""
     return value.replace("\r", "").replace("\n", "")
+
+
+def _decode_doh_txt_record(value: str) -> str:
+    """Decode JSON DoH TXT data into one logical TXT record."""
+    text = value.strip()
+    if not text:
+        return ""
+    try:
+        chunks = shlex.split(text)
+    except ValueError:
+        return text.strip('"')
+    if chunks:
+        return "".join(chunks)
+    return text.strip('"')
 
 
 def _ip_to_arpa_name(ip: str) -> str:
@@ -63,6 +78,7 @@ COMMON_DKIM_SELECTORS: List[str] = [
 
 # Seconds to wait for a single DNS query before giving up
 DNS_TIMEOUT: float = 5.0
+PUBLIC_RECURSIVE_NAMESERVERS: List[str] = ["1.1.1.1", "8.8.8.8"]
 
 DMARC_POLICY_VALUES = {"none", "quarantine", "reject"}
 DMARCBIS_ACTIVE_TAGS = {
@@ -625,6 +641,118 @@ class SystemDNSProvider(BaseDNSProvider):
         return []
 
 
+class PublicRecursiveDNSProvider(SystemDNSProvider):
+    """DNS provider pinned to public recursive resolvers.
+
+    The production app must not depend on the runtime host or Kubernetes DNS
+    configuration for internet DNS evidence. This provider uses dnspython with
+    an explicit resolver configuration backed by Cloudflare and Google Public
+    DNS.
+    """
+
+    nameservers: List[str] = PUBLIC_RECURSIVE_NAMESERVERS
+
+    def _resolver(self) -> Any:
+        import dns.asyncresolver  # type: ignore[import]
+
+        resolver = dns.asyncresolver.Resolver(configure=False)
+        resolver.nameservers = list(self.nameservers)
+        resolver.timeout = DNS_TIMEOUT
+        resolver.lifetime = DNS_TIMEOUT
+        return resolver
+
+    async def _resolve(self, name: str, record_type: str) -> Any:
+        return await self._resolver().resolve(
+            name,
+            record_type,
+            lifetime=DNS_TIMEOUT,
+            raise_on_no_answer=False,
+        )
+
+    async def lookup_txt(self, name: str) -> List[str]:
+        """Resolve TXT records through Cloudflare and Google Public DNS."""
+        import dns.exception  # type: ignore[import]
+
+        try:
+            answers = await self._resolve(name, "TXT")
+            result: List[str] = []
+            if answers:
+                for rdata in answers:
+                    result.append(
+                        "".join(
+                            string.decode("utf-8", errors="replace") for string in rdata.strings
+                        )
+                    )
+            return result
+        except dns.exception.DNSException as exc:
+            raise LookupError(f"TXT lookup failed for {name}: {exc}") from exc
+
+    async def lookup_ptr(self, ip: str) -> Optional[str]:
+        """Resolve a PTR record through public recursive DNS."""
+        import dns.exception  # type: ignore[import]
+
+        try:
+            answers = await self._resolve(_ip_to_arpa_name(ip), "PTR")
+            if answers:
+                for rdata in answers:
+                    return str(rdata).rstrip(".")
+        except (dns.exception.DNSException, ValueError):
+            pass
+        return None
+
+    async def lookup_cname(self, name: str) -> Optional[str]:
+        """Resolve a CNAME record through public recursive DNS."""
+        import dns.exception  # type: ignore[import]
+
+        try:
+            answers = await self._resolve(name, "CNAME")
+            if answers:
+                for rdata in answers:
+                    return str(rdata.target).rstrip(".")
+        except dns.exception.DNSException as exc:
+            logger.debug("CNAME lookup failed for %s: %s", _sanitize_for_log(name), exc)
+        return None
+
+    async def lookup_ns(self, domain: str) -> List[str]:
+        """Resolve authoritative NS records through public recursive DNS."""
+        import dns.exception  # type: ignore[import]
+
+        try:
+            answers = await self._resolve(domain, "NS")
+            if answers:
+                return sorted(str(rdata.target).rstrip(".").lower() for rdata in answers)
+        except dns.exception.DNSException as exc:
+            logger.debug("NS lookup failed for %s: %s", _sanitize_for_log(domain), exc)
+        return []
+
+    async def lookup_mx(self, domain: str) -> List[str]:
+        """Resolve MX hostnames through public recursive DNS."""
+        import dns.exception  # type: ignore[import]
+
+        try:
+            answers = await self._resolve(domain, "MX")
+            if answers:
+                return [
+                    str(rdata.exchange).rstrip(".").lower()
+                    for rdata in sorted(answers, key=lambda item: int(item.preference))
+                ]
+        except dns.exception.DNSException as exc:
+            logger.debug("MX lookup failed for %s: %s", _sanitize_for_log(domain), exc)
+        return []
+
+    async def lookup_tlsa(self, name: str) -> List[str]:
+        """Resolve TLSA records through public recursive DNS."""
+        import dns.exception  # type: ignore[import]
+
+        try:
+            answers = await self._resolve(name, "TLSA")
+            if answers:
+                return [str(rdata).strip() for rdata in answers]
+        except dns.exception.DNSException as exc:
+            logger.debug("TLSA lookup failed for %s: %s", _sanitize_for_log(name), exc)
+        return []
+
+
 class CloudflareDNSProvider(BaseDNSProvider):
     """DNS provider using Cloudflare DoH and, when configured, the REST API.
 
@@ -848,7 +976,7 @@ class CloudflareDNSProvider(BaseDNSProvider):
                 for answer in data.get("Answer", []):
                     if answer.get("type") == 16:  # TXT record type
                         # Cloudflare wraps TXT values in double-quotes
-                        txt = answer.get("data", "").strip('"')
+                        txt = _decode_doh_txt_record(answer.get("data", ""))
                         records.append(txt)
                 return records
         except (httpx.RequestError, httpx.HTTPStatusError, httpx.TimeoutException) as exc:
@@ -1139,7 +1267,7 @@ def get_default_provider(db: Any = None) -> BaseDNSProvider:
             api_token=api_token or settings.CLOUDFLARE_API_TOKEN,
             zone_id=zone_id or settings.CLOUDFLARE_ZONE_ID,
         )
-    return SystemDNSProvider()
+    return PublicRecursiveDNSProvider()
 
 
 def extract_dmarc_policy(dmarc_record: Optional[str]) -> Optional[str]:

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -159,10 +159,10 @@
                 <div class="form-control w-full">
                     <label class="label"><span class="label-text font-medium">DNS Resolver</span></label>
                     <select x-model="s['dns.resolver']" class="input input-bordered w-full">
-                        <option value="system">System (OS default)</option>
-                        <option value="cloudflare">Cloudflare DoH (1.1.1.1)</option>
+                        <option value="public">Public DNS (1.1.1.1 + 8.8.8.8)</option>
+                        <option value="cloudflare">Cloudflare DoH</option>
                     </select>
-                    <label class="label"><span class="label-text-alt text-muted-foreground">System resolver uses the OS-configured DNS server; Cloudflare uses DNS-over-HTTPS</span></label>
+                    <label class="label"><span class="label-text-alt text-muted-foreground">Public DNS bypasses the host resolver; Cloudflare uses DNS-over-HTTPS.</span></label>
                 </div>
                 <div class="flex justify-end">
                     <button type="submit" class="btn btn-default btn-md" :disabled="saving">

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -33,7 +33,7 @@ from app.services.bimi import BIMIResult
 from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
 from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
 from app.services.dns_provider_detection import detect_dns_provider
-from app.services.dns_resolver import DomainDNSResult, SystemDNSProvider
+from app.services.dns_resolver import DomainDNSResult, PublicRecursiveDNSProvider
 from app.services.mta_sts import MTAStsResult
 from app.services.remediation_dispatch import summarize_remediation_activity
 from app.services.report_persistence import save_parsed_report
@@ -368,7 +368,7 @@ def test_dns_endpoint_labels_backend_fallback_evidence(authed_client: TestClient
         spf=True,
         spf_record="v=spf1 -all",
         lookup_status="fallback",
-        lookup_error="No DNS evidence from SystemDNSProvider; using GoogleDNSProvider.",
+        lookup_error="No DNS evidence from PublicRecursiveDNSProvider; using CloudflareDNSProvider.",
     )
 
     with _mock_dns(result):
@@ -377,7 +377,7 @@ def test_dns_endpoint_labels_backend_fallback_evidence(authed_client: TestClient
     assert response.status_code == 200
     data = response.json()
     assert data["lookupStatus"] == "fallback"
-    assert "GoogleDNSProvider" in data["lookupError"]
+    assert "CloudflareDNSProvider" in data["lookupError"]
     assert data["dmarc"] is True
     assert data["spf"] is True
 
@@ -1238,11 +1238,8 @@ async def test_dns_cache_allows_old_positive_evidence_to_expire(db_session):
 @pytest.mark.asyncio
 async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_session):
     """A primary resolver with no evidence should not force a false F grade."""
-    primary_provider = SystemDNSProvider()
+    primary_provider = PublicRecursiveDNSProvider()
     primary_check = AsyncMock(
-        return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
-    )
-    cloudflare_check = AsyncMock(
         return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
     )
     fallback_result = DomainDNSResult(
@@ -1258,12 +1255,8 @@ async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_sessio
         patch.object(primary_provider, "check_domain", new=primary_check),
         patch(
             "app.services.dns_cache.CloudflareDNSProvider.check_domain",
-            new=cloudflare_check,
-        ),
-        patch(
-            "app.services.dns_cache.GoogleDNSProvider.check_domain",
             new=AsyncMock(return_value=fallback_result),
-        ) as google_fallback,
+        ) as cloudflare_fallback,
     ):
         result, cached, _checked = await resolve_domain_dns_cached(
             db_session,
@@ -1277,16 +1270,15 @@ async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_sessio
     assert result.spf is True
     assert result.dns_provider is not None
     assert result.lookup_status == "fallback"
-    assert "GoogleDNSProvider" in (result.lookup_error or "")
+    assert "CloudflareDNSProvider" in (result.lookup_error or "")
     primary_check.assert_awaited_once()
-    cloudflare_check.assert_awaited_once()
-    google_fallback.assert_awaited_once()
+    cloudflare_fallback.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_dns_cache_propagates_fallback_cancellation(db_session):
     """Request cancellation must not be swallowed by defensive fallback handling."""
-    primary_provider = SystemDNSProvider()
+    primary_provider = PublicRecursiveDNSProvider()
     primary_check = AsyncMock(
         return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
     )
@@ -1296,10 +1288,6 @@ async def test_dns_cache_propagates_fallback_cancellation(db_session):
         patch.object(primary_provider, "check_domain", new=primary_check),
         patch(
             "app.services.dns_cache.CloudflareDNSProvider.check_domain",
-            new=AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)),
-        ),
-        patch(
-            "app.services.dns_cache.GoogleDNSProvider.check_domain",
             new=fallback_check,
         ),
         pytest.raises(asyncio.CancelledError),
@@ -1319,7 +1307,7 @@ async def test_dns_cache_propagates_fallback_cancellation(db_session):
 async def test_dns_cache_fallback_failure_log_omits_user_values(db_session, caplog):
     """Fallback failure logging should not echo domains or exception messages."""
     domain = "bad.example\nforged-log-line"
-    primary_provider = SystemDNSProvider()
+    primary_provider = PublicRecursiveDNSProvider()
     primary_check = AsyncMock(
         return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
     )
@@ -1331,10 +1319,6 @@ async def test_dns_cache_fallback_failure_log_omits_user_values(db_session, capl
         patch(
             "app.services.dns_cache.CloudflareDNSProvider.check_domain",
             new=fallback_check,
-        ),
-        patch(
-            "app.services.dns_cache.GoogleDNSProvider.check_domain",
-            new=AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)),
         ),
     ):
         result, cached, _checked = await resolve_domain_dns_cached(

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -18,6 +18,7 @@ from app.services.dns_resolver import (
     CloudflareDNSProvider,
     DemoDNSProvider,
     DomainDNSResult,
+    PublicRecursiveDNSProvider,
     SystemDNSProvider,
     extract_dmarc_policy,
     get_default_provider,
@@ -692,6 +693,36 @@ async def test_cloudflare_provider_parses_doh_response():
 
 
 @pytest.mark.asyncio
+async def test_cloudflare_provider_joins_split_doh_txt_chunks():
+    """DoH TXT chunks from one answer must be one logical record."""
+    from unittest.mock import MagicMock
+
+    fake_response_data = {
+        "Answer": [
+            {
+                "type": 16,
+                "data": (
+                    '"v=DMARC1; p=reject; ruf=mailto" '
+                    '":postmaster@example.com; sp=reject"'
+                ),
+            },
+        ]
+    }
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = lambda: fake_response_data
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        provider = CloudflareDNSProvider()
+        records = await provider.lookup_txt("_dmarc.example.com")
+
+    assert records == [
+        "v=DMARC1; p=reject; ruf=mailto:postmaster@example.com; sp=reject"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_cloudflare_provider_raises_on_http_error():
     import httpx
 
@@ -929,9 +960,10 @@ async def test_cloudflare_provider_raises_when_rest_api_reports_error():
 # ---------------------------------------------------------------------------
 
 
-def test_get_default_provider_returns_system():
+def test_get_default_provider_returns_public_recursive():
     provider = get_default_provider()
-    assert isinstance(provider, SystemDNSProvider)
+    assert isinstance(provider, PublicRecursiveDNSProvider)
+    assert provider.nameservers == ["1.1.1.1", "8.8.8.8"]
 
 
 def test_get_default_provider_uses_cloudflare_settings(db_session):


### PR DESCRIPTION
## Summary\n- stop using the host/system resolver as the default domain DNS evidence path\n- use explicit public recursive DNS through 1.1.1.1 and 8.8.8.8, with Cloudflare DoH fallback\n- fix Cloudflare DoH TXT chunk joining so split DMARC records parse correctly\n- update settings copy and resolver tests for the public resolver default\n\n## Validation\n- /tmp/dmarq-live-audit-venv/bin/pytest -q backend/app/tests/test_dns_resolver.py backend/app/tests/test_dns_endpoints.py -k "dns_cache_uses_public_fallback or dns_cache_propagates_fallback or dns_cache_fallback_failure or get_default_provider or cloudflare_provider_joins_split or cloudflare_provider_parses_doh"\n- /tmp/dmarq-live-audit-venv/bin/pytest -q backend/app/tests/test_dns_resolver.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dns_guidance.py backend/app/tests/test_health_score.py\n- /tmp/dmarq-live-audit-venv/bin/flake8 backend/app/services/dns_resolver.py backend/app/services/dns_cache.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_dns_endpoints.py backend/app/api/api_v1/endpoints/settings.py backend/app/api/api_v1/endpoints/setup.py\n- git diff --check\n\nManual live DNS verification: cklnet.com resolves DMARC, SPF, DKIM selector 20250805100204pm, and Cloudflare NS through both PublicRecursiveDNSProvider and CloudflareDNSProvider.\n