### PR TITLE
[codex] Remove inline progress styles for CSP

### DIFF
--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1055,13 +1055,19 @@ function domainDetailsApp(domainId) {
         sourceVolumeBars(source) {
             const history = (source.volume_history || []).slice(-14);
             const max = Math.max(...history.map(point => Number(point.count || 0)), 1);
-            return history.map(point => {
+            const slotWidth = 140 / Math.max(history.length, 1);
+            const barWidth = Math.max(4, slotWidth - 2);
+            return history.map((point, index) => {
                 const count = Number(point.count || 0);
                 const failed = Number(point.failed || 0);
+                const height = Math.max(12, Math.round((count / max) * 100));
                 return {
                     ...point,
                     failed,
-                    height: Math.max(12, Math.round((count / max) * 100)),
+                    x: Math.round((index * slotWidth + 1) * 10) / 10,
+                    y: 100 - height,
+                    width: Math.round(barWidth * 10) / 10,
+                    height,
                     label: `${point.date}: ${this.formatLargeNumber(count)} emails${failed ? ', ' + this.formatLargeNumber(failed) + ' failed' : ''}`,
                 };
             });

--- a/backend/app/static/js/members-page.js
+++ b/backend/app/static/js/members-page.js
@@ -362,11 +362,15 @@ function membershipApp() {
             return `${this.formatLimitValue(limit.current, limit.unit)} / ${this.formatLimitValue(limit.limit, limit.unit)}`;
         },
 
+        limitTrackWidth(limit) {
+            return Math.min(Math.max(Number(limit.usage_percent || 0), 0), 100);
+        },
+
         limitTrackClass(limit) {
-            if (limit.limit === null || limit.limit === undefined) return 'bg-[#2c9aa3]';
-            if (limit.usage_percent >= 100) return 'bg-[#ff6333]';
-            if (limit.near_limit) return 'bg-[#f2a23a]';
-            return 'bg-[#2c9aa3]';
+            if (limit.limit === null || limit.limit === undefined) return 'text-success';
+            if (limit.usage_percent >= 100) return 'text-error';
+            if (limit.near_limit) return 'text-warning';
+            return 'text-success';
         },
 
         ownerBadgeClass() {

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1866,13 +1866,21 @@
                                                 <span x-show="source.report_count" x-text="source.report_count + ' report' + (source.report_count === 1 ? '' : 's')"></span>
                                             </div>
                                         </div>
-                                        <div class="flex h-8 items-end gap-0.5" x-show="source.volume_history?.length">
+                                        <div class="h-8" x-show="source.volume_history?.length">
+                                            <svg class="h-8 w-full overflow-visible" viewBox="0 0 140 100" preserveAspectRatio="none" role="img" aria-label="Recent sending volume">
                                             <template x-for="point in sourceVolumeBars(source)" :key="point.date">
-                                                <div class="tooltip flex-1 rounded-t"
-                                                     :class="point.failed > 0 ? 'bg-[#ff6f3c]' : 'bg-[#2f9da5]'"
-                                                     x-effect="$el.style.height = point.height + '%'"
-                                                     :data-tip="point.label"></div>
+                                                <rect
+                                                     :x="point.x"
+                                                     :y="point.y"
+                                                     :width="point.width"
+                                                     :height="point.height"
+                                                     rx="1.5"
+                                                     class="fill-current"
+                                                     :class="point.failed > 0 ? 'text-error' : 'text-success'">
+                                                    <title x-text="point.label"></title>
+                                                </rect>
                                             </template>
+                                            </svg>
                                         </div>
                                     </div>
                                 {% endcall %}

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1866,21 +1866,21 @@
                                                 <span x-show="source.report_count" x-text="source.report_count + ' report' + (source.report_count === 1 ? '' : 's')"></span>
                                             </div>
                                         </div>
-                                        <div class="h-8" x-show="source.volume_history?.length">
-                                            <svg class="h-8 w-full overflow-visible" viewBox="0 0 140 100" preserveAspectRatio="none" role="img" aria-label="Recent sending volume">
+                                        <div class="flex h-8 gap-0.5" x-show="source.volume_history?.length" role="img" aria-label="Recent sending volume">
                                             <template x-for="point in sourceVolumeBars(source)" :key="point.date">
-                                                <rect
-                                                     :x="point.x"
-                                                     :y="point.y"
-                                                     :width="point.width"
-                                                     :height="point.height"
-                                                     rx="1.5"
-                                                     class="fill-current"
-                                                     :class="point.failed > 0 ? 'text-error' : 'text-success'">
-                                                    <title x-text="point.label"></title>
-                                                </rect>
+                                                <svg class="h-8 flex-1 overflow-visible" :viewBox="'0 0 ' + point.width + ' 100'" preserveAspectRatio="none" aria-hidden="true">
+                                                    <rect
+                                                         x="0"
+                                                         :y="point.y"
+                                                         :width="point.width"
+                                                         :height="point.height"
+                                                         rx="1.5"
+                                                         class="fill-current"
+                                                         :class="point.failed > 0 ? 'text-error' : 'text-success'">
+                                                        <title x-text="point.label"></title>
+                                                    </rect>
+                                                </svg>
                                             </template>
-                                            </svg>
                                         </div>
                                     </div>
                                 {% endcall %}

--- a/backend/app/templates/members.html
+++ b/backend/app/templates/members.html
@@ -179,9 +179,11 @@
                                                   x-text="formatLimitUsage(limit)"></span>
                                         </div>
                                         <div class="mt-3 h-2 overflow-hidden rounded-full bg-[#ebe9e6]">
-                                            <div class="h-full rounded-full"
-                                                 :class="limitTrackClass(limit)"
-                                                 x-effect="$el.style.width = `${Math.min(limit.usage_percent || 0, 100)}%`"></div>
+                                            <svg class="h-2 w-full" viewBox="0 0 100 4" preserveAspectRatio="none" aria-hidden="true">
+                                                <rect x="0" y="0" :width="limitTrackWidth(limit)" height="4" rx="2"
+                                                      class="fill-current"
+                                                      :class="limitTrackClass(limit)"></rect>
+                                            </svg>
                                         </div>
                                         <p class="mt-2 text-xs text-[#7a4a12]" x-show="limit.message" x-text="limit.message"></p>
                                     </div>

--- a/backend/app/templates/tls_reports.html
+++ b/backend/app/templates/tls_reports.html
@@ -74,10 +74,10 @@
                     <template x-for="day in summary.trends" :key="day.date">
                         <div class="grid grid-cols-[6.5rem_1fr_7rem] gap-3 items-center">
                             <span class="text-sm text-base-content/70" x-text="day.date"></span>
-                            <div class="h-3 rounded bg-base-300 overflow-hidden flex">
-                                <div class="bg-success" x-effect="$el.style.width = `${trendSuccessWidth(day)}%`"></div>
-                                <div class="bg-error" x-effect="$el.style.width = `${trendFailureWidth(day)}%`"></div>
-                            </div>
+                            <svg class="h-3 w-full rounded bg-base-300 overflow-hidden" viewBox="0 0 100 6" preserveAspectRatio="none" aria-hidden="true">
+                                <rect class="text-success fill-current" x="0" y="0" :width="trendSuccessWidth(day)" height="6"></rect>
+                                <rect class="text-error fill-current" :x="trendSuccessWidth(day)" y="0" :width="trendFailureWidth(day)" height="6"></rect>
+                            </svg>
                             <span class="text-right text-sm font-medium" x-text="formatNumber(day.failed_sessions) + ' failed'"></span>
                         </div>
                     </template>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -655,7 +655,10 @@ def test_tls_reports_uses_external_page_script_for_csp_migration():
     assert "bindControls()" in script
     assert "event.target instanceof Element" in script
     assert 'x-init="init()"' not in template
-    assert 'x-effect="$el.style.width' in template
+    assert 'x-effect="$el.style.width' not in template
+    assert "trendSuccessWidth(day)" in template
+    assert "trendFailureWidth(day)" in template
+    assert "viewBox=\"0 0 100 6\"" in template
     assert not _has_inline_style(template)
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
@@ -1101,7 +1104,11 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "reputationEvidencePreview" in script
     assert "Use Refresh reputation" in template
     assert 'colspan="9"' in template
-    assert "x-effect=\"$el.style.height = point.height + '%'" in template
+    assert "x-effect=\"$el.style.height = point.height + '%'" not in template
+    assert 'viewBox="0 0 140 100"' in template
+    assert 'aria-label="Recent sending volume"' in template
+    assert "point.y" in template
+    assert "point.width" in template
     assert "x-html" not in template
     assert not _has_inline_style(template)
 
@@ -1187,6 +1194,9 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert "Billing & Plan" in template
     assert "currentBillingOwner().owner" in template
     assert "planLimitRows()" in template
+    assert "limitTrackWidth(limit)" in template
+    assert "limitTrackWidth" in script
+    assert 'x-effect="$el.style.width' not in template
     assert "invoice_delivery_label" in template
     assert 'x-text="membership.user.email"' in template
     assert '@click=' not in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1105,10 +1105,12 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "Use Refresh reputation" in template
     assert 'colspan="9"' in template
     assert "x-effect=\"$el.style.height = point.height + '%'" not in template
-    assert 'viewBox="0 0 140 100"' in template
     assert 'aria-label="Recent sending volume"' in template
+    assert ':viewBox="\'0 0 \' + point.width + \' 100\'"' in template
+    assert "<template x-for=\"point in sourceVolumeBars(source)\"" in template
     assert "point.y" in template
     assert "point.width" in template
+    assert "<svg class=\"h-8 w-full overflow-visible\"" not in template
     assert "x-html" not in template
     assert not _has_inline_style(template)
 


### PR DESCRIPTION
## Summary
- replace TLS trend bars with SVG attributes instead of Alpine inline style mutation
- replace domain detail sending-volume bars with SVG attributes
- replace member plan-limit bars with SVG attributes and theme fill classes

## Validation
- node --check backend/app/static/js/members-page.js backend/app/static/js/domain-details-page.js backend/app/static/js/tls-reports-page.js
- pytest -q backend/app/tests/test_dashboard_template_security.py
- git diff --check

Part of #598.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated several dashboard charts to use SVG-based rendering for cleaner, more consistent visuals.
  * Improved progress and trend displays for sending sources, plan limits, and TLS failures.

* **Bug Fixes**
  * Added more precise chart sizing and positioning so bars scale better across different amounts of data.
  * Improved limit usage display with clearer color states and clamped percentages for more accurate progress indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->