### PR TITLE
[codex] Add modular DNS resolver profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,12 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # AKAMAI_CLIENT_SECRET="your_akamai_client_secret"
 # AKAMAI_ACCESS_TOKEN="your_akamai_access_token"
 # AKAMAI_ACCOUNT_SWITCH_KEY="optional_account_switch_key"
+# Akamai ETP resolver profile. Keep account-specific resolver values in
+# 1Password/Kubernetes secrets; do not commit real resolver addresses.
+# AKAMAI_ETP_DNS_SERVERS="resolver-ip-1,resolver-ip-2,resolver-ipv6-1,resolver-ipv6-2"
+# AKAMAI_ETP_DOH_HOSTNAME="your-doh-hostname"
+# AKAMAI_ETP_DOT_HOSTNAME="your-dot-hostname"
+# AKAMAI_ETP_PROXY_CHAINING_URL="https://your-proxy-chaining-hostname:443"
 
 # Authentication
 # AUTH_MODE options: auto, disabled, logto, authentik, oidc, trusted_proxy

--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,14 @@ FIRST_SUPERUSER_PASSWORD="adminpassword"
 # AKAMAI_ETP_DOH_HOSTNAME="your-doh-hostname"
 # AKAMAI_ETP_DOT_HOSTNAME="your-dot-hostname"
 # AKAMAI_ETP_PROXY_CHAINING_URL="https://your-proxy-chaining-hostname:443"
+# Enterprise or custom resolver profiles. Keep concrete enterprise endpoints in
+# 1Password/Kubernetes secrets and select the matching profile in settings.
+# INFOBLOX_DNS_SERVERS="resolver-ip-1,resolver-ip-2"
+# INFOBLOX_DOH_HOSTNAME="resolver.example.net"
+# INFOBLOX_DOT_HOSTNAME="resolver.example.net"
+# DMARQ_DNS_CUSTOM_SERVERS="resolver-ip-1,resolver-ip-2"
+# DMARQ_DNS_CUSTOM_DOH_HOSTNAME="resolver.example.net"
+# DMARQ_DNS_CUSTOM_DOT_HOSTNAME="resolver.example.net"
 
 # Authentication
 # AUTH_MODE options: auto, disabled, logto, authentik, oidc, trusted_proxy

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -134,7 +134,10 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
     {
         "key": "dns.resolver",
         "value": "public",
-        "description": "DNS resolver to use: public, cloudflare, or akamai_etp",
+        "description": (
+            "DNS resolver to use: public, cloudflare, quad9, opendns, "
+            "dns4eu_unfiltered, dns4eu_protective, akamai_etp, infoblox, or custom"
+        ),
         "value_type": "string",
         "category": "dns",
     },

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -134,7 +134,7 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
     {
         "key": "dns.resolver",
         "value": "public",
-        "description": "DNS resolver to use: public or cloudflare",
+        "description": "DNS resolver to use: public, cloudflare, or akamai_etp",
         "value_type": "string",
         "category": "dns",
     },

--- a/backend/app/api/api_v1/endpoints/setup.py
+++ b/backend/app/api/api_v1/endpoints/setup.py
@@ -263,7 +263,10 @@ async def setup_system(
             db,
             DNS_RESOLVER_KEY,
             "cloudflare",
-            description="DNS resolver to use: public, cloudflare, or akamai_etp",
+            description=(
+                "DNS resolver to use: public, cloudflare, quad9, opendns, "
+                "dns4eu_unfiltered, dns4eu_protective, akamai_etp, infoblox, or custom"
+            ),
             category="dns",
         )
     db.commit()

--- a/backend/app/api/api_v1/endpoints/setup.py
+++ b/backend/app/api/api_v1/endpoints/setup.py
@@ -263,7 +263,7 @@ async def setup_system(
             db,
             DNS_RESOLVER_KEY,
             "cloudflare",
-            description="DNS resolver to use: public or cloudflare",
+            description="DNS resolver to use: public, cloudflare, or akamai_etp",
             category="dns",
         )
     db.commit()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -83,6 +83,10 @@ class Settings(BaseSettings):
     AKAMAI_ACCESS_TOKEN: Optional[str] = None
     AKAMAI_ACCOUNT_SWITCH_KEY: Optional[str] = None
     AKAMAI_ACCOUNT_KEY: Optional[str] = None
+    AKAMAI_ETP_DNS_SERVERS: Optional[str] = None
+    AKAMAI_ETP_DOH_HOSTNAME: Optional[str] = None
+    AKAMAI_ETP_DOT_HOSTNAME: Optional[str] = None
+    AKAMAI_ETP_PROXY_CHAINING_URL: Optional[str] = None
     POSTMARK_ACCOUNT_TOKEN: Optional[str] = None
     WEBHOOK_SECRET: Optional[str] = None
     WEBHOOK_MAX_EMAIL_SIZE_MB: int = 25

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -87,6 +87,12 @@ class Settings(BaseSettings):
     AKAMAI_ETP_DOH_HOSTNAME: Optional[str] = None
     AKAMAI_ETP_DOT_HOSTNAME: Optional[str] = None
     AKAMAI_ETP_PROXY_CHAINING_URL: Optional[str] = None
+    INFOBLOX_DNS_SERVERS: Optional[str] = None
+    INFOBLOX_DOH_HOSTNAME: Optional[str] = None
+    INFOBLOX_DOT_HOSTNAME: Optional[str] = None
+    DMARQ_DNS_CUSTOM_SERVERS: Optional[str] = None
+    DMARQ_DNS_CUSTOM_DOH_HOSTNAME: Optional[str] = None
+    DMARQ_DNS_CUSTOM_DOT_HOSTNAME: Optional[str] = None
     POSTMARK_ACCOUNT_TOKEN: Optional[str] = None
     WEBHOOK_SECRET: Optional[str] = None
     WEBHOOK_MAX_EMAIL_SIZE_MB: int = 25

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -15,6 +15,7 @@ from app.core.database import get_db
 from app.services.api_tokens import find_api_token, parse_scopes, record_api_token_use
 
 settings = get_settings()
+_INITIAL_SETTINGS = settings
 logger = logging.getLogger(__name__)
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -22,6 +23,14 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 # Security schemes for authentication
 security_bearer = HTTPBearer(auto_error=False)
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+def _current_settings():
+    """Return fresh settings unless tests deliberately patch this module."""
+    if settings is not _INITIAL_SETTINGS:
+        return settings
+    return get_settings()
+
 
 # In-memory API keys storage
 # ⚠️ WARNING: This is a simple in-memory implementation suitable for:
@@ -152,7 +161,12 @@ async def verify_token(
     token = credentials.credentials
 
     try:
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        current_settings = _current_settings()
+        payload = jwt.decode(
+            token,
+            current_settings.SECRET_KEY,
+            algorithms=[current_settings.ALGORITHM],
+        )
         return payload
     except JWTError as e:
         logger.warning("Invalid JWT token: %s", str(e))
@@ -181,14 +195,18 @@ async def require_admin_auth(
     Returns an authentication context dict describing how the request was
     authenticated.  Raises ``HTTP 401`` when no valid credential is present.
     """
+    current_settings = _current_settings()
     # 0. Auth globally disabled
-    if settings.AUTH_DISABLED or getattr(settings, "active_auth_provider", "") == "disabled":
+    if (
+        current_settings.AUTH_DISABLED
+        or getattr(current_settings, "active_auth_provider", "") == "disabled"
+    ):
         return {"auth_type": "disabled"}
 
     # 1. Trusted proxy / Authentik Outpost headers
     from app.core.auth_providers import trusted_proxy_auth_context  # local import
 
-    proxy_context = trusted_proxy_auth_context(request, settings)
+    proxy_context = trusted_proxy_auth_context(request, current_settings)
     if proxy_context is not None:
         return proxy_context
 
@@ -216,7 +234,9 @@ async def require_admin_auth(
         # Fallback: legacy python-jose JWT (pre-Logto API keys / CI tokens)
         try:
             payload = jwt.decode(
-                bearer.credentials, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+                bearer.credentials,
+                current_settings.SECRET_KEY,
+                algorithms=[current_settings.ALGORITHM],
             )
             return {"auth_type": "jwt", "payload": payload}
         except JWTError as e:
@@ -357,12 +377,17 @@ def create_access_token(subject: Union[str, Any], expires_delta: timedelta = Non
     """
     Create a JWT access token for authentication
     """
+    current_settings = _current_settings()
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+        expire = datetime.utcnow() + timedelta(minutes=current_settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode = {"exp": expire, "sub": str(subject)}
-    encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    encoded_jwt = jwt.encode(
+        to_encode,
+        current_settings.SECRET_KEY,
+        algorithm=current_settings.ALGORITHM,
+    )
     return encoded_jwt
 
 

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -390,6 +390,7 @@ async def resolve_domain_dns_cached(
 ) -> Tuple[DomainDNSResult, bool, datetime]:
     """Resolve DNS for a domain, reusing a fresh cached result when available."""
     now = _utcnow_naive()
+    provider = _normalize_dns_provider(provider)
     provider_name = provider.__class__.__name__
     selectors_key = _selectors_key(selectors)
     row = _cache_row(
@@ -471,6 +472,7 @@ def get_cached_domain_dns_result(
     selectors: List[str],
 ) -> Tuple[Optional[DomainDNSResult], bool, Optional[datetime]]:
     """Return the latest cached DNS result without performing network lookups."""
+    provider = _normalize_dns_provider(provider)
     row = _cache_row(
         db,
         domain=domain,

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -258,6 +258,15 @@ def _fallback_candidates(provider: BaseDNSProvider) -> List[BaseDNSProvider]:
     ]
 
 
+def _normalize_dns_provider(provider: BaseDNSProvider) -> BaseDNSProvider:
+    if isinstance(provider, SystemDNSProvider) and not isinstance(
+        provider, PublicRecursiveDNSProvider
+    ):
+        logger.info("Replacing system DNS resolver with public recursive DNS provider.")
+        return PublicRecursiveDNSProvider()
+    return provider
+
+
 async def _run_dns_candidate(
     candidate: BaseDNSProvider,
     domain: str,
@@ -313,9 +322,10 @@ async def _resolve_with_fallback(  # noqa: C901
     selectors: List[str],
 ) -> DomainDNSResult:
     """Resolve DNS, checking independent resolvers before accepting an empty result."""
+    provider = _normalize_dns_provider(provider)
     if not isinstance(
         provider,
-        (SystemDNSProvider, PublicRecursiveDNSProvider, CloudflareDNSProvider),
+        (PublicRecursiveDNSProvider, CloudflareDNSProvider),
     ):
         return await provider.check_domain(domain, selectors=selectors)
 

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -45,6 +45,18 @@ def _parse_csv_setting(value: Optional[str]) -> List[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
+def _parse_doh_endpoint(value: str) -> Tuple[str, str, int]:
+    endpoint = value.strip()
+    if not endpoint:
+        raise LookupError("DNS-over-HTTPS hostname is not configured.")
+    if "://" not in endpoint:
+        return endpoint, "/dns-query", 443
+    parsed = urlparse(endpoint)
+    if not parsed.hostname:
+        raise LookupError("DNS-over-HTTPS hostname is invalid.")
+    return parsed.hostname, parsed.path or "/dns-query", parsed.port or 443
+
+
 def _ip_to_arpa_name(ip: str) -> str:
     """Convert an IP address string to its reverse-DNS ARPA lookup name.
 
@@ -85,6 +97,25 @@ COMMON_DKIM_SELECTORS: List[str] = [
 # Seconds to wait for a single DNS query before giving up
 DNS_TIMEOUT: float = 5.0
 PUBLIC_RECURSIVE_NAMESERVERS: List[str] = ["1.1.1.1", "8.8.8.8"]
+QUAD9_NAMESERVERS: List[str] = ["9.9.9.9", "149.112.112.112", "2620:fe::fe", "2620:fe::9"]
+OPENDNS_NAMESERVERS: List[str] = [
+    "208.67.222.222",
+    "208.67.220.220",
+    "2620:119:35::35",
+    "2620:119:53::53",
+]
+DNS4EU_UNFILTERED_NAMESERVERS: List[str] = [
+    "86.54.11.100",
+    "86.54.11.200",
+    "2a13:1001::86:54:11:100",
+    "2a13:1001::86:54:11:200",
+]
+DNS4EU_PROTECTIVE_NAMESERVERS: List[str] = [
+    "86.54.11.1",
+    "86.54.11.201",
+    "2a13:1001::86:54:11:1",
+    "2a13:1001::86:54:11:201",
+]
 
 DMARC_POLICY_VALUES = {"none", "quarantine", "reject"}
 DMARCBIS_ACTIVE_TAGS = {
@@ -759,8 +790,10 @@ class PublicRecursiveDNSProvider(SystemDNSProvider):
         return []
 
 
-class AkamaiETPDNSProvider(PublicRecursiveDNSProvider):
-    """DNS provider backed by deployment-specific Akamai ETP resolver settings."""
+class ConfiguredRecursiveDNSProvider(PublicRecursiveDNSProvider):
+    """Recursive DNS provider backed by named public or deployment-specific resolvers."""
+
+    provider_label: str = "Configured DNS"
 
     def __init__(
         self,
@@ -777,8 +810,122 @@ class AkamaiETPDNSProvider(PublicRecursiveDNSProvider):
 
     def _resolver(self) -> Any:
         if not self.nameservers:
-            raise LookupError("Akamai ETP DNS servers are not configured.")
+            if self.doh_hostname:
+                raise LookupError(
+                    f"{self.provider_label} DNS servers are not configured; using DoH."
+                )
+            raise LookupError(
+                f"{self.provider_label} DNS servers or DoH hostname are not configured."
+            )
         return super()._resolver()
+
+    async def _resolve(self, name: str, record_type: str) -> Any:
+        import dns.exception  # type: ignore[import]
+
+        if self.nameservers:
+            try:
+                return await super()._resolve(name, record_type)
+            except dns.exception.DNSException as exc:
+                if not self.doh_hostname:
+                    raise
+                logger.debug(
+                    "%s recursive DNS lookup failed for %s/%s; trying DoH fallback: %s",
+                    self.provider_label,
+                    _sanitize_for_log(name),
+                    record_type,
+                    exc,
+                )
+        if not self.doh_hostname:
+            raise LookupError(
+                f"{self.provider_label} DNS servers or DoH hostname are not configured."
+            )
+
+        import dns.asyncquery  # type: ignore[import]
+        import dns.message  # type: ignore[import]
+
+        where, path, port = _parse_doh_endpoint(self.doh_hostname)
+        query = dns.message.make_query(name, record_type)
+        response = await dns.asyncquery.https(
+            query,
+            where=where,
+            path=path,
+            port=port,
+            timeout=DNS_TIMEOUT,
+        )
+        records: List[Any] = []
+        for rrset in response.answer:
+            records.extend(rrset)
+        return records
+
+
+class AkamaiETPDNSProvider(ConfiguredRecursiveDNSProvider):
+    """DNS provider backed by deployment-specific Akamai ETP resolver settings."""
+
+    provider_label = "Akamai ETP"
+
+
+class Quad9DNSProvider(ConfiguredRecursiveDNSProvider):
+    """Quad9 secure recursive resolver profile."""
+
+    provider_label = "Quad9"
+
+    def __init__(self) -> None:
+        super().__init__(
+            nameservers=QUAD9_NAMESERVERS,
+            doh_hostname="https://dns.quad9.net/dns-query",
+            dot_hostname="dns.quad9.net",
+        )
+
+
+class OpenDNSProvider(ConfiguredRecursiveDNSProvider):
+    """Cisco OpenDNS recursive resolver profile."""
+
+    provider_label = "OpenDNS"
+
+    def __init__(self) -> None:
+        super().__init__(
+            nameservers=OPENDNS_NAMESERVERS,
+            doh_hostname="https://doh.opendns.com/dns-query",
+            dot_hostname="dns.opendns.com",
+        )
+
+
+class DNS4EUUnfilteredDNSProvider(ConfiguredRecursiveDNSProvider):
+    """DNS4EU unfiltered resolver profile for diagnostic DNS evidence."""
+
+    provider_label = "DNS4EU unfiltered"
+
+    def __init__(self) -> None:
+        super().__init__(
+            nameservers=DNS4EU_UNFILTERED_NAMESERVERS,
+            doh_hostname="https://unfiltered.joindns4.eu/dns-query",
+            dot_hostname="unfiltered.joindns4.eu",
+        )
+
+
+class DNS4EUProtectiveDNSProvider(ConfiguredRecursiveDNSProvider):
+    """DNS4EU protective resolver profile for optional European protective DNS checks."""
+
+    provider_label = "DNS4EU protective"
+
+    def __init__(self) -> None:
+        super().__init__(
+            nameservers=DNS4EU_PROTECTIVE_NAMESERVERS,
+            doh_hostname="https://protective.joindns4.eu/dns-query",
+            dot_hostname="protective.joindns4.eu",
+        )
+
+
+class InfobloxDNSProvider(ConfiguredRecursiveDNSProvider):
+    """Infoblox resolver profile supplied by enterprise deployment secrets."""
+
+    provider_label = "Infoblox"
+
+
+class CustomDNSProvider(ConfiguredRecursiveDNSProvider):
+    """Operator-defined recursive resolver profile supplied by deployment secrets."""
+
+    provider_label = "Custom DNS"
 
 
 class CloudflareDNSProvider(BaseDNSProvider):
@@ -1288,6 +1435,26 @@ def get_default_provider(db: Any = None) -> BaseDNSProvider:
         return DemoDNSProvider()
 
     resolver = (_setting_value(db, "dns.resolver") or "").strip().lower()
+    if resolver == "quad9":
+        return Quad9DNSProvider()
+    if resolver == "opendns":
+        return OpenDNSProvider()
+    if resolver == "dns4eu_unfiltered":
+        return DNS4EUUnfilteredDNSProvider()
+    if resolver == "dns4eu_protective":
+        return DNS4EUProtectiveDNSProvider()
+    if resolver == "infoblox":
+        return InfobloxDNSProvider(
+            nameservers=_parse_csv_setting(settings.INFOBLOX_DNS_SERVERS),
+            doh_hostname=settings.INFOBLOX_DOH_HOSTNAME,
+            dot_hostname=settings.INFOBLOX_DOT_HOSTNAME,
+        )
+    if resolver == "custom":
+        return CustomDNSProvider(
+            nameservers=_parse_csv_setting(settings.DMARQ_DNS_CUSTOM_SERVERS),
+            doh_hostname=settings.DMARQ_DNS_CUSTOM_DOH_HOSTNAME,
+            dot_hostname=settings.DMARQ_DNS_CUSTOM_DOT_HOSTNAME,
+        )
     if resolver == "akamai_etp":
         return AkamaiETPDNSProvider(
             nameservers=_parse_csv_setting(settings.AKAMAI_ETP_DNS_SERVERS),

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -39,6 +39,12 @@ def _decode_doh_txt_record(value: str) -> str:
     return text.strip('"')
 
 
+def _parse_csv_setting(value: Optional[str]) -> List[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
 def _ip_to_arpa_name(ip: str) -> str:
     """Convert an IP address string to its reverse-DNS ARPA lookup name.
 
@@ -753,6 +759,28 @@ class PublicRecursiveDNSProvider(SystemDNSProvider):
         return []
 
 
+class AkamaiETPDNSProvider(PublicRecursiveDNSProvider):
+    """DNS provider backed by deployment-specific Akamai ETP resolver settings."""
+
+    def __init__(
+        self,
+        *,
+        nameservers: Optional[List[str]] = None,
+        doh_hostname: Optional[str] = None,
+        dot_hostname: Optional[str] = None,
+        proxy_chaining_url: Optional[str] = None,
+    ) -> None:
+        self.nameservers = list(nameservers or [])
+        self.doh_hostname = doh_hostname
+        self.dot_hostname = dot_hostname
+        self.proxy_chaining_url = proxy_chaining_url
+
+    def _resolver(self) -> Any:
+        if not self.nameservers:
+            raise LookupError("Akamai ETP DNS servers are not configured.")
+        return super()._resolver()
+
+
 class CloudflareDNSProvider(BaseDNSProvider):
     """DNS provider using Cloudflare DoH and, when configured, the REST API.
 
@@ -1260,6 +1288,13 @@ def get_default_provider(db: Any = None) -> BaseDNSProvider:
         return DemoDNSProvider()
 
     resolver = (_setting_value(db, "dns.resolver") or "").strip().lower()
+    if resolver == "akamai_etp":
+        return AkamaiETPDNSProvider(
+            nameservers=_parse_csv_setting(settings.AKAMAI_ETP_DNS_SERVERS),
+            doh_hostname=settings.AKAMAI_ETP_DOH_HOSTNAME,
+            dot_hostname=settings.AKAMAI_ETP_DOT_HOSTNAME,
+            proxy_chaining_url=settings.AKAMAI_ETP_PROXY_CHAINING_URL,
+        )
     if resolver == "cloudflare":
         api_token = _decrypt_setting_value(_setting_value(db, "cloudflare.api_token"))
         zone_id = _setting_value(db, "cloudflare.zone_id")

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -49,12 +49,14 @@ def _parse_doh_endpoint(value: str) -> Tuple[str, str, int]:
     endpoint = value.strip()
     if not endpoint:
         raise LookupError("DNS-over-HTTPS hostname is not configured.")
-    if "://" not in endpoint:
-        return endpoint, "/dns-query", 443
-    parsed = urlparse(endpoint)
+    url = endpoint if "://" in endpoint else f"https://{endpoint}"
+    parsed = urlparse(url)
     if not parsed.hostname:
         raise LookupError("DNS-over-HTTPS hostname is invalid.")
-    return parsed.hostname, parsed.path or "/dns-query", parsed.port or 443
+    path = parsed.path or "/dns-query"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    return url, path, parsed.port or 443
 
 
 def _ip_to_arpa_name(ip: str) -> str:
@@ -841,7 +843,9 @@ class ConfiguredRecursiveDNSProvider(PublicRecursiveDNSProvider):
             )
 
         import dns.asyncquery  # type: ignore[import]
+        import dns.exception  # type: ignore[import]
         import dns.message  # type: ignore[import]
+        import dns.rcode  # type: ignore[import]
 
         where, path, port = _parse_doh_endpoint(self.doh_hostname)
         query = dns.message.make_query(name, record_type)
@@ -852,6 +856,12 @@ class ConfiguredRecursiveDNSProvider(PublicRecursiveDNSProvider):
             port=port,
             timeout=DNS_TIMEOUT,
         )
+        response_rcode = response.rcode()
+        if response_rcode != dns.rcode.NOERROR:
+            raise dns.exception.DNSException(
+                f"{self.provider_label} DoH lookup for {name}/{record_type} "
+                f"returned {dns.rcode.to_text(response_rcode)}"
+            )
         records: List[Any] = []
         for rrset in response.answer:
             records.extend(rrset)

--- a/backend/app/services/source_reputation_feeds.py
+++ b/backend/app/services/source_reputation_feeds.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 
 from app.core.config import Settings, get_settings
 from app.models.dns_cache import DNSCache
+from app.services.dns_resolver import PUBLIC_RECURSIVE_NAMESERVERS
 
 _CACHE_PROVIDER = "source-reputation-feed-v1"
 
@@ -102,9 +103,15 @@ class DNSBLFeedProvider:
     ) -> None:
         self.config = config
         self.timeout_seconds = timeout_seconds
-        self._resolver = resolver or dns.resolver.Resolver()
+        self._resolver = resolver or self._public_resolver()
         self._resolver.lifetime = timeout_seconds
         self._resolver.timeout = timeout_seconds
+
+    @staticmethod
+    def _public_resolver() -> dns.resolver.Resolver:
+        resolver = dns.resolver.Resolver(configure=False)
+        resolver.nameservers = list(PUBLIC_RECURSIVE_NAMESERVERS)
+        return resolver
 
     async def lookup_ip(self, ip: str) -> FeedLookupEvidence:
         checked_at = _utcnow_iso()

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -161,9 +161,15 @@
                     <select x-model="s['dns.resolver']" class="input input-bordered w-full">
                         <option value="public">Public DNS (1.1.1.1 + 8.8.8.8)</option>
                         <option value="cloudflare">Cloudflare DoH</option>
+                        <option value="quad9">Quad9 secure DNS</option>
+                        <option value="opendns">OpenDNS / Cisco Umbrella</option>
+                        <option value="dns4eu_unfiltered">DNS4EU unfiltered</option>
+                        <option value="dns4eu_protective">DNS4EU protective</option>
                         <option value="akamai_etp">Akamai ETP DNS (from deployment secrets)</option>
+                        <option value="infoblox">Infoblox DNS (from deployment secrets)</option>
+                        <option value="custom">Custom DNS (from deployment secrets)</option>
                     </select>
-                    <label class="label"><span class="label-text-alt text-muted-foreground">Public DNS bypasses the host resolver. Akamai ETP uses resolver values supplied by environment or secret configuration.</span></label>
+                    <label class="label"><span class="label-text-alt text-muted-foreground">All profiles bypass the host resolver. Enterprise and custom profiles use resolver values supplied by environment or secret configuration.</span></label>
                 </div>
                 <div class="flex justify-end">
                     <button type="submit" class="btn btn-default btn-md" :disabled="saving">

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -161,8 +161,9 @@
                     <select x-model="s['dns.resolver']" class="input input-bordered w-full">
                         <option value="public">Public DNS (1.1.1.1 + 8.8.8.8)</option>
                         <option value="cloudflare">Cloudflare DoH</option>
+                        <option value="akamai_etp">Akamai ETP DNS (from deployment secrets)</option>
                     </select>
-                    <label class="label"><span class="label-text-alt text-muted-foreground">Public DNS bypasses the host resolver; Cloudflare uses DNS-over-HTTPS.</span></label>
+                    <label class="label"><span class="label-text-alt text-muted-foreground">Public DNS bypasses the host resolver. Akamai ETP uses resolver values supplied by environment or secret configuration.</span></label>
                 </div>
                 <div class="flex justify-end">
                     <button type="submit" class="btn btn-default btn-md" :disabled="saving">

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1318,6 +1318,8 @@ async def test_dns_cache_replaces_system_provider_with_public_resolver(db_sessio
     assert cached is False
     assert result.dmarc is True
     assert result.spf is True
+    cache_row = db_session.query(DNSCache).one()
+    assert cache_row.provider == "PublicRecursiveDNSProvider"
     system_check.assert_not_awaited()
     public_check.assert_awaited_once()
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -33,7 +33,11 @@ from app.services.bimi import BIMIResult
 from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
 from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
 from app.services.dns_provider_detection import detect_dns_provider
-from app.services.dns_resolver import DomainDNSResult, PublicRecursiveDNSProvider
+from app.services.dns_resolver import (
+    DomainDNSResult,
+    PublicRecursiveDNSProvider,
+    SystemDNSProvider,
+)
 from app.services.mta_sts import MTAStsResult
 from app.services.remediation_dispatch import summarize_remediation_activity
 from app.services.report_persistence import save_parsed_report
@@ -1273,6 +1277,49 @@ async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_sessio
     assert "CloudflareDNSProvider" in (result.lookup_error or "")
     primary_check.assert_awaited_once()
     cloudflare_fallback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dns_cache_replaces_system_provider_with_public_resolver(db_session):
+    """Host/Kubernetes DNS must not be used for domain evidence lookups."""
+    system_provider = SystemDNSProvider()
+    system_check = AsyncMock(
+        return_value=DomainDNSResult(
+            dmarc=False,
+            spf=False,
+            dkim=False,
+            lookup_status="lookup_failed",
+            lookup_error="local resolver timeout",
+        )
+    )
+    public_result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject",
+        spf=True,
+        spf_record="v=spf1 -all",
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+        dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
+    )
+
+    with (
+        patch.object(system_provider, "check_domain", new=system_check),
+        patch(
+            "app.services.dns_cache.PublicRecursiveDNSProvider.check_domain",
+            new=AsyncMock(return_value=public_result),
+        ) as public_check,
+    ):
+        result, cached, _checked = await resolve_domain_dns_cached(
+            db_session,
+            system_provider,
+            DOMAIN,
+            selectors=[],
+        )
+
+    assert cached is False
+    assert result.dmarc is True
+    assert result.spf is True
+    system_check.assert_not_awaited()
+    public_check.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -10,10 +10,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.core.config import get_settings
 from app.core.credential_encryption import encrypt_secret
 from app.models.setting import Setting
 from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import (
+    AkamaiETPDNSProvider,
     BaseDNSProvider,
     CloudflareDNSProvider,
     DemoDNSProvider,
@@ -985,6 +987,27 @@ def test_get_default_provider_uses_cloudflare_settings(db_session):
     assert isinstance(provider, CloudflareDNSProvider)
     assert provider.api_token == "cf-token"
     assert provider.zone_id == "zone-1"
+
+
+def test_get_default_provider_uses_akamai_etp_env_profile(db_session, monkeypatch):
+    monkeypatch.setenv("AKAMAI_ETP_DNS_SERVERS", "192.0.2.53, 2001:db8::53")
+    monkeypatch.setenv("AKAMAI_ETP_DOH_HOSTNAME", "resolver.example.test")
+    monkeypatch.setenv("AKAMAI_ETP_DOT_HOSTNAME", "dot-resolver.example.test")
+    monkeypatch.setenv("AKAMAI_ETP_PROXY_CHAINING_URL", "https://proxy.example.test:443")
+    get_settings.cache_clear()
+    db_session.add(Setting(key="dns.resolver", value="akamai_etp", category="dns"))
+    db_session.commit()
+
+    try:
+        provider = get_default_provider(db_session)
+    finally:
+        get_settings.cache_clear()
+
+    assert isinstance(provider, AkamaiETPDNSProvider)
+    assert provider.nameservers == ["192.0.2.53", "2001:db8::53"]
+    assert provider.doh_hostname == "resolver.example.test"
+    assert provider.dot_hostname == "dot-resolver.example.test"
+    assert provider.proxy_chaining_url == "https://proxy.example.test:443"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -1106,11 +1106,16 @@ def test_get_default_provider_uses_custom_env_profile(db_session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_configured_provider_uses_doh_when_nameservers_are_not_configured():
+    import dns.rcode  # type: ignore[import]
+
     class FakeTxt:
         strings = [b"v=DMARC1; ", b"p=reject"]
 
     class FakeResponse:
         answer = [[FakeTxt()]]
+
+        def rcode(self):
+            return dns.rcode.NOERROR
 
     provider = ConfiguredRecursiveDNSProvider(
         doh_hostname="https://resolver.example.test/custom-dns"
@@ -1122,9 +1127,63 @@ async def test_configured_provider_uses_doh_when_nameservers_are_not_configured(
     assert records == ["v=DMARC1; p=reject"]
     doh.assert_awaited_once()
     _, kwargs = doh.await_args
-    assert kwargs["where"] == "resolver.example.test"
+    assert kwargs["where"] == "https://resolver.example.test/custom-dns"
     assert kwargs["path"] == "/custom-dns"
     assert kwargs["port"] == 443
+
+
+@pytest.mark.asyncio
+async def test_configured_provider_falls_back_to_doh_after_nameserver_failure():
+    import dns.exception  # type: ignore[import]
+    import dns.rcode  # type: ignore[import]
+
+    class FakeTxt:
+        strings = [b"v=spf1 ", b"include:example.net -all"]
+
+    class FakeResponse:
+        answer = [[FakeTxt()]]
+
+        def rcode(self):
+            return dns.rcode.NOERROR
+
+    provider = ConfiguredRecursiveDNSProvider(
+        nameservers=["192.0.2.53"],
+        doh_hostname="https://resolver.example.test:8443/custom-dns?profile=prod",
+    )
+
+    with patch(
+        "app.services.dns_resolver.PublicRecursiveDNSProvider._resolve",
+        new=AsyncMock(side_effect=dns.exception.DNSException("timeout")),
+    ) as recursive_lookup:
+        with patch("dns.asyncquery.https", new=AsyncMock(return_value=FakeResponse())) as doh:
+            records = await provider.lookup_txt("example.com")
+
+    assert records == ["v=spf1 include:example.net -all"]
+    recursive_lookup.assert_awaited_once_with("example.com", "TXT")
+    doh.assert_awaited_once()
+    _, kwargs = doh.await_args
+    assert kwargs["where"] == "https://resolver.example.test:8443/custom-dns?profile=prod"
+    assert kwargs["path"] == "/custom-dns?profile=prod"
+    assert kwargs["port"] == 8443
+
+
+@pytest.mark.asyncio
+async def test_configured_provider_raises_on_doh_error_response_code():
+    import dns.rcode  # type: ignore[import]
+
+    class FakeResponse:
+        answer = []
+
+        def rcode(self):
+            return dns.rcode.SERVFAIL
+
+    provider = ConfiguredRecursiveDNSProvider(
+        doh_hostname="https://resolver.example.test/dns-query"
+    )
+
+    with patch("dns.asyncquery.https", new=AsyncMock(return_value=FakeResponse())):
+        with pytest.raises(LookupError, match="SERVFAIL"):
+            await provider.lookup_txt("example.com")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -18,9 +18,16 @@ from app.services.dns_resolver import (
     AkamaiETPDNSProvider,
     BaseDNSProvider,
     CloudflareDNSProvider,
+    ConfiguredRecursiveDNSProvider,
+    CustomDNSProvider,
     DemoDNSProvider,
+    DNS4EUProtectiveDNSProvider,
+    DNS4EUUnfilteredDNSProvider,
     DomainDNSResult,
+    InfobloxDNSProvider,
+    OpenDNSProvider,
     PublicRecursiveDNSProvider,
+    Quad9DNSProvider,
     SystemDNSProvider,
     extract_dmarc_policy,
     get_default_provider,
@@ -704,8 +711,7 @@ async def test_cloudflare_provider_joins_split_doh_txt_chunks():
             {
                 "type": 16,
                 "data": (
-                    '"v=DMARC1; p=reject; ruf=mailto" '
-                    '":postmaster@example.com; sp=reject"'
+                    '"v=DMARC1; p=reject; ruf=mailto" ' '":postmaster@example.com; sp=reject"'
                 ),
             },
         ]
@@ -719,9 +725,7 @@ async def test_cloudflare_provider_joins_split_doh_txt_chunks():
         provider = CloudflareDNSProvider()
         records = await provider.lookup_txt("_dmarc.example.com")
 
-    assert records == [
-        "v=DMARC1; p=reject; ruf=mailto:postmaster@example.com; sp=reject"
-    ]
+    assert records == ["v=DMARC1; p=reject; ruf=mailto:postmaster@example.com; sp=reject"]
 
 
 @pytest.mark.asyncio
@@ -989,6 +993,58 @@ def test_get_default_provider_uses_cloudflare_settings(db_session):
     assert provider.zone_id == "zone-1"
 
 
+@pytest.mark.parametrize(
+    ("setting_value", "expected_type", "expected_nameservers", "expected_doh"),
+    [
+        (
+            "quad9",
+            Quad9DNSProvider,
+            ["9.9.9.9", "149.112.112.112", "2620:fe::fe", "2620:fe::9"],
+            "https://dns.quad9.net/dns-query",
+        ),
+        (
+            "opendns",
+            OpenDNSProvider,
+            ["208.67.222.222", "208.67.220.220", "2620:119:35::35", "2620:119:53::53"],
+            "https://doh.opendns.com/dns-query",
+        ),
+        (
+            "dns4eu_unfiltered",
+            DNS4EUUnfilteredDNSProvider,
+            [
+                "86.54.11.100",
+                "86.54.11.200",
+                "2a13:1001::86:54:11:100",
+                "2a13:1001::86:54:11:200",
+            ],
+            "https://unfiltered.joindns4.eu/dns-query",
+        ),
+        (
+            "dns4eu_protective",
+            DNS4EUProtectiveDNSProvider,
+            [
+                "86.54.11.1",
+                "86.54.11.201",
+                "2a13:1001::86:54:11:1",
+                "2a13:1001::86:54:11:201",
+            ],
+            "https://protective.joindns4.eu/dns-query",
+        ),
+    ],
+)
+def test_get_default_provider_uses_static_recursive_profiles(
+    db_session, setting_value, expected_type, expected_nameservers, expected_doh
+):
+    db_session.add(Setting(key="dns.resolver", value=setting_value, category="dns"))
+    db_session.commit()
+
+    provider = get_default_provider(db_session)
+
+    assert isinstance(provider, expected_type)
+    assert provider.nameservers == expected_nameservers
+    assert provider.doh_hostname == expected_doh
+
+
 def test_get_default_provider_uses_akamai_etp_env_profile(db_session, monkeypatch):
     monkeypatch.setenv("AKAMAI_ETP_DNS_SERVERS", "192.0.2.53, 2001:db8::53")
     monkeypatch.setenv("AKAMAI_ETP_DOH_HOSTNAME", "resolver.example.test")
@@ -1008,6 +1064,67 @@ def test_get_default_provider_uses_akamai_etp_env_profile(db_session, monkeypatc
     assert provider.doh_hostname == "resolver.example.test"
     assert provider.dot_hostname == "dot-resolver.example.test"
     assert provider.proxy_chaining_url == "https://proxy.example.test:443"
+
+
+def test_get_default_provider_uses_infoblox_env_profile(db_session, monkeypatch):
+    monkeypatch.setenv("INFOBLOX_DNS_SERVERS", "192.0.2.54,2001:db8::54")
+    monkeypatch.setenv("INFOBLOX_DOH_HOSTNAME", "https://infoblox.example.test/dns-query")
+    monkeypatch.setenv("INFOBLOX_DOT_HOSTNAME", "infoblox.example.test")
+    get_settings.cache_clear()
+    db_session.add(Setting(key="dns.resolver", value="infoblox", category="dns"))
+    db_session.commit()
+
+    try:
+        provider = get_default_provider(db_session)
+    finally:
+        get_settings.cache_clear()
+
+    assert isinstance(provider, InfobloxDNSProvider)
+    assert provider.nameservers == ["192.0.2.54", "2001:db8::54"]
+    assert provider.doh_hostname == "https://infoblox.example.test/dns-query"
+    assert provider.dot_hostname == "infoblox.example.test"
+
+
+def test_get_default_provider_uses_custom_env_profile(db_session, monkeypatch):
+    monkeypatch.setenv("DMARQ_DNS_CUSTOM_SERVERS", "192.0.2.55,2001:db8::55")
+    monkeypatch.setenv("DMARQ_DNS_CUSTOM_DOH_HOSTNAME", "https://resolver.example.test/dns-query")
+    monkeypatch.setenv("DMARQ_DNS_CUSTOM_DOT_HOSTNAME", "resolver.example.test")
+    get_settings.cache_clear()
+    db_session.add(Setting(key="dns.resolver", value="custom", category="dns"))
+    db_session.commit()
+
+    try:
+        provider = get_default_provider(db_session)
+    finally:
+        get_settings.cache_clear()
+
+    assert isinstance(provider, CustomDNSProvider)
+    assert provider.nameservers == ["192.0.2.55", "2001:db8::55"]
+    assert provider.doh_hostname == "https://resolver.example.test/dns-query"
+    assert provider.dot_hostname == "resolver.example.test"
+
+
+@pytest.mark.asyncio
+async def test_configured_provider_uses_doh_when_nameservers_are_not_configured():
+    class FakeTxt:
+        strings = [b"v=DMARC1; ", b"p=reject"]
+
+    class FakeResponse:
+        answer = [[FakeTxt()]]
+
+    provider = ConfiguredRecursiveDNSProvider(
+        doh_hostname="https://resolver.example.test/custom-dns"
+    )
+
+    with patch("dns.asyncquery.https", new=AsyncMock(return_value=FakeResponse())) as doh:
+        records = await provider.lookup_txt("_dmarc.example.com")
+
+    assert records == ["v=DMARC1; p=reject"]
+    doh.assert_awaited_once()
+    _, kwargs = doh.await_args
+    assert kwargs["where"] == "resolver.example.test"
+    assert kwargs["path"] == "/custom-dns"
+    assert kwargs["port"] == 443
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/test_source_reputation_feeds.py
+++ b/backend/app/tests/test_source_reputation_feeds.py
@@ -4,6 +4,7 @@ import dns.resolver
 import httpx
 import pytest
 
+from app.services.dns_resolver import PUBLIC_RECURSIVE_NAMESERVERS
 from app.services.source_reputation_feeds import (
     AbuseIPDBFeedProvider,
     DNSBLFeedProvider,
@@ -127,7 +128,7 @@ def test_dnsbl_default_resolver_uses_public_recursive_nameservers():
         )
     )
 
-    assert provider._resolver.nameservers == ["1.1.1.1", "8.8.8.8"]
+    assert provider._resolver.nameservers == list(PUBLIC_RECURSIVE_NAMESERVERS)
 
 
 class NoNameserversResolver:

--- a/backend/app/tests/test_source_reputation_feeds.py
+++ b/backend/app/tests/test_source_reputation_feeds.py
@@ -117,6 +117,19 @@ def test_feed_registry_exposes_safe_metadata_only():
     assert "secret" not in registry["abuseipdb"]
 
 
+def test_dnsbl_default_resolver_uses_public_recursive_nameservers():
+    provider = DNSBLFeedProvider(
+        FeedProviderConfig(
+            provider_id="demo_feed",
+            display_name="Demo Reputation Feed",
+            enabled=True,
+            query_zone="example.test",
+        )
+    )
+
+    assert provider._resolver.nameservers == ["1.1.1.1", "8.8.8.8"]
+
+
 class NoNameserversResolver:
     lifetime = 0.0
     timeout = 0.0

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -390,6 +390,10 @@ operational policy if long-term storage size matters.
 | `DMARQ_DNS_CUSTOM_DOH_HOSTNAME` | Optional custom DNS-over-HTTPS hostname used when DNS server IPs are not configured or as fallback after resolver failure | - | `op://...` |
 | `DMARQ_DNS_CUSTOM_DOT_HOSTNAME` | Optional custom DNS-over-TLS hostname for operator context | - | `op://...` |
 
+The `op://...` examples are intentional 1Password secret-reference placeholders
+for deployment environments that inject tenant-specific DNS resolver details at
+runtime instead of storing raw secrets in the repository.
+
 ### Email Service and Webhook Integrations
 
 | Variable | Description | Default | Example |

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -188,6 +188,10 @@ possible, or inject `AKAMAI_HOST`, `AKAMAI_CLIENT_TOKEN`,
 Use `AKAMAI_ACCOUNT_SWITCH_KEY` only when your Akamai client needs to operate
 against a delegated account.
 
+For Akamai ETP resolver-backed DNS checks, select the `akamai_etp` resolver
+profile in DMARQ settings and inject the assigned resolver values through your
+secret manager. These values are account-specific and should not be committed.
+
 ### Mail Authentication Defaults
 
 The Settings page includes DMARC defaults used by domain-level DNS guidance and
@@ -368,6 +372,10 @@ operational policy if long-term storage size matters.
 | `AKAMAI_CLIENT_SECRET` | Akamai EdgeGrid client secret when not using `.edgerc` | - | `your_akamai_client_secret` |
 | `AKAMAI_ACCESS_TOKEN` | Akamai EdgeGrid access token when not using `.edgerc` | - | `your_akamai_access_token` |
 | `AKAMAI_ACCOUNT_SWITCH_KEY` | Optional Akamai account switch key for managed-account access | - | `A-CCT1234:A-CCT5432` |
+| `AKAMAI_ETP_DNS_SERVERS` | Comma-separated Akamai ETP resolver IP addresses assigned to this deployment | - | `op://...` |
+| `AKAMAI_ETP_DOH_HOSTNAME` | Optional Akamai ETP DNS-over-HTTPS hostname for future resolver transports and operator context | - | `op://...` |
+| `AKAMAI_ETP_DOT_HOSTNAME` | Optional Akamai ETP DNS-over-TLS hostname for operator context | - | `op://...` |
+| `AKAMAI_ETP_PROXY_CHAINING_URL` | Optional Akamai ETP proxy chaining URL for operator context | - | `op://...` |
 
 ### Email Service and Webhook Integrations
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -188,9 +188,16 @@ possible, or inject `AKAMAI_HOST`, `AKAMAI_CLIENT_TOKEN`,
 Use `AKAMAI_ACCOUNT_SWITCH_KEY` only when your Akamai client needs to operate
 against a delegated account.
 
-For Akamai ETP resolver-backed DNS checks, select the `akamai_etp` resolver
-profile in DMARQ settings and inject the assigned resolver values through your
-secret manager. These values are account-specific and should not be committed.
+For resolver-backed DNS checks, DMARQ ships with public profiles for Public DNS,
+Cloudflare DoH, Quad9, OpenDNS, and DNS4EU. Select `dns4eu_unfiltered` for
+diagnostic DNS evidence when you want an EU-based resolver without protective
+filtering that could hide real DNS records. Use `dns4eu_protective` only when
+the intentional security-filtering behavior is part of the test.
+
+For Akamai ETP, Infoblox, or custom resolver-backed DNS checks, select the
+matching resolver profile in DMARQ settings and inject the assigned resolver
+values through your secret manager. These values may be account-specific and
+should not be committed.
 
 ### Mail Authentication Defaults
 
@@ -373,9 +380,15 @@ operational policy if long-term storage size matters.
 | `AKAMAI_ACCESS_TOKEN` | Akamai EdgeGrid access token when not using `.edgerc` | - | `your_akamai_access_token` |
 | `AKAMAI_ACCOUNT_SWITCH_KEY` | Optional Akamai account switch key for managed-account access | - | `A-CCT1234:A-CCT5432` |
 | `AKAMAI_ETP_DNS_SERVERS` | Comma-separated Akamai ETP resolver IP addresses assigned to this deployment | - | `op://...` |
-| `AKAMAI_ETP_DOH_HOSTNAME` | Optional Akamai ETP DNS-over-HTTPS hostname for future resolver transports and operator context | - | `op://...` |
+| `AKAMAI_ETP_DOH_HOSTNAME` | Optional Akamai ETP DNS-over-HTTPS hostname used when DNS server IPs are not configured or as fallback after resolver failure | - | `op://...` |
 | `AKAMAI_ETP_DOT_HOSTNAME` | Optional Akamai ETP DNS-over-TLS hostname for operator context | - | `op://...` |
 | `AKAMAI_ETP_PROXY_CHAINING_URL` | Optional Akamai ETP proxy chaining URL for operator context | - | `op://...` |
+| `INFOBLOX_DNS_SERVERS` | Comma-separated Infoblox resolver IP addresses assigned to this deployment | - | `op://...` |
+| `INFOBLOX_DOH_HOSTNAME` | Optional Infoblox DNS-over-HTTPS hostname used when DNS server IPs are not configured or as fallback after resolver failure | - | `op://...` |
+| `INFOBLOX_DOT_HOSTNAME` | Optional Infoblox DNS-over-TLS hostname for operator context | - | `op://...` |
+| `DMARQ_DNS_CUSTOM_SERVERS` | Comma-separated custom recursive resolver IP addresses for this deployment | - | `op://...` |
+| `DMARQ_DNS_CUSTOM_DOH_HOSTNAME` | Optional custom DNS-over-HTTPS hostname used when DNS server IPs are not configured or as fallback after resolver failure | - | `op://...` |
+| `DMARQ_DNS_CUSTOM_DOT_HOSTNAME` | Optional custom DNS-over-TLS hostname for operator context | - | `op://...` |
 
 ### Email Service and Webhook Integrations
 


### PR DESCRIPTION
## Summary
- replace the Akamai-only resolver special case with a reusable configured recursive DNS provider
- add resolver profiles for Quad9, OpenDNS/Cisco Umbrella, DNS4EU unfiltered/protective, Akamai ETP, Infoblox, and custom deployment resolvers
- expose the profiles in settings and document only environment variable names for secret-backed resolvers

## Notes
- no account-specific Akamai ETP resolver values are committed
- DNS4EU unfiltered is intended for diagnostic DNS evidence; protective DNS4EU remains available when filtering behavior is intentionally part of the test
- app.dmarq.org currently has no AKAMAI_ETP_* secret keys or deployment env wiring; those should be added through the 1Password-backed ExternalSecret path before selecting the Akamai ETP profile in production

## Validation
- /tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dns_resolver.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_source_reputation_feeds.py
- ../dmarq-auth-venv/bin/isort --check-only backend/app/services/dns_resolver.py backend/app/core/config.py backend/app/api/api_v1/endpoints/settings.py backend/app/api/api_v1/endpoints/setup.py backend/app/tests/test_dns_resolver.py
- ../dmarq-auth-venv/bin/flake8 backend/app/services/dns_resolver.py backend/app/core/config.py backend/app/api/api_v1/endpoints/settings.py backend/app/api/api_v1/endpoints/setup.py backend/app/tests/test_dns_resolver.py
- /tmp/dmarq-live-audit-venv/bin/python -m py_compile backend/app/services/dns_resolver.py backend/app/core/config.py backend/app/api/api_v1/endpoints/settings.py backend/app/api/api_v1/endpoints/setup.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded DNS resolver options with additional public, enterprise, and custom profiles.
  * Added support for configuring resolver endpoints via environment settings and deployment secrets.
  * Updated settings screens to show the new resolver choices and clearer guidance.

* **Bug Fixes**
  * Improved DNS lookup caching so system-based resolution now uses the expected public resolver behavior.
  * Made DNS reputation checks use a consistent public resolver configuration by default.

* **Documentation**
  * Updated deployment guidance to cover the new resolver profiles and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->