### PR TITLE
[codex] Prepare TLS reports page for Alpine CSP runtime

### DIFF
--- a/backend/app/static/js/tls-reports-page.js
+++ b/backend/app/static/js/tls-reports-page.js
@@ -20,6 +20,30 @@ function tlsReportsApp() {
             this.bindControls();
             this.refresh();
         },
+        get showError() {
+            return !this.loading && Boolean(this.error);
+        },
+        get showEmptyTrends() {
+            return !this.loading && !this.error && this.summary.trends.length === 0;
+        },
+        get showTrends() {
+            return !this.loading && !this.error && this.summary.trends.length > 0;
+        },
+        get uploadIdle() {
+            return !this.uploading;
+        },
+        get uploadDisabled() {
+            return this.uploading || !this.selectedFile;
+        },
+        get uploadMessageClass() {
+            return this.uploadError ? 'text-error' : 'text-success';
+        },
+        get showNoTopFailures() {
+            return this.summary.top_failures.length === 0;
+        },
+        get showNoAffectedDomains() {
+            return this.summary.affected_domains.length === 0;
+        },
         bindControls() {
             const root = this.$root || document;
             if (root.dataset?.tlsControlsBound === 'true') {
@@ -83,7 +107,7 @@ function tlsReportsApp() {
             try {
                 const response = await fetch(`/api/v1/tls-reports/summary?${params.toString()}`);
                 if (!response.ok) throw new Error('Unable to load TLS report summary');
-                this.summary = await response.json();
+                this.summary = this.normalizeSummary(await response.json());
             } catch (err) {
                 this.error = err.message || 'Unable to load TLS report summary';
             } finally {
@@ -129,5 +153,38 @@ function tlsReportsApp() {
         trendFailureWidth(day) {
             return Math.round((Number(day.failed_sessions || 0) / this.trendTotal(day)) * 100);
         },
+        normalizeSummary(payload) {
+            const summary = payload || emptySummary;
+            const trends = (summary.trends || []).map((day) => ({
+                ...day,
+                success_width: this.trendSuccessWidth(day),
+                failure_width: this.trendFailureWidth(day),
+                failed_label: `${this.formatNumber(day.failed_sessions)} failed`,
+            }));
+            const topFailures = (summary.top_failures || []).map((failure) => ({
+                ...failure,
+                affected_domains_label: this.joinValues(failure.affected_domains),
+                receiving_mx_hostnames_label: this.joinValues(failure.receiving_mx_hostnames),
+            }));
+            const affectedDomains = (summary.affected_domains || []).map((item) => ({
+                ...item,
+                domain_url: `/domains/${encodeURIComponent(item.domain || '')}`,
+            }));
+            return {
+                totals: { ...emptySummary.totals, ...(summary.totals || {}) },
+                trends,
+                top_failures: topFailures,
+                affected_domains: affectedDomains,
+                privacy: { ...emptySummary.privacy, ...(summary.privacy || {}) },
+            };
+        },
+        joinValues(values) {
+            const joined = (values || []).filter(Boolean).join(', ');
+            return joined || '-';
+        },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('tlsReportsApp', tlsReportsApp);
+});

--- a/backend/app/static/js/tls-reports-page.js
+++ b/backend/app/static/js/tls-reports-page.js
@@ -39,10 +39,18 @@ function tlsReportsApp() {
             return this.uploadError ? 'text-error' : 'text-success';
         },
         get showNoTopFailures() {
-            return this.summary.top_failures.length === 0;
+            return (
+                !this.loading
+                && !this.error
+                && this.summary.top_failures.length === 0
+            );
         },
         get showNoAffectedDomains() {
-            return this.summary.affected_domains.length === 0;
+            return (
+                !this.loading
+                && !this.error
+                && this.summary.affected_domains.length === 0
+            );
         },
         bindControls() {
             const root = this.$root || document;

--- a/backend/app/templates/tls_reports.html
+++ b/backend/app/templates/tls_reports.html
@@ -5,7 +5,7 @@
 {% block title %}DMARQ - TLS Reports{% endblock %}
 
 {% block content %}
-<div class="container mx-auto py-4" x-data="tlsReportsApp()" data-tls-reports-page>
+<div class="container mx-auto py-4" x-data="tlsReportsApp" data-tls-reports-page>
     <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between mb-6">
         <div>
             <h1 class="text-2xl font-bold">TLS Reports</h1>
@@ -64,21 +64,21 @@
                 <template x-if="loading">
                     <div class="py-12 text-center"><span class="loading loading-spinner loading-lg"></span></div>
                 </template>
-                <template x-if="!loading && error">
+                <template x-if="showError">
                     <div class="alert alert-error" x-text="error"></div>
                 </template>
-                <template x-if="!loading && !error && summary.trends.length === 0">
+                <template x-if="showEmptyTrends">
                     <p class="text-base-content/60">No TLS report data is available for the current filters.</p>
                 </template>
-                <div class="space-y-3" x-show="!loading && !error && summary.trends.length > 0">
+                <div class="space-y-3" x-show="showTrends">
                     <template x-for="day in summary.trends" :key="day.date">
                         <div class="grid grid-cols-[6.5rem_1fr_7rem] gap-3 items-center">
                             <span class="text-sm text-base-content/70" x-text="day.date"></span>
                             <svg class="h-3 w-full rounded bg-base-300 overflow-hidden" viewBox="0 0 100 6" preserveAspectRatio="none" aria-hidden="true">
-                                <rect class="text-success fill-current" x="0" y="0" :width="trendSuccessWidth(day)" height="6"></rect>
-                                <rect class="text-error fill-current" :x="trendSuccessWidth(day)" y="0" :width="trendFailureWidth(day)" height="6"></rect>
+                                <rect class="text-success fill-current" x="0" y="0" :width="day.success_width" height="6"></rect>
+                                <rect class="text-error fill-current" :x="day.success_width" y="0" :width="day.failure_width" height="6"></rect>
                             </svg>
-                            <span class="text-right text-sm font-medium" x-text="formatNumber(day.failed_sessions) + ' failed'"></span>
+                            <span class="text-right text-sm font-medium" x-text="day.failed_label"></span>
                         </div>
                     </template>
                 </div>
@@ -93,11 +93,11 @@
             {% call card_content() %}
                 <form class="space-y-3" data-tls-upload-form>
                     <input type="file" class="file-input file-input-bordered w-full" accept=".json,.gz,.gzip,.zip,application/json,application/zip" data-tls-upload-file>
-                    <button class="btn btn-primary w-full" type="submit" :disabled="uploading || !selectedFile">
-                        <span x-show="!uploading">Upload TLS Report</span>
+                    <button class="btn btn-primary w-full" type="submit" :disabled="uploadDisabled">
+                        <span x-show="uploadIdle">Upload TLS Report</span>
                         <span x-show="uploading" class="loading loading-spinner loading-sm"></span>
                     </button>
-                    <p class="text-sm" :class="uploadError ? 'text-error' : 'text-success'" x-show="uploadMessage" x-text="uploadMessage"></p>
+                    <p class="text-sm" :class="uploadMessageClass" x-show="uploadMessage" x-text="uploadMessage"></p>
                 </form>
             {% endcall %}
         {% endcall %}
@@ -120,15 +120,15 @@
                         {% endcall %}
                     {% endcall %}
                     {% call tbody() %}
-                        <template x-if="summary.top_failures.length === 0">
+                        <template x-if="showNoTopFailures">
                             <tr><td colspan="4" class="text-center py-8 text-base-content/60">No failures found.</td></tr>
                         </template>
                         <template x-for="failure in summary.top_failures" :key="failure.result_type">
                             {% call tr() %}
                                 {% call td() %}<span class="badge badge-error badge-outline" x-text="failure.result_type"></span>{% endcall %}
                                 {% call td("text-right font-semibold") %}<span x-text="formatNumber(failure.failed_sessions)"></span>{% endcall %}
-                                {% call td() %}<span class="block max-w-56 truncate" x-text="failure.affected_domains.join(', ') || '-'"></span>{% endcall %}
-                                {% call td() %}<span class="block max-w-56 truncate" x-text="failure.receiving_mx_hostnames.join(', ') || '-'"></span>{% endcall %}
+                                {% call td() %}<span class="block max-w-56 truncate" x-text="failure.affected_domains_label"></span>{% endcall %}
+                                {% call td() %}<span class="block max-w-56 truncate" x-text="failure.receiving_mx_hostnames_label"></span>{% endcall %}
                             {% endcall %}
                         </template>
                     {% endcall %}
@@ -152,12 +152,12 @@
                         {% endcall %}
                     {% endcall %}
                     {% call tbody() %}
-                        <template x-if="summary.affected_domains.length === 0">
+                        <template x-if="showNoAffectedDomains">
                             <tr><td colspan="4" class="text-center py-8 text-base-content/60">No affected domains found.</td></tr>
                         </template>
                         <template x-for="item in summary.affected_domains" :key="item.domain">
                             {% call tr() %}
-                                {% call td() %}<a class="link link-hover font-medium" :href="'/domains/' + encodeURIComponent(item.domain)" x-text="item.domain"></a>{% endcall %}
+                                {% call td() %}<a class="link link-hover font-medium" :href="item.domain_url" x-text="item.domain"></a>{% endcall %}
                                 {% call td("text-right") %}<span x-text="item.reports"></span>{% endcall %}
                                 {% call td("text-right font-semibold") %}<span x-text="formatNumber(item.failed_sessions)"></span>{% endcall %}
                                 {% call td("text-right") %}<span x-text="formatPercent(item.failure_rate)"></span>{% endcall %}

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -637,7 +637,8 @@ def test_tls_reports_uses_external_page_script_for_csp_migration():
     script = _tls_reports_script()
 
     assert 'src="/static/js/tls-reports-page.js"' in template
-    assert "tlsReportsApp()" in template
+    assert 'x-data="tlsReportsApp"' in template
+    assert "Alpine.data('tlsReportsApp', tlsReportsApp)" in script
     assert "/api/v1/tls-reports/summary?" in script
     assert "/api/v1/tls-reports/upload" in script
     assert "Unable to load TLS report summary" in script
@@ -653,11 +654,16 @@ def test_tls_reports_uses_external_page_script_for_csp_migration():
     assert "data-tls-reports-page" in template
     assert "data-tls-refresh" in script
     assert "bindControls()" in script
+    assert "normalizeSummary" in script
     assert "event.target instanceof Element" in script
     assert 'x-init="init()"' not in template
     assert 'x-effect="$el.style.width' not in template
-    assert "trendSuccessWidth(day)" in template
-    assert "trendFailureWidth(day)" in template
+    assert "trendSuccessWidth(day)" not in template
+    assert "trendFailureWidth(day)" not in template
+    assert 'x-text="day.failed_label"' in template
+    assert 'x-text="failure.affected_domains_label"' in template
+    assert 'x-text="failure.receiving_mx_hostnames_label"' in template
+    assert ':href="item.domain_url"' in template
     assert "viewBox=\"0 0 100 6\"" in template
     assert not _has_inline_style(template)
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -347,6 +347,40 @@ const dnsCached = {
   lookupError: 'TXT lookup timed out; showing cached DNS evidence from 2026-07-03T12:00:00Z.',
 };
 
+const tlsSummary = {
+  totals: {
+    reports: 2,
+    successful_sessions: 9870,
+    failed_sessions: 13,
+    failure_rate: 0.0013,
+  },
+  trends: [
+    { date: '2026-07-02', successful_sessions: 4831, failed_sessions: 7 },
+    { date: '2026-07-03', successful_sessions: 5039, failed_sessions: 6 },
+  ],
+  top_failures: [
+    {
+      result_type: 'certificate-host-mismatch',
+      failed_sessions: 9,
+      affected_domains: ['cklnet.com'],
+      receiving_mx_hostnames: ['mx1.cklnet.com'],
+    },
+  ],
+  affected_domains: [
+    {
+      domain: 'cklnet.com',
+      reports: 2,
+      failed_sessions: 13,
+      failure_rate: 0.0013,
+    },
+  ],
+  privacy: {
+    retention: 'TLS reports are retained for 365 days.',
+    stored_fields: ['report metadata', 'policy domain', 'failure aggregate counts'],
+    not_stored: ['message body', 'recipient local-parts'],
+  },
+};
+
 function json(body, status = 200) {
   return { status, contentType: 'application/json', body: JSON.stringify(body) };
 }
@@ -385,6 +419,7 @@ async function installApiMocks(page) {
       '/api/v1/reports': reports,
       '/api/v1/health/operations': operationsHealth,
       '/api/v1/reports/browser-smoke-cklnet': reportDetail,
+      '/api/v1/tls-reports/summary': tlsSummary,
       '/api/v1/domains/cklnet.com/stats': {
         complianceRate: 92.1,
         totalEmails: 2849,
@@ -824,4 +859,21 @@ test('operations health page renders the registered Alpine component', async ({ 
   await expect(page.getByText('DNS cache refresh queue is healthy')).toBeVisible();
   await expect(page.getByText('gmail backfill', { exact: true })).toBeVisible();
   await expect(page.getByText('Gmail backfill can resume from the saved cursor.')).toBeVisible();
+});
+
+test('tls reports page renders summary data from the registered Alpine component', async ({ page }) => {
+  await page.goto('/tls-reports');
+
+  await expect(page.getByRole('heading', { name: 'TLS Reports' })).toBeVisible();
+  await expect(page.getByText('9,870')).toBeVisible();
+  await expect(page.locator('[x-text="formatNumber(summary.totals.failed_sessions)"]')).toHaveText('13');
+  await expect(page.locator('[x-text="formatPercent(summary.totals.failure_rate)"]')).toHaveText('0.1%');
+  await expect(page.getByText('7 failed')).toBeVisible();
+  await expect(page.getByText('certificate-host-mismatch')).toBeVisible();
+  await expect(page.getByText('mx1.cklnet.com')).toBeVisible();
+  await expect(page.getByText('TLS reports are retained for 365 days.')).toBeVisible();
+
+  const domainLink = page.getByRole('link', { name: 'cklnet.com' });
+  await expect(domainLink).toHaveAttribute('href', '/domains/cklnet.com');
+  await expect(page.getByText('No TLS report data is available for the current filters.')).not.toBeVisible();
 });

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -865,7 +865,12 @@ test('tls reports page renders summary data from the registered Alpine component
   await page.goto('/tls-reports');
 
   await expect(page.getByRole('heading', { name: 'TLS Reports' })).toBeVisible();
-  await expect(page.getByText('9,870')).toBeVisible();
+  const successfulSessions = page.locator(
+    '[x-text="formatNumber(summary.totals.successful_sessions)"]',
+  );
+  await expect(successfulSessions).toHaveText(
+    /^9(?:[\s,.\u202f])?870$/,
+  );
   await expect(page.locator('[x-text="formatNumber(summary.totals.failed_sessions)"]')).toHaveText('13');
   await expect(page.locator('[x-text="formatPercent(summary.totals.failure_rate)"]')).toHaveText('0.1%');
   await expect(page.getByText('7 failed')).toBeVisible();


### PR DESCRIPTION
## Summary
- moves the TLS Reports page to the registered Alpine component form required by the CSP runtime migration
- normalizes trend widths, failure labels, domain links, and upload state classes in the external page script instead of template expressions
- adds browser-smoke coverage for the TLS Reports page with mocked TLS-RPT data

## Related issue
- Part of #598

## Local validation
- `/tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_tls_reports_api.py`
- `node --check backend/app/static/js/tls-reports-page.js && node --check backend/tests/browser/live-dmarc-flows.spec.js`
- `NODE_PATH=/tmp/dmarq-ai-redaction-none/backend/node_modules DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-live-audit-venv/bin/python /tmp/dmarq-ai-redaction-none/backend/node_modules/.bin/playwright test -c playwright.config.cjs --grep "tls reports page renders summary data"`
- `git diff --check`

## Notes
- No DNS writes or live provider mutations.
- Continues the strict-CSP migration one page at a time.