### PR TITLE
[codex] Prepare page roots for strict CSP

### DIFF
--- a/backend/app/static/js/base-layout.js
+++ b/backend/app/static/js/base-layout.js
@@ -1,12 +1,9 @@
-document.addEventListener('alpine:init', () => {
+if (typeof document !== 'undefined') {
     const multiWorkspaceUiEnabled = () =>
         document.documentElement.dataset.multiWorkspaceUi === 'true';
 
-    Alpine.data('userMenu', (options = {}) => {
-        const enabled =
-            options.multiWorkspaceUiEnabled === undefined
-                ? multiWorkspaceUiEnabled()
-                : Boolean(options.multiWorkspaceUiEnabled);
+    const userMenu = () => {
+        const enabled = multiWorkspaceUiEnabled();
         return {
             user: null,
             workspaces: [],
@@ -123,8 +120,12 @@ document.addEventListener('alpine:init', () => {
                 };
             },
         };
+    };
+
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('userMenu', userMenu);
     });
-});
+}
 
 (function attachWorkspaceContextToFetch() {
     const originalFetch = window.fetch;

--- a/backend/app/static/js/base-layout.js
+++ b/backend/app/static/js/base-layout.js
@@ -18,6 +18,12 @@ document.addEventListener('alpine:init', () => {
                 this.bindControls();
                 this.loadUser();
             },
+            get showWorkspaceSwitcher() {
+                return this.workspaces.length > 1;
+            },
+            get showSignIn() {
+                return !this.user;
+            },
             bindControls() {
                 if (typeof document === 'undefined') return;
                 const hasElement = typeof Element !== 'undefined';
@@ -39,7 +45,7 @@ document.addEventListener('alpine:init', () => {
                 try {
                     const res = await fetch('/api/v1/auth/me');
                     if (res.ok) {
-                        this.user = await res.json();
+                        this.user = this.normalizeUser(await res.json());
                     }
                 } catch (_) {
                     // User identity is optional for public or setup views.
@@ -59,7 +65,9 @@ document.addEventListener('alpine:init', () => {
                         return;
                     }
                     const data = await res.json();
-                    this.workspaces = data.workspaces || [];
+                    this.workspaces = (data.workspaces || []).map((workspace) =>
+                        this.normalizeWorkspace(workspace)
+                    );
                     const saved = String(this.selectedWorkspaceId || '');
                     const selected = this.workspaces.find(
                         (workspace) => String(workspace.id) === saved && workspace.active
@@ -92,6 +100,27 @@ document.addEventListener('alpine:init', () => {
                 const prefix = workspace.organization ? `${workspace.organization.name} / ` : '';
                 const suffix = workspace.active ? '' : ' (inactive)';
                 return `${prefix}${workspace.name}${suffix}`;
+            },
+            normalizeUser(user) {
+                const profile = user || {};
+                const fullName = String(profile.full_name || '').trim();
+                const email = String(profile.email || '').trim();
+                const displayName = fullName || email || 'Unknown user';
+                return {
+                    ...profile,
+                    display_name: displayName,
+                    email_label: email,
+                    show_email: Boolean(fullName && email),
+                    avatar_alt: displayName,
+                    initial: displayName.slice(0, 1).toUpperCase() || '?',
+                    show_placeholder_avatar: !profile.picture,
+                };
+            },
+            normalizeWorkspace(workspace) {
+                return {
+                    ...workspace,
+                    disabled: !workspace.active,
+                };
             },
         };
     });

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -67,6 +67,104 @@ function dashboardApp() {
             const domain = this.selectedDnsDomainRecord;
             return domain ? this.domainHref(domain) : '/domains';
         },
+
+        get healthScore() {
+            return this.healthSummary && this.healthSummary.score !== undefined && this.healthSummary.score !== null
+                ? this.healthSummary.score
+                : 0;
+        },
+
+        get healthGrade() {
+            return this.healthSummary && this.healthSummary.grade
+                ? this.healthSummary.grade
+                : 'F';
+        },
+
+        get healthStatus() {
+            return this.healthSummary && this.healthSummary.status
+                ? this.healthSummary.status
+                : 'unknown';
+        },
+
+        get healthAttentionDomains() {
+            return this.healthSummary && this.healthSummary.attention_domains
+                ? this.healthSummary.attention_domains
+                : 0;
+        },
+
+        get healthDomainCount() {
+            return this.healthSummary && this.healthSummary.domain_count
+                ? this.healthSummary.domain_count
+                : 0;
+        },
+
+        get hasHealthHistoryPoints() {
+            return Boolean(this.healthHistory && this.healthHistory.points && this.healthHistory.points.length);
+        },
+
+        get healthScoreDeltaClass() {
+            return this.healthHistory && (Number(this.healthHistory.score_delta) || 0) >= 0
+                ? 'text-[#247982]'
+                : 'text-[#b8431d]';
+        },
+
+        get healthScoreDeltaLabel() {
+            return this.formatScoreDelta(this.healthHistory ? this.healthHistory.score_delta : null);
+        },
+
+        get topHealthActions() {
+            const actions = this.healthSummary && Array.isArray(this.healthSummary.top_actions)
+                ? this.healthSummary.top_actions
+                : [];
+            return actions.slice(0, 3);
+        },
+
+        get hasTopHealthActions() {
+            return this.topHealthActions.length > 0;
+        },
+
+        get selectedDnsPolicyLabel() {
+            const record = this.selectedDnsDomainRecord;
+            return record && record.dmarc_policy ? `Policy: ${record.dmarc_policy}` : 'Policy: unknown';
+        },
+
+        get selectedDnsWarningsCount() {
+            const record = this.selectedDnsDomainRecord;
+            const warnings = record && Array.isArray(record.dmarc_warnings)
+                ? record.dmarc_warnings
+                : [];
+            return warnings.length;
+        },
+
+        get hasSelectedDnsWarnings() {
+            return this.selectedDnsWarningsCount > 0;
+        },
+
+        get selectedDnsWarningsPlural() {
+            return this.selectedDnsWarningsCount === 1 ? '' : 's';
+        },
+
+        get demoTourStepLabel() {
+            return `Step ${this.demoTourStepIndex + 1} of ${this.demoTourSteps.length}`;
+        },
+
+        get currentDemoTourTitle() {
+            const step = this.currentDemoTourStep();
+            return step ? step.title : '';
+        },
+
+        get currentDemoTourBody() {
+            const step = this.currentDemoTourStep();
+            return step ? step.body : '';
+        },
+
+        get isLastDemoTourStep() {
+            return this.demoTourStepIndex + 1 >= this.demoTourSteps.length;
+        },
+
+        get demoTourNextLabel() {
+            return this.isLastDemoTourStep ? 'Finish' : 'Next';
+        },
         
         init() {
             this.bindControls();
@@ -805,8 +903,28 @@ function dashboardApp() {
             return this.healthSummary?.remediation || {};
         },
 
+        domainActionHref(action) {
+            return action && action.domain
+                ? `/domains/${encodeURIComponent(action.domain)}`
+                : '/domains';
+        },
+
+        domainHealthHref(domainHealth) {
+            return domainHealth && domainHealth.domain
+                ? `/domains/${encodeURIComponent(domainHealth.domain)}`
+                : '/domains';
+        },
+
         domainRemediation(domainName) {
             return this.domainByName(domainName)?.remediation || {};
+        },
+
+        domainRemediationStatus(domainName) {
+            return this.domainRemediation(domainName).status || 'none';
+        },
+
+        hasDomainRemediation(domainName) {
+            return this.domainRemediationStatus(domainName) !== 'none';
         },
 
         remediationStatusLabel(status) {

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1521,3 +1521,9 @@ function dashboardApp() {
         }
     }
 }
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('dashboardApp', dashboardApp);
+    });
+}

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1,4 +1,4 @@
-function domainDetailsApp(domainId) {
+function domainDetailsApp(domainId = '') {
     return {
         domainId: domainId,
         stats: {
@@ -204,6 +204,7 @@ function domainDetailsApp(domainId) {
         refreshingPage: false,
 
         init() {
+            this.domainId = this.$el?.dataset?.domainId || this.domainId;
             this.bindPageControls();
             const storedVolumeScale = this.loadStoredVolumeScale();
             if (storedVolumeScale === 'linear' || storedVolumeScale === 'logarithmic') {
@@ -2183,4 +2184,10 @@ function domainDetailsApp(domainId) {
             return 'bg-red-100 text-red-800';
         }
     };
+}
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('domainDetailsApp', domainDetailsApp);
+    });
 }

--- a/backend/app/static/js/forensic-report-detail-page.js
+++ b/backend/app/static/js/forensic-report-detail-page.js
@@ -123,6 +123,8 @@ function forensicReportDetailApp() {
     };
 }
 
-document.addEventListener('alpine:init', () => {
-    Alpine.data('forensicReportDetailApp', forensicReportDetailApp);
-});
+if (typeof document !== 'undefined') {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('forensicReportDetailApp', forensicReportDetailApp);
+    });
+}

--- a/backend/app/static/js/forensic-report-detail-page.js
+++ b/backend/app/static/js/forensic-report-detail-page.js
@@ -1,11 +1,67 @@
-function forensicReportDetailApp(reportId) {
+function forensicReportDetailApp() {
     return {
-        reportId,
+        reportId: '',
         report: null,
         loading: false,
         error: '',
         async init() {
+            this.reportId = this.$el?.dataset?.reportId || '';
             await this.fetchReport();
+        },
+        get showError() {
+            return !this.loading && Boolean(this.error);
+        },
+        get showReport() {
+            return !this.loading && !this.error && Boolean(this.report);
+        },
+        get reportExternalId() {
+            return this.report?.report_id || this.reportId;
+        },
+        get reportDomain() {
+            return this.report?.domain || this.report?.reported_domain || 'unknown domain';
+        },
+        get domainUrl() {
+            const domain = this.report?.domain || this.report?.reported_domain || '';
+            return `/domains/${encodeURIComponent(domain)}`;
+        },
+        get authFailureLabel() {
+            return this.report?.auth_failure || 'unknown';
+        },
+        get deliveryResultLabel() {
+            return this.report?.delivery_result || 'unknown';
+        },
+        get sourceIpLabel() {
+            return this.report?.source_ip || '-';
+        },
+        get arrivalLabel() {
+            return this.formatDate(this.report?.arrival_date || this.report?.processed_at);
+        },
+        get analysis() {
+            return this.report?.analysis || {};
+        },
+        get priorityLabel() {
+            return this.analysis.priority || 'unknown';
+        },
+        get priorityBadgeClass() {
+            return this.priorityClass(this.analysis.priority);
+        },
+        get diagnosisLabel() {
+            return this.analysis.diagnosis || 'No analysis is available for this sample.';
+        },
+        get recommendations() {
+            return this.analysis.recommendations || [];
+        },
+        get signals() {
+            return this.analysis.signals || [];
+        },
+        get privacyNote() {
+            return this.analysis.privacy_note || '';
+        },
+        get authenticationResultsLabel() {
+            return (
+                this.report?.authentication_results ||
+                'No Authentication-Results header was included.'
+            );
         },
         get identityFields() {
             if (!this.report) return [];
@@ -20,10 +76,21 @@ function forensicReportDetailApp(reportId) {
                 { label: 'Message Hash', value: this.report.original_message_id, mono: true },
                 { label: 'Feedback Type', value: this.report.feedback_type },
                 { label: 'Reporter Agent', value: this.report.user_agent },
-            ];
+            ].map((item) => ({
+                ...item,
+                css_class: item.mono ? 'font-mono text-sm' : '',
+                display_value: item.value || '-',
+            }));
         },
         get feedbackHeaderEntries() {
-            return Object.entries(this.report?.feedback_headers || {});
+            return Object.entries(this.report?.feedback_headers || {}).map(([key, value]) => ({
+                key,
+                label: this.labelize(key),
+                value: value || '-',
+            }));
+        },
+        get hasNoFeedbackHeaderEntries() {
+            return this.feedbackHeaderEntries.length === 0;
         },
         async fetchReport() {
             this.loading = true;
@@ -55,3 +122,7 @@ function forensicReportDetailApp(reportId) {
         },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('forensicReportDetailApp', forensicReportDetailApp);
+});

--- a/backend/app/static/js/mail-sources-page.js
+++ b/backend/app/static/js/mail-sources-page.js
@@ -874,3 +874,9 @@ function mailSourcesApp() {
         },
     };
 }
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('mailSourcesApp', mailSourcesApp);
+    });
+}

--- a/backend/app/static/js/members-page.js
+++ b/backend/app/static/js/members-page.js
@@ -452,3 +452,9 @@ function membershipApp() {
         },
     };
 }
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('membershipApp', membershipApp);
+    });
+}

--- a/backend/app/static/js/onboarding-page.js
+++ b/backend/app/static/js/onboarding-page.js
@@ -46,7 +46,9 @@ function workspaceOnboarding(options = {}) {
             return this.showDnsOnlyNotice ? 'btn-primary' : 'btn-outline';
         },
         get taskPreviewLabel() {
-            return this.tasks.length ? `${this.tasks.length} tasks` : 'No preview yet';
+            return this.tasks.length
+                ? `${this.tasks.length} task${this.tasks.length === 1 ? '' : 's'}`
+                : 'No preview yet';
         },
         get showNoTasks() {
             return this.tasks.length === 0;
@@ -226,6 +228,8 @@ function workspaceOnboarding(options = {}) {
     };
 }
 
-document.addEventListener('alpine:init', () => {
-    Alpine.data('workspaceOnboarding', workspaceOnboarding);
-});
+if (typeof document !== 'undefined') {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('workspaceOnboarding', workspaceOnboarding);
+    });
+}

--- a/backend/app/static/js/onboarding-page.js
+++ b/backend/app/static/js/onboarding-page.js
@@ -27,9 +27,37 @@ function workspaceOnboarding(options = {}) {
         get singleUserMode() {
             return !this.multiWorkspaceUiEnabled;
         },
+        get showWorkspaceSwitchSuccess() {
+            return this.multiWorkspaceUiEnabled && Boolean(this.result?.workspace);
+        },
+        get resultWorkspaceName() {
+            return this.result?.workspace?.name || '';
+        },
+        get showImapFields() {
+            return this.form.mailSourcePath === 'imap';
+        },
+        get showDnsOnlyNotice() {
+            return this.form.mailSourcePath === 'dns_only';
+        },
+        get imapButtonClass() {
+            return this.showImapFields ? 'btn-primary' : 'btn-outline';
+        },
+        get dnsOnlyButtonClass() {
+            return this.showDnsOnlyNotice ? 'btn-primary' : 'btn-outline';
+        },
+        get taskPreviewLabel() {
+            return this.tasks.length ? `${this.tasks.length} tasks` : 'No preview yet';
+        },
+        get showNoTasks() {
+            return this.tasks.length === 0;
+        },
         init() {
             if (this.initialized) return;
             this.initialized = true;
+            const flag = this.$el?.dataset?.multiWorkspaceUi;
+            if (flag === 'true' || flag === 'false') {
+                this.multiWorkspaceUiEnabled = flag === 'true';
+            }
             this.draftFields().forEach((field) => {
                 const storedValue = localStorage.getItem(`dmarq.onboarding.${field}`);
                 if (storedValue !== null) {
@@ -144,13 +172,13 @@ function workspaceOnboarding(options = {}) {
                 }
                 if (mode === 'preview') {
                     this.plan = data.plan;
-                    this.tasks = data.plan?.tasks || [];
+                    this.tasks = this.normalizeTasks(data.plan?.tasks);
                     this.success = this.singleUserMode
                         ? 'Preview is ready. Review the task list before applying setup.'
                         : 'Preview is ready. Review the task list before creating the workspace.';
                 } else {
                     this.result = data.result;
-                    this.tasks = data.result?.tasks || [];
+                    this.tasks = this.normalizeTasks(data.result?.tasks);
                     this.success = this.singleUserMode
                         ? 'Mail health setup was applied.'
                         : 'Workspace onboarding was applied.';
@@ -175,6 +203,12 @@ function workspaceOnboarding(options = {}) {
             }
             return detail || '';
         },
+        normalizeTasks(tasks) {
+            return (tasks || []).map((task) => ({
+                ...task,
+                url: task.href || '#',
+            }));
+        },
         persistAppliedWorkspace(result) {
             if (!this.multiWorkspaceUiEnabled) return;
             const workspaceId = result?.workspace?.id;
@@ -191,3 +225,7 @@ function workspaceOnboarding(options = {}) {
         },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('workspaceOnboarding', workspaceOnboarding);
+});

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -1,4 +1,4 @@
-function reportDetailApp(reportId) {
+function reportDetailApp(reportId = '') {
     return {
         reportId: reportId,
         report: null,
@@ -8,6 +8,7 @@ function reportDetailApp(reportId) {
         reputationRefreshError: '',
 
         async init() {
+            this.reportId = this.$el?.dataset?.reportId || this.reportId;
             this.bindPageControls();
             await this.fetchReport();
         },
@@ -226,4 +227,10 @@ function reportDetailApp(reportId) {
             return (reputation?.evidence || []).slice(0, 3);
         },
     };
+}
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('reportDetailApp', reportDetailApp);
+    });
 }

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -1036,3 +1036,9 @@ function settingsApp() {
         },
     };
 }
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('settingsApp', settingsApp);
+    });
+}

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -647,6 +647,35 @@ function settingsApp() {
             return this.cfZones.filter(zone => !zone.imported).length;
         },
 
+        dnsProviderImportErrorTitle() {
+            return `${this.selectedDnsProviderName()} discovery needs attention`;
+        },
+
+        dnsProviderNoImportableZonesTitle() {
+            return `${this.selectedDnsProviderName()} returned no importable zones`;
+        },
+
+        alertPreviewLabel() {
+            if (!this.alertPreview) return 'No active alerts found.';
+            return `${this.alertPreview} active alert${this.alertPreview === 1 ? '' : 's'} found.`;
+        },
+
+        summaryPreviewLabel() {
+            const summary = this.summaryPreview || {};
+            const alerts = Array.isArray(summary.alerts) ? summary.alerts : [];
+            return [
+                `${summary.total_messages || 0} messages`,
+                `${summary.reports_processed || 0} reports`,
+                `${alerts.length} active alerts.`,
+            ].join(', ');
+        },
+
+        configAuditValueLabel(item) {
+            const oldValue = item && item.old_value ? item.old_value : '(empty)';
+            const newValue = item && item.new_value ? item.new_value : '(empty)';
+            return `${oldValue} -> ${newValue}`;
+        },
+
         providerErrorDetail(data, fallback) {
             const detail = data?.detail;
             if (typeof detail === 'string') return detail;
@@ -767,6 +796,60 @@ function settingsApp() {
 
         selectedCloudflareOAuthRequiresAllowlisting() {
             return Boolean(this.selectedCloudflareOAuthProfile()?.requires_client_allowlisting);
+        },
+
+        selectedCloudflareOAuthDescription() {
+            const profile = this.selectedCloudflareOAuthProfile();
+            return profile && profile.description
+                ? profile.description
+                : 'Choose how much Cloudflare access DMARQ should request.';
+        },
+
+        selectedCloudflareOAuthScopes() {
+            const profile = this.selectedCloudflareOAuthProfile();
+            return profile && profile.scopes ? profile.scopes : 'zone.read dns.read';
+        },
+
+        selectedCloudflareOAuthWarning() {
+            const profile = this.selectedCloudflareOAuthProfile();
+            return profile && profile.warning ? profile.warning : '';
+        },
+
+        selectedCloudflareOAuthHasWarning() {
+            return Boolean(this.selectedCloudflareOAuthWarning());
+        },
+
+        hasAIModels() {
+            return Array.isArray(this.aiModels) && this.aiModels.length > 0;
+        },
+
+        aiConnectionStatusLabel() {
+            return this.aiConnectionResult && this.aiConnectionResult.success
+                ? 'Connection OK'
+                : 'Connection failed';
+        },
+
+        aiConnectionMessage() {
+            return this.aiConnectionResult && this.aiConnectionResult.message
+                ? this.aiConnectionResult.message
+                : '';
+        },
+
+        aiConnectionBadgeClass() {
+            return this.aiConnectionResult && this.aiConnectionResult.success
+                ? 'badge-success'
+                : 'badge-error';
+        },
+
+        aiConnectionProviderLabel() {
+            return this.aiConnectionResult && this.aiConnectionResult.provider
+                ? this.aiConnectionResult.provider
+                : 'AI';
+        },
+
+        aiModelsDiscoveredLabel() {
+            const count = Array.isArray(this.aiModels) ? this.aiModels.length : 0;
+            return `${count} model${count === 1 ? '' : 's'} discovered.`;
         },
 
         async connectCloudflare() {

--- a/backend/app/templates/components/ui/alert.html
+++ b/backend/app/templates/components/ui/alert.html
@@ -2,7 +2,7 @@
 <div 
     class="alert alert-{{ variant }} shadow-lg mb-4" 
     {% if id %}id="{{ id }}"{% endif %}
-    {% if dismissible %}x-data="alertComponent()" x-show="open"{% endif %}
+    {% if dismissible %}x-data="alertComponent" x-show="open"{% endif %}
 >
     {% if variant == 'info' %}
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info flex-shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -6,7 +6,7 @@
 {% block title %}DMARQ - {{ domain.name }} Details{% endblock %}
 
 {% block content %}
-<div class="space-y-6" x-data="domainDetailsApp('{{ domain_id }}')" data-domain-detail-page>
+<div class="space-y-6" x-data="domainDetailsApp" data-domain-detail-page data-domain-id="{{ domain_id }}">
     <nav class="text-sm text-[#5f5c78]">
         <ol class="flex items-center space-x-2">
             <li><a href="/" class="font-semibold hover:text-[#2f9da5]">Dashboard</a></li>

--- a/backend/app/templates/forensic_report_detail.html
+++ b/backend/app/templates/forensic_report_detail.html
@@ -4,7 +4,7 @@
 {% block title %}DMARQ - Forensic Report Detail{% endblock %}
 
 {% block content %}
-<div class="space-y-6" x-data="forensicReportDetailApp({{ report_id }})" data-forensic-report-detail-page>
+<div class="space-y-6" x-data="forensicReportDetailApp" data-forensic-report-detail-page data-report-id="{{ report_id }}">
     <nav class="text-sm text-[#5f5c78]">
         <ol class="flex items-center space-x-2">
             <li><a href="/" class="font-semibold hover:text-[#2f9da5]">Dashboard</a></li>
@@ -21,11 +21,11 @@
         </div>
     </template>
 
-    <template x-if="!loading && error">
+    <template x-if="showError">
         <div class="alert alert-error mb-6" x-text="error"></div>
     </template>
 
-    <template x-if="!loading && !error && report">
+    <template x-if="showReport">
         <div class="space-y-6">
             <div class="rounded-lg bg-white p-6 shadow-sm">
                 <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
@@ -33,14 +33,14 @@
                         <p class="mb-2 text-sm font-semibold uppercase tracking-wide text-[#ff6f3c]">Forensic sample</p>
                         <h1 class="text-3xl font-bold tracking-normal text-[#07071f]">Forensic Investigation</h1>
                         <p class="mt-2 text-[#5f5c78]">
-                            <span x-text="report.report_id"></span>
+                            <span x-text="reportExternalId"></span>
                             <span>&bull;</span>
-                            <span x-text="report.domain || report.reported_domain || 'unknown domain'"></span>
+                            <span x-text="reportDomain"></span>
                         </p>
                     </div>
                     <div class="flex flex-wrap gap-2">
                         <a href="/forensics" class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]">Back to Forensics</a>
-                        <a class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]" :href="'/domains/' + encodeURIComponent(report.domain || report.reported_domain)">Domain</a>
+                        <a class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]" :href="domainUrl">Domain</a>
                     </div>
                 </div>
             </div>
@@ -49,28 +49,28 @@
                 {% call card() %}
                     {% call card_header() %}{% call card_title() %}Failure{% endcall %}{% endcall %}
                     {% call card_content() %}
-                        <div class="text-2xl font-bold uppercase text-[#ff6f3c]" x-text="report.auth_failure || 'unknown'"></div>
+                        <div class="text-2xl font-bold uppercase text-[#ff6f3c]" x-text="authFailureLabel"></div>
                         <p class="mt-1 text-sm text-[#5f5c78]">Authentication failure</p>
                     {% endcall %}
                 {% endcall %}
                 {% call card() %}
                     {% call card_header() %}{% call card_title() %}Delivery{% endcall %}{% endcall %}
                     {% call card_content() %}
-                        <div class="text-2xl font-bold uppercase text-[#120d36]" x-text="report.delivery_result || 'unknown'"></div>
+                        <div class="text-2xl font-bold uppercase text-[#120d36]" x-text="deliveryResultLabel"></div>
                         <p class="mt-1 text-sm text-[#5f5c78]">Receiver outcome</p>
                     {% endcall %}
                 {% endcall %}
                 {% call card() %}
                     {% call card_header() %}{% call card_title() %}Source IP{% endcall %}{% endcall %}
                     {% call card_content() %}
-                        <div class="text-xl font-bold font-mono text-[#120d36]" x-text="report.source_ip || '-'"></div>
+                        <div class="text-xl font-bold font-mono text-[#120d36]" x-text="sourceIpLabel"></div>
                         <p class="mt-1 text-sm text-[#5f5c78]">Observed sender</p>
                     {% endcall %}
                 {% endcall %}
                 {% call card() %}
                     {% call card_header() %}{% call card_title() %}Arrival{% endcall %}{% endcall %}
                     {% call card_content() %}
-                        <div class="text-sm font-semibold text-[#120d36]" x-text="formatDate(report.arrival_date || report.processed_at)"></div>
+                        <div class="text-sm font-semibold text-[#120d36]" x-text="arrivalLabel"></div>
                         <p class="mt-1 text-sm text-[#5f5c78]">Sample timestamp</p>
                     {% endcall %}
                 {% endcall %}
@@ -83,17 +83,17 @@
                             {% call card_title() %}Failure Sample Analysis{% endcall %}
                             {% call card_description() %}Privacy-preserving diagnosis from the redacted failure sample{% endcall %}
                         </div>
-                        <span class="badge uppercase" :class="priorityClass(report.analysis?.priority)" x-text="report.analysis?.priority || 'unknown'"></span>
+                        <span class="badge uppercase" :class="priorityBadgeClass" x-text="priorityLabel"></span>
                     </div>
                 {% endcall %}
                 {% call card_content() %}
                     <div class="space-y-4">
-                        <p class="font-medium" x-text="report.analysis?.diagnosis || 'No analysis is available for this sample.'"></p>
+                        <p class="font-medium" x-text="diagnosisLabel"></p>
                         <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
                             <div>
                                 <p class="text-sm font-semibold mb-2">Recommended Actions</p>
                                 <ul class="text-sm space-y-1 list-disc pl-4">
-                                    <template x-for="action in report.analysis?.recommendations || []" :key="action">
+                                    <template x-for="action in recommendations" :key="action">
                                         <li x-text="action"></li>
                                     </template>
                                 </ul>
@@ -101,13 +101,13 @@
                             <div>
                                 <p class="text-sm font-semibold mb-2">Signals</p>
                                 <ul class="text-sm space-y-1 list-disc pl-4">
-                                    <template x-for="signal in report.analysis?.signals || []" :key="signal">
+                                    <template x-for="signal in signals" :key="signal">
                                         <li x-text="signal"></li>
                                     </template>
                                 </ul>
                             </div>
                         </div>
-                        <p class="text-xs text-base-content/60" x-text="report.analysis?.privacy_note"></p>
+                        <p class="text-xs text-base-content/60" x-text="privacyNote"></p>
                     </div>
                 {% endcall %}
             {% endcall %}
@@ -122,7 +122,7 @@
                         <template x-for="item in identityFields" :key="item.label">
                             <div class="min-w-0">
                                 <p class="text-sm text-base-content/60" x-text="item.label"></p>
-                                <p class="font-medium break-words" :class="item.mono ? 'font-mono text-sm' : ''" x-text="item.value || '-'"></p>
+                                <p class="font-medium break-words" :class="item.css_class" x-text="item.display_value"></p>
                             </div>
                         </template>
                     </div>
@@ -134,7 +134,7 @@
                     {% call card_title() %}Authentication Results{% endcall %}
                 {% endcall %}
                 {% call card_content() %}
-                    <pre class="bg-base-200 rounded p-4 text-sm whitespace-pre-wrap break-words" x-text="report.authentication_results || 'No Authentication-Results header was included.'"></pre>
+                    <pre class="bg-base-200 rounded p-4 text-sm whitespace-pre-wrap break-words" x-text="authenticationResultsLabel"></pre>
                 {% endcall %}
             {% endcall %}
 
@@ -144,13 +144,13 @@
                 {% endcall %}
                 {% call card_content() %}
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <template x-if="feedbackHeaderEntries.length === 0">
+                        <template x-if="hasNoFeedbackHeaderEntries">
                             <p class="text-base-content/60">No additional feedback headers were included.</p>
                         </template>
-                        <template x-for="[key, value] in feedbackHeaderEntries" :key="key">
+                        <template x-for="entry in feedbackHeaderEntries" :key="entry.key">
                             <div class="min-w-0">
-                                <p class="text-sm text-base-content/60" x-text="labelize(key)"></p>
-                                <p class="font-medium break-words" x-text="value || '-'"></p>
+                                <p class="text-sm text-base-content/60" x-text="entry.label"></p>
+                                <p class="font-medium break-words" x-text="entry.value"></p>
                             </div>
                         </template>
                     </div>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -77,18 +77,18 @@
             <div class="rounded-lg bg-[#f4f3f2] p-5">
                 <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]">System Health</p>
                 <div class="mt-4 flex items-end gap-4">
-                    <div class="text-6xl font-bold leading-none text-[#120d36]" x-text="healthSummary?.score ?? 0"></div>
+                    <div class="text-6xl font-bold leading-none text-[#120d36]" x-text="healthScore"></div>
                     <div class="pb-1">
                         <div class="inline-flex min-w-16 justify-center rounded-md px-3 py-1 text-2xl font-bold"
-                             :class="gradeClass(healthSummary?.grade)"
-                             x-text="healthSummary?.grade || 'F'"></div>
-                        <p class="mt-2 text-sm font-semibold capitalize text-[#5f5c78]" x-text="healthSummary?.status || 'unknown'"></p>
+                             :class="gradeClass(healthGrade)"
+                             x-text="healthGrade"></div>
+                        <p class="mt-2 text-sm font-semibold capitalize text-[#5f5c78]" x-text="healthStatus"></p>
                     </div>
                 </div>
                 <p class="mt-4 text-sm text-[#5f5c78]">
-                    <span x-text="healthSummary?.attention_domains || 0"></span>
+                    <span x-text="healthAttentionDomains"></span>
                     <span> of </span>
-                    <span x-text="healthSummary?.domain_count || 0"></span>
+                    <span x-text="healthDomainCount"></span>
                     <span> domains need attention.</span>
                 </p>
                 <div class="mt-5 grid gap-2 border-t border-[#dfdfdf] pt-4 text-sm">
@@ -110,12 +110,12 @@
                               x-text="remediationTotals().resolved || 0"></span>
                     </div>
                 </div>
-                <div class="mt-5 border-t border-[#dfdfdf] pt-4" x-show="healthHistory?.points?.length">
+                <div class="mt-5 border-t border-[#dfdfdf] pt-4" x-show="hasHealthHistoryPoints">
                     <div class="mb-3 flex items-center justify-between gap-3">
                         <p class="text-sm font-semibold text-[#120d36]">Score Trend</p>
                         <p class="text-sm font-semibold"
-                           :class="(healthHistory?.score_delta || 0) >= 0 ? 'text-[#247982]' : 'text-[#b8431d]'">
-                            <span x-text="formatScoreDelta(healthHistory?.score_delta)"></span>
+                           :class="healthScoreDeltaClass">
+                            <span x-text="healthScoreDeltaLabel"></span>
                         </p>
                     </div>
                     <div class="h-24">
@@ -133,14 +133,14 @@
                         <a href="/domains" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open domains</a>
                     </div>
                     <div class="mt-4 grid gap-3">
-                        <template x-if="!(healthSummary?.top_actions || []).length">
+                        <template x-if="!hasTopHealthActions">
                             <div class="rounded-md border border-[#e6e3e1] p-4 text-sm text-[#5f5c78]">
                                 No immediate remediation actions. Keep monitoring reports and DNS drift.
                             </div>
                         </template>
-                        <template x-for="action in (healthSummary?.top_actions || []).slice(0, 3)" :key="action.domain + action.type">
+                        <template x-for="action in topHealthActions" :key="action.domain + action.type">
                             <a class="rounded-md border border-[#e6e3e1] p-4 transition hover:border-[#2f9da5] hover:shadow-sm"
-                               :href="`/domains/${encodeURIComponent(action.domain)}`">
+                               :href="domainActionHref(action)">
                                 <div class="flex items-start justify-between gap-3">
                                     <div>
                                         <p class="text-xs font-semibold uppercase tracking-wide"
@@ -175,14 +175,14 @@
                     <div class="mt-4 space-y-3">
                         <template x-for="domainHealth in healthDomains()" :key="domainHealth.domain">
                             <a class="flex items-center justify-between gap-3 rounded-md border border-[#e6e3e1] p-3 transition hover:border-[#2f9da5]"
-                               :href="`/domains/${encodeURIComponent(domainHealth.domain)}`">
+                               :href="domainHealthHref(domainHealth)">
                                 <div class="min-w-0">
                                     <p class="truncate font-semibold text-[#120d36]" x-text="domainHealth.domain"></p>
                                     <p class="mt-1 text-xs capitalize text-[#5f5c78]" x-text="domainHealth.status"></p>
-                                    <template x-if="domainRemediation(domainHealth.domain)?.status && domainRemediation(domainHealth.domain).status !== 'none'">
+                                    <template x-if="hasDomainRemediation(domainHealth.domain)">
                                         <p class="mt-1 text-xs font-semibold"
-                                           :class="remediationStatusClass(domainRemediation(domainHealth.domain).status)"
-                                           x-text="remediationStatusLabel(domainRemediation(domainHealth.domain).status)"></p>
+                                           :class="remediationStatusClass(domainRemediationStatus(domainHealth.domain))"
+                                           x-text="remediationStatusLabel(domainRemediationStatus(domainHealth.domain))"></p>
                                     </template>
                                 </div>
                                 <div class="text-right">
@@ -283,9 +283,9 @@
                 </div>
             </div>
             <div class="mt-4 rounded-md bg-[#f4f3f2] p-3 text-sm text-[#5f5c78]" x-show="selectedDnsDomainRecord">
-                <span class="font-semibold text-[#120d36]" x-text="selectedDnsDomainRecord?.dmarc_policy ? 'Policy: ' + selectedDnsDomainRecord.dmarc_policy : 'Policy: unknown'"></span>
-                <span x-show="selectedDnsDomainRecord?.dmarc_warnings?.length">
-                    · <span x-text="selectedDnsDomainRecord?.dmarc_warnings?.length || 0"></span> lint warning<span x-show="(selectedDnsDomainRecord?.dmarc_warnings?.length || 0) !== 1">s</span>
+                <span class="font-semibold text-[#120d36]" x-text="selectedDnsPolicyLabel"></span>
+                <span x-show="hasSelectedDnsWarnings">
+                    · <span x-text="selectedDnsWarningsCount"></span> lint warning<span x-text="selectedDnsWarningsPlural"></span>
                 </span>
             </div>
         </section>
@@ -457,15 +457,15 @@
             <div class="flex items-start justify-between gap-4">
                 <div>
                     <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]"
-                       x-text="`Step ${demoTourStepIndex + 1} of ${demoTourSteps.length}`"></p>
-                    <h3 class="mt-1 text-xl font-semibold text-[#120d36]" x-text="currentDemoTourStep()?.title"></h3>
+                       x-text="demoTourStepLabel"></p>
+                    <h3 class="mt-1 text-xl font-semibold text-[#120d36]" x-text="currentDemoTourTitle"></h3>
                 </div>
                 <button type="button"
                         class="rounded-md px-2 py-1 text-lg text-[#5f5c78] hover:bg-[#f4f3f2]"
                         aria-label="Close guided demo"
                         data-dashboard-demo-tour-close>×</button>
             </div>
-            <p class="mt-3 text-sm text-[#5f5c78]" x-text="currentDemoTourStep()?.body"></p>
+            <p class="mt-3 text-sm text-[#5f5c78]" x-text="currentDemoTourBody"></p>
             <div class="mt-5 flex items-center justify-between gap-3">
                 <button type="button"
                         class="rounded-md border border-[#dfdfdf] px-3 py-2 text-sm font-semibold text-[#120d36] disabled:opacity-40"
@@ -474,7 +474,7 @@
                 <button type="button"
                         class="rounded-md bg-[#272a5f] px-4 py-2 text-sm font-semibold text-white hover:bg-[#171346]"
                         data-dashboard-demo-tour-next
-                        x-text="demoTourStepIndex + 1 >= demoTourSteps.length ? 'Finish' : 'Next'"></button>
+                        x-text="demoTourNextLabel"></button>
             </div>
         </div>
     </div>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -9,7 +9,7 @@
 {% block page_title %}Dashboard{% endblock %}
 
 {% block content %}
-<div class="dashboard-page space-y-6" x-data="dashboardApp()">
+<div class="dashboard-page space-y-6" x-data="dashboardApp">
     <div x-show="dashboardLoading"
          x-cloak
          class="rounded-lg border border-[#e6e3e1] bg-white p-6 shadow-sm"

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -38,7 +38,7 @@
 </head>
 <body class="min-h-screen bg-[#f4f3f2] font-body antialiased text-[#07071f]">
     <header class="fixed inset-x-0 top-0 z-40 flex h-24 items-center bg-[#272a5f] px-5 text-white shadow-sm md:px-10"
-            x-data="userMenu({ multiWorkspaceUiEnabled: {{ multi_workspace_ui_enabled | tojson }} })"
+            x-data="userMenu"
             data-user-menu>
         <div class="flex flex-1 items-center">
             <a href="/" class="inline-flex items-center gap-4" aria-label="DMARQ Dashboard">
@@ -60,7 +60,7 @@
         </div>
         <div class="flex items-center gap-3">
             {% if multi_workspace_ui_enabled %}
-            <div class="hidden min-w-48 md:block" x-show="workspaces.length > 1" x-cloak>
+            <div class="hidden min-w-48 md:block" x-show="showWorkspaceSwitcher" x-cloak>
                 <label class="sr-only" for="workspace-switcher">Workspace</label>
                 <select id="workspace-switcher"
                         class="select select-sm w-full border-white/30 bg-white/95 text-[#272a5f]"
@@ -68,7 +68,7 @@
                         data-workspace-switcher>
                     <template x-for="workspace in workspaces" :key="workspace.id">
                         <option :value="workspace.id"
-                                :disabled="!workspace.active"
+                                :disabled="workspace.disabled"
                                 x-text="workspaceLabel(workspace)"></option>
                     </template>
                 </select>
@@ -91,17 +91,17 @@
                         <label tabindex="0" class="btn btn-ghost btn-circle avatar placeholder h-12 w-12 rounded-full border border-white/40 bg-white/90 text-[#272a5f] hover:bg-white">
                             <div class="rounded-full w-10">
                                 <template x-if="user.picture">
-                                    <img :src="user.picture" :alt="user.full_name || user.email" class="h-10 w-10 rounded-full object-cover">
+                                    <img :src="user.picture" :alt="user.avatar_alt" class="h-10 w-10 rounded-full object-cover">
                                 </template>
-                                <template x-if="!user.picture">
-                                    <span class="text-sm font-semibold" x-text="(user.full_name || user.email || '?')[0].toUpperCase()"></span>
+                                <template x-if="user.show_placeholder_avatar">
+                                    <span class="text-sm font-semibold" x-text="user.initial"></span>
                                 </template>
                             </div>
                         </label>
                         <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 text-base-content rounded-box w-56">
                             <li class="menu-title px-2 py-1">
-                                <span class="text-xs font-semibold truncate" x-text="user.full_name || user.email"></span>
-                                <span class="text-xs text-base-content/50 truncate" x-text="user.email" x-show="user.full_name"></span>
+                                <span class="text-xs font-semibold truncate" x-text="user.display_name"></span>
+                                <span class="text-xs text-base-content/50 truncate" x-text="user.email_label" x-show="user.show_email"></span>
                             </li>
                             <li><a href="/profile">Profile &amp; Security</a></li>
                             {% if multi_workspace_ui_enabled %}
@@ -127,7 +127,7 @@
                         </ul>
                     </div>
                 </template>
-                <template x-if="!user">
+                <template x-if="showSignIn">
                     <a href="/login" class="btn btn-ghost btn-sm">Sign in</a>
                 </template>
             </div>

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -9,7 +9,7 @@
 {% block page_title %}Mail Sources{% endblock %}
 
 {% block content %}
-<div class="grid gap-4 md:gap-8 py-4" x-data="mailSourcesApp()" data-mail-sources-page>
+<div class="grid gap-4 md:gap-8 py-4" x-data="mailSourcesApp" data-mail-sources-page>
 
     <!-- Page header -->
     <div class="flex items-center justify-between">

--- a/backend/app/templates/members.html
+++ b/backend/app/templates/members.html
@@ -4,7 +4,7 @@
 {% block title %}Members - DMARQ{% endblock %}
 
 {% block content %}
-<div x-data="membershipApp()" class="mx-auto max-w-7xl space-y-6 py-4" data-members-page>
+<div x-data="membershipApp" class="mx-auto max-w-7xl space-y-6 py-4" data-members-page>
     <section class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
             <p class="text-sm font-semibold uppercase text-[#2c9aa3]">Access control</p>

--- a/backend/app/templates/onboarding.html
+++ b/backend/app/templates/onboarding.html
@@ -4,7 +4,8 @@
 
 {% block content %}
 <div class="mx-auto max-w-7xl space-y-6"
-     x-data="workspaceOnboarding({ multiWorkspaceUiEnabled: {{ multi_workspace_ui_enabled | tojson }} })"
+     x-data="workspaceOnboarding"
+     data-multi-workspace-ui="{{ multi_workspace_ui_enabled | tojson }}"
      data-onboarding-page x-cloak>
     <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
@@ -41,9 +42,9 @@
     <div x-show="success" role="alert" class="alert alert-success">
         <div>
             <p class="font-semibold" x-text="success"></p>
-            <p class="text-sm" x-show="multiWorkspaceUiEnabled && result?.workspace">
+            <p class="text-sm" x-show="showWorkspaceSwitchSuccess">
                 The active browser workspace has been switched to
-                <span class="font-medium" x-text="result?.workspace?.name"></span>.
+                <span class="font-medium" x-text="resultWorkspaceName"></span>.
             </p>
         </div>
     </div>
@@ -173,15 +174,15 @@
                     </div>
                     <div class="join">
                         <button type="button" class="btn join-item btn-sm"
-                                :class="form.mailSourcePath === 'imap' ? 'btn-primary' : 'btn-outline'"
+                                :class="imapButtonClass"
                                 data-onboarding-mail-path="imap">IMAP</button>
                         <button type="button" class="btn join-item btn-sm"
-                                :class="form.mailSourcePath === 'dns_only' ? 'btn-primary' : 'btn-outline'"
+                                :class="dnsOnlyButtonClass"
                                 data-onboarding-mail-path="dns_only">DNS only</button>
                     </div>
                 </div>
 
-                <div x-show="form.mailSourcePath === 'imap'" class="mt-5 grid gap-4 md:grid-cols-3">
+                <div x-show="showImapFields" class="mt-5 grid gap-4 md:grid-cols-3">
                     <label class="form-control">
                         <span class="label-text font-medium">IMAP server</span>
                         <input x-model.trim="form.imapServer" type="text"
@@ -199,7 +200,7 @@
                     </label>
                 </div>
 
-                <div x-show="form.mailSourcePath === 'dns_only'" class="mt-5 rounded-lg border border-[#2f9da6]/25 bg-[#2f9da6]/10 p-4 text-sm leading-6 text-[#07071f]/75">
+                <div x-show="showDnsOnlyNotice" class="mt-5 rounded-lg border border-[#2f9da6]/25 bg-[#2f9da6]/10 p-4 text-sm leading-6 text-[#07071f]/75">
                     {% if multi_workspace_ui_enabled %}
                     DMARQ will create the workspace and DNS checklist without storing mailbox credentials.
                     {% else %}
@@ -256,16 +257,16 @@
                 <div class="flex items-center justify-between gap-4">
                     <h2 class="text-lg font-semibold">Task preview</h2>
                     <span class="text-xs font-semibold uppercase tracking-wide text-[#07071f]/50"
-                          x-text="tasks.length ? `${tasks.length} tasks` : 'No preview yet'"></span>
+                          x-text="taskPreviewLabel"></span>
                 </div>
                 <div class="mt-4 space-y-3">
-                    <template x-if="!tasks.length">
+                    <template x-if="showNoTasks">
                         <p class="rounded-lg border border-dashed border-[#07071f]/20 p-4 text-sm text-[#07071f]/60">
                             Preview or apply setup to see the exact follow-up list.
                         </p>
                     </template>
                     <template x-for="task in tasks" :key="task.id">
-                        <a :href="task.href || '#'"
+                        <a :href="task.url"
                            class="block rounded-lg border border-[#07071f]/10 p-4 transition hover:border-[#2f9da6]/60 hover:bg-[#2f9da6]/5">
                             <div class="flex items-start justify-between gap-3">
                                 <div>

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -6,7 +6,7 @@
 {% block title %}DMARQ - Report Detail{% endblock %}
 
 {% block content %}
-<div class="space-y-6" x-data="reportDetailApp('{{ report_id }}')" x-cloak>
+<div class="space-y-6" x-data="reportDetailApp" data-report-detail-page data-report-id="{{ report_id }}" x-cloak>
     <nav class="text-sm text-[#5f5c78]">
         <ol class="flex items-center space-x-2">
             <li><a href="/" class="font-semibold hover:text-[#2f9da5]">Dashboard</a></li>

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -11,7 +11,7 @@
 {% block content %}
 <div
     data-settings-page
-    x-data="settingsApp()"
+    x-data="settingsApp"
     class="space-y-6 py-4"
 >
 

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -214,17 +214,17 @@
                                     </template>
                                 </select>
                                 <div class="text-xs text-[#5f5c78]">
-                                    <p x-text="selectedCloudflareOAuthProfile()?.description || 'Choose how much Cloudflare access DMARQ should request.'"></p>
+                                    <p x-text="selectedCloudflareOAuthDescription()"></p>
                                     <p class="mt-1">
                                         Request scopes:
-                                        <span class="font-mono" x-text="selectedCloudflareOAuthProfile()?.scopes || 'zone.read dns.read'"></span>
+                                        <span class="font-mono" x-text="selectedCloudflareOAuthScopes()"></span>
                                     </p>
                                     <p class="mt-1" x-show="selectedCloudflareOAuthPermissions().length">
                                         Cloudflare client permissions:
                                         <span x-text="selectedCloudflareOAuthPermissions().join(', ')"></span>
                                     </p>
-                                    <p class="mt-1 text-warning" x-show="selectedCloudflareOAuthProfile()?.warning"
-                                        x-text="selectedCloudflareOAuthProfile()?.warning"></p>
+                                    <p class="mt-1 text-warning" x-show="selectedCloudflareOAuthHasWarning()"
+                                        x-text="selectedCloudflareOAuthWarning()"></p>
                                 </div>
                             </div>
                             <p class="mt-1 text-xs text-[#5f5c78]" x-show="cfOAuthStatus.scopes">
@@ -337,14 +337,14 @@
                     </div>
                     <template x-if="dnsProviderImportError">
                         <div class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-                            <p class="font-semibold" x-text="`${selectedDnsProviderName()} discovery needs attention`"></p>
+                            <p class="font-semibold" x-text="dnsProviderImportErrorTitle()"></p>
                             <p class="mt-1" x-text="dnsProviderImportError"></p>
                             <p class="mt-1 text-xs" x-show="selectedDnsProviderSetupHint()" x-text="selectedDnsProviderSetupHint()"></p>
                         </div>
                     </template>
                     <template x-if="dnsProviderImportSummary && !dnsProviderImportError && importableDnsProviderZoneCount() === 0">
                         <div class="rounded-md border border-border bg-base-100 px-3 py-3 text-sm text-base-content/70">
-                            <p class="font-semibold text-base-content" x-text="`${selectedDnsProviderName()} returned no importable zones`"></p>
+                            <p class="font-semibold text-base-content" x-text="dnsProviderNoImportableZonesTitle()"></p>
                             <p class="mt-1" x-text="dnsProviderImportSummary"></p>
                             <p class="mt-1 text-xs" x-show="selectedDnsProviderSetupHint()" x-text="selectedDnsProviderSetupHint()"></p>
                         </div>
@@ -667,7 +667,7 @@
 
                     <template x-if="alertPreview !== null">
                         <div class="alert" :class="alertPreview > 0 ? 'alert-warning' : 'alert-success'">
-                            <span x-text="alertPreview > 0 ? `${alertPreview} active alert${alertPreview === 1 ? '' : 's'} found.` : 'No active alerts found.'"></span>
+                            <span x-text="alertPreviewLabel()"></span>
                         </div>
                     </template>
                 </div>
@@ -728,7 +728,7 @@
 
                     <template x-if="summaryPreview">
                         <div class="alert alert-info">
-                            <span x-text="`${summaryPreview.total_messages} messages, ${summaryPreview.reports_processed} reports, ${summaryPreview.alerts.length} active alerts.`"></span>
+                            <span x-text="summaryPreviewLabel()"></span>
                         </div>
                     </template>
                 </div>
@@ -803,7 +803,7 @@
                                 <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                                     <div>
                                         <div class="text-sm font-semibold" x-text="item.key"></div>
-                                        <div class="text-sm text-muted-foreground" x-text="`${item.old_value || '(empty)'} -> ${item.new_value || '(empty)'}`"></div>
+                                        <div class="text-sm text-muted-foreground" x-text="configAuditValueLabel(item)"></div>
                                     </div>
                                     <div class="text-xs text-muted-foreground" x-text="new Date(item.changed_at).toLocaleString()"></div>
                                 </div>
@@ -1073,14 +1073,14 @@
                     </div>
                     <div class="form-control w-full">
                         <label class="label"><span class="label-text font-medium">Model</span></label>
-                        <template x-if="aiModels.length">
+                        <template x-if="hasAIModels()">
                             <select x-model="s['ai.model']" class="input input-bordered w-full">
                                 <template x-for="model in aiModels" :key="model">
                                     <option :value="model" x-text="model"></option>
                                 </template>
                             </select>
                         </template>
-                        <template x-if="!aiModels.length">
+                        <template x-if="!hasAIModels()">
                             <input type="text" x-model="s['ai.model']" class="input input-bordered w-full" placeholder="Optional model name" />
                         </template>
                     </div>
@@ -1124,12 +1124,12 @@
                 <div class="rounded-lg border border-border p-3" x-show="aiConnectionResult">
                     <div class="flex items-start justify-between gap-3">
                         <div>
-                            <p class="text-sm font-medium" x-text="aiConnectionResult?.success ? 'Connection OK' : 'Connection failed'"></p>
-                            <p class="text-sm text-muted-foreground" x-text="aiConnectionResult?.message"></p>
+                            <p class="text-sm font-medium" x-text="aiConnectionStatusLabel()"></p>
+                            <p class="text-sm text-muted-foreground" x-text="aiConnectionMessage()"></p>
                         </div>
-                        <span class="badge" :class="aiConnectionResult?.success ? 'badge-success' : 'badge-error'" x-text="aiConnectionResult?.provider || 'AI'"></span>
+                        <span class="badge" :class="aiConnectionBadgeClass()" x-text="aiConnectionProviderLabel()"></span>
                     </div>
-                    <p class="mt-2 text-xs text-muted-foreground" x-show="aiModels.length" x-text="`${aiModels.length} model${aiModels.length === 1 ? '' : 's'} discovered.`"></p>
+                    <p class="mt-2 text-xs text-muted-foreground" x-show="hasAIModels()" x-text="aiModelsDiscoveredLabel()"></p>
                 </div>
                 <div class="form-control">
                     <label class="label cursor-pointer justify-start gap-3">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1251,8 +1251,8 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert 'x-effect="$el.style.width' not in template
     assert "invoice_delivery_label" in template
     assert 'x-text="membership.user.email"' in template
-    assert "@click=" not in template
-    assert "@change=" not in template
+    assert "@click" not in template
+    assert "@change" not in template
     assert "@submit" not in template
     assert "data-members-page" in template
     assert "data-members-scope" in template
@@ -1296,6 +1296,7 @@ def test_base_template_propagates_selected_workspace_context():
     assert "data-multi-workspace-ui" in template
     assert 'x-data="userMenu"' in template
     assert "userMenu({" not in template
+    assert "Alpine.data('userMenu', userMenu)" in script
     assert "multiWorkspaceUiEnabled" in script
     assert "/api/v1/workspaces" in script
     assert "dmarq.selectedWorkspaceId" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -623,11 +623,24 @@ def test_forensic_report_detail_uses_external_page_script_for_csp_migration():
     script = _forensic_report_detail_script()
 
     assert 'src="/static/js/forensic-report-detail-page.js"' in template
-    assert "forensicReportDetailApp" in template
+    assert 'x-data="forensicReportDetailApp"' in template
+    assert "forensicReportDetailApp(" not in template
+    assert "Alpine.data('forensicReportDetailApp', forensicReportDetailApp)" in script
     assert "/api/v1/forensics/${this.reportId}" in script
     assert "Forensic report not found" in script
     assert "feedbackHeaderEntries" in script
+    assert "showReport" in template
+    assert "showError" in template
+    assert "domainUrl" in template
+    assert "priorityBadgeClass" in template
+    assert "authenticationResultsLabel" in template
+    assert "hasNoFeedbackHeaderEntries" in template
+    assert "report.domain || report.reported_domain" not in template
+    assert "report.analysis?." not in template
+    assert "encodeURIComponent" not in template
+    assert "feedbackHeaderEntries.length === 0" not in template
     assert "data-forensic-report-detail-page" in template
+    assert "data-report-id" in template
     assert 'x-init="init()"' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -685,9 +685,15 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "refresh_reputation=true" in script
     assert "reputationRefreshing" in template
     assert "reputationRefreshError" in template
-    assert "if (!refreshReputation) {\n                        this.reputationRefreshError = '';" in script
+    assert (
+        "if (!refreshReputation) {\n                        this.reputationRefreshError = '';"
+        in script
+    )
     assert "Reputation refresh timed out. Please try again in a moment." in script
-    assert "const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;" in script
+    assert (
+        "const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;"
+        in script
+    )
     assert "bindPageControls()" in script
     assert "event.target instanceof Element" in script
     assert "/api/v1/reports/${encodeURIComponent(this.reportId)}" in script
@@ -794,7 +800,7 @@ def test_settings_controls_are_bound_from_external_script():
     assert "@submit" not in template
     assert "@change" not in template
     assert "showAIKey = !showAIKey" not in template
-    assert 'testWebhook(hook.id)' not in template
+    assert "testWebhook(hook.id)" not in template
     assert "x-html" not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
@@ -882,7 +888,7 @@ def test_mail_sources_form_actions_are_bound_from_external_script():
     assert 'x-on:click="showPassword = !showPassword"' not in template
     assert 'x-on:change="applyM365FolderSelection($event.target.value)"' not in template
     assert 'x-on:click="loadM365Folders()"' not in template
-    assert 'x-on:input="form.m365_folder_id = \'\'"' not in template
+    assert "x-on:input=\"form.m365_folder_id = ''\"" not in template
     assert 'x-on:click="testAdHoc()"' not in template
     assert 'x-on:click="connectGmail()"' not in template
     assert 'x-on:click="connectM365()"' not in template
@@ -958,11 +964,11 @@ def test_domain_details_exposes_migration_readiness_without_html_injection():
     assert "I am migrating data" in template
     assert "data-domain-detail-migration-action" in template
     assert "handleMigrationAction" in script
-    assert "@click=\"enableMigrationTools()\"" not in template
+    assert '@click="enableMigrationTools()"' not in template
     assert '@click="previewMigrationImport"' not in template
-    assert "@click=\"loadMigrationImportSample\"" not in template
-    assert "@click=\"applyMigrationPreviewBaseline\"" not in template
-    assert "@click=\"compareMigrationBaseline\"" not in template
+    assert '@click="loadMigrationImportSample"' not in template
+    assert '@click="applyMigrationPreviewBaseline"' not in template
+    assert '@click="compareMigrationBaseline"' not in template
     assert "x-html" not in template
 
 
@@ -1112,11 +1118,11 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert 'colspan="9"' in template
     assert "x-effect=\"$el.style.height = point.height + '%'" not in template
     assert 'aria-label="Recent sending volume"' in template
-    assert ':viewBox="\'0 0 \' + point.width + \' 100\'"' in template
-    assert "<template x-for=\"point in sourceVolumeBars(source)\"" in template
+    assert ":viewBox=\"'0 0 ' + point.width + ' 100'\"" in template
+    assert '<template x-for="point in sourceVolumeBars(source)"' in template
     assert "point.y" in template
     assert "point.width" in template
-    assert "<svg class=\"h-8 w-full overflow-visible\"" not in template
+    assert '<svg class="h-8 w-full overflow-visible"' not in template
     assert "x-html" not in template
     assert not _has_inline_style(template)
 
@@ -1128,7 +1134,10 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "loadInitialData()" in script
     assert "async fetchWithTimeout" in script
     assert "Promise.allSettled" in script
-    assert "const response = await this.fetchWithTimeout(\n                    `/api/v1/domains/${this.domainId}/stats`" in script
+    assert (
+        "const response = await this.fetchWithTimeout(\n                    `/api/v1/domains/${this.domainId}/stats`"
+        in script
+    )
     assert "The request timed out. Reload data or try again in a moment." in script
     assert "dnsRecordsLoading" in template
     assert "Checking DMARC record..." in template
@@ -1207,9 +1216,9 @@ def test_members_template_uses_membership_api_without_html_injection():
     assert 'x-effect="$el.style.width' not in template
     assert "invoice_delivery_label" in template
     assert 'x-text="membership.user.email"' in template
-    assert '@click=' not in template
-    assert '@change=' not in template
-    assert '@submit' not in template
+    assert "@click=" not in template
+    assert "@change=" not in template
+    assert "@submit" not in template
     assert "data-members-page" in template
     assert "data-members-scope" in template
     assert "data-members-invite-form" in template
@@ -1250,14 +1259,19 @@ def test_base_template_propagates_selected_workspace_context():
 
     assert 'src="/static/js/base-layout.js"' in template
     assert "data-multi-workspace-ui" in template
-    assert "multiWorkspaceUiEnabled" in template
+    assert 'x-data="userMenu"' in template
+    assert "userMenu({" not in template
+    assert "multiWorkspaceUiEnabled" in script
     assert "/api/v1/workspaces" in script
     assert "dmarq.selectedWorkspaceId" in script
     assert "X-DMARQ-Workspace-ID" in script
     assert "withoutWorkspaceContext(input, init)" in script
     assert "headers.delete(workspaceHeaderName)" in script
     assert "dmarq:workspace-changed" in script
-    assert "workspaces.length > 1" in template
+    assert "workspaces.length > 1" not in template
+    assert "showWorkspaceSwitcher" in template
+    assert "normalizeUser" in script
+    assert "normalizeWorkspace" in script
     assert "localStorage.removeItem('dmarq.selectedWorkspaceId')" in script
     assert "input instanceof URL" in script
     assert 'x-init="loadUser()"' not in template
@@ -1266,6 +1280,10 @@ def test_base_template_propagates_selected_workspace_context():
     assert "data-workspace-switcher" in template
     assert "bindControls()" in script
     assert "data-workspace-switcher" in script
+    assert "user.full_name || user.email" not in template
+    assert "(user.full_name || user.email || '?')[0].toUpperCase()" not in template
+    assert ':disabled="!workspace.active"' not in template
+    assert ':disabled="workspace.disabled"' in template
     assert "onclick=" not in template
     assert "data-release-modal-trigger" in template
     assert 'href="/static/css/app.css"' in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -359,6 +359,9 @@ def test_alert_component_uses_external_close_control_for_csp_migration():
     script = _read_project_file("static", "js", "pages.js")
 
     assert 'x-on:click="close()"' not in template
+    assert 'x-data="alertComponent"' in template
+    assert "alertComponent()" not in template
+    assert "Alpine.data('alertComponent'" in script
     assert "data-alert-close" in template
     assert "data-alert-close" in script
     assert "bindControls()" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -230,10 +230,15 @@ def test_settings_cloudflare_oauth_uses_popup_with_full_window_fallback():
 
     assert "Request scopes:" in template
     assert "Cloudflare client permissions:" in template
-    assert "selectedCloudflareOAuthProfile()" in template
+    assert "selectedCloudflareOAuthDescription()" in template
+    assert "selectedCloudflareOAuthScopes()" in template
+    assert "selectedCloudflareOAuthHasWarning()" in template
     assert "selectedCloudflareOAuthPermissions()" in template
     assert "selectedCloudflareOAuthProfile()" in script
     assert "selectedCloudflareOAuthPermissions()" in script
+    assert "selectedCloudflareOAuthDescription()" in script
+    assert "selectedCloudflareOAuthScopes()" in script
+    assert "selectedCloudflareOAuthHasWarning()" in script
     assert "Requesting Cloudflare OAuth scopes:" in script
     assert "window.open(" in script
     assert "'dmarq-cloudflare-oauth'" in script
@@ -790,8 +795,10 @@ def test_settings_exposes_provider_agnostic_dns_import_without_html_injection():
     assert "selectedDnsProviderConnectionLabel()" in template
     assert "selectedDnsProviderConnectionHint()" in template
     assert "providerErrorDetail" in script
-    assert "returned no importable zones" in template
-    assert "discovery needs attention" in template
+    assert "dnsProviderNoImportableZonesTitle()" in template
+    assert "dnsProviderImportErrorTitle()" in template
+    assert "returned no importable zones" in script
+    assert "discovery needs attention" in script
     assert "Provider setup docs" in template
     assert "/api/v1/domains/dns/import/${encodeURIComponent(providerId)}/preview" in script
     assert "/api/v1/domains/dns/import/${encodeURIComponent(providerId)}" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -677,7 +677,7 @@ def test_tls_reports_uses_external_page_script_for_csp_migration():
     assert 'x-text="failure.affected_domains_label"' in template
     assert 'x-text="failure.receiving_mx_hostnames_label"' in template
     assert ':href="item.domain_url"' in template
-    assert "viewBox=\"0 0 100 6\"" in template
+    assert 'viewBox="0 0 100 6"' in template
     assert not _has_inline_style(template)
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
@@ -1346,13 +1346,17 @@ def test_onboarding_template_uses_single_user_setup_story_by_default():
     assert "Connect Gmail or IMAP" in rendered
     assert "Apply setup" in rendered
     assert "One monitored domain with DMARC report and DNS setup tasks." in rendered
-    assert "multiWorkspaceUiEnabled: false" in rendered
+    assert 'data-multi-workspace-ui="false"' in rendered
     assert 'src="/static/js/onboarding-page.js"' in template
     assert "data-onboarding-page" in template
+    assert 'x-data="workspaceOnboarding"' in template
+    assert "workspaceOnboarding({" not in template
+    assert "Alpine.data('workspaceOnboarding', workspaceOnboarding)" in script
     assert "/api/v1/onboarding/preview" in script
     assert "/api/v1/onboarding/apply" in script
     assert "draftFields()" in script
     assert "normalizeDomain(value)" in script
+    assert "normalizeTasks(tasks)" in script
     assert "dmarq.selectedWorkspaceId" in script
     assert "bindControls()" in script
     assert "data-onboarding-preview" in template
@@ -1364,6 +1368,14 @@ def test_onboarding_template_uses_single_user_setup_story_by_default():
     assert '@click="previewPlan"' not in template
     assert '@click="applyPlan"' not in template
     assert '@click="form.mailSourcePath = ' not in template
+    assert "result?.workspace" not in template
+    assert "form.mailSourcePath ===" not in template
+    assert "tasks.length ?" not in template
+    assert "!tasks.length" not in template
+    assert "task.href || '#'" not in template
+    assert "showWorkspaceSwitchSuccess" in template
+    assert "taskPreviewLabel" in template
+    assert "showNoTasks" in template
     assert 'x-init="init()"' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
     assert "Account boundary" not in rendered
@@ -1379,7 +1391,7 @@ def test_onboarding_template_keeps_workspace_story_for_multi_workspace_mode():
     assert "Create workspace" in rendered
     assert "Organization and workspace" in rendered
     assert "Starter plan entitlement records" in rendered
-    assert "multiWorkspaceUiEnabled: true" in rendered
+    assert 'data-multi-workspace-ui="true"' in rendered
 
 
 def test_dashboard_hides_multi_user_demo_mode_controls():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -303,6 +303,9 @@ def test_dashboard_uses_external_page_script_for_csp_migration():
 
     assert 'src="/static/js/chart.umd.min.js"' in template
     assert 'src="/static/js/dashboard-page.js"' in template
+    assert 'x-data="dashboardApp"' in template
+    assert "dashboardApp()" not in template
+    assert "Alpine.data('dashboardApp', dashboardApp)" in script
     assert "cdn.tailwindcss.com" not in template
     assert "enforcement-gauge-bg" in template
     assert ".enforcement-gauge-bg" in styles
@@ -715,7 +718,11 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "/api/v1/reports/${encodeURIComponent(this.reportId)}" in script
     assert "deleteReport(domain, reportId)" in script
     assert "sourceLocation(record)" in script
-    assert 'x-data="reportDetailApp' in template
+    assert 'x-data="reportDetailApp"' in template
+    assert "reportDetailApp(" not in template
+    assert "Alpine.data('reportDetailApp', reportDetailApp)" in script
+    assert "data-report-detail-page" in template
+    assert "data-report-id" in template
     assert "x-cloak" in template
     assert '@click="fetchReport()"' not in template
     assert "this.loading = true;" in script
@@ -734,6 +741,9 @@ def test_settings_exposes_provider_agnostic_dns_import_without_html_injection():
     script = _settings_script()
 
     assert "data-settings-page" in template
+    assert 'x-data="settingsApp"' in template
+    assert "settingsApp()" not in template
+    assert "Alpine.data('settingsApp', settingsApp)" in script
     assert "DNS Provider Connectors" in template
     assert 'id="provider-integrations"' in template
     assert "Provider Domain Discovery" in template
@@ -827,6 +837,9 @@ def test_mail_sources_list_actions_are_bound_from_external_script():
 
     assert _has_script_src(template, "/static/js/mail-sources-page.js")
     assert "data-mail-sources-page" in template
+    assert 'x-data="mailSourcesApp"' in template
+    assert "mailSourcesApp()" not in template
+    assert "Alpine.data('mailSourcesApp', mailSourcesApp)" in script
     assert "data-mail-source-add" in template
     assert "data-mail-source-toggle" in template
     assert "data-mail-source-edit" in template
@@ -922,6 +935,10 @@ def test_domain_details_exposes_health_history_without_html_injection():
     assert "/posture/history?capture_current=false" in script
     assert "/posture/evidence/export?capture_current=false" in script
     assert "encodeURIComponent(this.domainId)" in script
+    assert 'x-data="domainDetailsApp"' in template
+    assert "domainDetailsApp(" not in template
+    assert "Alpine.data('domainDetailsApp', domainDetailsApp)" in script
+    assert "data-domain-id" in template
     assert "health-score-chart" in template
     assert "x-html" not in template
     assert _has_script_src(template, "/static/js/domain-details-page.js")
@@ -1216,7 +1233,9 @@ def test_members_template_uses_membership_api_without_html_injection():
     script = (Path(__file__).resolve().parents[1] / "static" / "js" / "members-page.js").read_text()
 
     assert _has_script_src(template, "/static/js/members-page.js")
-    assert "membershipApp()" in template
+    assert 'x-data="membershipApp"' in template
+    assert "membershipApp()" not in template
+    assert "Alpine.data('membershipApp', membershipApp)" in script
     assert 'x-init="init()"' not in template
     assert "/api/v1/organizations" in script
     assert "/api/v1/memberships/organizations/" in script

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -584,7 +584,8 @@ def test_mail_sources_template_exposes_backfill_progress_controls():
     ).read_text()
 
     assert 'src="/static/js/mail-sources-page.js"' in template
-    assert "mailSourcesApp()" in template
+    assert 'x-data="mailSourcesApp"' in template
+    assert "mailSourcesApp()" not in template
     assert "data-backfill-progress" in template
     assert "status_summary" in template
     assert "progress_percent" in script

--- a/backend/app/tests/test_security.py
+++ b/backend/app/tests/test_security.py
@@ -141,9 +141,7 @@ class TestSecurityHeaders:
 
         assert "'unsafe-eval'" in csp
         script_src = next(
-            part.strip()
-            for part in csp.split(";")
-            if part.strip().startswith("script-src ")
+            part.strip() for part in csp.split(";") if part.strip().startswith("script-src ")
         )
         assert "'unsafe-inline'" not in script_src
         assert script_src == "script-src 'self' 'unsafe-eval'"

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -182,7 +182,10 @@ class TestSetupPage:
         assert response.status_code == 200
         assert "Mail health setup" in response.text
         assert "Apply setup" in response.text
-        assert "workspaceOnboarding({" in response.text
+        assert 'x-data="workspaceOnboarding"' in response.text
+        assert "workspaceOnboarding({" not in response.text
+        assert 'data-multi-workspace-ui="false"' in response.text
+        assert "data-onboarding-page" in response.text
         assert 'src="/static/js/onboarding-page.js"' in response.text
 
 


### PR DESCRIPTION
## What changed
- Registers remaining Alpine page root factories through external scripts instead of calling factories from templates.
- Moves domain/report/forensic/onboarding IDs into data attributes so strict CSP does not need inline Alpine function calls.
- Normalizes base layout, alert, onboarding, forensic detail, domain detail, report detail, dashboard, settings, members, and mail source roots.
- Extends template security guards so x-data factory calls do not return.

## Why
This is a bounded #598 hardening slice. It removes the remaining template-level x-data function calls while keeping the broader strict-CSP default flip separate.

## Validation
- pytest -q backend/app/tests/test_dashboard_template_security.py
- black --check / isort --check-only for the touched test file
- node --check for touched page scripts
- git diff --check
- Playwright smokes for dashboard, onboarding, and domain detail flows

Refs #598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated page components to load more reliably across screens, including dashboard, settings, mail sources, members, reports, and onboarding.
  * Improved account and workspace display with clearer sign-in, workspace switching, avatar, and email indicators.
  * Enhanced onboarding and report detail views with richer labels, task previews, and clearer fallback text.

* **Bug Fixes**
  * Fixed missing data handling so pages show sensible defaults when some details are unavailable.
  * Reduced page initialization errors in non-browser environments.

* **Tests**
  * Expanded template coverage for updated page wiring and state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->