### PR TITLE
fix: harden sender PTR enrichment

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -6371,15 +6371,25 @@ def _ptr_lookup_providers(provider: Any) -> List[Any]:
 async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Optional[str]:
     """Perform a PTR lookup for *ip*, returning ``None`` on any error or timeout."""
     try:
-        ipaddress.ip_address(ip)  # validate before making a DNS query
+        parsed_ip = ipaddress.ip_address(ip)  # validate before making a DNS query
     except ValueError:
+        return None
+    if not parsed_ip.is_global:
         return None
     for candidate in _ptr_lookup_providers(provider):
         try:
             hostname = await asyncio.wait_for(candidate.lookup_ptr(ip), timeout=timeout)
         except asyncio.CancelledError:
             raise
-        except Exception:
+        except Exception as exc:
+            logger.debug(
+                "PTR lookup provider failed during sender enrichment",
+                extra={
+                    "provider": candidate.__class__.__name__,
+                    "ip": ip,
+                    "error": str(exc),
+                },
+            )
             continue
         if hostname:
             return str(hostname).rstrip(".")

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -6377,6 +6377,8 @@ async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Opti
     for candidate in _ptr_lookup_providers(provider):
         try:
             hostname = await asyncio.wait_for(candidate.lookup_ptr(ip), timeout=timeout)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             continue
         if hostname:

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -70,7 +70,9 @@ from app.services.dns_provider_writes import (
     simulate_demo_dns_write,
 )
 from app.services.dns_resolver import (
+    CloudflareDNSProvider,
     DomainDNSResult,
+    PublicRecursiveDNSProvider,
     extract_dmarc_policy,
     get_default_provider,
 )
@@ -6352,16 +6354,34 @@ def _reputation_recommendations(item: Optional[SourceReputation]) -> List[Source
     ]
 
 
+def _ptr_lookup_providers(provider: Any) -> List[Any]:
+    """Return resolver candidates for reverse-DNS sender enrichment."""
+    providers = [provider]
+    provider_class = provider.__class__
+    provider_name = provider_class.__name__
+    if provider_name == "DemoDNSProvider":
+        return providers
+    if provider_class is not PublicRecursiveDNSProvider:
+        providers.append(PublicRecursiveDNSProvider())
+    if provider_class is not CloudflareDNSProvider:
+        providers.append(CloudflareDNSProvider())
+    return providers
+
+
 async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Optional[str]:
     """Perform a PTR lookup for *ip*, returning ``None`` on any error or timeout."""
     try:
         ipaddress.ip_address(ip)  # validate before making a DNS query
     except ValueError:
         return None
-    try:
-        return await asyncio.wait_for(provider.lookup_ptr(ip), timeout=timeout)
-    except Exception:
-        return None
+    for candidate in _ptr_lookup_providers(provider):
+        try:
+            hostname = await asyncio.wait_for(candidate.lookup_ptr(ip), timeout=timeout)
+        except Exception:
+            continue
+        if hostname:
+            return str(hostname).rstrip(".")
+    return None
 
 
 async def _source_networks_by_ip(
@@ -6453,13 +6473,6 @@ async def get_domain_sources(
 
     sources = store.get_domain_sources(domain_name, days=days)
     reports = store.get_domain_reports(domain_name)
-    intelligence = build_source_intelligence(
-        domain_name,
-        reports,
-        sources,
-        period_days=days,
-    )
-    anomalies_by_ip = intelligence.get("anomalies_by_ip", {})
     provider = get_default_provider(db)
     settings = get_settings()
 
@@ -6467,6 +6480,21 @@ async def get_domain_sources(
     ptr_task = asyncio.gather(*[_safe_ptr_lookup(provider, ip) for ip in ips])
     network_task = asyncio.create_task(_source_networks_by_ip(db, provider, ips, settings))
     hostnames, networks_by_ip = await asyncio.gather(ptr_task, network_task)
+    geo_by_ip = {
+        str(source.get("source_ip") or "unknown"): merge_network_into_geo(
+            source_geo_for(str(source.get("source_ip") or "unknown"), source),
+            networks_by_ip.get(str(source.get("source_ip") or "unknown")),
+        )
+        for source in sources
+    }
+    intelligence = build_source_intelligence(
+        domain_name,
+        reports,
+        sources,
+        period_days=days,
+        geo_by_ip=geo_by_ip,
+    )
+    anomalies_by_ip = intelligence.get("anomalies_by_ip", {})
 
     source_entries = []
     sender_by_ip: Dict[str, Dict[str, Any]] = {}
@@ -6524,7 +6552,13 @@ async def get_domain_sources(
                 hostname=hostname,
                 sender=SenderIdentity(**sender),
                 geo=SourceGeo(
-                    **merge_network_into_geo(source_geo_for(ip, source), networks_by_ip.get(ip))
+                    **(
+                        geo_by_ip.get(ip)
+                        or merge_network_into_geo(
+                            source_geo_for(ip, source),
+                            networks_by_ip.get(ip),
+                        )
+                    )
                 ),
                 anomalies=[SourceAnomaly(**anomaly) for anomaly in source_anomalies],
                 reputation=(
@@ -6600,11 +6634,23 @@ async def get_domain_source_intelligence(
     domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
     sources = store.get_domain_sources(domain_name, days=days)
+    provider = get_default_provider(db)
+    settings = get_settings()
+    ips = [str(source.get("source_ip") or "unknown") for source in sources]
+    networks_by_ip = await _source_networks_by_ip(db, provider, ips, settings)
+    geo_by_ip = {
+        str(source.get("source_ip") or "unknown"): merge_network_into_geo(
+            source_geo_for(str(source.get("source_ip") or "unknown"), source),
+            networks_by_ip.get(str(source.get("source_ip") or "unknown")),
+        )
+        for source in sources
+    }
     intelligence = build_source_intelligence(
         domain_name,
         store.get_domain_reports(domain_name),
         sources,
         period_days=days,
+        geo_by_ip=geo_by_ip,
     )
     return SourceIntelligenceResponse(
         domain=intelligence["domain"],

--- a/backend/app/services/sender_intelligence.py
+++ b/backend/app/services/sender_intelligence.py
@@ -434,11 +434,24 @@ def _add_rollup(target: Dict[str, Dict[str, Any]], record: Dict[str, Any]) -> No
     item["regions"].add(item["geo"]["region"])
 
 
-def _summarize_regions(sources: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _geo_for_source(
+    ip: str,
+    source: Dict[str, Any],
+    geo_by_ip: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    if geo_by_ip and ip in geo_by_ip:
+        return geo_by_ip[ip]
+    return source_geo_for(ip, source)
+
+
+def _summarize_regions(
+    sources: Iterable[Dict[str, Any]],
+    geo_by_ip: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
     regions: Dict[str, Dict[str, Any]] = {}
     for source in sources:
         ip = str(source.get("source_ip") or source.get("ip") or "unknown")
-        geo = source_geo_for(ip, source)
+        geo = _geo_for_source(ip, source, geo_by_ip)
         key = geo["region"]
         item = regions.setdefault(
             key,
@@ -595,6 +608,7 @@ def build_source_intelligence(
     sources: Iterable[Dict[str, Any]],
     *,
     period_days: int = 30,
+    geo_by_ip: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Build region summaries and anomaly hints for one domain."""
     source_rows = list(sources)
@@ -632,7 +646,7 @@ def build_source_intelligence(
         else:
             _add_rollup(baseline, row)
 
-    regions = _summarize_regions(source_rows)
+    regions = _summarize_regions(source_rows, geo_by_ip)
     baseline_regions = {
         region
         for item in baseline.values()
@@ -705,10 +719,10 @@ def _profile_score(
     # Authentication domains and DKIM selectors describe how the message passed
     # authentication, not necessarily which infrastructure originated it. A
     # forwarder can preserve a provider DKIM signature while sending from Yahoo,
-    # Microsoft, or self-hosted infrastructure. When PTR exists and does not
-    # match the provider, keep auth-domain/selector matches as weak context only
-    # so they cannot rename the sending host by themselves.
-    allow_auth_evidence = not host_values or bool(host_matches) or bool(extension_matches)
+    # Microsoft, or self-hosted infrastructure. Keep auth-domain/selector
+    # matches as context unless PTR or explicit report metadata already ties the
+    # source to the provider.
+    allow_auth_evidence = bool(host_matches) or bool(extension_matches)
 
     domain_matches = _contains_any(domain_values, profile.domain_tokens)
     if domain_matches and allow_auth_evidence:

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2519,6 +2519,7 @@ def test_report_selector_map_handles_empty_and_malformed_details(db_session):
 # ---------------------------------------------------------------------------
 
 # A failing-source report used for sources tests
+FAILING_SOURCE_IP = "104.245.209.200"
 FAILING_SOURCE_REPORT = {
     "domain": DOMAIN,
     "report_id": "fail-src-001",
@@ -2526,7 +2527,7 @@ FAILING_SOURCE_REPORT = {
     "policy": {"p": "reject", "sp": "", "pct": "100"},
     "records": [
         {
-            "source_ip": "10.0.0.1",
+            "source_ip": FAILING_SOURCE_IP,
             "count": 3,
             "disposition": "reject",
             "dkim_result": "fail",
@@ -2561,7 +2562,7 @@ def test_sources_endpoint_includes_hostname(authed_client: TestClient):
     assert response.status_code == 200
     sources = response.json()["sources"]
     # Find the failing source
-    failing = next((s for s in sources if s["ip"] == "10.0.0.1"), None)
+    failing = next((s for s in sources if s["ip"] == FAILING_SOURCE_IP), None)
     assert failing is not None
     assert failing["hostname"] == "mail.example.com"
 
@@ -2590,7 +2591,7 @@ def test_sources_endpoint_omits_spf_fix_hint_for_unknown_failing_ip(
 
     assert response.status_code == 200
     sources = response.json()["sources"]
-    failing = next((s for s in sources if s["ip"] == "10.0.0.1"), None)
+    failing = next((s for s in sources if s["ip"] == FAILING_SOURCE_IP), None)
     assert failing is not None
     assert failing["spf_fix_hint"] is None
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2784,7 +2784,7 @@ def test_source_recommendations_do_not_suggest_raw_spf_ip_for_unknown_forwarder(
 
 
 @pytest.mark.asyncio
-async def test_safe_ptr_lookup_skips_invalid_ips():
+async def test_safe_ptr_lookup_skips_invalid_ips(monkeypatch: pytest.MonkeyPatch):
     """PTR lookup refuses invalid source addresses before querying DNS."""
 
     class InvalidProvider:
@@ -2794,6 +2794,21 @@ async def test_safe_ptr_lookup_skips_invalid_ips():
     class FailingProvider:
         async def lookup_ptr(self, _ip):
             raise LookupError("no PTR")
+
+    class EmptyFallbackProvider:
+        async def lookup_ptr(self, _ip):
+            return None
+
+    monkeypatch.setattr(
+        domains_endpoint,
+        "PublicRecursiveDNSProvider",
+        lambda: EmptyFallbackProvider(),
+    )
+    monkeypatch.setattr(
+        domains_endpoint,
+        "CloudflareDNSProvider",
+        lambda: EmptyFallbackProvider(),
+    )
 
     assert (
         await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
@@ -2807,6 +2822,32 @@ async def test_safe_ptr_lookup_skips_invalid_ips():
         )
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_safe_ptr_lookup_uses_public_fallback(monkeypatch: pytest.MonkeyPatch):
+    """PTR lookup falls back when the selected deployment resolver has no answer."""
+
+    class EmptyPrimaryProvider:
+        async def lookup_ptr(self, _ip):
+            return None
+
+    class WorkingFallbackProvider:
+        async def lookup_ptr(self, ip):
+            assert ip == "104.245.209.200"
+            return "mta200a-ord.mtasv.net."
+
+    monkeypatch.setattr(
+        domains_endpoint,
+        "PublicRecursiveDNSProvider",
+        lambda: WorkingFallbackProvider(),
+    )
+
+    hostname = await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
+        EmptyPrimaryProvider(), "104.245.209.200"
+    )
+
+    assert hostname == "mta200a-ord.mtasv.net"
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2851,6 +2851,35 @@ async def test_safe_ptr_lookup_uses_public_fallback(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
+async def test_safe_ptr_lookup_propagates_cancellation(monkeypatch: pytest.MonkeyPatch):
+    """Request cancellation must not be hidden as a recoverable DNS miss."""
+
+    class CancelledProvider:
+        async def lookup_ptr(self, _ip):
+            raise asyncio.CancelledError()
+
+    class UnexpectedFallbackProvider:
+        async def lookup_ptr(self, _ip):
+            raise AssertionError("fallback should not run after cancellation")
+
+    monkeypatch.setattr(
+        domains_endpoint,
+        "PublicRecursiveDNSProvider",
+        lambda: UnexpectedFallbackProvider(),
+    )
+    monkeypatch.setattr(
+        domains_endpoint,
+        "CloudflareDNSProvider",
+        lambda: UnexpectedFallbackProvider(),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
+            CancelledProvider(), "104.245.209.200"
+        )
+
+
+@pytest.mark.asyncio
 async def test_source_networks_by_ip_handles_disabled_and_failed_enrichment(
     db_session,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2818,6 +2818,12 @@ async def test_safe_ptr_lookup_skips_invalid_ips(monkeypatch: pytest.MonkeyPatch
     )
     assert (
         await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
+            InvalidProvider(), "10.0.0.1"
+        )
+        is None
+    )
+    assert (
+        await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
             FailingProvider(), "203.0.113.7"
         )
         is None

--- a/backend/app/tests/test_sender_intelligence.py
+++ b/backend/app/tests/test_sender_intelligence.py
@@ -69,6 +69,25 @@ def test_identify_sender_does_not_treat_auth_domain_only_as_postmark():
     assert sender["status"] == "unknown"
 
 
+def test_identify_sender_does_not_treat_missing_ptr_auth_domain_as_postmark():
+    sender = identify_sender(
+        "104.245.209.200",
+        {
+            "spf_domains": ["pm.mtasv.net"],
+            "dkim_domains": ["pm.mtasv.net"],
+            "dkim_selectors": ["pm20250324"],
+            "dmarc_result": "pass",
+            "dmarc_fail_count": 0,
+        },
+        hostname=None,
+        domain="cklnet.com",
+    )
+
+    assert sender["id"] == "unknown-sender"
+    assert sender["name"] == "Unknown sender"
+    assert sender["status"] == "unknown"
+
+
 def test_identify_sender_keeps_owned_infrastructure_ahead_of_auth_domain_hint():
     sender = identify_sender(
         "2a01:4f8:c17:311b::1",
@@ -138,11 +157,16 @@ def test_identify_sender_flags_ambiguous_provider_evidence():
         "dmarc_result": "pass",
     }
 
-    sender = identify_sender("203.0.113.7", source, hostname=None, domain="example.com")
+    sender = identify_sender(
+        "203.0.113.7",
+        source,
+        hostname="relay.google.com.stripe.com",
+        domain="example.com",
+    )
 
     assert sender["id"] == "ambiguous-sender"
     assert sender["status"] == "ambiguous"
-    assert sender["confidence"] == 40
+    assert sender["confidence"] == 60
     assert "Confirm the service owner" in sender["remediation_hint"]
 
 
@@ -298,6 +322,39 @@ def test_build_source_intelligence_handles_no_data():
         "critical": 0,
         "warnings": 0,
     }
+
+
+def test_build_source_intelligence_uses_network_geo_overrides():
+    sources = [{"source_ip": "104.245.209.200", "count": 42, "dmarc_fail_count": 0}]
+
+    intelligence = build_source_intelligence(
+        "example.com",
+        [],
+        sources,
+        period_days=30,
+        geo_by_ip={
+            "104.245.209.200": {
+                "country": "United States",
+                "country_code": "US",
+                "region": "North America",
+                "asn": "AS23352",
+                "network": "SERVERCENTRAL - DEFT.COM, US",
+                "source": "team-cymru",
+            }
+        },
+    )
+
+    assert intelligence["regions"] == [
+        {
+            "region": "North America",
+            "country_codes": ["US"],
+            "message_count": 42,
+            "source_count": 1,
+            "failed_count": 0,
+            "failure_rate": 0.0,
+            "networks": ["SERVERCENTRAL - DEFT.COM, US"],
+        }
+    ]
 
 
 def test_build_source_intelligence_accepts_iso_report_dates():


### PR DESCRIPTION
## Summary
- add PTR fallback for sender-source reverse DNS so configured resolvers do not leave known public PTRs as unavailable
- make sender provider detection conservative: SPF/DKIM auth domains alone no longer label a source as Postmark or another provider
- reuse network enrichment for source-intelligence region summaries so widgets do not show Unknown while table rows have ASN/country data

## Local validation
- .venv/bin/python -m pytest backend/app/tests/test_sender_intelligence.py backend/app/tests/test_domain_detail_endpoints.py -q
- .venv/bin/python -m compileall -q backend/app/services/sender_intelligence.py backend/app/api/api_v1/endpoints/domains.py
- .venv/bin/python -m flake8 backend/app/services/sender_intelligence.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_sender_intelligence.py backend/app/tests/test_domain_detail_endpoints.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sender/source enrichment so location and network details show up more consistently in source intelligence and source views.
  * Made reverse-DNS lookup more reliable by trying additional safe fallback paths when the primary lookup does not return a result.
  * Tightened sender detection so missing PTR-based context no longer boosts confidence incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->