### PR TITLE
fix: harden DNS evidence refresh

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -120,6 +120,9 @@ class Settings(BaseSettings):
     IPGEOLOCATION_TIMEOUT_SECONDS: float = 2.0
     CLOUDFLARE_RADAR_API_TOKEN: Optional[str] = None
     CLOUDFLARE_RADAR_TIMEOUT_SECONDS: float = 2.0
+    DNS_STARTUP_PREWARM_ENABLED: bool = True
+    DNS_STARTUP_PREWARM_LIMIT: int = 50
+    DNS_STARTUP_PREWARM_CONCURRENCY: int = 4
 
     # Optional Stripe Billing integration. Self-hosted and provider-billed
     # deployments work without these values.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,7 +60,22 @@ settings = get_settings()
 
 # Global variables for background task management
 background_task = None
+dns_prewarm_task = None
 last_check_time = None
+
+
+async def _cancel_background_task(task: Optional[asyncio.Task], label: str) -> None:
+    """Cancel and await a background task so shutdown does not leave it pending."""
+    if not task:
+        return
+    if task.done():
+        return
+    logger.info("Cancelling %s background task", label)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
 
 
 def _poll_single_imap_source(source: MailSource) -> None:
@@ -492,7 +507,7 @@ def create_app() -> FastAPI:
     @application.on_event("startup")
     async def startup_event():
         """Initialize background tasks and security on application startup"""
-        global background_task  # pylint: disable=global-statement
+        global background_task, dns_prewarm_task  # pylint: disable=global-statement
 
         run_startup_checks(settings)
 
@@ -553,11 +568,15 @@ def create_app() -> FastAPI:
         logger.info("Starting IMAP polling background task")
         mark_scheduler_started()
         background_task = asyncio.create_task(scheduled_imap_polling())
-        asyncio.create_task(prewarm_dns_cache())
+        dns_prewarm_task = asyncio.create_task(prewarm_dns_cache())
 
     @application.on_event("shutdown")
     async def shutdown_event():
         """Clean up background tasks on application shutdown"""
+        global dns_prewarm_task  # pylint: disable=global-statement
+
+        await _cancel_background_task(dns_prewarm_task, "DNS prewarm")
+        dns_prewarm_task = None
         if background_task:
             logger.info("Cancelling IMAP polling background task")
             background_task.cancel()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,15 +33,16 @@ from app.middleware.demo import DemoReadOnlyMiddleware
 from app.middleware.security import SecurityHeadersMiddleware
 from app.models.domain import Domain
 from app.models.mail_source import MailSource  # noqa: F401 – ensure table is registered
+from app.services.dns_prewarm import prewarm_dns_cache
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
 from app.services.mail_service_imports import mail_service_context_from_domain
 from app.services.mail_source_backfill_worker import run_due_mail_source_backfill_jobs
 from app.services.microsoft_graph_client import MicrosoftGraphClient
+from app.services.release_info import build_release_info
 from app.services.report_persistence import hydrate_report_store_from_db
 from app.services.report_store import ReportStore
-from app.services.release_info import build_release_info
 from app.services.runtime_status import (
     mark_scheduler_cycle_started,
     mark_scheduler_error,
@@ -552,6 +553,7 @@ def create_app() -> FastAPI:
         logger.info("Starting IMAP polling background task")
         mark_scheduler_started()
         background_task = asyncio.create_task(scheduled_imap_polling())
+        asyncio.create_task(prewarm_dns_cache())
 
     @application.on_event("shutdown")
     async def shutdown_event():

--- a/backend/app/services/bimi.py
+++ b/backend/app/services/bimi.py
@@ -151,19 +151,24 @@ async def check_bimi_with_fallback(
     selector: str = "default",
 ) -> BIMIResult:
     """Resolve BIMI with public fallback if the primary resolver fails."""
-    first_result: Optional[BIMIResult] = None
-    for candidate in dns_fallback_candidates(provider):
+    normalized_selector = (selector or "default").strip().lower()
+    candidates = dns_fallback_candidates(provider)
+    if not candidates:
+        return BIMIResult(
+            selector=normalized_selector,
+            query_name=f"{normalized_selector}._bimi.{domain}",
+            errors=["BIMI DNS lookup failed for all configured resolvers."],
+        )
+
+    first_result = await check_bimi(domain, candidates[0], selector=selector)
+    if not _dns_lookup_failed(first_result):
+        return first_result
+
+    for candidate in candidates[1:]:
         result = await check_bimi(domain, candidate, selector=selector)
-        if first_result is None:
-            first_result = result
         if not _dns_lookup_failed(result):
             return result
-    normalized_selector = (selector or "default").strip().lower()
-    return first_result or BIMIResult(
-        selector=normalized_selector,
-        query_name=f"{normalized_selector}._bimi.{domain}",
-        errors=["BIMI DNS lookup failed for all configured resolvers."],
-    )
+    return first_result
 
 
 async def check_bimi_cached(

--- a/backend/app/services/bimi.py
+++ b/backend/app/services/bimi.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
 from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS
+from app.services.dns_fallbacks import dns_fallback_candidates
 from app.services.dns_resolver import BaseDNSProvider
 
 _CACHE_KEY_PREFIX = "bimi-v1"
@@ -139,6 +140,32 @@ async def check_bimi(
     return parsed
 
 
+def _dns_lookup_failed(result: BIMIResult) -> bool:
+    return any("DNS lookup failed" in error for error in result.errors)
+
+
+async def check_bimi_with_fallback(
+    domain: str,
+    provider: BaseDNSProvider,
+    *,
+    selector: str = "default",
+) -> BIMIResult:
+    """Resolve BIMI with public fallback if the primary resolver fails."""
+    first_result: Optional[BIMIResult] = None
+    for candidate in dns_fallback_candidates(provider):
+        result = await check_bimi(domain, candidate, selector=selector)
+        if first_result is None:
+            first_result = result
+        if not _dns_lookup_failed(result):
+            return result
+    normalized_selector = (selector or "default").strip().lower()
+    return first_result or BIMIResult(
+        selector=normalized_selector,
+        query_name=f"{normalized_selector}._bimi.{domain}",
+        errors=["BIMI DNS lookup failed for all configured resolvers."],
+    )
+
+
 async def check_bimi_cached(
     db: Session,
     provider: BaseDNSProvider,
@@ -165,7 +192,7 @@ async def check_bimi_cached(
     if row and not refresh and _is_fresh(row, ttl_seconds, now):
         return _result_from_json(row.result_json), True, row.checked_at
 
-    result = await check_bimi(domain, provider, selector=normalized_selector)
+    result = await check_bimi_with_fallback(domain, provider, selector=normalized_selector)
     payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
     if row is None:
         row = DNSCache(

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -14,6 +14,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
+from app.services.dns_fallbacks import dns_fallback_candidates
 from app.services.dns_provider_detection import detection_from_json
 from app.services.dns_resolver import (
     BaseDNSProvider,
@@ -245,17 +246,7 @@ DNSCandidateResult = Tuple[str, Optional[DomainDNSResult], Optional[Exception]]
 
 
 def _fallback_candidates(provider: BaseDNSProvider) -> List[BaseDNSProvider]:
-    fallback_types: List[type[BaseDNSProvider]] = [
-        PublicRecursiveDNSProvider,
-        CloudflareDNSProvider,
-    ]
-    provider_types = [provider.__class__] + [
-        fallback_type for fallback_type in fallback_types if not isinstance(provider, fallback_type)
-    ]
-    return [
-        provider if index == 0 else provider_type()
-        for index, provider_type in enumerate(provider_types)
-    ]
+    return dns_fallback_candidates(provider)
 
 
 def _normalize_dns_provider(provider: BaseDNSProvider) -> BaseDNSProvider:

--- a/backend/app/services/dns_fallbacks.py
+++ b/backend/app/services/dns_fallbacks.py
@@ -7,6 +7,7 @@ from typing import List
 from app.services.dns_resolver import (
     BaseDNSProvider,
     CloudflareDNSProvider,
+    DemoDNSProvider,
     PublicRecursiveDNSProvider,
 )
 
@@ -19,10 +20,10 @@ def dns_fallback_candidates(provider: BaseDNSProvider) -> List[BaseDNSProvider]:
     when that resolver is missing or slow and public DNS has a clear answer.
     """
     candidates: List[BaseDNSProvider] = [provider]
-    if provider.__class__.__name__ == "DemoDNSProvider":
+    if isinstance(provider, DemoDNSProvider):
         return candidates
-    if provider.__class__ is not PublicRecursiveDNSProvider:
+    if not isinstance(provider, PublicRecursiveDNSProvider):
         candidates.append(PublicRecursiveDNSProvider())
-    if provider.__class__ is not CloudflareDNSProvider:
+    if not isinstance(provider, CloudflareDNSProvider):
         candidates.append(CloudflareDNSProvider())
     return candidates

--- a/backend/app/services/dns_fallbacks.py
+++ b/backend/app/services/dns_fallbacks.py
@@ -1,0 +1,28 @@
+"""Shared DNS resolver fallback helpers."""
+
+from __future__ import annotations
+
+from typing import List
+
+from app.services.dns_resolver import (
+    BaseDNSProvider,
+    CloudflareDNSProvider,
+    PublicRecursiveDNSProvider,
+)
+
+
+def dns_fallback_candidates(provider: BaseDNSProvider) -> List[BaseDNSProvider]:
+    """Return primary plus independent public fallback resolvers.
+
+    Deployment-specific resolvers such as Akamai ETP can be useful as the
+    primary view, but read-only DNS evidence should not degrade to "unknown"
+    when that resolver is missing or slow and public DNS has a clear answer.
+    """
+    candidates: List[BaseDNSProvider] = [provider]
+    if provider.__class__.__name__ == "DemoDNSProvider":
+        return candidates
+    if provider.__class__ is not PublicRecursiveDNSProvider:
+        candidates.append(PublicRecursiveDNSProvider())
+    if provider.__class__ is not CloudflareDNSProvider:
+        candidates.append(CloudflareDNSProvider())
+    return candidates

--- a/backend/app/services/dns_prewarm.py
+++ b/backend/app/services/dns_prewarm.py
@@ -20,6 +20,10 @@ def _domain_selectors(domain: Domain) -> List[str]:
     return [selector.strip() for selector in raw.split(",") if selector.strip()]
 
 
+def _canonical_domain_name(name: str) -> str:
+    return name.strip().rstrip(".").lower()
+
+
 async def _prewarm_domain(domain_id: int, domain_name: str, selectors: List[str]) -> None:
     db = SessionLocal()
     try:
@@ -64,7 +68,9 @@ async def prewarm_dns_cache() -> None:
             .all()
         )
         candidates = [
-            (domain.id, domain.name, _domain_selectors(domain)) for domain in domains if domain.name
+            (domain.id, canonical_name, _domain_selectors(domain))
+            for domain in domains
+            if domain.name and (canonical_name := _canonical_domain_name(domain.name))
         ]
     finally:
         db.close()

--- a/backend/app/services/dns_prewarm.py
+++ b/backend/app/services/dns_prewarm.py
@@ -1,0 +1,84 @@
+"""Background DNS cache prewarming for monitored domains."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import List
+
+from app.core.config import get_settings
+from app.core.database import SessionLocal
+from app.models.domain import Domain
+from app.services.dns_cache import resolve_domain_dns_cached
+from app.services.dns_resolver import get_default_provider
+
+logger = logging.getLogger(__name__)
+
+
+def _domain_selectors(domain: Domain) -> List[str]:
+    raw = domain.dkim_selectors or ""
+    return [selector.strip() for selector in raw.split(",") if selector.strip()]
+
+
+async def _prewarm_domain(domain_id: int, domain_name: str, selectors: List[str]) -> None:
+    db = SessionLocal()
+    try:
+        provider = get_default_provider(db)
+        await resolve_domain_dns_cached(
+            db,
+            provider,
+            domain_name,
+            selectors=selectors,
+            refresh=True,
+        )
+        logger.info("Prewarmed DNS cache for domain id=%s", domain_id)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.warning(
+            "DNS cache prewarm failed for domain id=%s with %s",
+            domain_id,
+            exc.__class__.__name__,
+        )
+    finally:
+        db.close()
+
+
+async def prewarm_dns_cache() -> None:
+    """Refresh DNS cache rows shortly after startup without blocking startup."""
+    settings = get_settings()
+    if not settings.DNS_STARTUP_PREWARM_ENABLED:
+        return
+
+    limit = max(0, int(settings.DNS_STARTUP_PREWARM_LIMIT or 0))
+    if limit == 0:
+        return
+
+    db = SessionLocal()
+    try:
+        domains = (
+            db.query(Domain)
+            .filter(Domain.active.is_(True))
+            .order_by(Domain.updated_at.desc(), Domain.id.asc())
+            .limit(limit)
+            .all()
+        )
+        candidates = [
+            (domain.id, domain.name, _domain_selectors(domain)) for domain in domains if domain.name
+        ]
+    finally:
+        db.close()
+
+    if not candidates:
+        return
+
+    concurrency = max(1, int(settings.DNS_STARTUP_PREWARM_CONCURRENCY or 1))
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _bounded(domain_id: int, domain_name: str, selectors: List[str]) -> None:
+        async with semaphore:
+            await _prewarm_domain(domain_id, domain_name, selectors)
+
+    logger.info("Starting DNS cache prewarm for %d domain(s)", len(candidates))
+    await asyncio.gather(*(_bounded(*candidate) for candidate in candidates))
+    logger.info("Finished DNS cache prewarm for %d domain(s)", len(candidates))

--- a/backend/app/services/mta_sts.py
+++ b/backend/app/services/mta_sts.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
 from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS
+from app.services.dns_fallbacks import dns_fallback_candidates
 from app.services.dns_resolver import BaseDNSProvider
 
 _CACHE_KEY = "mta-sts-v1"
@@ -181,6 +182,28 @@ async def check_mta_sts(domain: str, provider: BaseDNSProvider) -> MTAStsResult:
     return result
 
 
+def _dns_lookup_failed(result: MTAStsResult) -> bool:
+    return any("DNS lookup failed" in error for error in result.errors)
+
+
+async def check_mta_sts_with_fallback(
+    domain: str,
+    provider: BaseDNSProvider,
+) -> MTAStsResult:
+    """Resolve MTA-STS with public fallback if the primary resolver fails."""
+    first_result: Optional[MTAStsResult] = None
+    for candidate in dns_fallback_candidates(provider):
+        result = await check_mta_sts(domain, candidate)
+        if first_result is None:
+            first_result = result
+        if not _dns_lookup_failed(result):
+            return result
+    return first_result or MTAStsResult(
+        policy_url=f"https://mta-sts.{domain}/.well-known/mta-sts.txt",
+        errors=["MTA-STS DNS lookup failed for all configured resolvers."],
+    )
+
+
 async def check_mta_sts_cached(
     db: Session,
     provider: BaseDNSProvider,
@@ -204,7 +227,7 @@ async def check_mta_sts_cached(
     if row and not refresh and _is_fresh(row, ttl_seconds, now):
         return _result_from_json(row.result_json), True, row.checked_at
 
-    result = await check_mta_sts(domain, provider)
+    result = await check_mta_sts_with_fallback(domain, provider)
     payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
     if row is None:
         row = DNSCache(

--- a/backend/app/services/mta_sts.py
+++ b/backend/app/services/mta_sts.py
@@ -191,17 +191,22 @@ async def check_mta_sts_with_fallback(
     provider: BaseDNSProvider,
 ) -> MTAStsResult:
     """Resolve MTA-STS with public fallback if the primary resolver fails."""
-    first_result: Optional[MTAStsResult] = None
-    for candidate in dns_fallback_candidates(provider):
+    candidates = dns_fallback_candidates(provider)
+    if not candidates:
+        return MTAStsResult(
+            policy_url=f"https://mta-sts.{domain}/.well-known/mta-sts.txt",
+            errors=["MTA-STS DNS lookup failed for all configured resolvers."],
+        )
+
+    first_result = await check_mta_sts(domain, candidates[0])
+    if not _dns_lookup_failed(first_result):
+        return first_result
+
+    for candidate in candidates[1:]:
         result = await check_mta_sts(domain, candidate)
-        if first_result is None:
-            first_result = result
         if not _dns_lookup_failed(result):
             return result
-    return first_result or MTAStsResult(
-        policy_url=f"https://mta-sts.{domain}/.well-known/mta-sts.txt",
-        errors=["MTA-STS DNS lookup failed for all configured resolvers."],
-    )
+    return first_result
 
 
 async def check_mta_sts_cached(

--- a/backend/app/tests/test_bimi.py
+++ b/backend/app/tests/test_bimi.py
@@ -82,6 +82,41 @@ async def test_check_bimi_falls_back_after_dns_lookup_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_check_bimi_returns_primary_dns_failure_when_all_resolvers_fail(monkeypatch):
+    primary = AsyncMock()
+    primary.lookup_txt = AsyncMock(side_effect=LookupError("primary timed out"))
+    fallback = AsyncMock()
+    fallback.lookup_txt = AsyncMock(side_effect=LookupError("fallback timed out"))
+
+    monkeypatch.setattr(
+        "app.services.bimi.dns_fallback_candidates",
+        lambda _provider: [primary, fallback],
+    )
+
+    result = await check_bimi_with_fallback("example.com", primary)
+
+    assert result.errors == ["BIMI DNS lookup failed: primary timed out"]
+    primary.lookup_txt.assert_awaited_once()
+    fallback.lookup_txt.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_bimi_reports_empty_fallback_candidates(monkeypatch):
+    provider = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.bimi.dns_fallback_candidates",
+        lambda _provider: [],
+    )
+
+    result = await check_bimi_with_fallback("example.com", provider, selector="News")
+
+    assert result.selector == "news"
+    assert result.query_name == "news._bimi.example.com"
+    assert result.errors == ["BIMI DNS lookup failed for all configured resolvers."]
+    provider.lookup_txt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_check_bimi_cached_reuses_fresh_result(db_session):
     provider = AsyncMock()
     provider.lookup_txt = AsyncMock(return_value=["v=BIMI1; l=https://example.com/logo.svg"])

--- a/backend/app/tests/test_bimi.py
+++ b/backend/app/tests/test_bimi.py
@@ -5,7 +5,12 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from app.models.dns_cache import DNSCache
-from app.services.bimi import check_bimi, check_bimi_cached, parse_bimi_record
+from app.services.bimi import (
+    check_bimi,
+    check_bimi_cached,
+    check_bimi_with_fallback,
+    parse_bimi_record,
+)
 
 
 def test_parse_bimi_record_requires_single_bimi_record():
@@ -54,6 +59,26 @@ async def test_check_bimi_looks_up_default_selector():
     assert result.status == "pass"
     assert result.query_name == "default._bimi.example.com"
     provider.lookup_txt.assert_awaited_once_with("default._bimi.example.com")
+
+
+@pytest.mark.asyncio
+async def test_check_bimi_falls_back_after_dns_lookup_failure(monkeypatch):
+    primary = AsyncMock()
+    primary.lookup_txt = AsyncMock(side_effect=LookupError("local resolver timed out"))
+    fallback = AsyncMock()
+    fallback.lookup_txt = AsyncMock(return_value=["v=BIMI1; l=https://example.com/logo.svg"])
+
+    monkeypatch.setattr(
+        "app.services.bimi.dns_fallback_candidates",
+        lambda _provider: [primary, fallback],
+    )
+
+    result = await check_bimi_with_fallback("example.com", primary)
+
+    assert result.status == "pass"
+    assert result.logo_url == "https://example.com/logo.svg"
+    primary.lookup_txt.assert_awaited_once()
+    fallback.lookup_txt.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_fallbacks.py
+++ b/backend/app/tests/test_dns_fallbacks.py
@@ -1,0 +1,52 @@
+from app.services.dns_fallbacks import dns_fallback_candidates
+from app.services.dns_resolver import (
+    BaseDNSProvider,
+    CloudflareDNSProvider,
+    DemoDNSProvider,
+    PublicRecursiveDNSProvider,
+)
+
+
+class _CustomProvider(BaseDNSProvider):
+    async def lookup_txt(self, _name: str):
+        return []
+
+
+class _CloudflareSubclass(CloudflareDNSProvider):
+    pass
+
+
+def test_dns_fallback_candidates_keep_demo_provider_isolated():
+    provider = DemoDNSProvider()
+
+    assert dns_fallback_candidates(provider) == [provider]
+
+
+def test_dns_fallback_candidates_use_isinstance_for_public_provider():
+    provider = PublicRecursiveDNSProvider()
+
+    candidates = dns_fallback_candidates(provider)
+
+    assert candidates[0] is provider
+    assert sum(isinstance(candidate, PublicRecursiveDNSProvider) for candidate in candidates) == 1
+    assert any(isinstance(candidate, CloudflareDNSProvider) for candidate in candidates)
+
+
+def test_dns_fallback_candidates_do_not_duplicate_provider_subclasses():
+    provider = _CloudflareSubclass()
+
+    candidates = dns_fallback_candidates(provider)
+
+    assert candidates[0] is provider
+    assert sum(isinstance(candidate, CloudflareDNSProvider) for candidate in candidates) == 1
+    assert any(isinstance(candidate, PublicRecursiveDNSProvider) for candidate in candidates)
+
+
+def test_dns_fallback_candidates_add_both_public_resolvers_for_custom_provider():
+    provider = _CustomProvider()
+
+    candidates = dns_fallback_candidates(provider)
+
+    assert candidates[0] is provider
+    assert any(isinstance(candidate, PublicRecursiveDNSProvider) for candidate in candidates)
+    assert any(isinstance(candidate, CloudflareDNSProvider) for candidate in candidates)

--- a/backend/app/tests/test_dns_prewarm.py
+++ b/backend/app/tests/test_dns_prewarm.py
@@ -10,7 +10,7 @@ from app.services import dns_prewarm
 async def test_prewarm_dns_cache_refreshes_active_domains(db_session, monkeypatch):
     db_session.add(
         Domain(
-            name="example.com",
+            name=" Example.COM. ",
             active=True,
             dkim_selectors="google, mailgun",
         )
@@ -40,3 +40,21 @@ async def test_prewarm_dns_cache_refreshes_active_domains(db_session, monkeypatc
     assert domain == "example.com"
     assert resolve.await_args.kwargs["selectors"] == ["google", "mailgun"]
     assert resolve.await_args.kwargs["refresh"] is True
+
+
+def test_domain_selectors_strip_empty_entries():
+    domain = Domain(name="example.com", dkim_selectors=" google, , mailgun ,")
+
+    assert dns_prewarm._domain_selectors(domain) == [  # pylint: disable=protected-access
+        "google",
+        "mailgun",
+    ]
+
+
+def test_canonical_domain_name_normalizes_imported_values():
+    assert (
+        dns_prewarm._canonical_domain_name(  # pylint: disable=protected-access
+            " Example.COM. "
+        )
+        == "example.com"
+    )

--- a/backend/app/tests/test_dns_prewarm.py
+++ b/backend/app/tests/test_dns_prewarm.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.models.domain import Domain
+from app.services import dns_prewarm
+
+
+@pytest.mark.asyncio
+async def test_prewarm_dns_cache_refreshes_active_domains(db_session, monkeypatch):
+    db_session.add(
+        Domain(
+            name="example.com",
+            active=True,
+            dkim_selectors="google, mailgun",
+        )
+    )
+    db_session.add(Domain(name="inactive.example", active=False))
+    db_session.commit()
+    resolver = AsyncMock()
+
+    monkeypatch.setattr(
+        dns_prewarm,
+        "get_default_provider",
+        lambda _db: resolver,
+    )
+    monkeypatch.setattr(dns_prewarm, "SessionLocal", lambda: db_session)
+    resolve = AsyncMock()
+    monkeypatch.setattr(dns_prewarm, "resolve_domain_dns_cached", resolve)
+    settings = dns_prewarm.get_settings()
+    monkeypatch.setattr(settings, "DNS_STARTUP_PREWARM_ENABLED", True)
+    monkeypatch.setattr(settings, "DNS_STARTUP_PREWARM_LIMIT", 10)
+    monkeypatch.setattr(settings, "DNS_STARTUP_PREWARM_CONCURRENCY", 2)
+
+    await dns_prewarm.prewarm_dns_cache()
+
+    resolve.assert_awaited_once()
+    _, provider, domain, *args = resolve.await_args.args
+    assert provider is resolver
+    assert domain == "example.com"
+    assert resolve.await_args.kwargs["selectors"] == ["google", "mailgun"]
+    assert resolve.await_args.kwargs["refresh"] is True

--- a/backend/app/tests/test_main_polling.py
+++ b/backend/app/tests/test_main_polling.py
@@ -5,6 +5,33 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+@pytest.mark.asyncio
+async def test_cancel_background_task_cancels_pending_task():
+    from app.main import _cancel_background_task
+
+    task = asyncio.create_task(asyncio.Event().wait())
+
+    await _cancel_background_task(task, "test")
+
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_cancel_background_task_ignores_completed_task():
+    from app.main import _cancel_background_task
+
+    async def done():
+        return "finished"
+
+    task = asyncio.create_task(done())
+    await task
+
+    await _cancel_background_task(task, "test")
+
+    assert task.done()
+    assert task.result() == "finished"
+
+
 class TestNextSleepSeconds:
     def test_uses_shortest_enabled_source_interval_without_db_query(self):
         from app.main import _next_sleep_seconds

--- a/backend/app/tests/test_mta_sts.py
+++ b/backend/app/tests/test_mta_sts.py
@@ -251,6 +251,41 @@ async def test_check_mta_sts_falls_back_after_dns_lookup_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_check_mta_sts_returns_primary_dns_failure_when_all_resolvers_fail(
+    monkeypatch,
+):
+    primary = AsyncMock()
+    primary.lookup_txt = AsyncMock(side_effect=LookupError("primary timed out"))
+    fallback = AsyncMock()
+    fallback.lookup_txt = AsyncMock(side_effect=LookupError("fallback timed out"))
+
+    monkeypatch.setattr(
+        "app.services.mta_sts.dns_fallback_candidates",
+        lambda _provider: [primary, fallback],
+    )
+
+    result = await check_mta_sts_with_fallback("example.com", primary)
+
+    assert result.errors == ["MTA-STS DNS lookup failed: primary timed out"]
+    primary.lookup_txt.assert_awaited_once()
+    fallback.lookup_txt.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_mta_sts_reports_empty_fallback_candidates(monkeypatch):
+    provider = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.mta_sts.dns_fallback_candidates",
+        lambda _provider: [],
+    )
+
+    result = await check_mta_sts_with_fallback("example.com", provider)
+
+    assert result.errors == ["MTA-STS DNS lookup failed for all configured resolvers."]
+    provider.lookup_txt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_check_mta_sts_cached_refresh_updates_existing_row(db_session, monkeypatch):
     provider = AsyncMock()
     provider.lookup_txt = AsyncMock(return_value=["v=STSv1; id=20260523"])

--- a/backend/app/tests/test_mta_sts.py
+++ b/backend/app/tests/test_mta_sts.py
@@ -11,6 +11,7 @@ from app.services.mta_sts import (
     MTAStsResult,
     check_mta_sts,
     check_mta_sts_cached,
+    check_mta_sts_with_fallback,
     parse_mta_sts_policy,
     parse_mta_sts_record,
 )
@@ -228,6 +229,25 @@ async def test_check_mta_sts_reports_policy_host_resolution_error(monkeypatch):
         "Publish DNS for mta-sts.example.com and serve "
         "https://mta-sts.example.com/.well-known/mta-sts.txt over HTTPS."
     ]
+
+
+@pytest.mark.asyncio
+async def test_check_mta_sts_falls_back_after_dns_lookup_failure(monkeypatch):
+    primary = AsyncMock()
+    primary.lookup_txt = AsyncMock(side_effect=LookupError("local resolver timed out"))
+    fallback = AsyncMock()
+    fallback.lookup_txt = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(
+        "app.services.mta_sts.dns_fallback_candidates",
+        lambda _provider: [primary, fallback],
+    )
+
+    result = await check_mta_sts_with_fallback("example.com", primary)
+
+    assert result.errors == ["No _mta-sts TXT record was found."]
+    primary.lookup_txt.assert_awaited_once()
+    fallback.lookup_txt.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- share DNS fallback candidates so domain DNS, MTA-STS, and BIMI checks retry public resolvers before showing false missing evidence
- keep Kubernetes/system DNS out of domain posture decisions while preserving configured providers as primary resolvers
- prewarm active-domain DNS cache shortly after startup with bounded concurrency so first dashboard views do not start from empty DNS state

## Local validation
- /tmp/dmarq-sender-dns-fix/.venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py backend/app/tests/test_mta_sts.py backend/app/tests/test_bimi.py backend/app/tests/test_dns_prewarm.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_config.py -q
- /tmp/dmarq-sender-dns-fix/.venv/bin/python -m black --check backend/app/services/dns_fallbacks.py backend/app/services/dns_cache.py backend/app/services/mta_sts.py backend/app/services/bimi.py backend/app/services/dns_prewarm.py backend/app/core/config.py backend/app/main.py backend/app/tests/test_mta_sts.py backend/app/tests/test_bimi.py backend/app/tests/test_dns_prewarm.py
- /tmp/dmarq-sender-dns-fix/.venv/bin/python -m isort --check-only backend/app/services/dns_fallbacks.py backend/app/services/dns_cache.py backend/app/services/mta_sts.py backend/app/services/bimi.py backend/app/services/dns_prewarm.py backend/app/core/config.py backend/app/main.py backend/app/tests/test_mta_sts.py backend/app/tests/test_bimi.py backend/app/tests/test_dns_prewarm.py
- /tmp/dmarq-sender-dns-fix/.venv/bin/python -m flake8 backend/app/services/dns_fallbacks.py backend/app/services/dns_cache.py backend/app/services/mta_sts.py backend/app/services/bimi.py backend/app/services/dns_prewarm.py backend/app/core/config.py backend/app/main.py backend/app/tests/test_mta_sts.py backend/app/tests/test_bimi.py backend/app/tests/test_dns_prewarm.py