### PR TITLE
fix: address background task CodeQL comments

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -75,7 +75,7 @@ async def _cancel_background_task(task: Optional[asyncio.Task], label: str) -> N
     try:
         await task
     except asyncio.CancelledError:
-        pass
+        logger.debug("%s background task cancelled during shutdown", label)
 
 
 def _poll_single_imap_source(source: MailSource) -> None:

--- a/backend/app/tests/test_main_polling.py
+++ b/backend/app/tests/test_main_polling.py
@@ -24,12 +24,13 @@ async def test_cancel_background_task_ignores_completed_task():
         return "finished"
 
     task = asyncio.create_task(done())
-    await task
+    result = await task
 
     await _cancel_background_task(task, "test")
 
     assert task.done()
-    assert task.result() == "finished"
+    assert result == "finished"
+    assert task.result() == result
 
 
 class TestNextSleepSeconds:


### PR DESCRIPTION
## Summary
- log expected background task cancellation instead of using an empty except block
- keep the completed-task test result explicit so the awaited value is asserted

## Validation
- git diff --check
- /tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_main_polling.py::test_cancel_background_task_cancels_pending_task backend/app/tests/test_main_polling.py::test_cancel_background_task_ignores_completed_task
- /tmp/dmarq-live-audit-venv/bin/python -m flake8 backend/app/main.py backend/app/tests/test_main_polling.py