### PR TITLE
feat: summarize remediation loop on dashboard

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1716,6 +1716,10 @@ REMEDIATION_DNS_ACTION_TYPES = {
     "missing_dkim",
     "dmarc_lint",
 }
+REMEDIATION_REPUTATION_ACTION_TYPES = {
+    "source_reputation_listed",
+    "source_reputation_review",
+}
 REMEDIATION_SEVERITY_RANK = {
     "critical": 4,
     "high": 3,
@@ -1731,7 +1735,7 @@ def _remediation_loop_state(action: Dict[str, Any]) -> str:
     severity = str(action.get("severity") or "info")
     if action_type in REMEDIATION_DNS_ACTION_TYPES and severity in {"critical", "high"}:
         return "needs_approval"
-    if action_type in {"low_compliance", "source_reputation"}:
+    if action_type in {"low_compliance", *REMEDIATION_REPUTATION_ACTION_TYPES}:
         return "investigate"
     return "manual_action"
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -40,8 +40,8 @@ from app.services.cloudflare_oauth import (
     build_cloudflare_authorization_url,
     build_cloudflare_oauth_state,
     cloudflare_oauth_configured,
-    cloudflare_scopes_for_profile,
     cloudflare_scope_profile_metadata,
+    cloudflare_scopes_for_profile,
     decode_cloudflare_oauth_state,
     exchange_cloudflare_oauth_code,
     normalize_cloudflare_scope_profile,
@@ -1710,6 +1710,87 @@ class DomainSummaryResponse(BaseModel):
     health_summary: Dict[str, Any] = Field(default_factory=dict)
 
 
+REMEDIATION_DNS_ACTION_TYPES = {
+    "missing_dmarc",
+    "missing_spf",
+    "missing_dkim",
+    "dmarc_lint",
+}
+REMEDIATION_SEVERITY_RANK = {
+    "critical": 4,
+    "high": 3,
+    "medium": 2,
+    "low": 1,
+    "info": 0,
+}
+
+
+def _remediation_loop_state(action: Dict[str, Any]) -> str:
+    """Classify current health actions into dashboard remediation buckets."""
+    action_type = str(action.get("type") or "")
+    severity = str(action.get("severity") or "info")
+    if action_type in REMEDIATION_DNS_ACTION_TYPES and severity in {"critical", "high"}:
+        return "needs_approval"
+    if action_type in {"low_compliance", "source_reputation"}:
+        return "investigate"
+    return "manual_action"
+
+
+def _build_dashboard_remediation_loop(
+    domains: List[Dict[str, Any]],
+    remediation_activity: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return a visible remediation-loop summary for the workspace dashboard."""
+    counters = {
+        "fixed": int((remediation_activity.get("summary") or {}).get("resolved") or 0),
+        "needs_approval": 0,
+        "manual_action": 0,
+        "investigate": 0,
+    }
+    items: List[Dict[str, Any]] = []
+
+    for domain in domains:
+        domain_name = str(domain.get("domain_name") or domain.get("id") or "")
+        health = domain.get("health") or {}
+        for action in health.get("actions") or []:
+            state = _remediation_loop_state(action)
+            counters[state] += 1
+            items.append(
+                {
+                    "domain": domain_name,
+                    "state": state,
+                    "severity": str(action.get("severity") or "info"),
+                    "title": str(action.get("title") or "Review remediation item"),
+                    "detail": str(action.get("detail") or ""),
+                    "next_step": str(action.get("next_step") or "Review the domain evidence."),
+                    "score_impact": int(action.get("score_impact") or 0),
+                    "type": str(action.get("type") or "health_action"),
+                }
+            )
+
+    items.sort(
+        key=lambda item: (
+            item["state"] != "needs_approval",
+            -REMEDIATION_SEVERITY_RANK.get(str(item.get("severity") or "info"), 0),
+            -int(item.get("score_impact") or 0),
+            str(item.get("domain") or ""),
+        )
+    )
+    total_open = counters["needs_approval"] + counters["manual_action"] + counters["investigate"]
+    return {
+        **counters,
+        "total_open": total_open,
+        "dispatch_enqueued": int(
+            (remediation_activity.get("summary") or {}).get("dispatch_enqueued") or 0
+        ),
+        "operator_follow_up": int(
+            (remediation_activity.get("summary") or {}).get("needs_operator_follow_up") or 0
+        ),
+        "status": "clear" if total_open == 0 else "needs_attention",
+        "items": items[:5],
+    }
+
+
 class SelectorRequest(BaseModel):
     """Request body for adding a DKIM selector"""
 
@@ -2767,9 +2848,7 @@ def _posture_score(checks: List[DNSHealthCheck]) -> int:
     total_weight = sum(weights.get(check.key, 0) for check in checks)
     if total_weight <= 0:
         return 0
-    passing_weight = sum(
-        weights.get(check.key, 0) for check in checks if check.status == "pass"
-    )
+    passing_weight = sum(weights.get(check.key, 0) for check in checks if check.status == "pass")
     return round((passing_weight / total_weight) * 100)
 
 
@@ -3345,6 +3424,10 @@ async def get_domains_summary(
 
     health_summary = build_health_summary(domains_list, domain_health)
     health_summary["remediation"] = remediation_activity["summary"]
+    health_summary["remediation_loop"] = _build_dashboard_remediation_loop(
+        domains_list,
+        remediation_activity,
+    )
 
     return DomainSummaryResponse(
         total_domains=total_domains,
@@ -5423,9 +5506,9 @@ async def cloudflare_oauth_callback(
                     "or update the allowed scopes on the Cloudflare OAuth client.</p>"
                     f"<p><strong>Selected profile:</strong> {html.escape(profile_id)}</p>"
                     f"<p><strong>Requested scopes:</strong> <code>{requested_scopes}</code></p>"
-                    "<p><a href=\""
+                    '<p><a href="'
                     f"{html.escape(retry_href)}"
-                    "\">Retry with read-only Cloudflare access</a></p>"
+                    '">Retry with read-only Cloudflare access</a></p>'
                 )
                 if permission_items:
                     details += (
@@ -6453,8 +6536,7 @@ async def _source_reputations_by_ip(
             ),
             timeout=max(
                 0.5,
-                float(settings.SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS)
-                * (2 if refresh else 1),
+                float(settings.SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS) * (2 if refresh else 1),
             ),
         )
         return source_reputation_by_ip(reputation_result)

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -903,6 +903,35 @@ function dashboardApp() {
             return this.healthSummary?.remediation || {};
         },
 
+        remediationLoop() {
+            return this.healthSummary?.remediation_loop || {};
+        },
+
+        remediationLoopItems() {
+            const items = this.remediationLoop().items;
+            return Array.isArray(items) ? items : [];
+        },
+
+        hasRemediationLoopItems() {
+            return this.remediationLoopItems().length > 0;
+        },
+
+        remediationLoopStateLabel(state) {
+            return {
+                needs_approval: 'Needs approval',
+                manual_action: 'Manual action',
+                investigate: 'Investigate'
+            }[String(state || '')] || 'Review';
+        },
+
+        remediationLoopStateClass(state) {
+            return {
+                needs_approval: 'bg-[#edf7f7] text-[#247982]',
+                manual_action: 'bg-[#fff7df] text-[#8a6418]',
+                investigate: 'bg-[#fff1ea] text-[#b8431d]'
+            }[String(state || '')] || 'bg-[#f8f7f6] text-[#5f5c78]';
+        },
+
         domainActionHref(action) {
             return action && action.domain
                 ? `/domains/${encodeURIComponent(action.domain)}`

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -201,6 +201,58 @@
         </div>
     </section>
 
+    <section class="rounded-lg bg-white p-6 shadow-sm" x-show="healthSummary && hasDomainData" x-cloak>
+        <div class="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]">Remediation Loop</p>
+                <h2 class="mt-1 text-2xl font-semibold tracking-normal text-[#07071f]">Current fix queue</h2>
+            </div>
+            <a href="/domains" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open domain worklist</a>
+        </div>
+        <div class="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <div class="rounded-md border border-[#e6e3e1] p-4">
+                <p class="text-sm text-[#5f5c78]">Fixed</p>
+                <p class="mt-2 text-3xl font-bold text-[#247982]" x-text="remediationLoop().fixed || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Operator-marked and verified items</p>
+            </div>
+            <div class="rounded-md border border-[#e6e3e1] p-4">
+                <p class="text-sm text-[#5f5c78]">Needs approval</p>
+                <p class="mt-2 text-3xl font-bold text-[#120d36]" x-text="remediationLoop().needs_approval || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">DNS or policy changes to review</p>
+            </div>
+            <div class="rounded-md border border-[#e6e3e1] p-4">
+                <p class="text-sm text-[#5f5c78]">Manual action</p>
+                <p class="mt-2 text-3xl font-bold text-[#8a6418]" x-text="remediationLoop().manual_action || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Tasks for mail or DNS owners</p>
+            </div>
+            <div class="rounded-md border border-[#e6e3e1] p-4">
+                <p class="text-sm text-[#5f5c78]">Investigate</p>
+                <p class="mt-2 text-3xl font-bold text-[#b8431d]" x-text="remediationLoop().investigate || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Sender or report evidence to confirm</p>
+            </div>
+        </div>
+        <div class="mt-5 grid gap-3 lg:grid-cols-2" x-show="hasRemediationLoopItems()">
+            <template x-for="item in remediationLoopItems()" :key="item.domain + item.type + item.title">
+                <a class="rounded-md border border-[#e6e3e1] p-4 transition hover:border-[#2f9da5] hover:shadow-sm"
+                   :href="domainActionHref(item)">
+                    <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                            <span class="inline-flex rounded-md px-2 py-1 text-xs font-semibold"
+                                  :class="remediationLoopStateClass(item.state)"
+                                  x-text="remediationLoopStateLabel(item.state)"></span>
+                            <h3 class="mt-2 font-semibold text-[#120d36]" x-text="item.title"></h3>
+                        </div>
+                        <span class="rounded-full bg-[#f8f7f6] px-3 py-1 text-xs font-semibold text-[#5f5c78]"
+                              x-text="item.severity"></span>
+                    </div>
+                    <p class="mt-2 text-sm text-[#5f5c78]" x-text="item.detail"></p>
+                    <p class="mt-2 text-sm font-semibold text-[#272a5f]" x-text="item.next_step"></p>
+                    <p class="mt-2 text-xs text-[#5f5c78]" x-text="item.domain"></p>
+                </a>
+            </template>
+        </div>
+    </section>
+
     <div class="grid grid-cols-1 gap-6 xl:grid-cols-12" x-show="hasDomainData" x-cloak>
         <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6" data-tour="compliance-chart">
             <div class="mb-3 grid gap-2 sm:flex sm:items-start sm:justify-between sm:gap-4">

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -578,8 +578,7 @@ def test_dns_lint_endpoint_uses_configured_mail_auth_defaults(
     assert response.status_code == 200
     targets = {record["code"]: record for record in response.json()["target_records"]}
     assert targets["target_dmarc"]["value"] == (
-        "v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@cklnet.com; "
-        "pct=25; adkim=r; aspf=r"
+        "v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@cklnet.com; " "pct=25; adkim=r; aspf=r"
     )
     assert targets["target_tls_rpt"]["value"] == "v=TLSRPTv1; rua=mailto:tls-reports@cklnet.com"
 
@@ -628,8 +627,7 @@ def test_dns_lint_endpoint_prefers_domain_dmarc_mailbox_override(
     assert response.status_code == 200
     targets = {record["code"]: record for record in response.json()["target_records"]}
     assert targets["target_dmarc"]["value"] == (
-        "v=DMARC1; p=none; rua=mailto:dmarc-example@tenant.example; "
-        "pct=100; adkim=r; aspf=r"
+        "v=DMARC1; p=none; rua=mailto:dmarc-example@tenant.example; " "pct=100; adkim=r; aspf=r"
     )
 
 
@@ -704,21 +702,30 @@ def test_int_setting_value_preserves_zero_and_falls_back(db_session):
     )
     db_session.commit()
 
-    assert domains_endpoint._int_setting_value(
-        db_session,
-        "dmarc.default_percentage_zero",
-        100,
-    ) == 0
-    assert domains_endpoint._int_setting_value(
-        db_session,
-        "dmarc.default_percentage_invalid",
-        100,
-    ) == 100
-    assert domains_endpoint._int_setting_value(
-        db_session,
-        "dmarc.default_percentage_missing",
-        100,
-    ) == 100
+    assert (
+        domains_endpoint._int_setting_value(
+            db_session,
+            "dmarc.default_percentage_zero",
+            100,
+        )
+        == 0
+    )
+    assert (
+        domains_endpoint._int_setting_value(
+            db_session,
+            "dmarc.default_percentage_invalid",
+            100,
+        )
+        == 100
+    )
+    assert (
+        domains_endpoint._int_setting_value(
+            db_session,
+            "dmarc.default_percentage_missing",
+            100,
+        )
+        == 100
+    )
 
 
 def test_dns_lint_endpoint_accepts_locale_for_operator_guidance(authed_client: TestClient):
@@ -1243,9 +1250,7 @@ async def test_dns_cache_allows_old_positive_evidence_to_expire(db_session):
 async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_session):
     """A primary resolver with no evidence should not force a false F grade."""
     primary_provider = PublicRecursiveDNSProvider()
-    primary_check = AsyncMock(
-        return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
-    )
+    primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
     fallback_result = DomainDNSResult(
         dmarc=True,
         dmarc_record="v=DMARC1; p=reject",
@@ -1328,9 +1333,7 @@ async def test_dns_cache_replaces_system_provider_with_public_resolver(db_sessio
 async def test_dns_cache_propagates_fallback_cancellation(db_session):
     """Request cancellation must not be swallowed by defensive fallback handling."""
     primary_provider = PublicRecursiveDNSProvider()
-    primary_check = AsyncMock(
-        return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
-    )
+    primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
     fallback_check = AsyncMock(side_effect=asyncio.CancelledError())
 
     with (
@@ -1357,9 +1360,7 @@ async def test_dns_cache_fallback_failure_log_omits_user_values(db_session, capl
     """Fallback failure logging should not echo domains or exception messages."""
     domain = "bad.example\nforged-log-line"
     primary_provider = PublicRecursiveDNSProvider()
-    primary_check = AsyncMock(
-        return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)
-    )
+    primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
     fallback_check = AsyncMock(side_effect=RuntimeError(f"resolver failed for {domain}"))
     caplog.set_level(logging.DEBUG, logger="app.services.dns_cache")
 
@@ -2092,6 +2093,7 @@ def test_summary_includes_remediation_activity(authed_client: TestClient, db_ses
     assert data["health_summary"]["remediation"]["domains_with_activity"] == 1
     assert data["health_summary"]["remediation"]["resolved"] == 1
     assert data["health_summary"]["remediation"]["delivery_count"] == 1
+    assert data["health_summary"]["remediation_loop"]["fixed"] == 1
 
     activity = summarize_remediation_activity(
         db_session,
@@ -2100,6 +2102,36 @@ def test_summary_includes_remediation_activity(authed_client: TestClient, db_ses
         row_limit=1,
     )
     assert activity["domains"]["quiet.example"]["latest_state"] == "acknowledged"
+
+
+def test_summary_includes_current_remediation_loop(
+    authed_client: TestClient,
+    db_session,
+):
+    """Dashboard summaries expose current operator work, not only historic audit rows."""
+    _persist_minimal_report(db_session)
+    degraded_dns = DomainDNSResult(
+        dmarc=False,
+        dmarc_record=None,
+        spf=False,
+        spf_record=None,
+        dkim=True,
+        dkim_selectors=["google"],
+        dkim_record="v=DKIM1; k=rsa; p=ABC",
+    )
+
+    with _mock_dns(degraded_dns):
+        response = authed_client.get("/api/v1/domains/summary?refresh=true")
+
+    assert response.status_code == 200
+    loop = response.json()["health_summary"]["remediation_loop"]
+    assert loop["status"] == "needs_attention"
+    assert loop["needs_approval"] >= 2
+    assert loop["total_open"] >= 2
+    assert loop["items"][0]["domain"] == DOMAIN
+    assert loop["items"][0]["state"] == "needs_approval"
+    assert loop["items"][0]["title"]
+    assert loop["items"][0]["next_step"]
 
 
 def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_session):
@@ -2143,7 +2175,9 @@ def test_summary_refresh_dns_exception_marks_lookup_failed(authed_client: TestCl
     action_types = [action["type"] for action in domain["health"]["actions"]]
     assert "dns_evidence_unavailable" in action_types
     dns_action = next(
-        action for action in domain["health"]["actions"] if action["type"] == "dns_evidence_unavailable"
+        action
+        for action in domain["health"]["actions"]
+        if action["type"] == "dns_evidence_unavailable"
     )
     evidence = {item["label"]: item["value"] for item in dns_action["evidence"]}
     assert evidence["dns_evidence"] == "DNS lookup failed"
@@ -2235,10 +2269,12 @@ async def test_domain_health_grade_treats_pending_dns_as_unavailable(db_session)
             new=AsyncMock(return_value=(reputation, False, None)),
         ),
     ):
-        health = await domains_endpoint._build_domain_health_grade(  # pylint: disable=protected-access
-            db_session,
-            DOMAIN,
-            ReportStore.get_instance(),
+        health = (
+            await domains_endpoint._build_domain_health_grade(  # pylint: disable=protected-access
+                db_session,
+                DOMAIN,
+                ReportStore.get_instance(),
+            )
         )
 
     action_types = [action["type"] for action in health["actions"]]

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -21,7 +21,11 @@ from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
-from app.api.api_v1.endpoints.domains import _domain_names_for_summary, _spf_fix_hint
+from app.api.api_v1.endpoints.domains import (
+    _domain_names_for_summary,
+    _remediation_loop_state,
+    _spf_fix_hint,
+)
 from app.models.dns_cache import DNSCache, DNSRecordChange
 from app.models.domain import Domain
 from app.models.organization import Entitlement, Organization
@@ -2132,6 +2136,15 @@ def test_summary_includes_current_remediation_loop(
     assert loop["items"][0]["state"] == "needs_approval"
     assert loop["items"][0]["title"]
     assert loop["items"][0]["next_step"]
+
+
+@pytest.mark.parametrize(
+    "action_type",
+    ["source_reputation_listed", "source_reputation_review"],
+)
+def test_remediation_loop_classifies_reputation_actions_as_investigate(action_type: str):
+    """Reputation health actions should remain investigation work, not manual tasks."""
+    assert _remediation_loop_state({"type": action_type, "severity": "high"}) == "investigate"
 
 
 def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_session):


### PR DESCRIPTION
## Summary
- add a dashboard-level remediation loop summary derived from existing domain health actions and remediation audit activity
- show fixed, needs-approval, manual-action, and investigation buckets directly on the dashboard
- add focused API coverage for historic resolved markers and current remediation work items

## Why
Issue #384 needs the product to feel less like a passive DMARC report viewer and more like an operator work queue. This slice makes the main dashboard answer what is fixed, what needs approval, and what still needs manual work without adding risky DNS writes or AI behavior.

Refs #384

## Validation
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py -q -k "remediation_loop or remediation_activity"`
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`
- `cd backend && DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-sender-dns-fix/.venv/bin/python npm run test:browser`
