### PR TITLE
test: address CSP review nitpicks

### DIFF
--- a/backend/app/tests/test_security.py
+++ b/backend/app/tests/test_security.py
@@ -4,6 +4,7 @@ Security-focused tests for DMARQ application.
 Covers API key management, domain validation, file upload limits, and XML parsing security.
 """
 
+import json
 import re
 from pathlib import Path
 
@@ -163,7 +164,9 @@ class TestSecurityHeaders:
     def test_base_template_uses_local_csp_alpine(self):
         """The bundled Alpine runtime should be the CSP-compatible local build."""
         template = Path(__file__).resolve().parents[1] / "templates" / "layouts" / "base.html"
+        package_json = Path(__file__).resolve().parents[2] / "package.json"
         body = template.read_text()
+        package = json.loads(package_json.read_text())
         alpine = (
             Path(__file__).resolve().parents[1] / "static" / "js" / "vendor" / "alpine.min.js"
         ).read_text()
@@ -177,7 +180,7 @@ class TestSecurityHeaders:
         assert 'src="/static/js/base-layout.js"' in body
         assert 'href="/static/css/app.css"' in body
         assert 'href="/static/css/page-utilities.css"' in body
-        assert "Using the x-html directive is prohibited in the CSP build" in alpine
+        assert "@alpinejs/csp" in package["devDependencies"]
         assert "new Function" not in alpine
 
     @pytest.mark.parametrize("template_name", ["login.html", "setup.html"])

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -661,23 +661,13 @@ async function installCspViolationRecorder(page) {
   });
 }
 
-function isKnownStrictCspMigrationBlocker(violation) {
-  void violation;
-  return false;
-}
-
 test.beforeEach(async ({ page }) => {
   await installCspViolationRecorder(page);
   await installApiMocks(page);
 });
 
 test.afterEach(async ({ page }) => {
-  const violations = page.__dmarqCspViolations || [];
-  const unexpectedViolations = violations.filter(
-    (violation) => !isKnownStrictCspMigrationBlocker(violation)
-  );
-
-  expect(unexpectedViolations, 'unexpected CSP report-only violations').toEqual([]);
+  expect(page.__dmarqCspViolations || [], 'unexpected CSP report-only violations').toEqual([]);
 });
 
 test('dashboard becomes useful before false empty states appear', async ({ page }) => {


### PR DESCRIPTION
## Summary
- remove the dead CSP violation allowlist helper now that all violations fail the browser smoke directly
- avoid coupling the Alpine CSP test to a minified vendor error string

## Validation
- git diff --check
- node --check backend/tests/browser/live-dmarc-flows.spec.js
- /tmp/dmarq-live-audit-venv/bin/python -m pytest -q backend/app/tests/test_security.py::TestSecurityHeaders::test_base_template_uses_local_csp_alpine

Follow-up for low-value CodeRabbit review notes on #617.