### PR TITLE
feat: show domain remediation worklist status

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1795,6 +1795,45 @@ def _build_dashboard_remediation_loop(
     }
 
 
+def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
+    """Summarize current remediation work for one dashboard domain row."""
+    counters = {
+        "needs_approval": 0,
+        "manual_action": 0,
+        "investigate": 0,
+    }
+    items: List[Dict[str, Any]] = []
+    domain_name = str(domain.get("domain_name") or domain.get("id") or "")
+    for action in (domain.get("health") or {}).get("actions") or []:
+        state = _remediation_loop_state(action)
+        counters[state] += 1
+        items.append(
+            {
+                "domain": domain_name,
+                "state": state,
+                "severity": str(action.get("severity") or "info"),
+                "title": str(action.get("title") or "Review remediation item"),
+                "next_step": str(action.get("next_step") or "Review the domain evidence."),
+                "score_impact": int(action.get("score_impact") or 0),
+            }
+        )
+
+    items.sort(
+        key=lambda item: (
+            item["state"] != "needs_approval",
+            -REMEDIATION_SEVERITY_RANK.get(str(item.get("severity") or "info"), 0),
+            -int(item.get("score_impact") or 0),
+        )
+    )
+    total_open = counters["needs_approval"] + counters["manual_action"] + counters["investigate"]
+    return {
+        **counters,
+        "total_open": total_open,
+        "status": "clear" if total_open == 0 else "needs_attention",
+        "primary": items[0] if items else None,
+    }
+
+
 class SelectorRequest(BaseModel):
     """Request body for adding a DKIM selector"""
 
@@ -3417,6 +3456,7 @@ async def get_domains_summary(
             "remediation": remediation_by_domain.get(domain_name, {}),
         }
         domain_row["health"] = score_domain_health(domain_row)
+        domain_row["remediation_workload"] = _domain_remediation_workload(domain_row)
         domains_list.append(domain_row)
 
     domain_health = [domain["health"] for domain in domains_list]

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1548,7 +1548,7 @@ function dashboardApp() {
                 row.appendChild(this.createDomainNameCell(domain.domain_name));
                 row.appendChild(this.createTextCell(this.formatLargeNumber(domain.total_emails || 0)));
                 row.appendChild(this.createGradeCell(domain.health));
-                row.appendChild(this.createRemediationCell(domain.remediation));
+                row.appendChild(this.createRemediationCell(domain.remediation, domain.remediation_workload));
                 row.appendChild(this.createPassRateCell(domain.pass_rate || 0));
                 row.appendChild(this.createTextCell(this.formatLargeNumber(domain.failed_count || 0)));
                 row.appendChild(this.createTextCell(this.formatLargeNumber(domain.report_count || 0)));
@@ -1591,27 +1591,39 @@ function dashboardApp() {
             return cell;
         },
 
-        createRemediationCell(remediation) {
+        createRemediationCell(remediation, workload) {
             const cell = document.createElement('td');
             cell.className = 'table-cell';
 
             const wrapper = document.createElement('div');
             wrapper.className = 'flex flex-col gap-1';
 
-            const status = remediation?.status || 'none';
+            const openCount = Number(workload?.total_open || 0);
+            const status = openCount > 0 ? 'activity' : (remediation?.status || 'none');
             const badge = document.createElement('span');
             badge.className = `inline-flex w-fit rounded-md bg-[#f8f7f6] px-2 py-1 text-xs font-semibold ${this.remediationStatusClass(status)}`;
-            badge.textContent = this.remediationStatusLabel(status);
+            badge.textContent = openCount > 0
+                ? `${this.formatLargeNumber(openCount)} open`
+                : this.remediationStatusLabel(status);
             wrapper.appendChild(badge);
 
             const latest = document.createElement('span');
             latest.className = 'text-xs text-muted-foreground whitespace-nowrap';
-            if (remediation?.latest_at) {
+            if (workload?.primary?.state) {
+                latest.textContent = this.remediationLoopStateLabel(workload.primary.state);
+            } else if (remediation?.latest_at) {
                 latest.textContent = new Date(remediation.latest_at).toLocaleString();
             } else {
                 latest.textContent = 'No operator action';
             }
             wrapper.appendChild(latest);
+
+            if (workload?.primary?.title) {
+                const action = document.createElement('span');
+                action.className = 'max-w-48 truncate text-xs text-muted-foreground';
+                action.textContent = workload.primary.title;
+                wrapper.appendChild(action);
+            }
 
             cell.appendChild(wrapper);
             return cell;

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2136,6 +2136,12 @@ def test_summary_includes_current_remediation_loop(
     assert loop["items"][0]["state"] == "needs_approval"
     assert loop["items"][0]["title"]
     assert loop["items"][0]["next_step"]
+    domain = response.json()["domains"][0]
+    assert domain["remediation_workload"]["status"] == "needs_attention"
+    assert domain["remediation_workload"]["needs_approval"] >= 2
+    assert domain["remediation_workload"]["total_open"] >= 2
+    assert domain["remediation_workload"]["primary"]["state"] == "needs_approval"
+    assert domain["remediation_workload"]["primary"]["title"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add a per-domain remediation workload summary to the dashboard summary API
- show open remediation work directly in the domain compliance table instead of only historical operator activity
- keep the existing audit status as a fallback when no current work is open

## Why
The dashboard-level remediation loop is useful, but operators also need to scan which domains currently need action without opening every detail page. This keeps the self-hosted single-user flow focused on actionable domain work.

Refs #384

## Validation
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py -q -k "remediation_loop or remediation_activity"`
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py`
- `cd backend && DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-sender-dns-fix/.venv/bin/python npm run test:browser`
