### PR TITLE
feat: add remediation guidance paths

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1099,6 +1099,15 @@ class RemediationEvidence(BaseModel):
     value: str
 
 
+class RemediationGuidancePath(BaseModel):
+    """Operator-facing path for completing a remediation item."""
+
+    key: str
+    label: str
+    summary: str
+    owner: str
+
+
 class RemediationActionPlan(BaseModel):
     """Operator-facing action plan for one remediation queue item."""
 
@@ -1106,7 +1115,7 @@ class RemediationActionPlan(BaseModel):
     diagnosis: str
     prerequisites: List[str] = Field(default_factory=list)
     steps: List[str] = Field(default_factory=list)
-    guidance_paths: List[Dict[str, str]] = Field(default_factory=list)
+    guidance_paths: List[RemediationGuidancePath] = Field(default_factory=list)
     completion_criteria: str
     automation_path: str
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1106,6 +1106,7 @@ class RemediationActionPlan(BaseModel):
     diagnosis: str
     prerequisites: List[str] = Field(default_factory=list)
     steps: List[str] = Field(default_factory=list)
+    guidance_paths: List[Dict[str, str]] = Field(default_factory=list)
     completion_criteria: str
     automation_path: str
 

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -308,25 +308,23 @@ def _action_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         )
         steps = steps or ["Review the evidence and complete the recommended operator action."]
 
+    automation_path = (
+        "provider_preview"
+        if automation.get("eligible")
+        else ("investigate" if state == "investigate" else "manual")
+    )
+
     return {
         "owner": owner,
         "diagnosis": str(item.get("detail") or item.get("title") or "Review this finding."),
         "prerequisites": prerequisites[:5],
         "steps": steps[:6],
         "completion_criteria": completion,
-        "automation_path": (
-            "provider_preview"
-            if automation.get("eligible")
-            else ("investigate" if state == "investigate" else "manual")
-        ),
+        "automation_path": automation_path,
         "guidance_paths": _guidance_paths_for_item(
             item,
             owner=owner,
-            automation_path=(
-                "provider_preview"
-                if automation.get("eligible")
-                else ("investigate" if state == "investigate" else "manual")
-            ),
+            automation_path=automation_path,
         ),
     }
 
@@ -337,7 +335,7 @@ def _guidance_paths_for_item(
     owner: str,
     automation_path: str,
 ) -> List[Dict[str, str]]:
-    """Return provider and self-hosted guidance paths for one remediation item."""
+    """Return operator guidance paths for one remediation item."""
     automation = item.get("automation") or {}
     provider = str(automation.get("provider") or "detected provider")
     source = str(item.get("source") or "remediation")

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -319,7 +319,89 @@ def _action_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
             if automation.get("eligible")
             else ("investigate" if state == "investigate" else "manual")
         ),
+        "guidance_paths": _guidance_paths_for_item(
+            item,
+            owner=owner,
+            automation_path=(
+                "provider_preview"
+                if automation.get("eligible")
+                else ("investigate" if state == "investigate" else "manual")
+            ),
+        ),
     }
+
+
+def _guidance_paths_for_item(
+    item: Dict[str, Any],
+    *,
+    owner: str,
+    automation_path: str,
+) -> List[Dict[str, str]]:
+    """Return provider and self-hosted guidance paths for one remediation item."""
+    automation = item.get("automation") or {}
+    provider = str(automation.get("provider") or "detected provider")
+    source = str(item.get("source") or "remediation")
+    state = str(item.get("state") or "")
+
+    if automation_path == "provider_preview":
+        return [
+            {
+                "key": "provider",
+                "label": f"{provider} guided repair",
+                "summary": "Use the connected DNS provider preview and approve the exact record mutation.",
+                "owner": owner,
+            },
+            {
+                "key": "manual",
+                "label": "Manual DNS fallback",
+                "summary": "Copy the proposed record into the authoritative DNS provider if provider automation is not desired.",
+                "owner": "Domain DNS operator",
+            },
+        ]
+    if source == "dns_lint":
+        return [
+            {
+                "key": "provider",
+                "label": "DNS provider console",
+                "summary": "Open the authoritative DNS zone and apply the record value from the remediation plan.",
+                "owner": "Domain DNS operator",
+            },
+            {
+                "key": "self_hosted",
+                "label": "Self-hosted DNS",
+                "summary": "Update the zone file or DNS management system, reload the service, then refresh DMARQ evidence.",
+                "owner": "DNS platform operator",
+            },
+        ]
+    if state == "investigate":
+        return [
+            {
+                "key": "provider",
+                "label": "Mail provider investigation",
+                "summary": "Check sender signatures, bounce domains, and provider authentication status before changing DNS.",
+                "owner": "Mail operations owner",
+            },
+            {
+                "key": "self_hosted",
+                "label": "Self-hosted mail investigation",
+                "summary": "Review MTA logs, DKIM signing configuration, SPF envelope sender alignment, and recent sending hosts.",
+                "owner": "Mail server operator",
+            },
+        ]
+    return [
+        {
+            "key": "provider",
+            "label": "Provider-guided remediation",
+            "summary": "Use the provider dashboard to confirm required DNS or sender settings before applying changes.",
+            "owner": owner,
+        },
+        {
+            "key": "self_hosted",
+            "label": "Self-hosted remediation",
+            "summary": "Apply the equivalent mail or DNS configuration directly in the local infrastructure.",
+            "owner": owner,
+        },
+    ]
 
 
 def build_remediation_queue(

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -422,6 +422,19 @@
                                                 </li>
                                             </template>
                                         </ol>
+                                        <template x-if="(item.action_plan.guidance_paths || []).length">
+                                            <div class="mt-3 grid gap-2 md:grid-cols-2">
+                                                <template x-for="path in item.action_plan.guidance_paths" :key="item.id + '-path-' + path.key">
+                                                    <div class="rounded border border-[#d8ebe8] bg-white p-3">
+                                                        <div class="flex flex-wrap items-center justify-between gap-2">
+                                                            <p class="text-xs font-semibold uppercase text-[#1f7c83]" x-text="path.label"></p>
+                                                            <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#5f5c78]" x-text="path.owner"></span>
+                                                        </div>
+                                                        <p class="mt-2 text-xs text-[#5f5c78]" x-text="path.summary"></p>
+                                                    </div>
+                                                </template>
+                                            </div>
+                                        </template>
                                         <p class="mt-3 text-xs text-[#5f5c78]">
                                             <span class="font-semibold">Done when: </span>
                                             <span x-text="item.action_plan.completion_criteria"></span>

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -265,3 +265,44 @@ def test_remediation_queue_requires_recommended_provider_for_automation():
     assert queue["items"][0]["notification"]["event"] == (
         "dmarq.remediation.manual_action_required"
     )
+
+
+def test_remediation_queue_adds_generic_operator_guidance_for_health_actions():
+    queue = build_remediation_queue(
+        domain="example.com",
+        health={
+            "actions": [
+                {
+                    "type": "review_forwarding",
+                    "severity": "high",
+                    "title": "Review forwarding alignment",
+                    "detail": "Some forwarded messages are failing DMARC.",
+                    "next_step": "Confirm whether the forwarding path is expected.",
+                }
+            ]
+        },
+        dns_guidance={"findings": [], "change_plans": []},
+    )
+
+    assert queue["status"] == "needs_manual_action"
+    assert queue["items"][0]["action_plan"]["automation_path"] == "manual"
+    assert queue["items"][0]["action_plan"]["guidance_paths"] == [
+        {
+            "key": "provider",
+            "label": "Provider-guided remediation",
+            "summary": (
+                "Use the provider dashboard to confirm required DNS or sender settings "
+                "before applying changes."
+            ),
+            "owner": "Mail operations owner",
+        },
+        {
+            "key": "self_hosted",
+            "label": "Self-hosted remediation",
+            "summary": (
+                "Apply the equivalent mail or DNS configuration directly in the "
+                "local infrastructure."
+            ),
+            "owner": "Mail operations owner",
+        },
+    ]

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -81,6 +81,9 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
     )
     assert queue["items"][0]["action_plan"]["owner"] == "Domain DNS operator"
     assert queue["items"][0]["action_plan"]["automation_path"] == "provider_preview"
+    assert queue["items"][0]["action_plan"]["guidance_paths"][0]["key"] == "provider"
+    assert "cloudflare" in queue["items"][0]["action_plan"]["guidance_paths"][0]["label"].lower()
+    assert queue["items"][0]["action_plan"]["guidance_paths"][1]["key"] == "manual"
     assert (
         "preview the provider mutation"
         in " ".join(queue["items"][0]["action_plan"]["steps"]).lower()
@@ -173,6 +176,10 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
     assert queue["items"][0]["automation"]["eligible"] is False
     assert queue["items"][0]["automation"]["apply_endpoint"] is None
     assert queue["items"][0]["action_plan"]["automation_path"] == "manual"
+    assert {path["key"] for path in queue["items"][0]["action_plan"]["guidance_paths"]} == {
+        "provider",
+        "self_hosted",
+    }
     assert queue["items"][0]["action_plan"]["completion_criteria"]
     assert queue["items"][0]["notification"]["state"] == "summary_only"
     assert queue["items"][0]["notification"]["event"] == "dmarq.remediation.summary"


### PR DESCRIPTION
## Summary
- add provider and self-hosted guidance paths to remediation action plans
- render those paths on the domain detail remediation queue
- extend queue tests for provider-preview and manual/self-hosted remediation paths

## Why
Issue #384 requires the remediation loop to work for commercial providers and self-hosted infrastructure. The queue already had next steps and automation eligibility; this adds explicit operator paths so a user can see which playbook applies to their environment.

Refs #384

## Validation
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m pytest backend/app/tests/test_remediation_queue.py -q`
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m black --check backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py`
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m isort --check-only backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py`
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m flake8 backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py`
- `cd backend && DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-sender-dns-fix/.venv/bin/python npm run test:browser`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance path details to remediation action plans.
  * Remediation items now show a new guidance paths section in the UI when available, with labels, owners, and summaries.

* **Bug Fixes**
  * Improved remediation guidance to vary based on item type and state, providing more relevant next-step options.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->