### PR TITLE
fix: use fallback DNS for configured resolvers

### DIFF
--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -19,6 +19,7 @@ from app.services.dns_provider_detection import detection_from_json
 from app.services.dns_resolver import (
     BaseDNSProvider,
     CloudflareDNSProvider,
+    ConfiguredRecursiveDNSProvider,
     DomainDNSResult,
     PublicRecursiveDNSProvider,
     SystemDNSProvider,
@@ -316,7 +317,7 @@ async def _resolve_with_fallback(  # noqa: C901
     provider = _normalize_dns_provider(provider)
     if not isinstance(
         provider,
-        (PublicRecursiveDNSProvider, CloudflareDNSProvider),
+        (PublicRecursiveDNSProvider, CloudflareDNSProvider, ConfiguredRecursiveDNSProvider),
     ):
         return await provider.check_domain(domain, selectors=selectors)
 

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -19,7 +19,6 @@ from app.services.dns_provider_detection import detection_from_json
 from app.services.dns_resolver import (
     BaseDNSProvider,
     CloudflareDNSProvider,
-    ConfiguredRecursiveDNSProvider,
     DomainDNSResult,
     PublicRecursiveDNSProvider,
     SystemDNSProvider,
@@ -315,10 +314,7 @@ async def _resolve_with_fallback(  # noqa: C901
 ) -> DomainDNSResult:
     """Resolve DNS, checking independent resolvers before accepting an empty result."""
     provider = _normalize_dns_provider(provider)
-    if not isinstance(
-        provider,
-        (PublicRecursiveDNSProvider, CloudflareDNSProvider, ConfiguredRecursiveDNSProvider),
-    ):
+    if not isinstance(provider, (PublicRecursiveDNSProvider, CloudflareDNSProvider)):
         return await provider.check_domain(domain, selectors=selectors)
 
     first_empty_result: Optional[DomainDNSResult] = None

--- a/backend/app/services/dns_fallbacks.py
+++ b/backend/app/services/dns_fallbacks.py
@@ -7,6 +7,7 @@ from typing import List
 from app.services.dns_resolver import (
     BaseDNSProvider,
     CloudflareDNSProvider,
+    ConfiguredRecursiveDNSProvider,
     DemoDNSProvider,
     PublicRecursiveDNSProvider,
 )
@@ -22,7 +23,9 @@ def dns_fallback_candidates(provider: BaseDNSProvider) -> List[BaseDNSProvider]:
     candidates: List[BaseDNSProvider] = [provider]
     if isinstance(provider, DemoDNSProvider):
         return candidates
-    if not isinstance(provider, PublicRecursiveDNSProvider):
+    if not isinstance(provider, PublicRecursiveDNSProvider) or isinstance(
+        provider, ConfiguredRecursiveDNSProvider
+    ):
         candidates.append(PublicRecursiveDNSProvider())
     if not isinstance(provider, CloudflareDNSProvider):
         candidates.append(CloudflareDNSProvider())

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -38,6 +38,7 @@ from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
 from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
 from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import (
+    CloudflareDNSProvider,
     ConfiguredRecursiveDNSProvider,
     DomainDNSResult,
     PublicRecursiveDNSProvider,
@@ -1057,24 +1058,30 @@ async def test_dns_cache_uses_public_fallback_for_configured_resolver(db_session
         async def check_domain(self, domain, selectors=None):  # pylint: disable=unused-argument
             return DomainDNSResult(dmarc=False, spf=False, dkim=False)
 
-    class PositiveFallbackProvider(ConfiguredRecursiveDNSProvider):
-        async def check_domain(self, domain, selectors=None):  # pylint: disable=unused-argument
-            return DomainDNSResult(
-                dmarc=True,
-                dmarc_record="v=DMARC1; p=reject",
-                spf=True,
-                spf_record="v=spf1 -all",
-                nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
-                dns_provider=detect_dns_provider(
-                    ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
-                ),
-            )
+    async def positive_public_result(
+        self,
+        domain,
+        selectors=None,
+    ):  # pylint: disable=unused-argument
+        return DomainDNSResult(
+            dmarc=True,
+            dmarc_record="v=DMARC1; p=reject",
+            spf=True,
+            spf_record="v=spf1 -all",
+            nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+            dns_provider=detect_dns_provider(["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]),
+        )
 
     primary = EmptyConfiguredProvider()
-    fallback = PositiveFallbackProvider()
     monkeypatch.setattr(
-        "app.services.dns_cache.dns_fallback_candidates",
-        lambda provider: [provider, fallback],
+        PublicRecursiveDNSProvider,
+        "check_domain",
+        positive_public_result,
+    )
+    monkeypatch.setattr(
+        CloudflareDNSProvider,
+        "check_domain",
+        AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False)),
     )
 
     result, cached, _checked = await resolve_domain_dns_cached(
@@ -1088,7 +1095,7 @@ async def test_dns_cache_uses_public_fallback_for_configured_resolver(db_session
     assert cached is False
     assert result.lookup_status == "fallback"
     assert result.lookup_error == (
-        "No DNS evidence from EmptyConfiguredProvider; using PositiveFallbackProvider."
+        "No DNS evidence from EmptyConfiguredProvider; using PublicRecursiveDNSProvider."
     )
     assert result.dmarc is True
     assert result.spf is True

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -38,6 +38,7 @@ from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
 from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
 from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import (
+    ConfiguredRecursiveDNSProvider,
     DomainDNSResult,
     PublicRecursiveDNSProvider,
     SystemDNSProvider,
@@ -1046,6 +1047,53 @@ async def test_dns_cache_preserves_provider_detection(db_session):
     assert second.nameservers == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
     assert second.dns_provider is not None
     assert second.dns_provider.provider_id == "cloudflare"
+
+
+@pytest.mark.asyncio
+async def test_dns_cache_uses_public_fallback_for_configured_resolver(db_session, monkeypatch):
+    """Configured resolver misses should not hide positive public DNS evidence."""
+
+    class EmptyConfiguredProvider(ConfiguredRecursiveDNSProvider):
+        async def check_domain(self, domain, selectors=None):  # pylint: disable=unused-argument
+            return DomainDNSResult(dmarc=False, spf=False, dkim=False)
+
+    class PositiveFallbackProvider(ConfiguredRecursiveDNSProvider):
+        async def check_domain(self, domain, selectors=None):  # pylint: disable=unused-argument
+            return DomainDNSResult(
+                dmarc=True,
+                dmarc_record="v=DMARC1; p=reject",
+                spf=True,
+                spf_record="v=spf1 -all",
+                nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+                dns_provider=detect_dns_provider(
+                    ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
+                ),
+            )
+
+    primary = EmptyConfiguredProvider()
+    fallback = PositiveFallbackProvider()
+    monkeypatch.setattr(
+        "app.services.dns_cache.dns_fallback_candidates",
+        lambda provider: [provider, fallback],
+    )
+
+    result, cached, _checked = await resolve_domain_dns_cached(
+        db_session,
+        primary,
+        DOMAIN,
+        selectors=[],
+        refresh=True,
+    )
+
+    assert cached is False
+    assert result.lookup_status == "fallback"
+    assert result.lookup_error == (
+        "No DNS evidence from EmptyConfiguredProvider; using PositiveFallbackProvider."
+    )
+    assert result.dmarc is True
+    assert result.spf is True
+    assert result.dns_provider is not None
+    assert result.dns_provider.provider_id == "cloudflare"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- lets configured recursive resolver profiles use the same fallback DNS evidence flow as public and Cloudflare resolvers
- prevents Akamai ETP, Infoblox, DNS4EU, OpenDNS, Quad9, and custom resolver misses from hiding positive public DNS evidence
- adds a regression test for configured resolver empty results recovered by fallback evidence

## Validation
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py -k 'dns_cache' -q`\n- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m pytest backend/app/tests/test_dns_resolver.py -q`\n- `/tmp/dmarq-sender-dns-fix/.venv/bin/black --check backend/app/services/dns_cache.py backend/app/tests/test_dns_endpoints.py`\n- `/tmp/dmarq-sender-dns-fix/.venv/bin/isort --check-only backend/app/services/dns_cache.py backend/app/tests/test_dns_endpoints.py`\n- `/tmp/dmarq-sender-dns-fix/.venv/bin/flake8 backend/app/services/dns_cache.py backend/app/tests/test_dns_endpoints.py`