### PR TITLE
feat: hide empty monitored domains

### DIFF
--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -6,6 +6,7 @@ function domainsApp() {
         loading: true,
         refreshing: false,
         loadError: '',
+        showEmptyDomains: false,
         saving: false,
         createError: '',
         editError: '',
@@ -57,12 +58,19 @@ function domainsApp() {
                     return;
                 }
 
+                const emptyToggle = event.target.closest('[data-domain-toggle-empty]');
+                if (emptyToggle && root.contains(emptyToggle)) {
+                    this.showEmptyDomains = !this.showEmptyDomains;
+                    return;
+                }
+
                 const editButton = event.target.closest('[data-domain-edit]');
                 if (!editButton || !root.contains(editButton)) {
                     return;
                 }
                 const domainIndex = Number.parseInt(editButton.dataset.domainIndex || '', 10);
-                const domain = Number.isInteger(domainIndex) ? this.domains[domainIndex] : null;
+                const visibleDomains = this.visibleDomains();
+                const domain = Number.isInteger(domainIndex) ? visibleDomains[domainIndex] : null;
                 if (domain) {
                     this.openEditDialog(domain);
                 }
@@ -241,6 +249,9 @@ function domainsApp() {
                 description: domain.description || '',
                 dkim_selectors: Array.isArray(domain.dkim_selectors) ? domain.dkim_selectors : [],
             };
+            normalized.has_activity =
+                Number(normalized.reports_count || 0) > 0 ||
+                Number(normalized.emails_count || 0) > 0;
 
             return {
                 ...normalized,
@@ -259,6 +270,25 @@ function domainsApp() {
         dmarcStatusText(domain) {
             if (domain.dns_pending) return 'Pending DNS refresh';
             return domain.dmarc_policy || 'Not configured';
+        },
+
+        visibleDomains() {
+            if (this.showEmptyDomains) {
+                return this.domains;
+            }
+            return this.domains.filter((domain) => domain.has_activity);
+        },
+
+        hiddenEmptyDomainCount() {
+            return this.domains.filter((domain) => !domain.has_activity).length;
+        },
+
+        activeDomainCount() {
+            return this.visibleDomains().length;
+        },
+
+        showEmptyDomainHint() {
+            return !this.loading && !this.loadError && this.domains.length > 0 && this.activeDomainCount() === 0;
         },
 
         genericDnsStatusText(domain, key) {

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -287,6 +287,11 @@ function domainsApp() {
             return this.visibleDomains().length;
         },
 
+        formatCount(value, noun) {
+            const count = Number(value || 0);
+            return `${count} ${noun}${count === 1 ? '' : 's'}`;
+        },
+
         showEmptyDomainHint() {
             return !this.loading && !this.loadError && this.domains.length > 0 && this.activeDomainCount() === 0;
         },

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -107,9 +107,9 @@
                                 {% call td() %}
                                     <div class="font-medium" x-text="domain.name"></div>
                                     <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                                        <span x-text="`${domain.reports_count || 0} reports`"></span>
+                                        <span x-text="formatCount(domain.reports_count, 'report')"></span>
                                         <span>·</span>
-                                        <span x-text="`${domain.emails_count || 0} messages`"></span>
+                                        <span x-text="formatCount(domain.emails_count, 'message')"></span>
                                         <span x-show="!domain.has_activity" class="badge badge-ghost badge-xs">empty</span>
                                     </div>
                                 {% endcall %}

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -23,6 +23,13 @@
                     {% call card_title() %}Monitored Domains{% endcall %}
                     <div class="flex items-center gap-2">
                         <button type="button"
+                                class="btn btn-ghost btn-sm"
+                                data-domain-toggle-empty
+                                :aria-pressed="showEmptyDomains ? 'true' : 'false'"
+                                x-show="hiddenEmptyDomainCount() > 0"
+                                x-text="showEmptyDomains ? 'Hide empty domains' : `Show ${hiddenEmptyDomainCount()} empty`">
+                        </button>
+                        <button type="button"
                                 class="btn btn-outline btn-sm"
                                 data-domain-refresh
                                 :disabled="loading || refreshing">
@@ -35,7 +42,11 @@
                     </div>
                 </div>
                 {% call card_description() %}
-                    Domains currently being monitored for DMARC compliance
+                    <span x-text="activeDomainCount()"></span>
+                    visible monitored domain<span x-show="activeDomainCount() !== 1">s</span>
+                    <span x-show="hiddenEmptyDomainCount() > 0 && !showEmptyDomains">
+                        · <span x-text="hiddenEmptyDomainCount()"></span> without reports or volume hidden
+                    </span>
                 {% endcall %}
             {% endcall %}
             {% call card_content() %}
@@ -79,10 +90,28 @@
                                 {% endcall %}
                             {% endcall %}
                         </template>
-                        <template x-for="(domain, index) in domains" :key="index">
+                        <template x-if="showEmptyDomainHint()">
+                            {% call tr() %}
+                                {% call td(colspan="5", class="text-center") %}
+                                    <div class="flex flex-col items-center gap-3 py-5 text-muted-foreground">
+                                        <p>All monitored domains are currently hidden because no reports or mail volume have been observed yet.</p>
+                                        <button type="button" class="btn btn-outline btn-sm" data-domain-toggle-empty>
+                                            Show empty domains
+                                        </button>
+                                    </div>
+                                {% endcall %}
+                            {% endcall %}
+                        </template>
+                        <template x-for="(domain, index) in visibleDomains()" :key="domain.name">
                             {% call tr() %}
                                 {% call td() %}
                                     <div class="font-medium" x-text="domain.name"></div>
+                                    <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                        <span x-text="`${domain.reports_count || 0} reports`"></span>
+                                        <span>·</span>
+                                        <span x-text="`${domain.emails_count || 0} messages`"></span>
+                                        <span x-show="!domain.has_activity" class="badge badge-ghost badge-xs">empty</span>
+                                    </div>
                                 {% endcall %}
                                 {% call td() %}
                                     <div class="flex items-center">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -474,7 +474,10 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert '@submit.prevent="updateDomain' not in template
     assert '@click="closeCreate' not in template
     assert '@click="closeEdit' not in template
-    assert "@click=" not in template
+    assert '@click=' not in template
+    assert "formatCount(domain.reports_count, 'report')" in template
+    assert "formatCount(domain.emails_count, 'message')" in template
+    assert "formatCount(value, noun)" in script
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -440,6 +440,15 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert "bindPageControls()" in script
     assert "data-domain-refresh" in template
     assert "data-domain-refresh" in script
+    assert "data-domain-toggle-empty" in template
+    assert "data-domain-toggle-empty" in script
+    assert "showEmptyDomains" in script
+    assert "visibleDomains()" in script
+    assert "hiddenEmptyDomainCount()" in script
+    assert "showEmptyDomainHint()" in script
+    assert "visibleDomains()" in template
+    assert "without reports or volume hidden" in template
+    assert "Show empty domains" in template
     assert "data-domain-create-open" in template
     assert "data-domain-create-open" in script
     assert "data-domain-create-dialog" in template
@@ -465,6 +474,7 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert '@submit.prevent="updateDomain' not in template
     assert '@click="closeCreate' not in template
     assert '@click="closeEdit' not in template
+    assert "@click=" not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
@@ -476,6 +486,10 @@ def test_domains_page_distinguishes_loading_error_and_empty_states():
     assert "Domains could not be loaded." in script
     assert "No domains found. Add a domain to get started." in template
     assert "Retry loading domains" in template
+    assert "All monitored domains are currently hidden" in template
+    assert "has_activity" in script
+    assert "reports_count" in script
+    assert "emails_count" in script
     assert '@click="fetchDomains()"' not in template
     assert '@click="fetchDomains({ refresh: true })"' not in template
     assert "data-domain-retry-load" in template


### PR DESCRIPTION
## Summary
- hides monitored domains with no reports and no observed message volume by default on the domain management page
- adds a visible toggle and count so DNS-only/imported domains can be shown again without deleting them
- keeps edit actions wired against the filtered visible list and shows report/message counts per row

## Validation
- `/tmp/dmarq-sender-dns-fix/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -k 'domains' -q`\n- `/tmp/dmarq-sender-dns-fix/.venv/bin/black --check backend/app/tests/test_dashboard_template_security.py`\n- `/tmp/dmarq-sender-dns-fix/.venv/bin/isort --check-only backend/app/tests/test_dashboard_template_security.py`\n- `/tmp/dmarq-sender-dns-fix/.venv/bin/flake8 backend/app/tests/test_dashboard_template_security.py`\n- `DMARQ_BROWSER_SMOKE_PYTHON=/tmp/dmarq-sender-dns-fix/.venv/bin/python npm --prefix backend run test:browser`