### PR TITLE
feat: summarize report sender reputation

### DIFF
--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -29,6 +29,7 @@ from app.services.source_network import (
     merge_network_into_geo,
 )
 from app.services.source_reputation import (
+    DomainReputation,
     SourceReputation,
     build_source_reputation_cached,
     reputation_presentation,
@@ -668,6 +669,7 @@ class ReportDetail(BaseModel):
     policy: ReportPolicyDetail
     records: List[ReportRecordDetail]
     summary: ReportSummaryDetail
+    reputation_summary: Dict[str, Any] = Field(default_factory=dict)
 
 
 def _record_review_guidance(record: Dict[str, Any]) -> Dict[str, Any]:
@@ -779,6 +781,111 @@ def _source_reputation_dict(item: SourceReputation) -> Dict[str, Any]:
     }
 
 
+def _report_reputation_summary(result: Optional[DomainReputation]) -> Dict[str, Any]:
+    """Return a report-level sender reputation summary for the detail page."""
+    if result is None:
+        return {
+            "status": "unavailable",
+            "status_label": "Reputation unavailable",
+            "status_detail": "Sender reputation could not be calculated for this report.",
+            "total_sources": 0,
+            "listed_sources": 0,
+            "sources_needing_review": 0,
+            "clean_sources": 0,
+            "unknown_sources": 0,
+            "highest_risk_score": None,
+            "feed_status": "unavailable",
+            "feed_summary": "No reputation evidence is available.",
+            "checked_at": "",
+            "worst_source": None,
+            "recommendations": [],
+        }
+
+    sources = list(result.sources or [])
+    summary = dict(result.summary or {})
+    worst = sources[0] if sources else None
+    worst_view = reputation_presentation(worst) if worst else None
+    feed_statuses = [reputation_presentation(item).feed_status for item in sources]
+    listed_sources = int(summary.get("listed") or 0)
+    review_sources = int(summary.get("suspicious") or 0)
+    if listed_sources:
+        status = "listed"
+        status_label = "Listed sender detected"
+        status_detail = "At least one sending IP has reputation listing evidence."
+    elif review_sources:
+        status = "attention"
+        status_label = "Sender review needed"
+        status_detail = "At least one sending IP has risk signals that need review."
+    elif sources:
+        status = "clean"
+        status_label = "No reputation findings"
+        status_detail = "No configured reputation feed or local signal flagged these sources."
+    else:
+        status = "unknown"
+        status_label = "No sending sources"
+        status_detail = "This report does not contain sending-source records."
+
+    if "listed" in feed_statuses:
+        feed_status = "listed"
+        feed_summary = "At least one reputation feed returned a listing."
+    elif "error" in feed_statuses:
+        feed_status = "error"
+        feed_summary = "One or more reputation lookups returned errors."
+    elif "checked" in feed_statuses:
+        feed_status = "checked"
+        feed_summary = "External reputation feeds checked without listings."
+    elif "not_configured" in feed_statuses:
+        feed_status = "not_configured"
+        feed_summary = "External reputation feeds are not configured."
+    elif "local_only" in feed_statuses:
+        feed_status = "local_only"
+        feed_summary = "Using local DMARC evidence only; external feeds are not enabled."
+    else:
+        feed_status = "unknown"
+        feed_summary = "No reputation feed evidence is available."
+
+    recommendations: List[str] = []
+    for source in sources:
+        for recommendation in source.recommendations:
+            if recommendation not in recommendations:
+                recommendations.append(recommendation)
+            if len(recommendations) >= 3:
+                break
+        if len(recommendations) >= 3:
+            break
+    highest_risk_score = summary.get("highest_risk_score")
+    if highest_risk_score is None and sources:
+        highest_risk_score = max(source.risk_score for source in sources)
+
+    return {
+        "status": status,
+        "status_label": status_label,
+        "status_detail": status_detail,
+        "total_sources": int(summary.get("total_sources") or len(sources)),
+        "listed_sources": listed_sources,
+        "sources_needing_review": review_sources,
+        "clean_sources": int(summary.get("clean") or 0),
+        "unknown_sources": int(summary.get("unknown") or 0),
+        "highest_risk_score": highest_risk_score,
+        "feed_status": feed_status,
+        "feed_summary": feed_summary,
+        "checked_at": result.checked_at,
+        "worst_source": (
+            {
+                "ip": worst.ip,
+                "status": worst.status,
+                "status_label": worst_view.status_label if worst_view else worst.status,
+                "risk_score": worst.risk_score,
+                "summary": worst.summary,
+                "listings": worst.listings,
+            }
+            if worst
+            else None
+        ),
+        "recommendations": recommendations,
+    }
+
+
 def _source_details(
     ip: str,
     record: Dict[str, Any],
@@ -881,6 +988,7 @@ async def get_report_by_id(
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))
         for ip, row, hostname in zip(ips, source_rows, hostnames, strict=True)
     }
+    reputation_result: Optional[DomainReputation] = None
     reputations_by_ip: Dict[str, SourceReputation] = {}
     try:
         reputation_result, _, _ = await build_source_reputation_cached(
@@ -949,4 +1057,5 @@ async def get_report_by_id(
         policy=policy_detail,
         records=record_details,
         summary=summary_detail,
+        reputation_summary=_report_reputation_summary(reputation_result),
     )

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -781,69 +781,84 @@ def _source_reputation_dict(item: SourceReputation) -> Dict[str, Any]:
     }
 
 
-def _report_reputation_summary(result: Optional[DomainReputation]) -> Dict[str, Any]:
-    """Return a report-level sender reputation summary for the detail page."""
-    if result is None:
-        return {
-            "status": "unavailable",
-            "status_label": "Reputation unavailable",
-            "status_detail": "Sender reputation could not be calculated for this report.",
-            "total_sources": 0,
-            "listed_sources": 0,
-            "sources_needing_review": 0,
-            "clean_sources": 0,
-            "unknown_sources": 0,
-            "highest_risk_score": None,
-            "feed_status": "unavailable",
-            "feed_summary": "No reputation evidence is available.",
-            "checked_at": "",
-            "worst_source": None,
-            "recommendations": [],
-        }
+def _empty_report_reputation_summary() -> Dict[str, Any]:
+    return {
+        "status": "unavailable",
+        "status_label": "Reputation unavailable",
+        "status_detail": "Sender reputation could not be calculated for this report.",
+        "total_sources": 0,
+        "listed_sources": 0,
+        "sources_needing_review": 0,
+        "clean_sources": 0,
+        "unknown_sources": 0,
+        "highest_risk_score": None,
+        "feed_status": "unavailable",
+        "feed_summary": "No reputation evidence is available.",
+        "checked_at": "",
+        "worst_source": None,
+        "recommendations": [],
+    }
 
-    sources = list(result.sources or [])
-    summary = dict(result.summary or {})
-    worst = sources[0] if sources else None
-    worst_view = reputation_presentation(worst) if worst else None
-    feed_statuses = [reputation_presentation(item).feed_status for item in sources]
-    listed_sources = int(summary.get("listed") or 0)
-    review_sources = int(summary.get("suspicious") or 0)
+
+def _report_reputation_status(
+    sources: List[SourceReputation], listed_sources: int, review_sources: int
+) -> Dict[str, str]:
     if listed_sources:
-        status = "listed"
-        status_label = "Listed sender detected"
-        status_detail = "At least one sending IP has reputation listing evidence."
-    elif review_sources:
-        status = "attention"
-        status_label = "Sender review needed"
-        status_detail = "At least one sending IP has risk signals that need review."
-    elif sources:
-        status = "clean"
-        status_label = "No reputation findings"
-        status_detail = "No configured reputation feed or local signal flagged these sources."
-    else:
-        status = "unknown"
-        status_label = "No sending sources"
-        status_detail = "This report does not contain sending-source records."
+        return {
+            "status": "listed",
+            "status_label": "Listed sender detected",
+            "status_detail": "At least one sending IP has reputation listing evidence.",
+        }
+    if review_sources:
+        return {
+            "status": "attention",
+            "status_label": "Sender review needed",
+            "status_detail": "At least one sending IP has risk signals that need review.",
+        }
+    if sources:
+        return {
+            "status": "clean",
+            "status_label": "No reputation findings",
+            "status_detail": "No configured reputation feed or local signal flagged these sources.",
+        }
+    return {
+        "status": "unknown",
+        "status_label": "No sending sources",
+        "status_detail": "This report does not contain sending-source records.",
+    }
 
+
+def _report_feed_summary(sources: List[SourceReputation]) -> Dict[str, str]:
+    feed_statuses = [reputation_presentation(item).feed_status for item in sources]
     if "listed" in feed_statuses:
-        feed_status = "listed"
-        feed_summary = "At least one reputation feed returned a listing."
-    elif "error" in feed_statuses:
-        feed_status = "error"
-        feed_summary = "One or more reputation lookups returned errors."
-    elif "checked" in feed_statuses:
-        feed_status = "checked"
-        feed_summary = "External reputation feeds checked without listings."
-    elif "not_configured" in feed_statuses:
-        feed_status = "not_configured"
-        feed_summary = "External reputation feeds are not configured."
-    elif "local_only" in feed_statuses:
-        feed_status = "local_only"
-        feed_summary = "Using local DMARC evidence only; external feeds are not enabled."
-    else:
-        feed_status = "unknown"
-        feed_summary = "No reputation feed evidence is available."
+        return {
+            "feed_status": "listed",
+            "feed_summary": "At least one reputation feed returned a listing.",
+        }
+    if "error" in feed_statuses:
+        return {
+            "feed_status": "error",
+            "feed_summary": "One or more reputation lookups returned errors.",
+        }
+    if "checked" in feed_statuses:
+        return {
+            "feed_status": "checked",
+            "feed_summary": "External reputation feeds checked without listings.",
+        }
+    if "not_configured" in feed_statuses:
+        return {
+            "feed_status": "not_configured",
+            "feed_summary": "External reputation feeds are not configured.",
+        }
+    if "local_only" in feed_statuses:
+        return {
+            "feed_status": "local_only",
+            "feed_summary": "Using local DMARC evidence only; external feeds are not enabled.",
+        }
+    return {"feed_status": "unknown", "feed_summary": "No reputation feed evidence is available."}
 
+
+def _report_reputation_recommendations(sources: List[SourceReputation]) -> List[str]:
     recommendations: List[str] = []
     for source in sources:
         for recommendation in source.recommendations:
@@ -853,36 +868,49 @@ def _report_reputation_summary(result: Optional[DomainReputation]) -> Dict[str, 
                 break
         if len(recommendations) >= 3:
             break
+    return recommendations
+
+
+def _report_worst_source(worst: Optional[SourceReputation]) -> Optional[Dict[str, Any]]:
+    if not worst:
+        return None
+    worst_view = reputation_presentation(worst)
+    return {
+        "ip": worst.ip,
+        "status": worst.status,
+        "status_label": worst_view.status_label,
+        "risk_score": worst.risk_score,
+        "summary": worst.summary,
+        "listings": worst.listings,
+    }
+
+
+def _report_reputation_summary(result: Optional[DomainReputation]) -> Dict[str, Any]:
+    """Return a report-level sender reputation summary for the detail page."""
+    if result is None:
+        return _empty_report_reputation_summary()
+
+    sources = list(result.sources or [])
+    summary = dict(result.summary or {})
+    listed_sources = int(summary.get("listed") or 0)
+    review_sources = int(summary.get("suspicious") or 0)
     highest_risk_score = summary.get("highest_risk_score")
     if highest_risk_score is None and sources:
         highest_risk_score = max(source.risk_score for source in sources)
+    status_view = _report_reputation_status(sources, listed_sources, review_sources)
 
     return {
-        "status": status,
-        "status_label": status_label,
-        "status_detail": status_detail,
+        **status_view,
         "total_sources": int(summary.get("total_sources") or len(sources)),
         "listed_sources": listed_sources,
         "sources_needing_review": review_sources,
         "clean_sources": int(summary.get("clean") or 0),
         "unknown_sources": int(summary.get("unknown") or 0),
         "highest_risk_score": highest_risk_score,
-        "feed_status": feed_status,
-        "feed_summary": feed_summary,
+        **_report_feed_summary(sources),
         "checked_at": result.checked_at,
-        "worst_source": (
-            {
-                "ip": worst.ip,
-                "status": worst.status,
-                "status_label": worst_view.status_label if worst_view else worst.status,
-                "risk_score": worst.risk_score,
-                "summary": worst.summary,
-                "listings": worst.listings,
-            }
-            if worst
-            else None
-        ),
-        "recommendations": recommendations,
+        "worst_source": _report_worst_source(sources[0] if sources else None),
+        "recommendations": _report_reputation_recommendations(sources),
     }
 
 

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -189,6 +189,21 @@ function reportDetailApp(reportId = '') {
             return 'bg-gray-100 text-gray-800';
         },
 
+        reportReputationClass(status) {
+            if (status === 'listed') return 'bg-red-100 text-red-800';
+            if (status === 'attention') return 'bg-yellow-100 text-yellow-800';
+            if (status === 'clean') return 'bg-green-100 text-green-800';
+            return 'bg-gray-100 text-gray-800';
+        },
+
+        reportReputationRiskLabel(summary) {
+            const score = summary?.highest_risk_score;
+            if (typeof score === 'number') {
+                return `highest risk ${score}/100`;
+            }
+            return 'risk unknown';
+        },
+
         reputationFeedClass(status) {
             if (status === 'listed') return 'bg-red-50 text-red-800';
             if (status === 'error') return 'bg-yellow-50 text-yellow-800';

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -120,6 +120,73 @@
                 {% endcall %}
             </div>
 
+            <!-- Sender Reputation Summary -->
+            {% call card() %}
+                {% call card_header() %}
+                    {% call card_title() %}Sender Reputation{% endcall %}
+                    {% call card_description() %}Highest-risk sending IPs observed in this report{% endcall %}
+                {% endcall %}
+                {% call card_content() %}
+                    <div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)]">
+                        <div class="space-y-3">
+                            <div class="flex flex-wrap items-center gap-2">
+                                <span class="inline-flex items-center rounded px-2 py-1 text-xs font-semibold"
+                                      :class="reportReputationClass(report.reputation_summary?.status)"
+                                      x-text="report.reputation_summary?.status_label || 'Reputation unavailable'"></span>
+                                <span class="inline-flex items-center rounded bg-base-200 px-2 py-1 font-mono text-xs text-base-content/80"
+                                      x-text="reportReputationRiskLabel(report.reputation_summary)"></span>
+                                <span class="inline-flex items-center rounded px-2 py-1 text-xs"
+                                      :class="reputationFeedClass(report.reputation_summary?.feed_status)"
+                                      x-text="report.reputation_summary?.feed_summary || 'No reputation feed evidence is available.'"></span>
+                            </div>
+                            <p class="text-sm text-[#5f5c78]" x-text="report.reputation_summary?.status_detail || 'Sender reputation could not be calculated for this report.'"></p>
+                            <template x-if="report.reputation_summary?.worst_source">
+                                <div class="rounded border border-[#dfdfdf] bg-[#fbfbfb] p-3 text-sm text-[#5f5c78]">
+                                    <div class="font-semibold text-[#120d36]">
+                                        Highest-risk source:
+                                        <span class="font-mono" x-text="report.reputation_summary.worst_source.ip"></span>
+                                    </div>
+                                    <div>
+                                        <span x-text="report.reputation_summary.worst_source.status_label"></span>
+                                        <span>&middot;</span>
+                                        <span x-text="'risk ' + report.reputation_summary.worst_source.risk_score + '/100'"></span>
+                                    </div>
+                                    <div x-text="report.reputation_summary.worst_source.summary"></div>
+                                </div>
+                            </template>
+                        </div>
+                        <div class="grid grid-cols-2 gap-3 text-sm">
+                            <div class="rounded border border-[#dfdfdf] p-3">
+                                <div class="text-xs font-semibold uppercase tracking-wide text-[#5f5c78]">Sources</div>
+                                <div class="text-2xl font-bold text-[#120d36]" x-text="report.reputation_summary?.total_sources ?? 0"></div>
+                            </div>
+                            <div class="rounded border border-[#dfdfdf] p-3">
+                                <div class="text-xs font-semibold uppercase tracking-wide text-[#5f5c78]">Listed</div>
+                                <div class="text-2xl font-bold text-[#ff6f3c]" x-text="report.reputation_summary?.listed_sources ?? 0"></div>
+                            </div>
+                            <div class="rounded border border-[#dfdfdf] p-3">
+                                <div class="text-xs font-semibold uppercase tracking-wide text-[#5f5c78]">Needs review</div>
+                                <div class="text-2xl font-bold text-[#c77700]" x-text="report.reputation_summary?.sources_needing_review ?? 0"></div>
+                            </div>
+                            <div class="rounded border border-[#dfdfdf] p-3">
+                                <div class="text-xs font-semibold uppercase tracking-wide text-[#5f5c78]">Clean</div>
+                                <div class="text-2xl font-bold text-[#2f9da5]" x-text="report.reputation_summary?.clean_sources ?? 0"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <template x-if="(report.reputation_summary?.recommendations || []).length">
+                        <div class="mt-4 rounded border border-[#d8edf0] bg-[#f3fbfc] p-3">
+                            <div class="mb-2 text-sm font-semibold text-[#120d36]">Recommended next steps</div>
+                            <ul class="space-y-1 text-sm text-[#5f5c78]">
+                                <template x-for="item in report.reputation_summary.recommendations" :key="item">
+                                    <li x-text="item"></li>
+                                </template>
+                            </ul>
+                        </div>
+                    </template>
+                {% endcall %}
+            {% endcall %}
+
             <!-- Report Metadata -->
             {% call card() %}
                 {% call card_header() %}

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -966,6 +966,134 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
     assert reputation_summary["recommendations"] == ["Follow the provider delisting process."]
 
 
+def test_report_reputation_summary_covers_empty_and_unchecked_sources():
+    unavailable = reports_endpoint._report_reputation_summary(None)
+    assert unavailable["status"] == "unavailable"
+    assert unavailable["feed_status"] == "unavailable"
+
+    no_sources = reports_endpoint._report_reputation_summary(
+        DomainReputation(
+            domain="example.com",
+            status="unknown",
+            checked_at="2026-07-01T00:00:00Z",
+            sources=[],
+            summary={},
+        )
+    )
+
+    assert no_sources["status"] == "unknown"
+    assert no_sources["total_sources"] == 0
+    assert no_sources["feed_status"] == "unknown"
+    assert no_sources["worst_source"] is None
+    assert no_sources["recommendations"] == []
+
+
+def test_report_reputation_summary_covers_feed_status_and_attention_branches():
+    suspicious = SourceReputation(
+        ip="192.0.2.55",
+        status="suspicious",
+        risk_score=41,
+        summary="Local source needs review.",
+        evidence=[
+            ReputationEvidence(
+                label="External reputation feeds",
+                value="Lookup timed out",
+                source="external",
+            )
+        ],
+        recommendations=["Confirm source owner.", "Review authentication failures."],
+        checked_at="2026-07-01T00:00:00Z",
+    )
+    clean_external = SourceReputation(
+        ip="198.51.100.20",
+        status="clean",
+        risk_score=2,
+        summary="No reputation listing observed.",
+        evidence=[
+            ReputationEvidence(
+                label="External reputation feeds",
+                value="Checked without listings",
+                source="external",
+            )
+        ],
+        checked_at="2026-07-01T00:00:00Z",
+    )
+    not_configured = SourceReputation(
+        ip="203.0.113.10",
+        status="unknown",
+        risk_score=0,
+        summary="External feeds not configured.",
+        evidence=[
+            ReputationEvidence(
+                label="External reputation feeds",
+                value="External feeds not configured",
+                source="external",
+            )
+        ],
+        checked_at="2026-07-01T00:00:00Z",
+    )
+    local_only = SourceReputation(
+        ip="203.0.113.11",
+        status="clean",
+        risk_score=0,
+        summary="Local evidence only.",
+        checked_at="2026-07-01T00:00:00Z",
+    )
+
+    attention_summary = reports_endpoint._report_reputation_summary(
+        DomainReputation(
+            domain="example.com",
+            status="suspicious",
+            checked_at="2026-07-01T00:00:00Z",
+            sources=[suspicious, clean_external],
+            summary={"total_sources": 2, "suspicious": 1, "clean": 1},
+        )
+    )
+
+    assert attention_summary["status"] == "attention"
+    assert attention_summary["feed_status"] == "error"
+    assert attention_summary["highest_risk_score"] == 41
+    assert attention_summary["worst_source"]["ip"] == "192.0.2.55"
+    assert attention_summary["recommendations"] == [
+        "Confirm source owner.",
+        "Review authentication failures.",
+    ]
+
+    checked_summary = reports_endpoint._report_reputation_summary(
+        DomainReputation(
+            domain="example.com",
+            status="clean",
+            checked_at="2026-07-01T00:00:00Z",
+            sources=[clean_external],
+            summary={"total_sources": 1, "clean": 1, "highest_risk_score": 2},
+        )
+    )
+    assert checked_summary["status"] == "clean"
+    assert checked_summary["feed_status"] == "checked"
+
+    not_configured_summary = reports_endpoint._report_reputation_summary(
+        DomainReputation(
+            domain="example.com",
+            status="unknown",
+            checked_at="2026-07-01T00:00:00Z",
+            sources=[not_configured],
+            summary={"total_sources": 1, "unknown": 1},
+        )
+    )
+    assert not_configured_summary["feed_status"] == "not_configured"
+
+    local_only_summary = reports_endpoint._report_reputation_summary(
+        DomainReputation(
+            domain="example.com",
+            status="clean",
+            checked_at="2026-07-01T00:00:00Z",
+            sources=[local_only],
+            summary={"total_sources": 1, "clean": 1},
+        )
+    )
+    assert local_only_summary["feed_status"] == "local_only"
+
+
 def test_get_report_by_id_refreshes_reputation_cache(
     authed_client: TestClient,
     db_session,

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -956,6 +956,14 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
     assert "Example DNSBL" in record["reputation"]["feed_summary"]
     assert record["reputation"]["risk_score"] == 82
     assert record["reputation"]["listings"] == ["Example DNSBL"]
+    reputation_summary = response.json()["reputation_summary"]
+    assert reputation_summary["status"] == "listed"
+    assert reputation_summary["status_label"] == "Listed sender detected"
+    assert reputation_summary["listed_sources"] == 1
+    assert reputation_summary["highest_risk_score"] == 82
+    assert reputation_summary["feed_status"] == "listed"
+    assert reputation_summary["worst_source"]["ip"] == "193.138.195.141"
+    assert reputation_summary["recommendations"] == ["Follow the provider delisting process."]
 
 
 def test_get_report_by_id_refreshes_reputation_cache(
@@ -1000,7 +1008,9 @@ def test_get_report_by_id_refreshes_reputation_cache(
     monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
 
-    response = authed_client.get("/api/v1/reports/source-intel-refresh-report?refresh_reputation=true")
+    response = authed_client.get(
+        "/api/v1/reports/source-intel-refresh-report?refresh_reputation=true"
+    )
 
     assert response.status_code == 200
     assert captured_refresh == [True]
@@ -1034,6 +1044,7 @@ def test_get_report_by_id_continues_when_reputation_enrichment_fails(
     record = response.json()["records"][0]
     assert record["source_details"]["sender"]
     assert record["reputation"] is None
+    assert response.json()["reputation_summary"]["status"] == "unavailable"
 
 
 def test_get_report_by_id_surfaces_refresh_reputation_failure(
@@ -1057,7 +1068,9 @@ def test_get_report_by_id_surfaces_refresh_reputation_failure(
     monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", failing_reputation)
 
-    response = authed_client.get("/api/v1/reports/source-intel-refresh-failure?refresh_reputation=true")
+    response = authed_client.get(
+        "/api/v1/reports/source-intel-refresh-failure?refresh_reputation=true"
+    )
 
     assert response.status_code == 503
     assert response.json()["detail"] == "Source reputation could not be refreshed."


### PR DESCRIPTION
## Summary
- adds a report-level sender reputation summary to aggregate report details
- surfaces highest-risk source, feed coverage, counts, and recommended next steps above the records table
- keeps existing per-IP reputation details intact

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_reports_api.py -q`
- `git diff --check`
- `.venv/bin/python -m py_compile backend/app/api/api_v1/endpoints/reports.py`

Part of #384.