### PR TITLE
feat: add remediation loop context

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1750,6 +1750,62 @@ def _remediation_loop_state(action: Dict[str, Any]) -> str:
     return "manual_action"
 
 
+def _remediation_loop_context(state: str, action: Dict[str, Any]) -> Dict[str, str]:
+    """Return operator-facing context for a dashboard remediation bucket."""
+    action_type = str(action.get("type") or "")
+    if state == "needs_approval":
+        return {
+            "state_label": "Needs approval",
+            "owner": "Domain DNS operator",
+            "automation_path": "provider_preview",
+            "completion_criteria": "DNS change is previewed, approved, applied, and verified.",
+            "why": "A high-impact DNS or policy finding can move through a controlled approval path.",
+        }
+    if state == "investigate":
+        return {
+            "state_label": "Investigate",
+            "owner": (
+                "Mail operations owner"
+                if action_type not in REMEDIATION_REPUTATION_ACTION_TYPES
+                else "Deliverability owner"
+            ),
+            "automation_path": "investigate",
+            "completion_criteria": "Sender legitimacy is confirmed before any DNS or policy change.",
+            "why": "This finding needs evidence review before DMARQ can suggest a safe repair.",
+        }
+    return {
+        "state_label": "Manual action",
+        "owner": "Mail or DNS operator",
+        "automation_path": "manual",
+        "completion_criteria": "The operator completes the recommended action and refreshes evidence.",
+        "why": "This item is not safe or specific enough for one-click repair yet.",
+    }
+
+
+def _dashboard_remediation_item(
+    domain_name: str,
+    action: Dict[str, Any],
+    *,
+    include_detail: bool = True,
+) -> Dict[str, Any]:
+    """Convert one health action into a dashboard remediation-loop item."""
+    state = _remediation_loop_state(action)
+    context = _remediation_loop_context(state, action)
+    item = {
+        "domain": domain_name,
+        "state": state,
+        "severity": str(action.get("severity") or "info"),
+        "title": str(action.get("title") or "Review remediation item"),
+        "next_step": str(action.get("next_step") or "Review the domain evidence."),
+        "score_impact": int(action.get("score_impact") or 0),
+        "type": str(action.get("type") or "health_action"),
+        **context,
+    }
+    if include_detail:
+        item["detail"] = str(action.get("detail") or "")
+    return item
+
+
 def _build_dashboard_remediation_loop(
     domains: List[Dict[str, Any]],
     remediation_activity: Dict[str, Any],
@@ -1769,18 +1825,7 @@ def _build_dashboard_remediation_loop(
         for action in health.get("actions") or []:
             state = _remediation_loop_state(action)
             counters[state] += 1
-            items.append(
-                {
-                    "domain": domain_name,
-                    "state": state,
-                    "severity": str(action.get("severity") or "info"),
-                    "title": str(action.get("title") or "Review remediation item"),
-                    "detail": str(action.get("detail") or ""),
-                    "next_step": str(action.get("next_step") or "Review the domain evidence."),
-                    "score_impact": int(action.get("score_impact") or 0),
-                    "type": str(action.get("type") or "health_action"),
-                }
-            )
+            items.append(_dashboard_remediation_item(domain_name, action))
 
     items.sort(
         key=lambda item: (
@@ -1817,16 +1862,7 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
     for action in (domain.get("health") or {}).get("actions") or []:
         state = _remediation_loop_state(action)
         counters[state] += 1
-        items.append(
-            {
-                "domain": domain_name,
-                "state": state,
-                "severity": str(action.get("severity") or "info"),
-                "title": str(action.get("title") or "Review remediation item"),
-                "next_step": str(action.get("next_step") or "Review the domain evidence."),
-                "score_impact": int(action.get("score_impact") or 0),
-            }
-        )
+        items.append(_dashboard_remediation_item(domain_name, action, include_detail=False))
 
     items.sort(
         key=lambda item: (

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2216,6 +2216,52 @@ def test_remediation_loop_classifies_reputation_actions_as_investigate(action_ty
     assert _remediation_loop_state({"type": action_type, "severity": "high"}) == "investigate"
 
 
+@pytest.mark.parametrize(
+    ("action", "expected_context"),
+    [
+        (
+            {"type": "source_reputation_listed", "severity": "high"},
+            {
+                "state": "investigate",
+                "state_label": "Investigate",
+                "owner": "Deliverability owner",
+                "automation_path": "investigate",
+            },
+        ),
+        (
+            {"type": "low_compliance", "severity": "medium"},
+            {
+                "state": "investigate",
+                "state_label": "Investigate",
+                "owner": "Mail operations owner",
+                "automation_path": "investigate",
+            },
+        ),
+        (
+            {"type": "tls_coverage_gap", "severity": "medium"},
+            {
+                "state": "manual_action",
+                "state_label": "Manual action",
+                "owner": "Mail or DNS operator",
+                "automation_path": "manual",
+            },
+        ),
+    ],
+)
+def test_dashboard_remediation_item_includes_context_for_non_approval_states(
+    action: dict,
+    expected_context: dict,
+):
+    """Non-approval remediation buckets should expose stable operator context."""
+    item = domains_endpoint._dashboard_remediation_item(DOMAIN, action)
+
+    for key, value in expected_context.items():
+        assert item[key] == value
+    assert item["domain"] == DOMAIN
+    assert item["completion_criteria"]
+    assert item["why"]
+
+
 def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_session):
     """Empty DNS results stay false without being labeled resolver failures."""
     _persist_minimal_report(db_session)

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2189,6 +2189,11 @@ def test_summary_includes_current_remediation_loop(
     assert loop["total_open"] >= 2
     assert loop["items"][0]["domain"] == DOMAIN
     assert loop["items"][0]["state"] == "needs_approval"
+    assert loop["items"][0]["state_label"] == "Needs approval"
+    assert loop["items"][0]["owner"] == "Domain DNS operator"
+    assert loop["items"][0]["automation_path"] == "provider_preview"
+    assert loop["items"][0]["completion_criteria"]
+    assert loop["items"][0]["why"]
     assert loop["items"][0]["title"]
     assert loop["items"][0]["next_step"]
     domain = response.json()["domains"][0]
@@ -2196,6 +2201,9 @@ def test_summary_includes_current_remediation_loop(
     assert domain["remediation_workload"]["needs_approval"] >= 2
     assert domain["remediation_workload"]["total_open"] >= 2
     assert domain["remediation_workload"]["primary"]["state"] == "needs_approval"
+    assert domain["remediation_workload"]["primary"]["state_label"] == "Needs approval"
+    assert domain["remediation_workload"]["primary"]["owner"] == "Domain DNS operator"
+    assert domain["remediation_workload"]["primary"]["automation_path"] == "provider_preview"
     assert domain["remediation_workload"]["primary"]["title"]
 
 


### PR DESCRIPTION
## Summary
- adds operator-facing context to dashboard remediation loop items
- includes state label, owner, automation path, completion criteria, and rationale for each current fix item
- keeps the existing remediation counters and ordering intact

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py -q`
- `git diff --check`
- `.venv/bin/python -m py_compile backend/app/api/api_v1/endpoints/domains.py`

Part of #384.