### PR TITLE
ci: retry gitops manifest pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,11 @@ jobs:
               fi
               echo "GitOps push failed on attempt ${attempt}; rebasing onto latest main before retry."
               git fetch origin main
-              git rebase origin/main
+              if ! git rebase origin/main; then
+                echo "::error::Failed to rebase nonproduction GitOps manifest update onto latest main."
+                git rebase --abort || true
+                exit 1
+              fi
             done
             echo "::error::Failed to push nonproduction GitOps manifest update after rebasing."
             exit 1
@@ -473,7 +477,11 @@ jobs:
               fi
               echo "GitOps push failed on attempt ${attempt}; rebasing onto latest main before retry."
               git fetch origin main
-              git rebase origin/main
+              if ! git rebase origin/main; then
+                echo "::error::Failed to rebase production GitOps manifest update onto latest main."
+                git rebase --abort || true
+                exit 1
+              fi
             done
             echo "::error::Failed to push production GitOps manifest update after rebasing."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,16 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "chore(gitops): update dmarq nonprod images to ${{ steps.tag.outputs.short_sha }}"
-            git push
+            for attempt in 1 2 3; do
+              if git push; then
+                exit 0
+              fi
+              echo "GitOps push failed on attempt ${attempt}; rebasing onto latest main before retry."
+              git fetch origin main
+              git rebase origin/main
+            done
+            echo "::error::Failed to push nonproduction GitOps manifest update after rebasing."
+            exit 1
           fi
 
   # ── Stage 4b: GitOps – gated production manifest promotion ───────────────
@@ -458,5 +467,14 @@ jobs:
             echo "No production changes to commit"
           else
             git commit -m "chore(gitops): promote dmarq prod image to ${{ steps.tag.outputs.short_sha }}"
-            git push
+            for attempt in 1 2 3; do
+              if git push; then
+                exit 0
+              fi
+              echo "GitOps push failed on attempt ${attempt}; rebasing onto latest main before retry."
+              git fetch origin main
+              git rebase origin/main
+            done
+            echo "::error::Failed to push production GitOps manifest update after rebasing."
+            exit 1
           fi


### PR DESCRIPTION
## Summary
- retry GitOps manifest pushes after rebasing onto the latest k8s-cluster-state main
- apply the same retry flow to non-production and gated production manifest jobs

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
- git diff --check

Follow-up to the #625 post-merge CI failure where the parallel production and non-production GitOps jobs raced on pushes to christianlouis/k8s-cluster-state.