### PR TITLE
fix: allow manual release GitOps deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: false
         type: boolean
+      deploy_gitops:
+        description: Also update GitOps manifests for this manually selected release
+        required: false
+        default: false
+        type: boolean
   schedule:
     # Weekly security scan on Mondays at 00:00 UTC
     - cron: '0 0 * * 1'
@@ -305,7 +310,7 @@ jobs:
     name: Update K8s Manifests
     runs-on: ubuntu-latest
     needs: [docker]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_gitops == 'true')
     permissions:
       contents: read
 
@@ -401,7 +406,7 @@ jobs:
     name: Promote Production K8s Manifest
     runs-on: ubuntu-latest
     needs: [docker]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_gitops == 'true')
     environment: dmarq-production-gitops
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,8 +232,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.release_ref || github.ref }}
+
+      - name: Checkout selected release ref
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_ref != ''
+        env:
+          RELEASE_REF: ${{ github.event.inputs.release_ref }}
+        run: |
+          git fetch --tags --force --depth=100 origin main
+          git checkout "$RELEASE_REF"
 
       - name: Resolve release image tag
         id: release_ref


### PR DESCRIPTION
## Summary
- add an explicit deploy_gitops workflow_dispatch switch to the CI workflow
- allow manually selected release builds to update nonprod and production GitOps manifests when that switch is set
- keep the existing automatic main-branch push behavior unchanged

## Validation
- Ruby YAML parser loaded .github/workflows/ci.yml successfully
- git diff --check

This fixes the current release gap where semantic-release creates a version commit/tag with GITHUB_TOKEN, but that follow-up push does not trigger CI/GitOps automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional manual release setting to update GitOps manifests during a workflow run.
  * Expanded production manifest updates so they can run either on main branch changes or when manually enabled for a selected release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->