### PR TITLE
fix: reuse prewarmed DNS evidence in summaries

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -49,7 +49,11 @@ from app.services.cloudflare_oauth import (
 )
 from app.services.dane import check_dane_cached
 from app.services.demo_data import DEMO_DAYS, build_demo_health_score_history
-from app.services.dns_cache import get_cached_domain_dns_result, resolve_domain_dns_cached
+from app.services.dns_cache import (
+    get_cached_domain_dns_result,
+    get_latest_cached_domain_dns_evidence,
+    resolve_domain_dns_cached,
+)
 from app.services.dns_guidance import MailAuthSetupDefaults, build_dns_guidance
 from app.services.dns_provider_connectors import (
     provider_connector_metadata,
@@ -3341,6 +3345,20 @@ async def _resolve_summary_dns_result(
                 cached_result,
                 cached=cached,
                 checked_at=checked_at,
+                pending=False,
+            )
+        fallback_result, fallback_cached, fallback_checked_at = (
+            get_latest_cached_domain_dns_evidence(
+                db,
+                provider,
+                domain_name,
+            )
+        )
+        if fallback_result is not None:
+            return _with_dns_summary_metadata(
+                fallback_result,
+                cached=fallback_cached,
+                checked_at=fallback_checked_at,
                 pending=False,
             )
         return _pending_dns_summary_result()

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -470,3 +470,36 @@ def get_cached_domain_dns_result(
     if row is None:
         return None, False, None
     return _result_from_json(row.result_json), True, row.checked_at
+
+
+def get_latest_cached_domain_dns_evidence(
+    db: Session,
+    provider: BaseDNSProvider,
+    domain: str,
+) -> Tuple[Optional[DomainDNSResult], bool, Optional[datetime]]:
+    """Return the newest cached DNS row with positive evidence for a domain.
+
+    Summary pages sometimes have a richer selector set than startup prewarming.
+    This lets them display already-known DMARC/SPF/NS evidence while the exact
+    selector-specific cache row is still warming up.
+    """
+    provider = _normalize_dns_provider(provider)
+    rows = (
+        db.query(DNSCache)
+        .filter(
+            DNSCache.domain == domain,
+            DNSCache.provider == provider.__class__.__name__,
+        )
+        .order_by(DNSCache.checked_at.desc())
+        .limit(25)
+        .all()
+    )
+    for row in rows:
+        try:
+            result = _result_from_json(row.result_json)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            logger.debug("Ignoring unreadable DNS cache row while finding latest evidence")
+            continue
+        if _has_dns_evidence(result):
+            return result, True, row.checked_at
+    return None, False, None

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -35,7 +35,11 @@ from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services.bimi import BIMIResult
 from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
-from app.services.dns_cache import _selectors_key, resolve_domain_dns_cached
+from app.services.dns_cache import (
+    _selectors_key,
+    get_latest_cached_domain_dns_evidence,
+    resolve_domain_dns_cached,
+)
 from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import (
     CloudflareDNSProvider,
@@ -1048,6 +1052,42 @@ async def test_dns_cache_preserves_provider_detection(db_session):
     assert second.nameservers == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
     assert second.dns_provider is not None
     assert second.dns_provider.provider_id == "cloudflare"
+
+
+@pytest.mark.asyncio
+async def test_latest_cached_dns_evidence_ignores_selector_key_mismatch(db_session):
+    """Summary pages can reuse positive prewarm evidence with a different selector key."""
+    mock_provider = AsyncMock()
+    prewarmed_dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 include:_spf.example.com -all",
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+    )
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=mock_provider.__class__.__name__,
+            selectors_key=_selectors_key([]),
+            result_json=json.dumps(asdict(prewarmed_dns), sort_keys=True),
+            checked_at=datetime(2026, 7, 4, 18, 0, 0),
+        )
+    )
+    db_session.commit()
+
+    result, cached, checked_at = get_latest_cached_domain_dns_evidence(
+        db_session,
+        mock_provider,
+        DOMAIN,
+    )
+
+    assert cached is True
+    assert checked_at == datetime(2026, 7, 4, 18, 0, 0)
+    assert result is not None
+    assert result.dmarc is True
+    assert result.spf is True
+    assert result.nameservers == ["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"]
 
 
 @pytest.mark.asyncio
@@ -2460,6 +2500,48 @@ def test_summary_endpoint_uses_database_aggregates_without_hydration(
     assert data["reports_processed"] == 1
     assert data["domains"][0]["pass_rate"] == 100.0
     assert data["domains"][0]["dns_pending"] is True
+    assert provider.check_domain.await_count == 0
+
+
+def test_summary_endpoint_reuses_prewarmed_dns_evidence_with_different_selectors(
+    authed_client: TestClient,
+    db_session,
+):
+    """Startup prewarm should keep summary pages from showing pending DNS after deploy."""
+    _persist_minimal_report(db_session)
+    provider = AsyncMock()
+    provider.check_domain = AsyncMock(return_value=MOCK_DNS_RESULT)
+    prewarmed_dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 include:_spf.example.com -all",
+        nameservers=["ada.ns.cloudflare.com", "ian.ns.cloudflare.com"],
+    )
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=provider.__class__.__name__,
+            selectors_key=_selectors_key([]),
+            result_json=json.dumps(asdict(prewarmed_dns), sort_keys=True),
+            checked_at=datetime(2026, 7, 4, 18, 0, 0),
+        )
+    )
+    db_session.commit()
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.get_default_provider",
+        return_value=provider,
+    ):
+        response = authed_client.get("/api/v1/domains/summary")
+
+    assert response.status_code == 200
+    domain = response.json()["domains"][0]
+    assert domain["dns_pending"] is False
+    assert domain["dns_cached"] is True
+    assert domain["dns_evidence_source"] == "cached_dns"
+    assert domain["dmarc_status"] is True
+    assert domain["spf_status"] is True
     assert provider.check_domain.await_count == 0
 
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1091,6 +1091,40 @@ async def test_latest_cached_dns_evidence_ignores_selector_key_mismatch(db_sessi
 
 
 @pytest.mark.asyncio
+async def test_latest_cached_dns_evidence_skips_invalid_and_empty_rows(db_session):
+    """Only positive, readable DNS cache rows should be reused as summary evidence."""
+    mock_provider = AsyncMock()
+    for selectors, result_json, checked_at in (
+        (["broken"], "{", datetime(2026, 7, 4, 18, 2, 0)),
+        (
+            ["empty"],
+            json.dumps(asdict(DomainDNSResult()), sort_keys=True),
+            datetime(2026, 7, 4, 18, 1, 0),
+        ),
+    ):
+        db_session.add(
+            DNSCache(
+                domain=DOMAIN,
+                provider=mock_provider.__class__.__name__,
+                selectors_key=_selectors_key(selectors),
+                result_json=result_json,
+                checked_at=checked_at,
+            )
+        )
+    db_session.commit()
+
+    result, cached, checked_at = get_latest_cached_domain_dns_evidence(
+        db_session,
+        mock_provider,
+        DOMAIN,
+    )
+
+    assert result is None
+    assert cached is False
+    assert checked_at is None
+
+
+@pytest.mark.asyncio
 async def test_dns_cache_uses_public_fallback_for_configured_resolver(db_session, monkeypatch):
     """Configured resolver misses should not hide positive public DNS evidence."""
 


### PR DESCRIPTION
## Summary
- Reuse the newest positive cached DNS evidence for a domain/provider when the exact selector-specific cache row is missing.
- Keep exact selector-cache hits and explicit refreshes authoritative.
- Add regression coverage for prewarm cache rows created without report-derived DKIM selectors.

Fixes #630.

## Validation
- /tmp/dmarq-384-loop-context/.venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py -q (98 passed)
- git diff --check