### PR TITLE
fix: clamp future source recency timestamps

### DIFF
--- a/backend/app/services/report_store.py
+++ b/backend/app/services/report_store.py
@@ -115,6 +115,25 @@ def _report_time_window(report: Dict[str, Any]) -> tuple[Optional[int], Optional
     return begin, end
 
 
+def _now_timestamp() -> int:
+    return int(datetime.now(timezone.utc).timestamp())
+
+
+def _observed_report_window(report: Dict[str, Any]) -> tuple[Optional[int], Optional[int]]:
+    """Return a source-observation window, clamped so UI recency never points ahead."""
+    begin, end = _report_time_window(report)
+    observed_start = begin if begin is not None else end
+    observed_end = end if end is not None else begin
+    now = _now_timestamp()
+    if observed_start is not None and observed_start > now:
+        observed_start = now
+    if observed_end is not None and observed_end > now:
+        observed_end = now
+    if observed_start is not None and observed_end is not None and observed_start > observed_end:
+        observed_start = observed_end
+    return observed_start, observed_end
+
+
 def _date_bucket(timestamp: Optional[int]) -> Optional[str]:
     if timestamp is None:
         return None
@@ -127,9 +146,7 @@ def _update_source_window(
     count: int,
     dmarc_passed: bool,
 ) -> None:
-    begin, end = _report_time_window(report)
-    observed_start = begin if begin is not None else end
-    observed_end = end if end is not None else begin
+    observed_start, observed_end = _observed_report_window(report)
 
     if observed_start is not None:
         current_first = source.get("first_seen")

--- a/backend/app/tests/test_report_store.py
+++ b/backend/app/tests/test_report_store.py
@@ -1,3 +1,4 @@
+from app.services import report_store as report_store_module
 from app.services.report_store import ReportStore, _auth_status_from_counts, _dominant_result
 
 
@@ -189,6 +190,38 @@ class TestReportStore:
             {"date": "2024-02-01", "count": 5, "passed": 0, "failed": 5},
         ]
         assert "_volume_by_date" not in source
+
+    def test_get_domain_sources_clamps_future_report_end_to_current_time(self, monkeypatch):
+        store = ReportStore.get_instance()
+        now = 1706788800
+        report = _sample_report("test.com")
+        report.update(
+            {
+                "report_id": "future-period-end",
+                "begin_timestamp": 1706745600,
+                "end_timestamp": 1706831999,
+                "records": [
+                    {
+                        "source_ip": "203.0.113.9",
+                        "count": 4,
+                        "disposition": "none",
+                        "dkim_result": "pass",
+                        "spf_result": "pass",
+                        "header_from": "test.com",
+                    }
+                ],
+            }
+        )
+        monkeypatch.setattr(report_store_module, "_now_timestamp", lambda: now)
+
+        store.add_report(report)
+
+        source = store.get_domain_sources("test.com")[0]
+        assert source["first_seen"] == 1706745600
+        assert source["last_seen"] == now
+        assert source["volume_history"] == [
+            {"date": "2024-02-01", "count": 4, "passed": 4, "failed": 0},
+        ]
 
     def test_get_domain_sources_ignores_missing_date_sentinel_timestamps(self):
         store = ReportStore.get_instance()


### PR DESCRIPTION
## Summary
- Clamp report-derived source observation windows to the current time before exposing first/last sent metadata.
- Prevent demo and timezone-crossing DMARC report periods from rendering future Last sent values.
- Add focused ReportStore regression coverage for future report-end timestamps.

Fixes #631.

## Validation
- /tmp/dmarq-384-loop-context/.venv/bin/python -m pytest backend/app/tests/test_report_store.py -q (24 passed)
- git diff --check