### PR TITLE
Hide empty domains from management by default

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1721,6 +1721,8 @@ class DomainSummaryResponse(BaseModel):
     overall_pass_rate: float
     reports_processed: int
     domains: List[Dict[str, Any]]
+    empty_domains_count: int = 0
+    empty_domains_hidden: int = 0
     health_summary: Dict[str, Any] = Field(default_factory=dict)
 
 
@@ -3388,6 +3390,10 @@ async def _resolve_summary_dns_result(
 @router.get("/summary", response_model=DomainSummaryResponse)
 async def get_domains_summary(
     refresh: bool = Query(False, title="Refresh cached DNS results"),
+    include_empty: bool = Query(
+        True,
+        title="Include domains with no reports or observed mail volume",
+    ),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
@@ -3426,6 +3432,20 @@ async def get_domains_summary(
             domains,
             workspace_id=workspace.id,
         )
+
+    def _has_activity(domain_name: str) -> bool:
+        summary = summaries.get(domain_name, {})
+        return bool(
+            int(summary.get("reports_processed", 0) or 0) > 0
+            or int(summary.get("total_count", 0) or 0) > 0
+        )
+
+    empty_domains = [domain_name for domain_name in domains if not _has_activity(domain_name)]
+    empty_domains_count = len(empty_domains)
+    if not include_empty and empty_domains:
+        hidden = set(empty_domains)
+        domains = [domain_name for domain_name in domains if domain_name not in hidden]
+    empty_domains_hidden = empty_domains_count if not include_empty else 0
 
     # Perform DNS checks for all domains, reusing fresh cached results.
     provider = get_default_provider(db)
@@ -3543,6 +3563,8 @@ async def get_domains_summary(
         overall_pass_rate=overall_pass_rate,
         reports_processed=total_reports,
         domains=domains_list,
+        empty_domains_count=empty_domains_count,
+        empty_domains_hidden=empty_domains_hidden,
         health_summary=health_summary,
     )
 

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -1,6 +1,8 @@
 function domainsApp() {
     return {
         domains: [],
+        emptyDomainsCount: 0,
+        emptyDomainsHidden: 0,
         openCreate: false,
         openEdit: false,
         loading: true,
@@ -60,7 +62,7 @@ function domainsApp() {
 
                 const emptyToggle = event.target.closest('[data-domain-toggle-empty]');
                 if (emptyToggle && root.contains(emptyToggle)) {
-                    this.showEmptyDomains = !this.showEmptyDomains;
+                    this.setShowEmptyDomains(!this.showEmptyDomains);
                     return;
                 }
 
@@ -98,26 +100,42 @@ function domainsApp() {
 
         async fetchDomains(options = {}) {
             const refresh = Boolean(options.refresh);
+            const includeEmpty =
+                options.includeEmpty === undefined ? this.showEmptyDomains : Boolean(options.includeEmpty);
             this.loading = !refresh;
             this.refreshing = refresh;
             this.loadError = '';
             try {
-                const response = await fetch(
-                    `/api/v1/domains/summary${refresh ? '?refresh=true' : ''}`
-                );
+                const params = new URLSearchParams();
+                params.set('include_empty', includeEmpty ? 'true' : 'false');
+                if (refresh) {
+                    params.set('refresh', 'true');
+                }
+                const response = await fetch(`/api/v1/domains/summary?${params.toString()}`);
                 if (!response.ok) {
                     throw new Error('Domains could not be loaded. Refresh the page or check the API service.');
                 }
                 const data = await response.json();
 
                 this.domains = data.domains.map((domain) => this.normalizeDomain(domain));
+                this.emptyDomainsCount = Number(data.empty_domains_count || 0);
+                this.emptyDomainsHidden = Number(data.empty_domains_hidden || 0);
             } catch (error) {
                 this.domains = [];
+                this.emptyDomainsCount = 0;
+                this.emptyDomainsHidden = 0;
                 this.loadError = error.message || 'Domains could not be loaded.';
                 console.error('Error fetching domains:', error);
             } finally {
                 this.loading = false;
                 this.refreshing = false;
+            }
+        },
+
+        async setShowEmptyDomains(show) {
+            this.showEmptyDomains = Boolean(show);
+            if (this.showEmptyDomains && this.emptyDomainsHidden > 0) {
+                await this.fetchDomains({ includeEmpty: true });
             }
         },
 
@@ -280,7 +298,11 @@ function domainsApp() {
         },
 
         hiddenEmptyDomainCount() {
-            return this.domains.filter((domain) => !domain.has_activity).length;
+            if (!this.showEmptyDomains && this.emptyDomainsHidden > 0) {
+                return this.emptyDomainsHidden;
+            }
+            const localEmptyCount = this.domains.filter((domain) => !domain.has_activity).length;
+            return Math.max(localEmptyCount, this.emptyDomainsCount || 0);
         },
 
         activeDomainCount() {
@@ -293,7 +315,12 @@ function domainsApp() {
         },
 
         showEmptyDomainHint() {
-            return !this.loading && !this.loadError && this.domains.length > 0 && this.activeDomainCount() === 0;
+            return (
+                !this.loading &&
+                !this.loadError &&
+                this.hiddenEmptyDomainCount() > 0 &&
+                this.activeDomainCount() === 0
+            );
         },
 
         genericDnsStatusText(domain, key) {

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -83,7 +83,7 @@
                                 {% endcall %}
                             {% endcall %}
                         </template>
-                        <template x-if="!loading && !loadError && domains.length === 0">
+                        <template x-if="!loading && !loadError && domains.length === 0 && hiddenEmptyDomainCount() === 0">
                             {% call tr() %}
                                 {% call td(colspan="5", class="text-center") %}
                                     <p class="py-4 text-muted-foreground">No domains found. Add a domain to get started.</p>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -498,7 +498,7 @@ def test_domains_page_distinguishes_loading_error_and_empty_states():
     assert "data-domain-retry-load" in template
     assert "data-domain-retry-load" in script
     assert 'x-if="!loading && loadError"' in template
-    assert 'x-if="!loading && !loadError && domains.length === 0"' in template
+    assert 'x-if="!loading && !loadError && domains.length === 0 && hiddenEmptyDomainCount() === 0"' in template
 
 
 def test_upload_uses_external_page_script_for_csp_migration():

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2537,6 +2537,42 @@ def test_summary_endpoint_uses_database_aggregates_without_hydration(
     assert provider.check_domain.await_count == 0
 
 
+def test_summary_endpoint_can_hide_empty_domains_before_dns_work(
+    authed_client: TestClient,
+    db_session,
+):
+    """Domain management can skip empty imported zones before DNS summary work runs."""
+    _persist_minimal_report(db_session)
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add(Domain(name="empty.example", workspace_id=workspace.id, active=True))
+    db_session.commit()
+
+    provider = AsyncMock(check_domain=AsyncMock(return_value=MOCK_DNS_RESULT))
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.get_default_provider",
+        return_value=provider,
+    ):
+        default_response = authed_client.get("/api/v1/domains/summary")
+        filtered_response = authed_client.get(
+            "/api/v1/domains/summary?include_empty=false&refresh=true"
+        )
+
+    assert default_response.status_code == 200
+    default_data = default_response.json()
+    assert default_data["total_domains"] == 2
+    assert default_data["empty_domains_count"] == 1
+    assert default_data["empty_domains_hidden"] == 0
+
+    assert filtered_response.status_code == 200
+    filtered_data = filtered_response.json()
+    assert filtered_data["total_domains"] == 1
+    assert filtered_data["empty_domains_count"] == 1
+    assert filtered_data["empty_domains_hidden"] == 1
+    assert [domain["domain_name"] for domain in filtered_data["domains"]] == [DOMAIN]
+    assert provider.check_domain.await_count == 1
+
+
 def test_summary_endpoint_reuses_prewarmed_dns_evidence_with_different_selectors(
     authed_client: TestClient,
     db_session,


### PR DESCRIPTION
## Summary\n- hide domains without reports or observed mail volume by default on the domain management page\n- add an opt-in summary API flag so the page can skip empty domains before DNS/provider checks\n- keep existing summary behavior backwards-compatible for other callers\n\nCloses #635\n\n## Local validation\n- python -m pytest backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py -q\n- black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py\n- isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py