### PR TITLE
Expose per-domain DMARC mailbox override in domain management

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3513,6 +3513,9 @@ async def get_domains_summary(
             "domain_name": domain_name,
             "description": stored_domain.description if stored_domain else None,
             "dkim_selectors": manual_selectors_by_domain.get(domain_name, []),
+            "dmarc_report_mailbox": (
+                stored_domain.dmarc_report_mailbox if stored_domain else None
+            ),
             "total_emails": summary.get("total_count", 0),
             "passed_count": summary.get("passed_count", 0),
             "failed_count": summary.get("failed_count", 0),

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -16,11 +16,13 @@ function domainsApp() {
             name: '',
             description: '',
             dkim_selectors: '',
+            dmarc_report_mailbox: '',
         },
         editDomain: {
             name: '',
             description: '',
             dkim_selectors: '',
+            dmarc_report_mailbox: '',
         },
 
         init() {
@@ -142,7 +144,12 @@ function domainsApp() {
         closeCreate() {
             this.openCreate = false;
             this.createError = '';
-            this.newDomain = { name: '', description: '', dkim_selectors: '' };
+            this.newDomain = {
+                name: '',
+                description: '',
+                dkim_selectors: '',
+                dmarc_report_mailbox: '',
+            };
         },
 
         openEditDialog(domain) {
@@ -153,6 +160,7 @@ function domainsApp() {
                 dkim_selectors: Array.isArray(domain.dkim_selectors)
                     ? domain.dkim_selectors.join(', ')
                     : '',
+                dmarc_report_mailbox: domain.dmarc_report_mailbox || '',
             };
             this.openEdit = true;
         },
@@ -160,7 +168,12 @@ function domainsApp() {
         closeEdit() {
             this.openEdit = false;
             this.editError = '';
-            this.editDomain = { name: '', description: '', dkim_selectors: '' };
+            this.editDomain = {
+                name: '',
+                description: '',
+                dkim_selectors: '',
+                dmarc_report_mailbox: '',
+            };
         },
 
         apiErrorDetail(data, fallback) {
@@ -202,6 +215,7 @@ function domainsApp() {
                         name: this.newDomain.name,
                         description: this.newDomain.description || null,
                         dkim_selectors: selectors,
+                        dmarc_report_mailbox: this.newDomain.dmarc_report_mailbox || null,
                     }),
                 });
                 if (!response.ok) {
@@ -234,6 +248,7 @@ function domainsApp() {
                         body: JSON.stringify({
                             description: this.editDomain.description || null,
                             dkim_selectors: selectors,
+                            dmarc_report_mailbox: this.editDomain.dmarc_report_mailbox || null,
                         }),
                     }
                 );
@@ -266,6 +281,7 @@ function domainsApp() {
                 compliance_rate: domain.pass_rate,
                 description: domain.description || '',
                 dkim_selectors: Array.isArray(domain.dkim_selectors) ? domain.dkim_selectors : [],
+                dmarc_report_mailbox: domain.dmarc_report_mailbox || '',
             };
             normalized.has_activity =
                 Number(normalized.reports_count || 0) > 0 ||

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -24,6 +24,7 @@ function domainsApp() {
             dkim_selectors: '',
             dmarc_report_mailbox: '',
         },
+        editDmarcReportMailboxLoaded: false,
 
         init() {
             this.bindPageControls();
@@ -98,6 +99,9 @@ function domainsApp() {
                 event.preventDefault();
                 this.updateDomain();
             });
+            root.querySelector('[data-domain-edit-mailbox]')?.addEventListener('input', () => {
+                this.editDmarcReportMailboxLoaded = true;
+            });
         },
 
         async fetchDomains(options = {}) {
@@ -154,6 +158,10 @@ function domainsApp() {
 
         openEditDialog(domain) {
             this.editError = '';
+            this.editDmarcReportMailboxLoaded = Object.prototype.hasOwnProperty.call(
+                domain,
+                'dmarc_report_mailbox'
+            );
             this.editDomain = {
                 name: domain.name,
                 description: domain.description || '',
@@ -174,6 +182,7 @@ function domainsApp() {
                 dkim_selectors: '',
                 dmarc_report_mailbox: '',
             };
+            this.editDmarcReportMailboxLoaded = false;
         },
 
         apiErrorDetail(data, fallback) {
@@ -240,16 +249,19 @@ function domainsApp() {
                     .split(',')
                     .map((selector) => selector.trim())
                     .filter(Boolean);
+                const payload = {
+                    description: this.editDomain.description || null,
+                    dkim_selectors: selectors,
+                };
+                if (this.editDmarcReportMailboxLoaded) {
+                    payload.dmarc_report_mailbox = this.editDomain.dmarc_report_mailbox || null;
+                }
                 const response = await fetch(
                     `/api/v1/domains/domains/${encodeURIComponent(this.editDomain.name)}`,
                     {
                         method: 'PATCH',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({
-                            description: this.editDomain.description || null,
-                            dkim_selectors: selectors,
-                            dmarc_report_mailbox: this.editDomain.dmarc_report_mailbox || null,
-                        }),
+                        body: JSON.stringify(payload),
                     }
                 );
                 if (!response.ok) {
@@ -281,8 +293,10 @@ function domainsApp() {
                 compliance_rate: domain.pass_rate,
                 description: domain.description || '',
                 dkim_selectors: Array.isArray(domain.dkim_selectors) ? domain.dkim_selectors : [],
-                dmarc_report_mailbox: domain.dmarc_report_mailbox || '',
             };
+            if (Object.prototype.hasOwnProperty.call(domain, 'dmarc_report_mailbox')) {
+                normalized.dmarc_report_mailbox = domain.dmarc_report_mailbox || '';
+            }
             normalized.has_activity =
                 Number(normalized.reports_count || 0) > 0 ||
                 Number(normalized.emails_count || 0) > 0;

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -172,6 +172,11 @@
                     <span class="label-text font-medium">DKIM selectors</span>
                     <input x-model.trim="newDomain.dkim_selectors" type="text" placeholder="default, google, selector1" class="input input-bordered">
                 </label>
+                <label class="form-control">
+                    <span class="label-text font-medium">DMARC report mailbox override</span>
+                    <input x-model.trim="newDomain.dmarc_report_mailbox" type="email" placeholder="Use global default mailbox" class="input input-bordered">
+                    <span class="label-text-alt text-muted-foreground">Optional. Leave empty to use the aggregate report mailbox from Settings or dmarc@domain.</span>
+                </label>
                 <div x-show="createError" role="alert" class="alert alert-error py-3">
                     <span x-text="createError"></span>
                 </div>
@@ -201,6 +206,11 @@
                 <label class="form-control">
                     <span class="label-text font-medium">DKIM selectors</span>
                     <input x-model.trim="editDomain.dkim_selectors" type="text" placeholder="default, google, selector1" class="input input-bordered">
+                </label>
+                <label class="form-control">
+                    <span class="label-text font-medium">DMARC report mailbox override</span>
+                    <input x-model.trim="editDomain.dmarc_report_mailbox" type="email" placeholder="Use global default mailbox" class="input input-bordered">
+                    <span class="label-text-alt text-muted-foreground">Optional. Leave empty to use the aggregate report mailbox from Settings or dmarc@domain.</span>
                 </label>
                 <div x-show="editError" role="alert" class="alert alert-error py-3">
                     <span x-text="editError"></span>

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -174,7 +174,7 @@
                 </label>
                 <label class="form-control">
                     <span class="label-text font-medium">DMARC report mailbox override</span>
-                    <input x-model.trim="newDomain.dmarc_report_mailbox" type="email" placeholder="Use global default mailbox" class="input input-bordered">
+                    <input x-model.trim="newDomain.dmarc_report_mailbox" type="text" inputmode="email" placeholder="Use global default mailbox" class="input input-bordered">
                     <span class="label-text-alt text-muted-foreground">Optional. Leave empty to use the aggregate report mailbox from Settings or dmarc@domain.</span>
                 </label>
                 <div x-show="createError" role="alert" class="alert alert-error py-3">
@@ -209,7 +209,7 @@
                 </label>
                 <label class="form-control">
                     <span class="label-text font-medium">DMARC report mailbox override</span>
-                    <input x-model.trim="editDomain.dmarc_report_mailbox" type="email" placeholder="Use global default mailbox" class="input input-bordered">
+                    <input x-model.trim="editDomain.dmarc_report_mailbox" type="text" inputmode="email" placeholder="Use global default mailbox" class="input input-bordered" data-domain-edit-mailbox>
                     <span class="label-text-alt text-muted-foreground">Optional. Leave empty to use the aggregate report mailbox from Settings or dmarc@domain.</span>
                 </label>
                 <div x-show="editError" role="alert" class="alert alert-error py-3">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -468,6 +468,11 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert "method: 'PATCH'" in script
     assert "DMARC report mailbox override" in template
     assert "dmarc_report_mailbox" in script
+    assert 'inputmode="email"' in template
+    assert 'type="email" placeholder="Use global default mailbox"' not in template
+    assert "data-domain-edit-mailbox" in template
+    assert "data-domain-edit-mailbox" in script
+    assert "editDmarcReportMailboxLoaded" in script
     assert "Use global default mailbox" in template
     assert "editError" in template
     assert "data-domains-page" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -466,6 +466,9 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert "Edit monitored domain" in template
     assert "updateDomain()" in script
     assert "method: 'PATCH'" in script
+    assert "DMARC report mailbox override" in template
+    assert "dmarc_report_mailbox" in script
+    assert "Use global default mailbox" in template
     assert "editError" in template
     assert "data-domains-page" in template
     assert "dnsStatusClass(domain" not in template

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2147,6 +2147,14 @@ def test_enforcement_recommendation_common_states(
 def test_summary_includes_dns_fields(authed_client: TestClient, db_session):
     """The summary endpoint should include dmarc_status, spf_status, dkim_status."""
     _persist_minimal_report(db_session)
+    workspace = get_or_create_default_workspace(db_session)
+    stored_domain = db_session.query(Domain).filter_by(name=DOMAIN).first()
+    if stored_domain is None:
+        stored_domain = Domain(name=DOMAIN, workspace_id=workspace.id, active=True)
+        db_session.add(stored_domain)
+    stored_domain.workspace_id = workspace.id
+    stored_domain.dmarc_report_mailbox = "dmarc-example@tenant.example"
+    db_session.commit()
 
     with _mock_dns():
         response = authed_client.get("/api/v1/domains/summary?refresh=true")
@@ -2162,6 +2170,7 @@ def test_summary_includes_dns_fields(authed_client: TestClient, db_session):
     assert domain["spf_status"] is True
     assert domain["dkim_status"] is True
     assert domain["dmarc_policy"] == "none"
+    assert domain["dmarc_report_mailbox"] == "dmarc-example@tenant.example"
 
 
 def test_summary_includes_remediation_activity(authed_client: TestClient, db_session):


### PR DESCRIPTION
## Summary\n- add optional DMARC report mailbox override fields to the domain create/edit dialogs\n- send the existing dmarc_report_mailbox API field from the UI\n- keep the global aggregate report mailbox setting as the default when the override is empty\n\nCloses #637\n\n## Local validation\n- python -m pytest backend/app/tests/test_dashboard_template_security.py::test_domains_uses_external_page_script_for_csp_migration backend/app/tests/test_dns_endpoints.py::test_update_domain_persists_dmarc_report_mailbox_override backend/app/tests/test_dns_endpoints.py::test_update_domain_rejects_invalid_dmarc_report_mailbox -q\n- combined with #636 locally: python -m pytest backend/app/tests/test_dns_endpoints.py::test_summary_endpoint_can_hide_empty_domains_before_dns_work backend/app/tests/test_dashboard_template_security.py::test_domains_uses_external_page_script_for_csp_migration backend/app/tests/test_dns_endpoints.py::test_update_domain_persists_dmarc_report_mailbox_override backend/app/tests/test_dns_endpoints.py::test_update_domain_rejects_invalid_dmarc_report_mailbox -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional DMARC report mailbox override when creating or editing a monitored domain.
  * Existing domain data now preserves this mailbox setting when available.
  * Leaving the field blank will use the default mailbox setting.

* **Tests**
  * Updated coverage to verify the new mailbox field appears in the domains page and is included in page behavior checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->