### PR TITLE
[codex] Expose remediation queue to automation clients

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import csv
 import hashlib
 import html
@@ -583,6 +584,26 @@ def read_only_dns_change_plan_response(payload: Any) -> DNSChangePlanResponse:
         apply_endpoint=None,
         plans=plans,
     )
+
+
+def read_only_remediation_queue_response(payload: Any) -> "RemediationQueueResponse":
+    """Return remediation queue data without public write affordances."""
+    data = payload.model_dump() if hasattr(payload, "model_dump") else copy.deepcopy(payload)
+    for item in data.get("items") or []:
+        automation = item.get("automation") or {}
+        automation["apply_endpoint"] = None
+        item["automation"] = automation
+
+        notification = item.get("notification") or {}
+        preview = notification.get("payload_preview") or {}
+        preview_automation = preview.get("automation") or {}
+        preview_automation["apply_endpoint"] = None
+        if preview_automation:
+            preview["automation"] = preview_automation
+        if preview:
+            notification["payload_preview"] = preview
+        item["notification"] = notification
+    return RemediationQueueResponse(**data)
 
 
 DNS_AUTOMATION_OPERATIONS = {"create", "update"}
@@ -3513,9 +3534,7 @@ async def get_domains_summary(
             "domain_name": domain_name,
             "description": stored_domain.description if stored_domain else None,
             "dkim_selectors": manual_selectors_by_domain.get(domain_name, []),
-            "dmarc_report_mailbox": (
-                stored_domain.dmarc_report_mailbox if stored_domain else None
-            ),
+            "dmarc_report_mailbox": (stored_domain.dmarc_report_mailbox if stored_domain else None),
             "total_emails": summary.get("total_count", 0),
             "passed_count": summary.get("passed_count", 0),
             "failed_count": summary.get("failed_count", 0),

--- a/backend/app/api/api_v1/endpoints/mcp.py
+++ b/backend/app/api/api_v1/endpoints/mcp.py
@@ -110,6 +110,19 @@ READ_ONLY_TOOLS = [
         "readOnlyHint": True,
     },
     {
+        "name": "remediation_queue",
+        "description": "Return prioritized remediation work items without apply links.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "domain": {"type": "string"},
+                "refresh": {"type": "boolean", "default": False},
+            },
+            "required": ["domain"],
+        },
+        "readOnlyHint": True,
+    },
+    {
         "name": "source_intelligence",
         "description": "Return source geography summaries and anomaly hints for one domain.",
         "inputSchema": {
@@ -367,6 +380,56 @@ READ_ONLY_SYNC_HANDLERS = {
 }
 
 
+async def _call_remediation_queue_tool(
+    arguments: Dict[str, Any],
+    *,
+    db: Session,
+    auth_context: Dict[str, Any],
+    workspace_id: Optional[int],
+) -> Any:
+    workspace = resolve_authorized_workspace(
+        db,
+        auth_context,
+        PERMISSION_REPORTS_READ,
+        selected_workspace_id=workspace_id,
+    )
+    queue = await domains._build_domain_remediation_queue_for_workspace(
+        db,
+        workspace=workspace,
+        domain_id=_tool_domain(arguments),
+        refresh=bool(arguments.get("refresh", False)),
+    )
+    queue = domains.attach_remediation_dispatch_previews(db, workspace=workspace, queue=queue)
+    return domains.read_only_remediation_queue_response(queue)
+
+
+async def _call_health_evidence_export_tool(
+    arguments: Dict[str, Any],
+    *,
+    db: Session,
+    auth_context: Dict[str, Any],
+    workspace_id: Optional[int],
+) -> Dict[str, Any]:
+    domain = _tool_domain(arguments)
+    rows = await domains.build_domain_health_evidence_export_rows(
+        domain_id=domain,
+        start_date=_tool_optional_date(arguments, "start_date"),
+        end_date=_tool_optional_date(arguments, "end_date"),
+        limit=_tool_limit(arguments),
+        capture_current=False,
+        db=db,
+        auth_context=auth_context,
+        selected_workspace_id=workspace_id,
+    )
+    return {"scope": "domain", "domain": domain, "rows": rows}
+
+
+READ_ONLY_ASYNC_HANDLERS = {
+    "health_evidence_export": _call_health_evidence_export_tool,
+    "remediation_queue": _call_remediation_queue_tool,
+}
+
+
 async def _call_read_only_tool(
     name: str,
     arguments: Dict[str, Any],
@@ -423,19 +486,14 @@ async def _call_read_only_tool(
             auth_context=auth_context,
             workspace_id=workspace_id,
         )
-    if name == "health_evidence_export":
-        domain = _tool_domain(arguments)
-        rows = await domains.build_domain_health_evidence_export_rows(
-            domain_id=domain,
-            start_date=_tool_optional_date(arguments, "start_date"),
-            end_date=_tool_optional_date(arguments, "end_date"),
-            limit=_tool_limit(arguments),
-            capture_current=False,
+    async_handler = READ_ONLY_ASYNC_HANDLERS.get(name)
+    if async_handler is not None:
+        return await async_handler(
+            arguments,
             db=db,
             auth_context=auth_context,
-            selected_workspace_id=workspace_id,
+            workspace_id=workspace_id,
         )
-        return {"scope": "domain", "domain": domain, "rows": rows}
     raise KeyError(name)
 
 

--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -138,6 +138,28 @@ async def public_domain_action_proposals(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
 
+@router.get(
+    "/domains/{domain_id}/remediation",
+    response_model=domains.RemediationQueueResponse,
+)
+async def public_domain_remediation_queue(
+    domain_id: str = Path(..., title="The domain ID or name"),
+    refresh: bool = Query(False, title="Refresh cached DNS posture"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_api_token_scope(READ_POSTURE_SCOPE)),
+):
+    """Return the prioritized remediation queue without write affordances."""
+    workspace = resolve_authorized_workspace(db, _auth, PERMISSION_REPORTS_READ)
+    queue = await domains._build_domain_remediation_queue_for_workspace(
+        db,
+        workspace=workspace,
+        domain_id=domain_id,
+        refresh=refresh,
+    )
+    queue = domains.attach_remediation_dispatch_previews(db, workspace=workspace, queue=queue)
+    return domains.read_only_remediation_queue_response(queue)
+
+
 @router.get("/alerts")
 async def public_alert_history(
     active: Optional[bool] = Query(None, title="Filter active or resolved alerts"),

--- a/backend/app/services/export_catalog.py
+++ b/backend/app/services/export_catalog.py
@@ -85,6 +85,13 @@ PUBLIC_EXPORT_ENDPOINTS = [
         "description": "Read-only DNS change plans without apply links.",
     },
     {
+        "key": "remediation_queue",
+        "method": "GET",
+        "path_template": "/api/v1/public/domains/{domain}/remediation",
+        "scope": READ_POSTURE_SCOPE,
+        "description": "Prioritized remediation work items without apply links.",
+    },
+    {
         "key": "action_proposals",
         "method": "GET",
         "path_template": "/api/v1/public/domains/{domain}/action-proposals",
@@ -136,6 +143,11 @@ MCP_EXPORT_TOOLS = [
     {
         "name": "dns_change_plan",
         "description": "Return read-only DNS change plans without apply links.",
+        "read_only": True,
+    },
+    {
+        "name": "remediation_queue",
+        "description": "Return prioritized remediation work items without apply links.",
         "read_only": True,
     },
     {

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -64,6 +64,63 @@ def _persist_report(db_session: Session) -> None:
     db_session.commit()
 
 
+def _sample_remediation_queue(domain=DOMAIN):
+    return {
+        "domain": domain,
+        "status": "needs_approval",
+        "summary": {"total": 1, "approval_ready": 1},
+        "items": [
+            {
+                "id": "dns:dmarc_missing",
+                "source": "dns_lint",
+                "state": "approval_ready",
+                "severity": "critical",
+                "confidence": "high",
+                "title": "Publish DMARC",
+                "detail": "No DMARC record is visible.",
+                "next_steps": ["Create the TXT record."],
+                "evidence": [{"label": "record", "value": "_dmarc.example.com"}],
+                "blast_radius": "DNS TXT record",
+                "prerequisites": ["Review the DNS diff."],
+                "expected_health_score_impact": "Expected to remove a DNS-health finding.",
+                "action_plan": {
+                    "owner": "DNS operator",
+                    "diagnosis": "DMARC is missing.",
+                    "prerequisites": ["DNS access"],
+                    "steps": ["Publish a DMARC TXT record."],
+                    "guidance_paths": [],
+                    "completion_criteria": "DMARC resolves.",
+                    "automation_path": "Preview the DNS write in DMARQ.",
+                },
+                "automation": {
+                    "eligible": True,
+                    "requires_approval": True,
+                    "provider": "cloudflare",
+                    "plan_id": "plan-1",
+                    "apply_endpoint": "/api/v1/domains/example.com/dns/change-plan/apply",
+                    "reason": "Safe provider-backed DNS preview is available.",
+                },
+                "notification": {
+                    "state": "approval_required",
+                    "event": "dmarq.remediation.approval_required",
+                    "channel": "email_security",
+                    "dedupe_key": "dmarq:remediation:example.com:dns:dmarc_missing",
+                    "reason": "Notify an operator that a safe DNS repair is ready.",
+                    "next_transition": "verified_after_apply",
+                    "payload_preview": {
+                        "automation": {
+                            "eligible": True,
+                            "apply_endpoint": ("/api/v1/domains/example.com/dns/change-plan/apply"),
+                        }
+                    },
+                    "history": [],
+                    "dispatch": {"eligible": False, "reason": "disabled"},
+                },
+            }
+        ],
+    }
+
+
 def _set_setting(db: Session, key: str, value: str, category: str) -> None:
     row = db.query(Setting).filter(Setting.key == key).first()
     if row is None:
@@ -815,10 +872,7 @@ def test_ai_redaction_mode_none_keeps_pii_but_redacts_secrets(db_session: Sessio
     redacted = ai_assistance.redact_safe_value(
         {
             "contact": "admin@example.com",
-            "details": (
-                "api_key=sk-test-secret "
-                "opaque=abcdefghijklmnopqrstuvwxyz1234567890"
-            ),
+            "details": ("api_key=sk-test-secret " "opaque=abcdefghijklmnopqrstuvwxyz1234567890"),
         },
         mode=config.redaction_mode,
     )
@@ -830,9 +884,7 @@ def test_ai_redaction_mode_none_keeps_pii_but_redacts_secrets(db_session: Sessio
     rules = ai_assistance._redaction_rules("none")
     assert "email local-parts and domains are preserved" in rules
     assert "secret-like key/value fragments" in rules
-    assert "no email local-part redaction" in ai_assistance._redaction_rules(
-        "balanced"
-    )
+    assert "no email local-part redaction" in ai_assistance._redaction_rules("balanced")
 
 
 def test_report_selectors_ignore_malformed_entries():
@@ -1042,6 +1094,14 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
             new=AsyncMock(return_value={"domain": DOMAIN, "regions": []}),
         ) as intelligence,
         patch(
+            "app.api.api_v1.endpoints.mcp.domains._build_domain_remediation_queue_for_workspace",
+            new=AsyncMock(return_value=_sample_remediation_queue()),
+        ) as remediation_queue,
+        patch(
+            "app.api.api_v1.endpoints.mcp.domains.attach_remediation_dispatch_previews",
+            side_effect=lambda db, workspace, queue: queue,
+        ) as remediation_dispatch,
+        patch(
             "app.api.api_v1.endpoints.mcp.domains.build_domain_health_evidence_export_rows",
             new=AsyncMock(return_value=[{"domain": DOMAIN, "score": 72, "grade": "C"}]),
         ) as health_evidence,
@@ -1095,6 +1155,13 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
             auth_context=auth_context,
             workspace_id=None,
         )
+        remediation_result = await mcp_endpoint._call_read_only_tool(
+            "remediation_queue",
+            {"domain": DOMAIN, "refresh": True},
+            db=db_session,
+            auth_context=auth_context,
+            workspace_id=None,
+        )
         health_evidence_result = await mcp_endpoint._call_read_only_tool(
             "health_evidence_export",
             {"domain": DOMAIN, "start_date": "2026-06-01", "limit": "25"},
@@ -1121,6 +1188,13 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
     assert dns_plan_result.plans[0].applies_automatically is False
     assert intelligence_result["regions"] == []
     assert proposals["proposals"]
+    assert remediation_result.domain == DOMAIN
+    assert remediation_result.items[0].automation.eligible is True
+    assert remediation_result.items[0].automation.apply_endpoint is None
+    assert (
+        remediation_result.items[0].notification.payload_preview["automation"]["apply_endpoint"]
+        is None
+    )
     assert health_evidence_result["scope"] == "domain"
     assert health_evidence_result["rows"][0]["score"] == 72
     assert usage_result["summary"]["domain_count"] == 1
@@ -1130,6 +1204,8 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
     dns_lint.assert_awaited_once()
     dns_change_plan.assert_awaited_once()
     intelligence.assert_awaited_once()
+    remediation_queue.assert_awaited_once()
+    remediation_dispatch.assert_called_once()
     health_evidence.assert_awaited_once()
 
 
@@ -1353,6 +1429,7 @@ def test_mcp_requires_enabled_scoped_token(client: TestClient, db_session: Sessi
         "domain_posture",
         "dns_lint",
         "dns_change_plan",
+        "remediation_queue",
         "health_evidence_export",
         "alert_history",
         "export_catalog",

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -91,6 +91,63 @@ def _persist_failing_report(db_session, report=None, *, workspace_id=None):
     db_session.commit()
 
 
+def _sample_remediation_queue(domain=DOMAIN):
+    return {
+        "domain": domain,
+        "status": "needs_approval",
+        "summary": {"total": 1, "approval_ready": 1},
+        "items": [
+            {
+                "id": "dns:dmarc_missing",
+                "source": "dns_lint",
+                "state": "approval_ready",
+                "severity": "critical",
+                "confidence": "high",
+                "title": "Publish DMARC",
+                "detail": "No DMARC record is visible.",
+                "next_steps": ["Create the TXT record."],
+                "evidence": [{"label": "record", "value": "_dmarc.example.com"}],
+                "blast_radius": "DNS TXT record",
+                "prerequisites": ["Review the DNS diff."],
+                "expected_health_score_impact": "Expected to remove a DNS-health finding.",
+                "action_plan": {
+                    "owner": "DNS operator",
+                    "diagnosis": "DMARC is missing.",
+                    "prerequisites": ["DNS access"],
+                    "steps": ["Publish a DMARC TXT record."],
+                    "guidance_paths": [],
+                    "completion_criteria": "DMARC resolves.",
+                    "automation_path": "Preview the DNS write in DMARQ.",
+                },
+                "automation": {
+                    "eligible": True,
+                    "requires_approval": True,
+                    "provider": "cloudflare",
+                    "plan_id": "plan-1",
+                    "apply_endpoint": "/api/v1/domains/example.com/dns/change-plan/apply",
+                    "reason": "Safe provider-backed DNS preview is available.",
+                },
+                "notification": {
+                    "state": "approval_required",
+                    "event": "dmarq.remediation.approval_required",
+                    "channel": "email_security",
+                    "dedupe_key": "dmarq:remediation:example.com:dns:dmarc_missing",
+                    "reason": "Notify an operator that a safe DNS repair is ready.",
+                    "next_transition": "verified_after_apply",
+                    "payload_preview": {
+                        "automation": {
+                            "eligible": True,
+                            "apply_endpoint": ("/api/v1/domains/example.com/dns/change-plan/apply"),
+                        }
+                    },
+                    "history": [],
+                    "dispatch": {"eligible": False, "reason": "disabled"},
+                },
+            }
+        ],
+    }
+
+
 def test_public_reports_api_requires_scoped_token(client: TestClient, db_session):
     """Stable public report endpoints require scoped tokens and audit usage."""
     _seed_report_store()
@@ -440,6 +497,53 @@ def test_public_action_proposals_use_posture_scope(client: TestClient, db_sessio
     assert body["proposals"]
     assert body["proposals"][0]["mutates_state"] is False
     assert body["proposals"][0]["requires_human_confirmation"] is True
+
+
+def test_public_remediation_queue_is_read_only_and_posture_scoped(
+    client: TestClient,
+    db_session,
+):
+    """Public remediation queues keep actionability but remove write links."""
+    _persist_failing_report(db_session)
+    posture_token = create_api_token(
+        db_session,
+        name="posture remediation bot",
+        scopes=[READ_POSTURE_SCOPE],
+    )
+    reports_token = create_api_token(
+        db_session,
+        name="reports bot",
+        scopes=[READ_REPORTS_SCOPE],
+    )
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.public.domains._build_domain_remediation_queue_for_workspace",
+            new=AsyncMock(return_value=_sample_remediation_queue()),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.public.domains.attach_remediation_dispatch_previews",
+            side_effect=lambda db, workspace, queue: queue,
+        ),
+    ):
+        denied = client.get(
+            f"/api/v1/public/domains/{DOMAIN}/remediation",
+            headers={"X-API-Key": reports_token.secret},
+        )
+        response = client.get(
+            f"/api/v1/public/domains/{DOMAIN}/remediation",
+            headers={"X-API-Key": posture_token.secret},
+        )
+
+    assert denied.status_code == 403
+    assert response.status_code == 200
+    body = response.json()
+    assert body["domain"] == DOMAIN
+    assert body["summary"]["approval_ready"] == 1
+    item = body["items"][0]
+    assert item["automation"]["eligible"] is True
+    assert item["automation"]["apply_endpoint"] is None
+    assert item["notification"]["payload_preview"]["automation"]["apply_endpoint"] is None
 
 
 def test_public_action_proposals_are_workspace_scoped(client: TestClient, db_session):

--- a/docs/reference/ai-mcp-automation.md
+++ b/docs/reference/ai-mcp-automation.md
@@ -83,6 +83,7 @@ The current tools are read-only:
 - `domain_sources`
 - `dns_lint`
 - `dns_change_plan`
+- `remediation_queue`
 - `source_intelligence`
 - `action_proposals`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -82,6 +82,7 @@ through the `/public` path and avoid UI-specific payloads.
 | `GET /public/domains/{domain_id}/posture/evidence/export` | `posture:read` | Sanitized health score evidence export |
 | `GET /public/domains/{domain_id}/dns/lint` | `posture:read` | DNS lint findings, target records, and evidence |
 | `GET /public/domains/{domain_id}/dns/change-plan` | `posture:read` | Read-only DNS change plans without apply links |
+| `GET /public/domains/{domain_id}/remediation` | `posture:read` | Prioritized remediation queue without apply links |
 | `GET /public/domains/{domain_id}/action-proposals` | `posture:read` | Reviewable read-only remediation proposals |
 | `GET /public/alerts` | `posture:read` | Sanitized alert history for monitored workspace domains |
 | `GET /public/tls-reports/summary` | `tls-reports:read` | SMTP TLS report trends and failure groups |
@@ -135,6 +136,7 @@ The MCP endpoint currently exposes these read-only tools:
 | `domain_sources` | Return enriched DMARC sending sources |
 | `dns_lint` | Return DNS lint findings, evidence, and target records |
 | `dns_change_plan` | Return read-only DNS change plans without apply links |
+| `remediation_queue` | Return prioritized remediation work items without apply links |
 | `source_intelligence` | Return source regions and anomaly hints |
 | `action_proposals` | Return reviewable remediation proposals without applying them |
 
@@ -508,6 +510,7 @@ Available tools:
 | `domain_sources` | Return enriched DMARC sending sources |
 | `dns_lint` | Return DNS lint findings, evidence, and target records |
 | `dns_change_plan` | Return read-only DNS change plans without apply links |
+| `remediation_queue` | Return prioritized remediation work items without apply links |
 | `source_intelligence` | Return source regions and anomaly hints |
 | `action_proposals` | Return reviewable remediation proposals without applying changes |
 


### PR DESCRIPTION
## Summary

Adds a read-only remediation queue surface for automation clients:

- exposes `GET /api/v1/public/domains/{domain_id}/remediation` behind `posture:read`
- adds the `remediation_queue` MCP tool
- adds the endpoint/tool to the export catalog and API/MCP docs
- strips direct DNS apply links from public and MCP remediation responses while preserving priorities, evidence, steps, and automation eligibility

Closes #641.
Refs #309, #384.

## Validation

- `.venv/bin/python -m pytest backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py -q`
- `.venv/bin/python -m black --check backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `.venv/bin/python -m isort --check-only backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/api/api_v1/endpoints/public.py backend/app/api/api_v1/endpoints/mcp.py backend/app/services/export_catalog.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `git diff --check`
