### PR TITLE
Clarify remediation queue loading states

### DIFF
--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -82,6 +82,8 @@ function domainDetailsApp(domainId = '') {
             items: [],
             verified_items: []
         },
+        remediationQueueLoading: true,
+        remediationQueueError: '',
         remediationAction: {
             itemId: '',
             action: '',
@@ -254,6 +256,9 @@ function domainDetailsApp(domainId = '') {
                 } else if (button.matches('[data-domain-detail-remediation-action]')) {
                     event.preventDefault();
                     this.handleRemediationAction(button);
+                } else if (button.matches('[data-domain-detail-remediation-retry]')) {
+                    event.preventDefault();
+                    this.fetchRemediationQueue();
                 } else if (button.matches('[data-domain-detail-migration-action]')) {
                     event.preventDefault();
                     this.handleMigrationAction(button.dataset.domainDetailMigrationAction);
@@ -1446,21 +1451,29 @@ function domainDetailsApp(domainId = '') {
         },
 
         async fetchRemediationQueue() {
+            this.remediationQueueLoading = true;
+            this.remediationQueueError = '';
             try {
-                const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation`);
+                const response = await this.fetchWithTimeout(
+                    `/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation`
+                );
                 if (!response.ok) {
                     console.error('Error fetching remediation queue:', {
                         domainId: this.domainId,
                         status: response.status,
                         statusText: response.statusText
                     });
+                    this.remediationQueueError = 'Remediation queue could not be loaded.';
                     this.resetRemediationQueue();
                     return;
                 }
                 this.remediationQueue = await response.json();
             } catch (error) {
                 console.error('Error fetching remediation queue:', error);
+                this.remediationQueueError = error.message || 'Remediation queue could not be loaded.';
                 this.resetRemediationQueue();
+            } finally {
+                this.remediationQueueLoading = false;
             }
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -298,7 +298,7 @@
                             <h3 class="font-semibold text-[#07071f]">Remediation Queue</h3>
                             <p class="mt-1 text-sm text-[#5f5c78]">Prioritized fixes with evidence, prerequisites, and approval status.</p>
                         </div>
-                        <div class="flex flex-wrap gap-2 text-xs">
+                        <div class="flex flex-wrap gap-2 text-xs" x-show="!remediationQueueLoading && !remediationQueueError">
                             <span class="rounded bg-white px-2 py-1 font-semibold text-[#272a5f]">
                                 <span x-text="remediationQueue.summary.total"></span><span> open</span>
                             </span>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -322,7 +322,26 @@
                             </span>
                         </div>
                     </div>
-                    <template x-if="(remediationQueue.verified_items || []).length > 0">
+                    <template x-if="remediationQueueLoading">
+                        <div class="mt-4 flex items-center gap-3 rounded-lg border border-[#e6e3e1] bg-white p-4 text-sm text-[#5f5c78]">
+                            <span class="loading loading-spinner loading-sm"></span>
+                            <span>Loading remediation queue...</span>
+                        </div>
+                    </template>
+                    <template x-if="!remediationQueueLoading && remediationQueueError">
+                        <div class="mt-4 rounded-lg border border-red-100 bg-red-50 p-4">
+                            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                <p class="text-sm font-semibold text-red-700" x-text="remediationQueueError"></p>
+                                <button type="button"
+                                        class="btn btn-outline btn-sm border-red-200 text-red-700 hover:bg-red-100"
+                                        :disabled="remediationQueueLoading"
+                                        data-domain-detail-remediation-retry>
+                                    Retry remediation queue
+                                </button>
+                            </div>
+                        </div>
+                    </template>
+                    <template x-if="!remediationQueueLoading && !remediationQueueError && (remediationQueue.verified_items || []).length > 0">
                         <div class="mt-4 rounded-lg border border-[#d8ebe8] bg-[#f2fbf9] p-3">
                             <div class="flex flex-wrap items-center justify-between gap-2">
                                 <p class="text-xs font-semibold uppercase text-[#5f5c78]">Verified fixes</p>
@@ -353,7 +372,7 @@
                             </div>
                         </div>
                     </template>
-                    <template x-if="remediationQueue.items.length > 0">
+                    <template x-if="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length > 0">
                         <div class="mt-4 grid gap-3 md:grid-cols-3">
                             <div class="rounded-lg bg-white p-3">
                                 <p class="text-xs font-semibold uppercase text-[#5f5c78]">Notification readiness</p>
@@ -375,11 +394,11 @@
                             </div>
                         </div>
                     </template>
-                    <template x-if="remediationQueue.items.length === 0">
+                    <template x-if="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length === 0">
                         <p class="mt-4 text-sm text-[#5f5c78]">No remediation items are queued for this domain.</p>
                     </template>
                     <div class="mt-4 grid gap-3 xl:grid-cols-2">
-                        <template x-for="item in remediationQueue.items.slice(0, 6)" :key="item.id">
+                        <template x-for="item in (!remediationQueueLoading && !remediationQueueError ? remediationQueue.items.slice(0, 6) : [])" :key="item.id">
                             <div class="rounded-lg border border-[#e6e3e1] bg-white p-4">
                                 <div class="flex items-start justify-between gap-3">
                                     <div class="min-w-0">
@@ -559,7 +578,7 @@
                             </div>
                         </template>
                     </div>
-                    <template x-if="remediationQueue.items.length > 6">
+                    <template x-if="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length > 6">
                         <p class="mt-3 text-xs font-semibold text-[#5f5c78]">
                             <span>+</span><span x-text="remediationQueue.items.length - 6"></span><span> more remediation items</span>
                         </p>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -482,7 +482,7 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert '@submit.prevent="updateDomain' not in template
     assert '@click="closeCreate' not in template
     assert '@click="closeEdit' not in template
-    assert '@click=' not in template
+    assert "@click=" not in template
     assert "formatCount(domain.reports_count, 'report')" in template
     assert "formatCount(domain.emails_count, 'message')" in template
     assert "formatCount(value, noun)" in script
@@ -506,7 +506,10 @@ def test_domains_page_distinguishes_loading_error_and_empty_states():
     assert "data-domain-retry-load" in template
     assert "data-domain-retry-load" in script
     assert 'x-if="!loading && loadError"' in template
-    assert 'x-if="!loading && !loadError && domains.length === 0 && hiddenEmptyDomainCount() === 0"' in template
+    assert (
+        'x-if="!loading && !loadError && domains.length === 0 && hiddenEmptyDomainCount() === 0"'
+        in template
+    )
 
 
 def test_upload_uses_external_page_script_for_csp_migration():
@@ -1221,6 +1224,12 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "sourceIntelligence.loading" in template
     assert "Loading source intelligence..." in template
     assert "Source intelligence could not be loaded." in script
+    assert "remediationQueueLoading" in script
+    assert "remediationQueueError" in script
+    assert "Loading remediation queue..." in template
+    assert "Remediation queue could not be loaded." in script
+    assert "Retry remediation queue" in template
+    assert "data-domain-detail-remediation-retry" in template
     assert "No sending sources match this filter." in template
     assert (
         "(!sourceIntelligence.loading && !sourceIntelligence.error ? sourceIntelligence.regions.slice(0, 4) : [])"
@@ -1232,6 +1241,14 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     )
     assert "(!sourcesLoading && !sourcesError ? filteredSources : [])" in template
     assert "(!reportsLoading && !reportsError ? reports : [])" in template
+    assert (
+        "(!remediationQueueLoading && !remediationQueueError ? remediationQueue.items.slice(0, 6) : [])"
+        in template
+    )
+    assert (
+        'x-if="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length === 0"'
+        in template
+    )
     assert "x-html" not in template
 
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1230,6 +1230,13 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "Remediation queue could not be loaded." in script
     assert "Retry remediation queue" in template
     assert "data-domain-detail-remediation-retry" in template
+    assert (
+        '<div class="flex flex-wrap gap-2 text-xs" x-show="!remediationQueueLoading && !remediationQueueError">'
+        in template
+    )
+    assert "remediationQueue.summary.total" in template
+    assert "remediationQueue.summary.approval_ready" in template
+    assert "remediationQueue.summary.manual_action" in template
     assert "No sending sources match this filter." in template
     assert (
         "(!sourceIntelligence.loading && !sourceIntelligence.error ? sourceIntelligence.regions.slice(0, 4) : [])"


### PR DESCRIPTION
## Summary
- Add explicit loading and error state for the domain-detail remediation queue
- Add a retry control that reuses the existing external page script handler
- Keep verified fixes, queue cards, and the empty state hidden until the queue request has actually completed

## Why
The remediation queue was initialized with zero counts, so slow or failed requests could briefly look like a genuine empty queue. This makes the domain detail page clearer while the remediation loop data is still loading.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q`
- `.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py::test_domain_details_distinguishes_loading_error_and_empty_states -q`
- `.venv/bin/python -m black --check backend/app/tests/test_dashboard_template_security.py`
- `.venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py`
- `.venv/bin/python -m isort --check-only backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

Refs #384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer remediation queue behavior on the Domain Details page, including loading, error, and retry states.
  * Users can now retry fetching remediation items directly from the error message.

* **Bug Fixes**
  * Improved handling for failed or timed-out remediation queue loads.
  * The page now shows empty and “more items” states more reliably when remediation data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->