### PR TITLE
Surface next remediation on domain details

### DIFF
--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -512,6 +512,23 @@ function domainDetailsApp(domainId = '') {
             return 'No remediation notifications need operator dispatch.';
         },
 
+        get primaryRemediationItem() {
+            if (this.remediationQueueLoading || this.remediationQueueError) return null;
+            return (this.remediationQueue.items || [])[0] || null;
+        },
+
+        get primaryRemediationNextStep() {
+            const item = this.primaryRemediationItem;
+            if (!item) return '';
+            return (item.next_steps || [])[0] || 'Review the evidence and decide whether this fix is still needed.';
+        },
+
+        get primaryRemediationDispatchText() {
+            const dispatch = this.primaryRemediationItem?.notification?.dispatch;
+            if (!dispatch) return 'No operator notification configured for this item yet.';
+            return this.remediationDispatchNextStep(dispatch);
+        },
+
         get healthEvidenceExportUrl() {
             return `/api/v1/domains/${encodeURIComponent(this.domainId)}/posture/evidence/export?capture_current=false`;
         },

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -90,7 +90,7 @@
                                 <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next remediation</p>
                                 <span class="rounded px-2 py-1 text-xs font-semibold capitalize"
                                       :class="remediationStateClass(primaryRemediationItem.state)"
-                                      x-text="primaryRemediationItem.state.replace('_', ' ')"></span>
+                                      x-text="primaryRemediationItem.state.split('_').join(' ')"></span>
                                 <span class="inline-flex items-center gap-1 text-xs font-semibold uppercase text-[#5f5c78]">
                                     <span class="h-2 w-2 rounded-full"
                                           :class="remediationSeverityDotClass(primaryRemediationItem.severity)"></span>
@@ -472,7 +472,7 @@
                                         <div class="flex flex-wrap items-center gap-2">
                                             <span class="rounded px-2 py-1 text-xs font-semibold capitalize"
                                                   :class="remediationStateClass(item.state)"
-                                                  x-text="item.state.replace('_', ' ')"></span>
+                                                  x-text="item.state.split('_').join(' ')"></span>
                                             <span class="inline-flex items-center gap-1 text-xs font-semibold uppercase text-[#5f5c78]">
                                                 <span class="h-2 w-2 rounded-full"
                                                       :class="remediationSeverityDotClass(item.severity)"></span>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -61,6 +61,73 @@
                     </button>
                 </div>
             </div>
+            <div class="mt-5 rounded-lg border border-[#e6e3e1] bg-[#fbfaf9] p-4">
+                <template x-if="remediationQueueLoading">
+                    <div class="flex items-center gap-3 text-sm text-[#5f5c78]">
+                        <span class="loading loading-spinner loading-sm"></span>
+                        <span>Loading next remediation...</span>
+                    </div>
+                </template>
+                <template x-if="!remediationQueueLoading && remediationQueueError">
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next remediation</p>
+                            <p class="mt-1 text-sm font-semibold text-red-700">Next remediation could not be loaded.</p>
+                            <p class="mt-1 text-sm text-[#5f5c78]" x-text="remediationQueueError"></p>
+                        </div>
+                        <button type="button"
+                                class="btn btn-outline btn-sm border-red-200 text-red-700 hover:bg-red-100"
+                                :disabled="remediationQueueLoading"
+                                data-domain-detail-remediation-retry>
+                            Retry remediation queue
+                        </button>
+                    </div>
+                </template>
+                <template x-if="primaryRemediationItem">
+                    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                        <div class="min-w-0">
+                            <div class="flex flex-wrap items-center gap-2">
+                                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next remediation</p>
+                                <span class="rounded px-2 py-1 text-xs font-semibold capitalize"
+                                      :class="remediationStateClass(primaryRemediationItem.state)"
+                                      x-text="primaryRemediationItem.state.replace('_', ' ')"></span>
+                                <span class="inline-flex items-center gap-1 text-xs font-semibold uppercase text-[#5f5c78]">
+                                    <span class="h-2 w-2 rounded-full"
+                                          :class="remediationSeverityDotClass(primaryRemediationItem.severity)"></span>
+                                    <span x-text="primaryRemediationItem.severity"></span>
+                                </span>
+                            </div>
+                            <h2 class="mt-2 text-lg font-semibold text-[#07071f]" x-text="primaryRemediationItem.title"></h2>
+                            <p class="mt-1 text-sm text-[#5f5c78]" x-text="primaryRemediationItem.detail"></p>
+                            <div class="mt-3 grid gap-3 md:grid-cols-2">
+                                <div class="rounded-md bg-white p-3">
+                                    <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next step</p>
+                                    <p class="mt-1 text-sm text-[#120d36]" x-text="primaryRemediationNextStep"></p>
+                                </div>
+                                <div class="rounded-md bg-white p-3">
+                                    <p class="text-xs font-semibold uppercase text-[#5f5c78]">Operator dispatch</p>
+                                    <p class="mt-1 text-sm text-[#120d36]" x-text="primaryRemediationDispatchText"></p>
+                                </div>
+                            </div>
+                        </div>
+                        <a href="#remediation-queue" class="btn btn-sm border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f]">
+                            Open queue
+                        </a>
+                    </div>
+                </template>
+                <template x-if="!remediationQueueLoading && !remediationQueueError && !primaryRemediationItem">
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next remediation</p>
+                            <p class="mt-1 text-sm font-semibold text-[#07071f]">No remediation queued</p>
+                            <p class="mt-1 text-sm text-[#5f5c78]">No current health fix needs operator action for this domain.</p>
+                        </div>
+                        <a href="#remediation-queue" class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5]">
+                            Review queue
+                        </a>
+                    </div>
+                </template>
+            </div>
         </div>
 
         <!-- Ownership proof -->
@@ -292,7 +359,7 @@
                     </div>
                 </div>
 
-                <div class="mt-5 rounded-lg border border-[#e6e3e1] bg-[#f8f7f6] p-4">
+                <div id="remediation-queue" class="mt-5 rounded-lg border border-[#e6e3e1] bg-[#f8f7f6] p-4">
                     <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                         <div>
                             <h3 class="font-semibold text-[#07071f]">Remediation Queue</h3>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1226,6 +1226,15 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "Source intelligence could not be loaded." in script
     assert "remediationQueueLoading" in script
     assert "remediationQueueError" in script
+    assert "primaryRemediationItem" in script
+    assert "primaryRemediationNextStep" in script
+    assert "primaryRemediationDispatchText" in script
+    assert "Next remediation" in template
+    assert "Loading next remediation..." in template
+    assert "Next remediation could not be loaded." in template
+    assert "No remediation queued" in template
+    assert 'href="#remediation-queue"' in template
+    assert 'id="remediation-queue"' in template
     assert "Loading remediation queue..." in template
     assert "Remediation queue could not be loaded." in script
     assert "Retry remediation queue" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1233,6 +1233,8 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "Loading next remediation..." in template
     assert "Next remediation could not be loaded." in template
     assert "No remediation queued" in template
+    assert "primaryRemediationItem.state.split('_').join(' ')" in template
+    assert "item.state.split('_').join(' ')" in template
     assert 'href="#remediation-queue"' in template
     assert 'id="remediation-queue"' in template
     assert "Loading remediation queue..." in template


### PR DESCRIPTION
## What changed
- Added a compact Next remediation panel near the top of each domain detail page.
- Shows loading, error/retry, empty, and actionable queue states before the operator scrolls into the full posture section.
- Added a stable remediation queue anchor so the top panel can jump to the detailed queue.

## Why
Operators currently need to scroll into the posture/remediation area before seeing the highest-priority fix. That makes affected domains look under-explained even when remediation data exists.

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py::test_domain_details_distinguishes_loading_error_and_empty_states -q
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q
- .venv/bin/python -m black --check backend/app/tests/test_dashboard_template_security.py
- .venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py
- .venv/bin/python -m isort --check-only backend/app/tests/test_dashboard_template_security.py
- .venv/bin/python -m pylint backend/app/tests/test_dashboard_template_security.py --disable=all --enable=E,F
- git diff --check

Refs #384