### PR TITLE
Deep link dashboard remediation cards

### DIFF
--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -938,6 +938,12 @@ function dashboardApp() {
                 : '/domains';
         },
 
+        domainRemediationHref(domainName) {
+            return domainName
+                ? `/domains/${encodeURIComponent(domainName)}#remediation-queue`
+                : '/domains';
+        },
+
         domainHealthHref(domainHealth) {
             return domainHealth && domainHealth.domain
                 ? `/domains/${encodeURIComponent(domainHealth.domain)}`

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -234,7 +234,7 @@
         <div class="mt-5 grid gap-3 lg:grid-cols-2" x-show="hasRemediationLoopItems()">
             <template x-for="item in remediationLoopItems()" :key="item.domain + item.type + item.title">
                 <a class="rounded-md border border-[#e6e3e1] p-4 transition hover:border-[#2f9da5] hover:shadow-sm"
-                   :href="domainActionHref(item)">
+                   :href="domainRemediationHref(item.domain)">
                     <div class="flex items-start justify-between gap-3">
                         <div class="min-w-0">
                             <span class="inline-flex rounded-md px-2 py-1 text-xs font-semibold"
@@ -247,7 +247,10 @@
                     </div>
                     <p class="mt-2 text-sm text-[#5f5c78]" x-text="item.detail"></p>
                     <p class="mt-2 text-sm font-semibold text-[#272a5f]" x-text="item.next_step"></p>
-                    <p class="mt-2 text-xs text-[#5f5c78]" x-text="item.domain"></p>
+                    <p class="mt-2 text-xs text-[#5f5c78]">
+                        <span x-text="item.domain"></span>
+                        <span> · Open remediation queue</span>
+                    </p>
                 </a>
             </template>
         </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -128,6 +128,29 @@ def _run_dashboard_poll_summary(payload: dict[str, object]) -> str:
     return result.stdout
 
 
+def _run_dashboard_expression(expression: str) -> str:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required to execute dashboard-page.js behavior tests")
+
+    script_path = Path(__file__).resolve().parents[1] / "static" / "js" / "dashboard-page.js"
+    runner = textwrap.dedent("""
+        const fs = require('fs');
+        const script = fs.readFileSync(process.argv[1], 'utf8');
+        const expression = process.argv[2];
+        const dashboardAppFactory = new Function(`${script}\\nreturn dashboardApp;`)();
+        const app = dashboardAppFactory();
+        process.stdout.write(String(new Function('app', `return ${expression};`)(app)));
+        """)
+    result = subprocess.run(
+        [node, "-e", runner, str(script_path), expression],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
 def _operations_template() -> str:
     return _read_project_file("templates", "operations.html")
 
@@ -287,6 +310,24 @@ def test_dashboard_exposes_workspace_health_history():
     assert "item.label.replaceAll('_', ' ')" in template
     assert "/api/v1/domains/summary/health/history" in script
     assert "fetchWorkspaceHealthHistory" in script
+
+
+def test_dashboard_remediation_cards_deep_link_to_domain_queue():
+    template = _dashboard_template()
+    script = _dashboard_script()
+
+    assert ':href="domainRemediationHref(item.domain)"' in template
+    assert "Open remediation queue" in template
+    assert "domainRemediationHref(domainName)" in script
+    assert "#remediation-queue" in script
+    assert "encodeURIComponent(domainName)" in script
+
+
+def test_dashboard_remediation_queue_href_encodes_domain_and_anchor():
+    assert (
+        _run_dashboard_expression("app.domainRemediationHref('mail.example/a b')")
+        == "/domains/mail.example%2Fa%20b#remediation-queue"
+    )
 
 
 def test_dashboard_clears_all_chart_instances():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -106,49 +106,42 @@ def _mail_sources_script() -> str:
     return _read_project_file("static", "js", "mail-sources-page.js")
 
 
-def _run_dashboard_poll_summary(payload: dict[str, object]) -> str:
+def _run_dashboard_script(runner_body: str, *args: str) -> str:
     node = shutil.which("node")
     if not node:
         pytest.skip("node is required to execute dashboard-page.js behavior tests")
 
     script_path = Path(__file__).resolve().parents[1] / "static" / "js" / "dashboard-page.js"
-    runner = textwrap.dedent("""
+    runner = textwrap.dedent(f"""
         const fs = require('fs');
         const script = fs.readFileSync(process.argv[1], 'utf8');
-        const payload = JSON.parse(process.argv[2]);
-        const dashboardAppFactory = new Function(`${script}\\nreturn dashboardApp;`)();
-        process.stdout.write(dashboardAppFactory().summarizePollResults(payload));
+        const dashboardAppFactory = new Function(`${{script}}\\nreturn dashboardApp;`)();
+        {runner_body}
         """)
     result = subprocess.run(
-        [node, "-e", runner, str(script_path), json.dumps(payload)],
+        [node, "-e", runner, str(script_path), *args],
         check=True,
         text=True,
         capture_output=True,
     )
     return result.stdout
+
+
+def _run_dashboard_poll_summary(payload: dict[str, object]) -> str:
+    runner_body = """
+        const payload = JSON.parse(process.argv[2]);
+        process.stdout.write(dashboardAppFactory().summarizePollResults(payload));
+        """
+    return _run_dashboard_script(runner_body, json.dumps(payload))
 
 
 def _run_dashboard_expression(expression: str) -> str:
-    node = shutil.which("node")
-    if not node:
-        pytest.skip("node is required to execute dashboard-page.js behavior tests")
-
-    script_path = Path(__file__).resolve().parents[1] / "static" / "js" / "dashboard-page.js"
-    runner = textwrap.dedent("""
-        const fs = require('fs');
-        const script = fs.readFileSync(process.argv[1], 'utf8');
+    runner_body = """
         const expression = process.argv[2];
-        const dashboardAppFactory = new Function(`${script}\\nreturn dashboardApp;`)();
         const app = dashboardAppFactory();
         process.stdout.write(String(new Function('app', `return ${expression};`)(app)));
-        """)
-    result = subprocess.run(
-        [node, "-e", runner, str(script_path), expression],
-        check=True,
-        text=True,
-        capture_output=True,
-    )
-    return result.stdout
+        """
+    return _run_dashboard_script(runner_body, expression)
 
 
 def _operations_template() -> str:


### PR DESCRIPTION
## Summary
- link dashboard remediation-loop cards directly to the domain remediation queue anchor
- label the dashboard cards so operators know the click opens the remediation queue
- add template and JS behavior coverage for the encoded deep link

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_cards_deep_link_to_domain_queue backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_queue_href_encodes_domain_and_anchor -q
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q
- .venv/bin/black --check backend/app/tests/test_dashboard_template_security.py
- .venv/bin/flake8 backend/app/tests/test_dashboard_template_security.py
- node --check backend/app/static/js/dashboard-page.js

Refs #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct links from remediation items to the related domain’s remediation queue.
  * Domain links now safely handle special characters and fall back to the main domains page when no domain is available.

* **Bug Fixes**
  * Updated remediation item cards so the displayed link text and destination are clearer and more consistent.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->