### PR TITLE
Clarify dashboard remediation resolved state

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1838,8 +1838,10 @@ def _build_dashboard_remediation_loop(
     remediation_activity: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Return a visible remediation-loop summary for the workspace dashboard."""
+    resolved_count = int((remediation_activity.get("summary") or {}).get("resolved") or 0)
     counters = {
-        "fixed": int((remediation_activity.get("summary") or {}).get("resolved") or 0),
+        "resolved": resolved_count,
+        "fixed": resolved_count,
         "needs_approval": 0,
         "manual_action": 0,
         "investigate": 0,

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -211,9 +211,10 @@
         </div>
         <div class="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
             <div class="rounded-md border border-[#e6e3e1] p-4">
-                <p class="text-sm text-[#5f5c78]">Fixed</p>
-                <p class="mt-2 text-3xl font-bold text-[#247982]" x-text="remediationLoop().fixed || 0"></p>
-                <p class="mt-1 text-xs text-[#5f5c78]">Operator-marked and verified items</p>
+                <p class="text-sm text-[#5f5c78]">Resolved</p>
+                <p class="mt-2 text-3xl font-bold text-[#247982]"
+                   x-text="remediationLoop().resolved || remediationLoop().fixed || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Operator-marked resolved items</p>
             </div>
             <div class="rounded-md border border-[#e6e3e1] p-4">
                 <p class="text-sm text-[#5f5c78]">Needs approval</p>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -316,6 +316,14 @@ def test_dashboard_remediation_cards_deep_link_to_domain_queue():
     assert "encodeURIComponent(domainName)" in script
 
 
+def test_dashboard_remediation_loop_uses_resolved_language():
+    template = _dashboard_template()
+
+    assert "Resolved" in template
+    assert "Operator-marked resolved items" in template
+    assert "remediationLoop().resolved || remediationLoop().fixed || 0" in template
+
+
 def test_dashboard_remediation_queue_href_encodes_domain_and_anchor():
     assert (
         _run_dashboard_expression("app.domainRemediationHref('mail.example/a b')")

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2235,6 +2235,7 @@ def test_summary_includes_remediation_activity(authed_client: TestClient, db_ses
     assert data["health_summary"]["remediation"]["domains_with_activity"] == 1
     assert data["health_summary"]["remediation"]["resolved"] == 1
     assert data["health_summary"]["remediation"]["delivery_count"] == 1
+    assert data["health_summary"]["remediation_loop"]["resolved"] == 1
     assert data["health_summary"]["remediation_loop"]["fixed"] == 1
 
     activity = summarize_remediation_activity(


### PR DESCRIPTION
## Summary
- add an explicit remediation_loop.resolved dashboard summary field while keeping the existing fixed alias for compatibility
- change the dashboard remediation loop card from Fixed to Resolved so operator-marked lifecycle state is not overstated as verified repair
- add focused API/template coverage for the resolved language and summary alias

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py::test_summary_includes_remediation_activity backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_loop_uses_resolved_language -q
- .venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py
- .venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py
- node --check backend/app/static/js/dashboard-page.js