### PR TITLE
Show remediation card context on dashboard

### DIFF
--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -248,6 +248,16 @@
                     </div>
                     <p class="mt-2 text-sm text-[#5f5c78]" x-text="item.detail"></p>
                     <p class="mt-2 text-sm font-semibold text-[#272a5f]" x-text="item.next_step"></p>
+                    <div class="mt-3 grid gap-2 text-xs text-[#5f5c78] sm:grid-cols-2">
+                        <div>
+                            <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Owner</p>
+                            <p class="mt-1 text-[#120d36]" x-text="item.owner"></p>
+                        </div>
+                        <div>
+                            <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Done when</p>
+                            <p class="mt-1 text-[#120d36]" x-text="item.completion_criteria"></p>
+                        </div>
+                    </div>
                     <p class="mt-2 text-xs text-[#5f5c78]">
                         <span x-text="item.domain"></span>
                         <span> · Open remediation queue</span>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -324,6 +324,15 @@ def test_dashboard_remediation_loop_uses_resolved_language():
     assert "remediationLoop().resolved || remediationLoop().fixed || 0" in template
 
 
+def test_dashboard_remediation_cards_show_owner_and_completion_context():
+    template = _dashboard_template()
+
+    assert "Owner" in template
+    assert "Done when" in template
+    assert 'x-text="item.owner"' in template
+    assert 'x-text="item.completion_criteria"' in template
+
+
 def test_dashboard_remediation_queue_href_encodes_domain_and_anchor():
     assert (
         _run_dashboard_expression("app.domainRemediationHref('mail.example/a b')")


### PR DESCRIPTION
## Summary
- show remediation owner and completion criteria directly on dashboard remediation cards
- keep dashboard cards linked to the domain remediation queue while making the next operator step clearer before clicking through
- add template coverage for the visible owner/completion context

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_cards_show_owner_and_completion_context backend/app/tests/test_dns_endpoints.py::test_summary_includes_current_remediation_loop -q
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q
- .venv/bin/black --check backend/app/tests/test_dashboard_template_security.py
- .venv/bin/flake8 backend/app/tests/test_dashboard_template_security.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The “Current fix queue” cards now show two additional details for each item: **Owner** and **Done when**.
  * These fields appear alongside the existing item information to give a clearer view of each remediation item.

* **Tests**
  * Added coverage to verify the remediation cards display the new labels and values correctly in the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->