### PR TITLE
Show verified fixed remediation on dashboard

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1838,10 +1838,13 @@ def _build_dashboard_remediation_loop(
     remediation_activity: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Return a visible remediation-loop summary for the workspace dashboard."""
-    resolved_count = int((remediation_activity.get("summary") or {}).get("resolved") or 0)
+    activity_summary = remediation_activity.get("summary") or {}
+    resolved_count = int(activity_summary.get("resolved") or 0)
+    verified_fixed_count = int(activity_summary.get("verified_fixed") or 0)
     counters = {
         "resolved": resolved_count,
         "fixed": resolved_count,
+        "verified_fixed": verified_fixed_count,
         "needs_approval": 0,
         "manual_action": 0,
         "investigate": 0,
@@ -1868,12 +1871,8 @@ def _build_dashboard_remediation_loop(
     return {
         **counters,
         "total_open": total_open,
-        "dispatch_enqueued": int(
-            (remediation_activity.get("summary") or {}).get("dispatch_enqueued") or 0
-        ),
-        "operator_follow_up": int(
-            (remediation_activity.get("summary") or {}).get("needs_operator_follow_up") or 0
-        ),
+        "dispatch_enqueued": int(activity_summary.get("dispatch_enqueued") or 0),
+        "operator_follow_up": int(activity_summary.get("needs_operator_follow_up") or 0),
         "status": "clear" if total_open == 0 else "needs_attention",
         "items": items[:5],
     }
@@ -3477,12 +3476,6 @@ async def get_domains_summary(
         domain.name: domain
         for domain in workspace_domain_query(db, workspace).filter(Domain.name.in_(domains)).all()
     }
-    remediation_activity = summarize_remediation_activity(
-        db,
-        workspace=workspace,
-        domains=domains,
-    )
-    remediation_by_domain = remediation_activity["domains"]
 
     async def _dns_for_domain(domain_name: str) -> DomainDNSResult:
         manual_selectors = manual_selectors_by_domain.get(domain_name, [])
@@ -3561,11 +3554,30 @@ async def get_domains_summary(
             ),
             "dmarc_warnings": dns.dmarc_warnings,
             "dmarc_suggestions": dns.dmarc_suggestions,
-            "remediation": remediation_by_domain.get(domain_name, {}),
+            "remediation": {},
         }
         domain_row["health"] = score_domain_health(domain_row)
         domain_row["remediation_workload"] = _domain_remediation_workload(domain_row)
         domains_list.append(domain_row)
+
+    active_remediation_item_ids = {
+        str(domain.get("domain_name") or domain.get("id") or ""): [
+            f"health:{action.get('type')}"
+            for action in (domain.get("health") or {}).get("actions") or []
+            if str(action.get("type") or "").strip()
+        ]
+        for domain in domains_list
+    }
+    remediation_activity = summarize_remediation_activity(
+        db,
+        workspace=workspace,
+        domains=domains,
+        active_item_ids_by_domain=active_remediation_item_ids,
+    )
+    remediation_by_domain = remediation_activity["domains"]
+    for domain_row in domains_list:
+        domain_name = str(domain_row.get("domain_name") or domain_row.get("id") or "")
+        domain_row["remediation"] = remediation_by_domain.get(domain_name, {})
 
     domain_health = [domain["health"] for domain in domains_list]
 

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -160,6 +160,7 @@ def _history_entry(row: WorkspaceAuditLog) -> Optional[Dict[str, Any]]:
         label = f"Lifecycle {lifecycle_state.replace('_', ' ')}"
 
     return {
+        "item_id": str(row.entity_id or ""),
         "action": action,
         "state": state,
         "label": label,
@@ -185,13 +186,19 @@ def _empty_domain_activity(domain: str) -> Dict[str, Any]:
         "resolved": 0,
         "rejected": 0,
         "snoozed": 0,
+        "verified_fixed": 0,
         "dispatch_enqueued": 0,
         "delivery_count": 0,
         "needs_operator_follow_up": False,
     }
 
 
-def _apply_activity_entry(summary: Dict[str, Any], entry: Dict[str, Any]) -> None:
+def _apply_activity_entry(
+    summary: Dict[str, Any],
+    entry: Dict[str, Any],
+    *,
+    active_item_ids: Optional[Set[str]] = None,
+) -> None:
     state = str(entry.get("state") or "")
     if summary["latest_state"] is None:
         summary["latest_state"] = state
@@ -199,6 +206,10 @@ def _apply_activity_entry(summary: Dict[str, Any], entry: Dict[str, Any]) -> Non
         summary["latest_at"] = entry.get("created_at")
     if state in {"previewed", "acknowledged", "resolved", "rejected", "snoozed"}:
         summary[state] += 1
+    if state == "resolved" and active_item_ids is not None:
+        item_id = str(entry.get("item_id") or "")
+        if item_id.startswith("health:") and item_id not in active_item_ids:
+            summary["verified_fixed"] += 1
     if state == "delivery_enqueued":
         summary["dispatch_enqueued"] += 1
         summary["delivery_count"] += _safe_int(entry.get("delivery_count"))
@@ -235,6 +246,7 @@ def _remediation_activity_totals(summaries: Dict[str, Dict[str, Any]]) -> Dict[s
         ),
         "dispatch_enqueued": sum(summary["dispatch_enqueued"] for summary in summaries.values()),
         "resolved": sum(summary["resolved"] for summary in summaries.values()),
+        "verified_fixed": sum(summary["verified_fixed"] for summary in summaries.values()),
         "operator_holds": sum(
             summary["rejected"] + summary["snoozed"] for summary in summaries.values()
         ),
@@ -250,6 +262,7 @@ def summarize_remediation_activity(
     *,
     workspace: Workspace,
     domains: Iterable[str],
+    active_item_ids_by_domain: Optional[Dict[str, Iterable[str]]] = None,
     row_limit: int = 500,
 ) -> Dict[str, Any]:
     """Summarize remediation audit activity without rebuilding domain queues."""
@@ -266,12 +279,20 @@ def summarize_remediation_activity(
                 "domains_with_activity": 0,
                 "dispatch_enqueued": 0,
                 "resolved": 0,
+                "verified_fixed": 0,
                 "operator_holds": 0,
                 "needs_operator_follow_up": 0,
                 "delivery_count": 0,
             },
             "domains": summaries,
         }
+    active_item_ids = {
+        normalize_domain_name(domain): {
+            str(item_id or "") for item_id in item_ids if str(item_id or "").strip()
+        }
+        for domain, item_ids in (active_item_ids_by_domain or {}).items()
+        if normalize_domain_name(domain)
+    }
 
     normalized_entity_name = func.lower(func.rtrim(func.trim(WorkspaceAuditLog.entity_name), "."))
     rows: List[WorkspaceAuditLog] = []
@@ -297,7 +318,11 @@ def summarize_remediation_activity(
         entry = _history_entry(row)
         if entry is None:
             continue
-        _apply_activity_entry(summaries[domain], entry)
+        _apply_activity_entry(
+            summaries[domain],
+            entry,
+            active_item_ids=active_item_ids.get(domain),
+        )
 
     for summary in summaries.values():
         _finalize_activity_summary(summary)

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -109,6 +109,11 @@
                         <span class="font-semibold text-[#247982]"
                               x-text="remediationTotals().resolved || 0"></span>
                     </div>
+                    <div class="flex items-center justify-between gap-3">
+                        <span class="text-[#5f5c78]">Verified fixed</span>
+                        <span class="font-semibold text-[#247982]"
+                              x-text="remediationTotals().verified_fixed || 0"></span>
+                    </div>
                 </div>
                 <div class="mt-5 border-t border-[#dfdfdf] pt-4" x-show="hasHealthHistoryPoints">
                     <div class="mb-3 flex items-center justify-between gap-3">
@@ -209,7 +214,13 @@
             </div>
             <a href="/domains" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open domain worklist</a>
         </div>
-        <div class="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <div class="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+            <div class="rounded-md border border-[#e6e3e1] p-4">
+                <p class="text-sm text-[#5f5c78]">Verified fixed</p>
+                <p class="mt-2 text-3xl font-bold text-[#247982]"
+                   x-text="remediationLoop().verified_fixed || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Resolved items no longer observed</p>
+            </div>
             <div class="rounded-md border border-[#e6e3e1] p-4">
                 <p class="text-sm text-[#5f5c78]">Resolved</p>
                 <p class="mt-2 text-3xl font-bold text-[#247982]"

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -322,6 +322,9 @@ def test_dashboard_remediation_loop_uses_resolved_language():
     assert "Resolved" in template
     assert "Operator-marked resolved items" in template
     assert "remediationLoop().resolved || remediationLoop().fixed || 0" in template
+    assert "Verified fixed" in template
+    assert "Resolved items no longer observed" in template
+    assert "remediationLoop().verified_fixed || 0" in template
 
 
 def test_dashboard_remediation_cards_show_owner_and_completion_context():

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2234,9 +2234,11 @@ def test_summary_includes_remediation_activity(authed_client: TestClient, db_ses
     assert domain["remediation"]["dispatch_enqueued"] == 1
     assert data["health_summary"]["remediation"]["domains_with_activity"] == 1
     assert data["health_summary"]["remediation"]["resolved"] == 1
+    assert data["health_summary"]["remediation"]["verified_fixed"] == 0
     assert data["health_summary"]["remediation"]["delivery_count"] == 1
     assert data["health_summary"]["remediation_loop"]["resolved"] == 1
     assert data["health_summary"]["remediation_loop"]["fixed"] == 1
+    assert data["health_summary"]["remediation_loop"]["verified_fixed"] == 0
 
     activity = summarize_remediation_activity(
         db_session,

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -486,6 +486,7 @@ def test_summarize_remediation_activity_handles_empty_domain_inputs(db_session):
             "domains_with_activity": 0,
             "dispatch_enqueued": 0,
             "resolved": 0,
+            "verified_fixed": 0,
             "operator_holds": 0,
             "needs_operator_follow_up": 0,
             "delivery_count": 0,
@@ -559,6 +560,49 @@ def test_summarize_remediation_activity_reports_status_variants(db_session):
     assert activity["summary"]["domains_with_activity"] == 3
     assert activity["summary"]["operator_holds"] == 1
     assert activity["summary"]["needs_operator_follow_up"] == 2
+
+
+def test_summarize_remediation_activity_counts_verified_fixed_items(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add_all(
+        [
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="health:missing_dkim",
+                entity_name="Fixed.Example",
+                details=json.dumps({"lifecycle_state": "resolved"}),
+                created_at=datetime(2026, 7, 1, 8, 0, 0, tzinfo=timezone.utc),
+            ),
+            WorkspaceAuditLog(
+                workspace_id=workspace.id,
+                actor_type="operator",
+                action="remediation.notification_lifecycle_recorded",
+                entity_type="remediation_notification",
+                entity_id="health:low_compliance",
+                entity_name="Fixed.Example",
+                details=json.dumps({"lifecycle_state": "resolved"}),
+                created_at=datetime(2026, 7, 1, 9, 0, 0, tzinfo=timezone.utc),
+            ),
+        ]
+    )
+    db_session.commit()
+
+    activity = remediation_dispatch.summarize_remediation_activity(
+        db_session,
+        workspace=workspace,
+        domains=["fixed.example"],
+        active_item_ids_by_domain={"fixed.example": ["health:low_compliance"]},
+    )
+
+    domain = activity["domains"]["fixed.example"]
+    assert domain["resolved"] == 2
+    assert domain["verified_fixed"] == 1
+    assert activity["summary"]["resolved"] == 2
+    assert activity["summary"]["verified_fixed"] == 1
+    assert activity["summary"]["needs_operator_follow_up"] == 0
 
 
 def test_build_remediation_dispatch_preview_fetches_context_when_not_preloaded(monkeypatch):


### PR DESCRIPTION
## What changed
- add a `verified_fixed` remediation activity counter for health remediation markers that were operator-resolved and are no longer observed in current health findings
- surface `Verified fixed` separately from operator-marked `Resolved` on the dashboard summary and remediation-loop cards
- keep the dashboard counter conservative by only counting current health remediation IDs, avoiding false verification for DNS plan markers that the summary API does not rebuild

## Why
The dashboard previously showed operator-resolved markers but did not separate that from evidence-backed fixes. This makes the remediation loop clearer: `Resolved` means an operator marked the lifecycle, while `Verified fixed` means the current evidence no longer contains that health finding.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py::test_summarize_remediation_activity_handles_empty_domain_inputs backend/app/tests/test_remediation_dispatch.py::test_summarize_remediation_activity_reports_status_variants backend/app/tests/test_remediation_dispatch.py::test_summarize_remediation_activity_counts_verified_fixed_items backend/app/tests/test_dns_endpoints.py::test_summary_includes_remediation_activity backend/app/tests/test_dns_endpoints.py::test_summary_includes_current_remediation_loop backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_loop_uses_resolved_language backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_cards_show_owner_and_completion_context -q`
- `.venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py -q`
- `.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q`
- `.venv/bin/black --check backend/app/services/remediation_dispatch.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `.venv/bin/flake8 backend/app/services/remediation_dispatch.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py`

Refs #384
