### PR TITLE
[codex] Clarify domain verified repair history

### DIFF
--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -410,8 +410,13 @@
                     </template>
                     <template x-if="!remediationQueueLoading && !remediationQueueError && (remediationQueue.verified_items || []).length > 0">
                         <div class="mt-4 rounded-lg border border-[#d8ebe8] bg-[#f2fbf9] p-3">
-                            <div class="flex flex-wrap items-center justify-between gap-2">
-                                <p class="text-xs font-semibold uppercase text-[#5f5c78]">Verified fixes</p>
+                            <div class="flex flex-wrap items-start justify-between gap-3">
+                                <div>
+                                    <p class="text-xs font-semibold uppercase text-[#5f5c78]">Evidence-verified repairs</p>
+                                    <p class="mt-1 text-xs text-[#45505f]">
+                                        These items were marked resolved by an operator and are no longer present in the current remediation queue.
+                                    </p>
+                                </div>
                                 <span class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#1f7c83]">
                                     <span x-text="remediationQueue.verified_items.length"></span><span> no longer observed</span>
                                 </span>
@@ -426,10 +431,14 @@
                                                   x-text="verified.label"></span>
                                         </div>
                                         <p class="mt-2 text-[#45505f]" x-text="verified.detail"></p>
+                                        <p class="mt-2 text-[#5f5c78]">
+                                            <span>Keep monitoring this repair; no DNS or mail settings were changed by this verification marker.</span>
+                                        </p>
                                         <p class="mt-2 rounded bg-[#f6f8fb] px-2 py-1 text-[#45505f]"
                                            x-show="verified.operator_note"
                                            x-text="verified.operator_note"></p>
                                         <p class="mt-1 text-[#5f5c78]">
+                                            <span>Marked resolved </span>
                                             <span x-text="formatIsoDate(verified.recorded_at)"></span>
                                             <span x-show="verified.actor_type"> · </span>
                                             <span x-show="verified.actor_type" x-text="verified.actor_type"></span>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1195,6 +1195,26 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "x-html" not in template
 
 
+def test_domain_details_distinguishes_evidence_verified_repairs_without_html_injection():
+    template = _domain_details_template()
+
+    assert "Evidence-verified repairs" in template
+    assert (
+        "These items were marked resolved by an operator and are no longer present "
+        "in the current remediation queue."
+    ) in template
+    assert "Keep monitoring this repair; no DNS or mail settings were changed" in template
+    assert "remediationQueue.verified_items.length" in template
+    assert "remediationQueue.verified_items.slice(0, 4)" in template
+    assert "verified.item_id" in template
+    assert "verified.label" in template
+    assert "verified.detail" in template
+    assert "verified.operator_note" in template
+    assert "formatIsoDate(verified.recorded_at)" in template
+    assert "verified.actor_type" in template
+    assert "x-html" not in template
+
+
 def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     template = _domain_details_template()
     script = _domain_details_script()


### PR DESCRIPTION
## What changed
- Clarifies the domain detail remediation queue's verified repair section as evidence-verified repairs.
- Explains that these items were operator-marked resolved and are no longer present in the current remediation queue.
- Keeps item ID, label, detail, operator note, timestamp, and actor rendered via text bindings only.

## Why
The dashboard already separates operator-resolved items from evidence-verified repairs. The domain detail page had the underlying data but the copy was too terse and could be read as if DMARQ had made an automatic repair. This makes the human-in-the-loop state explicit.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py::test_domain_details_distinguishes_evidence_verified_repairs_without_html_injection backend/app/tests/test_dashboard_template_security.py::test_domain_details_exposes_remediation_action_plans_without_html_injection -q`
- `.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q`
- `git diff --check`
