### PR TITLE
[codex] Clarify remediation history labels

### DIFF
--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -28,6 +28,13 @@ DEFAULT_DISPATCH_EVENTS = {
 }
 ACKNOWLEDGED_LIFECYCLE_STATES = {"previewed", "acknowledged"}
 OPERATOR_HELD_LIFECYCLE_STATES = {"resolved", "rejected", "snoozed"}
+LIFECYCLE_HISTORY_LABELS = {
+    "previewed": "Marked reviewed",
+    "acknowledged": "Marked acknowledged",
+    "resolved": "Marked resolved",
+    "rejected": "Marked rejected",
+    "snoozed": "Marked snoozed",
+}
 BLOCKED_REASON_NEXT_STEPS = (
     (
         "Remediation dispatch is disabled",
@@ -157,7 +164,10 @@ def _history_entry(row: WorkspaceAuditLog) -> Optional[Dict[str, Any]]:
         if not lifecycle_state:
             return None
         state = lifecycle_state
-        label = f"Lifecycle {lifecycle_state.replace('_', ' ')}"
+        label = LIFECYCLE_HISTORY_LABELS.get(
+            lifecycle_state,
+            f"Marked {lifecycle_state.replace('_', ' ')}",
+        )
 
     return {
         "item_id": str(row.entity_id or ""),

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -468,6 +468,7 @@ def test_notification_histories_return_sanitized_recent_audit_events(db_session)
     assert "deliveries" not in history[0]
     assert "actor_id" not in history[0]
     assert history[1]["state"] == "acknowledged"
+    assert history[1]["label"] == "Marked acknowledged"
     assert history[1]["operator_note"] == "Reviewed with DNS owner"
 
 


### PR DESCRIPTION
## What changed
- Replaces technical remediation lifecycle history labels such as `Lifecycle acknowledged` with operator-facing labels like `Marked acknowledged`.
- Keeps dispatch history labels unchanged.
- Preserves the sanitized history payload: no actor IDs or delivery payload internals are returned.

## Why
The domain detail remediation history should read like an operator activity log, not an internal lifecycle-state dump. This supports the #384 human-in-the-loop remediation loop without changing behavior or write safety.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py::test_notification_histories_return_sanitized_recent_audit_events -q`
- `.venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py -q`
- `.venv/bin/python -m black --check backend/app/services/remediation_dispatch.py backend/app/tests/test_remediation_dispatch.py`
- `.venv/bin/python -m flake8 backend/app/services/remediation_dispatch.py backend/app/tests/test_remediation_dispatch.py`
- `git diff --check`
