### PR TITLE
[codex] Prevent stale GitOps manifest updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,8 +349,30 @@ jobs:
             fi
           fi
 
+      - name: Confirm source ref is still current
+        id: source-ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "push" ] || [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "current=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          latest_sha="$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/commits/main" | jq -r '.sha')"
+          if [ "$latest_sha" != "${{ github.sha }}" ]; then
+            echo "::notice::Skipping GitOps update because main advanced to ${latest_sha} after this run started."
+            echo "current=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "current=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout k8s-cluster-state
-        if: steps.pat-check.outputs.available == 'true'
+        if: steps.pat-check.outputs.available == 'true' && steps.source-ref.outputs.current == 'true'
         uses: actions/checkout@v4
         with:
           repository: ${{ env.K8S_STATE_REPO }}
@@ -359,7 +381,7 @@ jobs:
           ref: main
 
       - name: Update image tags in GitOps manifests
-        if: steps.pat-check.outputs.available == 'true'
+        if: steps.pat-check.outputs.available == 'true' && steps.source-ref.outputs.current == 'true'
         uses: mikefarah/yq@v4.44.6
         env:
           IMAGE: ${{ steps.tag.outputs.image }}
@@ -376,7 +398,7 @@ jobs:
             done
 
       - name: Commit and push manifest update
-        if: steps.pat-check.outputs.available == 'true'
+        if: steps.pat-check.outputs.available == 'true' && steps.source-ref.outputs.current == 'true'
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
@@ -446,8 +468,30 @@ jobs:
             fi
           fi
 
+      - name: Confirm source ref is still current
+        id: source-ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "push" ] || [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "current=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          latest_sha="$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/commits/main" | jq -r '.sha')"
+          if [ "$latest_sha" != "${{ github.sha }}" ]; then
+            echo "::notice::Skipping GitOps update because main advanced to ${latest_sha} after this run started."
+            echo "current=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "current=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout k8s-cluster-state
-        if: steps.pat-check.outputs.available == 'true'
+        if: steps.pat-check.outputs.available == 'true' && steps.source-ref.outputs.current == 'true'
         uses: actions/checkout@v4
         with:
           repository: ${{ env.K8S_STATE_REPO }}
@@ -456,7 +500,7 @@ jobs:
           ref: main
 
       - name: Update production image tag in GitOps manifest
-        if: steps.pat-check.outputs.available == 'true'
+        if: steps.pat-check.outputs.available == 'true' && steps.source-ref.outputs.current == 'true'
         uses: mikefarah/yq@v4.44.6
         env:
           IMAGE: ${{ steps.tag.outputs.image }}
@@ -469,7 +513,7 @@ jobs:
               "$manifest"
 
       - name: Commit and push production manifest update
-        if: steps.pat-check.outputs.available == 'true'
+        if: steps.pat-check.outputs.available == 'true' && steps.source-ref.outputs.current == 'true'
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -1,7 +1,6 @@
 import importlib.util
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
@@ -57,22 +56,34 @@ def test_release_rollout_compare_reports_drift():
     assert any("version expected 1.2.4" in failure for failure in failures)
     assert any("environment expected demo" in failure for failure in failures)
     assert any("build SHA expected prefix deadbee" in failure for failure in failures)
-    assert any("image expected ghcr.io/christianlouis/dmarq:deadbee" in failure for failure in failures)
+    assert any(
+        "image expected ghcr.io/christianlouis/dmarq:deadbee" in failure for failure in failures
+    )
 
 
 def test_release_workflow_build_metadata_uses_checked_out_ref():
     """Docker build metadata must describe the commit used to build the image."""
-    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(
-        encoding="utf-8"
-    )
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
     assert "FULL_SHA=$(git rev-parse HEAD)" in workflow
     assert "DMARQ_BUILD_SHA=${{ steps.release_ref.outputs.full_sha }}" in workflow
     assert "DMARQ_BUILD_REF=${{ steps.release_ref.outputs.build_ref }}" in workflow
     assert "DMARQ_BUILD_DATE=${{ steps.release_ref.outputs.build_date }}" in workflow
-    build_args = workflow.split("build-args: |", maxsplit=1)[1].split(
-        "cache-from:", maxsplit=1
-    )[0]
+    build_args = workflow.split("build-args: |", maxsplit=1)[1].split("cache-from:", maxsplit=1)[0]
     assert "github.sha" not in build_args
     assert "github.ref_name" not in build_args
     assert "github.event.head_commit.timestamp" not in build_args
+
+
+def test_release_workflow_skips_gitops_for_stale_main_runs():
+    """Older main CI runs must not roll GitOps manifests back after main advances."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("Confirm source ref is still current") == 2
+    assert workflow.count("https://api.github.com/repos/${{ github.repository }}/commits/main") == 2
+    assert workflow.count("Skipping GitOps update because main advanced") == 2
+    assert workflow.count("steps.source-ref.outputs.current == 'true'") == 6
+    assert (
+        'if [ "${{ github.event_name }}" != "push" ] || '
+        '[ "${{ github.ref }}" != "refs/heads/main" ]; then'
+    ) in workflow


### PR DESCRIPTION
Closes #651.

## What changed
- Adds a GitOps source-ref guard before both nonproduction and production manifest writes.
- For push-triggered `main` runs, the workflow checks whether `github.sha` still matches the current `main` head before checking out and modifying the k8s state repo.
- If `main` advanced after the run started, the GitOps checkout/update/commit steps are skipped with an explicit notice.
- Manual `workflow_dispatch` GitOps deployments remain allowed for the selected ref.
- Adds regression coverage that asserts both GitOps jobs contain the stale-run guard and gated write steps.

## Why
After #649 and #650 merged close together, the older #649 main CI run finished its GitOps manifest write after the newer #650 run and temporarily rolled demo/prod back from `3e72d8f` to `6ac2130`. This prevents older completed runs from overwriting newer deployment manifests.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_release_rollout_script.py::test_release_workflow_skips_gitops_for_stale_main_runs -q`
- `.venv/bin/python -m pytest backend/app/tests/test_release_rollout_script.py -q`
- `.venv/bin/python -m black --check backend/app/tests/test_release_rollout_script.py`
- `.venv/bin/python -m flake8 backend/app/tests/test_release_rollout_script.py`
- YAML parse check for `.github/workflows/ci.yml`
- `git diff --check`
