### PR TITLE
[codex] Skip GitOps updates when SHA lookup fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,11 +359,16 @@ jobs:
             exit 0
           fi
 
-          latest_sha="$(curl -fsSL \
+          if ! latest_sha="$(curl -fsSL \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/commits/main" | jq -r '.sha')"
+            "https://api.github.com/repos/${{ github.repository }}/commits/main" | jq -r '.sha')"; then
+            echo "::notice::Skipping GitOps update because the current main SHA could not be resolved."
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [ "$latest_sha" != "${{ github.sha }}" ]; then
             echo "::notice::Skipping GitOps update because main advanced to ${latest_sha} after this run started."
             echo "current=false" >> "$GITHUB_OUTPUT"
@@ -478,11 +483,16 @@ jobs:
             exit 0
           fi
 
-          latest_sha="$(curl -fsSL \
+          if ! latest_sha="$(curl -fsSL \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/commits/main" | jq -r '.sha')"
+            "https://api.github.com/repos/${{ github.repository }}/commits/main" | jq -r '.sha')"; then
+            echo "::notice::Skipping GitOps update because the current main SHA could not be resolved."
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [ "$latest_sha" != "${{ github.sha }}" ]; then
             echo "::notice::Skipping GitOps update because main advanced to ${latest_sha} after this run started."
             echo "current=false" >> "$GITHUB_OUTPUT"

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -82,7 +82,10 @@ def test_release_workflow_skips_gitops_for_stale_main_runs():
     assert workflow.count("Confirm source ref is still current") == 2
     assert workflow.count("https://api.github.com/repos/${{ github.repository }}/commits/main") == 2
     assert workflow.count("Skipping GitOps update because main advanced") == 2
-    assert workflow.count("Skipping GitOps update because the current main SHA could not be resolved") == 2
+    assert (
+        workflow.count("Skipping GitOps update because the current main SHA could not be resolved")
+        == 2
+    )
     assert workflow.count("steps.source-ref.outputs.current == 'true'") == 6
     assert (
         'if [ "${{ github.event_name }}" != "push" ] || '

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -82,6 +82,7 @@ def test_release_workflow_skips_gitops_for_stale_main_runs():
     assert workflow.count("Confirm source ref is still current") == 2
     assert workflow.count("https://api.github.com/repos/${{ github.repository }}/commits/main") == 2
     assert workflow.count("Skipping GitOps update because main advanced") == 2
+    assert workflow.count("Skipping GitOps update because the current main SHA could not be resolved") == 2
     assert workflow.count("steps.source-ref.outputs.current == 'true'") == 6
     assert (
         'if [ "${{ github.event_name }}" != "push" ] || '


### PR DESCRIPTION
## Summary
- Treat current-main SHA lookup failures as non-current GitOps runs instead of failing the job
- Keep both nonprod and production GitOps jobs on the same safe fallback path
- Extend release workflow regression coverage for the API/jq failure fallback

## Validation
- git diff --check
- python3 inline runner for backend/app/tests/test_release_rollout_script.py (pytest unavailable in this clean clone)