### PR TITLE
Deploy semantic release commits through GitOps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     name: Semantic Release
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       id-token: write
 
@@ -25,6 +26,7 @@ jobs:
           python-version: "3.13"
 
       - name: Semantic Release
+        id: semantic
         uses: python-semantic-release/python-semantic-release@v10
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,3 +35,16 @@ jobs:
           tag: true
           push: true
           vcs_release: true
+
+      - name: Deploy released version through CI GitOps gate
+        if: steps.semantic.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.semantic.outputs.tag }}
+        run: |
+          gh workflow run ci.yml \
+            --ref main \
+            -f release_ref="${RELEASE_TAG}" \
+            -f release_tag="${RELEASE_TAG}" \
+            -f promote_stable=true \
+            -f deploy_gitops=true

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -91,3 +91,16 @@ def test_release_workflow_skips_gitops_for_stale_main_runs():
         'if [ "${{ github.event_name }}" != "push" ] || '
         '[ "${{ github.ref }}" != "refs/heads/main" ]; then'
     ) in workflow
+
+
+def test_release_workflow_dispatches_gitops_deploy_after_release():
+    """Semantic-release commits must trigger the deploy workflow explicitly."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert "actions: write" in workflow
+    assert "id: semantic" in workflow
+    assert "steps.semantic.outputs.released == 'true'" in workflow
+    assert "gh workflow run ci.yml" in workflow
+    assert 'release_ref="${RELEASE_TAG}"' in workflow
+    assert 'release_tag="${RELEASE_TAG}"' in workflow
+    assert "-f deploy_gitops=true" in workflow


### PR DESCRIPTION
## Summary
- dispatch the existing CI workflow after python-semantic-release creates a release commit/tag
- pass the release tag into the manual CI deploy inputs so the released version is built and written to GitOps
- add a focused regression test that keeps the release workflow wired to the deploy gate

## Validation
- `.venv/bin/pytest backend/app/tests/test_release_rollout_script.py`
- `.venv/bin/black --check backend/app/tests/test_release_rollout_script.py`
- `.venv/bin/flake8 backend/app/tests/test_release_rollout_script.py`
- workflow YAML parsed via PyYAML
- `git diff --check`
