### PR TITLE
[codex] Add remediation verification plans

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1145,6 +1145,16 @@ class RemediationActionPlan(BaseModel):
     automation_path: str
 
 
+class RemediationVerificationPlan(BaseModel):
+    """Read-only evidence checks before a remediation item is treated as fixed."""
+
+    label: str
+    status: str
+    summary: str
+    evidence_needed: List[str] = Field(default_factory=list)
+    next_check: str
+
+
 class RemediationNotification(BaseModel):
     """Read-only notification routing metadata for one remediation item."""
 
@@ -1175,6 +1185,7 @@ class RemediationQueueItem(BaseModel):
     prerequisites: List[str] = Field(default_factory=list)
     expected_health_score_impact: str
     action_plan: RemediationActionPlan
+    verification_plan: RemediationVerificationPlan
     automation: RemediationAutomation
     notification: RemediationNotification
 

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -235,6 +235,7 @@ def _dns_item(
         },
     }
     item["action_plan"] = _action_plan_for_item(item)
+    item["verification_plan"] = _verification_plan_for_item(item)
     return item
 
 
@@ -395,6 +396,7 @@ def _health_item(domain: str, action: Dict[str, Any]) -> Dict[str, Any]:
         },
     }
     item["action_plan"] = _action_plan_for_item(item)
+    item["verification_plan"] = _verification_plan_for_item(item)
     return item
 
 
@@ -459,6 +461,77 @@ def _action_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
             owner=owner,
             automation_path=automation_path,
         ),
+    }
+
+
+def _verification_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Return read-only evidence DMARQ should check before considering an item fixed."""
+    automation = item.get("automation") or {}
+    source = str(item.get("source") or "remediation")
+    state = str(item.get("state") or "")
+
+    if automation.get("eligible"):
+        provider = str(automation.get("provider") or "connected DNS provider")
+        return {
+            "label": "Verify after approved provider repair",
+            "status": "pending_operator_approval",
+            "summary": (
+                f"DMARQ should only mark this fixed after the approved {provider} write is "
+                "visible in fresh DNS evidence."
+            ),
+            "evidence_needed": [
+                "The provider preview was approved and applied by a human operator.",
+                "A fresh DNS lookup returns the expected record value from authoritative evidence.",
+                "The remediation item disappears from the current queue after DNS refresh.",
+            ],
+            "next_check": "Refresh DNS posture after provider propagation, then rebuild the queue.",
+        }
+
+    if source == "dns_lint":
+        return {
+            "label": "Verify DNS evidence after manual repair",
+            "status": "pending_dns_refresh",
+            "summary": (
+                "Manual DNS changes are complete only when DMARQ can read the corrected record "
+                "from trusted resolver evidence."
+            ),
+            "evidence_needed": [
+                "Authoritative DNS returns the expected TXT or CNAME record.",
+                "The original DNS lint finding is no longer present after refresh.",
+                "No new DNS lint finding was introduced by the change.",
+            ],
+            "next_check": "Run a DNS refresh after propagation and review the updated lint result.",
+        }
+
+    if state == "investigate":
+        return {
+            "label": "Verify sender evidence before repair",
+            "status": "pending_sender_review",
+            "summary": (
+                "Investigation items are not fixed until the sender is classified and fresh "
+                "DMARC reports prove the chosen treatment."
+            ),
+            "evidence_needed": [
+                "The sender is classified as legitimate, forwarding, abuse, or stale traffic.",
+                "Recent report rows show the source now passes DMARC or is intentionally blocked.",
+                "Source intelligence and last-sent timestamps still match the operator decision.",
+            ],
+            "next_check": "Wait for the next receiver report window, then confirm active sources.",
+        }
+
+    return {
+        "label": "Verify domain health after operator action",
+        "status": "pending_report_evidence",
+        "summary": (
+            "Health items should stay open until fresh DMARC or DNS evidence confirms the "
+            "underlying finding is gone."
+        ),
+        "evidence_needed": [
+            "Fresh DMARC reports or DNS checks cover the affected source or record.",
+            "The same health action no longer appears in the remediation queue.",
+            "Any remaining failures are documented as expected or intentionally blocked.",
+        ],
+        "next_check": "Refresh domain health after new evidence is imported.",
     }
 
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -536,6 +536,29 @@
                                         </p>
                                     </div>
                                 </template>
+                                <template x-if="item.verification_plan">
+                                    <div class="mt-3 rounded border border-[#e6e3e1] bg-white p-3">
+                                        <div class="flex flex-wrap items-center justify-between gap-2">
+                                            <p class="text-xs font-semibold uppercase text-[#5f5c78]">Verification</p>
+                                            <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]"
+                                                  x-text="item.verification_plan.status.replaceAll('_', ' ')"></span>
+                                        </div>
+                                        <p class="mt-2 text-sm font-semibold text-[#120d36]" x-text="item.verification_plan.label"></p>
+                                        <p class="mt-1 text-sm text-[#5f5c78]" x-text="item.verification_plan.summary"></p>
+                                        <ul class="mt-3 space-y-1 text-sm text-[#45505f]">
+                                            <template x-for="evidence in (item.verification_plan.evidence_needed || []).slice(0, 3)" :key="item.id + '-verify-' + evidence">
+                                                <li class="flex gap-2">
+                                                    <span class="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[#2f9da5]"></span>
+                                                    <span x-text="evidence"></span>
+                                                </li>
+                                            </template>
+                                        </ul>
+                                        <p class="mt-3 text-xs text-[#5f5c78]">
+                                            <span class="font-semibold">Next check: </span>
+                                            <span x-text="item.verification_plan.next_check"></span>
+                                        </p>
+                                    </div>
+                                </template>
                                 <template x-if="item.notification && item.notification.dispatch">
                                     <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3">
                                         <div class="flex flex-wrap items-center justify-between gap-2">

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -92,6 +92,13 @@ def _sample_remediation_queue(domain=DOMAIN):
                     "completion_criteria": "DMARC resolves.",
                     "automation_path": "Preview the DNS write in DMARQ.",
                 },
+                "verification_plan": {
+                    "label": "Verify DNS evidence after manual repair",
+                    "status": "pending_dns_refresh",
+                    "summary": "DMARC must resolve from fresh DNS evidence.",
+                    "evidence_needed": ["Fresh DNS returns the expected record."],
+                    "next_check": "Refresh DNS posture after propagation.",
+                },
                 "automation": {
                     "eligible": True,
                     "requires_approval": True,

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1175,6 +1175,10 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "item.action_plan.owner" in template
     assert "item.action_plan.steps" in template
     assert "item.action_plan.completion_criteria" in template
+    assert "Verification" in template
+    assert "item.verification_plan.status" in template
+    assert "item.verification_plan.evidence_needed" in template
+    assert "item.verification_plan.next_check" in template
     assert "Notification dispatch" in template
     assert "Reviewed" in template
     assert "Acknowledge" in template

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -817,6 +817,10 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
     assert data["items"][0]["id"] == "dns:dmarc-missing"
     assert data["items"][0]["automation"]["eligible"] is True
     assert data["items"][0]["automation"]["provider"] == "cloudflare"
+    assert data["items"][0]["verification_plan"]["status"] == "pending_operator_approval"
+    assert "fresh DNS evidence" in data["items"][0]["verification_plan"]["summary"]
+    assert data["items"][1]["verification_plan"]["status"] == "pending_sender_review"
+    assert "receiver report window" in data["items"][1]["verification_plan"]["next_check"]
     dispatch = data["items"][0]["notification"]["dispatch"]
     assert dispatch["enabled"] is False
     assert dispatch["eligible"] is False

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -119,6 +119,13 @@ def _sample_remediation_queue(domain=DOMAIN):
                     "completion_criteria": "DMARC resolves.",
                     "automation_path": "Preview the DNS write in DMARQ.",
                 },
+                "verification_plan": {
+                    "label": "Verify DNS evidence after manual repair",
+                    "status": "pending_dns_refresh",
+                    "summary": "DMARC must resolve from fresh DNS evidence.",
+                    "evidence_needed": ["Fresh DNS returns the expected record."],
+                    "next_check": "Refresh DNS posture after propagation.",
+                },
                 "automation": {
                     "eligible": True,
                     "requires_approval": True,

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -89,6 +89,14 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         in " ".join(queue["items"][0]["action_plan"]["steps"]).lower()
     )
     assert queue["items"][0]["action_plan"]["completion_criteria"]
+    assert queue["items"][0]["verification_plan"]["status"] == "pending_operator_approval"
+    assert "fresh DNS evidence" in queue["items"][0]["verification_plan"]["summary"]
+    assert any(
+        "provider preview was approved" in evidence
+        for evidence in queue["items"][0]["verification_plan"]["evidence_needed"]
+    )
+    assert queue["items"][1]["verification_plan"]["status"] == "pending_sender_review"
+    assert "next receiver report window" in queue["items"][1]["verification_plan"]["next_check"]
     notification = queue["items"][0]["notification"]
     assert notification == {
         "state": "approval_required",


### PR DESCRIPTION
## What changed
- Added a read-only `verification_plan` to every remediation queue item.
- Surfaced verification evidence and next-check guidance on the domain detail remediation cards.
- Extended queue/API/template tests so provider-backed DNS repairs and sender investigations require fresh evidence before they look complete.

## Why
Issue #384 still needs stronger post-fix verification beyond “the queue item disappeared.” This slice makes the required proof explicit before future provider repair automation can treat a remediation as fixed.

## Validation
- `.venv/bin/pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py -k "remediation_queue"`
- `.venv/bin/pytest backend/app/tests/test_dashboard_template_security.py -k "remediation_action_plans"`
- `.venv/bin/pytest backend/app/tests/test_public_api.py -k "remediation_queue"`
- `.venv/bin/pytest backend/app/tests/test_ai_mcp.py::test_mcp_read_only_tool_dispatch_covers_new_domain_tools`
- `.venv/bin/black --check backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `.venv/bin/flake8 backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py`
- `git diff --check`

Refs #384
