### PR TITLE
feat: show remediation verification checks on dashboard

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1797,6 +1797,10 @@ def _remediation_loop_context(state: str, action: Dict[str, Any]) -> Dict[str, s
             "owner": "Domain DNS operator",
             "automation_path": "provider_preview",
             "completion_criteria": "DNS change is previewed, approved, applied, and verified.",
+            "verification_next_check": (
+                "Refresh DNS posture after provider propagation and confirm the item leaves "
+                "the queue."
+            ),
             "why": "A high-impact DNS or policy finding can move through a controlled approval path.",
         }
     if state == "investigate":
@@ -1809,6 +1813,10 @@ def _remediation_loop_context(state: str, action: Dict[str, Any]) -> Dict[str, s
             ),
             "automation_path": "investigate",
             "completion_criteria": "Sender legitimacy is confirmed before any DNS or policy change.",
+            "verification_next_check": (
+                "Wait for fresh receiver reports, then confirm the active source now passes "
+                "DMARC or is intentionally blocked."
+            ),
             "why": "This finding needs evidence review before DMARQ can suggest a safe repair.",
         }
     return {
@@ -1816,6 +1824,9 @@ def _remediation_loop_context(state: str, action: Dict[str, Any]) -> Dict[str, s
         "owner": "Mail or DNS operator",
         "automation_path": "manual",
         "completion_criteria": "The operator completes the recommended action and refreshes evidence.",
+        "verification_next_check": (
+            "Refresh domain health after the operator action and confirm the finding is gone."
+        ),
         "why": "This item is not safe or specific enough for one-click repair yet.",
     }
 

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -269,6 +269,10 @@
                             <p class="mt-1 text-[#120d36]" x-text="item.completion_criteria"></p>
                         </div>
                     </div>
+                    <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3 text-xs">
+                        <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Next verification</p>
+                        <p class="mt-1 text-[#120d36]" x-text="item.verification_next_check"></p>
+                    </div>
                     <p class="mt-2 text-xs text-[#5f5c78]">
                         <span x-text="item.domain"></span>
                         <span> · Open remediation queue</span>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -332,8 +332,10 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
 
     assert "Owner" in template
     assert "Done when" in template
+    assert "Next verification" in template
     assert 'x-text="item.owner"' in template
     assert 'x-text="item.completion_criteria"' in template
+    assert 'x-text="item.verification_next_check"' in template
 
 
 def test_dashboard_remediation_queue_href_encodes_domain_and_anchor():

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2279,6 +2279,7 @@ def test_summary_includes_current_remediation_loop(
     assert loop["items"][0]["owner"] == "Domain DNS operator"
     assert loop["items"][0]["automation_path"] == "provider_preview"
     assert loop["items"][0]["completion_criteria"]
+    assert "Refresh DNS posture" in loop["items"][0]["verification_next_check"]
     assert loop["items"][0]["why"]
     assert loop["items"][0]["title"]
     assert loop["items"][0]["next_step"]
@@ -2290,6 +2291,10 @@ def test_summary_includes_current_remediation_loop(
     assert domain["remediation_workload"]["primary"]["state_label"] == "Needs approval"
     assert domain["remediation_workload"]["primary"]["owner"] == "Domain DNS operator"
     assert domain["remediation_workload"]["primary"]["automation_path"] == "provider_preview"
+    assert (
+        "Refresh DNS posture"
+        in domain["remediation_workload"]["primary"]["verification_next_check"]
+    )
     assert domain["remediation_workload"]["primary"]["title"]
 
 
@@ -2345,6 +2350,7 @@ def test_dashboard_remediation_item_includes_context_for_non_approval_states(
         assert item[key] == value
     assert item["domain"] == DOMAIN
     assert item["completion_criteria"]
+    assert item["verification_next_check"]
     assert item["why"]
 
 


### PR DESCRIPTION
## What changed
- Adds `verification_next_check` to dashboard remediation-loop items.
- Shows a visible `Next verification` block on each dashboard remediation card.
- Keeps the domain queue as the deeper drill-down, but gives operators the immediate post-fix evidence check before clicking through.

## Why
#384 is about a safe remediation loop, not just action buttons. After #655 added verification plans on the domain detail queue, this carries the same evidence-first language onto the dashboard so the operator can see what proof is needed after a fix.

## Validation
- `.venv/bin/pytest backend/app/tests/test_dns_endpoints.py -k "current_remediation_loop or dashboard_remediation_item"`
- `.venv/bin/pytest backend/app/tests/test_dashboard_template_security.py -k "remediation_cards_show_owner"`
- `.venv/bin/black --check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `.venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

Refs #384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Next verification” field to remediation queue items so users can see the next check step alongside owner and completion details.
  * Expanded remediation context to include clearer next-check guidance for different item states.

* **Tests**
  * Updated dashboard and API coverage to verify the new “Next verification” information appears in remediation item data and cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->