### PR TITLE
feat: include remediation verification context in notifications

### DIFF
--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -140,6 +140,8 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
     """Return the sanitized event payload that would be sent for a queue item."""
     notification = item.get("notification") or {}
     automation = item.get("automation") or {}
+    action_plan = item.get("action_plan") or {}
+    verification_plan = item.get("verification_plan") or {}
     return {
         "schema_version": "dmarq.remediation.notification.v1",
         "domain": domain,
@@ -162,6 +164,23 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
             "provider": automation.get("provider"),
             "plan_id": automation.get("plan_id"),
             "apply_endpoint": automation.get("apply_endpoint"),
+        },
+        "action_plan": {
+            "owner": str(action_plan.get("owner") or ""),
+            "automation_path": str(action_plan.get("automation_path") or ""),
+            "completion_criteria": str(action_plan.get("completion_criteria") or ""),
+            "steps": [str(step) for step in action_plan.get("steps", []) if str(step).strip()][:5],
+        },
+        "verification": {
+            "label": str(verification_plan.get("label") or ""),
+            "status": str(verification_plan.get("status") or ""),
+            "summary": str(verification_plan.get("summary") or ""),
+            "next_check": str(verification_plan.get("next_check") or ""),
+            "evidence_needed": [
+                str(evidence)
+                for evidence in verification_plan.get("evidence_needed", [])
+                if str(evidence).strip()
+            ][:5],
         },
         "evidence": [
             {"label": str(row.get("label") or "evidence"), "value": str(row.get("value") or "")}

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -130,6 +130,32 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
             "plan_id": "dmarc-missing",
             "apply_endpoint": "/api/v1/domains/example.com/dns/change-plan/apply",
         },
+        "action_plan": {
+            "owner": "Domain DNS operator",
+            "automation_path": "provider_preview",
+            "completion_criteria": "Provider preview is approved, applied, and verified by DMARQ.",
+            "steps": [
+                "Open the DNS change plan and preview the provider mutation.",
+                "Confirm the zone, record name, old value, new value, and TTL.",
+                "Approve the change, then refresh DNS posture after propagation.",
+            ],
+        },
+        "verification": {
+            "label": "Verify after approved provider repair",
+            "status": "pending_operator_approval",
+            "summary": (
+                "DMARQ should only mark this fixed after the approved cloudflare write is "
+                "visible in fresh DNS evidence."
+            ),
+            "next_check": (
+                "Refresh DNS posture after provider propagation, then rebuild the queue."
+            ),
+            "evidence_needed": [
+                "The provider preview was approved and applied by a human operator.",
+                "A fresh DNS lookup returns the expected record value from authoritative evidence.",
+                "The remediation item disappears from the current queue after DNS refresh.",
+            ],
+        },
         "evidence": [{"label": "finding", "value": "_dmarc.example.com"}],
     }
     assert queue["items"][1]["notification"]["state"] == "investigation_required"


### PR DESCRIPTION
## Summary
- include the operator action plan in remediation notification payload previews
- include the remediation verification plan, next check, and required evidence in the same payload
- keep payload evidence bounded and text-only for Human-in-the-loop webhook consumers

## Validation
- `.venv/bin/pytest backend/app/tests/test_remediation_queue.py`
- `.venv/bin/black --check backend/app/services/remediation_queue.py backend/app/tests/test_remediation_queue.py`
- `.venv/bin/flake8 backend/app/services/remediation_queue.py backend/app/tests/test_remediation_queue.py`
- `git diff --check`

Part of #384.
