### PR TITLE
docs: close roadmap api migration slices

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -1,6 +1,6 @@
 # DMARQ Product Roadmap
 
-Last updated: 2026-07-01
+Last updated: 2026-07-05
 
 DMARQ has moved beyond its original MVP. The product now parses aggregate and
 forensic DMARC reports, imports from IMAP/Gmail/Microsoft 365, persists report
@@ -98,30 +98,17 @@ Completed or substantially delivered:
 - Demo deployment that rolls forward from main through CI/GitOps.
 - Kubernetes high-availability work for tolerating loss of one hardware host.
 
-The main open strategic issues are:
+Strategic issue status:
 
-- [Issue #12](https://github.com/christianlouis/dmarq/issues/12): user
-  management, SaaS, ISP/OEM, subscription, and billing tracker. Most foundation
-  slices are complete; the remaining active child is enterprise identity and
-  support-access hardening.
-- [Issue #304](https://github.com/christianlouis/dmarq/issues/304): health
-  score, A-F rating, and remediation action plan.
-- [Issue #305](https://github.com/christianlouis/dmarq/issues/305): competitive
-  parity tracker for DMARC monitoring platforms.
-- [Issue #310](https://github.com/christianlouis/dmarq/issues/310): DANE, ARC,
-  and ARF competitive protocol coverage. The first shipped slice is passive
-  DANE/TLSA posture with live STARTTLS SPKI hash suggestions for TLSA `3 1 1`
-  records when MX access succeeds; ARC and deeper ARF work remain separate
-  design slices.
-- [Issue #384](https://github.com/christianlouis/dmarq/issues/384): autonomous
-  mail health remediation loop with human approval.
-- [Issue #385](https://github.com/christianlouis/dmarq/issues/385): sender IP
-  reputation and blacklist monitoring. The first shipped slices provide passive,
-  cached source reputation evidence plus opt-in DNSBL and AbuseIPDB enrichment.
-- [Issue #386](https://github.com/christianlouis/dmarq/issues/386): ecosystem
-  integration roadmap.
-- [Issue #387](https://github.com/christianlouis/dmarq/issues/387):
-  localization and multilingual remediation guidance.
+| Issue | Status | Notes |
+| --- | --- | --- |
+| [#12](https://github.com/christianlouis/dmarq/issues/12) | open | Broad user-auth, SaaS, ISP/OEM, subscription, and billing tracker. Keep this parked for the self-hosted demo unless auth work is explicitly reactivated. |
+| [#243](https://github.com/christianlouis/dmarq/issues/243) | open | Enterprise identity, provisioning, and support-access hardening. Treat as the active child under #12. |
+| [#305](https://github.com/christianlouis/dmarq/issues/305) | complete as roadmap parent | Competitive-parity direction is now captured here and in the referenced product docs. New work should use focused child issues instead of reopening the parent. |
+| [#309](https://github.com/christianlouis/dmarq/issues/309) | complete for current read-only API/MCP scope | Stable public API and MCP read-only surfaces exist for health, reports, DNS, sources, remediation, alerts, usage, and export discovery. Future write or provider-admin tools need separate scoped issues. |
+| [#311](https://github.com/christianlouis/dmarq/issues/311) | complete for safe migration readiness | Parallel-reporting, parity checklist, historical export preview, idempotency metadata, and portability docs are in place. A future persisted historical-import writer should be a separate explicit issue. |
+| [#312](https://github.com/christianlouis/dmarq/issues/312) | parked | MSP/ISP/multi-tenant demo polish is intentionally not part of the current `demo.dmarq.org` single-user self-hosted story. |
+| [#384](https://github.com/christianlouis/dmarq/issues/384) | active | Continue with human-approved provider repair progression, operator verification history, and remediation notifications. |
 
 ## Roadmap Tracks
 

--- a/docs/reference/ai-mcp-automation.md
+++ b/docs/reference/ai-mcp-automation.md
@@ -89,6 +89,25 @@ The current tools are read-only:
 
 Create a token with the `mcp:read` scope and send it through `X-API-Key`.
 
+### MCP Safety Contract
+
+The MCP endpoint is a read-only operational surface. Tools may summarize,
+filter, and explain evidence that DMARQ already stores, but they do not mutate
+domains, DNS, reports, alerts, provider connections, or workspace settings.
+
+| Tool family | Safe use | Mutation boundary |
+| --- | --- | --- |
+| Inventory | List domains and workspace usage | No domain creation or deletion |
+| Reports and sources | Summarize reports, source intelligence, and anomalies | No report ingestion trigger or mailbox access |
+| DNS posture | Return lint findings and read-only change plans | No DNS write or provider apply link |
+| Remediation | Return queue items, evidence, action plans, and verification context | No automatic dispatch or repair |
+| Alerts | Return sanitized alert history | No alert-rule writes |
+
+For agent workflows, treat MCP output as the evidence packet that prepares a
+human decision. Operators still approve provider writes, notification dispatch,
+or mail-server changes through the product UI or a future explicitly scoped
+write API.
+
 ## Audit
 
 DMARQ records sanitized workspace audit events for:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -150,7 +150,7 @@ responses are tenant-scoped, read-only, and evidence-linked.
 | Domain inventory | `reports:read` or `mcp:read` | `GET /public/domains`, `list_domains` | Domain summaries and aggregate counts only. |
 | Mail-health dashboard | `posture:read` or `mcp:read` | `GET /public/domains/{domain_id}/posture`, `domain_posture` | Includes score, grade, DNS health, and action guidance. |
 | Sending-source review | `reports:read` or `mcp:read` | `GET /public/domains/{domain_id}/sources`, `domain_sources` | Includes source intelligence and reputation posture without mailbox secrets. |
-| DNS review | `posture:read` or `mcp:read` | `dns_lint`, `dns_change_plan` | Change plans are read-only; public endpoints do not expose apply links. |
+| DNS review | `posture:read` or `mcp:read` | `GET /public/domains/{domain_id}/dns/lint`, `GET /public/domains/{domain_id}/dns/change-plan`, `dns_lint`, `dns_change_plan` | Change plans are read-only; public endpoints do not expose apply links. |
 | Human-in-the-loop remediation | `posture:read` or `mcp:read` | `GET /public/domains/{domain_id}/remediation`, `remediation_queue` | Queue items include evidence, action plans, automation eligibility, and verification context. |
 | Operational reporting | `reports:read`, `posture:read`, or `mcp:read` | `GET /public/usage`, `workspace_usage` | Workspace usage counts for capacity and monthly reviews. |
 | Alert export | `posture:read` or `mcp:read` | `GET /public/alerts`, `alert_history` | Sanitized alert lifecycle rows only. |
@@ -160,7 +160,7 @@ Example read-only remediation request:
 ```bash
 curl -sS \
   -H "X-API-Key: $DMARQ_API_TOKEN" \
-  "https://your-dmarq-instance.com/api/v1/public/domains/example.com/remediation"
+  "https://your-dmarq-instance.com/api/v1/public/domains/{domain_id}/remediation"
 ```
 
 Example MCP tool call:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -140,6 +140,47 @@ The MCP endpoint currently exposes these read-only tools:
 | `source_intelligence` | Return source regions and anomaly hints |
 | `action_proposals` | Return reviewable remediation proposals without applying them |
 
+### Automation Scope Matrix
+
+Use the smallest token scope that supports the workflow. Public API and MCP
+responses are tenant-scoped, read-only, and evidence-linked.
+
+| Workflow | Token scope | Endpoint or tool | Notes |
+| --- | --- | --- | --- |
+| Domain inventory | `reports:read` or `mcp:read` | `GET /public/domains`, `list_domains` | Domain summaries and aggregate counts only. |
+| Mail-health dashboard | `posture:read` or `mcp:read` | `GET /public/domains/{domain_id}/posture`, `domain_posture` | Includes score, grade, DNS health, and action guidance. |
+| Sending-source review | `reports:read` or `mcp:read` | `GET /public/domains/{domain_id}/sources`, `domain_sources` | Includes source intelligence and reputation posture without mailbox secrets. |
+| DNS review | `posture:read` or `mcp:read` | `dns_lint`, `dns_change_plan` | Change plans are read-only; public endpoints do not expose apply links. |
+| Human-in-the-loop remediation | `posture:read` or `mcp:read` | `GET /public/domains/{domain_id}/remediation`, `remediation_queue` | Queue items include evidence, action plans, automation eligibility, and verification context. |
+| Operational reporting | `reports:read`, `posture:read`, or `mcp:read` | `GET /public/usage`, `workspace_usage` | Workspace usage counts for capacity and monthly reviews. |
+| Alert export | `posture:read` or `mcp:read` | `GET /public/alerts`, `alert_history` | Sanitized alert lifecycle rows only. |
+
+Example read-only remediation request:
+
+```bash
+curl -sS \
+  -H "X-API-Key: $DMARQ_API_TOKEN" \
+  "https://your-dmarq-instance.com/api/v1/public/domains/example.com/remediation"
+```
+
+Example MCP tool call:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "remediation-example",
+  "method": "tools/call",
+  "params": {
+    "name": "remediation_queue",
+    "arguments": {"domain": "example.com"}
+  }
+}
+```
+
+These automation surfaces intentionally stop at proposals and evidence. DNS
+apply operations remain UI/provider-specific, require explicit operator
+approval, and are not exposed through the read-only public/MCP contract.
+
 ### Provider API
 
 Provider, ISP, MSP, and hosting-control-panel integrations use

--- a/docs/user_guide/migration.md
+++ b/docs/user_guide/migration.md
@@ -19,6 +19,20 @@ The domain detail page includes a **Migration Readiness** panel. It tracks the
 parallel-reporting window, aggregate report count, observed sending sources,
 DNS lint status, and export availability for each domain.
 
+### Cutover decision gates
+
+Do not remove the previous DMARC platform just because the first DMARQ report
+arrived. Use these gates instead:
+
+| Gate | Ready when | Keep both tools when |
+| --- | --- | --- |
+| Reporting overlap | DMARQ has at least 14 report days for active domains | reports are sparse, delayed, or missing major receivers |
+| Volume parity | DMARQ and the previous tool show explainable message-volume differences | one tool has materially higher volume with no known cause |
+| Sender parity | Active legitimate senders appear in both tools or are explained | a provider, self-hosted MTA, or forwarding path is missing |
+| Alignment parity | Pass/fail rates are close enough for the same date window | failures differ and no receiver/reporting explanation exists |
+| DNS posture | DMARC, SPF, DKIM, MTA-STS/TLS-RPT/BIMI findings are reviewed | unresolved DNS lint findings affect legitimate mail |
+| Rollback evidence | Old routes, reporting addresses, and delegated records are documented | the old platform uses managed DNS or opaque hosted routes |
+
 The same panel includes **Migration Parity**. Enter values from the same date
 window in the current DMARC platform to compare:
 
@@ -93,6 +107,22 @@ DMARQ currently provides these portable exports for migration and offboarding:
 
 These exports intentionally avoid raw message bodies and forensic content.
 They are meant for parity checks, audit evidence, and rollback decisions.
+
+## Current implementation status
+
+The safe migration workflow is complete for planning, parity review, preview,
+and offboarding evidence:
+
+- parallel-reporting guidance and cutover gates
+- domain-detail migration readiness
+- migration parity baseline comparison
+- read-only CSV/JSON historical export preview
+- stable row and report import keys for idempotency review
+- CSV/JSON evidence exports for leaving DMARQ
+
+DMARQ does not yet persist vendor-specific historical exports into aggregate
+report storage. That should remain a separate explicit feature because it needs
+operator-confirmed field mapping, duplicate handling, and rollback behavior.
 
 ## Import limitations
 


### PR DESCRIPTION
## Summary
- mark the current roadmap parent/status for #305, #309, and #311 in the product roadmap
- add a public API/MCP automation scope matrix and read-only remediation examples
- document the MCP safety contract and migration cutover decision gates
- clarify that future persisted historical vendor imports should be a separate explicit feature

## Validation
- `git diff --check`
- local internal Markdown link check for the changed docs

Closes #305.
Closes #309.
Closes #311.
