### PR TITLE
feat: enforce upstream mfa assurance

### DIFF
--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -31,6 +31,7 @@ from app.core.auth_providers import (
     build_oidc_authorization_url,
     configured_oidc_provider,
     decode_oidc_state,
+    enforce_mfa_claims,
     exchange_oidc_callback,
     sync_external_user,
     trusted_proxy_claims_from_request,
@@ -225,7 +226,7 @@ async def _handle_external_oidc_callback(
         return RedirectResponse(url="/login?error=callback_failed", status_code=302)
 
     try:
-        claims = await exchange_oidc_callback(request, provider, code=code)
+        claims = await exchange_oidc_callback(request, provider, code=code, settings=settings)
         user = sync_external_user(claims, db)
     except HTTPException as exc:
         logger.warning("%s callback rejected: %s", provider.label, exc.detail)
@@ -276,6 +277,10 @@ async def callback(
 
     try:
         claims = client.getIdTokenClaims()
+        enforce_mfa_claims("logto", claims, settings)
+    except HTTPException as exc:
+        logger.warning("Logto callback rejected: %s", exc.detail)
+        return RedirectResponse(url="/login?error=callback_failed", status_code=302)
     except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.warning("Failed to extract ID-token claims: %s", exc)
         return RedirectResponse(url="/login?error=token_error", status_code=302)

--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -277,7 +277,7 @@ async def callback(
 
     try:
         claims = client.getIdTokenClaims()
-        enforce_mfa_claims("logto", claims, settings)
+        enforce_mfa_claims(claims, settings)
     except HTTPException as exc:
         logger.warning("Logto callback rejected: %s", exc.detail)
         return RedirectResponse(url="/login?error=callback_failed", status_code=302)

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -418,26 +418,24 @@ def mfa_claim_context(
 
 
 def enforce_mfa_claims(
-    provider: str,
     payload: Any,
     settings: Settings | None = None,
 ) -> tuple[bool, tuple[str, ...]]:
     """Return MFA claim context and enforce the deployment policy when required."""
     mfa_verified, mfa_claims = mfa_claim_context(payload, settings)
-    _enforce_mfa_policy(mfa_verified=mfa_verified, provider=provider, settings=settings)
+    _enforce_mfa_policy(mfa_verified=mfa_verified, settings=settings)
     return mfa_verified, mfa_claims
 
 
 def _enforce_mfa_policy(
     *,
     mfa_verified: bool,
-    provider: str,
     settings: Settings | None = None,
 ) -> None:
     cfg = settings or get_settings()
     if not _enabled_flag(getattr(cfg, "AUTH_REQUIRE_MFA", False)) or mfa_verified:
         return
-    logger.warning("Rejecting %s login because MFA assurance claims were not present", provider)
+    logger.warning("Rejecting external login because MFA assurance claims were not present")
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
         detail=(
@@ -692,7 +690,7 @@ def normalize_external_claims(
             allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
         ),
     )
-    mfa_verified, mfa_claims = enforce_mfa_claims(provider, payload, cfg)
+    mfa_verified, mfa_claims = enforce_mfa_claims(payload, cfg)
     return ExternalIdentityClaims(
         provider=provider,
         subject=subject,
@@ -1003,7 +1001,6 @@ def trusted_proxy_claims_from_request(
     groups = _normalize_string_claims(request.headers.get(cfg.AUTH_TRUSTED_PROXY_GROUPS_HEADER))
     mfa_header = getattr(cfg, "AUTH_TRUSTED_PROXY_MFA_HEADER", "X-Authentik-Meta-Amr")
     mfa_verified, mfa_claims = enforce_mfa_claims(
-        provider,
         {"amr": request.headers.get(mfa_header)},
         cfg,
     )

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -102,7 +102,8 @@ class AuthProviderOption:
             "active": getattr(cfg, "active_auth_provider", "unconfigured") == self.provider,
             "configured": auth_provider_configured(self.provider, cfg),
             "mfa_policy": {
-                "required": _enabled_flag(getattr(cfg, "AUTH_REQUIRE_MFA", False)),
+                "required": self.supports_mfa_policy
+                and _enabled_flag(getattr(cfg, "AUTH_REQUIRE_MFA", False)),
                 "claim_names": sorted(_split_csv(getattr(cfg, "AUTH_MFA_CLAIM_NAMES", ""))),
             },
         }

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Optional
@@ -59,6 +60,8 @@ class ExternalIdentityClaims:
     groups: tuple[str, ...] = ()
     workspace_roles: tuple[tuple[str, str], ...] = ()
     organization_roles: tuple[tuple[str, str], ...] = ()
+    mfa_verified: bool = False
+    mfa_claims: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -77,6 +80,7 @@ class AuthProviderOption:
     supports_trusted_proxy: bool = False
     supports_single_user: bool = False
     supports_multi_user: bool = False
+    supports_mfa_policy: bool = False
 
     def as_dict(self, settings: Settings | None = None) -> dict[str, Any]:
         """Return JSON/template-safe provider metadata."""
@@ -94,8 +98,13 @@ class AuthProviderOption:
             "supports_trusted_proxy": self.supports_trusted_proxy,
             "supports_single_user": self.supports_single_user,
             "supports_multi_user": self.supports_multi_user,
+            "supports_mfa_policy": self.supports_mfa_policy,
             "active": getattr(cfg, "active_auth_provider", "unconfigured") == self.provider,
             "configured": auth_provider_configured(self.provider, cfg),
+            "mfa_policy": {
+                "required": _enabled_flag(getattr(cfg, "AUTH_REQUIRE_MFA", False)),
+                "claim_names": sorted(_split_csv(getattr(cfg, "AUTH_MFA_CLAIM_NAMES", ""))),
+            },
         }
 
 
@@ -137,6 +146,7 @@ AUTH_PROVIDER_OPTIONS: tuple[AuthProviderOption, ...] = (
         supports_direct_oidc=True,
         supports_single_user=True,
         supports_multi_user=True,
+        supports_mfa_policy=True,
     ),
     AuthProviderOption(
         provider="authentik",
@@ -153,6 +163,7 @@ AUTH_PROVIDER_OPTIONS: tuple[AuthProviderOption, ...] = (
         supports_direct_oidc=True,
         supports_single_user=True,
         supports_multi_user=True,
+        supports_mfa_policy=True,
     ),
     AuthProviderOption(
         provider="trusted_proxy",
@@ -168,6 +179,7 @@ AUTH_PROVIDER_OPTIONS: tuple[AuthProviderOption, ...] = (
         supports_trusted_proxy=True,
         supports_single_user=True,
         supports_multi_user=True,
+        supports_mfa_policy=True,
     ),
     AuthProviderOption(
         provider="oidc",
@@ -184,6 +196,7 @@ AUTH_PROVIDER_OPTIONS: tuple[AuthProviderOption, ...] = (
         supports_direct_oidc=True,
         supports_single_user=True,
         supports_multi_user=True,
+        supports_mfa_policy=True,
     ),
     AuthProviderOption(
         provider="keycloak",
@@ -197,6 +210,7 @@ AUTH_PROVIDER_OPTIONS: tuple[AuthProviderOption, ...] = (
         supports_direct_oidc=True,
         supports_single_user=True,
         supports_multi_user=True,
+        supports_mfa_policy=True,
     ),
     AuthProviderOption(
         provider="entra_id",
@@ -210,6 +224,7 @@ AUTH_PROVIDER_OPTIONS: tuple[AuthProviderOption, ...] = (
         supports_direct_oidc=True,
         supports_single_user=True,
         supports_multi_user=True,
+        supports_mfa_policy=True,
     ),
     AuthProviderOption(
         provider="google_workspace",
@@ -223,6 +238,7 @@ AUTH_PROVIDER_OPTIONS: tuple[AuthProviderOption, ...] = (
         supports_direct_oidc=True,
         supports_single_user=True,
         supports_multi_user=True,
+        supports_mfa_policy=True,
     ),
     AuthProviderOption(
         provider="cloudflare_access",
@@ -238,6 +254,7 @@ AUTH_PROVIDER_OPTIONS: tuple[AuthProviderOption, ...] = (
         supports_trusted_proxy=True,
         supports_single_user=True,
         supports_multi_user=True,
+        supports_mfa_policy=True,
     ),
     AuthProviderOption(
         provider="akamai_eaa",
@@ -253,6 +270,7 @@ AUTH_PROVIDER_OPTIONS: tuple[AuthProviderOption, ...] = (
         supports_trusted_proxy=True,
         supports_single_user=True,
         supports_multi_user=True,
+        supports_mfa_policy=True,
     ),
 )
 
@@ -311,6 +329,121 @@ def _split_csv(value: Optional[str]) -> set[str]:
     if not value:
         return set()
     return {item.strip().lower() for item in value.split(",") if item.strip()}
+
+
+def _split_csv_sequence(value: Optional[str]) -> tuple[str, ...]:
+    if not value:
+        return ()
+    normalized: list[str] = []
+    seen = set()
+    for item in value.split(","):
+        text = item.strip().lower()
+        if text and text not in seen:
+            normalized.append(text)
+            seen.add(text)
+    return tuple(normalized)
+
+
+def _enabled_flag(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _claim_value(payload: Any, name: str) -> Any:
+    if isinstance(payload, Mapping):
+        return payload.get(name)
+    value = getattr(payload, name, None)
+    if isinstance(value, (str, int, float, bool, list, tuple, set)):
+        return value
+    return None
+
+
+def _flatten_claim_values(value: Any) -> tuple[str, ...]:
+    """Return claim values as lower-case tokens without exposing raw claim payloads."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        raw_values = re.split(r"[\s,]+", value)
+    elif isinstance(value, (list, tuple, set)):
+        raw_values = []
+        for item in value:
+            raw_values.extend(_flatten_claim_values(item))
+    elif isinstance(value, (int, float, bool)):
+        raw_values = [str(value)]
+    else:
+        return ()
+
+    normalized: list[str] = []
+    seen = set()
+    for item in raw_values:
+        text = str(item).strip().lower()
+        if text and text not in seen:
+            normalized.append(text)
+            seen.add(text)
+    return tuple(normalized)
+
+
+def _mfa_claim_names(settings: Settings | None = None) -> tuple[str, ...]:
+    cfg = settings or get_settings()
+    return _split_csv_sequence(getattr(cfg, "AUTH_MFA_CLAIM_NAMES", "amr,acr"))
+
+
+def _mfa_claim_values(settings: Settings | None = None) -> set[str]:
+    cfg = settings or get_settings()
+    return _split_csv(getattr(cfg, "AUTH_MFA_CLAIM_VALUES", "mfa,otp,totp,webauthn,hwk,swk,phr"))
+
+
+def mfa_claim_context(
+    payload: Any, settings: Settings | None = None
+) -> tuple[bool, tuple[str, ...]]:
+    """Return whether IdP claims satisfy the configured MFA policy."""
+    names = _mfa_claim_names(settings)
+    accepted = _mfa_claim_values(settings)
+    observed: list[str] = []
+    seen = set()
+    verified = False
+    for name in names:
+        for value in _flatten_claim_values(_claim_value(payload, name)):
+            claim = f"{name}:{value}"
+            if claim not in seen:
+                observed.append(claim)
+                seen.add(claim)
+            if value in accepted:
+                verified = True
+    return verified, tuple(observed)
+
+
+def enforce_mfa_claims(
+    provider: str,
+    payload: Any,
+    settings: Settings | None = None,
+) -> tuple[bool, tuple[str, ...]]:
+    """Return MFA claim context and enforce the deployment policy when required."""
+    mfa_verified, mfa_claims = mfa_claim_context(payload, settings)
+    _enforce_mfa_policy(mfa_verified=mfa_verified, provider=provider, settings=settings)
+    return mfa_verified, mfa_claims
+
+
+def _enforce_mfa_policy(
+    *,
+    mfa_verified: bool,
+    provider: str,
+    settings: Settings | None = None,
+) -> None:
+    cfg = settings or get_settings()
+    if not _enabled_flag(getattr(cfg, "AUTH_REQUIRE_MFA", False)) or mfa_verified:
+        return
+    logger.warning("Rejecting %s login because MFA assurance claims were not present", provider)
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            "This DMARQ deployment requires MFA at the identity provider, but the "
+            "login did not include an accepted MFA assurance claim."
+        ),
+    )
 
 
 def email_allowed(
@@ -452,6 +585,7 @@ async def exchange_oidc_callback(
     provider: OIDCProviderConfig,
     *,
     code: str,
+    settings: Settings | None = None,
 ) -> ExternalIdentityClaims:
     """Exchange an authorization code and return normalized user claims."""
     metadata = await fetch_oidc_discovery(provider)
@@ -506,6 +640,7 @@ async def exchange_oidc_callback(
         allowed_domains=provider.allowed_domains,
         group_workspace_role_map=provider.group_workspace_role_map,
         group_organization_role_map=provider.group_organization_role_map,
+        settings=settings,
     )
 
 
@@ -517,8 +652,10 @@ def normalize_external_claims(
     allowed_domains: Optional[str] = None,
     group_workspace_role_map: Optional[str] = None,
     group_organization_role_map: Optional[str] = None,
+    settings: Settings | None = None,
 ) -> ExternalIdentityClaims:
     """Normalize provider-specific claim JSON into the DMARQ user shape."""
+    cfg = settings or get_settings()
     subject = str(payload.get("sub") or payload.get("uid") or "").strip()
     email = str(payload.get("email") or "").strip().lower()
     if not subject:
@@ -554,6 +691,7 @@ def normalize_external_claims(
             allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
         ),
     )
+    mfa_verified, mfa_claims = enforce_mfa_claims(provider, payload, cfg)
     return ExternalIdentityClaims(
         provider=provider,
         subject=subject,
@@ -565,6 +703,8 @@ def normalize_external_claims(
         groups=groups,
         workspace_roles=workspace_roles,
         organization_roles=organization_roles,
+        mfa_verified=mfa_verified,
+        mfa_claims=mfa_claims,
     )
 
 
@@ -860,6 +1000,12 @@ def trusted_proxy_claims_from_request(
         return None
     provider = (cfg.AUTH_TRUSTED_PROXY_PROVIDER or "trusted_proxy").strip().lower()
     groups = _normalize_string_claims(request.headers.get(cfg.AUTH_TRUSTED_PROXY_GROUPS_HEADER))
+    mfa_header = getattr(cfg, "AUTH_TRUSTED_PROXY_MFA_HEADER", "X-Authentik-Meta-Amr")
+    mfa_verified, mfa_claims = enforce_mfa_claims(
+        provider,
+        {"amr": request.headers.get(mfa_header)},
+        cfg,
+    )
     return ExternalIdentityClaims(
         provider=provider,
         subject=subject or email,
@@ -878,6 +1024,8 @@ def trusted_proxy_claims_from_request(
             cfg.AUTH_TRUSTED_PROXY_GROUP_ORGANIZATION_ROLE_MAP,
             allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
         ),
+        mfa_verified=mfa_verified,
+        mfa_claims=mfa_claims,
     )
 
 
@@ -896,4 +1044,5 @@ def trusted_proxy_auth_context(
         "email": claims.email,
         "name": claims.name,
         "username": claims.username,
+        "mfa_verified": claims.mfa_verified,
     }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -165,6 +165,9 @@ class Settings(BaseSettings):
     OIDC_ALLOWED_DOMAINS: Optional[str] = None
     OIDC_GROUP_WORKSPACE_ROLE_MAP: Optional[str] = None
     OIDC_GROUP_ORGANIZATION_ROLE_MAP: Optional[str] = None
+    AUTH_REQUIRE_MFA: bool = False
+    AUTH_MFA_CLAIM_NAMES: str = "amr,acr"
+    AUTH_MFA_CLAIM_VALUES: str = "mfa,otp,totp,webauthn,hwk,swk,phr"
 
     AUTHENTIK_ISSUER_URL: Optional[str] = None
     AUTHENTIK_CLIENT_ID: Optional[str] = None
@@ -185,6 +188,7 @@ class Settings(BaseSettings):
     AUTH_TRUSTED_PROXY_USERNAME_HEADER: str = "X-Authentik-Username"
     AUTH_TRUSTED_PROXY_SUBJECT_HEADER: str = "X-Authentik-Uid"
     AUTH_TRUSTED_PROXY_GROUPS_HEADER: str = "X-Authentik-Groups"
+    AUTH_TRUSTED_PROXY_MFA_HEADER: str = "X-Authentik-Meta-Amr"
     AUTH_TRUSTED_PROXY_ALLOWED_EMAILS: Optional[str] = None
     AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS: Optional[str] = None
     AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP: Optional[str] = None

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -210,6 +210,18 @@ class TestExternalAuthProviders:
         assert providers["cloudflare_access"]["auth_mode"] == "trusted_proxy"
         assert providers["akamai_eaa"]["status"] == "planned"
 
+    def test_auth_provider_registry_scopes_mfa_requirement_to_supported_providers(self):
+        settings = Settings(AUTH_REQUIRE_MFA=True)
+
+        providers = {entry["provider"]: entry for entry in auth_provider_registry(settings)}
+
+        assert providers["disabled"]["supports_mfa_policy"] is False
+        assert providers["disabled"]["mfa_policy"]["required"] is False
+        assert providers["local"]["supports_mfa_policy"] is False
+        assert providers["local"]["mfa_policy"]["required"] is False
+        assert providers["authentik"]["supports_mfa_policy"] is True
+        assert providers["authentik"]["mfa_policy"]["required"] is True
+
     def test_authentik_config_selects_direct_oidc_provider(self):
         settings = Settings(
             AUTH_MODE="authentik",

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -33,10 +33,11 @@ from app.core.auth_providers import (
     create_oidc_state,
     decode_oidc_state,
     exchange_oidc_callback,
+    mfa_claim_context,
     normalize_external_claims,
     sync_external_user,
-    trusted_proxy_claims_from_request,
     trusted_proxy_auth_context,
+    trusted_proxy_claims_from_request,
 )
 from app.core.config import Settings, get_settings
 from app.core.logto import (
@@ -201,6 +202,9 @@ class TestExternalAuthProviders:
         assert providers["logto"]["auth_mode"] == "logto"
         assert providers["authentik"]["configured"] is True
         assert providers["authentik"]["active"] is True
+        assert providers["authentik"]["supports_mfa_policy"] is True
+        assert providers["authentik"]["mfa_policy"]["required"] is False
+        assert providers["authentik"]["mfa_policy"]["claim_names"] == ["acr", "amr"]
         assert providers["oidc"]["auth_mode"] == "oidc"
         assert providers["keycloak"]["status"] == "ready_via_generic_oidc"
         assert providers["cloudflare_access"]["auth_mode"] == "trusted_proxy"
@@ -296,6 +300,52 @@ class TestExternalAuthProviders:
             )
 
         assert exc.value.status_code == 403
+
+    def test_mfa_claim_context_accepts_common_oidc_assurance_claims(self):
+        settings = Settings(AUTH_MFA_CLAIM_NAMES="amr,acr")
+
+        verified, claims = mfa_claim_context(
+            {
+                "amr": ["single_factor", "webauthn"],
+                "acr": "urn:example:loa",
+            },
+            settings,
+        )
+
+        assert verified is True
+        assert claims == ("amr:single_factor", "amr:webauthn", "acr:urn:example:loa")
+
+    def test_normalize_external_claims_records_mfa_claims(self):
+        claims = normalize_external_claims(
+            "authentik",
+            {
+                "sub": "authentik-user-1",
+                "email": "owner@example.com",
+                "amr": ["single_factor", "mfa"],
+            },
+            allowed_domains="example.com",
+        )
+
+        assert claims.mfa_verified is True
+        assert claims.mfa_claims == ("amr:single_factor", "amr:mfa")
+
+    def test_normalize_external_claims_enforces_required_mfa(self):
+        settings = Settings(AUTH_REQUIRE_MFA=True)
+
+        with pytest.raises(HTTPException) as exc:
+            normalize_external_claims(
+                "authentik",
+                {
+                    "sub": "authentik-user-1",
+                    "email": "owner@example.com",
+                    "amr": ["single_factor"],
+                },
+                allowed_domains="example.com",
+                settings=settings,
+            )
+
+        assert exc.value.status_code == 403
+        assert "requires MFA" in exc.value.detail
 
     def test_normalize_external_claims_extracts_idp_role_claims(self):
         claims = normalize_external_claims(
@@ -646,6 +696,7 @@ class TestExternalAuthProviders:
             "email": "owner@example.com",
             "name": "Owner",
             "username": "owner",
+            "mfa_verified": False,
         }
 
     def test_trusted_proxy_claims_apply_group_role_mappings(self):
@@ -670,6 +721,43 @@ class TestExternalAuthProviders:
         assert claims.groups == ("dmarq-admins", "other")
         assert claims.workspace_roles == (("primary", "workspace_owner"),)
         assert claims.organization_roles == (("customer-one", "organization_owner"),)
+
+    def test_trusted_proxy_claims_enforce_required_mfa_header(self):
+        settings = Settings(
+            AUTH_MODE="trusted_proxy",
+            AUTH_REQUIRE_MFA=True,
+            AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS="example.com",
+            AUTH_TRUSTED_PROXY_MFA_HEADER="X-SSO-Amr",
+        )
+        request = MagicMock()
+        request.headers = {
+            "X-Authentik-Email": "owner@example.com",
+            "X-Authentik-Uid": "authentik-user-1",
+            "X-SSO-Amr": "single_factor,mfa",
+        }
+
+        claims = trusted_proxy_claims_from_request(request, settings)
+
+        assert claims is not None
+        assert claims.mfa_verified is True
+        assert claims.mfa_claims == ("amr:single_factor", "amr:mfa")
+
+    def test_trusted_proxy_claims_reject_missing_required_mfa_header(self):
+        settings = Settings(
+            AUTH_MODE="trusted_proxy",
+            AUTH_REQUIRE_MFA=True,
+            AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS="example.com",
+        )
+        request = MagicMock()
+        request.headers = {
+            "X-Authentik-Email": "owner@example.com",
+            "X-Authentik-Uid": "authentik-user-1",
+        }
+
+        with pytest.raises(HTTPException) as exc:
+            trusted_proxy_claims_from_request(request, settings)
+
+        assert exc.value.status_code == 403
 
     @pytest.mark.asyncio
     async def test_oidc_callback_rejects_unverified_id_token_without_userinfo(self):
@@ -850,6 +938,41 @@ class TestCallbackEndpoint:
         assert res.headers["location"] == "/"
         set_cookie = res.headers.get("set-cookie", "")
         assert SESSION_COOKIE in set_cookie
+
+    def test_callback_enforces_required_logto_mfa_claim(self, client: TestClient):
+        """Required MFA blocks Logto callbacks without accepted assurance claims."""
+        claims = self._make_mock_claims()
+        mock_client = self._mock_client(claims=claims)
+
+        with patch("app.api.api_v1.endpoints.auth.settings") as mock_settings:
+            mock_settings.logto_configured = True
+            mock_settings.AUTH_REQUIRE_MFA = True
+            mock_settings.AUTH_MFA_CLAIM_NAMES = "amr,acr"
+            mock_settings.AUTH_MFA_CLAIM_VALUES = "mfa,otp,totp,webauthn"
+            with patch("app.api.api_v1.endpoints.auth.make_logto_client", return_value=mock_client):
+                res = client.get("/api/v1/auth/callback?code=good", follow_redirects=False)
+
+        assert res.status_code == 302
+        assert "callback_failed" in res.headers["location"]
+        assert SESSION_COOKIE not in res.headers.get("set-cookie", "")
+
+    def test_callback_accepts_logto_mfa_amr_claim(self, client: TestClient):
+        """Required MFA allows Logto callbacks that include an accepted amr value."""
+        claims = self._make_mock_claims()
+        claims.amr = ["single_factor", "mfa"]
+        mock_client = self._mock_client(claims=claims)
+
+        with patch("app.api.api_v1.endpoints.auth.settings") as mock_settings:
+            mock_settings.logto_configured = True
+            mock_settings.AUTH_REQUIRE_MFA = True
+            mock_settings.AUTH_MFA_CLAIM_NAMES = "amr,acr"
+            mock_settings.AUTH_MFA_CLAIM_VALUES = "mfa,otp,totp,webauthn"
+            with patch("app.api.api_v1.endpoints.auth.make_logto_client", return_value=mock_client):
+                res = client.get("/api/v1/auth/callback?code=good", follow_redirects=False)
+
+        assert res.status_code == 302
+        assert res.headers["location"] == "/"
+        assert SESSION_COOKIE in res.headers.get("set-cookie", "")
 
     def test_callback_success_respects_logto_next_cookie(self, client: TestClient):
         """After a successful callback the user is redirected to the stored next URL."""

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -57,7 +57,7 @@ paths.
 | `AUTH_DISABLED` | Disable authentication entirely. Only use for local development or a separately protected deployment. | `false` | `true`, `false` |
 | `PUBLIC_BASE_URL` | Public URL used when building OAuth callback URLs behind a reverse proxy or ingress | Auto-detected | `https://dmarq.example.com` |
 | `MULTI_WORKSPACE_UI_ENABLED` | Show workspace switching and Members access-control navigation. Keep disabled for self-hosted single-workspace installs. | `false` | `true`, `false` |
-| `AUTH_REQUIRE_MFA` | Require an accepted MFA assurance claim from direct OIDC or trusted-proxy authentication before DMARQ issues a session. | `false` | `true`, `false` |
+| `AUTH_REQUIRE_MFA` | Require an accepted MFA assurance claim from Logto, direct OIDC, or trusted-proxy authentication before DMARQ issues a session. | `false` | `true`, `false` |
 | `AUTH_MFA_CLAIM_NAMES` | Comma-separated claim names to inspect for MFA assurance. Common OIDC claims are `amr` and `acr`. | `amr,acr` | `amr,acr` |
 | `AUTH_MFA_CLAIM_VALUES` | Comma-separated claim values accepted as MFA proof. Adjust this to the values emitted by your IdP. | `mfa,otp,totp,webauthn,hwk,swk,phr` | `mfa,webauthn` |
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -57,6 +57,16 @@ paths.
 | `AUTH_DISABLED` | Disable authentication entirely. Only use for local development or a separately protected deployment. | `false` | `true`, `false` |
 | `PUBLIC_BASE_URL` | Public URL used when building OAuth callback URLs behind a reverse proxy or ingress | Auto-detected | `https://dmarq.example.com` |
 | `MULTI_WORKSPACE_UI_ENABLED` | Show workspace switching and Members access-control navigation. Keep disabled for self-hosted single-workspace installs. | `false` | `true`, `false` |
+| `AUTH_REQUIRE_MFA` | Require an accepted MFA assurance claim from direct OIDC or trusted-proxy authentication before DMARQ issues a session. | `false` | `true`, `false` |
+| `AUTH_MFA_CLAIM_NAMES` | Comma-separated claim names to inspect for MFA assurance. Common OIDC claims are `amr` and `acr`. | `amr,acr` | `amr,acr` |
+| `AUTH_MFA_CLAIM_VALUES` | Comma-separated claim values accepted as MFA proof. Adjust this to the values emitted by your IdP. | `mfa,otp,totp,webauthn,hwk,swk,phr` | `mfa,webauthn` |
+
+When `AUTH_REQUIRE_MFA=true`, DMARQ does not perform MFA itself. It verifies
+that the upstream identity provider or trusted proxy explicitly states that MFA
+was used. For OIDC providers, this usually comes through `amr` values such as
+`mfa`, `otp`, or `webauthn`. For trusted-proxy deployments, configure the proxy
+to forward a dedicated assurance header and strip any inbound spoofed copy of
+that header before the request reaches DMARQ.
 
 #### Logto
 
@@ -131,6 +141,7 @@ owner.
 | `AUTH_TRUSTED_PROXY_SUBJECT_HEADER` | Header containing the stable user id | `X-Authentik-Uid` | `X-Authentik-Uid` |
 | `AUTH_TRUSTED_PROXY_NAME_HEADER` | Header containing display name | `X-Authentik-Name` | `X-Authentik-Name` |
 | `AUTH_TRUSTED_PROXY_USERNAME_HEADER` | Header containing username | `X-Authentik-Username` | `X-Authentik-Username` |
+| `AUTH_TRUSTED_PROXY_MFA_HEADER` | Header containing MFA assurance values when `AUTH_REQUIRE_MFA=true` | `X-Authentik-Meta-Amr` | `X-SSO-Amr` |
 | `AUTH_TRUSTED_PROXY_ALLOWED_EMAILS` | Optional comma-separated email allowlist | - | `admin@example.com` |
 | `AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS` | Optional comma-separated domain allowlist | - | `example.com` |
 | `AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP` | Optional trusted-proxy group to DMARQ workspace role mapping. Use comma- or semicolon-separated `group=workspace-slug:role` entries. | - | `dmarq-admins=primary:workspace_owner` |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -13,7 +13,9 @@ the setup UI. It contains provider metadata and configured/active booleans, but
 never returns client secrets. Each provider entry includes its `provider`,
 `label`, `auth_mode`, `status`, deployment model, setup hint, secret field names,
 docs URL, `supports_direct_oidc`, `supports_trusted_proxy`,
-`supports_single_user`, `supports_multi_user`, and configured/active state.
+`supports_single_user`, `supports_multi_user`, `supports_mfa_policy`,
+configured/active state, and an `mfa_policy` summary containing the current
+requirement flag plus the claim names DMARQ will inspect.
 
 Current ready providers include `disabled` (`No app auth`), `logto`,
 `authentik` (`Authentik OIDC`), `oidc` (`Generic OIDC`), and


### PR DESCRIPTION
## Summary
- add configurable upstream MFA assurance enforcement for Logto, direct OIDC/AuthentiK, and trusted-proxy auth
- expose MFA policy support and active claim names in the auth provider registry
- document the new MFA environment variables and trusted-proxy assurance header

Refs #243. Completes the MFA enforcement policy slice; SCIM provisioning, enterprise audit export, and support-access controls remain separate #243 slices.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_auth.py -q`
- `.venv/bin/python -m black --check backend/app/core/config.py backend/app/core/auth_providers.py backend/app/api/api_v1/endpoints/auth.py backend/app/tests/test_auth.py`
- `.venv/bin/python -m isort --check-only backend/app/core/config.py backend/app/core/auth_providers.py backend/app/api/api_v1/endpoints/auth.py backend/app/tests/test_auth.py`
- `.venv/bin/python -m flake8 backend/app/core/config.py backend/app/core/auth_providers.py backend/app/api/api_v1/endpoints/auth.py backend/app/tests/test_auth.py`
- `.venv/bin/python -m pylint backend/app/core/auth_providers.py backend/app/api/api_v1/endpoints/auth.py --disable=all --enable=syntax-error,undefined-variable,unused-import,unused-argument`
- `git diff --check origin/main...HEAD`
