### PR TITLE
feat: add auditable support access grants

### DIFF
--- a/backend/app/api/api_v1/endpoints/audit.py
+++ b/backend/app/api/api_v1/endpoints/audit.py
@@ -84,6 +84,7 @@ ENTERPRISE_AUDIT_EXPORT_FIELDS = [
 SUPPORT_ACCESS_ENTITY_TYPE = "support_access_grant"
 SUPPORT_ACCESS_CREATED_ACTION = "support_access.grant_created"
 SUPPORT_ACCESS_REVOKED_ACTION = "support_access.grant_revoked"
+SUPPORT_ACCESS_SCOPE = "read_only_diagnostics"
 
 
 def _authorized_audit_workspace(
@@ -118,12 +119,24 @@ def _authorized_support_admin_workspace(
     selected_workspace_id: Optional[int] = None,
 ):
     """Resolve the workspace for explicit support-access administration."""
-    return resolve_authorized_workspace(
-        db,
-        auth_context,
-        PERMISSION_WORKSPACE_ADMIN,
-        selected_workspace_id=selected_workspace_id,
-    )
+    if selected_workspace_id is not None:
+        return resolve_authorized_workspace(
+            db,
+            auth_context,
+            PERMISSION_WORKSPACE_ADMIN,
+            selected_workspace_id=selected_workspace_id,
+        )
+
+    workspace = get_default_workspace(db)
+    if workspace is None:
+        if (auth_context or {}).get("auth_type") not in {"api_key", "disabled"}:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Workspace permission required: {PERMISSION_WORKSPACE_ADMIN}",
+            )
+        workspace = assign_default_workspace_to_unscoped_rows(db, commit=False)
+    require_workspace_permission(auth_context, PERMISSION_WORKSPACE_ADMIN, db, workspace)
+    return assign_default_workspace_to_unscoped_rows(db, commit=False)
 
 
 def _parse_timestamp(value: Any) -> Optional[datetime]:
@@ -281,6 +294,11 @@ async def create_support_access_grant(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="expires_at must be a future timestamp",
+        )
+    if payload.scope != SUPPORT_ACCESS_SCOPE:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"scope must be {SUPPORT_ACCESS_SCOPE}",
         )
     grant_id = uuid4().hex
     record_workspace_audit_log(

--- a/backend/app/api/api_v1/endpoints/audit.py
+++ b/backend/app/api/api_v1/endpoints/audit.py
@@ -1,24 +1,33 @@
 """Workspace RBAC and audit endpoints."""
 
 import csv
+from datetime import datetime, timezone
 from io import StringIO
 from typing import Any, Dict, List, Optional
+from uuid import uuid4
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.core.security import require_admin_auth
+from app.models.workspace_access import WorkspaceAuditLog
 from app.services.workspace_access import (
     PERMISSION_AUDIT_READ,
+    PERMISSION_WORKSPACE_ADMIN,
     list_workspace_roles,
     parse_selected_workspace_id,
     require_workspace_permission,
     resolve_authorized_workspace,
 )
-from app.services.workspace_audit import build_enterprise_audit_export, list_workspace_audit_logs
+from app.services.workspace_audit import (
+    audit_log_to_dict,
+    build_enterprise_audit_export,
+    list_workspace_audit_logs,
+    record_workspace_audit_log,
+)
 from app.services.workspaces import assign_default_workspace_to_unscoped_rows, get_default_workspace
 
 router = APIRouter()
@@ -36,6 +45,27 @@ class WorkspaceAuditLogResponse(BaseModel):
     audit: List[Dict[str, Any]]
 
 
+class SupportAccessGrantRequest(BaseModel):
+    """Explicit customer-approved support access grant."""
+
+    approved_principal: str = Field(..., min_length=3, max_length=255)
+    reason: str = Field(..., min_length=5, max_length=1000)
+    expires_at: datetime
+    scope: str = Field(default="read_only_diagnostics", max_length=80)
+
+
+class SupportAccessRevokeRequest(BaseModel):
+    """Reason for revoking an approved support access grant."""
+
+    reason: str = Field(default="Revoked by workspace administrator", max_length=1000)
+
+
+class SupportAccessGrantResponse(BaseModel):
+    """Visible support access grant state."""
+
+    grants: List[Dict[str, Any]]
+
+
 ENTERPRISE_AUDIT_EXPORT_FIELDS = [
     "category",
     "workspace_id",
@@ -50,6 +80,10 @@ ENTERPRISE_AUDIT_EXPORT_FIELDS = [
     "ip_address",
     "created_at",
 ]
+
+SUPPORT_ACCESS_ENTITY_TYPE = "support_access_grant"
+SUPPORT_ACCESS_CREATED_ACTION = "support_access.grant_created"
+SUPPORT_ACCESS_REVOKED_ACTION = "support_access.grant_revoked"
 
 
 def _authorized_audit_workspace(
@@ -76,6 +110,94 @@ def _authorized_audit_workspace(
         workspace = assign_default_workspace_to_unscoped_rows(db)
     require_workspace_permission(auth_context, PERMISSION_AUDIT_READ, db, workspace)
     return assign_default_workspace_to_unscoped_rows(db)
+
+
+def _authorized_support_admin_workspace(
+    auth_context: Dict[str, Any],
+    db: Session,
+    selected_workspace_id: Optional[int] = None,
+):
+    """Resolve the workspace for explicit support-access administration."""
+    return resolve_authorized_workspace(
+        db,
+        auth_context,
+        PERMISSION_WORKSPACE_ADMIN,
+        selected_workspace_id=selected_workspace_id,
+    )
+
+
+def _parse_timestamp(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _support_access_grant_from_audit(row) -> Dict[str, Any]:
+    audit_row = audit_log_to_dict(row)
+    details = audit_row.get("details") or {}
+    expires_at = _parse_timestamp(details.get("expires_at"))
+    now = datetime.now(timezone.utc)
+    status_value = str(details.get("status") or "active")
+    expired = bool(expires_at and expires_at <= now)
+    status_value = "expired" if status_value == "active" and expired else status_value
+    return {
+        "id": audit_row.get("entity_id"),
+        "workspace_id": audit_row.get("workspace_id"),
+        "approved_principal": details.get("approved_principal"),
+        "scope": details.get("scope"),
+        "reason": details.get("reason"),
+        "status": status_value,
+        "expires_at": details.get("expires_at"),
+        "created_at": audit_row.get("created_at"),
+        "last_changed_at": audit_row.get("created_at"),
+        "last_action": audit_row.get("action"),
+        "actor_type": audit_row.get("actor_type"),
+        "actor_id": audit_row.get("actor_id"),
+    }
+
+
+def _list_latest_support_access_grants(
+    db: Session,
+    *,
+    workspace,
+    include_inactive: bool = False,
+    limit: int = 100,
+) -> List[Dict[str, Any]]:
+    rows = (
+        db.query(WorkspaceAuditLog)
+        .filter(
+            WorkspaceAuditLog.workspace_id == workspace.id,
+            WorkspaceAuditLog.entity_type == SUPPORT_ACCESS_ENTITY_TYPE,
+        )
+        .order_by(
+            WorkspaceAuditLog.created_at.desc(),
+            WorkspaceAuditLog.id.desc(),
+        )
+        .limit(max(1, min(limit * 5, 500)))
+        .all()
+    )
+    grants: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in rows:
+        entity_id = str(row.entity_id or "")
+        if not entity_id or entity_id in seen:
+            continue
+        seen.add(entity_id)
+        grant = _support_access_grant_from_audit(row)
+        if include_inactive or grant["status"] == "active":
+            grants.append(grant)
+        if len(grants) >= limit:
+            break
+    return grants
 
 
 @router.get("/roles", response_model=WorkspaceRoleResponse)
@@ -110,6 +232,150 @@ async def get_workspace_audit_logs(
             entity_type=entity_type,
         )
     }
+
+
+@router.get("/support-access/grants", response_model=SupportAccessGrantResponse)
+async def list_support_access_grants(
+    include_inactive: bool = False,
+    limit: int = Query(50, ge=1, le=100),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> SupportAccessGrantResponse:
+    """Return visible support-access grants for the selected workspace."""
+    workspace = _authorized_audit_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    return {
+        "grants": _list_latest_support_access_grants(
+            db,
+            workspace=workspace,
+            include_inactive=include_inactive,
+            limit=limit,
+        )
+    }
+
+
+@router.post(
+    "/support-access/grants",
+    response_model=SupportAccessGrantResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_support_access_grant(
+    payload: SupportAccessGrantRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> SupportAccessGrantResponse:
+    """Create an explicit, time-boxed support access approval marker."""
+    workspace = _authorized_support_admin_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    expires_at = _parse_timestamp(payload.expires_at)
+    if expires_at is None or expires_at <= datetime.now(timezone.utc):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="expires_at must be a future timestamp",
+        )
+    grant_id = uuid4().hex
+    record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action=SUPPORT_ACCESS_CREATED_ACTION,
+        entity_type=SUPPORT_ACCESS_ENTITY_TYPE,
+        entity_id=grant_id,
+        entity_name=payload.approved_principal,
+        details={
+            "status": "active",
+            "approved_principal": payload.approved_principal,
+            "scope": payload.scope,
+            "reason": payload.reason,
+            "expires_at": expires_at.isoformat(),
+            "impersonation_enabled": False,
+            "customer_visible": True,
+        },
+        request=request,
+        auth_context=_auth,
+        commit=True,
+    )
+    return {
+        "grants": _list_latest_support_access_grants(
+            db,
+            workspace=workspace,
+            include_inactive=True,
+            limit=1,
+        )
+    }
+
+
+@router.post("/support-access/grants/{grant_id}/revoke", response_model=SupportAccessGrantResponse)
+async def revoke_support_access_grant(
+    grant_id: str,
+    payload: SupportAccessRevokeRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> SupportAccessGrantResponse:
+    """Revoke a previously approved support access grant."""
+    workspace = _authorized_support_admin_workspace(
+        _auth,
+        db,
+        parse_selected_workspace_id(selected_workspace),
+    )
+    existing = (
+        db.query(WorkspaceAuditLog)
+        .filter(
+            WorkspaceAuditLog.workspace_id == workspace.id,
+            WorkspaceAuditLog.entity_type == SUPPORT_ACCESS_ENTITY_TYPE,
+            WorkspaceAuditLog.entity_id == grant_id,
+        )
+        .order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
+        .first()
+    )
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Support access grant not found",
+        )
+    existing_grant = _support_access_grant_from_audit(existing)
+    if existing_grant["status"] == "revoked":
+        return {"grants": [existing_grant]}
+    record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action=SUPPORT_ACCESS_REVOKED_ACTION,
+        entity_type=SUPPORT_ACCESS_ENTITY_TYPE,
+        entity_id=grant_id,
+        entity_name=existing.entity_name,
+        details={
+            "status": "revoked",
+            "approved_principal": existing_grant.get("approved_principal"),
+            "scope": existing_grant.get("scope"),
+            "reason": payload.reason,
+            "expires_at": existing_grant.get("expires_at"),
+            "customer_visible": True,
+        },
+        request=request,
+        auth_context=_auth,
+        commit=True,
+    )
+    latest = (
+        db.query(WorkspaceAuditLog)
+        .filter(
+            WorkspaceAuditLog.workspace_id == workspace.id,
+            WorkspaceAuditLog.entity_type == SUPPORT_ACCESS_ENTITY_TYPE,
+            WorkspaceAuditLog.entity_id == grant_id,
+        )
+        .order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
+        .first()
+    )
+    return {"grants": [_support_access_grant_from_audit(latest)] if latest else []}
 
 
 @router.get("/export")

--- a/backend/app/tests/test_workspace_audit.py
+++ b/backend/app/tests/test_workspace_audit.py
@@ -572,6 +572,8 @@ def test_support_access_grants_are_customer_visible_and_audited(
         assert visible.json()["grants"][0]["id"] == grant_id
 
     with _client_as_user(test_app, db_session, analyst) as client:
+        list_denied = client.get("/api/v1/audit/support-access/grants")
+        assert list_denied.status_code == 403
         denied = client.post(
             "/api/v1/audit/support-access/grants",
             json={
@@ -583,6 +585,16 @@ def test_support_access_grants_are_customer_visible_and_audited(
         assert denied.status_code == 403
 
     with _client_as_user(test_app, db_session, owner) as client:
+        invalid_scope = client.post(
+            "/api/v1/audit/support-access/grants",
+            json={
+                "approved_principal": "support@dmarq.example",
+                "reason": "Reject misleading support scope",
+                "expires_at": expires_at,
+                "scope": "admin",
+            },
+        )
+        assert invalid_scope.status_code == 422
         revoked = client.post(
             f"/api/v1/audit/support-access/grants/{grant_id}/revoke",
             json={"reason": "Investigation finished"},
@@ -608,6 +620,32 @@ def test_support_access_grants_are_customer_visible_and_audited(
     ]
     assert rows[0].ip_address == "203.0.113.42"
     assert "customer_visible" in rows[0].details
+
+
+def test_support_access_grants_deny_jwt_without_bootstrapping_default_workspace(
+    test_app,
+    db_session: Session,
+):
+    """Support grant writes cannot migrate legacy rows before authorization."""
+    unscoped_domain = Domain(name="unscoped-support-access.example", active=True)
+    db_session.add(unscoped_domain)
+    db_session.commit()
+    expires_at = (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat()
+
+    with _client_as_jwt(test_app, db_session, "unknown-support-sub") as client:
+        response = client.post(
+            "/api/v1/audit/support-access/grants",
+            json={
+                "approved_principal": "support@dmarq.example",
+                "reason": "Should not mutate before authorization",
+                "expires_at": expires_at,
+            },
+        )
+
+    assert response.status_code == 403
+    assert db_session.query(Workspace).count() == 0
+    db_session.refresh(unscoped_domain)
+    assert unscoped_domain.workspace_id is None
 
 
 def test_mail_source_changes_create_workspace_audit_without_secret_values(

--- a/backend/app/tests/test_workspace_audit.py
+++ b/backend/app/tests/test_workspace_audit.py
@@ -1,6 +1,7 @@
 import csv
 import json
 from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 
 from fastapi.testclient import TestClient
@@ -531,6 +532,82 @@ def test_workspace_audit_logs_deny_jwt_without_bootstrapping_default_workspace(
     assert db_session.query(Workspace).count() == 0
     db_session.refresh(unscoped_domain)
     assert unscoped_domain.workspace_id is None
+
+
+def test_support_access_grants_are_customer_visible_and_audited(
+    test_app,
+    db_session: Session,
+):
+    """Support access requires an explicit time-boxed grant and remains visible."""
+    workspace = get_or_create_default_workspace(db_session)
+    owner = _add_user(db_session, "support-owner@example.com")
+    auditor = _add_user(db_session, "support-auditor@example.com")
+    analyst = _add_user(db_session, "support-analyst@example.com")
+    _add_membership(db_session, workspace, owner, ROLE_WORKSPACE_OWNER)
+    _add_membership(db_session, workspace, auditor, ROLE_AUDITOR)
+    _add_membership(db_session, workspace, analyst, ROLE_ANALYST)
+    db_session.commit()
+
+    expires_at = (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat()
+    with _client_as_user(test_app, db_session, owner) as client:
+        created = client.post(
+            "/api/v1/audit/support-access/grants",
+            json={
+                "approved_principal": "support@dmarq.example",
+                "reason": "Investigate sender intelligence regression",
+                "expires_at": expires_at,
+            },
+            headers={"x-forwarded-for": "203.0.113.42"},
+        )
+        assert created.status_code == 201
+        grant = created.json()["grants"][0]
+        assert grant["approved_principal"] == "support@dmarq.example"
+        assert grant["status"] == "active"
+        assert grant["scope"] == "read_only_diagnostics"
+        grant_id = grant["id"]
+
+    with _client_as_user(test_app, db_session, auditor) as client:
+        visible = client.get("/api/v1/audit/support-access/grants")
+        assert visible.status_code == 200
+        assert visible.json()["grants"][0]["id"] == grant_id
+
+    with _client_as_user(test_app, db_session, analyst) as client:
+        denied = client.post(
+            "/api/v1/audit/support-access/grants",
+            json={
+                "approved_principal": "support@dmarq.example",
+                "reason": "Should not be allowed",
+                "expires_at": expires_at,
+            },
+        )
+        assert denied.status_code == 403
+
+    with _client_as_user(test_app, db_session, owner) as client:
+        revoked = client.post(
+            f"/api/v1/audit/support-access/grants/{grant_id}/revoke",
+            json={"reason": "Investigation finished"},
+        )
+        assert revoked.status_code == 200
+        assert revoked.json()["grants"][0]["status"] == "revoked"
+        active = client.get("/api/v1/audit/support-access/grants")
+        assert active.status_code == 200
+        assert active.json()["grants"] == []
+        all_grants = client.get("/api/v1/audit/support-access/grants?include_inactive=true")
+        assert all_grants.status_code == 200
+        assert all_grants.json()["grants"][0]["status"] == "revoked"
+
+    rows = (
+        db_session.query(WorkspaceAuditLog)
+        .filter(WorkspaceAuditLog.entity_type == "support_access_grant")
+        .order_by(WorkspaceAuditLog.id)
+        .all()
+    )
+    assert [row.action for row in rows] == [
+        "support_access.grant_created",
+        "support_access.grant_revoked",
+    ]
+    assert rows[0].ip_address == "203.0.113.42"
+    assert "customer_visible" in rows[0].details
 
 
 def test_mail_source_changes_create_workspace_audit_without_secret_values(

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -267,6 +267,21 @@ filters:
 
 Audit details redact secret-like fields before they are stored.
 
+#### Support Access Grants
+
+```text
+GET /audit/support-access/grants
+POST /audit/support-access/grants
+POST /audit/support-access/grants/{grant_id}/revoke
+```
+
+Support access is explicit and customer-visible. A workspace owner can approve a
+time-boxed read-only diagnostics grant for a named support principal, and every
+create/revoke action is written to the workspace audit log and enterprise audit
+export. Listing grants requires `audit:read`; creating or revoking grants
+requires `workspace:admin`. These endpoints do not enable silent
+impersonation.
+
 ### Workspace Onboarding
 
 Workspace onboarding endpoints require administrator access and render/apply


### PR DESCRIPTION
## Summary
- add explicit, time-boxed support access grant endpoints under workspace audit
- require workspace admin rights to create/revoke grants and audit-read rights to list them
- record create/revoke actions in workspace audit logs and document that these endpoints do not enable silent impersonation

Closes #243

## Local validation
- .venv/bin/python -m pytest backend/app/tests/test_workspace_audit.py backend/app/tests/test_scim.py -q
- .venv/bin/python -m black --check backend/app/api/api_v1/endpoints/audit.py backend/app/tests/test_workspace_audit.py
- .venv/bin/python -m isort --check-only backend/app/api/api_v1/endpoints/audit.py backend/app/tests/test_workspace_audit.py
- .venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/audit.py backend/app/tests/test_workspace_audit.py
- git diff --check