### PR TITLE
Fix SCIM workspace upsert hardening

### DIFF
--- a/backend/app/api/api_v1/endpoints/scim.py
+++ b/backend/app/api/api_v1/endpoints/scim.py
@@ -338,7 +338,14 @@ def _upsert_scim_user(
     if display_name:
         user.full_name = display_name
     user.is_verified = True
-    db.flush()
+    try:
+        db.flush()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="SCIM user conflicts with an existing identity",
+        ) from exc
     workspace_role, organization_role = _role_from_groups(payload.groups)
     _upsert_memberships(
         db,
@@ -466,7 +473,7 @@ async def list_scim_users(
     }
 
 
-@router.post("/Users", status_code=status.HTTP_201_CREATED)
+@router.post("/Users")
 async def create_scim_user(
     payload: ScimUserWrite,
     request: Request,

--- a/backend/app/api/api_v1/endpoints/scim.py
+++ b/backend/app/api/api_v1/endpoints/scim.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -167,19 +168,51 @@ def _role_from_groups(groups: List[ScimGroupRef]) -> Tuple[str, Optional[str]]:
 
 
 def _find_user(
-    db: Session, *, user_id: Optional[int] = None, payload: Optional[ScimUserWrite] = None
+    db: Session,
+    *,
+    workspace: Workspace,
+    user_id: Optional[int] = None,
+    payload: Optional[ScimUserWrite] = None,
 ):
+    query = (
+        db.query(User)
+        .join(WorkspaceMembership, WorkspaceMembership.user_id == User.id)
+        .filter(WorkspaceMembership.workspace_id == workspace.id)
+    )
     if user_id is not None:
-        return db.query(User).filter(User.id == user_id).first()
+        return query.filter(User.id == user_id).first()
     assert payload is not None
     external_id = (payload.externalId or "").strip() or None
     email = _primary_email(payload)
-    query = db.query(User)
     if external_id:
         user = query.filter(User.logto_id == external_id).first()
         if user is not None:
             return user
     return query.filter(User.email == email).first()
+
+
+def _scim_active_from_memberships(user: User) -> bool:
+    memberships = getattr(user, "_scim_memberships", None)
+    if memberships is None:
+        return bool(user.is_active)
+    return any(membership.active for membership in memberships)
+
+
+def _coerce_scim_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no"}:
+            return False
+    if isinstance(value, int) and value in {0, 1}:
+        return bool(value)
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail="SCIM active value must be a boolean",
+    )
 
 
 def _upsert_memberships(
@@ -252,7 +285,7 @@ def _scim_user_to_dict(user: User, workspace: Workspace) -> Dict[str, Any]:
         "id": str(user.id),
         "externalId": user.logto_id,
         "userName": user.email,
-        "active": bool(user.is_active),
+        "active": _scim_active_from_memberships(user),
         "name": {"formatted": user.full_name},
         "emails": [{"value": user.email, "primary": True}],
         "groups": groups,
@@ -280,7 +313,7 @@ def _load_workspace_memberships(db: Session, workspace: Workspace, users: List[U
     for row in rows:
         by_user.setdefault(row.user_id, []).append(row)
     for user in users:
-        setattr(user, "_scim_memberships", by_user.get(user.id, []))
+        user._scim_memberships = by_user.get(user.id, [])
 
 
 def _upsert_scim_user(
@@ -291,12 +324,12 @@ def _upsert_scim_user(
     request: Request,
     auth_context: Dict[str, Any],
     existing_user: Optional[User] = None,
-) -> User:
+) -> Tuple[User, bool]:
     email = _primary_email(payload)
-    user = existing_user or _find_user(db, payload=payload)
+    user = existing_user or _find_user(db, workspace=workspace, payload=payload)
     created = user is None
     if user is None:
-        user = User(email=email, is_superuser=False)
+        user = User(email=email, is_superuser=False, is_active=True)
         db.add(user)
     user.email = email
     if payload.externalId:
@@ -304,7 +337,6 @@ def _upsert_scim_user(
     display_name = _display_name(payload)
     if display_name:
         user.full_name = display_name
-    user.is_active = bool(payload.active)
     user.is_verified = True
     db.flush()
     workspace_role, organization_role = _role_from_groups(payload.groups)
@@ -333,7 +365,7 @@ def _upsert_scim_user(
         entity_name=user.email,
         details={
             "external_id": bool(payload.externalId),
-            "active": user.is_active,
+            "active": payload.active,
             "workspace_role": workspace_role,
             "organization_role": organization_role,
         },
@@ -343,7 +375,7 @@ def _upsert_scim_user(
     db.commit()
     db.refresh(user)
     _load_workspace_memberships(db, workspace, [user])
-    return user
+    return user, created
 
 
 def _validate_replace_targets_user(db: Session, *, existing: User, payload: ScimUserWrite) -> None:
@@ -385,7 +417,7 @@ def _user_or_404(db: Session, user_id: int, workspace: Workspace) -> User:
     user = db.query(User).filter(User.id == user_id).first()
     if user is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="SCIM user not found")
-    setattr(user, "_scim_memberships", [membership])
+    user._scim_memberships = [membership]
     return user
 
 
@@ -443,10 +475,13 @@ async def create_scim_user(
 ):
     """Create or upsert a SCIM user in the token workspace."""
     workspace = _workspace_for_token(db, _auth)
-    user = _upsert_scim_user(
+    user, created = _upsert_scim_user(
         db, workspace=workspace, payload=payload, request=request, auth_context=_auth
     )
-    return _scim_user_to_dict(user, workspace)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        content=_scim_user_to_dict(user, workspace),
+    )
 
 
 @router.get("/Users/{user_id}")
@@ -473,7 +508,7 @@ async def replace_scim_user(
     workspace = _workspace_for_token(db, _auth)
     existing = _user_or_404(db, user_id, workspace)
     _validate_replace_targets_user(db, existing=existing, payload=payload)
-    user = _upsert_scim_user(
+    user, _created = _upsert_scim_user(
         db,
         workspace=workspace,
         payload=payload,
@@ -499,23 +534,24 @@ async def patch_scim_user(
     for operation in payload.Operations:
         path = (operation.path or "").strip().lower()
         if operation.op.strip().lower() in {"replace", "add"} and path == "active":
-            user.is_active = bool(operation.value)
+            active = _coerce_scim_bool(operation.value)
             for membership in getattr(user, "_scim_memberships", []):
-                membership.active = bool(operation.value)
+                membership.active = active
             changed = True
     if not changed:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Only active-state SCIM patch operations are supported",
         )
+    active = _scim_active_from_memberships(user)
     record_workspace_audit_log(
         db,
         workspace=workspace,
-        action="scim.user_deactivated" if not user.is_active else "scim.user_activated",
+        action="scim.user_deactivated" if not active else "scim.user_activated",
         entity_type="user",
         entity_id=user.id,
         entity_name=user.email,
-        details={"active": user.is_active},
+        details={"active": active},
         auth_context=_auth,
         request=request,
     )
@@ -535,7 +571,6 @@ async def deactivate_scim_user(
     """Deactivate a SCIM user without deleting audit history."""
     workspace = _workspace_for_token(db, _auth)
     user = _user_or_404(db, user_id, workspace)
-    user.is_active = False
     for membership in getattr(user, "_scim_memberships", []):
         membership.active = False
     record_workspace_audit_log(

--- a/backend/app/services/api_tokens.py
+++ b/backend/app/services/api_tokens.py
@@ -60,6 +60,9 @@ def normalize_scopes(
         raise ValueError(f"Unsupported API token scope: {', '.join(invalid)}")
     if not normalized:
         raise ValueError("At least one API token scope is required")
+    normalized_set = set(normalized)
+    if normalized_set & SCIM_SCOPES and normalized_set - SCIM_SCOPES:
+        raise ValueError("SCIM API token scopes cannot be combined with non-SCIM scopes")
     return normalized
 
 

--- a/backend/app/tests/test_scim.py
+++ b/backend/app/tests/test_scim.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from app.models.api_token import APIToken
@@ -7,6 +8,7 @@ from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog, WorkspaceMembership
 from app.services.api_tokens import (
     ALL_API_TOKEN_SCOPES,
+    READ_REPORTS_SCOPE,
     SCIM_READ_SCOPE,
     SCIM_WRITE_SCOPE,
     create_api_token,
@@ -67,8 +69,8 @@ def test_scim_create_user_maps_workspace_role_and_audits(client: TestClient, db_
     assert api_token.usage_count == 1
 
 
-def test_scim_patch_and_delete_deactivate_user_and_membership(client: TestClient, db_session):
-    """SCIM deprovisioning keeps history and marks the local account inactive."""
+def test_scim_patch_and_delete_deactivate_workspace_membership(client: TestClient, db_session):
+    """SCIM deprovisioning only deactivates the token workspace membership."""
     token = _scim_token(db_session)
     created = client.post(
         "/api/v1/scim/v2/Users",
@@ -82,7 +84,7 @@ def test_scim_patch_and_delete_deactivate_user_and_membership(client: TestClient
         headers={"X-API-Key": token.secret},
         json={
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-            "Operations": [{"op": "Replace", "path": "active", "value": False}],
+            "Operations": [{"op": "Replace", "path": "active", "value": "False"}],
         },
     )
 
@@ -90,7 +92,7 @@ def test_scim_patch_and_delete_deactivate_user_and_membership(client: TestClient
     assert patched.json()["active"] is False
     user = db_session.query(User).filter(User.id == int(user_id)).one()
     membership = db_session.query(WorkspaceMembership).filter_by(user_id=user.id).one()
-    assert user.is_active is False
+    assert user.is_active is True
     assert membership.active is False
 
     deleted = client.delete(
@@ -101,6 +103,63 @@ def test_scim_patch_and_delete_deactivate_user_and_membership(client: TestClient
     assert deleted.status_code == 200
     actions = [row.action for row in db_session.query(WorkspaceAuditLog).all()]
     assert actions.count("scim.user_deactivated") == 2
+
+
+def test_scim_create_existing_user_returns_ok(client: TestClient, db_session):
+    """POST returns 200 when SCIM updates an existing workspace user."""
+    token = _scim_token(db_session)
+    created = client.post(
+        "/api/v1/scim/v2/Users",
+        headers={"X-API-Key": token.secret},
+        json={"userName": "existing@example.com", "externalId": "existing-id"},
+    )
+
+    updated = client.post(
+        "/api/v1/scim/v2/Users",
+        headers={"X-API-Key": token.secret},
+        json={
+            "userName": "existing@example.com",
+            "externalId": "existing-id",
+            "name": {"formatted": "Existing User"},
+            "groups": [{"value": "operator"}],
+        },
+    )
+
+    assert created.status_code == 201
+    assert updated.status_code == 200
+    assert updated.json()["id"] == created.json()["id"]
+    user = db_session.query(User).filter(User.email == "existing@example.com").one()
+    membership = db_session.query(WorkspaceMembership).filter_by(user_id=user.id).one()
+    assert user.full_name == "Existing User"
+    assert membership.role == "operator"
+
+
+def test_scim_create_does_not_update_user_from_another_workspace(
+    client: TestClient, db_session
+):
+    """SCIM identity matching is scoped to the token workspace."""
+    first = get_or_create_default_workspace(db_session)
+    second = Workspace(slug="scim-second", name="SCIM Second")
+    db_session.add(second)
+    db_session.commit()
+    first_token = _scim_token(db_session, workspace_id=first.id)
+    second_token = _scim_token(db_session, workspace_id=second.id)
+    created = client.post(
+        "/api/v1/scim/v2/Users",
+        headers={"X-API-Key": first_token.secret},
+        json={"userName": "shared@example.com", "externalId": "shared-id"},
+    )
+
+    conflicting = client.post(
+        "/api/v1/scim/v2/Users",
+        headers={"X-API-Key": second_token.secret},
+        json={"userName": "shared@example.com", "externalId": "shared-id"},
+    )
+
+    assert created.status_code == 201
+    assert conflicting.status_code == 409
+    user = db_session.query(User).filter(User.email == "shared@example.com").one()
+    assert db_session.query(WorkspaceMembership).filter_by(user_id=user.id).count() == 1
 
 
 def test_scim_read_scope_can_list_but_not_write(client: TestClient, db_session):
@@ -238,3 +297,14 @@ def test_scim_service_provider_config_documents_api_key_auth(client: TestClient)
     auth_scheme = response.json()["authenticationSchemes"][0]
     assert auth_scheme["type"] == "apikey"
     assert auth_scheme["name"] == "X-API-Key"
+
+
+def test_scim_scopes_cannot_mix_with_public_scopes(db_session):
+    """SCIM tokens must not share a credential with unrelated API scopes."""
+    with pytest.raises(ValueError, match="SCIM API token scopes"):
+        create_api_token(
+            db_session,
+            name="mixed-scim",
+            scopes=[SCIM_READ_SCOPE, READ_REPORTS_SCOPE],
+            allowed_scopes=ALL_API_TOKEN_SCOPES,
+        )


### PR DESCRIPTION
## Summary
- Scope SCIM identity matching to the token workspace to avoid cross-workspace user mutation
- Keep SCIM active/deactivate semantics on workspace memberships instead of toggling the global user account
- Return 200 for POST upserts, normalize string booleans in PATCH, and reject mixed SCIM/non-SCIM API token scopes
- Add regression coverage for workspace collisions, POST upserts, string false PATCH values, and mixed token scopes

## Validation
- git diff --check origin/main...HEAD
- .venv/bin/python -m py_compile backend/app/api/api_v1/endpoints/scim.py backend/app/services/api_tokens.py backend/app/tests/test_scim.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 90 .venv/bin/python -m pytest backend/app/tests/test_scim.py -q (timed out during startup with no output; same local pytest hang seen on the source branch)