### PR TITLE
test: cover SCIM active patch validation

### DIFF
--- a/backend/app/tests/test_scim.py
+++ b/backend/app/tests/test_scim.py
@@ -95,6 +95,28 @@ def test_scim_patch_and_delete_deactivate_workspace_membership(client: TestClien
     assert user.is_active is True
     assert membership.active is False
 
+    reactivated = client.patch(
+        f"/api/v1/scim/v2/Users/{user_id}",
+        headers={"X-API-Key": token.secret},
+        json={
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "add", "path": "active", "value": 1}],
+        },
+    )
+    invalid = client.patch(
+        f"/api/v1/scim/v2/Users/{user_id}",
+        headers={"X-API-Key": token.secret},
+        json={
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "Replace", "path": "active", "value": "later"}],
+        },
+    )
+
+    assert reactivated.status_code == 200
+    assert reactivated.json()["active"] is True
+    assert invalid.status_code == 422
+    assert invalid.json()["detail"] == "SCIM active value must be a boolean"
+
     deleted = client.delete(
         f"/api/v1/scim/v2/Users/{user_id}",
         headers={"X-API-Key": token.secret},
@@ -102,6 +124,7 @@ def test_scim_patch_and_delete_deactivate_workspace_membership(client: TestClien
 
     assert deleted.status_code == 200
     actions = [row.action for row in db_session.query(WorkspaceAuditLog).all()]
+    assert actions.count("scim.user_activated") == 1
     assert actions.count("scim.user_deactivated") == 2
 
 

--- a/backend/app/tests/test_scim.py
+++ b/backend/app/tests/test_scim.py
@@ -116,6 +116,8 @@ def test_scim_patch_and_delete_deactivate_workspace_membership(client: TestClien
     assert reactivated.json()["active"] is True
     assert invalid.status_code == 422
     assert invalid.json()["detail"] == "SCIM active value must be a boolean"
+    db_session.refresh(membership)
+    assert membership.active is True
 
     deleted = client.delete(
         f"/api/v1/scim/v2/Users/{user_id}",


### PR DESCRIPTION
## Summary
- add SCIM patch coverage for reactivation with numeric active values
- assert invalid active values return the SCIM validation error
- cover the activation audit path added by the SCIM hardening follow-up

## Validation
- git diff --check
- python -m py_compile backend/app/tests/test_scim.py
- pytest backend/app/tests/test_scim.py --cov=backend/app/api/api_v1/endpoints/scim.py --cov-report=term-missing --tb=short (aborted after ~2 minutes while the test import was still blocked; same local hang observed in prior heartbeat runs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SCIM membership updates now correctly support reactivating previously deactivated workspace members.
  * Invalid SCIM updates that set `active` to a non-boolean value now return a validation error instead of being accepted.
  * Audit activity tracking now reflects user reactivation events correctly after deletion-related SCIM actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->