### PR TITLE
feat: expose human-in-the-loop remediation loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.
 - The full Cloudflare DNS repair profile now requests DNS write access plus Radar read access so one-click repair and IP enrichment can work from the same consent flow.
 - Dashboard and domain detail pages now expose more actionable remediation context around DNS, DMARC, source authentication, and ownership state.
+- Remediation queues now expose incident families, loop state, priority scores, operator decisions, and provider/self-hosted/manual tracks across the domain detail UI, public API, and MCP.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -154,6 +154,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 DOMAIN_SELECTOR_LOOKUP_CHUNK_SIZE = 500
 REMEDIATION_NOTIFICATION_LIFECYCLE_STATES = {
+    "preview_change",
+    "approve_after_preview",
+    "mark_legitimate",
+    "mark_unknown",
+    "convert_to_manual_action",
     "previewed",
     "acknowledged",
     "snoozed",
@@ -1174,6 +1179,11 @@ class RemediationQueueItem(BaseModel):
 
     id: str
     source: str
+    incident_type: str = "domain_health_action"
+    loop_state: str = "observed"
+    remediation_track: str = "manual_only"
+    priority_score: int = 0
+    operator_decisions: List[str] = Field(default_factory=list)
     state: str
     severity: str
     confidence: str
@@ -1196,6 +1206,7 @@ class RemediationQueueResponse(BaseModel):
     domain: str
     status: str
     summary: Dict[str, int]
+    loop: Dict[str, Any] = Field(default_factory=dict)
     items: List[RemediationQueueItem]
 
 
@@ -1768,12 +1779,27 @@ REMEDIATION_REPUTATION_ACTION_TYPES = {
     "source_reputation_listed",
     "source_reputation_review",
 }
+REMEDIATION_INCIDENT_TYPES = {
+    "low_compliance": "legitimate_sender_failing_alignment",
+    "missing_dmarc": "dmarc_policy_missing_or_weak",
+    "policy_none": "dmarc_policy_missing_or_weak",
+    "missing_spf": "spf_include_or_record_problem",
+    "missing_dkim": "missing_or_broken_dkim",
+    "source_reputation_listed": "sending_ip_reputation_risk",
+    "source_reputation_review": "sending_ip_reputation_risk",
+    "review_forwarding": "forwarding_or_receiver_alignment_review",
+}
 REMEDIATION_SEVERITY_RANK = {
     "critical": 4,
     "high": 3,
     "medium": 2,
     "low": 1,
     "info": 0,
+}
+REMEDIATION_STATE_PRIORITY = {
+    "needs_approval": 40,
+    "manual_action": 30,
+    "investigate": 20,
 }
 
 
@@ -1831,6 +1857,57 @@ def _remediation_loop_context(state: str, action: Dict[str, Any]) -> Dict[str, s
     }
 
 
+def _remediation_incident_type(action: Dict[str, Any]) -> str:
+    action_type = str(action.get("type") or "")
+    if action_type in REMEDIATION_DNS_ACTION_TYPES:
+        if "dkim" in action_type:
+            return "missing_or_broken_dkim"
+        if "spf" in action_type:
+            return "spf_include_or_record_problem"
+        return "dmarc_policy_missing_or_weak"
+    return REMEDIATION_INCIDENT_TYPES.get(action_type, "domain_health_action")
+
+
+def _remediation_item_loop_state(state: str) -> str:
+    if state == "needs_approval":
+        return "proposal_ready_for_approval"
+    if state == "investigate":
+        return "evidence_review_required"
+    return "operator_action_required"
+
+
+def _remediation_track_for_action(state: str, action: Dict[str, Any]) -> str:
+    action_type = str(action.get("type") or "")
+    if state == "needs_approval":
+        return "provider_preview"
+    if action_type in REMEDIATION_REPUTATION_ACTION_TYPES:
+        return "reputation_review"
+    if state == "investigate":
+        return "sender_investigation"
+    if action_type in REMEDIATION_DNS_ACTION_TYPES:
+        return "manual_dns"
+    return "self_hosted_or_provider"
+
+
+def _remediation_priority_score(state: str, action: Dict[str, Any]) -> int:
+    severity = REMEDIATION_SEVERITY_RANK.get(str(action.get("severity") or "info"), 0) * 100
+    state_priority = REMEDIATION_STATE_PRIORITY.get(state, 0)
+    try:
+        impact = abs(int(float(str(action.get("score_impact") or "0"))))
+    except ValueError:
+        impact = 0
+    return severity + state_priority + min(impact, 50)
+
+
+def _remediation_operator_decisions(state: str) -> List[str]:
+    defaults = ["previewed", "acknowledged", "snoozed", "resolved", "rejected"]
+    if state == "needs_approval":
+        return ["preview_change", "approve_after_preview", *defaults]
+    if state == "investigate":
+        return ["mark_legitimate", "mark_unknown", "convert_to_manual_action", *defaults]
+    return defaults
+
+
 def _dashboard_remediation_item(
     domain_name: str,
     action: Dict[str, Any],
@@ -1840,9 +1917,15 @@ def _dashboard_remediation_item(
     """Convert one health action into a dashboard remediation-loop item."""
     state = _remediation_loop_state(action)
     context = _remediation_loop_context(state, action)
+    priority_score = _remediation_priority_score(state, action)
     item = {
         "domain": domain_name,
         "state": state,
+        "loop_state": _remediation_item_loop_state(state),
+        "incident_type": _remediation_incident_type(action),
+        "remediation_track": _remediation_track_for_action(state, action),
+        "priority_score": priority_score,
+        "operator_decisions": _remediation_operator_decisions(state),
         "severity": str(action.get("severity") or "info"),
         "title": str(action.get("title") or "Review remediation item"),
         "next_step": str(action.get("next_step") or "Review the domain evidence."),
@@ -1885,14 +1968,32 @@ def _build_dashboard_remediation_loop(
         key=lambda item: (
             item["state"] != "needs_approval",
             -REMEDIATION_SEVERITY_RANK.get(str(item.get("severity") or "info"), 0),
-            -int(item.get("score_impact") or 0),
+            -int(item.get("priority_score") or 0),
             str(item.get("domain") or ""),
         )
     )
     total_open = counters["needs_approval"] + counters["manual_action"] + counters["investigate"]
+    if counters["needs_approval"]:
+        loop_status = "approval_required"
+        next_action = "Preview and approve the highest-priority DNS repair."
+    elif counters["investigate"]:
+        loop_status = "investigation_required"
+        next_action = "Classify active sender or reputation findings before changing DNS."
+    elif counters["manual_action"]:
+        loop_status = "manual_action_required"
+        next_action = "Complete the highest-priority manual remediation step."
+    else:
+        loop_status = "clear"
+        next_action = "No current remediation work; keep importing reports and monitoring DNS."
     return {
         **counters,
         "total_open": total_open,
+        "loop_status": loop_status,
+        "next_action": next_action,
+        "what_dmarq_can_fix": counters["needs_approval"],
+        "what_needs_approval": counters["needs_approval"],
+        "what_needs_manual_action": counters["manual_action"],
+        "what_needs_investigation": counters["investigate"],
         "dispatch_enqueued": int(activity_summary.get("dispatch_enqueued") or 0),
         "operator_follow_up": int(activity_summary.get("needs_operator_follow_up") or 0),
         "status": "clear" if total_open == 0 else "needs_attention",
@@ -1918,13 +2019,17 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         key=lambda item: (
             item["state"] != "needs_approval",
             -REMEDIATION_SEVERITY_RANK.get(str(item.get("severity") or "info"), 0),
-            -int(item.get("score_impact") or 0),
+            -int(item.get("priority_score") or 0),
         )
     )
     total_open = counters["needs_approval"] + counters["manual_action"] + counters["investigate"]
     return {
         **counters,
         "total_open": total_open,
+        "what_dmarq_can_fix": counters["needs_approval"],
+        "what_needs_approval": counters["needs_approval"],
+        "what_needs_manual_action": counters["manual_action"],
+        "what_needs_investigation": counters["investigate"],
         "status": "clear" if total_open == 0 else "needs_attention",
         "primary": items[0] if items else None,
     }

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -26,9 +26,21 @@ DEFAULT_DISPATCH_EVENTS = {
     "dmarq.remediation.manual_action_required",
     "dmarq.remediation.investigation_required",
 }
-ACKNOWLEDGED_LIFECYCLE_STATES = {"previewed", "acknowledged"}
-OPERATOR_HELD_LIFECYCLE_STATES = {"resolved", "rejected", "snoozed"}
+ACKNOWLEDGED_LIFECYCLE_STATES = {
+    "previewed",
+    "preview_change",
+    "acknowledged",
+    "approve_after_preview",
+    "mark_legitimate",
+    "convert_to_manual_action",
+}
+OPERATOR_HELD_LIFECYCLE_STATES = {"resolved", "rejected", "snoozed", "mark_unknown"}
 LIFECYCLE_HISTORY_LABELS = {
+    "preview_change": "Previewed provider change",
+    "approve_after_preview": "Approved after preview",
+    "mark_legitimate": "Marked legitimate sender",
+    "mark_unknown": "Marked unknown sender",
+    "convert_to_manual_action": "Converted to manual action",
     "previewed": "Marked reviewed",
     "acknowledged": "Marked acknowledged",
     "resolved": "Marked resolved",
@@ -57,6 +69,10 @@ BLOCKED_REASON_NEXT_STEPS = (
     (
         "Operator marked this remediation item snoozed",
         "Wait for the snooze window or record a new lifecycle marker to resume.",
+    ),
+    (
+        "Operator marked this remediation item unknown sender",
+        "Keep the source treated as unauthorized until fresh evidence proves ownership.",
     ),
     (
         "No enabled webhook",
@@ -184,6 +200,12 @@ def _history_entry(row: WorkspaceAuditLog) -> Optional[Dict[str, Any]]:
     }
 
 
+def _lifecycle_reason_label(lifecycle_state: Optional[str]) -> str:
+    if lifecycle_state == "mark_unknown":
+        return "unknown sender"
+    return str(lifecycle_state or "").replace("_", " ")
+
+
 def _empty_domain_activity(domain: str) -> Dict[str, Any]:
     return {
         "domain": domain,
@@ -229,11 +251,11 @@ def _activity_status(summary: Dict[str, Any]) -> str:
     latest_state = summary["latest_state"]
     if latest_state == "resolved":
         return "resolved"
-    if latest_state in {"rejected", "snoozed"}:
+    if latest_state in {"rejected", "snoozed", "mark_unknown"}:
         return "operator_hold"
     if summary["dispatch_enqueued"]:
         return "dispatched"
-    if latest_state in {"previewed", "acknowledged"}:
+    if latest_state in ACKNOWLEDGED_LIFECYCLE_STATES:
         return "reviewed"
     if latest_state:
         return "activity"
@@ -529,9 +551,8 @@ def build_remediation_dispatch_preview(
 
     operator_hold = lifecycle_state in OPERATOR_HELD_LIFECYCLE_STATES
     if operator_hold:
-        blocked_reasons.append(
-            f"Operator marked this remediation item {str(lifecycle_state).replace('_', ' ')}."
-        )
+        label = _lifecycle_reason_label(lifecycle_state)
+        blocked_reasons.append(f"Operator marked this remediation item {label}.")
     else:
         if not enabled:
             blocked_reasons.append("Remediation dispatch is disabled in notification settings.")
@@ -577,11 +598,16 @@ def _verification_state(
             ),
             "recorded_at": lifecycle_recorded_at,
         }
-    if lifecycle_state in {"rejected", "snoozed"}:
+    if lifecycle_state in OPERATOR_HELD_LIFECYCLE_STATES:
+        label = (
+            LIFECYCLE_HISTORY_LABELS[lifecycle_state]
+            if lifecycle_state == "mark_unknown"
+            else str(lifecycle_state or "").replace("_", " ").title()
+        )
         return {
             "state": f"operator_{lifecycle_state}",
             "verified": False,
-            "label": lifecycle_state.replace("_", " ").title(),
+            "label": label,
             "detail": "Operator hold is active; DMARQ will keep showing current evidence.",
             "recorded_at": lifecycle_recorded_at,
         }

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -15,6 +15,22 @@ DNS_AUTOMATION_OPERATIONS = {"create", "update"}
 DNS_AUTOMATION_RECORD_TYPES = {"TXT", "CNAME"}
 SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
 DNS_SEVERITY = {"error": "critical", "warning": "medium", "info": "low"}
+STATE_PRIORITY = {
+    "approval_ready": 40,
+    "manual_action": 30,
+    "investigate": 20,
+    "informational": 10,
+}
+INCIDENT_TYPES = {
+    "low_compliance": "legitimate_sender_failing_alignment",
+    "missing_dmarc": "dmarc_policy_missing_or_weak",
+    "policy_none": "dmarc_policy_missing_or_weak",
+    "missing_spf": "spf_include_or_record_problem",
+    "missing_dkim": "missing_or_broken_dkim",
+    "source_reputation_listed": "sending_ip_reputation_risk",
+    "source_reputation_review": "sending_ip_reputation_risk",
+    "review_forwarding": "forwarding_or_receiver_alignment_review",
+}
 HEALTH_DNS_EQUIVALENTS = {
     "missing_dmarc": {"dmarc_missing"},
     "missing_spf": {"spf_missing"},
@@ -74,6 +90,21 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
         "manual_action": sum(1 for item in items if item["state"] == "manual_action"),
         "investigate": sum(1 for item in items if item["state"] == "investigate"),
         "informational": sum(1 for item in items if item["state"] == "informational"),
+        "provider_fix_available": sum(
+            1 for item in items if item.get("automation", {}).get("eligible")
+        ),
+        "self_hosted_guidance": sum(
+            1
+            for item in items
+            if any(
+                path.get("key") == "self_hosted"
+                for path in item.get("action_plan", {}).get("guidance_paths", [])
+            )
+        ),
+        "manual_only": sum(1 for item in items if _remediation_track(item) == "manual_only"),
+        "blocked_by_prerequisite": sum(
+            1 for item in items if _remediation_track(item) == "blocked_by_prerequisite"
+        ),
         "notify_approval_required": sum(
             1 for item in items if item.get("notification", {}).get("state") == "approval_required"
         ),
@@ -88,6 +119,124 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
         "notify_summary_only": sum(
             1 for item in items if item.get("notification", {}).get("state") == "summary_only"
         ),
+    }
+
+
+def _incident_type_for_item(item: Dict[str, Any]) -> str:
+    """Classify remediation work into stable product incident families."""
+    source = str(item.get("source") or "")
+    item_id = str(item.get("id") or "")
+    if source == "dns_lint" or item_id.startswith("dns:"):
+        if "dkim" in item_id:
+            return "missing_or_broken_dkim"
+        if "spf" in item_id:
+            return "spf_include_or_record_problem"
+        if "dmarc" in item_id:
+            return "dmarc_policy_missing_or_weak"
+        return "mail_provider_requires_dns_records"
+    action_type = item_id.removeprefix("health:")
+    return INCIDENT_TYPES.get(action_type, "domain_health_action")
+
+
+def _loop_state_for_item(item: Dict[str, Any]) -> str:
+    """Return the autonomous-loop state without implying unsupervised changes."""
+    if item.get("automation", {}).get("eligible"):
+        return "proposal_ready_for_approval"
+    state = str(item.get("state") or "")
+    if state == "investigate":
+        return "evidence_review_required"
+    if state == "manual_action":
+        return "operator_action_required"
+    return "observed"
+
+
+def _remediation_track(item: Dict[str, Any]) -> str:
+    """Summarize the safest next lane for this item."""
+    if item.get("automation", {}).get("eligible"):
+        return "provider_preview"
+    if item.get("state") == "investigate":
+        return "sender_investigation"
+    if str(item.get("incident_type") or "") == "sending_ip_reputation_risk":
+        return "reputation_review"
+    if str(item.get("source") or "") == "dns_lint":
+        if any(
+            "provider-specific" in str(prerequisite).lower()
+            for prerequisite in item.get("prerequisites", [])
+        ):
+            return "blocked_by_prerequisite"
+        return "manual_dns"
+    if any(
+        path.get("key") == "self_hosted"
+        for path in item.get("action_plan", {}).get("guidance_paths", [])
+    ):
+        return "self_hosted_or_provider"
+    return "manual_only"
+
+
+def _priority_score(item: Dict[str, Any]) -> int:
+    """Return deterministic ordering and dashboard priority score."""
+    severity = SEVERITY_RANK.get(str(item.get("severity") or "info"), 0) * 100
+    state = STATE_PRIORITY.get(str(item.get("state") or ""), 0)
+    automation = 15 if item.get("automation", {}).get("eligible") else 0
+    try:
+        impact = abs(int(float(str(item.get("expected_health_score_impact") or "0"))))
+    except ValueError:
+        impact = 0
+    return severity + state + automation + min(impact, 50)
+
+
+def _operator_decision_options(item: Dict[str, Any]) -> List[str]:
+    """Return allowed human-in-the-loop actions for UI and integrations."""
+    options = ["previewed", "acknowledged", "snoozed", "resolved", "rejected"]
+    if item.get("automation", {}).get("eligible"):
+        return ["preview_change", "approve_after_preview", *options]
+    if item.get("state") == "investigate":
+        return ["mark_legitimate", "mark_unknown", "convert_to_manual_action", *options]
+    return options
+
+
+def _apply_loop_metadata(items: List[Dict[str, Any]]) -> None:
+    for item in items:
+        item["incident_type"] = _incident_type_for_item(item)
+        item["loop_state"] = _loop_state_for_item(item)
+        item["remediation_track"] = _remediation_track(item)
+        item["priority_score"] = _priority_score(item)
+        item["operator_decisions"] = _operator_decision_options(item)
+
+
+def _loop_summary(domain: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return dashboard-ready remediation loop state for this domain."""
+    summary = _summary(items)
+    next_item = items[0] if items else None
+    if not items:
+        status = "clear"
+        next_action = "No current remediation work; keep importing reports and monitoring DNS."
+    elif summary["approval_ready"]:
+        status = "approval_required"
+        next_action = "Preview and approve the highest-priority provider-backed repair."
+    elif summary["investigate"]:
+        status = "investigation_required"
+        next_action = (
+            "Classify the highest-priority sender or reputation finding before changing DNS."
+        )
+    else:
+        status = "manual_action_required"
+        next_action = (
+            "Complete the highest-priority manual provider or self-hosted remediation step."
+        )
+    return {
+        "domain": domain,
+        "status": status,
+        "next_action": next_action,
+        "what_dmarq_can_fix": summary["provider_fix_available"],
+        "what_needs_approval": summary["approval_ready"],
+        "what_needs_manual_action": summary["manual_action"],
+        "what_needs_investigation": summary["investigate"],
+        "manual_only": summary["manual_only"],
+        "blocked_by_prerequisite": summary["blocked_by_prerequisite"],
+        "top_item_id": next_item.get("id") if next_item else None,
+        "top_incident_type": next_item.get("incident_type") if next_item else None,
+        "top_priority_score": next_item.get("priority_score") if next_item else 0,
     }
 
 
@@ -150,6 +299,10 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
         "state": str(item.get("state") or ""),
         "severity": str(item.get("severity") or "info"),
         "confidence": str(item.get("confidence") or "medium"),
+        "incident_type": str(item.get("incident_type") or ""),
+        "loop_state": str(item.get("loop_state") or ""),
+        "remediation_track": str(item.get("remediation_track") or ""),
+        "priority_score": int(item.get("priority_score") or 0),
         "title": str(item.get("title") or ""),
         "detail": str(item.get("detail") or ""),
         "notification_state": str(notification.get("state") or "summary_only"),
@@ -221,6 +374,10 @@ def _dns_item(
         prerequisites.append("Preview the provider mutation before approving the write.")
     else:
         prerequisites.append("Use the manual DNS-provider steps; provider write is not ready.")
+    if plan.get("provider_value_required"):
+        prerequisites.append(
+            "Provider-specific record value is required before DMARQ can preview a write."
+        )
     if recommended_provider:
         prerequisites.append(f"Use the detected provider path for {recommended_provider}.")
 
@@ -657,11 +814,13 @@ def build_remediation_queue(
             continue
         items.append(_health_item(domain, action))
 
+    _apply_loop_metadata(items)
     _attach_notification_profiles(domain, items)
     items.sort(
         key=lambda item: (
             item["state"] != "approval_ready",
             -SEVERITY_RANK.get(item["severity"], 0),
+            -int(item.get("priority_score") or 0),
             item["id"],
         )
     )
@@ -669,5 +828,6 @@ def build_remediation_queue(
         "domain": domain,
         "status": _queue_status(items),
         "summary": _summary(items),
+        "loop": _loop_summary(domain, items),
         "items": items,
     }

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -66,12 +66,21 @@ function domainDetailsApp(domainId = '') {
         },
         remediationQueue: {
             status: '',
+            loop: {
+                status: 'clear',
+                next_action: '',
+                top_incident_type: ''
+            },
             summary: {
                 total: 0,
                 approval_ready: 0,
                 manual_action: 0,
                 investigate: 0,
                 informational: 0,
+                provider_fix_available: 0,
+                self_hosted_guidance: 0,
+                manual_only: 0,
+                blocked_by_prerequisite: 0,
                 dispatch_ready: 0,
                 dispatch_blocked: 0,
                 dispatch_disabled: 0,
@@ -927,6 +936,99 @@ function domainDetailsApp(domainId = '') {
             return 'bg-base-200 text-base-content/70';
         },
 
+        remediationLoopStatusLabel(status) {
+            return {
+                approval_required: 'Approval required',
+                investigation_required: 'Investigation required',
+                manual_action_required: 'Manual action required',
+                clear: 'Clear'
+            }[status] || 'Needs review';
+        },
+
+        humanizeToken(value) {
+            return String(value || '')
+                .split('_')
+                .filter(Boolean)
+                .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+                .join(' ');
+        },
+
+        remediationIncidentLabel(value) {
+            const labels = {
+                dmarc_policy_missing_or_weak: 'DMARC policy',
+                spf_include_or_record_problem: 'SPF record',
+                missing_or_broken_dkim: 'DKIM signing',
+                mail_provider_requires_dns_records: 'Provider DNS',
+                legitimate_sender_failing_alignment: 'Sender alignment',
+                sending_ip_reputation_risk: 'IP reputation',
+                forwarding_or_receiver_alignment_review: 'Forwarding review',
+                domain_health_action: 'Domain health'
+            };
+            return labels[value] || this.humanizeToken(value || 'domain_health_action');
+        },
+
+        remediationTrackLabel(value) {
+            const labels = {
+                provider_preview: 'Provider preview',
+                manual_dns: 'Manual DNS',
+                sender_investigation: 'Sender investigation',
+                reputation_review: 'Reputation review',
+                self_hosted_or_provider: 'Provider or self-hosted',
+                blocked_by_prerequisite: 'Needs prerequisite',
+                manual_only: 'Manual only'
+            };
+            return labels[value] || this.humanizeToken(value || 'manual_only');
+        },
+
+        remediationDecisionLabel(value) {
+            const labels = {
+                preview_change: 'Preview change',
+                approve_after_preview: 'Approve after preview',
+                mark_legitimate: 'Mark legitimate',
+                mark_unknown: 'Mark unknown',
+                convert_to_manual_action: 'Convert to manual',
+                previewed: 'Reviewed',
+                acknowledged: 'Acknowledge',
+                snoozed: 'Snooze',
+                resolved: 'Resolve',
+                rejected: 'Reject'
+            };
+            return labels[value] || this.humanizeToken(value || '');
+        },
+
+        visibleRemediationDecisions(item) {
+            const allowed = item?.operator_decisions || [];
+            const preferredByState = {
+                approval_ready: [
+                    'preview_change',
+                    'approve_after_preview',
+                    'resolved',
+                    'snoozed',
+                    'rejected'
+                ],
+                investigate: [
+                    'mark_legitimate',
+                    'mark_unknown',
+                    'convert_to_manual_action',
+                    'resolved',
+                    'snoozed'
+                ],
+                manual_action: [
+                    'acknowledged',
+                    'resolved',
+                    'snoozed',
+                    'rejected'
+                ]
+            };
+            const preferred = preferredByState[item?.state] || [
+                'acknowledged',
+                'resolved',
+                'snoozed',
+                'rejected'
+            ];
+            return preferred.filter(decision => allowed.includes(decision));
+        },
+
         remediationDispatchStatus(dispatch) {
             if (dispatch?.delivery_enqueued) return 'delivery_enqueued';
             if (dispatch?.eligible) return 'ready';
@@ -967,6 +1069,7 @@ function domainDetailsApp(domainId = '') {
                 pending_operator_action: 'bg-yellow-100 text-yellow-800',
                 operator_rejected: 'bg-base-200 text-base-content/70',
                 operator_snoozed: 'bg-base-200 text-base-content/70',
+                operator_mark_unknown: 'bg-base-200 text-base-content/70',
                 not_started: 'bg-base-200 text-base-content/70'
             }[state] || 'bg-base-200 text-base-content/70';
         },
@@ -1445,12 +1548,21 @@ function domainDetailsApp(domainId = '') {
         resetRemediationQueue() {
             this.remediationQueue = {
                 status: 'unavailable',
+                loop: {
+                    status: 'clear',
+                    next_action: '',
+                    top_incident_type: ''
+                },
                 summary: {
                     total: 0,
                     approval_ready: 0,
                     manual_action: 0,
                     investigate: 0,
                     informational: 0,
+                    provider_fix_available: 0,
+                    self_hosted_guidance: 0,
+                    manual_only: 0,
+                    blocked_by_prerequisite: 0,
                     notify_approval_required: 0,
                     notify_action_required: 0,
                     notify_investigation_required: 0,

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -378,6 +378,12 @@
                             <span class="rounded bg-blue-100 px-2 py-1 font-semibold text-blue-700">
                                 <span x-text="remediationQueue.summary.investigate"></span><span> investigate</span>
                             </span>
+                            <span class="rounded bg-[#f2fbf9] px-2 py-1 font-semibold text-[#1f7c83]">
+                                <span x-text="remediationQueue.summary.provider_fix_available || 0"></span><span> provider fixes</span>
+                            </span>
+                            <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
+                                <span x-text="remediationQueue.summary.blocked_by_prerequisite || 0"></span><span> blocked by prerequisites</span>
+                            </span>
                             <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700">
                                 <span x-text="remediationQueue.summary.dispatch_ready || 0"></span><span> ready to notify</span>
                             </span>
@@ -450,6 +456,18 @@
                     </template>
                     <template x-if="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length > 0">
                         <div class="mt-4 grid gap-3 md:grid-cols-3">
+                            <div class="rounded-lg bg-white p-3 md:col-span-3">
+                                <div class="flex flex-wrap items-start justify-between gap-3">
+                                    <div>
+                                        <p class="text-xs font-semibold uppercase text-[#5f5c78]">Remediation loop</p>
+                                        <p class="mt-1 text-sm font-semibold text-[#120d36]" x-text="remediationLoopStatusLabel(remediationQueue.loop?.status)"></p>
+                                        <p class="mt-1 text-sm text-[#5f5c78]" x-text="remediationQueue.loop?.next_action || 'Review the highest priority remediation item.'"></p>
+                                    </div>
+                                    <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]">
+                                        <span>Top: </span><span x-text="remediationIncidentLabel(remediationQueue.loop?.top_incident_type)"></span>
+                                    </span>
+                                </div>
+                            </div>
                             <div class="rounded-lg bg-white p-3">
                                 <p class="text-xs font-semibold uppercase text-[#5f5c78]">Notification readiness</p>
                                 <p class="mt-1 text-sm text-[#120d36]" x-text="remediationReadinessText"></p>
@@ -488,6 +506,13 @@
                                                 <span x-text="item.severity"></span>
                                             </span>
                                             <span class="text-xs text-[#5f5c78]" x-text="item.source.replace('_', ' ')"></span>
+                                            <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]"
+                                                  x-text="remediationIncidentLabel(item.incident_type)"></span>
+                                            <span class="rounded bg-[#f2fbf9] px-2 py-1 text-xs font-semibold text-[#1f7c83]"
+                                                  x-text="remediationTrackLabel(item.remediation_track)"></span>
+                                            <span class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#5f5c78]">
+                                                <span>priority </span><span x-text="item.priority_score || 0"></span>
+                                            </span>
                                             <span x-show="item.notification"
                                                   class="rounded px-2 py-1 text-xs font-semibold"
                                                   :class="remediationNotificationClass(item.notification.state)"
@@ -584,27 +609,14 @@
                                             </div>
                                         </template>
                                         <div class="mt-3 flex flex-wrap gap-2">
-                                            <button type="button"
-                                                    class="btn btn-xs btn-outline"
-                                                    :disabled="remediationActionBusy(item)"
-                                                    :data-remediation-item-id="item.id"
-                                                    data-domain-detail-remediation-action="previewed">
-                                                Reviewed
-                                            </button>
-                                            <button type="button"
-                                                    class="btn btn-xs btn-outline"
-                                                    :disabled="remediationActionBusy(item)"
-                                                    :data-remediation-item-id="item.id"
-                                                    data-domain-detail-remediation-action="acknowledged">
-                                                Acknowledge
-                                            </button>
-                                            <button type="button"
-                                                    class="btn btn-xs btn-outline"
-                                                    :disabled="remediationActionBusy(item)"
-                                                    :data-remediation-item-id="item.id"
-                                                    data-domain-detail-remediation-action="resolved">
-                                                Resolve
-                                            </button>
+                                            <template x-for="decision in visibleRemediationDecisions(item)" :key="item.id + '-decision-' + decision">
+                                                <button type="button"
+                                                        class="btn btn-xs btn-outline"
+                                                        :disabled="remediationActionBusy(item)"
+                                                        :data-remediation-item-id="item.id"
+                                                        :data-domain-detail-remediation-action="decision"
+                                                        x-text="remediationDecisionLabel(decision)"></button>
+                                            </template>
                                             <button type="button"
                                                     class="btn btn-xs btn-primary"
                                                     :disabled="remediationActionBusy(item) || !item.notification.dispatch.eligible"

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -68,11 +68,29 @@ def _sample_remediation_queue(domain=DOMAIN):
     return {
         "domain": domain,
         "status": "needs_approval",
-        "summary": {"total": 1, "approval_ready": 1},
+        "summary": {
+            "total": 1,
+            "approval_ready": 1,
+            "provider_fix_available": 1,
+            "blocked_by_prerequisite": 0,
+        },
+        "loop": {
+            "status": "approval_required",
+            "next_action": "Preview and approve the highest-priority provider-backed repair.",
+            "what_dmarq_can_fix": 1,
+            "what_needs_approval": 1,
+            "top_item_id": "dns:dmarc_missing",
+            "top_incident_type": "dmarc_policy_missing_or_weak",
+        },
         "items": [
             {
                 "id": "dns:dmarc_missing",
                 "source": "dns_lint",
+                "incident_type": "dmarc_policy_missing_or_weak",
+                "loop_state": "proposal_ready_for_approval",
+                "remediation_track": "provider_preview",
+                "priority_score": 455,
+                "operator_decisions": ["preview_change", "approve_after_preview", "resolved"],
                 "state": "approval_ready",
                 "severity": "critical",
                 "confidence": "high",
@@ -1196,6 +1214,12 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
     assert intelligence_result["regions"] == []
     assert proposals["proposals"]
     assert remediation_result.domain == DOMAIN
+    assert remediation_result.loop["status"] == "approval_required"
+    assert remediation_result.loop["top_incident_type"] == "dmarc_policy_missing_or_weak"
+    assert remediation_result.items[0].incident_type == "dmarc_policy_missing_or_weak"
+    assert remediation_result.items[0].loop_state == "proposal_ready_for_approval"
+    assert remediation_result.items[0].remediation_track == "provider_preview"
+    assert "approve_after_preview" in remediation_result.items[0].operator_decisions
     assert remediation_result.items[0].automation.eligible is True
     assert remediation_result.items[0].automation.apply_endpoint is None
     assert (

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1182,19 +1182,23 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "item.verification_plan.evidence_needed" in template
     assert "item.verification_plan.next_check" in template
     assert "Notification dispatch" in template
-    assert "Reviewed" in template
-    assert "Acknowledge" in template
-    assert "Resolve" in template
+    assert "Remediation loop" in template
+    assert "remediationLoopStatusLabel" in template
+    assert "remediationIncidentLabel" in template
+    assert "remediationTrackLabel" in template
+    assert "visibleRemediationDecisions(item)" in template
     assert "Dispatch" in template
-    assert 'data-domain-detail-remediation-action="previewed"' in template
-    assert 'data-domain-detail-remediation-action="acknowledged"' in template
-    assert 'data-domain-detail-remediation-action="resolved"' in template
+    assert ':data-domain-detail-remediation-action="decision"' in template
     assert 'data-domain-detail-remediation-action="dispatch"' in template
     assert "recordRemediationLifecycle(item, 'previewed')" not in template
     assert "recordRemediationLifecycle(item, 'acknowledged')" not in template
     assert "recordRemediationLifecycle(item, 'resolved')" not in template
     assert "dispatchRemediationNotification(item)" not in template
     assert "handleRemediationAction" in script
+    assert "remediationDecisionLabel" in script
+    assert "approve_after_preview" in script
+    assert "mark_unknown" in script
+    assert "humanizeToken" in script
     assert "/remediation/notifications/audit" in script
     assert "/remediation/notifications/dispatch" in script
     assert "No DNS changes were made" in script

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2271,10 +2271,21 @@ def test_summary_includes_current_remediation_loop(
     assert response.status_code == 200
     loop = response.json()["health_summary"]["remediation_loop"]
     assert loop["status"] == "needs_attention"
+    assert loop["loop_status"] == "approval_required"
+    assert loop["what_dmarq_can_fix"] >= 2
+    assert loop["what_needs_approval"] >= 2
     assert loop["needs_approval"] >= 2
     assert loop["total_open"] >= 2
     assert loop["items"][0]["domain"] == DOMAIN
     assert loop["items"][0]["state"] == "needs_approval"
+    assert loop["items"][0]["loop_state"] == "proposal_ready_for_approval"
+    assert loop["items"][0]["incident_type"] in {
+        "dmarc_policy_missing_or_weak",
+        "spf_include_or_record_problem",
+    }
+    assert loop["items"][0]["remediation_track"] == "provider_preview"
+    assert loop["items"][0]["priority_score"] > 0
+    assert "approve_after_preview" in loop["items"][0]["operator_decisions"]
     assert loop["items"][0]["state_label"] == "Needs approval"
     assert loop["items"][0]["owner"] == "Domain DNS operator"
     assert loop["items"][0]["automation_path"] == "provider_preview"
@@ -2285,9 +2296,15 @@ def test_summary_includes_current_remediation_loop(
     assert loop["items"][0]["next_step"]
     domain = response.json()["domains"][0]
     assert domain["remediation_workload"]["status"] == "needs_attention"
+    assert domain["remediation_workload"]["what_dmarq_can_fix"] >= 2
+    assert domain["remediation_workload"]["what_needs_approval"] >= 2
     assert domain["remediation_workload"]["needs_approval"] >= 2
     assert domain["remediation_workload"]["total_open"] >= 2
     assert domain["remediation_workload"]["primary"]["state"] == "needs_approval"
+    assert domain["remediation_workload"]["primary"]["loop_state"] == (
+        "proposal_ready_for_approval"
+    )
+    assert domain["remediation_workload"]["primary"]["remediation_track"] == ("provider_preview")
     assert domain["remediation_workload"]["primary"]["state_label"] == "Needs approval"
     assert domain["remediation_workload"]["primary"]["owner"] == "Domain DNS operator"
     assert domain["remediation_workload"]["primary"]["automation_path"] == "provider_preview"

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -814,12 +814,25 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
     assert data["summary"]["total"] == 2
     assert data["summary"]["approval_ready"] == 1
     assert data["summary"]["investigate"] == 1
+    assert data["summary"]["provider_fix_available"] == 1
+    assert data["loop"]["status"] == "approval_required"
+    assert data["loop"]["what_dmarq_can_fix"] == 1
+    assert data["loop"]["what_needs_investigation"] == 1
+    assert data["loop"]["top_incident_type"] == "dmarc_policy_missing_or_weak"
     assert data["items"][0]["id"] == "dns:dmarc-missing"
+    assert data["items"][0]["incident_type"] == "dmarc_policy_missing_or_weak"
+    assert data["items"][0]["loop_state"] == "proposal_ready_for_approval"
+    assert data["items"][0]["remediation_track"] == "provider_preview"
+    assert data["items"][0]["priority_score"] == 455
+    assert "approve_after_preview" in data["items"][0]["operator_decisions"]
     assert data["items"][0]["automation"]["eligible"] is True
     assert data["items"][0]["automation"]["provider"] == "cloudflare"
     assert data["items"][0]["verification_plan"]["status"] == "pending_operator_approval"
     assert "fresh DNS evidence" in data["items"][0]["verification_plan"]["summary"]
     assert data["items"][1]["verification_plan"]["status"] == "pending_sender_review"
+    assert data["items"][1]["incident_type"] == "legitimate_sender_failing_alignment"
+    assert data["items"][1]["loop_state"] == "evidence_review_required"
+    assert data["items"][1]["remediation_track"] == "sender_investigation"
     assert "receiver report window" in data["items"][1]["verification_plan"]["next_check"]
     dispatch = data["items"][0]["notification"]["dispatch"]
     assert dispatch["enabled"] is False
@@ -1281,6 +1294,75 @@ def test_domain_remediation_notification_lifecycle_audit_records_sanitized_marke
     persisted_details = json.loads(audit_row.details)
     assert persisted_details["operator_note"] == "Reviewed with DNS owner"
     assert persisted_details["automation_provider"] == "cloudflare"
+
+
+def test_domain_remediation_notification_lifecycle_audit_records_sender_decision(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Investigation decisions are audit markers, not hidden DNS/provider writes."""
+
+    async def fake_domain_grade(db, domain_id, store, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 68,
+            "grade": "C",
+            "status": "attention",
+            "factors": {"report_confidence": 70},
+            "actions": [
+                {
+                    "type": "low_compliance",
+                    "severity": "high",
+                    "title": "Review failing senders",
+                    "detail": "Recent reports include an unknown failing sender.",
+                    "next_step": "Classify the sender before changing DNS.",
+                    "score_impact": 18,
+                }
+            ],
+        }
+
+    async def fake_dns_guidance(db, store, domain_id, refresh=False):
+        return {
+            "domain": domain_id,
+            "status": "ok",
+            "dns_provider": {"provider_id": "cloudflare"},
+            "findings": [],
+            "change_plans": [],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
+
+    response = seeded_client.post(
+        f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
+        json={
+            "item_id": "health:low_compliance",
+            "event": "dmarq.remediation.investigation_required",
+            "lifecycle_state": "mark_unknown",
+            "note": "This source is not owned by us.",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["item_id"] == "health:low_compliance"
+    assert data["lifecycle_state"] == "mark_unknown"
+    details = data["audit"]["details"]
+    assert details["sent"] is False
+    assert details["delivery_enqueued"] is False
+    assert details["dns_write_attempted"] is False
+
+    queue_response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+    assert queue_response.status_code == 200
+    item = queue_response.json()["items"][0]
+    assert item["id"] == "health:low_compliance"
+    assert item["notification"]["history"][0]["state"] == "mark_unknown"
+    assert item["notification"]["history"][0]["label"] == "Marked unknown sender"
+    assert item["notification"]["dispatch"]["operator_hold"] is True
+    assert item["notification"]["dispatch"]["verification"]["label"] == "Marked unknown sender"
+    assert "unknown sender" in item["notification"]["dispatch"]["blocked_reasons"][0]
+    assert db_session.query(WorkspaceAuditLog).count() == 1
 
 
 def test_domain_remediation_notification_lifecycle_audit_rejects_mismatched_event(

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -95,11 +95,29 @@ def _sample_remediation_queue(domain=DOMAIN):
     return {
         "domain": domain,
         "status": "needs_approval",
-        "summary": {"total": 1, "approval_ready": 1},
+        "summary": {
+            "total": 1,
+            "approval_ready": 1,
+            "provider_fix_available": 1,
+            "blocked_by_prerequisite": 0,
+        },
+        "loop": {
+            "status": "approval_required",
+            "next_action": "Preview and approve the highest-priority provider-backed repair.",
+            "what_dmarq_can_fix": 1,
+            "what_needs_approval": 1,
+            "top_item_id": "dns:dmarc_missing",
+            "top_incident_type": "dmarc_policy_missing_or_weak",
+        },
         "items": [
             {
                 "id": "dns:dmarc_missing",
                 "source": "dns_lint",
+                "incident_type": "dmarc_policy_missing_or_weak",
+                "loop_state": "proposal_ready_for_approval",
+                "remediation_track": "provider_preview",
+                "priority_score": 455,
+                "operator_decisions": ["preview_change", "approve_after_preview", "resolved"],
                 "state": "approval_ready",
                 "severity": "critical",
                 "confidence": "high",
@@ -547,7 +565,13 @@ def test_public_remediation_queue_is_read_only_and_posture_scoped(
     body = response.json()
     assert body["domain"] == DOMAIN
     assert body["summary"]["approval_ready"] == 1
+    assert body["loop"]["status"] == "approval_required"
+    assert body["loop"]["top_incident_type"] == "dmarc_policy_missing_or_weak"
     item = body["items"][0]
+    assert item["incident_type"] == "dmarc_policy_missing_or_weak"
+    assert item["loop_state"] == "proposal_ready_for_approval"
+    assert item["remediation_track"] == "provider_preview"
+    assert "approve_after_preview" in item["operator_decisions"]
     assert item["automation"]["eligible"] is True
     assert item["automation"]["apply_endpoint"] is None
     assert item["notification"]["payload_preview"]["automation"]["apply_endpoint"] is None

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -68,12 +68,38 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "manual_action": 0,
         "investigate": 1,
         "informational": 0,
+        "provider_fix_available": 1,
+        "self_hosted_guidance": 1,
+        "manual_only": 0,
+        "blocked_by_prerequisite": 0,
         "notify_approval_required": 1,
         "notify_action_required": 0,
         "notify_investigation_required": 1,
         "notify_summary_only": 0,
     }
+    assert queue["loop"] == {
+        "domain": "example.com",
+        "status": "approval_required",
+        "next_action": "Preview and approve the highest-priority provider-backed repair.",
+        "what_dmarq_can_fix": 1,
+        "what_needs_approval": 1,
+        "what_needs_manual_action": 0,
+        "what_needs_investigation": 1,
+        "manual_only": 0,
+        "blocked_by_prerequisite": 0,
+        "top_item_id": "dns:dmarc-missing",
+        "top_incident_type": "dmarc_policy_missing_or_weak",
+        "top_priority_score": 455,
+    }
     assert queue["items"][0]["id"] == "dns:dmarc-missing"
+    assert queue["items"][0]["incident_type"] == "dmarc_policy_missing_or_weak"
+    assert queue["items"][0]["loop_state"] == "proposal_ready_for_approval"
+    assert queue["items"][0]["remediation_track"] == "provider_preview"
+    assert queue["items"][0]["priority_score"] == 455
+    assert queue["items"][0]["operator_decisions"][:2] == [
+        "preview_change",
+        "approve_after_preview",
+    ]
     assert queue["items"][0]["state"] == "approval_ready"
     assert queue["items"][0]["automation"]["eligible"] is True
     assert queue["items"][0]["automation"]["apply_endpoint"] == (
@@ -115,6 +141,10 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "state": "approval_ready",
         "severity": "critical",
         "confidence": "high",
+        "incident_type": "dmarc_policy_missing_or_weak",
+        "loop_state": "proposal_ready_for_approval",
+        "remediation_track": "provider_preview",
+        "priority_score": 455,
         "title": "Publish DMARC",
         "detail": "No DMARC TXT record was found.",
         "notification_state": "approval_required",
@@ -159,6 +189,10 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "evidence": [{"label": "finding", "value": "_dmarc.example.com"}],
     }
     assert queue["items"][1]["notification"]["state"] == "investigation_required"
+    assert queue["items"][1]["incident_type"] == "legitimate_sender_failing_alignment"
+    assert queue["items"][1]["loop_state"] == "evidence_review_required"
+    assert queue["items"][1]["remediation_track"] == "sender_investigation"
+    assert "mark_legitimate" in queue["items"][1]["operator_decisions"]
     assert queue["items"][1]["notification"]["event"] == (
         "dmarq.remediation.investigation_required"
     )
@@ -205,8 +239,13 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
 
     assert queue["status"] == "needs_manual_action"
     assert queue["summary"]["manual_action"] == 1
+    assert queue["summary"]["blocked_by_prerequisite"] == 1
     assert queue["summary"]["notify_summary_only"] == 1
+    assert queue["loop"]["status"] == "manual_action_required"
+    assert queue["loop"]["blocked_by_prerequisite"] == 1
     assert queue["items"][0]["state"] == "manual_action"
+    assert queue["items"][0]["remediation_track"] == "blocked_by_prerequisite"
+    assert queue["items"][0]["loop_state"] == "operator_action_required"
     assert queue["items"][0]["automation"]["eligible"] is False
     assert queue["items"][0]["automation"]["apply_endpoint"] is None
     assert queue["items"][0]["action_plan"]["automation_path"] == "manual"

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -90,6 +90,10 @@ Completed or substantially delivered:
   Intelligence, SpamCop SCBL, Barracuda BRBL, and AbuseIPDB as the first
   provider set. Deeper commercial reputation feed contracts and UI
   configuration remain follow-up work.
+- Human-in-the-loop remediation queues that classify incidents, score
+  priority, separate provider-preview, manual DNS, self-hosted, sender
+  investigation, and reputation-review tracks, and keep all operator decisions
+  audit-only until a separate provider write is explicitly approved.
 - Cloudflare read-only inspection, DNS snapshots, and DNS change history.
 - Notifications, alert rules, alert history, and Apprise delivery.
 - API tokens, webhooks, SIEM templates, and ticketing/chatops templates.
@@ -103,12 +107,12 @@ Strategic issue status:
 | Issue | Status | Notes |
 | --- | --- | --- |
 | [#12](https://github.com/christianlouis/dmarq/issues/12) | open | Broad user-auth, SaaS, ISP/OEM, subscription, and billing tracker. Keep this parked for the self-hosted demo unless auth work is explicitly reactivated. |
-| [#243](https://github.com/christianlouis/dmarq/issues/243) | open | Enterprise identity, provisioning, and support-access hardening. Treat as the active child under #12. |
+| [#243](https://github.com/christianlouis/dmarq/issues/243) | complete | Enterprise identity, provisioning, and support-access hardening landed through focused child slices. |
 | [#305](https://github.com/christianlouis/dmarq/issues/305) | complete as roadmap parent | Competitive-parity direction is now captured here and in the referenced product docs. New work should use focused child issues instead of reopening the parent. |
 | [#309](https://github.com/christianlouis/dmarq/issues/309) | complete for current read-only API/MCP scope | Stable public API and MCP read-only surfaces exist for health, reports, DNS, sources, remediation, alerts, usage, and export discovery. Future write or provider-admin tools need separate scoped issues. |
 | [#311](https://github.com/christianlouis/dmarq/issues/311) | complete for safe migration readiness | Parallel-reporting, parity checklist, historical export preview, idempotency metadata, and portability docs are in place. A future persisted historical-import writer should be a separate explicit issue. |
 | [#312](https://github.com/christianlouis/dmarq/issues/312) | parked | MSP/ISP/multi-tenant demo polish is intentionally not part of the current `demo.dmarq.org` single-user self-hosted story. |
-| [#384](https://github.com/christianlouis/dmarq/issues/384) | active | Continue with human-approved provider repair progression, operator verification history, and remediation notifications. |
+| [#384](https://github.com/christianlouis/dmarq/issues/384) | active | First remediation-loop slices classify incidents, expose loop state and operator decisions, keep public/MCP views read-only, and show the queue in-product. Continue with deeper provider-specific repair flows and notification polish. |
 
 ## Roadmap Tracks
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -799,24 +799,37 @@ can be previewed through a provider connector or why it remains manual-only.
 queue for a domain. It groups DNS change plans and health-score actions into
 prioritized items with state, severity, next steps, evidence, blast radius,
 prerequisites, expected health-score impact, automation eligibility, and
-read-only notification routing metadata. DNS items that have a concrete safe
-TXT/CNAME provider write are marked `approval_ready` and point to the same
-explicit preview/apply endpoint used by the DNS change-plan UI. Notification
-metadata includes the event name, channel, dedupe key, reason, and next state
-transition that an operator workflow can use. Each notification also includes a
-read-only `dispatch` preview showing whether the item would be eligible for a
-future dispatch step, which channel would be used, whether a previewed or
-acknowledged lifecycle marker is still required, how many enabled webhook
-endpoints match the event, and why dispatch is currently blocked. Each item
-also includes a sanitized `payload_preview` using schema
+read-only notification routing metadata. Items also expose stable remediation
+loop fields so product and automation surfaces can use the same language:
+`incident_type`, `loop_state`, `remediation_track`, `priority_score`, and
+`operator_decisions`. DNS items that have a concrete safe TXT/CNAME provider
+write are marked `approval_ready` and point to the same explicit preview/apply
+endpoint used by the DNS change-plan UI. Placeholder DKIM/SPF records that
+still need provider-specific values are surfaced as blocked by prerequisite
+instead of being presented as one-click repairs.
+
+The top-level `loop` object summarizes what DMARQ can fix, what needs explicit
+approval, what needs manual action, what needs investigation, the current
+`status`, and the highest-priority incident. The queue `summary` mirrors these
+operator buckets with counters such as `provider_fix_available`,
+`self_hosted_guidance`, `manual_only`, and `blocked_by_prerequisite`.
+
+Notification metadata includes the event name, channel, dedupe key, reason, and
+next state transition that an operator workflow can use. Each notification also
+includes a read-only `dispatch` preview showing whether the item would be
+eligible for a future dispatch step, which channel would be used, whether a
+previewed or acknowledged lifecycle marker is still required, how many enabled
+webhook endpoints match the event, and why dispatch is currently blocked. Each
+item also includes a sanitized `payload_preview` using schema
 `dmarq.remediation.notification.v1`; it is the deterministic data shape a
 future webhook, ticketing, or chatops delivery would receive. The endpoint does
 not perform DNS writes, enqueue webhook deliveries, or send notifications.
-The queue `summary` also exposes dispatch readiness counters, including
-`dispatch_ready`, `dispatch_blocked`, `dispatch_disabled`,
-`dispatch_awaiting_acknowledgement`, and `dispatch_webhook_routes`, so
-dashboards can separate immediately actionable notifications from items blocked
-by settings, routing, or operator acknowledgement.
+After dispatch previews are attached, the queue `summary` also exposes dispatch
+readiness counters, including `dispatch_ready`, `dispatch_blocked`,
+`dispatch_disabled`, `dispatch_awaiting_acknowledgement`, and
+`dispatch_webhook_routes`, so dashboards can separate immediately actionable
+notifications from items blocked by settings, routing, or operator
+acknowledgement.
 
 Each notification also includes a compact `history` array derived from
 workspace audit events for the current queue item. The history lists recent
@@ -830,10 +843,13 @@ troubleshooting.
 operator lifecycle marker for one current remediation item. The request accepts
 `item_id`, `lifecycle_state`, and optional `event`, `dedupe_key`, and `note`.
 Supported lifecycle states are `previewed`, `acknowledged`, `snoozed`,
-`resolved`, and `rejected`. If `event` or `dedupe_key` is supplied, it must
-match the current queue item's notification metadata. The response includes the
-sanitized workspace audit row. This endpoint is deliberately audit-only: it
-does not enqueue webhook deliveries, send notifications, or attempt DNS writes.
+`resolved`, `rejected`, plus workflow-specific decisions:
+`preview_change`, `approve_after_preview`, `mark_legitimate`, `mark_unknown`,
+and `convert_to_manual_action`. If `event` or `dedupe_key` is supplied, it
+must match the current queue item's notification metadata. The response
+includes the sanitized workspace audit row. This endpoint is deliberately
+audit-only: it does not enqueue webhook deliveries, send notifications, or
+attempt DNS writes.
 
 `POST /domains/{domain_id}/remediation/notifications/dispatch` enqueues
 webhook deliveries for one current remediation item after explicit operator


### PR DESCRIPTION
## Summary
- classify remediation queue items into stable incident families, loop states, remediation tracks, priority scores, and operator decisions
- expose the remediation loop in domain detail UI, dashboard summaries, public API, and MCP read-only tools while keeping provider apply links stripped from public/MCP responses
- add audit-only operator decisions for sender investigation and provider-preview workflows without adding background DNS writes
- update API docs, roadmap status, and unreleased changelog notes

## Local validation
- .venv/bin/python -m pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_domain_detail_endpoints.py::test_domain_remediation_queue_groups_dns_and_health_actions backend/app/tests/test_domain_detail_endpoints.py::test_domain_remediation_notification_lifecycle_audit_records_sanitized_marker backend/app/tests/test_domain_detail_endpoints.py::test_domain_remediation_notification_lifecycle_audit_records_sender_decision backend/app/tests/test_domain_detail_endpoints.py::test_domain_remediation_notification_lifecycle_audit_rejects_invalid_state backend/app/tests/test_dns_endpoints.py::test_summary_includes_current_remediation_loop backend/app/tests/test_dashboard_template_security.py::test_domain_details_exposes_remediation_action_plans_without_html_injection backend/app/tests/test_public_api.py::test_public_remediation_queue_is_read_only_and_posture_scoped backend/app/tests/test_ai_mcp.py::test_mcp_read_only_tool_dispatch_covers_new_domain_tools -q
- node --check backend/app/static/js/domain-details-page.js
- git diff --check origin/main..HEAD

Refs #384