### PR TITLE
fix: keep public posture reads side-effect free

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -5006,6 +5006,24 @@ async def get_domain_posture_dashboard(
 ):
     """Return an evidence-first posture dashboard for a monitored domain."""
     workspace = _authorized_domain_read_workspace(_auth, db)
+    return await _build_domain_posture_dashboard_for_workspace(
+        db,
+        workspace=workspace,
+        domain_id=domain_id,
+        refresh=refresh,
+        capture_snapshot=not get_settings().DEMO_MODE,
+    )
+
+
+async def _build_domain_posture_dashboard_for_workspace(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domain_id: str,
+    refresh: bool = False,
+    capture_snapshot: bool = True,
+) -> PostureDashboardResponse:
+    """Build a posture dashboard, optionally persisting the current health snapshot."""
     store = ReportStore.get_instance()
     hydrate_report_store_from_db(db, store)
     if not _domain_exists(db, store, domain_id, workspace):
@@ -5022,7 +5040,7 @@ async def get_domain_posture_dashboard(
         refresh=refresh,
     )
     summary = store.get_domain_summary(domain_id)
-    if not get_settings().DEMO_MODE:
+    if capture_snapshot:
         _record_health_snapshot_from_posture(
             db,
             workspace_id=workspace.id,

--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -74,11 +74,13 @@ async def public_domain_posture(
     _auth: dict = Depends(require_api_token_scope(READ_POSTURE_SCOPE)),
 ):
     """Return the stable evidence-first posture payload for one domain."""
-    return await domains.get_domain_posture_dashboard(
+    workspace = resolve_authorized_workspace(db, _auth, PERMISSION_REPORTS_READ)
+    return await domains._build_domain_posture_dashboard_for_workspace(
+        db,
+        workspace=workspace,
         domain_id=domain_id,
         refresh=refresh,
-        db=db,
-        _auth=_auth,
+        capture_snapshot=False,
     )
 
 

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -9,6 +9,7 @@ from app.core.security import require_api_token_any_scope
 from app.models.alert import AlertHistory
 from app.models.api_token import APIToken
 from app.models.domain import Domain
+from app.models.health_score_snapshot import HealthScoreSnapshot
 from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
 from app.models.organization import BillingAccount, Organization
@@ -89,6 +90,43 @@ def _persist_report(db_session):
 def _persist_failing_report(db_session, report=None, *, workspace_id=None):
     save_parsed_report(db_session, report or FAILING_REPORT, workspace_id=workspace_id)
     db_session.commit()
+
+
+def _stub_current_posture(monkeypatch):
+    async def fake_dns_health(db, store, domain_id, refresh=False):
+        return domains_endpoint.DNSHealthResponse(
+            status="healthy",
+            policy="reject",
+            compliance_rate=98,
+            total_emails=1000,
+            failed_emails=20,
+            checks=[],
+            recommendations=[],
+        )
+
+    async def fake_domain_grade(db, domain_id, store, refresh=False):
+        return {
+            "domain": domain_id,
+            "score": 96,
+            "grade": "A",
+            "status": "healthy",
+            "factors": {
+                "dns_posture": 100,
+                "policy_strength": 100,
+                "report_confidence": 90,
+            },
+            "actions": [
+                {
+                    "type": "monitoring",
+                    "severity": "low",
+                    "title": "Keep monitoring",
+                    "score_impact": 1,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_health", fake_dns_health)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
 
 
 def _sample_remediation_queue(domain=DOMAIN):
@@ -472,6 +510,27 @@ def test_public_api_rejects_token_without_required_scope(client: TestClient, db_
 
     assert response.status_code == 403
     assert response.json()["detail"] == f"API token requires scope: {READ_POSTURE_SCOPE}"
+
+
+def test_public_posture_endpoint_does_not_write_health_snapshots(
+    client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Stable public posture reads must not mutate health history."""
+    _persist_report(db_session)
+    _stub_current_posture(monkeypatch)
+    created = create_api_token(db_session, name="posture bot", scopes=[READ_POSTURE_SCOPE])
+    before = db_session.query(HealthScoreSnapshot).count()
+
+    response = client.get(
+        f"/api/v1/public/domains/{DOMAIN}/posture?refresh=true",
+        headers={"X-API-Key": created.secret},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["health"]["score"] == 96
+    assert db_session.query(HealthScoreSnapshot).count() == before
 
 
 def test_public_action_proposals_use_posture_scope(client: TestClient, db_session):


### PR DESCRIPTION
## Summary
- split posture dashboard building so callers can choose whether to persist a health snapshot
- keep the admin posture route recording snapshots as before
- make the public posture endpoint explicitly read-only and side-effect free
- add a regression test proving public posture reads do not create health-score snapshots

## Local validation
- .venv/bin/python -m pytest backend/app/tests/test_public_api.py::test_public_posture_endpoint_does_not_write_health_snapshots backend/app/tests/test_domain_detail_endpoints.py::test_domain_posture_dashboard_records_current_snapshot -q
- git diff --check

Closes #665