### PR TITLE
fix: resolve numeric domain ids for report export

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -5881,18 +5881,11 @@ async def export_domain_reports(
         )
 
     workspace = _authorized_domain_read_workspace(_auth, db)
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
-
-    if not _domain_exists(db, store, domain_id, workspace):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Domain not found",
-        )
+    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
     reports = [
         report
-        for report in store.get_domain_reports(domain_id, limit=10000)
+        for report in store.get_domain_reports(domain_name, limit=10000)
         if _report_in_export_range(report, start_date, end_date)
     ]
 
@@ -5934,7 +5927,7 @@ async def export_domain_reports(
             policy = policy.get("p", "none")
         writer.writerow(
             [
-                domain_id,
+                domain_name,
                 report.get("report_id", "unknown"),
                 report.get("org_name", "Unknown Organization"),
                 _format_report_date(report.get("begin_timestamp") or report.get("begin_date")),
@@ -5957,7 +5950,7 @@ async def export_domain_reports(
             ]
         )
 
-    filename = f"{domain_id.replace('/', '_')}-dmarc-reports.csv"
+    filename = f"{domain_name.replace('/', '_')}-dmarc-reports.csv"
     return Response(
         content=output.getvalue(),
         media_type="text/csv",

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -384,6 +384,23 @@ def test_export_domain_reports_returns_csv(seeded_client: TestClient):
     assert rows[0]["generator"] == "ExampleRUA 2.0"
 
 
+def test_export_domain_reports_accepts_numeric_domain_id(
+    seeded_client: TestClient,
+    db_session,
+):
+    """CSV export resolves numeric path IDs to the canonical domain name."""
+    domain = db_session.query(Domain).filter(Domain.name == DOMAIN).one()
+
+    response = seeded_client.get(f"/api/v1/domains/{domain.id}/reports/export")
+
+    assert response.status_code == 200
+    assert f'filename="{DOMAIN}-dmarc-reports.csv"' in response.headers["content-disposition"]
+    rows = list(csv.DictReader(StringIO(response.text)))
+    assert len(rows) == 1
+    assert rows[0]["domain"] == DOMAIN
+    assert rows[0]["report_id"] == "rpt-dict-policy"
+
+
 def test_export_domain_reports_filters_by_date_range(authed_client: TestClient):
     """CSV export only includes reports inside the requested date range."""
     ReportStore.get_instance().add_report(REPORT_DICT_POLICY)


### PR DESCRIPTION
## Summary
- resolve numeric domain path IDs before exporting aggregate reports as CSV
- keep CSV rows and the download filename on the canonical domain name
- cover the numeric ID route with a regression test

## Root cause
The export endpoint accepted the same path parameter style as the domain detail routes, but it still treated the value as a literal domain name when loading reports and naming the file. Numeric IDs therefore did not resolve to the stored domain reports.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_domain_detail_endpoints.py::test_export_domain_reports_returns_csv backend/app/tests/test_domain_detail_endpoints.py::test_export_domain_reports_accepts_numeric_domain_id backend/app/tests/test_domain_detail_endpoints.py::test_export_domain_reports_unknown_domain_returns_404 -q`
- `.venv/bin/python -m black backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py`
- `git diff --check`

Closes #666
