### PR TITLE
feat: explain verified remediation repairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented shipped mail-health surfaces separately from future roadmap work
   so health scoring, evidence exports, read-only API/MCP access, and sender
   reputation no longer read as purely future features.
+- Added explicit verification metadata to evidence-verified remediation repairs
+  so operators can see why a previously resolved item is no longer considered
+  active.
 - Added in-product release metadata with version, image, git ref, build date, recent changes, and a link to the full changelog.
 - Added a domain-level DMARC/SPF/DKIM mail-authentication wizard entry point that renders generated target records as ordered setup steps.
 - Added an explicit AI redaction mode for operators who want to preserve email addresses and domains in AI context while still protecting secrets and opaque tokens.

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -449,10 +449,20 @@ def _verified_fixed_items(
                 "state": "verified_fixed",
                 "verified": True,
                 "label": "Verified fixed",
+                "verification_status": "no_longer_observed",
+                "verification_method": "current_queue_absence",
                 "detail": (
                     "This remediation item was marked resolved and no longer appears "
                     "in the current remediation queue."
                 ),
+                "next_check": (
+                    "Keep monitoring new DMARC reports and DNS refreshes; reopen only if "
+                    "the same finding returns."
+                ),
+                "evidence_needed": [
+                    "Current remediation queue does not contain this item ID.",
+                    "Latest operator lifecycle marker is resolved.",
+                ],
                 "recorded_at": _audit_timestamp(row.created_at),
                 "operator_note": details.get("operator_note"),
                 "actor_type": row.actor_type,

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -442,7 +442,7 @@
                                                   x-text="verified.verification_status ? verified.verification_status.replaceAll('_', ' ') : 'verified'"></span>
                                             <span class="rounded bg-[#f6f8fb] px-2 py-1 text-[#45505f]"
                                                   x-show="verified.verification_method"
-                                                  x-text="verified.verification_method.replaceAll('_', ' ')"></span>
+                                                  x-text="String(verified.verification_method || '').replaceAll('_', ' ')"></span>
                                         </div>
                                         <p class="mt-2 text-[#5f5c78]">
                                             <span x-text="verified.next_check || 'Keep monitoring this repair; no DNS or mail settings were changed by this verification marker.'"></span>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -437,9 +437,25 @@
                                                   x-text="verified.label"></span>
                                         </div>
                                         <p class="mt-2 text-[#45505f]" x-text="verified.detail"></p>
+                                        <div class="mt-2 flex flex-wrap gap-2">
+                                            <span class="rounded bg-[#edf7f5] px-2 py-1 font-semibold text-[#1f7c83]"
+                                                  x-text="verified.verification_status ? verified.verification_status.replaceAll('_', ' ') : 'verified'"></span>
+                                            <span class="rounded bg-[#f6f8fb] px-2 py-1 text-[#45505f]"
+                                                  x-show="verified.verification_method"
+                                                  x-text="verified.verification_method.replaceAll('_', ' ')"></span>
+                                        </div>
                                         <p class="mt-2 text-[#5f5c78]">
-                                            <span>Keep monitoring this repair; no DNS or mail settings were changed by this verification marker.</span>
+                                            <span x-text="verified.next_check || 'Keep monitoring this repair; no DNS or mail settings were changed by this verification marker.'"></span>
                                         </p>
+                                        <ul class="mt-2 space-y-1 text-[#45505f]" x-show="(verified.evidence_needed || []).length">
+                                            <template x-for="evidence in (verified.evidence_needed || []).slice(0, 3)"
+                                                      :key="verified.item_id + '-verified-evidence-' + evidence">
+                                                <li class="flex gap-2">
+                                                    <span class="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[#2f9da5]"></span>
+                                                    <span x-text="evidence"></span>
+                                                </li>
+                                            </template>
+                                        </ul>
                                         <p class="mt-2 rounded bg-[#f6f8fb] px-2 py-1 text-[#45505f]"
                                            x-show="verified.operator_note"
                                            x-text="verified.operator_note"></p>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1221,6 +1221,7 @@ def test_domain_details_distinguishes_evidence_verified_repairs_without_html_inj
     assert "verified.detail" in template
     assert "verified.verification_status" in template
     assert "verified.verification_method" in template
+    assert "String(verified.verification_method || '').replaceAll('_', ' ')" in template
     assert "verified.next_check" in template
     assert "verified.evidence_needed" in template
     assert "verified.operator_note" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1219,6 +1219,10 @@ def test_domain_details_distinguishes_evidence_verified_repairs_without_html_inj
     assert "verified.item_id" in template
     assert "verified.label" in template
     assert "verified.detail" in template
+    assert "verified.verification_status" in template
+    assert "verified.verification_method" in template
+    assert "verified.next_check" in template
+    assert "verified.evidence_needed" in template
     assert "verified.operator_note" in template
     assert "formatIsoDate(verified.recorded_at)" in template
     assert "verified.actor_type" in template

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -379,10 +379,20 @@ def test_attach_remediation_dispatch_previews_reports_verified_fixed_items(db_se
             "state": "verified_fixed",
             "verified": True,
             "label": "Verified fixed",
+            "verification_status": "no_longer_observed",
+            "verification_method": "current_queue_absence",
             "detail": (
                 "This remediation item was marked resolved and no longer appears "
                 "in the current remediation queue."
             ),
+            "next_check": (
+                "Keep monitoring new DMARC reports and DNS refreshes; reopen only if "
+                "the same finding returns."
+            ),
+            "evidence_needed": [
+                "Current remediation queue does not contain this item ID.",
+                "Latest operator lifecycle marker is resolved.",
+            ],
             "recorded_at": "2026-07-01T08:00:00Z",
             "operator_note": "Record is now visible after propagation.",
             "actor_type": "operator",

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -831,6 +831,12 @@ readiness counters, including `dispatch_ready`, `dispatch_blocked`,
 notifications from items blocked by settings, routing, or operator
 acknowledgement.
 
+When a previously resolved remediation item no longer appears in the current
+queue, the response includes it in `verified_items`. These entries include
+`verification_status`, `verification_method`, `next_check`, and bounded
+`evidence_needed` text so clients can explain why the repair is evidence
+verified instead of only operator-marked resolved.
+
 Each notification also includes a compact `history` array derived from
 workspace audit events for the current queue item. The history lists recent
 lifecycle markers and explicit dispatch enqueue events with timestamp, actor

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -834,7 +834,7 @@ acknowledgement.
 When a previously resolved remediation item no longer appears in the current
 queue, the response includes it in `verified_items`. These entries include
 `verification_status`, `verification_method`, `next_check`, and bounded
-`evidence_needed` text so clients can explain why the repair is evidence
+`evidence_needed` string lists so clients can explain why the repair is evidence
 verified instead of only operator-marked resolved.
 
 Each notification also includes a compact `history` array derived from

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -205,6 +205,12 @@ waiting for review, already acknowledged, or already queued for the configured
 webhook route. The timeline is read-only and highlights that remediation
 notification handling does not perform DNS writes.
 
+The same remediation section also highlights evidence-verified repairs. These
+are items an operator marked resolved that no longer appear in the current
+remediation queue. DMARQ shows the verification status, verification method,
+next check, and evidence needed so operators can distinguish current evidence
+from manual bookkeeping.
+
 If an operator selects a different provider than the nameserver-detected
 provider, DMARQ blocks the preview/apply request by default. The mismatch can be
 overridden only with an explicit confirmation that the selected provider


### PR DESCRIPTION
## Summary
- add explicit verification metadata to evidence-verified remediation repairs
- show verification status, method, next check, and evidence on domain detail pages
- document the verified-items payload for API and operator docs

## Why
#384 needs the product to distinguish operator bookkeeping from evidence-backed repair. A resolved marker alone is not enough; the UI should explain why DMARQ now considers an old item no longer active.

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py::test_attach_remediation_dispatch_previews_reports_verified_fixed_items backend/app/tests/test_dashboard_template_security.py::test_domain_details_distinguishes_evidence_verified_repairs_without_html_injection -q`
- `.venv/bin/python -m black backend/app/services/remediation_dispatch.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_dashboard_template_security.py`
- `.venv/bin/python -m flake8 backend/app/services/remediation_dispatch.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_dashboard_template_security.py`
- `node --check backend/app/static/js/domain-details-page.js`
- `git diff --check`

Part of #384
