### PR TITLE
Fix remediation loop decision metadata

### DIFF
--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -101,9 +101,9 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
                 for path in item.get("action_plan", {}).get("guidance_paths", [])
             )
         ),
-        "manual_only": sum(1 for item in items if _remediation_track(item) == "manual_only"),
+        "manual_only": sum(1 for item in items if item.get("remediation_track") == "manual_only"),
         "blocked_by_prerequisite": sum(
-            1 for item in items if _remediation_track(item) == "blocked_by_prerequisite"
+            1 for item in items if item.get("remediation_track") == "blocked_by_prerequisite"
         ),
         "notify_approval_required": sum(
             1 for item in items if item.get("notification", {}).get("state") == "approval_required"

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1011,7 +1011,8 @@ function domainDetailsApp(domainId = '') {
                     'mark_unknown',
                     'convert_to_manual_action',
                     'resolved',
-                    'snoozed'
+                    'snoozed',
+                    'rejected'
                 ],
                 manual_action: [
                     'acknowledged',

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1205,6 +1205,18 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "x-html" not in template
 
 
+def test_domain_details_investigation_actions_include_rejection_option():
+    """The UI should expose every investigation lifecycle decision from the API."""
+    script = _domain_details_script()
+    investigate_start = script.index("investigate: [")
+    investigate_end = script.index("],", investigate_start)
+    investigate_actions = script[investigate_start:investigate_end]
+
+    assert "'mark_legitimate'" in investigate_actions
+    assert "'convert_to_manual_action'" in investigate_actions
+    assert "'rejected'" in investigate_actions
+
+
 def test_domain_details_distinguishes_evidence_verified_repairs_without_html_injection():
     template = _domain_details_template()
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2315,6 +2315,24 @@ def test_summary_includes_current_remediation_loop(
     assert domain["remediation_workload"]["primary"]["title"]
 
 
+def test_dashboard_remediation_loop_is_clear_without_current_actions():
+    """Empty dashboard input should publish a stable no-work remediation loop."""
+    loop = domains_endpoint._build_dashboard_remediation_loop(
+        domains=[{"domain_name": DOMAIN, "health": {"actions": []}}],
+        remediation_activity={"summary": {"resolved": 2, "verified_fixed": 1}},
+    )
+
+    assert loop["status"] == "clear"
+    assert loop["loop_status"] == "clear"
+    assert loop["next_action"] == (
+        "No current remediation work; keep importing reports and monitoring DNS."
+    )
+    assert loop["total_open"] == 0
+    assert loop["items"] == []
+    assert loop["resolved"] == 2
+    assert loop["verified_fixed"] == 1
+
+
 @pytest.mark.parametrize(
     "action_type",
     ["source_reputation_listed", "source_reputation_review"],

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -1,5 +1,6 @@
 from app.services.remediation_queue import (
     _remediation_notification_payload,
+    _summary,
     build_remediation_queue,
 )
 
@@ -338,6 +339,29 @@ def test_remediation_queue_requires_recommended_provider_for_automation():
     assert queue["items"][0]["notification"]["event"] == (
         "dmarq.remediation.manual_action_required"
     )
+
+
+def test_remediation_summary_uses_stored_tracks_after_metadata_application():
+    """Summary counters should match each item's published remediation track."""
+    summary = _summary(
+        [
+            {
+                "state": "manual_action",
+                "source": "dns_lint",
+                "remediation_track": "manual_only",
+                "notification": {"state": "summary_only"},
+            },
+            {
+                "state": "manual_action",
+                "source": "health_score",
+                "remediation_track": "blocked_by_prerequisite",
+                "notification": {"state": "summary_only"},
+            },
+        ]
+    )
+
+    assert summary["manual_only"] == 1
+    assert summary["blocked_by_prerequisite"] == 1
 
 
 def test_remediation_queue_adds_generic_operator_guidance_for_health_actions():


### PR DESCRIPTION
## Summary
- expose the rejected lifecycle decision for investigation items in the domain details UI
- count remediation summary tracks from the already-published item metadata
- add focused regression coverage for stored track counts and clear dashboard loop state

## Validation
- git diff --check
- .venv/bin/python -m py_compile backend/app/services/remediation_queue.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 120 .venv/bin/python -m pytest backend/app/tests/test_remediation_queue.py::test_remediation_summary_uses_stored_tracks_after_metadata_application backend/app/tests/test_dns_endpoints.py::test_dashboard_remediation_loop_is_clear_without_current_actions backend/app/tests/test_dashboard_template_security.py::test_domain_details_investigation_actions_include_rejection_option -q (timed out during test startup with no output; same local dmarq pytest startup hang as prior runs)