### PR TITLE
feat: refine remediation operator queue flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard and domain detail pages now expose more actionable remediation context around DNS, DMARC, source authentication, and ownership state.
 - Remediation queues now expose incident families, loop state, priority scores, operator decisions, and provider/self-hosted/manual tracks across the domain detail UI, public API, and MCP.
 - Domain remediation cards now explain the verification method, freshness requirement, failure mode, and operator decision summary before an item can be treated as fixed.
+- Dashboard remediation cards now use the same priority-band, remediation-track, risk, and operator-decision language as the domain detail queue.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added human-approved DNS repair groundwork for provider-connected domains.
 - Added self-hosted demo refinements focused on the single-user, multiple-domain workflow.
 - Added richer remediation-loop verification context, including priority bands, risk labels, safe-automation flags, verified-fixed totals, and next-check evidence for resolved items that no longer appear in the active queue.
+- Added a domain remediation queue refresh control and expandable evidence-verified repair list for operators reviewing historical fixes.
 
 ### Changed
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain remediation actions now capture optional operator notes and show every notification dispatch blocker instead of only the first reason.
 - Domain remediation cards now show confidence and prerequisite context before the operator opens or approves a repair.
 - Dashboard action-plan cards now deep-link to the selected domain remediation queue instead of the generic domain overview.
+- Remediation queue summaries now expose hidden verified-repair counts separately from the visible compact list.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard remediation cards now use the same priority-band, remediation-track, risk, and operator-decision language as the domain detail queue.
 - Domain remediation actions now capture optional operator notes and show every notification dispatch blocker instead of only the first reason.
 - Domain remediation cards now show confidence and prerequisite context before the operator opens or approves a repair.
+- Dashboard action-plan cards now deep-link to the selected domain remediation queue instead of the generic domain overview.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain remediation cards now explain the verification method, freshness requirement, failure mode, and operator decision summary before an item can be treated as fixed.
 - Dashboard remediation cards now use the same priority-band, remediation-track, risk, and operator-decision language as the domain detail queue.
 - Domain remediation actions now capture optional operator notes and show every notification dispatch blocker instead of only the first reason.
+- Domain remediation cards now show confidence and prerequisite context before the operator opens or approves a repair.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remediation queues now expose incident families, loop state, priority scores, operator decisions, and provider/self-hosted/manual tracks across the domain detail UI, public API, and MCP.
 - Domain remediation cards now explain the verification method, freshness requirement, failure mode, and operator decision summary before an item can be treated as fixed.
 - Dashboard remediation cards now use the same priority-band, remediation-track, risk, and operator-decision language as the domain detail queue.
+- Domain remediation actions now capture optional operator notes and show every notification dispatch blocker instead of only the first reason.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1810,6 +1810,13 @@ REMEDIATION_STATE_PRIORITY = {
     "manual_action": 30,
     "investigate": 20,
 }
+REMEDIATION_TRACKS = {
+    "provider_preview",
+    "manual_dns",
+    "sender_investigation",
+    "reputation_review",
+    "self_hosted_or_provider",
+}
 
 
 def _remediation_loop_state(action: Dict[str, Any]) -> str:
@@ -1908,6 +1915,17 @@ def _remediation_priority_score(state: str, action: Dict[str, Any]) -> int:
     return severity + state_priority + min(impact, 50)
 
 
+def _remediation_priority_band(state: str, action: Dict[str, Any]) -> str:
+    score = _remediation_priority_score(state, action)
+    if score >= 400:
+        return "urgent"
+    if score >= 300:
+        return "high"
+    if score >= 200:
+        return "normal"
+    return "watch"
+
+
 def _remediation_operator_decisions(state: str) -> List[str]:
     defaults = ["previewed", "acknowledged", "snoozed", "resolved", "rejected"]
     if state == "needs_approval":
@@ -1915,6 +1933,27 @@ def _remediation_operator_decisions(state: str) -> List[str]:
     if state == "investigate":
         return ["mark_legitimate", "mark_unknown", "convert_to_manual_action", *defaults]
     return defaults
+
+
+def _remediation_risk_level(state: str, action: Dict[str, Any]) -> str:
+    if state == "investigate":
+        return "high"
+    severity = str(action.get("severity") or "info")
+    if state == "needs_approval" or severity in {"critical", "high"}:
+        return "medium"
+    return "low"
+
+
+def _remediation_safe_to_automate(state: str) -> bool:
+    return state == "needs_approval"
+
+
+def _remediation_operator_decision_summary(state: str) -> str:
+    if state == "needs_approval":
+        return "Preview the exact DNS or policy change, then explicitly approve or reject it."
+    if state == "investigate":
+        return "Classify the sender or reputation finding before changing DNS or policy."
+    return "Complete the manual action, refresh evidence, then mark the item resolved."
 
 
 def _dashboard_remediation_item(
@@ -1934,6 +1973,10 @@ def _dashboard_remediation_item(
         "incident_type": _remediation_incident_type(action),
         "remediation_track": _remediation_track_for_action(state, action),
         "priority_score": priority_score,
+        "priority_band": _remediation_priority_band(state, action),
+        "risk_level": _remediation_risk_level(state, action),
+        "safe_to_automate": _remediation_safe_to_automate(state),
+        "operator_decision_summary": _remediation_operator_decision_summary(state),
         "operator_decisions": _remediation_operator_decisions(state),
         "severity": str(action.get("severity") or "info"),
         "title": str(action.get("title") or "Review remediation item"),
@@ -1963,6 +2006,7 @@ def _build_dashboard_remediation_loop(
         "manual_action": 0,
         "investigate": 0,
     }
+    track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
 
     for domain in domains:
@@ -1971,7 +2015,9 @@ def _build_dashboard_remediation_loop(
         for action in health.get("actions") or []:
             state = _remediation_loop_state(action)
             counters[state] += 1
-            items.append(_dashboard_remediation_item(domain_name, action))
+            item = _dashboard_remediation_item(domain_name, action)
+            track_counters[f"track_{item['remediation_track']}"] += 1
+            items.append(item)
 
     items.sort(
         key=lambda item: (
@@ -1996,6 +2042,7 @@ def _build_dashboard_remediation_loop(
         next_action = "No current remediation work; keep importing reports and monitoring DNS."
     return {
         **counters,
+        **track_counters,
         "total_open": total_open,
         "loop_status": loop_status,
         "next_action": next_action,
@@ -2017,12 +2064,15 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         "manual_action": 0,
         "investigate": 0,
     }
+    track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
     domain_name = str(domain.get("domain_name") or domain.get("id") or "")
     for action in (domain.get("health") or {}).get("actions") or []:
         state = _remediation_loop_state(action)
         counters[state] += 1
-        items.append(_dashboard_remediation_item(domain_name, action, include_detail=False))
+        item = _dashboard_remediation_item(domain_name, action, include_detail=False)
+        track_counters[f"track_{item['remediation_track']}"] += 1
+        items.append(item)
 
     items.sort(
         key=lambda item: (
@@ -2034,6 +2084,7 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
     total_open = counters["needs_approval"] + counters["manual_action"] + counters["investigate"]
     return {
         **counters,
+        **track_counters,
         "total_open": total_open,
         "what_dmarq_can_fix": counters["needs_approval"],
         "what_needs_approval": counters["needs_approval"],

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.models.setting import Setting
@@ -464,9 +464,7 @@ def _verified_fixed_items_result(
         .subquery()
     )
     latest_lifecycle_ids = (
-        db.query(ranked_lifecycle_rows.c.audit_id)
-        .filter(ranked_lifecycle_rows.c.row_number == 1)
-        .subquery()
+        select(ranked_lifecycle_rows.c.audit_id).where(ranked_lifecycle_rows.c.row_number == 1)
     )
     verified_query = (
         db.query(WorkspaceAuditLog)

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -807,6 +807,15 @@ def _attach_dispatch_summary(
                 else len(verified_fixed_items or [])
             ),
             "dispatch_verified_fixed_visible": len(verified_fixed_items or []),
+            "dispatch_verified_fixed_hidden": max(
+                (
+                    verified_fixed_total
+                    if verified_fixed_total is not None
+                    else len(verified_fixed_items or [])
+                )
+                - len(verified_fixed_items or []),
+                0,
+            ),
         }
     )
     queue["summary"] = summary

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -952,7 +952,7 @@ function dashboardApp() {
 
         domainActionHref(action) {
             return action && action.domain
-                ? `/domains/${encodeURIComponent(action.domain)}`
+                ? `/domains/${encodeURIComponent(action.domain)}#remediation-queue`
                 : '/domains';
         },
 

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -932,6 +932,24 @@ function dashboardApp() {
             }[String(state || '')] || 'bg-[#f8f7f6] text-[#5f5c78]';
         },
 
+        remediationRiskClass(risk) {
+            return {
+                high: 'bg-red-100 text-red-700',
+                medium: 'bg-yellow-100 text-yellow-800',
+                low: 'bg-green-100 text-green-700'
+            }[String(risk || '').toLowerCase()] || 'bg-[#f8f7f6] text-[#5f5c78]';
+        },
+
+        remediationTrackLabel(track) {
+            return {
+                provider_preview: 'Provider preview',
+                manual_dns: 'Manual DNS',
+                sender_investigation: 'Sender investigation',
+                reputation_review: 'Reputation review',
+                self_hosted_or_provider: 'Provider or self-hosted'
+            }[String(track || '')] || 'Manual review';
+        },
+
         domainActionHref(action) {
             return action && action.domain
                 ? `/domains/${encodeURIComponent(action.domain)}`
@@ -1616,7 +1634,8 @@ function dashboardApp() {
             const latest = document.createElement('span');
             latest.className = 'text-xs text-muted-foreground whitespace-nowrap';
             if (workload?.primary?.state) {
-                latest.textContent = this.remediationLoopStateLabel(workload.primary.state);
+                const track = this.remediationTrackLabel(workload.primary.remediation_track);
+                latest.textContent = `${this.remediationLoopStateLabel(workload.primary.state)} · ${track}`;
             } else if (remediation?.latest_at) {
                 latest.textContent = new Date(remediation.latest_at).toLocaleString();
             } else {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -324,6 +324,21 @@ function domainDetailsApp(domainId = '') {
             this.recordRemediationLifecycle(item, action);
         },
 
+        remediationActionNote(action) {
+            if (!window.prompt) {
+                return '';
+            }
+            const label = this.remediationDecisionLabel(action || 'decision');
+            const note = window.prompt(
+                `Optional operator note for "${label}" (leave blank to continue):`,
+                ''
+            );
+            if (note === null) {
+                return null;
+            }
+            return String(note || '').trim();
+        },
+
         handleMigrationAction(action) {
             const handlers = {
                 enable: () => this.enableMigrationTools(),
@@ -1654,6 +1669,10 @@ function domainDetailsApp(domainId = '') {
                 };
                 return;
             }
+            const note = this.remediationActionNote(lifecycleState);
+            if (note === null) {
+                return;
+            }
             this.remediationAction = {
                 itemId: item.id,
                 action: lifecycleState,
@@ -1671,7 +1690,8 @@ function domainDetailsApp(domainId = '') {
                             item_id: item.id,
                             lifecycle_state: lifecycleState,
                             event: notification.event,
-                            dedupe_key: notification.dedupe_key
+                            dedupe_key: notification.dedupe_key,
+                            note
                         })
                     }
                 );
@@ -1715,6 +1735,10 @@ function domainDetailsApp(domainId = '') {
             if (!window.confirm('Dispatch this remediation notification to the configured webhook route? This does not make DNS changes.')) {
                 return;
             }
+            const note = this.remediationActionNote('dispatch');
+            if (note === null) {
+                return;
+            }
             this.remediationAction = {
                 itemId: item.id,
                 action: 'dispatch',
@@ -1732,7 +1756,8 @@ function domainDetailsApp(domainId = '') {
                             item_id: item.id,
                             confirm: true,
                             event: notification.event,
-                            dedupe_key: notification.dedupe_key
+                            dedupe_key: notification.dedupe_key,
+                            note
                         })
                     }
                 );

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -88,6 +88,7 @@ function domainDetailsApp(domainId = '') {
                 dispatch_webhook_routes: 0,
                 dispatch_verified_fixed: 0,
                 dispatch_verified_fixed_visible: 0,
+                dispatch_verified_fixed_hidden: 0,
                 track_provider_preview: 0,
                 track_manual_dns: 0,
                 track_sender_investigation: 0,
@@ -100,6 +101,8 @@ function domainDetailsApp(domainId = '') {
         },
         remediationQueueLoading: true,
         remediationQueueError: '',
+        showAllVerifiedRemediationItems: false,
+        remediationQueueLoadedAt: '',
         remediationAction: {
             itemId: '',
             action: '',
@@ -272,9 +275,15 @@ function domainDetailsApp(domainId = '') {
                 } else if (button.matches('[data-domain-detail-remediation-action]')) {
                     event.preventDefault();
                     this.handleRemediationAction(button);
-                } else if (button.matches('[data-domain-detail-remediation-retry]')) {
+                } else if (
+                    button.matches('[data-domain-detail-remediation-retry]') ||
+                    button.matches('[data-domain-detail-remediation-refresh]')
+                ) {
                     event.preventDefault();
                     this.fetchRemediationQueue();
+                } else if (button.matches('[data-domain-detail-verified-repairs-toggle]')) {
+                    event.preventDefault();
+                    this.showAllVerifiedRemediationItems = !this.showAllVerifiedRemediationItems;
                 } else if (button.matches('[data-domain-detail-migration-action]')) {
                     event.preventDefault();
                     this.handleMigrationAction(button.dataset.domainDetailMigrationAction);
@@ -1019,8 +1028,17 @@ function domainDetailsApp(domainId = '') {
         },
 
         verifiedItemsHiddenCount() {
+            const hidden = this.remediationQueue.summary?.dispatch_verified_fixed_hidden;
+            if (hidden !== undefined && hidden !== null) {
+                return Math.max(Number(hidden) || 0, 0);
+            }
             const visible = (this.remediationQueue.verified_items || []).length;
             return Math.max(this.verifiedItemsTotalCount() - visible, 0);
+        },
+
+        visibleVerifiedItems() {
+            const items = this.remediationQueue.verified_items || [];
+            return this.showAllVerifiedRemediationItems ? items : items.slice(0, 4);
         },
 
         remediationDecisionLabel(value) {
@@ -1590,6 +1608,8 @@ function domainDetailsApp(domainId = '') {
         },
 
         resetRemediationQueue() {
+            this.showAllVerifiedRemediationItems = false;
+            this.remediationQueueLoadedAt = '';
             this.remediationQueue = {
                 status: 'unavailable',
                 loop: {
@@ -1618,6 +1638,7 @@ function domainDetailsApp(domainId = '') {
                     dispatch_webhook_routes: 0,
                     dispatch_verified_fixed: 0,
                     dispatch_verified_fixed_visible: 0,
+                    dispatch_verified_fixed_hidden: 0,
                     track_provider_preview: 0,
                     track_manual_dns: 0,
                     track_sender_investigation: 0,
@@ -1633,6 +1654,7 @@ function domainDetailsApp(domainId = '') {
         async fetchRemediationQueue() {
             this.remediationQueueLoading = true;
             this.remediationQueueError = '';
+            this.showAllVerifiedRemediationItems = false;
             try {
                 const response = await this.fetchWithTimeout(
                     `/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation`
@@ -1648,6 +1670,7 @@ function domainDetailsApp(domainId = '') {
                     return;
                 }
                 this.remediationQueue = await response.json();
+                this.remediationQueueLoadedAt = new Date().toISOString();
             } catch (error) {
                 console.error('Error fetching remediation queue:', error);
                 this.remediationQueueError = error.message || 'Remediation queue could not be loaded.';

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -364,8 +364,11 @@
                         <div>
                             <h3 class="font-semibold text-[#07071f]">Remediation Queue</h3>
                             <p class="mt-1 text-sm text-[#5f5c78]">Prioritized fixes with evidence, prerequisites, and approval status.</p>
+                            <p class="mt-1 text-xs text-[#5f5c78]" x-show="remediationQueueLoadedAt">
+                                <span>Updated </span><span x-text="formatIsoDate(remediationQueueLoadedAt)"></span>
+                            </p>
                         </div>
-                        <div class="flex flex-wrap gap-2 text-xs" x-show="!remediationQueueLoading && !remediationQueueError">
+                        <div class="flex flex-wrap items-center gap-2 text-xs" x-show="!remediationQueueLoading && !remediationQueueError">
                             <span class="rounded bg-white px-2 py-1 font-semibold text-[#272a5f]">
                                 <span x-text="remediationQueue.summary.total"></span><span> open</span>
                             </span>
@@ -393,6 +396,12 @@
                             <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700">
                                 <span x-text="remediationQueue.summary.dispatch_verified_fixed || 0"></span><span> verified fixed</span>
                             </span>
+                            <button type="button"
+                                    class="btn btn-outline btn-xs"
+                                    :disabled="remediationQueueLoading"
+                                    data-domain-detail-remediation-refresh>
+                                Refresh queue
+                            </button>
                         </div>
                     </div>
                     <template x-if="remediationQueueLoading">
@@ -428,7 +437,7 @@
                                 </span>
                             </div>
                             <div class="mt-2 grid gap-2 md:grid-cols-2">
-                                <template x-for="verified in remediationQueue.verified_items.slice(0, 4)"
+                                <template x-for="verified in visibleVerifiedItems()"
                                           :key="'verified-' + verified.item_id">
                                     <div class="rounded border border-[#d8ebe8] bg-white px-3 py-2 text-xs">
                                         <div class="flex flex-wrap items-center justify-between gap-2">
@@ -471,9 +480,20 @@
                                     </div>
                                 </template>
                             </div>
-                            <p class="mt-2 text-xs text-[#5f5c78]" x-show="verifiedItemsHiddenCount() > 0">
-                                <span>+</span><span x-text="verifiedItemsHiddenCount()"></span><span> older verified repairs hidden from this compact view.</span>
-                            </p>
+                            <div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs"
+                                 x-show="verifiedItemsHiddenCount() > 0 || showAllVerifiedRemediationItems">
+                                <p class="text-[#5f5c78]" x-show="!showAllVerifiedRemediationItems && verifiedItemsHiddenCount() > 0">
+                                    <span>+</span><span x-text="verifiedItemsHiddenCount()"></span><span> older verified repairs hidden from this compact view.</span>
+                                </p>
+                                <p class="text-[#5f5c78]" x-show="showAllVerifiedRemediationItems">
+                                    <span>Showing </span><span x-text="(remediationQueue.verified_items || []).length"></span><span> recent verified repairs.</span>
+                                </p>
+                                <button type="button"
+                                        class="btn btn-outline btn-xs"
+                                        data-domain-detail-verified-repairs-toggle
+                                        x-text="showAllVerifiedRemediationItems ? 'Show compact view' : 'Show all visible repairs'">
+                                </button>
+                            </div>
                         </div>
                     </template>
                     <template x-if="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length > 0">

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -527,6 +527,9 @@
                                                       :class="remediationSeverityDotClass(item.severity)"></span>
                                                 <span x-text="item.severity"></span>
                                             </span>
+                                            <span class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#5f5c78] capitalize">
+                                                <span x-text="item.confidence || 'medium'"></span><span> confidence</span>
+                                            </span>
                                             <span class="text-xs text-[#5f5c78]" x-text="item.source.replace('_', ' ')"></span>
                                             <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]"
                                                   x-text="remediationIncidentLabel(item.incident_type)"></span>
@@ -565,6 +568,20 @@
                                         <p class="mt-2 text-sm text-[#120d36]" x-text="item.action_plan.diagnosis"></p>
                                         <p class="mt-2 rounded bg-white px-3 py-2 text-xs text-[#45505f]"
                                            x-text="item.action_plan.operator_decision_summary || 'Review and record an operator decision before closing this item.'"></p>
+                                        <template x-if="(item.action_plan.prerequisites || item.prerequisites || []).length">
+                                            <div class="mt-3 rounded border border-[#d8ebe8] bg-white p-3">
+                                                <p class="text-xs font-semibold uppercase text-[#1f7c83]">Prerequisites</p>
+                                                <ul class="mt-2 space-y-1 text-sm text-[#45505f]">
+                                                    <template x-for="prerequisite in (item.action_plan.prerequisites || item.prerequisites || []).slice(0, 4)"
+                                                              :key="item.id + '-prerequisite-' + prerequisite">
+                                                        <li class="flex gap-2">
+                                                            <span class="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[#2f9da5]"></span>
+                                                            <span x-text="prerequisite"></span>
+                                                        </li>
+                                                    </template>
+                                                </ul>
+                                            </div>
+                                        </template>
                                         <ol class="mt-3 space-y-1 text-sm text-[#45505f]">
                                             <template x-for="step in (item.action_plan.steps || []).slice(0, 4)" :key="item.id + '-plan-' + step">
                                                 <li class="flex gap-2">

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -558,6 +558,8 @@
                                                 <span class="rounded px-2 py-1 text-xs font-semibold capitalize"
                                                       :class="remediationRiskClass(item.action_plan.risk_level || 'medium')"
                                                       x-text="item.action_plan.risk_level || 'medium'"></span>
+                                                <span class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#5f5c78]"
+                                                      x-text="item.action_plan.safe_to_automate ? 'safe preview' : 'manual review'"></span>
                                             </div>
                                         </div>
                                         <p class="mt-2 text-sm text-[#120d36]" x-text="item.action_plan.diagnosis"></p>
@@ -637,7 +639,15 @@
                                         </div>
                                         <p class="mt-2 text-sm text-[#120d36]" x-text="remediationDispatchNextStep(item.notification.dispatch)"></p>
                                         <template x-if="(item.notification.dispatch.blocked_reasons || []).length">
-                                            <p class="mt-1 text-xs text-[#5f5c78]" x-text="item.notification.dispatch.blocked_reasons[0]"></p>
+                                            <ul class="mt-2 space-y-1 text-xs text-[#5f5c78]">
+                                                <template x-for="reason in item.notification.dispatch.blocked_reasons"
+                                                          :key="item.id + '-dispatch-blocker-' + reason">
+                                                    <li class="flex gap-2">
+                                                        <span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[#b45309]"></span>
+                                                        <span x-text="reason"></span>
+                                                    </li>
+                                                </template>
+                                            </ul>
                                         </template>
                                         <template x-if="item.notification.dispatch.verification">
                                             <div class="mt-3 rounded border border-[#e6e3e1] bg-white px-3 py-2 text-xs">

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -252,10 +252,17 @@
                             <span class="inline-flex rounded-md px-2 py-1 text-xs font-semibold"
                                   :class="remediationLoopStateClass(item.state)"
                                   x-text="remediationLoopStateLabel(item.state)"></span>
+                            <span class="ml-2 inline-flex rounded-md bg-[#f8f7f6] px-2 py-1 text-xs font-semibold text-[#5f5c78]"
+                                  x-text="remediationTrackLabel(item.remediation_track)"></span>
                             <h3 class="mt-2 font-semibold text-[#120d36]" x-text="item.title"></h3>
                         </div>
-                        <span class="rounded-full bg-[#f8f7f6] px-3 py-1 text-xs font-semibold text-[#5f5c78]"
-                              x-text="item.severity"></span>
+                        <div class="flex shrink-0 flex-col items-end gap-1">
+                            <span class="rounded-full bg-[#f8f7f6] px-3 py-1 text-xs font-semibold text-[#5f5c78]"
+                                  x-text="item.severity"></span>
+                            <span class="rounded-full px-3 py-1 text-xs font-semibold capitalize"
+                                  :class="remediationRiskClass(item.risk_level)"
+                                  x-text="item.priority_band || 'watch'"></span>
+                        </div>
                     </div>
                     <p class="mt-2 text-sm text-[#5f5c78]" x-text="item.detail"></p>
                     <p class="mt-2 text-sm font-semibold text-[#272a5f]" x-text="item.next_step"></p>
@@ -269,6 +276,8 @@
                             <p class="mt-1 text-[#120d36]" x-text="item.completion_criteria"></p>
                         </div>
                     </div>
+                    <p class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3 text-xs text-[#5f5c78]"
+                       x-text="item.operator_decision_summary"></p>
                     <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3 text-xs">
                         <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Next verification</p>
                         <p class="mt-1 text-[#120d36]" x-text="item.verification_next_check"></p>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -133,7 +133,7 @@
                     <div class="flex items-start justify-between gap-3">
                         <div>
                             <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Action Plan</h2>
-                            <p class="mt-1 text-sm text-[#5f5c78]">Prioritized fixes with expected score impact.</p>
+                            <p class="mt-1 text-sm text-[#5f5c78]">Prioritized fixes linked to domain remediation queues.</p>
                         </div>
                         <a href="/domains" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open domains</a>
                     </div>
@@ -171,6 +171,7 @@
                                 </div>
                                 <p class="mt-2 text-sm font-semibold text-[#272a5f]" x-text="action.next_step"></p>
                                 <p class="mt-2 text-xs text-[#5f5c78]" x-text="action.domain"></p>
+                                <p class="mt-1 text-xs font-semibold text-[#247982]">Open remediation queue</p>
                             </a>
                         </template>
                     </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -355,6 +355,14 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert 'x-text="verifiedItemsTotalCount()"' in template
     assert "verified_items_total" in script
     assert "verifiedItemsHiddenCount()" in template
+    assert "visibleVerifiedItems()" in template
+    assert "data-domain-detail-remediation-refresh" in template
+    assert "data-domain-detail-verified-repairs-toggle" in template
+    assert "fetchRemediationQueue()" in script
+    assert "showAllVerifiedRemediationItems = !this.showAllVerifiedRemediationItems" in script
+    assert "remediationQueueLoadedAt" in template
+    assert "formatIsoDate(remediationQueueLoadedAt)" in template
+    assert "remediationQueueLoadedAt" in script
     assert "verified.verification_method" in template
     assert "verified.verification_status" in template
     assert "verified.next_check" in template
@@ -1267,8 +1275,13 @@ def test_domain_details_distinguishes_evidence_verified_repairs_without_html_inj
     ) in template
     assert "Keep monitoring this repair; no DNS or mail settings were changed" in template
     assert "const visible = (this.remediationQueue.verified_items || []).length" in script
+    assert "dispatch_verified_fixed_hidden" in script
     assert "this.verifiedItemsTotalCount() - visible" in script
-    assert "remediationQueue.verified_items.slice(0, 4)" in template
+    assert "visibleVerifiedItems()" in template
+    assert "showAllVerifiedRemediationItems" in template
+    assert "Show compact view" in template
+    assert "Show all visible repairs" in template
+    assert "items.slice(0, 4)" in script
     assert "verified.item_id" in template
     assert "verified.label" in template
     assert "verified.detail" in template
@@ -1378,10 +1391,8 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "Remediation queue could not be loaded." in script
     assert "Retry remediation queue" in template
     assert "data-domain-detail-remediation-retry" in template
-    assert (
-        '<div class="flex flex-wrap gap-2 text-xs" x-show="!remediationQueueLoading && !remediationQueueError">'
-        in template
-    )
+    assert 'x-show="!remediationQueueLoading && !remediationQueueError"' in template
+    assert "flex flex-wrap items-center gap-2 text-xs" in template
     assert "remediationQueue.summary.total" in template
     assert "remediationQueue.summary.approval_ready" in template
     assert "remediationQueue.summary.manual_action" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -329,6 +329,7 @@ def test_dashboard_remediation_loop_uses_resolved_language():
 
 def test_dashboard_remediation_cards_show_owner_and_completion_context():
     template = _dashboard_template()
+    script = _dashboard_script()
 
     assert "Owner" in template
     assert "Done when" in template
@@ -336,6 +337,12 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert 'x-text="item.owner"' in template
     assert 'x-text="item.completion_criteria"' in template
     assert 'x-text="item.verification_next_check"' in template
+    assert "remediationTrackLabel(item.remediation_track)" in template
+    assert "remediationRiskClass(item.risk_level)" in template
+    assert "item.priority_band || 'watch'" in template
+    assert "item.operator_decision_summary" in template
+    assert "remediationRiskClass(risk)" in script
+    assert "remediationTrackLabel(track)" in script
 
 
 def test_domain_details_remediation_queue_shows_verification_context():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1203,7 +1203,9 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
 
     assert "Remediation Queue" in template
     assert "Action plan" in template
+    assert "item.confidence" in template
     assert "item.action_plan.owner" in template
+    assert "item.action_plan.prerequisites" in template
     assert "item.action_plan.steps" in template
     assert "item.action_plan.completion_criteria" in template
     assert "item.action_plan.safe_to_automate" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1206,11 +1206,14 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "item.action_plan.owner" in template
     assert "item.action_plan.steps" in template
     assert "item.action_plan.completion_criteria" in template
+    assert "item.action_plan.safe_to_automate" in template
     assert "Verification" in template
     assert "item.verification_plan.status" in template
     assert "item.verification_plan.evidence_needed" in template
     assert "item.verification_plan.next_check" in template
     assert "Notification dispatch" in template
+    assert "item.notification.dispatch.blocked_reasons" in template
+    assert "blocked_reasons[0]" not in template
     assert "Remediation loop" in template
     assert "remediationLoopStatusLabel" in template
     assert "remediationIncidentLabel" in template
@@ -1225,11 +1228,13 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "dispatchRemediationNotification(item)" not in template
     assert "handleRemediationAction" in script
     assert "remediationDecisionLabel" in script
+    assert "remediationActionNote(action)" in script
     assert "approve_after_preview" in script
     assert "mark_unknown" in script
     assert "humanizeToken" in script
     assert "/remediation/notifications/audit" in script
     assert "/remediation/notifications/dispatch" in script
+    assert "note" in script
     assert "No DNS changes were made" in script
     assert "x-html" not in template
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -309,10 +309,13 @@ def test_dashboard_remediation_cards_deep_link_to_domain_queue():
     template = _dashboard_template()
     script = _dashboard_script()
 
+    assert ':href="domainActionHref(action)"' in template
     assert ':href="domainRemediationHref(item.domain)"' in template
     assert "Open remediation queue" in template
+    assert "domainActionHref(action)" in script
     assert "domainRemediationHref(domainName)" in script
     assert "#remediation-queue" in script
+    assert "encodeURIComponent(action.domain)" in script
     assert "encodeURIComponent(domainName)" in script
 
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -862,6 +862,50 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
     ]
 
 
+def test_dashboard_remediation_loop_exposes_operator_decision_context():
+    """Workspace dashboard remediation cards use the same operator language as detail queues."""
+    loop = domains_endpoint._build_dashboard_remediation_loop(
+        [
+            {
+                "domain_name": "example.com",
+                "health": {
+                    "actions": [
+                        {
+                            "type": "missing_dmarc",
+                            "severity": "high",
+                            "title": "Publish DMARC",
+                            "detail": "No DMARC policy was found.",
+                            "next_step": "Publish a DMARC TXT record.",
+                            "score_impact": 30,
+                        },
+                        {
+                            "type": "source_reputation_review",
+                            "severity": "high",
+                            "title": "Review suspicious source",
+                            "detail": "A sending IP needs review.",
+                            "next_step": "Open source intelligence.",
+                            "score_impact": 10,
+                        },
+                    ]
+                },
+            }
+        ],
+        {"summary": {"resolved": 2, "verified_fixed": 1}},
+    )
+
+    assert loop["resolved"] == 2
+    assert loop["verified_fixed"] == 1
+    assert loop["track_provider_preview"] == 1
+    assert loop["track_reputation_review"] == 1
+    assert loop["items"][0]["priority_band"] == "high"
+    assert loop["items"][0]["safe_to_automate"] is True
+    assert loop["items"][0]["risk_level"] == "medium"
+    assert "Preview the exact DNS" in loop["items"][0]["operator_decision_summary"]
+    assert loop["items"][1]["remediation_track"] == "reputation_review"
+    assert loop["items"][1]["risk_level"] == "high"
+    assert loop["items"][1]["safe_to_automate"] is False
+
+
 def test_domain_remediation_dispatch_preview_becomes_eligible_without_enqueuing(
     seeded_client: TestClient,
     db_session,

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -145,6 +145,7 @@ def test_attach_remediation_dispatch_previews_adds_dashboard_summary(monkeypatch
     assert summary["dispatch_webhook_routes"] == 1
     assert summary["dispatch_verified_fixed"] == 0
     assert summary["dispatch_verified_fixed_visible"] == 0
+    assert summary["dispatch_verified_fixed_hidden"] == 0
 
 
 def test_attach_remediation_dispatch_previews_counts_operator_held_items(monkeypatch):
@@ -223,6 +224,7 @@ def test_attach_remediation_dispatch_previews_counts_operator_held_items(monkeyp
     assert result["summary"]["dispatch_snoozed"] == 0
     assert result["summary"]["dispatch_verified_fixed"] == 0
     assert result["summary"]["dispatch_verified_fixed_visible"] == 0
+    assert result["summary"]["dispatch_verified_fixed_hidden"] == 0
 
 
 def test_verification_state_covers_lifecycle_branches():
@@ -302,6 +304,7 @@ def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):
         "dispatch_snoozed": 0,
         "dispatch_verified_fixed": 0,
         "dispatch_verified_fixed_visible": 0,
+        "dispatch_verified_fixed_hidden": 0,
     }
     assert result["verified_items"] == []
     assert result["verified_items_total"] == 0
@@ -435,6 +438,7 @@ def test_verified_fixed_total_counts_beyond_visible_limit(db_session):
     assert result["verified_items_total"] == 45
     assert result["summary"]["dispatch_verified_fixed"] == 45
     assert result["summary"]["dispatch_verified_fixed_visible"] == 5
+    assert result["summary"]["dispatch_verified_fixed_hidden"] == 40
     assert len(result["verified_items"]) == 5
     assert result["verified_items"][0]["item_id"] == "dns:fixed-44"
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -838,9 +838,11 @@ notifications from items blocked by settings, routing, or operator
 acknowledgement. Resolved items that no longer appear in the current queue are
 returned as `verified_items`; `verified_items_total` and
 `dispatch_verified_fixed` report the scanned total even when the compact UI
-only displays the most recent rows. Each verified item includes its
-verification method, status, evidence requirements, next check, timestamp, and
-operator note.
+only displays the most recent rows. `dispatch_verified_fixed_visible` counts
+the returned rows, and `dispatch_verified_fixed_hidden` reports how many older
+verified repairs were omitted from the compact response. Each verified item
+includes its verification method, status, evidence requirements, next check,
+timestamp, and operator note.
 
 Each notification also includes a compact `history` array derived from
 workspace audit events for the current queue item. The history lists recent

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -823,8 +823,10 @@ next state transition that an operator workflow can use. Each notification also
 includes a read-only `dispatch` preview showing whether the item would be
 eligible for a future dispatch step, which channel would be used, whether a
 previewed or acknowledged lifecycle marker is still required, how many enabled
-webhook endpoints match the event, and why dispatch is currently blocked. Each
-item also includes a sanitized `payload_preview` using schema
+webhook endpoints match the event, and why dispatch is currently blocked. The
+`blocked_reasons` list is ordered and may contain multiple actionable blockers;
+clients should display the full list rather than only the first item. Each item
+also includes a sanitized `payload_preview` using schema
 `dmarq.remediation.notification.v1`; it is the deterministic data shape a
 future webhook, ticketing, or chatops delivery would receive. The endpoint does
 not perform DNS writes, enqueue webhook deliveries, or send notifications.
@@ -856,9 +858,9 @@ Supported lifecycle states are `previewed`, `acknowledged`, `snoozed`,
 `preview_change`, `approve_after_preview`, `mark_legitimate`, `mark_unknown`,
 and `convert_to_manual_action`. If `event` or `dedupe_key` is supplied, it
 must match the current queue item's notification metadata. The response
-includes the sanitized workspace audit row. This endpoint is deliberately
-audit-only: it does not enqueue webhook deliveries, send notifications, or
-attempt DNS writes.
+includes the sanitized workspace audit row, including the optional operator
+note when supplied. This endpoint is deliberately audit-only: it does not
+enqueue webhook deliveries, send notifications, or attempt DNS writes.
 
 `POST /domains/{domain_id}/remediation/notifications/dispatch` enqueues
 webhook deliveries for one current remediation item after explicit operator
@@ -868,9 +870,9 @@ the current queue item. The item's `dispatch.eligible` preview must already be
 true, which means dispatch is enabled, the event is configured, the channel is
 `webhook`, required lifecycle acknowledgement has been recorded, and at least
 one enabled webhook endpoint matches the event. The response includes persisted
-webhook delivery rows and a sanitized workspace audit row. The endpoint only
-queues notification delivery state; it does not send synchronously and never
-attempts DNS/provider writes.
+webhook delivery rows and a sanitized workspace audit row with the optional
+operator note. The endpoint only queues notification delivery state; it does
+not send synchronously and never attempts DNS/provider writes.
 
 The remediation dispatch preview is controlled by notification settings and is
 disabled by default:

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -106,9 +106,11 @@ whether remediation dispatch is enabled, whether the event is configured, if a
 previewed or acknowledged audit marker is still required, and whether an
 enabled webhook endpoint is subscribed to the event. This is a readiness check
 only; DMARQ does not enqueue webhook deliveries or send notifications from the
-queue view. The queue header summarizes how many items are ready to notify,
-blocked, awaiting acknowledgement, or covered by webhook routes so operators can
-see the next action without opening every item.
+queue view. The UI lists every dispatch blocker, not only the first one, so
+operators can fix settings, routing, acknowledgement, and webhook coverage in
+one pass. The queue header summarizes how many items are ready to notify,
+blocked, awaiting acknowledgement, or covered by webhook routes so operators
+can see the next action without opening every item.
 
 When an operator marks an item resolved and the same finding no longer appears
 in the current queue, the domain detail page lists it under evidence-verified
@@ -121,7 +123,14 @@ explicitly enqueue the notification through the dispatch API with
 `confirm=true`. Dispatch currently means "create persisted webhook delivery
 rows for configured endpoints"; it does not send from the queue view and does
 not apply DNS changes. The delivery history can then be inspected through the
-webhook delivery state.
+webhook delivery state. Lifecycle markers and dispatch requests may include an
+operator note; DMARQ stores that note in the audit trail and shows it in the
+recent operator history.
+
+Dashboard action-plan cards and remediation-loop cards both deep-link into the
+selected domain's remediation queue. Use those links when triaging workspace
+health: they keep the operator on the evidence and approval surface instead of
+dropping them on a generic domain overview.
 
 ### Source Intelligence
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -92,6 +92,8 @@ as approval-ready, manual, or investigate-only, and include the evidence,
 blast radius, prerequisites, and expected health-score impact. Approval-ready
 DNS items link back to the DNS change-plan review area; they still require an
 operator preview and explicit approval before any provider write is sent.
+Use **Refresh queue** to reload the remediation queue from the backend after
+new reports, DNS checks, or operator lifecycle changes are available.
 Each item now also shows the remediation track, priority band, owner, risk
 level, safe-automation flag, and the exact operator decision DMARQ expects next.
 Each item also shows a notification profile such as approval required, action
@@ -116,7 +118,9 @@ When an operator marks an item resolved and the same finding no longer appears
 in the current queue, the domain detail page lists it under evidence-verified
 repairs. That section shows how DMARQ verified the absence, what evidence was
 used, how many older verified repairs are hidden in the compact view, and what
-fresh reports or DNS checks should keep monitoring the fix.
+fresh reports or DNS checks should keep monitoring the fix. The compact view
+shows the newest verified repairs first and can be expanded to show every
+verified repair returned by the backend response.
 
 After a remediation notification is previewed or acknowledged, an operator can
 explicitly enqueue the notification through the dispatch API with


### PR DESCRIPTION
## Summary

This local wave continues #384 by tightening the remediation operator flow across dashboard, domain details, API payloads, docs, and changelog.

Changes included:
- Align dashboard remediation cards with the domain remediation queue context: remediation track, priority band, risk, and operator decision summary.
- Capture optional operator notes on remediation lifecycle/dispatch actions and show all dispatch blockers instead of only the first blocker.
- Surface remediation confidence, prerequisites, safe-to-automate context, and direct dashboard links into the domain remediation queue.
- Add expandable evidence-verified repairs, hidden verified-repair counts, a queue refresh control, and a last-updated timestamp on domain detail pages.
- Document the updated operator flow and API semantics.

## Validation

Local validation completed before pushing:
- `pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py::test_dashboard_remediation_loop_exposes_operator_decision_context -q` (`103 passed`)
- `cd backend && ../.venv/bin/python -m pytest -q` (`1845 passed`)
- `node --check backend/app/static/js/dashboard-page.js && node --check backend/app/static/js/domain-details-page.js`
- `flake8` on affected backend/test files
- `git diff --check origin/main...HEAD && git diff --check`

## Safety

No DNS/provider writes are introduced. The new controls refresh/read remediation state, record explicit operator notes when the operator chooses an action, and improve visibility into human-in-the-loop state.
