### PR TITLE
feat: surface remediation repair progression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added self-hosted demo refinements focused on the single-user, multiple-domain workflow.
 - Added richer remediation-loop verification context, including priority bands, risk labels, safe-automation flags, verified-fixed totals, and next-check evidence for resolved items that no longer appear in the active queue.
 - Added a domain remediation queue refresh control and expandable evidence-verified repair list for operators reviewing historical fixes.
+- Added explicit remediation repair-progression context so each queue item shows whether it is preview-ready, blocked by a prerequisite, waiting for sender classification, manual-only, or pending fresh verification evidence.
 
 ### Changed
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain remediation cards now show confidence and prerequisite context before the operator opens or approves a repair.
 - Dashboard action-plan cards now deep-link to the selected domain remediation queue instead of the generic domain overview.
 - Remediation queue summaries now expose hidden verified-repair counts separately from the visible compact list.
+- Remediation notification payloads now include the same repair-progression gates shown in the UI, keeping webhook/ticket previews aligned with human review.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -114,6 +114,27 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
         "blocked_by_prerequisite": sum(
             1 for item in items if item.get("remediation_track") == "blocked_by_prerequisite"
         ),
+        "repair_preview_ready": sum(
+            1
+            for item in items
+            if (item.get("repair_progression") or {}).get("stage") == "preview_ready"
+        ),
+        "repair_approval_pending": sum(
+            1
+            for item in items
+            if (item.get("repair_progression") or {}).get("stage")
+            == "approval_pending"
+        ),
+        "repair_blocked": sum(
+            1
+            for item in items
+            if (item.get("repair_progression") or {}).get("stage") == "blocked"
+        ),
+        "repair_needs_evidence": sum(
+            1
+            for item in items
+            if (item.get("repair_progression") or {}).get("verification_required")
+        ),
         "notify_approval_required": sum(
             1 for item in items if item.get("notification", {}).get("state") == "approval_required"
         ),
@@ -234,6 +255,92 @@ def _operator_decision_summary(item: Dict[str, Any]) -> str:
     return "Acknowledge the work, complete it manually, then mark it resolved only after fresh evidence confirms it."
 
 
+def _repair_progression_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the safe repair lane and gates without performing any mutation."""
+    automation = item.get("automation") or {}
+    track = str(item.get("remediation_track") or _remediation_track(item))
+    verification = item.get("verification_plan") or {}
+    state = str(item.get("state") or "")
+
+    if automation.get("eligible"):
+        return {
+            "stage": "preview_ready",
+            "label": "Preview ready",
+            "summary": "A connected DNS provider can prepare the exact mutation for review.",
+            "next_gate": "Human approval before apply",
+            "next_step": "Open the provider preview, compare old and new DNS values, then approve or reject.",
+            "can_preview": True,
+            "can_apply_after_approval": True,
+            "manual_fallback": True,
+            "verification_required": True,
+            "verification_status": str(verification.get("status") or "pending_operator_approval"),
+        }
+    if track == "blocked_by_prerequisite":
+        return {
+            "stage": "blocked",
+            "label": "Blocked by prerequisite",
+            "summary": "DMARQ needs a provider-specific value before this can become a safe repair.",
+            "next_gate": "Provider value required",
+            "next_step": "Fetch the exact DKIM, SPF, DMARC, or CNAME target from the mail provider first.",
+            "can_preview": False,
+            "can_apply_after_approval": False,
+            "manual_fallback": True,
+            "verification_required": True,
+            "verification_status": str(verification.get("status") or "pending_dns_refresh"),
+        }
+    if state == "investigate":
+        return {
+            "stage": "classification_required",
+            "label": "Classify sender",
+            "summary": "A human must decide whether the source is legitimate, forwarding, abuse, or stale.",
+            "next_gate": "Sender classification",
+            "next_step": "Review source intelligence and recent report evidence before changing SPF or DKIM.",
+            "can_preview": False,
+            "can_apply_after_approval": False,
+            "manual_fallback": False,
+            "verification_required": True,
+            "verification_status": str(verification.get("status") or "pending_sender_review"),
+        }
+    if track == "manual_dns":
+        return {
+            "stage": "manual_repair",
+            "label": "Manual DNS repair",
+            "summary": "The finding has DNS guidance but no connected safe write path yet.",
+            "next_gate": "Operator applies DNS manually",
+            "next_step": "Apply the suggested record in authoritative DNS, then refresh DMARQ evidence.",
+            "can_preview": False,
+            "can_apply_after_approval": False,
+            "manual_fallback": True,
+            "verification_required": True,
+            "verification_status": str(verification.get("status") or "pending_dns_refresh"),
+        }
+    if track == "reputation_review":
+        return {
+            "stage": "reputation_review",
+            "label": "Review reputation",
+            "summary": "The source needs reputation or blacklist evidence before operator closure.",
+            "next_gate": "Fresh reputation evidence",
+            "next_step": "Check current reputation feeds and decide whether to delist, stop, or accept the sender.",
+            "can_preview": False,
+            "can_apply_after_approval": False,
+            "manual_fallback": False,
+            "verification_required": True,
+            "verification_status": str(verification.get("status") or "pending_report_evidence"),
+        }
+    return {
+        "stage": "operator_review",
+        "label": "Operator review",
+        "summary": "The remediation remains manual until current evidence proves it is fixed.",
+        "next_gate": "Fresh evidence before closure",
+        "next_step": "Complete the operator action and import fresh reports or DNS checks before marking fixed.",
+        "can_preview": False,
+        "can_apply_after_approval": False,
+        "manual_fallback": True,
+        "verification_required": True,
+        "verification_status": str(verification.get("status") or "pending_report_evidence"),
+    }
+
+
 def _apply_loop_metadata(items: List[Dict[str, Any]]) -> None:
     for item in items:
         item["incident_type"] = _incident_type_for_item(item)
@@ -243,6 +350,7 @@ def _apply_loop_metadata(items: List[Dict[str, Any]]) -> None:
         item["priority_score"] = priority_score
         item["priority_band"] = _priority_band(item, score=priority_score)
         item["operator_decisions"] = _operator_decision_options(item)
+        item["repair_progression"] = _repair_progression_for_item(item)
 
 
 def _loop_summary(domain: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
@@ -280,6 +388,10 @@ def _loop_summary(domain: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
         "track_sender_investigation": summary["track_sender_investigation"],
         "track_reputation_review": summary["track_reputation_review"],
         "track_self_hosted_or_provider": summary["track_self_hosted_or_provider"],
+        "repair_preview_ready": summary["repair_preview_ready"],
+        "repair_approval_pending": summary["repair_approval_pending"],
+        "repair_blocked": summary["repair_blocked"],
+        "repair_needs_evidence": summary["repair_needs_evidence"],
         "top_item_id": next_item.get("id") if next_item else None,
         "top_incident_type": next_item.get("incident_type") if next_item else None,
         "top_loop_state": next_item.get("loop_state") if next_item else None,
@@ -340,6 +452,7 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
     automation = item.get("automation") or {}
     action_plan = item.get("action_plan") or {}
     verification_plan = item.get("verification_plan") or {}
+    repair_progression = item.get("repair_progression") or {}
     return {
         "schema_version": "dmarq.remediation.notification.v1",
         "domain": domain,
@@ -356,6 +469,20 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
         "operator_decisions": [
             str(decision) for decision in item.get("operator_decisions", []) if str(decision)
         ][:8],
+        "repair_progression": {
+            "stage": str(repair_progression.get("stage") or ""),
+            "label": str(repair_progression.get("label") or ""),
+            "summary": str(repair_progression.get("summary") or ""),
+            "next_gate": str(repair_progression.get("next_gate") or ""),
+            "next_step": str(repair_progression.get("next_step") or ""),
+            "can_preview": bool(repair_progression.get("can_preview")),
+            "can_apply_after_approval": bool(
+                repair_progression.get("can_apply_after_approval")
+            ),
+            "manual_fallback": bool(repair_progression.get("manual_fallback")),
+            "verification_required": bool(repair_progression.get("verification_required")),
+            "verification_status": str(repair_progression.get("verification_status") or ""),
+        },
         "title": str(item.get("title") or ""),
         "detail": str(item.get("detail") or ""),
         "notification_state": str(notification.get("state") or "summary_only"),

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1,3 +1,5 @@
+const VERIFIED_ITEMS_COMPACT_LIMIT = 4;
+
 function domainDetailsApp(domainId = '') {
     return {
         domainId: domainId,
@@ -1038,12 +1040,12 @@ function domainDetailsApp(domainId = '') {
         },
 
         hasMoreVisibleVerifiedItems() {
-            return (this.remediationQueue.verified_items || []).length > 4;
+            return (this.remediationQueue.verified_items || []).length > VERIFIED_ITEMS_COMPACT_LIMIT;
         },
 
         visibleVerifiedItems() {
             const items = this.remediationQueue.verified_items || [];
-            return this.showAllVerifiedRemediationItems ? items : items.slice(0, 4);
+            return this.showAllVerifiedRemediationItems ? items : items.slice(0, VERIFIED_ITEMS_COMPACT_LIMIT);
         },
 
         remediationDecisionLabel(value) {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -335,17 +335,18 @@ function domainDetailsApp(domainId = '') {
 
         remediationActionNote(action) {
             if (!window.prompt) {
-                return '';
+                return undefined;
             }
             const label = this.remediationDecisionLabel(action || 'decision');
             const note = window.prompt(
-                `Optional operator note for "${label}" (leave blank to continue):`,
+                `Optional operator note for "${label}" (leave blank to continue, max 500 chars):`,
                 ''
             );
             if (note === null) {
                 return null;
             }
-            return String(note || '').trim();
+            const trimmed = String(note || '').trim();
+            return trimmed ? trimmed.slice(0, 500) : undefined;
         },
 
         handleMigrationAction(action) {
@@ -1036,6 +1037,10 @@ function domainDetailsApp(domainId = '') {
             return Math.max(this.verifiedItemsTotalCount() - visible, 0);
         },
 
+        hasMoreVisibleVerifiedItems() {
+            return (this.remediationQueue.verified_items || []).length > 4;
+        },
+
         visibleVerifiedItems() {
             const items = this.remediationQueue.verified_items || [];
             return this.showAllVerifiedRemediationItems ? items : items.slice(0, 4);
@@ -1704,18 +1709,21 @@ function domainDetailsApp(domainId = '') {
                 error: ''
             };
             try {
+                const payload = {
+                    item_id: item.id,
+                    lifecycle_state: lifecycleState,
+                    event: notification.event,
+                    dedupe_key: notification.dedupe_key
+                };
+                if (note !== undefined) {
+                    payload.note = note;
+                }
                 const response = await fetch(
                     `/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation/notifications/audit`,
                     {
                         method: 'POST',
                         headers: this.workspaceHeaders(),
-                        body: JSON.stringify({
-                            item_id: item.id,
-                            lifecycle_state: lifecycleState,
-                            event: notification.event,
-                            dedupe_key: notification.dedupe_key,
-                            note
-                        })
+                        body: JSON.stringify(payload)
                     }
                 );
                 const data = await response.json().catch(() => ({}));
@@ -1770,18 +1778,21 @@ function domainDetailsApp(domainId = '') {
                 error: ''
             };
             try {
+                const payload = {
+                    item_id: item.id,
+                    confirm: true,
+                    event: notification.event,
+                    dedupe_key: notification.dedupe_key
+                };
+                if (note !== undefined) {
+                    payload.note = note;
+                }
                 const response = await fetch(
                     `/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation/notifications/dispatch`,
                     {
                         method: 'POST',
                         headers: this.workspaceHeaders(),
-                        body: JSON.stringify({
-                            item_id: item.id,
-                            confirm: true,
-                            event: notification.event,
-                            dedupe_key: notification.dedupe_key,
-                            note
-                        })
+                        body: JSON.stringify(payload)
                     }
                 );
                 const data = await response.json().catch(() => ({}));

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -481,9 +481,12 @@
                                 </template>
                             </div>
                             <div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs"
-                                 x-show="verifiedItemsHiddenCount() > 0 || showAllVerifiedRemediationItems">
+                                 x-show="hasMoreVisibleVerifiedItems() || verifiedItemsHiddenCount() > 0 || showAllVerifiedRemediationItems">
                                 <p class="text-[#5f5c78]" x-show="!showAllVerifiedRemediationItems && verifiedItemsHiddenCount() > 0">
                                     <span>+</span><span x-text="verifiedItemsHiddenCount()"></span><span> older verified repairs hidden from this compact view.</span>
+                                </p>
+                                <p class="text-[#5f5c78]" x-show="!showAllVerifiedRemediationItems && verifiedItemsHiddenCount() === 0 && hasMoreVisibleVerifiedItems()">
+                                    <span>Additional recent verified repairs are available in this view.</span>
                                 </p>
                                 <p class="text-[#5f5c78]" x-show="showAllVerifiedRemediationItems">
                                     <span>Showing </span><span x-text="(remediationQueue.verified_items || []).length"></span><span> recent verified repairs.</span>
@@ -677,8 +680,8 @@
                                         <p class="mt-2 text-sm text-[#120d36]" x-text="remediationDispatchNextStep(item.notification.dispatch)"></p>
                                         <template x-if="(item.notification.dispatch.blocked_reasons || []).length">
                                             <ul class="mt-2 space-y-1 text-xs text-[#5f5c78]">
-                                                <template x-for="reason in item.notification.dispatch.blocked_reasons"
-                                                          :key="item.id + '-dispatch-blocker-' + reason">
+                                                <template x-for="(reason, index) in item.notification.dispatch.blocked_reasons"
+                                                          :key="item.id + '-dispatch-blocker-' + index">
                                                     <li class="flex gap-2">
                                                         <span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[#b45309]"></span>
                                                         <span x-text="reason"></span>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -387,6 +387,12 @@
                             <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
                                 <span x-text="remediationQueue.summary.blocked_by_prerequisite || 0"></span><span> blocked by prerequisites</span>
                             </span>
+                            <span class="rounded bg-[#eef7ff] px-2 py-1 font-semibold text-[#24507a]">
+                                <span x-text="remediationQueue.summary.repair_preview_ready || 0"></span><span> preview ready</span>
+                            </span>
+                            <span class="rounded bg-[#fff8ed] px-2 py-1 font-semibold text-[#7a4a00]">
+                                <span x-text="remediationQueue.summary.repair_needs_evidence || 0"></span><span> need evidence</span>
+                            </span>
                             <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700">
                                 <span x-text="remediationQueue.summary.dispatch_ready || 0"></span><span> ready to notify</span>
                             </span>
@@ -512,6 +518,17 @@
                                         <span>Top: </span><span x-text="remediationIncidentLabel(remediationQueue.loop?.top_incident_type)"></span>
                                     </span>
                                 </div>
+                                <div class="mt-3 flex flex-wrap gap-2 text-xs">
+                                    <span class="rounded bg-[#eef7ff] px-2 py-1 font-semibold text-[#24507a]">
+                                        <span x-text="remediationQueue.loop?.repair_preview_ready || 0"></span><span> provider previews ready</span>
+                                    </span>
+                                    <span class="rounded bg-[#fff8ed] px-2 py-1 font-semibold text-[#7a4a00]">
+                                        <span x-text="remediationQueue.loop?.repair_needs_evidence || 0"></span><span> require fresh evidence</span>
+                                    </span>
+                                    <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
+                                        <span x-text="remediationQueue.loop?.repair_blocked || 0"></span><span> blocked before repair</span>
+                                    </span>
+                                </div>
                             </div>
                             <div class="rounded-lg bg-white p-3">
                                 <p class="text-xs font-semibold uppercase text-[#5f5c78]">Notification readiness</p>
@@ -574,6 +591,34 @@
                                     <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next step</p>
                                     <p class="mt-1 text-sm text-[#120d36]" x-text="item.next_steps[0] || 'Review the evidence.'"></p>
                                 </div>
+                                <template x-if="item.repair_progression">
+                                    <div class="mt-3 rounded border border-[#d5e9f8] bg-[#f7fbff] p-3">
+                                        <div class="flex flex-wrap items-center justify-between gap-2">
+                                            <p class="text-xs font-semibold uppercase text-[#24507a]">Repair progression</p>
+                                            <span class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#24507a]"
+                                                  x-text="item.repair_progression.label || item.repair_progression.stage"></span>
+                                        </div>
+                                        <p class="mt-2 text-sm text-[#120d36]" x-text="item.repair_progression.summary"></p>
+                                        <div class="mt-3 grid gap-2 md:grid-cols-3">
+                                            <div class="rounded bg-white px-3 py-2 text-xs text-[#45505f]">
+                                                <span class="font-semibold">Gate: </span>
+                                                <span x-text="item.repair_progression.next_gate || 'Operator review'"></span>
+                                            </div>
+                                            <div class="rounded bg-white px-3 py-2 text-xs text-[#45505f]">
+                                                <span class="font-semibold">Preview: </span>
+                                                <span x-text="item.repair_progression.can_preview ? 'available' : 'not available'"></span>
+                                            </div>
+                                            <div class="rounded bg-white px-3 py-2 text-xs text-[#45505f]">
+                                                <span class="font-semibold">Verify: </span>
+                                                <span x-text="item.repair_progression.verification_required ? item.repair_progression.verification_status : 'not required'"></span>
+                                            </div>
+                                        </div>
+                                        <p class="mt-3 text-xs text-[#5f5c78]">
+                                            <span class="font-semibold">Progress this by: </span>
+                                            <span x-text="item.repair_progression.next_step"></span>
+                                        </p>
+                                    </div>
+                                </template>
                                 <template x-if="item.action_plan">
                                     <div class="mt-3 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-3">
                                         <div class="flex flex-wrap items-center justify-between gap-2">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -376,6 +376,7 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "remediationRiskClass(value)" in script
     assert "verifiedItemsTotalCount()" in script
     assert "verifiedItemsHiddenCount()" in script
+    assert "hasMoreVisibleVerifiedItems()" in script
 
 
 def test_dashboard_remediation_queue_href_encodes_domain_and_anchor():
@@ -1226,6 +1227,8 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "item.verification_plan.next_check" in template
     assert "Notification dispatch" in template
     assert "item.notification.dispatch.blocked_reasons" in template
+    assert "(reason, index) in item.notification.dispatch.blocked_reasons" in template
+    assert "'-dispatch-blocker-' + index" in template
     assert "blocked_reasons[0]" not in template
     assert "Remediation loop" in template
     assert "remediationLoopStatusLabel" in template
@@ -1248,6 +1251,8 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "/remediation/notifications/audit" in script
     assert "/remediation/notifications/dispatch" in script
     assert "note" in script
+    assert "payload.note = note" in script
+    assert "trimmed ? trimmed.slice(0, 500) : undefined" in script
     assert "No DNS changes were made" in script
     assert "x-html" not in template
 
@@ -1278,6 +1283,7 @@ def test_domain_details_distinguishes_evidence_verified_repairs_without_html_inj
     assert "dispatch_verified_fixed_hidden" in script
     assert "this.verifiedItemsTotalCount() - visible" in script
     assert "visibleVerifiedItems()" in template
+    assert "hasMoreVisibleVerifiedItems()" in template
     assert "showAllVerifiedRemediationItems" in template
     assert "Show compact view" in template
     assert "Show all visible repairs" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -373,6 +373,13 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "item.verification_plan.verification_method" in template
     assert "item.verification_plan.freshness_requirement" in template
     assert "item.verification_plan.failure_mode" in template
+    assert "Repair progression" in template
+    assert "remediationQueue.summary.repair_preview_ready" in template
+    assert "remediationQueue.summary.repair_needs_evidence" in template
+    assert "remediationQueue.loop?.repair_blocked" in template
+    assert "item.repair_progression.next_gate" in template
+    assert "item.repair_progression.can_preview" in template
+    assert "item.repair_progression.verification_required" in template
     assert "remediationRiskClass(value)" in script
     assert "verifiedItemsTotalCount()" in script
     assert "verifiedItemsHiddenCount()" in script
@@ -1222,6 +1229,8 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "item.action_plan.steps" in template
     assert "item.action_plan.completion_criteria" in template
     assert "item.action_plan.safe_to_automate" in template
+    assert "item.repair_progression" in template
+    assert "item.repair_progression.next_step" in template
     assert "Verification" in template
     assert "item.verification_plan.status" in template
     assert "item.verification_plan.evidence_needed" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -377,6 +377,7 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "verifiedItemsTotalCount()" in script
     assert "verifiedItemsHiddenCount()" in script
     assert "hasMoreVisibleVerifiedItems()" in script
+    assert "VERIFIED_ITEMS_COMPACT_LIMIT = 4" in script
 
 
 def test_dashboard_remediation_queue_href_encodes_domain_and_anchor():
@@ -1287,7 +1288,7 @@ def test_domain_details_distinguishes_evidence_verified_repairs_without_html_inj
     assert "showAllVerifiedRemediationItems" in template
     assert "Show compact view" in template
     assert "Show all visible repairs" in template
-    assert "items.slice(0, 4)" in script
+    assert "items.slice(0, VERIFIED_ITEMS_COMPACT_LIMIT)" in script
     assert "verified.item_id" in template
     assert "verified.label" in template
     assert "verified.detail" in template

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -83,6 +83,10 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "self_hosted_guidance": 1,
         "manual_only": 0,
         "blocked_by_prerequisite": 0,
+        "repair_preview_ready": 1,
+        "repair_approval_pending": 0,
+        "repair_blocked": 0,
+        "repair_needs_evidence": 2,
         "notify_approval_required": 1,
         "notify_action_required": 0,
         "notify_investigation_required": 1,
@@ -110,6 +114,10 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "track_sender_investigation": 1,
         "track_reputation_review": 0,
         "track_self_hosted_or_provider": 0,
+        "repair_preview_ready": 1,
+        "repair_approval_pending": 0,
+        "repair_blocked": 0,
+        "repair_needs_evidence": 2,
         "top_item_id": "dns:dmarc-missing",
         "top_incident_type": "dmarc_policy_missing_or_weak",
         "top_loop_state": "proposal_ready_for_approval",
@@ -127,6 +135,20 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "preview_change",
         "approve_after_preview",
     ]
+    assert queue["items"][0]["repair_progression"] == {
+        "stage": "preview_ready",
+        "label": "Preview ready",
+        "summary": "A connected DNS provider can prepare the exact mutation for review.",
+        "next_gate": "Human approval before apply",
+        "next_step": (
+            "Open the provider preview, compare old and new DNS values, then approve or reject."
+        ),
+        "can_preview": True,
+        "can_apply_after_approval": True,
+        "manual_fallback": True,
+        "verification_required": True,
+        "verification_status": "pending_operator_approval",
+    }
     assert queue["items"][0]["state"] == "approval_ready"
     assert queue["items"][0]["automation"]["eligible"] is True
     assert queue["items"][0]["automation"]["apply_endpoint"] == (
@@ -193,6 +215,20 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
             "resolved",
             "rejected",
         ],
+        "repair_progression": {
+            "stage": "preview_ready",
+            "label": "Preview ready",
+            "summary": "A connected DNS provider can prepare the exact mutation for review.",
+            "next_gate": "Human approval before apply",
+            "next_step": (
+                "Open the provider preview, compare old and new DNS values, then approve or reject."
+            ),
+            "can_preview": True,
+            "can_apply_after_approval": True,
+            "manual_fallback": True,
+            "verification_required": True,
+            "verification_status": "pending_operator_approval",
+        },
         "title": "Publish DMARC",
         "detail": "No DMARC TXT record was found.",
         "notification_state": "approval_required",
@@ -304,6 +340,8 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
     assert queue["status"] == "needs_manual_action"
     assert queue["summary"]["manual_action"] == 1
     assert queue["summary"]["blocked_by_prerequisite"] == 1
+    assert queue["summary"]["repair_blocked"] == 1
+    assert queue["summary"]["repair_needs_evidence"] == 1
     assert queue["summary"]["notify_summary_only"] == 1
     assert queue["loop"]["status"] == "manual_action_required"
     assert queue["loop"]["blocked_by_prerequisite"] == 1
@@ -318,6 +356,9 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
         "self_hosted",
     }
     assert queue["items"][0]["action_plan"]["completion_criteria"]
+    assert queue["items"][0]["repair_progression"]["stage"] == "blocked"
+    assert queue["items"][0]["repair_progression"]["can_preview"] is False
+    assert queue["items"][0]["repair_progression"]["manual_fallback"] is True
     assert queue["items"][0]["notification"]["state"] == "summary_only"
     assert queue["items"][0]["notification"]["event"] == "dmarq.remediation.summary"
     assert queue["items"][0]["notification"]["payload_preview"]["event_type"] == (
@@ -396,6 +437,10 @@ def test_remediation_queue_requires_recommended_provider_for_automation():
     assert queue["items"][0]["automation"]["eligible"] is False
     assert queue["items"][0]["automation"]["provider"] is None
     assert queue["items"][0]["automation"]["apply_endpoint"] is None
+    assert queue["items"][0]["repair_progression"]["stage"] == "manual_repair"
+    assert queue["items"][0]["repair_progression"]["next_gate"] == (
+        "Operator applies DNS manually"
+    )
     assert queue["items"][0]["action_plan"]["owner"] == "Domain DNS operator"
     assert queue["items"][0]["action_plan"]["steps"]
     assert queue["items"][0]["notification"]["state"] == "action_required"

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -802,7 +802,13 @@ prerequisites, expected health-score impact, automation eligibility, and
 read-only notification routing metadata. Items also expose stable remediation
 loop fields so product and automation surfaces can use the same language:
 `incident_type`, `loop_state`, `remediation_track`, `priority_score`,
-`priority_band`, and `operator_decisions`. Each `action_plan` also explains the
+`priority_band`, `operator_decisions`, and `repair_progression`. The
+`repair_progression` object is read-only and explains the current safe repair
+stage (`preview_ready`, `blocked`, `classification_required`,
+`manual_repair`, `reputation_review`, or `operator_review`), the next approval
+gate, whether a provider preview is available, whether an apply could happen
+after explicit approval, whether a manual fallback exists, and which fresh
+verification status still has to clear. Each `action_plan` also explains the
 owner, risk level, whether the item is safe for provider automation, and the
 operator decision that should happen next. DNS items that have a concrete safe
 TXT/CNAME provider write are marked `approval_ready` and point to the same
@@ -816,7 +822,11 @@ approval, what needs manual action, what needs investigation, the current
 operator buckets with counters such as `provider_fix_available`,
 `self_hosted_guidance`, `manual_only`, `blocked_by_prerequisite`, and
 track-specific counters like `track_provider_preview`, `track_manual_dns`,
-`track_sender_investigation`, and `track_reputation_review`.
+`track_sender_investigation`, and `track_reputation_review`. They also expose
+repair-progression counters such as `repair_preview_ready`, `repair_blocked`,
+and `repair_needs_evidence`, so clients can distinguish a ready provider
+preview from a finding that still needs sender classification, provider values,
+or fresh report/DNS evidence.
 
 Notification metadata includes the event name, channel, dedupe key, reason, and
 next state transition that an operator workflow can use. Each notification also

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -96,6 +96,12 @@ Use **Refresh queue** to reload the remediation queue from the backend after
 new reports, DNS checks, or operator lifecycle changes are available.
 Each item now also shows the remediation track, priority band, owner, risk
 level, safe-automation flag, and the exact operator decision DMARQ expects next.
+The **Repair progression** panel separates the recommendation from the next
+safe gate. It tells the operator whether a connected provider preview is ready,
+whether a provider-specific value is still missing, whether a sending source
+must be classified first, whether the work is manual DNS, or whether fresh
+reputation/report/DNS evidence is still required before closure. This panel is
+read-only; it does not apply DNS changes or send provider requests.
 Each item also shows a notification profile such as approval required, action
 required, investigation required, or summary only. These labels explain how
 DMARQ would route the item into alerting or ticketing workflows; viewing the


### PR DESCRIPTION
## Summary
- harden remediation queue follow-up controls: stable dispatch blocker keys, compact verified-repair toggle behavior, and bounded optional operator notes
- add read-only repair progression metadata to remediation queue items and notification payload previews
- show repair progression gates in the domain detail queue: preview-ready, blocked by prerequisite, sender classification, manual DNS, reputation review, and fresh-evidence requirements
- document the new API/UI fields and update the changelog

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q`
- `.venv/bin/python -m pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_dashboard_template_security.py -q`
- `.venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_public_api.py backend/app/tests/test_domain_detail_endpoints.py::test_dashboard_remediation_loop_exposes_operator_decision_context -q`
- `node --check backend/app/static/js/domain-details-page.js`
- `.venv/bin/python -m flake8 backend/app/services/remediation_queue.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`
- full backend suite: `cd backend && ../.venv/bin/python -m pytest -q` → 1845 passed

## Safety
- Read-only remediation metadata and UI only.
- No provider writes, DNS mutation, webhook delivery send, or secret changes.
