### PR TITLE
feat: align remediation repair gates across dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard action-plan cards now deep-link to the selected domain remediation queue instead of the generic domain overview.
 - Remediation queue summaries now expose hidden verified-repair counts separately from the visible compact list.
 - Remediation notification payloads now include the same repair-progression gates shown in the UI, keeping webhook/ticket previews aligned with human review.
+- Domain remediation pages now show repair-progression gates in the top next-remediation panel and render preview/verification states as operator-readable labels.
+- Dashboard remediation-loop cards now expose the same repair-gate language and workspace counters for preview-ready, evidence-gated, and blocked repair work.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity
@@ -50,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed report detail views so sender-IP reputation appears as a dedicated score and assessment column instead of being buried in source metadata.
 - Fixed DNS fallback behavior so independent public resolvers are checked in parallel before a transient timeout can make records appear missing.
 - Fixed domain sending-source loading so PTR and network enrichment run in parallel instead of pushing report-backed source rows past the UI timeout.
+- Fixed the remediation queue API schema so `repair_progression` is preserved in typed domain remediation responses.
 - Fixed the Cloudflare permissions picker so selecting the full DNS repair profile no longer falls back to read-only scopes.
 - Fixed the release modal coverage so recent operator-facing work is visible from inside the app.
 - Fixed the remaining Settings page startup hook so CSP hardening no longer depends on template-level page initialization.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1166,6 +1166,21 @@ class RemediationVerificationPlan(BaseModel):
     next_check: str
 
 
+class RemediationRepairProgression(BaseModel):
+    """Read-only safe repair gate for one remediation item."""
+
+    stage: str
+    label: str
+    summary: str
+    next_gate: str
+    next_step: str
+    can_preview: bool = False
+    can_apply_after_approval: bool = False
+    manual_fallback: bool = False
+    verification_required: bool = True
+    verification_status: str = ""
+
+
 class RemediationNotification(BaseModel):
     """Read-only notification routing metadata for one remediation item."""
 
@@ -1203,6 +1218,7 @@ class RemediationQueueItem(BaseModel):
     expected_health_score_impact: str
     action_plan: RemediationActionPlan
     verification_plan: RemediationVerificationPlan
+    repair_progression: RemediationRepairProgression
     automation: RemediationAutomation
     notification: RemediationNotification
 
@@ -1956,6 +1972,62 @@ def _remediation_operator_decision_summary(state: str) -> str:
     return "Complete the manual action, refresh evidence, then mark the item resolved."
 
 
+def _dashboard_repair_progression(state: str, action: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a conservative repair gate for dashboard health-action summaries."""
+    action_type = str(action.get("type") or "")
+    if state == "needs_approval":
+        return {
+            "stage": "preview_ready",
+            "label": "Preview ready",
+            "summary": "A guided repair can be reviewed from the domain remediation queue.",
+            "next_gate": "Human approval before apply",
+            "next_step": "Open the domain queue, preview the proposed repair, then approve or reject it.",
+            "can_preview": True,
+            "can_apply_after_approval": True,
+            "manual_fallback": True,
+            "verification_required": True,
+            "verification_status": "pending_operator_approval",
+        }
+    if state == "investigate":
+        if action_type in REMEDIATION_REPUTATION_ACTION_TYPES:
+            return {
+                "stage": "reputation_review",
+                "label": "Review reputation",
+                "summary": "Fresh reputation evidence is required before this can be closed.",
+                "next_gate": "Fresh reputation evidence",
+                "next_step": "Open source intelligence and confirm whether the sender is trusted.",
+                "can_preview": False,
+                "can_apply_after_approval": False,
+                "manual_fallback": False,
+                "verification_required": True,
+                "verification_status": "pending_report_evidence",
+            }
+        return {
+            "stage": "classification_required",
+            "label": "Classify sender",
+            "summary": "A human must classify the sender before DNS or policy changes are safe.",
+            "next_gate": "Sender classification",
+            "next_step": "Review recent source evidence and decide whether this sender is legitimate.",
+            "can_preview": False,
+            "can_apply_after_approval": False,
+            "manual_fallback": False,
+            "verification_required": True,
+            "verification_status": "pending_sender_review",
+        }
+    return {
+        "stage": "manual_repair",
+        "label": "Manual repair",
+        "summary": "The operator must complete this work and refresh evidence before closure.",
+        "next_gate": "Fresh evidence before closure",
+        "next_step": "Complete the manual action, then refresh DMARQ evidence.",
+        "can_preview": False,
+        "can_apply_after_approval": False,
+        "manual_fallback": True,
+        "verification_required": True,
+        "verification_status": "pending_report_evidence",
+    }
+
+
 def _dashboard_remediation_item(
     domain_name: str,
     action: Dict[str, Any],
@@ -1978,6 +2050,7 @@ def _dashboard_remediation_item(
         "safe_to_automate": _remediation_safe_to_automate(state),
         "operator_decision_summary": _remediation_operator_decision_summary(state),
         "operator_decisions": _remediation_operator_decisions(state),
+        "repair_progression": _dashboard_repair_progression(state, action),
         "severity": str(action.get("severity") or "info"),
         "title": str(action.get("title") or "Review remediation item"),
         "next_step": str(action.get("next_step") or "Review the domain evidence."),
@@ -2005,6 +2078,9 @@ def _build_dashboard_remediation_loop(
         "needs_approval": 0,
         "manual_action": 0,
         "investigate": 0,
+        "repair_preview_ready": 0,
+        "repair_blocked": 0,
+        "repair_needs_evidence": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2016,6 +2092,13 @@ def _build_dashboard_remediation_loop(
             state = _remediation_loop_state(action)
             counters[state] += 1
             item = _dashboard_remediation_item(domain_name, action)
+            repair_progression = item.get("repair_progression") or {}
+            if repair_progression.get("stage") == "preview_ready":
+                counters["repair_preview_ready"] += 1
+            if repair_progression.get("stage") == "blocked":
+                counters["repair_blocked"] += 1
+            if repair_progression.get("verification_required"):
+                counters["repair_needs_evidence"] += 1
             track_counters[f"track_{item['remediation_track']}"] += 1
             items.append(item)
 
@@ -2063,6 +2146,9 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         "needs_approval": 0,
         "manual_action": 0,
         "investigate": 0,
+        "repair_preview_ready": 0,
+        "repair_blocked": 0,
+        "repair_needs_evidence": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2071,6 +2157,13 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         state = _remediation_loop_state(action)
         counters[state] += 1
         item = _dashboard_remediation_item(domain_name, action, include_detail=False)
+        repair_progression = item.get("repair_progression") or {}
+        if repair_progression.get("stage") == "preview_ready":
+            counters["repair_preview_ready"] += 1
+        if repair_progression.get("stage") == "blocked":
+            counters["repair_blocked"] += 1
+        if repair_progression.get("verification_required"):
+            counters["repair_needs_evidence"] += 1
         track_counters[f"track_{item['remediation_track']}"] += 1
         items.append(item)
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -599,6 +599,50 @@ def read_only_remediation_queue_response(payload: Any) -> "RemediationQueueRespo
         automation["apply_endpoint"] = None
         item["automation"] = automation
 
+        if "repair_progression" not in item:
+            verification = item.get("verification_plan") or {}
+            if automation.get("eligible"):
+                item["repair_progression"] = {
+                    "stage": "preview_ready",
+                    "label": "Preview ready",
+                    "summary": (
+                        "A connected DNS provider can prepare the exact mutation for review."
+                    ),
+                    "next_gate": "Human approval before apply",
+                    "next_step": (
+                        "Open the provider preview, compare old and new DNS values, "
+                        "then approve or reject."
+                    ),
+                    "can_preview": True,
+                    "can_apply_after_approval": True,
+                    "manual_fallback": True,
+                    "verification_required": True,
+                    "verification_status": str(
+                        verification.get("status") or "pending_operator_approval"
+                    ),
+                }
+            else:
+                item["repair_progression"] = {
+                    "stage": "operator_review",
+                    "label": "Operator review",
+                    "summary": (
+                        "The remediation remains manual until current evidence proves it "
+                        "is fixed."
+                    ),
+                    "next_gate": "Fresh evidence before closure",
+                    "next_step": (
+                        "Complete the operator action and import fresh reports or DNS "
+                        "checks before marking fixed."
+                    ),
+                    "can_preview": False,
+                    "can_apply_after_approval": False,
+                    "manual_fallback": True,
+                    "verification_required": True,
+                    "verification_status": str(
+                        verification.get("status") or "pending_report_evidence"
+                    ),
+                }
+
         notification = item.get("notification") or {}
         preview = notification.get("payload_preview") or {}
         preview_automation = preview.get("automation") or {}
@@ -2086,6 +2130,17 @@ def _dashboard_remediation_item(
     return item
 
 
+def _increment_repair_counters(counters: Dict[str, int], item: Dict[str, Any]) -> None:
+    """Count overlapping repair-gate facets for dashboard summaries."""
+    repair_progression = item.get("repair_progression") or {}
+    if repair_progression.get("stage") == "preview_ready":
+        counters["repair_preview_ready"] += 1
+    if repair_progression.get("stage") == "blocked":
+        counters["repair_blocked"] += 1
+    if repair_progression.get("verification_required"):
+        counters["repair_needs_evidence"] += 1
+
+
 def _build_dashboard_remediation_loop(
     domains: List[Dict[str, Any]],
     remediation_activity: Dict[str, Any],
@@ -2115,13 +2170,7 @@ def _build_dashboard_remediation_loop(
             state = _remediation_loop_state(action)
             counters[state] += 1
             item = _dashboard_remediation_item(domain_name, action)
-            repair_progression = item.get("repair_progression") or {}
-            if repair_progression.get("stage") == "preview_ready":
-                counters["repair_preview_ready"] += 1
-            if repair_progression.get("stage") == "blocked":
-                counters["repair_blocked"] += 1
-            if repair_progression.get("verification_required"):
-                counters["repair_needs_evidence"] += 1
+            _increment_repair_counters(counters, item)
             track_counters[f"track_{item['remediation_track']}"] += 1
             items.append(item)
 
@@ -2180,13 +2229,7 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         state = _remediation_loop_state(action)
         counters[state] += 1
         item = _dashboard_remediation_item(domain_name, action, include_detail=False)
-        repair_progression = item.get("repair_progression") or {}
-        if repair_progression.get("stage") == "preview_ready":
-            counters["repair_preview_ready"] += 1
-        if repair_progression.get("stage") == "blocked":
-            counters["repair_blocked"] += 1
-        if repair_progression.get("verification_required"):
-            counters["repair_needs_evidence"] += 1
+        _increment_repair_counters(counters, item)
         track_counters[f"track_{item['remediation_track']}"] += 1
         items.append(item)
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1829,6 +1829,7 @@ REMEDIATION_STATE_PRIORITY = {
 REMEDIATION_TRACKS = {
     "provider_preview",
     "manual_dns",
+    "blocked_by_prerequisite",
     "sender_investigation",
     "reputation_review",
     "self_hosted_or_provider",
@@ -1910,6 +1911,15 @@ def _remediation_item_loop_state(state: str) -> str:
 
 def _remediation_track_for_action(state: str, action: Dict[str, Any]) -> str:
     action_type = str(action.get("type") or "")
+    if (
+        str(action.get("source") or "") == "dns_lint"
+        and action_type in REMEDIATION_DNS_ACTION_TYPES
+        and any(
+            "provider-specific" in str(prerequisite).lower()
+            for prerequisite in action.get("prerequisites") or []
+        )
+    ):
+        return "blocked_by_prerequisite"
     if state == "needs_approval":
         return "provider_preview"
     if action_type in REMEDIATION_REPUTATION_ACTION_TYPES:
@@ -1975,6 +1985,19 @@ def _remediation_operator_decision_summary(state: str) -> str:
 def _dashboard_repair_progression(state: str, action: Dict[str, Any]) -> Dict[str, Any]:
     """Return a conservative repair gate for dashboard health-action summaries."""
     action_type = str(action.get("type") or "")
+    if _remediation_track_for_action(state, action) == "blocked_by_prerequisite":
+        return {
+            "stage": "blocked",
+            "label": "Blocked by prerequisite",
+            "summary": "DMARQ needs a provider-specific value before this can become a safe repair.",
+            "next_gate": "Provider value required",
+            "next_step": "Fetch the exact DKIM, SPF, DMARC, or CNAME target from the mail provider first.",
+            "can_preview": False,
+            "can_apply_after_approval": False,
+            "manual_fallback": True,
+            "verification_required": True,
+            "verification_status": "pending_dns_refresh",
+        }
     if state == "needs_approval":
         return {
             "stage": "preview_ready",

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -950,6 +950,26 @@ function dashboardApp() {
             }[String(track || '')] || 'Manual review';
         },
 
+        repairProgressionClass(progression) {
+            const stage = String(progression?.stage || '');
+            if (stage === 'preview_ready') return 'bg-green-100 text-green-700';
+            if (stage === 'blocked') return 'bg-red-100 text-red-700';
+            if (stage === 'classification_required') return 'bg-blue-100 text-blue-700';
+            if (stage === 'manual_repair') return 'bg-yellow-100 text-yellow-800';
+            if (stage === 'reputation_review') return 'bg-purple-100 text-purple-700';
+            return 'bg-[#f8f7f6] text-[#5f5c78]';
+        },
+
+        repairProgressionLabel(progression) {
+            if (!progression) return 'Operator review';
+            return progression.label || this.formatDemoLabel(progression.stage || 'operator_review');
+        },
+
+        repairProgressionNextStep(progression) {
+            if (!progression) return 'Open the remediation queue to review the next safe gate.';
+            return progression.next_step || progression.summary || 'Open the remediation queue to review the next safe gate.';
+        },
+
         domainActionHref(action) {
             return action && action.domain
                 ? `/domains/${encodeURIComponent(action.domain)}#remediation-queue`

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -83,6 +83,10 @@ function domainDetailsApp(domainId = '') {
                 self_hosted_guidance: 0,
                 manual_only: 0,
                 blocked_by_prerequisite: 0,
+                repair_preview_ready: 0,
+                repair_approval_pending: 0,
+                repair_blocked: 0,
+                repair_needs_evidence: 0,
                 dispatch_ready: 0,
                 dispatch_blocked: 0,
                 dispatch_disabled: 0,
@@ -572,6 +576,12 @@ function domainDetailsApp(domainId = '') {
             return this.remediationDispatchNextStep(dispatch);
         },
 
+        get primaryRepairProgressionText() {
+            const progression = this.primaryRemediationItem?.repair_progression;
+            if (!progression) return 'Repair status will appear after the remediation queue finishes loading.';
+            return this.repairProgressionNextStep(progression);
+        },
+
         get healthEvidenceExportUrl() {
             return `/api/v1/domains/${encodeURIComponent(this.domainId)}/posture/evidence/export?capture_current=false`;
         },
@@ -1012,6 +1022,37 @@ function domainDetailsApp(domainId = '') {
                 manual_only: 'Manual only'
             };
             return labels[value] || this.humanizeToken(value || 'manual_only');
+        },
+
+        repairProgressionClass(progression) {
+            const stage = String(progression?.stage || '');
+            if (stage === 'preview_ready') return 'bg-green-100 text-green-700';
+            if (stage === 'blocked') return 'bg-red-100 text-red-700';
+            if (stage === 'classification_required') return 'bg-blue-100 text-blue-700';
+            if (stage === 'manual_repair') return 'bg-yellow-100 text-yellow-800';
+            if (stage === 'reputation_review') return 'bg-purple-100 text-purple-700';
+            return 'bg-base-200 text-base-content/70';
+        },
+
+        repairProgressionLabel(progression) {
+            if (!progression) return 'Operator review';
+            return progression.label || this.humanizeToken(progression.stage || 'operator_review');
+        },
+
+        repairProgressionPreviewLabel(progression) {
+            if (progression?.can_preview) return 'provider preview available';
+            if (progression?.manual_fallback) return 'manual fallback only';
+            return 'not previewable yet';
+        },
+
+        repairProgressionVerificationLabel(progression) {
+            if (!progression?.verification_required) return 'not required';
+            return this.humanizeToken(progression.verification_status || 'pending evidence');
+        },
+
+        repairProgressionNextStep(progression) {
+            if (!progression) return 'Review the remediation queue before taking action.';
+            return progression.next_step || progression.summary || 'Review the repair gate before taking action.';
         },
 
         remediationRiskClass(value) {
@@ -1638,6 +1679,10 @@ function domainDetailsApp(domainId = '') {
                     notify_action_required: 0,
                     notify_investigation_required: 0,
                     notify_summary_only: 0,
+                    repair_preview_ready: 0,
+                    repair_approval_pending: 0,
+                    repair_blocked: 0,
+                    repair_needs_evidence: 0,
                     dispatch_ready: 0,
                     dispatch_blocked: 0,
                     dispatch_disabled: 0,

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -99,10 +99,19 @@
                             </div>
                             <h2 class="mt-2 text-lg font-semibold text-[#07071f]" x-text="primaryRemediationItem.title"></h2>
                             <p class="mt-1 text-sm text-[#5f5c78]" x-text="primaryRemediationItem.detail"></p>
-                            <div class="mt-3 grid gap-3 md:grid-cols-2">
+                            <div class="mt-3 grid gap-3 md:grid-cols-3">
                                 <div class="rounded-md bg-white p-3">
                                     <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next step</p>
                                     <p class="mt-1 text-sm text-[#120d36]" x-text="primaryRemediationNextStep"></p>
+                                </div>
+                                <div class="rounded-md bg-white p-3">
+                                    <div class="flex flex-wrap items-center justify-between gap-2">
+                                        <p class="text-xs font-semibold uppercase text-[#5f5c78]">Repair gate</p>
+                                        <span class="rounded px-2 py-1 text-xs font-semibold"
+                                              :class="repairProgressionClass(primaryRemediationItem.repair_progression)"
+                                              x-text="repairProgressionLabel(primaryRemediationItem.repair_progression)"></span>
+                                    </div>
+                                    <p class="mt-2 text-sm text-[#120d36]" x-text="primaryRepairProgressionText"></p>
                                 </div>
                                 <div class="rounded-md bg-white p-3">
                                     <p class="text-xs font-semibold uppercase text-[#5f5c78]">Operator dispatch</p>
@@ -595,8 +604,9 @@
                                     <div class="mt-3 rounded border border-[#d5e9f8] bg-[#f7fbff] p-3">
                                         <div class="flex flex-wrap items-center justify-between gap-2">
                                             <p class="text-xs font-semibold uppercase text-[#24507a]">Repair progression</p>
-                                            <span class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#24507a]"
-                                                  x-text="item.repair_progression.label || item.repair_progression.stage"></span>
+                                            <span class="rounded px-2 py-1 text-xs font-semibold"
+                                                  :class="repairProgressionClass(item.repair_progression)"
+                                                  x-text="repairProgressionLabel(item.repair_progression)"></span>
                                         </div>
                                         <p class="mt-2 text-sm text-[#120d36]" x-text="item.repair_progression.summary"></p>
                                         <div class="mt-3 grid gap-2 md:grid-cols-3">
@@ -606,16 +616,16 @@
                                             </div>
                                             <div class="rounded bg-white px-3 py-2 text-xs text-[#45505f]">
                                                 <span class="font-semibold">Preview: </span>
-                                                <span x-text="item.repair_progression.can_preview ? 'available' : 'not available'"></span>
+                                                <span x-text="repairProgressionPreviewLabel(item.repair_progression)"></span>
                                             </div>
                                             <div class="rounded bg-white px-3 py-2 text-xs text-[#45505f]">
                                                 <span class="font-semibold">Verify: </span>
-                                                <span x-text="item.repair_progression.verification_required ? item.repair_progression.verification_status : 'not required'"></span>
+                                                <span x-text="repairProgressionVerificationLabel(item.repair_progression)"></span>
                                             </div>
                                         </div>
                                         <p class="mt-3 text-xs text-[#5f5c78]">
                                             <span class="font-semibold">Progress this by: </span>
-                                            <span x-text="item.repair_progression.next_step"></span>
+                                            <span x-text="repairProgressionNextStep(item.repair_progression)"></span>
                                         </p>
                                     </div>
                                 </template>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -244,6 +244,26 @@
                 <p class="mt-1 text-xs text-[#5f5c78]">Sender or report evidence to confirm</p>
             </div>
         </div>
+        <div class="mt-3 grid gap-3 md:grid-cols-3">
+            <div class="rounded-md border border-[#d8ebe8] bg-[#f2fbf9] p-4">
+                <p class="text-sm text-[#5f5c78]">Repair previews ready</p>
+                <p class="mt-2 text-2xl font-bold text-[#247982]"
+                   x-text="remediationLoop().repair_preview_ready || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Provider-backed proposals ready for review</p>
+            </div>
+            <div class="rounded-md border border-[#f5dfbd] bg-[#fff8ed] p-4">
+                <p class="text-sm text-[#5f5c78]">Need fresh evidence</p>
+                <p class="mt-2 text-2xl font-bold text-[#8a6418]"
+                   x-text="remediationLoop().repair_needs_evidence || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Items that must be verified before closure</p>
+            </div>
+            <div class="rounded-md border border-[#e6e3e1] p-4">
+                <p class="text-sm text-[#5f5c78]">Blocked before repair</p>
+                <p class="mt-2 text-2xl font-bold text-[#5f5c78]"
+                   x-text="remediationLoop().repair_blocked || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Missing provider values or prerequisites</p>
+            </div>
+        </div>
         <div class="mt-5 grid gap-3 lg:grid-cols-2" x-show="hasRemediationLoopItems()">
             <template x-for="item in remediationLoopItems()" :key="item.domain + item.type + item.title">
                 <a class="rounded-md border border-[#e6e3e1] p-4 transition hover:border-[#2f9da5] hover:shadow-sm"
@@ -279,6 +299,15 @@
                     </div>
                     <p class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3 text-xs text-[#5f5c78]"
                        x-text="item.operator_decision_summary"></p>
+                    <div class="mt-3 rounded border border-[#d5e9f8] bg-[#f7fbff] p-3 text-xs">
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                            <p class="font-semibold uppercase tracking-wide text-[#24507a]">Repair gate</p>
+                            <span class="rounded px-2 py-1 font-semibold"
+                                  :class="repairProgressionClass(item.repair_progression)"
+                                  x-text="repairProgressionLabel(item.repair_progression)"></span>
+                        </div>
+                        <p class="mt-2 text-[#120d36]" x-text="repairProgressionNextStep(item.repair_progression)"></p>
+                    </div>
                     <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3 text-xs">
                         <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Next verification</p>
                         <p class="mt-1 text-[#120d36]" x-text="item.verification_next_check"></p>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -344,8 +344,21 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "remediationRiskClass(item.risk_level)" in template
     assert "item.priority_band || 'watch'" in template
     assert "item.operator_decision_summary" in template
+    assert "Repair previews ready" in template
+    assert "Need fresh evidence" in template
+    assert "Blocked before repair" in template
+    assert "remediationLoop().repair_preview_ready || 0" in template
+    assert "remediationLoop().repair_needs_evidence || 0" in template
+    assert "remediationLoop().repair_blocked || 0" in template
+    assert "Repair gate" in template
+    assert "repairProgressionClass(item.repair_progression)" in template
+    assert "repairProgressionLabel(item.repair_progression)" in template
+    assert "repairProgressionNextStep(item.repair_progression)" in template
     assert "remediationRiskClass(risk)" in script
     assert "remediationTrackLabel(track)" in script
+    assert "repairProgressionClass(progression)" in script
+    assert "repairProgressionLabel(progression)" in script
+    assert "repairProgressionNextStep(progression)" in script
 
 
 def test_domain_details_remediation_queue_shows_verification_context():
@@ -378,9 +391,18 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "remediationQueue.summary.repair_needs_evidence" in template
     assert "remediationQueue.loop?.repair_blocked" in template
     assert "item.repair_progression.next_gate" in template
-    assert "item.repair_progression.can_preview" in template
-    assert "item.repair_progression.verification_required" in template
+    assert "repairProgressionPreviewLabel(item.repair_progression)" in template
+    assert "repairProgressionVerificationLabel(item.repair_progression)" in template
+    assert "Repair gate" in template
+    assert "primaryRepairProgressionText" in template
     assert "remediationRiskClass(value)" in script
+    assert "repairProgressionClass(progression)" in script
+    assert "repairProgressionLabel(progression)" in script
+    assert "repairProgressionPreviewLabel(progression)" in script
+    assert "repairProgressionVerificationLabel(progression)" in script
+    assert "repairProgressionNextStep(progression)" in script
+    assert "repair_preview_ready: 0" in script
+    assert "repair_needs_evidence: 0" in script
     assert "verifiedItemsTotalCount()" in script
     assert "verifiedItemsHiddenCount()" in script
     assert "hasMoreVisibleVerifiedItems()" in script
@@ -1230,7 +1252,8 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "item.action_plan.completion_criteria" in template
     assert "item.action_plan.safe_to_automate" in template
     assert "item.repair_progression" in template
-    assert "item.repair_progression.next_step" in template
+    assert "repairProgressionNextStep(item.repair_progression)" in template
+    assert "repairProgressionClass(item.repair_progression)" in template
     assert "Verification" in template
     assert "item.verification_plan.status" in template
     assert "item.verification_plan.evidence_needed" in template

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2286,6 +2286,11 @@ def test_summary_includes_current_remediation_loop(
     assert loop["items"][0]["remediation_track"] == "provider_preview"
     assert loop["items"][0]["priority_score"] > 0
     assert "approve_after_preview" in loop["items"][0]["operator_decisions"]
+    assert loop["repair_preview_ready"] >= 2
+    assert loop["repair_needs_evidence"] >= 2
+    assert loop["repair_blocked"] == 0
+    assert loop["items"][0]["repair_progression"]["stage"] == "preview_ready"
+    assert loop["items"][0]["repair_progression"]["can_preview"] is True
     assert loop["items"][0]["state_label"] == "Needs approval"
     assert loop["items"][0]["owner"] == "Domain DNS operator"
     assert loop["items"][0]["automation_path"] == "provider_preview"
@@ -2299,10 +2304,15 @@ def test_summary_includes_current_remediation_loop(
     assert domain["remediation_workload"]["what_dmarq_can_fix"] >= 2
     assert domain["remediation_workload"]["what_needs_approval"] >= 2
     assert domain["remediation_workload"]["needs_approval"] >= 2
+    assert domain["remediation_workload"]["repair_preview_ready"] >= 2
+    assert domain["remediation_workload"]["repair_needs_evidence"] >= 2
     assert domain["remediation_workload"]["total_open"] >= 2
     assert domain["remediation_workload"]["primary"]["state"] == "needs_approval"
     assert domain["remediation_workload"]["primary"]["loop_state"] == (
         "proposal_ready_for_approval"
+    )
+    assert domain["remediation_workload"]["primary"]["repair_progression"]["stage"] == (
+        "preview_ready"
     )
     assert domain["remediation_workload"]["primary"]["remediation_track"] == ("provider_preview")
     assert domain["remediation_workload"]["primary"]["state_label"] == "Needs approval"
@@ -2331,6 +2341,9 @@ def test_dashboard_remediation_loop_is_clear_without_current_actions():
     assert loop["items"] == []
     assert loop["resolved"] == 2
     assert loop["verified_fixed"] == 1
+    assert loop["repair_preview_ready"] == 0
+    assert loop["repair_needs_evidence"] == 0
+    assert loop["repair_blocked"] == 0
 
 
 @pytest.mark.parametrize(

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -846,7 +846,13 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
     assert data["items"][0]["automation"]["provider"] == "cloudflare"
     assert data["items"][0]["verification_plan"]["status"] == "pending_operator_approval"
     assert "fresh DNS evidence" in data["items"][0]["verification_plan"]["summary"]
+    assert data["items"][0]["repair_progression"]["stage"] == "preview_ready"
+    assert data["items"][0]["repair_progression"]["can_preview"] is True
+    assert data["items"][0]["repair_progression"]["verification_status"] == (
+        "pending_operator_approval"
+    )
     assert data["items"][1]["verification_plan"]["status"] == "pending_sender_review"
+    assert data["items"][1]["repair_progression"]["stage"] == "classification_required"
     assert data["items"][1]["incident_type"] == "legitimate_sender_failing_alignment"
     assert data["items"][1]["loop_state"] == "evidence_review_required"
     assert data["items"][1]["remediation_track"] == "sender_investigation"
@@ -897,11 +903,17 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["verified_fixed"] == 1
     assert loop["track_provider_preview"] == 1
     assert loop["track_reputation_review"] == 1
+    assert loop["repair_preview_ready"] == 1
+    assert loop["repair_needs_evidence"] == 2
+    assert loop["repair_blocked"] == 0
     assert loop["items"][0]["priority_band"] == "high"
     assert loop["items"][0]["safe_to_automate"] is True
     assert loop["items"][0]["risk_level"] == "medium"
+    assert loop["items"][0]["repair_progression"]["stage"] == "preview_ready"
+    assert loop["items"][0]["repair_progression"]["can_preview"] is True
     assert "Preview the exact DNS" in loop["items"][0]["operator_decision_summary"]
     assert loop["items"][1]["remediation_track"] == "reputation_review"
+    assert loop["items"][1]["repair_progression"]["stage"] == "reputation_review"
     assert loop["items"][1]["risk_level"] == "high"
     assert loop["items"][1]["safe_to_automate"] is False
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -918,6 +918,43 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["items"][1]["safe_to_automate"] is False
 
 
+def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks():
+    """Dashboard repair-gate counters include blocked DNS repair prerequisites."""
+    loop = domains_endpoint._build_dashboard_remediation_loop(
+        [
+            {
+                "domain_name": "example.com",
+                "health": {
+                    "actions": [
+                        {
+                            "type": "missing_dkim",
+                            "source": "dns_lint",
+                            "severity": "high",
+                            "title": "Publish DKIM",
+                            "detail": "No DKIM selector was found.",
+                            "next_step": "Collect the provider-specific DKIM value.",
+                            "score_impact": 25,
+                            "prerequisites": [
+                                "A provider-specific final value is required before automation is safe."
+                            ],
+                        }
+                    ]
+                },
+            }
+        ],
+        {"summary": {}},
+    )
+
+    assert loop["track_blocked_by_prerequisite"] == 1
+    assert loop["repair_blocked"] == 1
+    assert loop["repair_preview_ready"] == 0
+    assert loop["repair_needs_evidence"] == 1
+    assert loop["items"][0]["remediation_track"] == "blocked_by_prerequisite"
+    assert loop["items"][0]["repair_progression"]["stage"] == "blocked"
+    assert loop["items"][0]["repair_progression"]["can_preview"] is False
+    assert "provider-specific value" in loop["items"][0]["repair_progression"]["summary"]
+
+
 def test_domain_remediation_dispatch_preview_becomes_eligible_without_enqueuing(
     seeded_client: TestClient,
     db_session,

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -182,6 +182,18 @@ def _sample_remediation_queue(domain=DOMAIN):
                     "evidence_needed": ["Fresh DNS returns the expected record."],
                     "next_check": "Refresh DNS posture after propagation.",
                 },
+                "repair_progression": {
+                    "stage": "preview_ready",
+                    "label": "Preview ready",
+                    "summary": "A connected DNS provider can prepare the exact mutation for review.",
+                    "next_gate": "Human approval before apply",
+                    "next_step": "Open the provider preview, compare old and new DNS values, then approve or reject.",
+                    "can_preview": True,
+                    "can_apply_after_approval": True,
+                    "manual_fallback": True,
+                    "verification_required": True,
+                    "verification_status": "pending_operator_approval",
+                },
                 "automation": {
                     "eligible": True,
                     "requires_approval": True,
@@ -630,6 +642,8 @@ def test_public_remediation_queue_is_read_only_and_posture_scoped(
     assert item["incident_type"] == "dmarc_policy_missing_or_weak"
     assert item["loop_state"] == "proposal_ready_for_approval"
     assert item["remediation_track"] == "provider_preview"
+    assert item["repair_progression"]["stage"] == "preview_ready"
+    assert item["repair_progression"]["can_apply_after_approval"] is True
     assert "approve_after_preview" in item["operator_decisions"]
     assert item["automation"]["eligible"] is True
     assert item["automation"]["apply_endpoint"] is None

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -64,6 +64,16 @@ detected in the current reporting window. These entries are designed to point to
 the next DNS or sender-configuration action rather than act as a general alert
 feed.
 
+### Remediation Loop
+
+The remediation loop card turns current domain health findings into operator
+work. It separates operator-marked resolved work from evidence-verified fixed
+work and shows the current approval, manual-action, and investigation counts.
+Repair-gate counters distinguish provider previews that are ready for review,
+items that still need fresh evidence before closure, and findings that are
+blocked before repair. Each dashboard item links to the selected domain's
+remediation queue for the full evidence, approval, and verification flow.
+
 ### Demo Mode
 
 When `DEMO_MODE=true`, the dashboard uses generated rolling data for

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -101,7 +101,9 @@ safe gate. It tells the operator whether a connected provider preview is ready,
 whether a provider-specific value is still missing, whether a sending source
 must be classified first, whether the work is manual DNS, or whether fresh
 reputation/report/DNS evidence is still required before closure. This panel is
-read-only; it does not apply DNS changes or send provider requests.
+read-only; it does not apply DNS changes or send provider requests. The top
+**Next remediation** panel mirrors the same repair-gate status so the operator
+can see the current blocker before opening the full queue.
 Each item also shows a notification profile such as approval required, action
 required, investigation required, or summary only. These labels explain how
 DMARQ would route the item into alerting or ticketing workflows; viewing the


### PR DESCRIPTION
## Summary
- surface the remediation repair gate consistently on the domain detail next-action card and full remediation queue
- add dashboard repair-gate counters for preview-ready, evidence-needed, and blocked-before-repair states
- preserve typed API repair progression metadata for public/read-only queue consumers
- update dashboard/domain user docs and changelog for the repair-gate wave

## Local validation
- node --check backend/app/static/js/dashboard-page.js
- node --check backend/app/static/js/domain-details-page.js
- .venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_public_api.py backend/app/tests/test_dns_endpoints.py
- git diff --check
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_public_api.py backend/app/tests/test_dns_endpoints.py -q --tb=short (301 passed)

## Safety
- UI/API/read-only metadata wave only; no live DNS/provider write path changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repair-gate status to remediation views, showing whether an item is ready for review, blocked, or needs more evidence.
  * Expanded dashboard and domain pages with clearer next-step, preview, and verification guidance for each remediation item.
  * Added new summary counters for repair progress across remediation queues.

* **Bug Fixes**
  * Preserved repair-progress details in API responses so the UI can display them reliably.

* **Documentation**
  * Updated dashboard and domain help content to explain the new remediation and repair-progression displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->