### PR TITLE
feat: add remediation decision checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added richer remediation-loop verification context, including priority bands, risk labels, safe-automation flags, verified-fixed totals, and next-check evidence for resolved items that no longer appear in the active queue.
 - Added a domain remediation queue refresh control and expandable evidence-verified repair list for operators reviewing historical fixes.
 - Added explicit remediation repair-progression context so each queue item shows whether it is preview-ready, blocked by a prerequisite, waiting for sender classification, manual-only, or pending fresh verification evidence.
+- Added remediation action-plan decision checkpoints and rollback guidance so operators can review evidence freshness and recovery paths before approving or closing a repair.
+- Added remediation verification closure gates and stale-evidence warnings so resolved items are not confused with evidence-verified repairs.
+- Added queue-level closure-gate and rollback-guidance counters to highlight remediation items that still need fresh evidence or a recovery path.
 
 ### Changed
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1195,6 +1195,9 @@ class RemediationActionPlan(BaseModel):
     risk_level: str = "medium"
     safe_to_automate: bool = False
     operator_decision_summary: str = ""
+    decision_checkpoints: List[str] = Field(default_factory=list)
+    rollback_plan: str = ""
+    requires_fresh_evidence: bool = True
 
 
 class RemediationVerificationPlan(BaseModel):
@@ -1205,6 +1208,8 @@ class RemediationVerificationPlan(BaseModel):
     verification_method: str = ""
     freshness_requirement: str = ""
     failure_mode: str = ""
+    closure_gate: str = ""
+    stale_evidence_warning: str = ""
     summary: str
     evidence_needed: List[str] = Field(default_factory=list)
     next_check: str

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -135,6 +135,22 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
             for item in items
             if (item.get("repair_progression") or {}).get("verification_required")
         ),
+        "requires_fresh_evidence": sum(
+            1
+            for item in items
+            if (item.get("action_plan") or {}).get("requires_fresh_evidence")
+        ),
+        "rollback_guidance": sum(
+            1 for item in items if (item.get("action_plan") or {}).get("rollback_plan")
+        ),
+        "closure_gate_required": sum(
+            1 for item in items if (item.get("verification_plan") or {}).get("closure_gate")
+        ),
+        "stale_evidence_warning": sum(
+            1
+            for item in items
+            if (item.get("verification_plan") or {}).get("stale_evidence_warning")
+        ),
         "notify_approval_required": sum(
             1 for item in items if item.get("notification", {}).get("state") == "approval_required"
         ),
@@ -392,6 +408,10 @@ def _loop_summary(domain: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
         "repair_approval_pending": summary["repair_approval_pending"],
         "repair_blocked": summary["repair_blocked"],
         "repair_needs_evidence": summary["repair_needs_evidence"],
+        "requires_fresh_evidence": summary["requires_fresh_evidence"],
+        "rollback_guidance": summary["rollback_guidance"],
+        "closure_gate_required": summary["closure_gate_required"],
+        "stale_evidence_warning": summary["stale_evidence_warning"],
         "top_item_id": next_item.get("id") if next_item else None,
         "top_incident_type": next_item.get("incident_type") if next_item else None,
         "top_loop_state": next_item.get("loop_state") if next_item else None,
@@ -505,6 +525,13 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
             "safe_to_automate": bool(action_plan.get("safe_to_automate")),
             "operator_decision_summary": str(action_plan.get("operator_decision_summary") or ""),
             "completion_criteria": str(action_plan.get("completion_criteria") or ""),
+            "decision_checkpoints": [
+                str(checkpoint)
+                for checkpoint in action_plan.get("decision_checkpoints", [])
+                if str(checkpoint).strip()
+            ][:5],
+            "rollback_plan": str(action_plan.get("rollback_plan") or ""),
+            "requires_fresh_evidence": bool(action_plan.get("requires_fresh_evidence", True)),
             "steps": [str(step) for step in action_plan.get("steps", []) if str(step).strip()][:5],
             "guidance_paths": [
                 {
@@ -522,6 +549,8 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
             "method": str(verification_plan.get("verification_method") or ""),
             "freshness_requirement": str(verification_plan.get("freshness_requirement") or ""),
             "failure_mode": str(verification_plan.get("failure_mode") or ""),
+            "closure_gate": str(verification_plan.get("closure_gate") or ""),
+            "stale_evidence_warning": str(verification_plan.get("stale_evidence_warning") or ""),
             "summary": str(verification_plan.get("summary") or ""),
             "next_check": str(verification_plan.get("next_check") or ""),
             "evidence_needed": [
@@ -784,6 +813,15 @@ def _action_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         completion = "Provider preview is approved, applied, and verified by DMARQ."
         risk_level = "medium"
         safe_to_automate = True
+        decision_checkpoints = [
+            "Confirm the authoritative zone and record owner before approving the preview.",
+            "Compare old and proposed DNS values, including TTL and record type.",
+            "Wait for fresh DNS evidence before treating the item as fixed.",
+        ]
+        rollback_plan = (
+            "If verification fails, restore the previous DNS value from the provider preview "
+            "or keep the manual remediation item open."
+        )
         steps = [
             "Open the DNS change plan and preview the provider mutation.",
             "Confirm the zone, record name, old value, new value, and TTL.",
@@ -797,6 +835,15 @@ def _action_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
             item.get("completion_criteria")
             or "Sender legitimacy is confirmed and the item is resolved or converted into a DNS repair."
         )
+        decision_checkpoints = [
+            "Confirm whether the sender is still active in recent DMARC reports.",
+            "Classify the source as legitimate, forwarding, abuse, or stale traffic.",
+            "Avoid SPF or DKIM changes until the sender owner is known.",
+        ]
+        rollback_plan = (
+            "If the classification is wrong, reopen the item and wait for fresh report "
+            "evidence before changing DNS or policy."
+        )
         steps = steps or [
             "Review the report evidence and sending-source history.",
             "Confirm whether the sender is legitimate for this domain.",
@@ -807,6 +854,15 @@ def _action_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         risk_level = "medium"
         safe_to_automate = False
         completion = "The DNS lint finding is no longer present after refresh."
+        decision_checkpoints = [
+            "Confirm the record is edited at the authoritative DNS provider.",
+            "Check whether the proposed value replaces or appends to existing records.",
+            "Refresh trusted resolver evidence after the DNS TTL has elapsed.",
+        ]
+        rollback_plan = (
+            "If the lint finding remains or mail flow worsens, restore the previous DNS "
+            "record value and keep the item open."
+        )
         steps = steps or [
             "Open the DNS guidance section.",
             "Apply the listed record change in the authoritative DNS provider.",
@@ -819,6 +875,15 @@ def _action_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         completion = str(
             item.get("completion_criteria")
             or "The underlying domain health action no longer appears in the remediation queue."
+        )
+        decision_checkpoints = [
+            "Confirm the finding still appears in current domain health evidence.",
+            "Complete the operator action outside DMARQ if needed.",
+            "Refresh DMARC report or DNS evidence before marking the item resolved.",
+        ]
+        rollback_plan = (
+            "If fresh evidence still shows the finding, leave the item open and update the "
+            "operator note instead of closing it."
         )
         steps = steps or ["Review the evidence and complete the recommended operator action."]
 
@@ -838,6 +903,9 @@ def _action_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         "risk_level": risk_level,
         "safe_to_automate": safe_to_automate,
         "operator_decision_summary": _operator_decision_summary(item),
+        "decision_checkpoints": decision_checkpoints[:5],
+        "rollback_plan": rollback_plan,
+        "requires_fresh_evidence": True,
         "guidance_paths": _guidance_paths_for_item(
             item,
             owner=owner,
@@ -860,6 +928,10 @@ def _verification_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
             "verification_method": "provider_write_then_dns_refresh",
             "freshness_requirement": "Fresh DNS evidence after provider propagation.",
             "failure_mode": "Keep the item open if the expected record is not visible.",
+            "closure_gate": "Close only after approved provider apply and fresh DNS evidence agree.",
+            "stale_evidence_warning": (
+                "Do not mark this fixed from the preview alone; DNS propagation evidence is required."
+            ),
             "summary": (
                 f"DMARQ should only mark this fixed after the approved {provider} write is "
                 "visible in fresh DNS evidence."
@@ -879,6 +951,10 @@ def _verification_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
             "verification_method": "manual_dns_refresh",
             "freshness_requirement": "Fresh resolver evidence after DNS TTL and propagation.",
             "failure_mode": "Keep the manual action open if the lint finding remains.",
+            "closure_gate": "Close only after a fresh DNS refresh no longer reports this lint finding.",
+            "stale_evidence_warning": (
+                "Cached or pre-change DNS evidence can make a repaired record look broken."
+            ),
             "summary": (
                 "Manual DNS changes are complete only when DMARQ can read the corrected record "
                 "from trusted resolver evidence."
@@ -898,6 +974,13 @@ def _verification_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
             "verification_method": "fresh_dmarc_report_window",
             "freshness_requirement": "A new receiver report covering the active sender.",
             "failure_mode": "Keep investigating if the sender remains unknown, failing, or stale.",
+            "closure_gate": (
+                "Close only after the sender is classified and a newer DMARC report confirms "
+                "the expected treatment."
+            ),
+            "stale_evidence_warning": (
+                "Old report rows can describe senders that no longer send mail for this domain."
+            ),
             "summary": (
                 "Investigation items are not fixed until the sender is classified and fresh "
                 "DMARC reports prove the chosen treatment."
@@ -916,6 +999,10 @@ def _verification_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         "verification_method": "fresh_health_rebuild",
         "freshness_requirement": "Fresh DMARC reports or DNS checks after the operator action.",
         "failure_mode": "Keep the item open if the same health action is still present.",
+        "closure_gate": "Close only after fresh health evidence removes the same finding.",
+        "stale_evidence_warning": (
+            "Do not close from an operator note alone; import or refresh evidence first."
+        ),
         "summary": (
             "Health items should stay open until fresh DMARC or DNS evidence confirms the "
             "underlying finding is gone."

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -402,6 +402,12 @@
                             <span class="rounded bg-[#fff8ed] px-2 py-1 font-semibold text-[#7a4a00]">
                                 <span x-text="remediationQueue.summary.repair_needs_evidence || 0"></span><span> need evidence</span>
                             </span>
+                            <span class="rounded bg-[#fff8ed] px-2 py-1 font-semibold text-[#7a4a00]">
+                                <span x-text="remediationQueue.summary.closure_gate_required || 0"></span><span> closure gates</span>
+                            </span>
+                            <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
+                                <span x-text="remediationQueue.summary.rollback_guidance || 0"></span><span> rollback notes</span>
+                            </span>
                             <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700">
                                 <span x-text="remediationQueue.summary.dispatch_ready || 0"></span><span> ready to notify</span>
                             </span>
@@ -537,6 +543,12 @@
                                     <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
                                         <span x-text="remediationQueue.loop?.repair_blocked || 0"></span><span> blocked before repair</span>
                                     </span>
+                                    <span class="rounded bg-[#fff8ed] px-2 py-1 font-semibold text-[#7a4a00]">
+                                        <span x-text="remediationQueue.loop?.closure_gate_required || 0"></span><span> closure gates</span>
+                                    </span>
+                                    <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
+                                        <span x-text="remediationQueue.loop?.rollback_guidance || 0"></span><span> rollback notes</span>
+                                    </span>
                                 </div>
                             </div>
                             <div class="rounded-lg bg-white p-3">
@@ -668,6 +680,24 @@
                                                 </li>
                                             </template>
                                         </ol>
+                                        <template x-if="(item.action_plan.decision_checkpoints || []).length">
+                                            <div class="mt-3 rounded border border-[#d8ebe8] bg-white p-3">
+                                                <div class="flex flex-wrap items-center justify-between gap-2">
+                                                    <p class="text-xs font-semibold uppercase text-[#1f7c83]">Decision checkpoints</p>
+                                                    <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#5f5c78]"
+                                                          x-text="item.action_plan.requires_fresh_evidence ? 'fresh evidence required' : 'current evidence enough'"></span>
+                                                </div>
+                                                <ul class="mt-2 space-y-1 text-sm text-[#45505f]">
+                                                    <template x-for="checkpoint in (item.action_plan.decision_checkpoints || []).slice(0, 4)"
+                                                              :key="item.id + '-checkpoint-' + checkpoint">
+                                                        <li class="flex gap-2">
+                                                            <span class="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[#2f9da5]"></span>
+                                                            <span x-text="checkpoint"></span>
+                                                        </li>
+                                                    </template>
+                                                </ul>
+                                            </div>
+                                        </template>
                                         <template x-if="(item.action_plan.guidance_paths || []).length">
                                             <div class="mt-3 grid gap-2 md:grid-cols-2">
                                                 <template x-for="path in item.action_plan.guidance_paths" :key="item.id + '-path-' + path.key">
@@ -685,6 +715,11 @@
                                             <span class="font-semibold">Done when: </span>
                                             <span x-text="item.action_plan.completion_criteria"></span>
                                         </p>
+                                        <p class="mt-2 rounded bg-white px-3 py-2 text-xs text-[#45505f]"
+                                           x-show="item.action_plan.rollback_plan">
+                                            <span class="font-semibold">If this does not verify: </span>
+                                            <span x-text="item.action_plan.rollback_plan"></span>
+                                        </p>
                                     </div>
                                 </template>
                                 <template x-if="item.verification_plan">
@@ -696,6 +731,11 @@
                                         </div>
                                         <p class="mt-2 text-sm font-semibold text-[#120d36]" x-text="item.verification_plan.label"></p>
                                         <p class="mt-1 text-sm text-[#5f5c78]" x-text="item.verification_plan.summary"></p>
+                                        <p class="mt-2 rounded bg-[#f2fbf9] px-3 py-2 text-xs text-[#1f7c83]"
+                                           x-show="item.verification_plan.closure_gate">
+                                            <span class="font-semibold">Closure gate: </span>
+                                            <span x-text="item.verification_plan.closure_gate"></span>
+                                        </p>
                                         <div class="mt-3 grid gap-2 md:grid-cols-3">
                                             <div class="rounded bg-[#f6f8fb] px-3 py-2 text-xs text-[#45505f]">
                                                 <span class="font-semibold">Method: </span>
@@ -722,6 +762,9 @@
                                             <span class="font-semibold">Next check: </span>
                                             <span x-text="item.verification_plan.next_check"></span>
                                         </p>
+                                        <p class="mt-2 text-xs text-[#7a4a00]"
+                                           x-show="item.verification_plan.stale_evidence_warning"
+                                           x-text="item.verification_plan.stale_evidence_warning"></p>
                                     </div>
                                 </template>
                                 <template x-if="item.notification && item.notification.dispatch">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1251,6 +1251,14 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "item.action_plan.steps" in template
     assert "item.action_plan.completion_criteria" in template
     assert "item.action_plan.safe_to_automate" in template
+    assert "Decision checkpoints" in template
+    assert "item.action_plan.decision_checkpoints" in template
+    assert "item.action_plan.requires_fresh_evidence" in template
+    assert "item.action_plan.rollback_plan" in template
+    assert "remediationQueue.summary.closure_gate_required" in template
+    assert "remediationQueue.summary.rollback_guidance" in template
+    assert "remediationQueue.loop?.closure_gate_required" in template
+    assert "remediationQueue.loop?.rollback_guidance" in template
     assert "item.repair_progression" in template
     assert "repairProgressionNextStep(item.repair_progression)" in template
     assert "repairProgressionClass(item.repair_progression)" in template
@@ -1258,6 +1266,9 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "item.verification_plan.status" in template
     assert "item.verification_plan.evidence_needed" in template
     assert "item.verification_plan.next_check" in template
+    assert "Closure gate" in template
+    assert "item.verification_plan.closure_gate" in template
+    assert "item.verification_plan.stale_evidence_warning" in template
     assert "Notification dispatch" in template
     assert "item.notification.dispatch.blocked_reasons" in template
     assert "(reason, index) in item.notification.dispatch.blocked_reasons" in template

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -87,6 +87,10 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "repair_approval_pending": 0,
         "repair_blocked": 0,
         "repair_needs_evidence": 2,
+        "requires_fresh_evidence": 2,
+        "rollback_guidance": 2,
+        "closure_gate_required": 2,
+        "stale_evidence_warning": 2,
         "notify_approval_required": 1,
         "notify_action_required": 0,
         "notify_investigation_required": 1,
@@ -118,6 +122,10 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "repair_approval_pending": 0,
         "repair_blocked": 0,
         "repair_needs_evidence": 2,
+        "requires_fresh_evidence": 2,
+        "rollback_guidance": 2,
+        "closure_gate_required": 2,
+        "stale_evidence_warning": 2,
         "top_item_id": "dns:dmarc-missing",
         "top_incident_type": "dmarc_policy_missing_or_weak",
         "top_loop_state": "proposal_ready_for_approval",
@@ -170,12 +178,20 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         in " ".join(queue["items"][0]["action_plan"]["steps"]).lower()
     )
     assert queue["items"][0]["action_plan"]["completion_criteria"]
+    assert queue["items"][0]["action_plan"]["requires_fresh_evidence"] is True
+    assert any(
+        "authoritative zone" in checkpoint
+        for checkpoint in queue["items"][0]["action_plan"]["decision_checkpoints"]
+    )
+    assert "restore the previous DNS value" in queue["items"][0]["action_plan"]["rollback_plan"]
     assert queue["items"][0]["verification_plan"]["status"] == "pending_operator_approval"
     assert queue["items"][0]["verification_plan"]["verification_method"] == (
         "provider_write_then_dns_refresh"
     )
     assert "Fresh DNS evidence" in queue["items"][0]["verification_plan"]["freshness_requirement"]
     assert "Keep the item open" in queue["items"][0]["verification_plan"]["failure_mode"]
+    assert "fresh DNS evidence agree" in queue["items"][0]["verification_plan"]["closure_gate"]
+    assert "preview alone" in queue["items"][0]["verification_plan"]["stale_evidence_warning"]
     assert "fresh DNS evidence" in queue["items"][0]["verification_plan"]["summary"]
     assert any(
         "provider preview was approved" in evidence
@@ -253,6 +269,16 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
                 "Preview the exact DNS diff, then explicitly approve or reject the proposed repair."
             ),
             "completion_criteria": "Provider preview is approved, applied, and verified by DMARQ.",
+            "decision_checkpoints": [
+                "Confirm the authoritative zone and record owner before approving the preview.",
+                "Compare old and proposed DNS values, including TTL and record type.",
+                "Wait for fresh DNS evidence before treating the item as fixed.",
+            ],
+            "rollback_plan": (
+                "If verification fails, restore the previous DNS value from the provider preview "
+                "or keep the manual remediation item open."
+            ),
+            "requires_fresh_evidence": True,
             "steps": [
                 "Open the DNS change plan and preview the provider mutation.",
                 "Confirm the zone, record name, old value, new value, and TTL.",
@@ -273,6 +299,10 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
             "method": "provider_write_then_dns_refresh",
             "freshness_requirement": "Fresh DNS evidence after provider propagation.",
             "failure_mode": "Keep the item open if the expected record is not visible.",
+            "closure_gate": "Close only after approved provider apply and fresh DNS evidence agree.",
+            "stale_evidence_warning": (
+                "Do not mark this fixed from the preview alone; DNS propagation evidence is required."
+            ),
             "summary": (
                 "DMARQ should only mark this fixed after the approved cloudflare write is "
                 "visible in fresh DNS evidence."
@@ -342,6 +372,8 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
     assert queue["summary"]["blocked_by_prerequisite"] == 1
     assert queue["summary"]["repair_blocked"] == 1
     assert queue["summary"]["repair_needs_evidence"] == 1
+    assert queue["summary"]["closure_gate_required"] == 1
+    assert queue["summary"]["rollback_guidance"] == 1
     assert queue["summary"]["notify_summary_only"] == 1
     assert queue["loop"]["status"] == "manual_action_required"
     assert queue["loop"]["blocked_by_prerequisite"] == 1
@@ -356,6 +388,12 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
         "self_hosted",
     }
     assert queue["items"][0]["action_plan"]["completion_criteria"]
+    assert queue["items"][0]["action_plan"]["requires_fresh_evidence"] is True
+    assert any(
+        "dns ttl" in checkpoint.lower()
+        for checkpoint in queue["items"][0]["action_plan"]["decision_checkpoints"]
+    )
+    assert "keep the item open" in queue["items"][0]["action_plan"]["rollback_plan"]
     assert queue["items"][0]["repair_progression"]["stage"] == "blocked"
     assert queue["items"][0]["repair_progression"]["can_preview"] is False
     assert queue["items"][0]["repair_progression"]["manual_fallback"] is True

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -96,6 +96,15 @@ Use **Refresh queue** to reload the remediation queue from the backend after
 new reports, DNS checks, or operator lifecycle changes are available.
 Each item now also shows the remediation track, priority band, owner, risk
 level, safe-automation flag, and the exact operator decision DMARQ expects next.
+Action plans include decision checkpoints and a rollback or fallback note so an
+operator can verify the zone, sender, evidence freshness, and recovery path
+before approving, closing, or converting a remediation item.
+Verification cards include a closure gate and stale-evidence warning. This is
+the rule DMARQ expects before an operator-resolved item should become an
+evidence-verified repair.
+The queue header also counts closure gates and rollback notes, so operators can
+spot how much work still needs fresh evidence or a recovery plan before opening
+every remediation card.
 The **Repair progression** panel separates the recommendation from the next
 safe gate. It tells the operator whether a connected provider preview is ready,
 whether a provider-specific value is still missing, whether a sending source


### PR DESCRIPTION
## Summary
- add remediation action-plan decision checkpoints, fresh-evidence requirements, and rollback guidance
- add verification closure gates and stale-evidence warnings so operator-resolved work is not confused with evidence-verified repair
- surface closure-gate and rollback-note counters in the domain remediation queue header and loop summary
- include the new guidance in notification payload previews, API schema, user docs, and changelog

## Local validation
- .venv/bin/python -m pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_public_api.py -q --tb=short (201 passed)
- node --check backend/app/static/js/domain-details-page.js
- .venv/bin/python -m flake8 backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_dashboard_template_security.py
- git diff --check origin/main..HEAD

## Safety
- Read-only UI/API/payload guidance only.
- No live DNS/provider writes, no notification dispatch behavior changes, and no secret changes.