### PR TITLE
feat: add remediation repair readiness context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added remediation action-plan decision checkpoints and rollback guidance so operators can review evidence freshness and recovery paths before approving or closing a repair.
 - Added remediation verification closure gates and stale-evidence warnings so resolved items are not confused with evidence-verified repairs.
 - Added queue-level closure-gate and rollback-guidance counters to highlight remediation items that still need fresh evidence or a recovery path.
+- Added remediation repair-readiness levels, scores, reasons, and blockers so operators can distinguish preview-ready work from manual, blocked, classification, and reputation-review work.
 
 ### Changed
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.
@@ -40,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remediation notification payloads now include the same repair-progression gates shown in the UI, keeping webhook/ticket previews aligned with human review.
 - Domain remediation pages now show repair-progression gates in the top next-remediation panel and render preview/verification states as operator-readable labels.
 - Dashboard remediation-loop cards now expose the same repair-gate language and workspace counters for preview-ready, evidence-gated, and blocked repair work.
+- Dashboard and domain remediation views now show repair-readiness counters and per-item readiness scores before an operator opens or dispatches remediation work.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -112,6 +112,10 @@ from app.services.remediation_dispatch import (
     summarize_remediation_activity,
 )
 from app.services.remediation_queue import build_remediation_queue
+from app.services.remediation_readiness import (
+    OPERATOR_REVIEW_READINESS_LEVELS,
+    repair_readiness_for_stage,
+)
 from app.services.report_persistence import (
     domain_summaries_from_db,
     hydrate_domain_report_store_from_db,
@@ -2046,11 +2050,9 @@ def _dashboard_repair_progression_with_readiness(
     stage = str(progression.get("stage") or "operator_review")
     reasons: List[str] = []
     blocked_by: List[str] = []
+    readiness = repair_readiness_for_stage(stage)
 
     if stage == "preview_ready":
-        readiness_level = "ready_for_preview"
-        readiness_label = "Ready for provider preview"
-        readiness_score = 80
         reasons.extend(
             [
                 "A guided repair can be previewed from the domain queue.",
@@ -2058,32 +2060,17 @@ def _dashboard_repair_progression_with_readiness(
             ]
         )
     elif stage == "blocked":
-        readiness_level = "blocked"
-        readiness_label = "Blocked before repair"
-        readiness_score = 20
         blocked_by.append("provider_specific_value")
         reasons.append("The provider-specific target value is missing.")
     elif stage == "classification_required":
-        readiness_level = "needs_classification"
-        readiness_label = "Needs sender classification"
-        readiness_score = 35
         blocked_by.append("sender_classification")
         reasons.append("The sender must be classified before DNS or policy changes are safe.")
     elif stage == "reputation_review":
-        readiness_level = "needs_reputation_review"
-        readiness_label = "Needs reputation review"
-        readiness_score = 40
         blocked_by.append("fresh_reputation_evidence")
         reasons.append("Fresh reputation or blacklist evidence is required before closure.")
     elif stage == "manual_repair":
-        readiness_level = "manual_repair"
-        readiness_label = "Manual repair path"
-        readiness_score = 50
         reasons.append("The operator must complete the work outside DMARQ, then refresh evidence.")
     else:
-        readiness_level = "needs_operator_review"
-        readiness_label = "Needs operator review"
-        readiness_score = 30
         reasons.append("The item needs fresh evidence and operator context before closure.")
 
     if progression.get("verification_required"):
@@ -2094,9 +2081,7 @@ def _dashboard_repair_progression_with_readiness(
 
     return {
         **progression,
-        "readiness_level": readiness_level,
-        "readiness_label": readiness_label,
-        "readiness_score": readiness_score,
+        **readiness,
         "readiness_reasons": reasons[:5],
         "blocked_by": list(dict.fromkeys(blocked_by))[:5],
         "next_safe_action": str(
@@ -2245,12 +2230,7 @@ def _increment_repair_counters(counters: Dict[str, int], item: Dict[str, Any]) -
         counters["repair_ready_for_preview"] += 1
     if readiness_level == "blocked":
         counters["repair_readiness_blocked"] += 1
-    if readiness_level in {
-        "needs_classification",
-        "needs_reputation_review",
-        "manual_repair",
-        "needs_operator_review",
-    }:
+    if readiness_level in OPERATOR_REVIEW_READINESS_LEVELS:
         counters["repair_waiting_on_operator"] += 1
     counters["repair_readiness_score"] = max(
         counters["repair_readiness_score"],

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1223,6 +1223,12 @@ class RemediationRepairProgression(BaseModel):
     summary: str
     next_gate: str
     next_step: str
+    readiness_level: str = "needs_operator_review"
+    readiness_label: str = "Needs operator review"
+    readiness_score: int = 0
+    readiness_reasons: List[str] = Field(default_factory=list)
+    blocked_by: List[str] = Field(default_factory=list)
+    next_safe_action: str = ""
     can_preview: bool = False
     can_apply_after_approval: bool = False
     manual_fallback: bool = False
@@ -2031,73 +2037,163 @@ def _remediation_operator_decision_summary(state: str) -> str:
     return "Complete the manual action, refresh evidence, then mark the item resolved."
 
 
+def _dashboard_repair_progression_with_readiness(
+    progression: Dict[str, Any],
+    *,
+    verification_status: str,
+) -> Dict[str, Any]:
+    """Add dashboard-safe read-only repair readiness metadata."""
+    stage = str(progression.get("stage") or "operator_review")
+    reasons: List[str] = []
+    blocked_by: List[str] = []
+
+    if stage == "preview_ready":
+        readiness_level = "ready_for_preview"
+        readiness_label = "Ready for provider preview"
+        readiness_score = 80
+        reasons.extend(
+            [
+                "A guided repair can be previewed from the domain queue.",
+                "A human approval gate is required before apply.",
+            ]
+        )
+    elif stage == "blocked":
+        readiness_level = "blocked"
+        readiness_label = "Blocked before repair"
+        readiness_score = 20
+        blocked_by.append("provider_specific_value")
+        reasons.append("The provider-specific target value is missing.")
+    elif stage == "classification_required":
+        readiness_level = "needs_classification"
+        readiness_label = "Needs sender classification"
+        readiness_score = 35
+        blocked_by.append("sender_classification")
+        reasons.append("The sender must be classified before DNS or policy changes are safe.")
+    elif stage == "reputation_review":
+        readiness_level = "needs_reputation_review"
+        readiness_label = "Needs reputation review"
+        readiness_score = 40
+        blocked_by.append("fresh_reputation_evidence")
+        reasons.append("Fresh reputation or blacklist evidence is required before closure.")
+    elif stage == "manual_repair":
+        readiness_level = "manual_repair"
+        readiness_label = "Manual repair path"
+        readiness_score = 50
+        reasons.append("The operator must complete the work outside DMARQ, then refresh evidence.")
+    else:
+        readiness_level = "needs_operator_review"
+        readiness_label = "Needs operator review"
+        readiness_score = 30
+        reasons.append("The item needs fresh evidence and operator context before closure.")
+
+    if progression.get("verification_required"):
+        blocked_by.append("fresh_evidence_before_closure")
+        reasons.append("Fresh evidence is required before DMARQ can call this fixed.")
+    if verification_status and verification_status != "verified":
+        blocked_by.append(verification_status)
+
+    return {
+        **progression,
+        "readiness_level": readiness_level,
+        "readiness_label": readiness_label,
+        "readiness_score": readiness_score,
+        "readiness_reasons": reasons[:5],
+        "blocked_by": list(dict.fromkeys(blocked_by))[:5],
+        "next_safe_action": str(
+            progression.get("next_step")
+            or progression.get("summary")
+            or "Open the remediation queue to review the next safe gate."
+        ),
+    }
+
+
 def _dashboard_repair_progression(state: str, action: Dict[str, Any]) -> Dict[str, Any]:
     """Return a conservative repair gate for dashboard health-action summaries."""
     action_type = str(action.get("type") or "")
     if _remediation_track_for_action(state, action) == "blocked_by_prerequisite":
-        return {
-            "stage": "blocked",
-            "label": "Blocked by prerequisite",
-            "summary": "DMARQ needs a provider-specific value before this can become a safe repair.",
-            "next_gate": "Provider value required",
-            "next_step": "Fetch the exact DKIM, SPF, DMARC, or CNAME target from the mail provider first.",
-            "can_preview": False,
-            "can_apply_after_approval": False,
-            "manual_fallback": True,
-            "verification_required": True,
-            "verification_status": "pending_dns_refresh",
-        }
+        verification_status = "pending_dns_refresh"
+        return _dashboard_repair_progression_with_readiness(
+            {
+                "stage": "blocked",
+                "label": "Blocked by prerequisite",
+                "summary": "DMARQ needs a provider-specific value before this can become a safe repair.",
+                "next_gate": "Provider value required",
+                "next_step": "Fetch the exact DKIM, SPF, DMARC, or CNAME target from the mail provider first.",
+                "can_preview": False,
+                "can_apply_after_approval": False,
+                "manual_fallback": True,
+                "verification_required": True,
+                "verification_status": verification_status,
+            },
+            verification_status=verification_status,
+        )
     if state == "needs_approval":
-        return {
-            "stage": "preview_ready",
-            "label": "Preview ready",
-            "summary": "A guided repair can be reviewed from the domain remediation queue.",
-            "next_gate": "Human approval before apply",
-            "next_step": "Open the domain queue, preview the proposed repair, then approve or reject it.",
-            "can_preview": True,
-            "can_apply_after_approval": True,
-            "manual_fallback": True,
-            "verification_required": True,
-            "verification_status": "pending_operator_approval",
-        }
+        verification_status = "pending_operator_approval"
+        return _dashboard_repair_progression_with_readiness(
+            {
+                "stage": "preview_ready",
+                "label": "Preview ready",
+                "summary": "A guided repair can be reviewed from the domain remediation queue.",
+                "next_gate": "Human approval before apply",
+                "next_step": "Open the domain queue, preview the proposed repair, then approve or reject it.",
+                "can_preview": True,
+                "can_apply_after_approval": True,
+                "manual_fallback": True,
+                "verification_required": True,
+                "verification_status": verification_status,
+            },
+            verification_status=verification_status,
+        )
     if state == "investigate":
         if action_type in REMEDIATION_REPUTATION_ACTION_TYPES:
-            return {
-                "stage": "reputation_review",
-                "label": "Review reputation",
-                "summary": "Fresh reputation evidence is required before this can be closed.",
-                "next_gate": "Fresh reputation evidence",
-                "next_step": "Open source intelligence and confirm whether the sender is trusted.",
+            verification_status = "pending_report_evidence"
+            return _dashboard_repair_progression_with_readiness(
+                {
+                    "stage": "reputation_review",
+                    "label": "Review reputation",
+                    "summary": "Fresh reputation evidence is required before this can be closed.",
+                    "next_gate": "Fresh reputation evidence",
+                    "next_step": "Open source intelligence and confirm whether the sender is trusted.",
+                    "can_preview": False,
+                    "can_apply_after_approval": False,
+                    "manual_fallback": False,
+                    "verification_required": True,
+                    "verification_status": verification_status,
+                },
+                verification_status=verification_status,
+            )
+        verification_status = "pending_sender_review"
+        return _dashboard_repair_progression_with_readiness(
+            {
+                "stage": "classification_required",
+                "label": "Classify sender",
+                "summary": "A human must classify the sender before DNS or policy changes are safe.",
+                "next_gate": "Sender classification",
+                "next_step": "Review recent source evidence and decide whether this sender is legitimate.",
                 "can_preview": False,
                 "can_apply_after_approval": False,
                 "manual_fallback": False,
                 "verification_required": True,
-                "verification_status": "pending_report_evidence",
-            }
-        return {
-            "stage": "classification_required",
-            "label": "Classify sender",
-            "summary": "A human must classify the sender before DNS or policy changes are safe.",
-            "next_gate": "Sender classification",
-            "next_step": "Review recent source evidence and decide whether this sender is legitimate.",
+                "verification_status": verification_status,
+            },
+            verification_status=verification_status,
+        )
+    verification_status = "pending_report_evidence"
+    return _dashboard_repair_progression_with_readiness(
+        {
+            "stage": "manual_repair",
+            "label": "Manual repair",
+            "summary": "The operator must complete this work and refresh evidence before closure.",
+            "next_gate": "Fresh evidence before closure",
+            "next_step": "Complete the manual action, then refresh DMARQ evidence.",
             "can_preview": False,
             "can_apply_after_approval": False,
-            "manual_fallback": False,
+            "manual_fallback": True,
             "verification_required": True,
-            "verification_status": "pending_sender_review",
-        }
-    return {
-        "stage": "manual_repair",
-        "label": "Manual repair",
-        "summary": "The operator must complete this work and refresh evidence before closure.",
-        "next_gate": "Fresh evidence before closure",
-        "next_step": "Complete the manual action, then refresh DMARQ evidence.",
-        "can_preview": False,
-        "can_apply_after_approval": False,
-        "manual_fallback": True,
-        "verification_required": True,
-        "verification_status": "pending_report_evidence",
-    }
+            "verification_status": verification_status,
+        },
+        verification_status=verification_status,
+    )
 
 
 def _dashboard_remediation_item(
@@ -2144,6 +2240,22 @@ def _increment_repair_counters(counters: Dict[str, int], item: Dict[str, Any]) -
         counters["repair_blocked"] += 1
     if repair_progression.get("verification_required"):
         counters["repair_needs_evidence"] += 1
+    readiness_level = str(repair_progression.get("readiness_level") or "")
+    if readiness_level == "ready_for_preview":
+        counters["repair_ready_for_preview"] += 1
+    if readiness_level == "blocked":
+        counters["repair_readiness_blocked"] += 1
+    if readiness_level in {
+        "needs_classification",
+        "needs_reputation_review",
+        "manual_repair",
+        "needs_operator_review",
+    }:
+        counters["repair_waiting_on_operator"] += 1
+    counters["repair_readiness_score"] = max(
+        counters["repair_readiness_score"],
+        int(repair_progression.get("readiness_score") or 0),
+    )
 
 
 def _build_dashboard_remediation_loop(
@@ -2164,6 +2276,10 @@ def _build_dashboard_remediation_loop(
         "repair_preview_ready": 0,
         "repair_blocked": 0,
         "repair_needs_evidence": 0,
+        "repair_ready_for_preview": 0,
+        "repair_waiting_on_operator": 0,
+        "repair_readiness_blocked": 0,
+        "repair_readiness_score": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2226,6 +2342,10 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         "repair_preview_ready": 0,
         "repair_blocked": 0,
         "repair_needs_evidence": 0,
+        "repair_ready_for_preview": 0,
+        "repair_waiting_on_operator": 0,
+        "repair_readiness_blocked": 0,
+        "repair_readiness_score": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Optional, Set
 
+from app.services.remediation_readiness import (
+    OPERATOR_REVIEW_READINESS_LEVELS,
+    repair_readiness_for_stage,
+)
 from app.services.webhook_events import (
     EVENT_REMEDIATION_APPROVAL_REQUIRED,
     EVENT_REMEDIATION_INVESTIGATION_REQUIRED,
@@ -141,12 +145,7 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
             1
             for item in items
             if (item.get("repair_progression") or {}).get("readiness_level")
-            in {
-                "needs_classification",
-                "needs_reputation_review",
-                "manual_repair",
-                "needs_operator_review",
-            }
+            in OPERATOR_REVIEW_READINESS_LEVELS
         ),
         "repair_readiness_blocked": sum(
             1
@@ -303,11 +302,9 @@ def _repair_progression_with_readiness(
     stage = str(progression.get("stage") or "operator_review")
     reasons: List[str] = []
     blocked_by: List[str] = []
+    readiness = repair_readiness_for_stage(stage)
 
     if stage == "preview_ready":
-        readiness_level = "ready_for_preview"
-        readiness_label = "Ready for provider preview"
-        readiness_score = 80
         reasons.extend(
             [
                 "A connected DNS provider can produce an exact change preview.",
@@ -315,32 +312,17 @@ def _repair_progression_with_readiness(
             ]
         )
     elif stage == "blocked":
-        readiness_level = "blocked"
-        readiness_label = "Blocked before repair"
-        readiness_score = 20
         blocked_by.append("provider_specific_value")
         reasons.append("The provider-specific target value is missing.")
     elif stage == "classification_required":
-        readiness_level = "needs_classification"
-        readiness_label = "Needs sender classification"
-        readiness_score = 35
         blocked_by.append("sender_classification")
         reasons.append("The sender must be classified before DNS or policy changes are safe.")
     elif stage == "reputation_review":
-        readiness_level = "needs_reputation_review"
-        readiness_label = "Needs reputation review"
-        readiness_score = 40
         blocked_by.append("fresh_reputation_evidence")
         reasons.append("Fresh reputation or blacklist evidence is required before closure.")
     elif stage == "manual_repair":
-        readiness_level = "manual_repair"
-        readiness_label = "Manual repair path"
-        readiness_score = 50
         reasons.append("The item has operator guidance but no connected safe write path.")
     else:
-        readiness_level = "needs_operator_review"
-        readiness_label = "Needs operator review"
-        readiness_score = 30
         reasons.append("The item needs fresh evidence and operator context before closure.")
 
     if progression.get("verification_required"):
@@ -352,9 +334,7 @@ def _repair_progression_with_readiness(
 
     return {
         **progression,
-        "readiness_level": readiness_level,
-        "readiness_label": readiness_label,
-        "readiness_score": readiness_score,
+        **readiness,
         "readiness_reasons": reasons[:5],
         "blocked_by": list(dict.fromkeys(blocked_by))[:5],
         "next_safe_action": str(

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -122,23 +122,46 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
         "repair_approval_pending": sum(
             1
             for item in items
-            if (item.get("repair_progression") or {}).get("stage")
-            == "approval_pending"
+            if (item.get("repair_progression") or {}).get("stage") == "approval_pending"
         ),
         "repair_blocked": sum(
-            1
-            for item in items
-            if (item.get("repair_progression") or {}).get("stage") == "blocked"
+            1 for item in items if (item.get("repair_progression") or {}).get("stage") == "blocked"
         ),
         "repair_needs_evidence": sum(
             1
             for item in items
             if (item.get("repair_progression") or {}).get("verification_required")
         ),
-        "requires_fresh_evidence": sum(
+        "repair_ready_for_preview": sum(
             1
             for item in items
-            if (item.get("action_plan") or {}).get("requires_fresh_evidence")
+            if (item.get("repair_progression") or {}).get("readiness_level") == "ready_for_preview"
+        ),
+        "repair_waiting_on_operator": sum(
+            1
+            for item in items
+            if (item.get("repair_progression") or {}).get("readiness_level")
+            in {
+                "needs_classification",
+                "needs_reputation_review",
+                "manual_repair",
+                "needs_operator_review",
+            }
+        ),
+        "repair_readiness_blocked": sum(
+            1
+            for item in items
+            if (item.get("repair_progression") or {}).get("readiness_level") == "blocked"
+        ),
+        "repair_readiness_score": max(
+            [
+                int((item.get("repair_progression") or {}).get("readiness_score") or 0)
+                for item in items
+            ]
+            or [0]
+        ),
+        "requires_fresh_evidence": sum(
+            1 for item in items if (item.get("action_plan") or {}).get("requires_fresh_evidence")
         ),
         "rollback_guidance": sum(
             1 for item in items if (item.get("action_plan") or {}).get("rollback_plan")
@@ -271,6 +294,77 @@ def _operator_decision_summary(item: Dict[str, Any]) -> str:
     return "Acknowledge the work, complete it manually, then mark it resolved only after fresh evidence confirms it."
 
 
+def _repair_progression_with_readiness(
+    progression: Dict[str, Any],
+    *,
+    verification_status: str,
+) -> Dict[str, Any]:
+    """Add operator-facing repair readiness without implying mutation."""
+    stage = str(progression.get("stage") or "operator_review")
+    reasons: List[str] = []
+    blocked_by: List[str] = []
+
+    if stage == "preview_ready":
+        readiness_level = "ready_for_preview"
+        readiness_label = "Ready for provider preview"
+        readiness_score = 80
+        reasons.extend(
+            [
+                "A connected DNS provider can produce an exact change preview.",
+                "A human approval gate is still required before apply.",
+            ]
+        )
+    elif stage == "blocked":
+        readiness_level = "blocked"
+        readiness_label = "Blocked before repair"
+        readiness_score = 20
+        blocked_by.append("provider_specific_value")
+        reasons.append("The provider-specific target value is missing.")
+    elif stage == "classification_required":
+        readiness_level = "needs_classification"
+        readiness_label = "Needs sender classification"
+        readiness_score = 35
+        blocked_by.append("sender_classification")
+        reasons.append("The sender must be classified before DNS or policy changes are safe.")
+    elif stage == "reputation_review":
+        readiness_level = "needs_reputation_review"
+        readiness_label = "Needs reputation review"
+        readiness_score = 40
+        blocked_by.append("fresh_reputation_evidence")
+        reasons.append("Fresh reputation or blacklist evidence is required before closure.")
+    elif stage == "manual_repair":
+        readiness_level = "manual_repair"
+        readiness_label = "Manual repair path"
+        readiness_score = 50
+        reasons.append("The item has operator guidance but no connected safe write path.")
+    else:
+        readiness_level = "needs_operator_review"
+        readiness_label = "Needs operator review"
+        readiness_score = 30
+        reasons.append("The item needs fresh evidence and operator context before closure.")
+
+    if progression.get("verification_required"):
+        blocked_by.append("fresh_evidence_before_closure")
+        reasons.append("Fresh evidence is required before DMARQ can call this fixed.")
+
+    if verification_status and verification_status != "verified":
+        blocked_by.append(verification_status)
+
+    return {
+        **progression,
+        "readiness_level": readiness_level,
+        "readiness_label": readiness_label,
+        "readiness_score": readiness_score,
+        "readiness_reasons": reasons[:5],
+        "blocked_by": list(dict.fromkeys(blocked_by))[:5],
+        "next_safe_action": str(
+            progression.get("next_step")
+            or progression.get("summary")
+            or "Review the remediation evidence before taking action."
+        ),
+    }
+
+
 def _repair_progression_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
     """Return the safe repair lane and gates without performing any mutation."""
     automation = item.get("automation") or {}
@@ -279,82 +373,106 @@ def _repair_progression_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
     state = str(item.get("state") or "")
 
     if automation.get("eligible"):
-        return {
-            "stage": "preview_ready",
-            "label": "Preview ready",
-            "summary": "A connected DNS provider can prepare the exact mutation for review.",
-            "next_gate": "Human approval before apply",
-            "next_step": "Open the provider preview, compare old and new DNS values, then approve or reject.",
-            "can_preview": True,
-            "can_apply_after_approval": True,
-            "manual_fallback": True,
-            "verification_required": True,
-            "verification_status": str(verification.get("status") or "pending_operator_approval"),
-        }
+        verification_status = str(verification.get("status") or "pending_operator_approval")
+        return _repair_progression_with_readiness(
+            {
+                "stage": "preview_ready",
+                "label": "Preview ready",
+                "summary": "A connected DNS provider can prepare the exact mutation for review.",
+                "next_gate": "Human approval before apply",
+                "next_step": "Open the provider preview, compare old and new DNS values, then approve or reject.",
+                "can_preview": True,
+                "can_apply_after_approval": True,
+                "manual_fallback": True,
+                "verification_required": True,
+                "verification_status": verification_status,
+            },
+            verification_status=verification_status,
+        )
     if track == "blocked_by_prerequisite":
-        return {
-            "stage": "blocked",
-            "label": "Blocked by prerequisite",
-            "summary": "DMARQ needs a provider-specific value before this can become a safe repair.",
-            "next_gate": "Provider value required",
-            "next_step": "Fetch the exact DKIM, SPF, DMARC, or CNAME target from the mail provider first.",
-            "can_preview": False,
-            "can_apply_after_approval": False,
-            "manual_fallback": True,
-            "verification_required": True,
-            "verification_status": str(verification.get("status") or "pending_dns_refresh"),
-        }
+        verification_status = str(verification.get("status") or "pending_dns_refresh")
+        return _repair_progression_with_readiness(
+            {
+                "stage": "blocked",
+                "label": "Blocked by prerequisite",
+                "summary": "DMARQ needs a provider-specific value before this can become a safe repair.",
+                "next_gate": "Provider value required",
+                "next_step": "Fetch the exact DKIM, SPF, DMARC, or CNAME target from the mail provider first.",
+                "can_preview": False,
+                "can_apply_after_approval": False,
+                "manual_fallback": True,
+                "verification_required": True,
+                "verification_status": verification_status,
+            },
+            verification_status=verification_status,
+        )
     if state == "investigate":
-        return {
-            "stage": "classification_required",
-            "label": "Classify sender",
-            "summary": "A human must decide whether the source is legitimate, forwarding, abuse, or stale.",
-            "next_gate": "Sender classification",
-            "next_step": "Review source intelligence and recent report evidence before changing SPF or DKIM.",
-            "can_preview": False,
-            "can_apply_after_approval": False,
-            "manual_fallback": False,
-            "verification_required": True,
-            "verification_status": str(verification.get("status") or "pending_sender_review"),
-        }
+        verification_status = str(verification.get("status") or "pending_sender_review")
+        return _repair_progression_with_readiness(
+            {
+                "stage": "classification_required",
+                "label": "Classify sender",
+                "summary": "A human must decide whether the source is legitimate, forwarding, abuse, or stale.",
+                "next_gate": "Sender classification",
+                "next_step": "Review source intelligence and recent report evidence before changing SPF or DKIM.",
+                "can_preview": False,
+                "can_apply_after_approval": False,
+                "manual_fallback": False,
+                "verification_required": True,
+                "verification_status": verification_status,
+            },
+            verification_status=verification_status,
+        )
     if track == "manual_dns":
-        return {
-            "stage": "manual_repair",
-            "label": "Manual DNS repair",
-            "summary": "The finding has DNS guidance but no connected safe write path yet.",
-            "next_gate": "Operator applies DNS manually",
-            "next_step": "Apply the suggested record in authoritative DNS, then refresh DMARQ evidence.",
+        verification_status = str(verification.get("status") or "pending_dns_refresh")
+        return _repair_progression_with_readiness(
+            {
+                "stage": "manual_repair",
+                "label": "Manual DNS repair",
+                "summary": "The finding has DNS guidance but no connected safe write path yet.",
+                "next_gate": "Operator applies DNS manually",
+                "next_step": "Apply the suggested record in authoritative DNS, then refresh DMARQ evidence.",
+                "can_preview": False,
+                "can_apply_after_approval": False,
+                "manual_fallback": True,
+                "verification_required": True,
+                "verification_status": verification_status,
+            },
+            verification_status=verification_status,
+        )
+    if track == "reputation_review":
+        verification_status = str(verification.get("status") or "pending_report_evidence")
+        return _repair_progression_with_readiness(
+            {
+                "stage": "reputation_review",
+                "label": "Review reputation",
+                "summary": "The source needs reputation or blacklist evidence before operator closure.",
+                "next_gate": "Fresh reputation evidence",
+                "next_step": "Check current reputation feeds and decide whether to delist, stop, or accept the sender.",
+                "can_preview": False,
+                "can_apply_after_approval": False,
+                "manual_fallback": False,
+                "verification_required": True,
+                "verification_status": verification_status,
+            },
+            verification_status=verification_status,
+        )
+    verification_status = str(verification.get("status") or "pending_report_evidence")
+    return _repair_progression_with_readiness(
+        {
+            "stage": "operator_review",
+            "label": "Operator review",
+            "summary": "The remediation remains manual until current evidence proves it is fixed.",
+            "next_gate": "Fresh evidence before closure",
+            "next_step": "Complete the operator action and import fresh reports or DNS checks before marking fixed.",
             "can_preview": False,
             "can_apply_after_approval": False,
             "manual_fallback": True,
             "verification_required": True,
-            "verification_status": str(verification.get("status") or "pending_dns_refresh"),
-        }
-    if track == "reputation_review":
-        return {
-            "stage": "reputation_review",
-            "label": "Review reputation",
-            "summary": "The source needs reputation or blacklist evidence before operator closure.",
-            "next_gate": "Fresh reputation evidence",
-            "next_step": "Check current reputation feeds and decide whether to delist, stop, or accept the sender.",
-            "can_preview": False,
-            "can_apply_after_approval": False,
-            "manual_fallback": False,
-            "verification_required": True,
-            "verification_status": str(verification.get("status") or "pending_report_evidence"),
-        }
-    return {
-        "stage": "operator_review",
-        "label": "Operator review",
-        "summary": "The remediation remains manual until current evidence proves it is fixed.",
-        "next_gate": "Fresh evidence before closure",
-        "next_step": "Complete the operator action and import fresh reports or DNS checks before marking fixed.",
-        "can_preview": False,
-        "can_apply_after_approval": False,
-        "manual_fallback": True,
-        "verification_required": True,
-        "verification_status": str(verification.get("status") or "pending_report_evidence"),
-    }
+            "verification_status": verification_status,
+        },
+        verification_status=verification_status,
+    )
 
 
 def _apply_loop_metadata(items: List[Dict[str, Any]]) -> None:
@@ -408,6 +526,10 @@ def _loop_summary(domain: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
         "repair_approval_pending": summary["repair_approval_pending"],
         "repair_blocked": summary["repair_blocked"],
         "repair_needs_evidence": summary["repair_needs_evidence"],
+        "repair_ready_for_preview": summary["repair_ready_for_preview"],
+        "repair_waiting_on_operator": summary["repair_waiting_on_operator"],
+        "repair_readiness_blocked": summary["repair_readiness_blocked"],
+        "repair_readiness_score": summary["repair_readiness_score"],
         "requires_fresh_evidence": summary["requires_fresh_evidence"],
         "rollback_guidance": summary["rollback_guidance"],
         "closure_gate_required": summary["closure_gate_required"],
@@ -495,10 +617,16 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
             "summary": str(repair_progression.get("summary") or ""),
             "next_gate": str(repair_progression.get("next_gate") or ""),
             "next_step": str(repair_progression.get("next_step") or ""),
+            "readiness_level": str(repair_progression.get("readiness_level") or ""),
+            "readiness_label": str(repair_progression.get("readiness_label") or ""),
+            "readiness_score": int(repair_progression.get("readiness_score") or 0),
+            "readiness_reasons": [
+                str(reason) for reason in repair_progression.get("readiness_reasons", [])
+            ][:5],
+            "blocked_by": [str(reason) for reason in repair_progression.get("blocked_by", [])][:5],
+            "next_safe_action": str(repair_progression.get("next_safe_action") or ""),
             "can_preview": bool(repair_progression.get("can_preview")),
-            "can_apply_after_approval": bool(
-                repair_progression.get("can_apply_after_approval")
-            ),
+            "can_apply_after_approval": bool(repair_progression.get("can_apply_after_approval")),
             "manual_fallback": bool(repair_progression.get("manual_fallback")),
             "verification_required": bool(repair_progression.get("verification_required")),
             "verification_status": str(repair_progression.get("verification_status") or ""),

--- a/backend/app/services/remediation_readiness.py
+++ b/backend/app/services/remediation_readiness.py
@@ -1,0 +1,51 @@
+"""Shared read-only remediation repair-readiness metadata."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+OPERATOR_REVIEW_READINESS_LEVELS = {
+    "needs_classification",
+    "needs_reputation_review",
+    "manual_repair",
+    "needs_operator_review",
+}
+
+_READINESS_BY_STAGE = {
+    "preview_ready": {
+        "readiness_level": "ready_for_preview",
+        "readiness_label": "Ready for provider preview",
+        "readiness_score": 80,
+    },
+    "blocked": {
+        "readiness_level": "blocked",
+        "readiness_label": "Blocked before repair",
+        "readiness_score": 20,
+    },
+    "classification_required": {
+        "readiness_level": "needs_classification",
+        "readiness_label": "Needs sender classification",
+        "readiness_score": 35,
+    },
+    "reputation_review": {
+        "readiness_level": "needs_reputation_review",
+        "readiness_label": "Needs reputation review",
+        "readiness_score": 40,
+    },
+    "manual_repair": {
+        "readiness_level": "manual_repair",
+        "readiness_label": "Manual repair path",
+        "readiness_score": 50,
+    },
+}
+
+_DEFAULT_READINESS = {
+    "readiness_level": "needs_operator_review",
+    "readiness_label": "Needs operator review",
+    "readiness_score": 30,
+}
+
+
+def repair_readiness_for_stage(stage: str) -> Dict[str, int | str]:
+    """Return the canonical readiness level, label, and score for a stage."""
+    return dict(_READINESS_BY_STAGE.get(stage, _DEFAULT_READINESS))

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -970,6 +970,26 @@ function dashboardApp() {
             return progression.next_step || progression.summary || 'Open the remediation queue to review the next safe gate.';
         },
 
+        repairReadinessClass(progression) {
+            const level = String(progression?.readiness_level || '');
+            if (level === 'ready_for_preview') return 'bg-green-100 text-green-700';
+            if (level === 'blocked') return 'bg-red-100 text-red-700';
+            if (level === 'needs_classification') return 'bg-blue-100 text-blue-700';
+            if (level === 'needs_reputation_review') return 'bg-purple-100 text-purple-700';
+            if (level === 'manual_repair') return 'bg-yellow-100 text-yellow-800';
+            return 'bg-[#f8f7f6] text-[#5f5c78]';
+        },
+
+        repairReadinessLabel(progression) {
+            if (!progression) return 'Needs operator review';
+            return progression.readiness_label || this.formatDemoLabel(progression.readiness_level || 'needs_operator_review');
+        },
+
+        repairReadinessScore(progression) {
+            const score = Number(progression?.readiness_score || 0);
+            return Number.isFinite(score) ? Math.max(0, Math.min(100, Math.round(score))) : 0;
+        },
+
         domainActionHref(action) {
             return action && action.domain
                 ? `/domains/${encodeURIComponent(action.domain)}#remediation-queue`
@@ -1655,7 +1675,8 @@ function dashboardApp() {
             latest.className = 'text-xs text-muted-foreground whitespace-nowrap';
             if (workload?.primary?.state) {
                 const track = this.remediationTrackLabel(workload.primary.remediation_track);
-                latest.textContent = `${this.remediationLoopStateLabel(workload.primary.state)} · ${track}`;
+                const readiness = this.repairReadinessLabel(workload.primary.repair_progression);
+                latest.textContent = `${this.remediationLoopStateLabel(workload.primary.state)} · ${track} · ${readiness}`;
             } else if (remediation?.latest_at) {
                 latest.textContent = new Date(remediation.latest_at).toLocaleString();
             } else {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1055,6 +1055,26 @@ function domainDetailsApp(domainId = '') {
             return progression.next_step || progression.summary || 'Review the repair gate before taking action.';
         },
 
+        repairReadinessClass(progression) {
+            const level = String(progression?.readiness_level || '');
+            if (level === 'ready_for_preview') return 'bg-green-100 text-green-700';
+            if (level === 'blocked') return 'bg-red-100 text-red-700';
+            if (level === 'needs_classification') return 'bg-blue-100 text-blue-700';
+            if (level === 'needs_reputation_review') return 'bg-purple-100 text-purple-700';
+            if (level === 'manual_repair') return 'bg-yellow-100 text-yellow-800';
+            return 'bg-base-200 text-base-content/70';
+        },
+
+        repairReadinessLabel(progression) {
+            if (!progression) return 'Needs operator review';
+            return progression.readiness_label || this.humanizeToken(progression.readiness_level || 'needs_operator_review');
+        },
+
+        repairReadinessScore(progression) {
+            const score = Number(progression?.readiness_score || 0);
+            return Number.isFinite(score) ? Math.max(0, Math.min(100, Math.round(score))) : 0;
+        },
+
         remediationRiskClass(value) {
             const risk = String(value || '').toLowerCase();
             if (risk === 'high') return 'bg-red-100 text-red-700';

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -535,13 +535,19 @@
                                 </div>
                                 <div class="mt-3 flex flex-wrap gap-2 text-xs">
                                     <span class="rounded bg-[#eef7ff] px-2 py-1 font-semibold text-[#24507a]">
-                                        <span x-text="remediationQueue.loop?.repair_preview_ready || 0"></span><span> provider previews ready</span>
+                                        <span x-text="remediationQueue.loop?.repair_ready_for_preview || remediationQueue.loop?.repair_preview_ready || 0"></span><span> provider previews ready</span>
                                     </span>
                                     <span class="rounded bg-[#fff8ed] px-2 py-1 font-semibold text-[#7a4a00]">
                                         <span x-text="remediationQueue.loop?.repair_needs_evidence || 0"></span><span> require fresh evidence</span>
                                     </span>
+                                    <span class="rounded bg-[#eef7ff] px-2 py-1 font-semibold text-[#24507a]">
+                                        <span x-text="remediationQueue.loop?.repair_waiting_on_operator || 0"></span><span> waiting on operator</span>
+                                    </span>
                                     <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
-                                        <span x-text="remediationQueue.loop?.repair_blocked || 0"></span><span> blocked before repair</span>
+                                        <span x-text="remediationQueue.loop?.repair_readiness_blocked || remediationQueue.loop?.repair_blocked || 0"></span><span> blocked before repair</span>
+                                    </span>
+                                    <span class="rounded bg-white px-2 py-1 font-semibold text-[#45505f]">
+                                        <span x-text="remediationQueue.loop?.repair_readiness_score || 0"></span><span>/100 top readiness</span>
                                     </span>
                                     <span class="rounded bg-[#fff8ed] px-2 py-1 font-semibold text-[#7a4a00]">
                                         <span x-text="remediationQueue.loop?.closure_gate_required || 0"></span><span> closure gates</span>
@@ -616,12 +622,21 @@
                                     <div class="mt-3 rounded border border-[#d5e9f8] bg-[#f7fbff] p-3">
                                         <div class="flex flex-wrap items-center justify-between gap-2">
                                             <p class="text-xs font-semibold uppercase text-[#24507a]">Repair progression</p>
-                                            <span class="rounded px-2 py-1 text-xs font-semibold"
-                                                  :class="repairProgressionClass(item.repair_progression)"
-                                                  x-text="repairProgressionLabel(item.repair_progression)"></span>
+                                            <div class="flex flex-wrap gap-2">
+                                                <span class="rounded px-2 py-1 text-xs font-semibold"
+                                                      :class="repairProgressionClass(item.repair_progression)"
+                                                      x-text="repairProgressionLabel(item.repair_progression)"></span>
+                                                <span class="rounded px-2 py-1 text-xs font-semibold"
+                                                      :class="repairReadinessClass(item.repair_progression)"
+                                                      x-text="repairReadinessLabel(item.repair_progression)"></span>
+                                            </div>
                                         </div>
                                         <p class="mt-2 text-sm text-[#120d36]" x-text="item.repair_progression.summary"></p>
-                                        <div class="mt-3 grid gap-2 md:grid-cols-3">
+                                        <div class="mt-3 grid gap-2 md:grid-cols-4">
+                                            <div class="rounded bg-white px-3 py-2 text-xs text-[#45505f]">
+                                                <span class="font-semibold">Readiness: </span>
+                                                <span x-text="repairReadinessScore(item.repair_progression)"></span><span>/100</span>
+                                            </div>
                                             <div class="rounded bg-white px-3 py-2 text-xs text-[#45505f]">
                                                 <span class="font-semibold">Gate: </span>
                                                 <span x-text="item.repair_progression.next_gate || 'Operator review'"></span>
@@ -637,8 +652,25 @@
                                         </div>
                                         <p class="mt-3 text-xs text-[#5f5c78]">
                                             <span class="font-semibold">Progress this by: </span>
-                                            <span x-text="repairProgressionNextStep(item.repair_progression)"></span>
+                                            <span x-text="item.repair_progression.next_safe_action || repairProgressionNextStep(item.repair_progression)"></span>
                                         </p>
+                                        <template x-if="(item.repair_progression.readiness_reasons || []).length">
+                                            <ul class="mt-3 space-y-1 text-xs text-[#45505f]">
+                                                <template x-for="reason in item.repair_progression.readiness_reasons.slice(0, 3)"
+                                                          :key="item.id + '-readiness-reason-' + reason">
+                                                    <li class="flex gap-2">
+                                                        <span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[#24507a]"></span>
+                                                        <span x-text="reason"></span>
+                                                    </li>
+                                                </template>
+                                            </ul>
+                                        </template>
+                                        <template x-if="(item.repair_progression.blocked_by || []).length">
+                                            <p class="mt-2 text-xs text-[#7a4a00]">
+                                                <span class="font-semibold">Still blocked by: </span>
+                                                <span x-text="item.repair_progression.blocked_by.map(humanizeToken).join(', ')"></span>
+                                            </p>
+                                        </template>
                                     </div>
                                 </template>
                                 <template x-if="item.action_plan">

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -244,11 +244,11 @@
                 <p class="mt-1 text-xs text-[#5f5c78]">Sender or report evidence to confirm</p>
             </div>
         </div>
-        <div class="mt-3 grid gap-3 md:grid-cols-3">
+        <div class="mt-3 grid gap-3 md:grid-cols-4">
             <div class="rounded-md border border-[#d8ebe8] bg-[#f2fbf9] p-4">
                 <p class="text-sm text-[#5f5c78]">Repair previews ready</p>
                 <p class="mt-2 text-2xl font-bold text-[#247982]"
-                   x-text="remediationLoop().repair_preview_ready || 0"></p>
+                   x-text="remediationLoop().repair_ready_for_preview || remediationLoop().repair_preview_ready || 0"></p>
                 <p class="mt-1 text-xs text-[#5f5c78]">Provider-backed proposals ready for review</p>
             </div>
             <div class="rounded-md border border-[#f5dfbd] bg-[#fff8ed] p-4">
@@ -257,10 +257,16 @@
                    x-text="remediationLoop().repair_needs_evidence || 0"></p>
                 <p class="mt-1 text-xs text-[#5f5c78]">Items that must be verified before closure</p>
             </div>
+            <div class="rounded-md border border-[#d5e9f8] bg-[#f7fbff] p-4">
+                <p class="text-sm text-[#5f5c78]">Waiting on operator</p>
+                <p class="mt-2 text-2xl font-bold text-[#24507a]"
+                   x-text="remediationLoop().repair_waiting_on_operator || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Classification, manual repair, or reputation review</p>
+            </div>
             <div class="rounded-md border border-[#e6e3e1] p-4">
                 <p class="text-sm text-[#5f5c78]">Blocked before repair</p>
                 <p class="mt-2 text-2xl font-bold text-[#5f5c78]"
-                   x-text="remediationLoop().repair_blocked || 0"></p>
+                   x-text="remediationLoop().repair_readiness_blocked || remediationLoop().repair_blocked || 0"></p>
                 <p class="mt-1 text-xs text-[#5f5c78]">Missing provider values or prerequisites</p>
             </div>
         </div>
@@ -307,6 +313,14 @@
                                   x-text="repairProgressionLabel(item.repair_progression)"></span>
                         </div>
                         <p class="mt-2 text-[#120d36]" x-text="repairProgressionNextStep(item.repair_progression)"></p>
+                        <div class="mt-2 flex flex-wrap gap-2">
+                            <span class="rounded px-2 py-1 font-semibold"
+                                  :class="repairReadinessClass(item.repair_progression)"
+                                  x-text="repairReadinessLabel(item.repair_progression)"></span>
+                            <span class="rounded bg-white px-2 py-1 font-semibold text-[#5f5c78]">
+                                <span x-text="repairReadinessScore(item.repair_progression)"></span><span>/100 readiness</span>
+                            </span>
+                        </div>
                     </div>
                     <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3 text-xs">
                         <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Next verification</p>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -261,7 +261,7 @@
                 <p class="text-sm text-[#5f5c78]">Waiting on operator</p>
                 <p class="mt-2 text-2xl font-bold text-[#24507a]"
                    x-text="remediationLoop().repair_waiting_on_operator || 0"></p>
-                <p class="mt-1 text-xs text-[#5f5c78]">Classification, manual repair, or reputation review</p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Classification, manual repair, reputation, or review</p>
             </div>
             <div class="rounded-md border border-[#e6e3e1] p-4">
                 <p class="text-sm text-[#5f5c78]">Blocked before repair</p>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -346,19 +346,33 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "item.operator_decision_summary" in template
     assert "Repair previews ready" in template
     assert "Need fresh evidence" in template
+    assert "Waiting on operator" in template
     assert "Blocked before repair" in template
-    assert "remediationLoop().repair_preview_ready || 0" in template
+    assert (
+        "remediationLoop().repair_ready_for_preview || remediationLoop().repair_preview_ready || 0"
+        in template
+    )
     assert "remediationLoop().repair_needs_evidence || 0" in template
-    assert "remediationLoop().repair_blocked || 0" in template
+    assert "remediationLoop().repair_waiting_on_operator || 0" in template
+    assert (
+        "remediationLoop().repair_readiness_blocked || remediationLoop().repair_blocked || 0"
+        in template
+    )
     assert "Repair gate" in template
     assert "repairProgressionClass(item.repair_progression)" in template
     assert "repairProgressionLabel(item.repair_progression)" in template
     assert "repairProgressionNextStep(item.repair_progression)" in template
+    assert "repairReadinessClass(item.repair_progression)" in template
+    assert "repairReadinessLabel(item.repair_progression)" in template
+    assert "repairReadinessScore(item.repair_progression)" in template
     assert "remediationRiskClass(risk)" in script
     assert "remediationTrackLabel(track)" in script
     assert "repairProgressionClass(progression)" in script
     assert "repairProgressionLabel(progression)" in script
     assert "repairProgressionNextStep(progression)" in script
+    assert "repairReadinessClass(progression)" in script
+    assert "repairReadinessLabel(progression)" in script
+    assert "repairReadinessScore(progression)" in script
 
 
 def test_domain_details_remediation_queue_shows_verification_context():
@@ -388,6 +402,12 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "item.verification_plan.failure_mode" in template
     assert "Repair progression" in template
     assert "remediationQueue.summary.repair_preview_ready" in template
+    assert "remediationQueue.loop?.repair_ready_for_preview" in template
+    assert "remediationQueue.loop?.repair_waiting_on_operator" in template
+    assert "remediationQueue.loop?.repair_readiness_blocked" in template
+    assert "remediationQueue.loop?.repair_readiness_score" in template
+    assert "item.repair_progression.readiness_reasons" in template
+    assert "item.repair_progression.blocked_by" in template
     assert "remediationQueue.summary.repair_needs_evidence" in template
     assert "remediationQueue.loop?.repair_blocked" in template
     assert "item.repair_progression.next_gate" in template

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -906,14 +906,21 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["repair_preview_ready"] == 1
     assert loop["repair_needs_evidence"] == 2
     assert loop["repair_blocked"] == 0
+    assert loop["repair_ready_for_preview"] == 1
+    assert loop["repair_waiting_on_operator"] == 1
+    assert loop["repair_readiness_blocked"] == 0
+    assert loop["repair_readiness_score"] == 80
     assert loop["items"][0]["priority_band"] == "high"
     assert loop["items"][0]["safe_to_automate"] is True
     assert loop["items"][0]["risk_level"] == "medium"
     assert loop["items"][0]["repair_progression"]["stage"] == "preview_ready"
     assert loop["items"][0]["repair_progression"]["can_preview"] is True
+    assert loop["items"][0]["repair_progression"]["readiness_level"] == "ready_for_preview"
+    assert loop["items"][0]["repair_progression"]["readiness_score"] == 80
     assert "Preview the exact DNS" in loop["items"][0]["operator_decision_summary"]
     assert loop["items"][1]["remediation_track"] == "reputation_review"
     assert loop["items"][1]["repair_progression"]["stage"] == "reputation_review"
+    assert loop["items"][1]["repair_progression"]["readiness_level"] == "needs_reputation_review"
     assert loop["items"][1]["risk_level"] == "high"
     assert loop["items"][1]["safe_to_automate"] is False
 
@@ -949,9 +956,14 @@ def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks
     assert loop["repair_blocked"] == 1
     assert loop["repair_preview_ready"] == 0
     assert loop["repair_needs_evidence"] == 1
+    assert loop["repair_ready_for_preview"] == 0
+    assert loop["repair_waiting_on_operator"] == 0
+    assert loop["repair_readiness_blocked"] == 1
+    assert loop["repair_readiness_score"] == 20
     assert loop["items"][0]["remediation_track"] == "blocked_by_prerequisite"
     assert loop["items"][0]["repair_progression"]["stage"] == "blocked"
     assert loop["items"][0]["repair_progression"]["can_preview"] is False
+    assert loop["items"][0]["repair_progression"]["readiness_level"] == "blocked"
     assert "provider-specific value" in loop["items"][0]["repair_progression"]["summary"]
 
 

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -87,6 +87,10 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "repair_approval_pending": 0,
         "repair_blocked": 0,
         "repair_needs_evidence": 2,
+        "repair_ready_for_preview": 1,
+        "repair_waiting_on_operator": 1,
+        "repair_readiness_blocked": 0,
+        "repair_readiness_score": 80,
         "requires_fresh_evidence": 2,
         "rollback_guidance": 2,
         "closure_gate_required": 2,
@@ -122,6 +126,10 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "repair_approval_pending": 0,
         "repair_blocked": 0,
         "repair_needs_evidence": 2,
+        "repair_ready_for_preview": 1,
+        "repair_waiting_on_operator": 1,
+        "repair_readiness_blocked": 0,
+        "repair_readiness_score": 80,
         "requires_fresh_evidence": 2,
         "rollback_guidance": 2,
         "closure_gate_required": 2,
@@ -156,6 +164,21 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "manual_fallback": True,
         "verification_required": True,
         "verification_status": "pending_operator_approval",
+        "readiness_level": "ready_for_preview",
+        "readiness_label": "Ready for provider preview",
+        "readiness_score": 80,
+        "readiness_reasons": [
+            "A connected DNS provider can produce an exact change preview.",
+            "A human approval gate is still required before apply.",
+            "Fresh evidence is required before DMARQ can call this fixed.",
+        ],
+        "blocked_by": [
+            "fresh_evidence_before_closure",
+            "pending_operator_approval",
+        ],
+        "next_safe_action": (
+            "Open the provider preview, compare old and new DNS values, then approve or reject."
+        ),
     }
     assert queue["items"][0]["state"] == "approval_ready"
     assert queue["items"][0]["automation"]["eligible"] is True
@@ -244,6 +267,21 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
             "manual_fallback": True,
             "verification_required": True,
             "verification_status": "pending_operator_approval",
+            "readiness_level": "ready_for_preview",
+            "readiness_label": "Ready for provider preview",
+            "readiness_score": 80,
+            "readiness_reasons": [
+                "A connected DNS provider can produce an exact change preview.",
+                "A human approval gate is still required before apply.",
+                "Fresh evidence is required before DMARQ can call this fixed.",
+            ],
+            "blocked_by": [
+                "fresh_evidence_before_closure",
+                "pending_operator_approval",
+            ],
+            "next_safe_action": (
+                "Open the provider preview, compare old and new DNS values, then approve or reject."
+            ),
         },
         "title": "Publish DMARC",
         "detail": "No DMARC TXT record was found.",
@@ -372,6 +410,10 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
     assert queue["summary"]["blocked_by_prerequisite"] == 1
     assert queue["summary"]["repair_blocked"] == 1
     assert queue["summary"]["repair_needs_evidence"] == 1
+    assert queue["summary"]["repair_ready_for_preview"] == 0
+    assert queue["summary"]["repair_waiting_on_operator"] == 0
+    assert queue["summary"]["repair_readiness_blocked"] == 1
+    assert queue["summary"]["repair_readiness_score"] == 20
     assert queue["summary"]["closure_gate_required"] == 1
     assert queue["summary"]["rollback_guidance"] == 1
     assert queue["summary"]["notify_summary_only"] == 1
@@ -397,6 +439,9 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
     assert queue["items"][0]["repair_progression"]["stage"] == "blocked"
     assert queue["items"][0]["repair_progression"]["can_preview"] is False
     assert queue["items"][0]["repair_progression"]["manual_fallback"] is True
+    assert queue["items"][0]["repair_progression"]["readiness_level"] == "blocked"
+    assert queue["items"][0]["repair_progression"]["readiness_score"] == 20
+    assert "provider_specific_value" in queue["items"][0]["repair_progression"]["blocked_by"]
     assert queue["items"][0]["notification"]["state"] == "summary_only"
     assert queue["items"][0]["notification"]["event"] == "dmarq.remediation.summary"
     assert queue["items"][0]["notification"]["payload_preview"]["event_type"] == (
@@ -476,9 +521,7 @@ def test_remediation_queue_requires_recommended_provider_for_automation():
     assert queue["items"][0]["automation"]["provider"] is None
     assert queue["items"][0]["automation"]["apply_endpoint"] is None
     assert queue["items"][0]["repair_progression"]["stage"] == "manual_repair"
-    assert queue["items"][0]["repair_progression"]["next_gate"] == (
-        "Operator applies DNS manually"
-    )
+    assert queue["items"][0]["repair_progression"]["next_gate"] == ("Operator applies DNS manually")
     assert queue["items"][0]["action_plan"]["owner"] == "Domain DNS operator"
     assert queue["items"][0]["action_plan"]["steps"]
     assert queue["items"][0]["notification"]["state"] == "action_required"

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -71,8 +71,11 @@ work. It separates operator-marked resolved work from evidence-verified fixed
 work and shows the current approval, manual-action, and investigation counts.
 Repair-gate counters distinguish provider previews that are ready for review,
 items that still need fresh evidence before closure, and findings that are
-blocked before repair. Each dashboard item links to the selected domain's
-remediation queue for the full evidence, approval, and verification flow.
+blocked before repair. The dashboard also separates items waiting on an operator
+for sender classification, manual repair, or reputation review. Each card shows
+the same readiness label and 0-100 score used on the domain remediation queue,
+then links to the selected domain for the full evidence, approval, and
+verification flow.
 
 ### Demo Mode
 

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -72,10 +72,10 @@ work and shows the current approval, manual-action, and investigation counts.
 Repair-gate counters distinguish provider previews that are ready for review,
 items that still need fresh evidence before closure, and findings that are
 blocked before repair. The dashboard also separates items waiting on an operator
-for sender classification, manual repair, or reputation review. Each card shows
-the same readiness label and 0-100 score used on the domain remediation queue,
-then links to the selected domain for the full evidence, approval, and
-verification flow.
+for sender classification, manual repair, reputation review, or general operator
+review. Each card shows the same readiness label and 0-100 score used on the
+domain remediation queue, then links to the selected domain for the full
+evidence, approval, and verification flow.
 
 ### Demo Mode
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -113,6 +113,11 @@ reputation/report/DNS evidence is still required before closure. This panel is
 read-only; it does not apply DNS changes or send provider requests. The top
 **Next remediation** panel mirrors the same repair-gate status so the operator
 can see the current blocker before opening the full queue.
+Repair progression also includes a readiness label, 0-100 readiness score,
+human-readable reasons, and blocker keys. Use this to separate work that is
+ready for provider preview from work that is blocked by missing provider values,
+sender classification, reputation evidence, or the required fresh-evidence
+closure gate.
 Each item also shows a notification profile such as approval required, action
 required, investigation required, or summary only. These labels explain how
 DMARQ would route the item into alerting or ticketing workflows; viewing the


### PR DESCRIPTION
## Summary
- add read-only remediation repair readiness levels, scores, reasons, blockers, and next-safe-action metadata to queue repair progression
- surface readiness counters on dashboard and domain remediation views, including waiting-on-operator and blocked-before-repair states
- include readiness context in notification payload previews, API schema, docs, changelog, and focused coverage

## Local validation
- `.venv/bin/python -m pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_public_api.py backend/app/tests/test_dashboard_template_security.py -q --tb=short` (214 passed)
- `node --check backend/app/static/js/domain-details-page.js && node --check backend/app/static/js/dashboard-page.js`
- `.venv/bin/python -m flake8 backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

## Safety
- read-only readiness metadata only
- no DNS/provider write behavior changed
- no notification dispatch behavior changed

Refs #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repair-readiness labels and 0–100 scores across remediation dashboards and domain health views.
  * Surfaced clearer status breakdowns such as ready for preview, waiting on operator, and blocked items.
  * Added more detailed remediation guidance, including top reasons, blockers, and the next safe action.

* **Bug Fixes**
  * Updated queue and item displays to show the most relevant readiness counts and status badges consistently across dashboard and domain pages.

* **Documentation**
  * Revised user guides to explain the new readiness indicators and remediation flow more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->