### PR TITLE
feat: surface remediation freshness gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added remediation verification closure gates and stale-evidence warnings so resolved items are not confused with evidence-verified repairs.
 - Added queue-level closure-gate and rollback-guidance counters to highlight remediation items that still need fresh evidence or a recovery path.
 - Added remediation repair-readiness levels, scores, reasons, and blockers so operators can distinguish preview-ready work from manual, blocked, classification, and reputation-review work.
+- Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 
 ### Changed
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -496,9 +496,19 @@ def _verified_fixed_items_result(
                 ),
                 "verification_status": "no_longer_observed",
                 "verification_method": "current_queue_absence",
+                "freshness_status": "current_queue_absence",
+                "freshness_label": "Fresh queue absence",
+                "closure_gate": (
+                    "Closed only while the latest remediation queue and imported evidence "
+                    "keep this finding absent."
+                ),
                 "next_check": (
                     "Keep importing fresh DMARC reports and refresh DNS evidence; reopen "
                     "the item if the same finding returns."
+                ),
+                "next_safe_action": (
+                    "Keep monitoring fresh report and DNS evidence before treating this "
+                    "repair as permanently closed."
                 ),
                 "evidence_needed": [
                     "The latest lifecycle marker for this item is resolved.",

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -507,7 +507,7 @@ def _verified_fixed_items_result(
                     "the item if the same finding returns."
                 ),
                 "next_safe_action": (
-                    "Keep monitoring fresh report and DNS evidence before treating this "
+                    "Keep monitoring fresh reports and DNS evidence before treating this "
                     "repair as permanently closed."
                 ),
                 "evidence_needed": [

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
 from sqlalchemy import func, or_, select
@@ -83,6 +83,7 @@ HISTORY_ACTIONS = {
     "remediation.notification_lifecycle_recorded",
     "remediation.notification_dispatch_enqueued",
 }
+VERIFIED_FIXED_STALE_AFTER = timedelta(days=7)
 
 
 def _truthy(value: Optional[str], *, default: bool = False) -> bool:
@@ -166,6 +167,32 @@ def _audit_timestamp(value: Any) -> Optional[str]:
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     return value.isoformat().replace("+00:00", "Z")
+
+
+def _verified_fixed_freshness(
+    recorded_at: Any, *, now: Optional[datetime] = None
+) -> Dict[str, str]:
+    if not isinstance(recorded_at, datetime):
+        return {
+            "freshness_status": "unknown_queue_absence_age",
+            "freshness_label": "Queue absence age unknown",
+        }
+    if recorded_at.tzinfo is None:
+        recorded_at = recorded_at.replace(tzinfo=timezone.utc)
+    if now is None:
+        now = datetime.now(timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    if now - recorded_at > VERIFIED_FIXED_STALE_AFTER:
+        return {
+            "freshness_status": "stale_queue_absence",
+            "freshness_label": "Stale queue absence",
+        }
+    return {
+        "freshness_status": "current_queue_absence",
+        "freshness_label": "Fresh queue absence",
+    }
 
 
 def _history_entry(row: WorkspaceAuditLog) -> Optional[Dict[str, Any]]:
@@ -484,6 +511,7 @@ def _verified_fixed_items_result(
         details = _audit_details(row)
         if details.get("lifecycle_state") != "resolved":
             continue
+        freshness = _verified_fixed_freshness(row.created_at)
         verified.append(
             {
                 "item_id": item_id,
@@ -496,8 +524,7 @@ def _verified_fixed_items_result(
                 ),
                 "verification_status": "no_longer_observed",
                 "verification_method": "current_queue_absence",
-                "freshness_status": "current_queue_absence",
-                "freshness_label": "Fresh queue absence",
+                **freshness,
                 "closure_gate": (
                     "Closed only while the latest remediation queue and imported evidence "
                     "keep this finding absent."

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -570,6 +570,24 @@ function domainDetailsApp(domainId = '') {
             return (item.next_steps || [])[0] || 'Review the evidence and decide whether this fix is still needed.';
         },
 
+        get primaryRemediationNextSafeAction() {
+            const item = this.primaryRemediationItem;
+            if (!item) return '';
+            return item.repair_progression?.next_safe_action || this.primaryRemediationNextStep;
+        },
+
+        get primaryRemediationReadinessContext() {
+            const reasons = this.primaryRemediationItem?.repair_progression?.readiness_reasons || [];
+            return reasons[0] || 'Review current evidence before opening, dispatching, or closing this remediation.';
+        },
+
+        get primaryRemediationBlockedText() {
+            const blockedBy = this.primaryRemediationItem?.repair_progression?.blocked_by || [];
+            if (!blockedBy.length) return 'No readiness blocker is currently recorded.';
+            const labels = blockedBy.slice(0, 3).map(reason => this.humanizeToken(reason));
+            return `Blocked by ${labels.join(', ')}.`;
+        },
+
         get primaryRemediationDispatchText() {
             const dispatch = this.primaryRemediationItem?.notification?.dispatch;
             if (!dispatch) return 'No operator notification configured for this item yet.';

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -96,13 +96,16 @@
                                           :class="remediationSeverityDotClass(primaryRemediationItem.severity)"></span>
                                     <span x-text="primaryRemediationItem.severity"></span>
                                 </span>
+                                <span class="rounded px-2 py-1 text-xs font-semibold"
+                                      :class="repairReadinessClass(primaryRemediationItem.repair_progression)"
+                                      x-text="repairReadinessLabel(primaryRemediationItem.repair_progression)"></span>
                             </div>
                             <h2 class="mt-2 text-lg font-semibold text-[#07071f]" x-text="primaryRemediationItem.title"></h2>
                             <p class="mt-1 text-sm text-[#5f5c78]" x-text="primaryRemediationItem.detail"></p>
-                            <div class="mt-3 grid gap-3 md:grid-cols-3">
+                            <div class="mt-3 grid gap-3 md:grid-cols-4">
                                 <div class="rounded-md bg-white p-3">
-                                    <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next step</p>
-                                    <p class="mt-1 text-sm text-[#120d36]" x-text="primaryRemediationNextStep"></p>
+                                    <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next safe action</p>
+                                    <p class="mt-1 text-sm text-[#120d36]" x-text="primaryRemediationNextSafeAction"></p>
                                 </div>
                                 <div class="rounded-md bg-white p-3">
                                     <div class="flex flex-wrap items-center justify-between gap-2">
@@ -112,6 +115,16 @@
                                               x-text="repairProgressionLabel(primaryRemediationItem.repair_progression)"></span>
                                     </div>
                                     <p class="mt-2 text-sm text-[#120d36]" x-text="primaryRepairProgressionText"></p>
+                                </div>
+                                <div class="rounded-md bg-white p-3">
+                                    <div class="flex flex-wrap items-center justify-between gap-2">
+                                        <p class="text-xs font-semibold uppercase text-[#5f5c78]">Readiness</p>
+                                        <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]">
+                                            <span x-text="repairReadinessScore(primaryRemediationItem.repair_progression)"></span><span>/100</span>
+                                        </span>
+                                    </div>
+                                    <p class="mt-2 text-sm text-[#120d36]" x-text="primaryRemediationReadinessContext"></p>
+                                    <p class="mt-1 text-xs text-[#5f5c78]" x-text="primaryRemediationBlockedText"></p>
                                 </div>
                                 <div class="rounded-md bg-white p-3">
                                     <p class="text-xs font-semibold uppercase text-[#5f5c78]">Operator dispatch</p>
@@ -463,8 +476,12 @@
                                     <div class="rounded border border-[#d8ebe8] bg-white px-3 py-2 text-xs">
                                         <div class="flex flex-wrap items-center justify-between gap-2">
                                             <span class="font-mono text-[#120d36]" x-text="verified.item_id"></span>
-                                            <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700"
-                                                  x-text="verified.label"></span>
+                                            <span class="flex flex-wrap items-center gap-1">
+                                                <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700"
+                                                      x-text="verified.label"></span>
+                                                <span class="rounded bg-[#f6f8fb] px-2 py-1 font-semibold text-[#45505f]"
+                                                      x-text="verified.freshness_label || 'Queue absence'"></span>
+                                            </span>
                                         </div>
                                         <p class="mt-2 text-[#45505f]" x-text="verified.detail"></p>
                                         <div class="mt-2 grid gap-2 md:grid-cols-2">
@@ -488,6 +505,14 @@
                                         </ul>
                                         <p class="mt-2 text-[#5f5c78]">
                                             <span x-text="verified.next_check || 'Keep monitoring this repair; no DNS or mail settings were changed by this verification marker.'"></span>
+                                        </p>
+                                        <p class="mt-2 rounded border border-[#d8ebe8] bg-[#f2fbf9] px-2 py-1 text-[#45505f]">
+                                            <span class="font-semibold">Closure gate: </span>
+                                            <span x-text="verified.closure_gate || 'Keep this item closed only while fresh evidence keeps it absent.'"></span>
+                                        </p>
+                                        <p class="mt-1 rounded bg-[#f6f8fb] px-2 py-1 text-[#45505f]">
+                                            <span class="font-semibold">Next safe action: </span>
+                                            <span x-text="verified.next_safe_action || verified.next_check || 'Keep monitoring fresh evidence.'"></span>
                                         </p>
                                         <p class="mt-2 rounded bg-[#f6f8fb] px-2 py-1 text-[#45505f]"
                                            x-show="verified.operator_note"

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1354,7 +1354,12 @@ def test_domain_details_distinguishes_evidence_verified_repairs_without_html_inj
     assert "items.slice(0, VERIFIED_ITEMS_COMPACT_LIMIT)" in script
     assert "verified.item_id" in template
     assert "verified.label" in template
+    assert "verified.freshness_label" in template
     assert "verified.detail" in template
+    assert "Closure gate" in template
+    assert "verified.closure_gate" in template
+    assert "Next safe action" in template
+    assert "verified.next_safe_action" in template
     assert "verified.operator_note" in template
     assert "formatIsoDate(verified.recorded_at)" in template
     assert "verified.actor_type" in template
@@ -1448,12 +1453,18 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "remediationQueueError" in script
     assert "primaryRemediationItem" in script
     assert "primaryRemediationNextStep" in script
+    assert "primaryRemediationNextSafeAction" in script
+    assert "primaryRemediationReadinessContext" in script
+    assert "primaryRemediationBlockedText" in script
     assert "primaryRemediationDispatchText" in script
     assert "Next remediation" in template
     assert "Loading next remediation..." in template
     assert "Next remediation could not be loaded." in template
     assert "No remediation queued" in template
     assert "primaryRemediationItem.state.split('_').join(' ')" in template
+    assert "repairReadinessLabel(primaryRemediationItem.repair_progression)" in template
+    assert "repairReadinessScore(primaryRemediationItem.repair_progression)" in template
+    assert "Next safe action" in template
     assert "item.state.split('_').join(' ')" in template
     assert 'href="#remediation-queue"' in template
     assert 'id="remediation-queue"' in template

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -312,6 +312,7 @@ def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):
 
 def test_attach_remediation_dispatch_previews_reports_verified_fixed_items(db_session):
     workspace = get_or_create_default_workspace(db_session)
+    resolved_at = datetime.now(timezone.utc) - timedelta(days=1)
     db_session.add_all(
         [
             WorkspaceAuditLog(
@@ -327,7 +328,7 @@ def test_attach_remediation_dispatch_previews_reports_verified_fixed_items(db_se
                         "operator_note": "Record is now visible after propagation.",
                     }
                 ),
-                created_at=datetime(2026, 7, 1, 8, 0, 0),
+                created_at=resolved_at,
             ),
             WorkspaceAuditLog(
                 workspace_id=workspace.id,
@@ -412,11 +413,28 @@ def test_attach_remediation_dispatch_previews_reports_verified_fixed_items(db_se
                 "The latest lifecycle marker for this item is resolved.",
                 "The same item id is absent from the current remediation queue.",
             ],
-            "recorded_at": "2026-07-01T08:00:00Z",
+            "recorded_at": remediation_dispatch._audit_timestamp(resolved_at),
             "operator_note": "Record is now visible after propagation.",
             "actor_type": "operator",
         }
     ]
+
+
+def test_verified_fixed_freshness_marks_old_absence_stale():
+    now = datetime(2026, 7, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+    assert remediation_dispatch._verified_fixed_freshness(
+        now - timedelta(days=1), now=now
+    ) == {
+        "freshness_status": "current_queue_absence",
+        "freshness_label": "Fresh queue absence",
+    }
+    assert remediation_dispatch._verified_fixed_freshness(
+        now - timedelta(days=8), now=now
+    ) == {
+        "freshness_status": "stale_queue_absence",
+        "freshness_label": "Stale queue absence",
+    }
 
 
 def test_verified_fixed_total_counts_beyond_visible_limit(db_session):

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -405,7 +405,7 @@ def test_attach_remediation_dispatch_previews_reports_verified_fixed_items(db_se
                 "the item if the same finding returns."
             ),
             "next_safe_action": (
-                "Keep monitoring fresh report and DNS evidence before treating this "
+                "Keep monitoring fresh reports and DNS evidence before treating this "
                 "repair as permanently closed."
             ),
             "evidence_needed": [

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -439,6 +439,12 @@ def test_verified_fixed_freshness_marks_old_absence_stale():
         "freshness_status": "unknown_queue_absence_age",
         "freshness_label": "Queue absence age unknown",
     }
+    assert remediation_dispatch._verified_fixed_freshness(
+        datetime(2026, 7, 14, 12, 0, 0), now=datetime(2026, 7, 15, 12, 0, 0)
+    ) == {
+        "freshness_status": "current_queue_absence",
+        "freshness_label": "Fresh queue absence",
+    }
 
 
 def test_verified_fixed_total_counts_beyond_visible_limit(db_session):

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -435,6 +435,10 @@ def test_verified_fixed_freshness_marks_old_absence_stale():
         "freshness_status": "stale_queue_absence",
         "freshness_label": "Stale queue absence",
     }
+    assert remediation_dispatch._verified_fixed_freshness(None, now=now) == {
+        "freshness_status": "unknown_queue_absence_age",
+        "freshness_label": "Queue absence age unknown",
+    }
 
 
 def test_verified_fixed_total_counts_beyond_visible_limit(db_session):

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -394,9 +394,19 @@ def test_attach_remediation_dispatch_previews_reports_verified_fixed_items(db_se
             ),
             "verification_status": "no_longer_observed",
             "verification_method": "current_queue_absence",
+            "freshness_status": "current_queue_absence",
+            "freshness_label": "Fresh queue absence",
+            "closure_gate": (
+                "Closed only while the latest remediation queue and imported evidence "
+                "keep this finding absent."
+            ),
             "next_check": (
                 "Keep importing fresh DMARC reports and refresh DNS evidence; reopen "
                 "the item if the same finding returns."
+            ),
+            "next_safe_action": (
+                "Keep monitoring fresh report and DNS evidence before treating this "
+                "repair as permanently closed."
             ),
             "evidence_needed": [
                 "The latest lifecycle marker for this item is resolved.",

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -851,8 +851,8 @@ returned as `verified_items`; `verified_items_total` and
 only displays the most recent rows. `dispatch_verified_fixed_visible` counts
 the returned rows, and `dispatch_verified_fixed_hidden` reports how many older
 verified repairs were omitted from the compact response. Each verified item
-includes its verification method, status, evidence requirements, next check,
-timestamp, and operator note.
+includes its verification method, status, freshness label, closure gate, next
+safe action, evidence requirements, next check, timestamp, and operator note.
 
 Each notification also includes a compact `history` array derived from
 workspace audit events for the current queue item. The history lists recent

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -112,7 +112,8 @@ must be classified first, whether the work is manual DNS, or whether fresh
 reputation/report/DNS evidence is still required before closure. This panel is
 read-only; it does not apply DNS changes or send provider requests. The top
 **Next remediation** panel mirrors the same repair-gate status so the operator
-can see the current blocker before opening the full queue.
+can see the current blocker, readiness label, readiness score, and next safe
+action before opening the full queue.
 Repair progression also includes a readiness label, 0-100 readiness score,
 human-readable reasons, and blocker keys. Use this to separate work that is
 ready for provider preview from work that is blocked by missing provider values,
@@ -140,9 +141,11 @@ When an operator marks an item resolved and the same finding no longer appears
 in the current queue, the domain detail page lists it under evidence-verified
 repairs. That section shows how DMARQ verified the absence, what evidence was
 used, how many older verified repairs are hidden in the compact view, and what
-fresh reports or DNS checks should keep monitoring the fix. The compact view
-shows the newest verified repairs first and can be expanded to show every
-verified repair returned by the backend response.
+fresh reports or DNS checks should keep monitoring the fix. It also shows the
+closure gate and next safe action so an operator can tell that a resolved marker
+is still conditional on fresh evidence staying clean. The compact view shows
+the newest verified repairs first and can be expanded to show every verified
+repair returned by the backend response.
 
 After a remediation notification is previewed or acknowledged, an operator can
 explicitly enqueue the notification through the dispatch API with


### PR DESCRIPTION
## Summary
- show repair readiness, readiness score, blockers, and next safe action in the top domain next-remediation card
- add freshness label, closure gate, and next safe action metadata for evidence-verified repairs
- update API/user docs and changelog for the remediation freshness/readiness surface

## Local validation
- .venv/bin/python -m pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py -q --tb=short
- node --check backend/app/static/js/domain-details-page.js
- .venv/bin/python -m flake8 backend/app/services/remediation_dispatch.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_dashboard_template_security.py
- git diff --check

Refs #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer remediation guidance with next safe action, readiness context, and blocker details in the domain details view.
  * Showed freshness status and closure guidance for evidence-verified repairs in the remediation queue.
* **Bug Fixes**
  * Improved display of verified repair status so resolved items better reflect fresh evidence requirements.
* **Documentation**
  * Updated changelog, API reference, and user guide to describe the new remediation and freshness information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->