### PR TITLE
feat: polish remediation operator queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added queue-level closure-gate and rollback-guidance counters to highlight remediation items that still need fresh evidence or a recovery path.
 - Added remediation repair-readiness levels, scores, reasons, and blockers so operators can distinguish preview-ready work from manual, blocked, classification, and reputation-review work.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
+- Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
+- Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.
+- Added domain remediation queue sorting by priority, repair readiness, or severity, plus filters for notification-ready and operator-waiting work.
+- Added an expandable domain remediation queue view so operators can open every matching item instead of only seeing the compact six-item list.
 
 ### Changed
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.
@@ -43,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain remediation pages now show repair-progression gates in the top next-remediation panel and render preview/verification states as operator-readable labels.
 - Dashboard remediation-loop cards now expose the same repair-gate language and workspace counters for preview-ready, evidence-gated, and blocked repair work.
 - Dashboard and domain remediation views now show repair-readiness counters and per-item readiness scores before an operator opens or dispatches remediation work.
+- Dashboard, domain remediation queue, and sending-source reputation refreshes now keep previously loaded evidence visible while a manual refresh runs.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity
@@ -59,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed DNS fallback behavior so independent public resolvers are checked in parallel before a transient timeout can make records appear missing.
 - Fixed domain sending-source loading so PTR and network enrichment run in parallel instead of pushing report-backed source rows past the UI timeout.
 - Fixed the remediation queue API schema so `repair_progression` is preserved in typed domain remediation responses.
+- Fixed dashboard and domain remediation refresh failures so transient backend errors no longer blank already-loaded operator evidence.
 - Fixed the Cloudflare permissions picker so selecting the full DNS repair profile no longer falls back to read-only scopes.
 - Fixed the release modal coverage so recent operator-facing work is visible from inside the app.
 - Fixed the remaining Settings page startup hook so CSP hardening no longer depends on template-level page initialization.

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -9,6 +9,9 @@ function dashboardApp() {
         healthHistory: null,
         dashboardLoading: true,
         dashboardError: '',
+        dashboardRefreshError: '',
+        domainSummaryLoadedAt: '',
+        remediationRefreshRunning: false,
         selectedDnsDomain: '',
         triggerPollRunning: false,
         triggerPollStatus: '',
@@ -165,6 +168,11 @@ function dashboardApp() {
         get demoTourNextLabel() {
             return this.isLastDemoTourStep ? 'Finish' : 'Next';
         },
+
+        get domainSummaryLoadedAtLabel() {
+            if (!this.domainSummaryLoadedAt) return '';
+            return new Date(this.domainSummaryLoadedAt).toLocaleString();
+        },
         
         init() {
             this.bindControls();
@@ -210,6 +218,12 @@ function dashboardApp() {
                 if (customApply && root.contains(customApply)) {
                     this.fetchDashboardStats();
                     this.fetchWorkspaceHealthHistory();
+                    return;
+                }
+
+                const remediationRefresh = event.target.closest('[data-dashboard-remediation-refresh]');
+                if (remediationRefresh && root.contains(remediationRefresh)) {
+                    this.fetchDomainSummary({ refresh: true });
                     return;
                 }
 
@@ -365,7 +379,7 @@ function dashboardApp() {
                 this.triggerPollStatus = 'success';
                 this.triggerPollMessage = this.summarizePollResults(data);
                 await this.getReportIntakeStatus();
-                await this.fetchDomainSummary();
+                await this.fetchDomainSummary({ refresh: true });
             } catch (error) {
                 this.triggerPollStatus = 'error';
                 this.triggerPollMessage = error.message || 'Could not trigger polling.';
@@ -374,16 +388,20 @@ function dashboardApp() {
             }
         },
         
-        async fetchDomainSummary() {
-            this.dashboardLoading = true;
+        async fetchDomainSummary(options = {}) {
+            const refresh = Boolean(options.refresh);
+            this.dashboardLoading = !refresh || !this.hasDomainData;
+            this.remediationRefreshRunning = refresh;
             this.dashboardError = '';
+            this.dashboardRefreshError = '';
             try {
                 const response = await fetch('/api/v1/domains/summary');
                 if (!response.ok) {
                     throw new Error('Dashboard data could not be loaded. Check the API service and try again.');
                 }
                 const data = await response.json();
-                
+                this.domainSummaryLoadedAt = new Date().toISOString();
+
                 if (data && data.domains && data.domains.length > 0) {
                     this.domains = data.domains || [];
                     this.healthSummary = data.health_summary || null;
@@ -411,7 +429,12 @@ function dashboardApp() {
                 }
             } catch (error) {
                 console.error('Error fetching domain summary:', error);
-                this.dashboardError = error.message || 'Dashboard data could not be loaded.';
+                const message = error.message || 'Dashboard data could not be loaded.';
+                if (refresh && this.hasDomainData) {
+                    this.dashboardRefreshError = `${message} Showing the previously loaded dashboard data.`;
+                    return;
+                }
+                this.dashboardError = message;
                 this.domains = [];
                 this.healthSummary = null;
                 this.healthHistory = null;
@@ -422,6 +445,7 @@ function dashboardApp() {
                 this.populateTopSources([]);
             } finally {
                 this.dashboardLoading = false;
+                this.remediationRefreshRunning = false;
             }
         },
 
@@ -909,11 +933,55 @@ function dashboardApp() {
 
         remediationLoopItems() {
             const items = this.remediationLoop().items;
-            return Array.isArray(items) ? items : [];
+            return Array.isArray(items)
+                ? [...items].sort((a, b) => (
+                    this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b) ||
+                    (Number(b?.priority_score) || 0) - (Number(a?.priority_score) || 0)
+                ))
+                : [];
         },
 
         hasRemediationLoopItems() {
             return this.remediationLoopItems().length > 0;
+        },
+
+        remediationLoopItemRank(item) {
+            const progression = item?.repair_progression || {};
+            const readinessLevel = String(progression.readiness_level || '');
+            const stage = String(progression.stage || '');
+            const state = String(item?.state || '');
+            const track = String(item?.remediation_track || '');
+            if (readinessLevel === 'ready_for_preview' || stage === 'preview_ready') return 0;
+            if (state === 'needs_approval') return 1;
+            if (readinessLevel === 'blocked' || stage === 'blocked') return 2;
+            if (readinessLevel === 'needs_reputation_review' || track === 'reputation_review') return 3;
+            if (state === 'investigate') return 4;
+            if (readinessLevel === 'manual_repair' || track === 'manual_dns' || state === 'manual_action') return 5;
+            return 6;
+        },
+
+        remediationLoopStatusLabel(status) {
+            return {
+                clear: 'Clear',
+                needs_attention: 'Needs attention',
+                approval_required: 'Approval required',
+                manual_action_required: 'Manual action required',
+                investigation_required: 'Investigation required'
+            }[String(status || '')] || 'Review';
+        },
+
+        remediationLoopStatusClass(status) {
+            return {
+                clear: 'bg-green-100 text-green-700',
+                needs_attention: 'bg-yellow-100 text-yellow-800',
+                approval_required: 'bg-[#edf7f7] text-[#247982]',
+                manual_action_required: 'bg-[#fff7df] text-[#8a6418]',
+                investigation_required: 'bg-[#fff1ea] text-[#b8431d]'
+            }[String(status || '')] || 'bg-[#f8f7f6] text-[#5f5c78]';
+        },
+
+        remediationIncidentLabel(value) {
+            return this.formatDemoLabel(value || 'none');
         },
 
         remediationLoopStateLabel(state) {
@@ -968,6 +1036,23 @@ function dashboardApp() {
         repairProgressionNextStep(progression) {
             if (!progression) return 'Open the remediation queue to review the next safe gate.';
             return progression.next_step || progression.summary || 'Open the remediation queue to review the next safe gate.';
+        },
+
+        repairProgressionNextSafeAction(progression) {
+            if (!progression) return 'Open the remediation queue to review the next safe action.';
+            return progression.next_safe_action || this.repairProgressionNextStep(progression);
+        },
+
+        repairReadinessReason(progression) {
+            const reasons = progression?.readiness_reasons || [];
+            return reasons[0] || 'Review the current remediation evidence before opening, dispatching, or closing this item.';
+        },
+
+        repairReadinessBlockedText(progression) {
+            const blockedBy = progression?.blocked_by || [];
+            if (!blockedBy.length) return '';
+            const labels = blockedBy.slice(0, 3).map(value => this.formatDemoLabel(value));
+            return `Blocked by ${labels.join(', ')}.`;
         },
 
         repairReadinessClass(progression) {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -106,9 +106,24 @@ function domainDetailsApp(domainId = '') {
             verified_items_total: 0
         },
         remediationQueueLoading: true,
+        remediationQueueRefreshing: false,
         remediationQueueError: '',
+        remediationQueueRefreshError: '',
         showAllVerifiedRemediationItems: false,
+        showAllRemediationQueueItems: false,
         remediationQueueLoadedAt: '',
+        remediationQueueFilter: 'all',
+        remediationQueueSort: 'priority',
+        remediationQueueFilterOptions: [
+            { value: 'all', label: 'All' },
+            { value: 'preview_ready', label: 'Preview ready' },
+            { value: 'blocked', label: 'Blocked' },
+            { value: 'needs_evidence', label: 'Needs evidence' },
+            { value: 'notify_ready', label: 'Ready to notify' },
+            { value: 'waiting_operator', label: 'Waiting' },
+            { value: 'manual', label: 'Manual' },
+            { value: 'reputation', label: 'Reputation' }
+        ],
         remediationAction: {
             itemId: '',
             action: '',
@@ -244,6 +259,9 @@ function domainDetailsApp(domainId = '') {
                 this.fetchSources();
                 this.fetchSourceIntelligence();
             });
+            this.$watch('remediationQueueSort', () => {
+                this.showAllRemediationQueueItems = false;
+            });
         },
 
         bindPageControls() {
@@ -281,15 +299,22 @@ function domainDetailsApp(domainId = '') {
                 } else if (button.matches('[data-domain-detail-remediation-action]')) {
                     event.preventDefault();
                     this.handleRemediationAction(button);
+                } else if (button.matches('[data-domain-detail-remediation-filter]')) {
+                    event.preventDefault();
+                    this.remediationQueueFilter = button.dataset.domainDetailRemediationFilter || 'all';
+                    this.showAllRemediationQueueItems = false;
                 } else if (
                     button.matches('[data-domain-detail-remediation-retry]') ||
                     button.matches('[data-domain-detail-remediation-refresh]')
                 ) {
                     event.preventDefault();
-                    this.fetchRemediationQueue();
+                    this.fetchRemediationQueue({ refresh: true });
                 } else if (button.matches('[data-domain-detail-verified-repairs-toggle]')) {
                     event.preventDefault();
                     this.showAllVerifiedRemediationItems = !this.showAllVerifiedRemediationItems;
+                } else if (button.matches('[data-domain-detail-remediation-toggle-all]')) {
+                    event.preventDefault();
+                    this.showAllRemediationQueueItems = !this.showAllRemediationQueueItems;
                 } else if (button.matches('[data-domain-detail-migration-action]')) {
                     event.preventDefault();
                     this.handleMigrationAction(button.dataset.domainDetailMigrationAction);
@@ -406,7 +431,7 @@ function domainDetailsApp(domainId = '') {
             window.setTimeout(() => {
                 Promise.allSettled([
                     this.fetchPosture(),
-                    this.fetchRemediationQueue(),
+                    this.fetchRemediationQueue({ refresh: true }),
                     this.fetchHealthHistory(),
                     this.fetchMtaSts(),
                     this.fetchBimi()
@@ -441,7 +466,7 @@ function domainDetailsApp(domainId = '') {
                     this.fetchDNSHealth({ refresh: true }),
                     this.fetchDNSGuidance({ refresh: true }),
                     this.fetchPosture({ refresh: true }),
-                    this.fetchRemediationQueue(),
+                    this.fetchRemediationQueue({ refresh: true }),
                     this.fetchHealthHistory(),
                     this.fetchMtaSts({ refresh: true }),
                     this.fetchBimi({ refresh: true }),
@@ -598,6 +623,11 @@ function domainDetailsApp(domainId = '') {
             const progression = this.primaryRemediationItem?.repair_progression;
             if (!progression) return 'Repair status will appear after the remediation queue finishes loading.';
             return this.repairProgressionNextStep(progression);
+        },
+
+        get primaryRepairReadinessReasonText() {
+            const progression = this.primaryRemediationItem?.repair_progression;
+            return this.repairReadinessReason(progression);
         },
 
         get healthEvidenceExportUrl() {
@@ -1073,6 +1103,22 @@ function domainDetailsApp(domainId = '') {
             return progression.next_step || progression.summary || 'Review the repair gate before taking action.';
         },
 
+        repairProgressionNextSafeAction(progression) {
+            if (!progression) return 'Review the remediation queue before taking action.';
+            return progression.next_safe_action || this.repairProgressionNextStep(progression);
+        },
+
+        repairReadinessReason(progression) {
+            const reasons = progression?.readiness_reasons || [];
+            return reasons[0] || 'Review current report, DNS, and provider evidence before closing this item.';
+        },
+
+        repairReadinessBlockedText(progression) {
+            const blockedBy = progression?.blocked_by || [];
+            if (!blockedBy.length) return '';
+            return `Blocked by ${blockedBy.slice(0, 3).map(value => this.humanizeToken(value)).join(', ')}.`;
+        },
+
         repairReadinessClass(progression) {
             const level = String(progression?.readiness_level || '');
             if (level === 'ready_for_preview') return 'bg-green-100 text-green-700';
@@ -1125,6 +1171,108 @@ function domainDetailsApp(domainId = '') {
         visibleVerifiedItems() {
             const items = this.remediationQueue.verified_items || [];
             return this.showAllVerifiedRemediationItems ? items : items.slice(0, VERIFIED_ITEMS_COMPACT_LIMIT);
+        },
+
+        visibleRemediationQueueItems() {
+            const items = this.filteredRemediationQueueItems(this.remediationQueueFilter);
+            return this.showAllRemediationQueueItems ? items : items.slice(0, 6);
+        },
+
+        remediationQueueTotalCount() {
+            return (this.remediationQueue.items || []).length;
+        },
+
+        remediationQueueFilteredCount() {
+            return this.filteredRemediationQueueItems(this.remediationQueueFilter).length;
+        },
+
+        remediationQueueHiddenCount() {
+            return Math.max(this.remediationQueueFilteredCount() - this.visibleRemediationQueueItems().length, 0);
+        },
+
+        remediationQueueFilterLabel() {
+            const match = this.remediationQueueFilterOptions.find(option => option.value === this.remediationQueueFilter);
+            return match?.label || 'All';
+        },
+
+        filteredRemediationQueueItems(filterValue) {
+            const filter = filterValue || 'all';
+            const items = this.remediationQueue.items || [];
+            return this.sortedRemediationQueueItems(
+                items.filter(item => this.remediationQueueFilterMatches(item, filter))
+            );
+        },
+
+        sortedRemediationQueueItems(items) {
+            const severityWeight = {
+                critical: 5,
+                high: 4,
+                error: 4,
+                medium: 3,
+                warning: 3,
+                low: 2,
+                info: 1
+            };
+            const score = item => Number(item?.priority_score || 0);
+            const readiness = item => this.repairReadinessScore(item?.repair_progression);
+            const severity = item => severityWeight[String(item?.severity || '').toLowerCase()] || 0;
+            const list = [...(items || [])];
+            if (this.remediationQueueSort === 'readiness') {
+                return list.sort((left, right) => (
+                    readiness(right) - readiness(left) ||
+                    score(right) - score(left) ||
+                    severity(right) - severity(left)
+                ));
+            }
+            if (this.remediationQueueSort === 'severity') {
+                return list.sort((left, right) => (
+                    severity(right) - severity(left) ||
+                    score(right) - score(left) ||
+                    readiness(right) - readiness(left)
+                ));
+            }
+            return list.sort((left, right) => (
+                score(right) - score(left) ||
+                severity(right) - severity(left) ||
+                readiness(right) - readiness(left)
+            ));
+        },
+
+        remediationQueueFilterMatches(item, filter) {
+            if (!item || filter === 'all') return true;
+            const progression = item.repair_progression || {};
+            const readinessLevel = String(progression.readiness_level || '');
+            const stage = String(progression.stage || '');
+            const track = String(item.remediation_track || '');
+            if (filter === 'preview_ready') {
+                return readinessLevel === 'ready_for_preview' || stage === 'preview_ready';
+            }
+            if (filter === 'blocked') {
+                return readinessLevel === 'blocked' || stage === 'blocked' || (progression.blocked_by || []).length > 0;
+            }
+            if (filter === 'needs_evidence') {
+                return Boolean(progression.verification_required) || stage === 'operator_review' || readinessLevel === 'needs_operator_review';
+            }
+            if (filter === 'notify_ready') {
+                return Boolean(item.notification?.dispatch?.eligible);
+            }
+            if (filter === 'waiting_operator') {
+                const dispatchStatus = this.remediationDispatchStatus(item.notification?.dispatch);
+                return dispatchStatus === 'blocked' ||
+                    item.notification?.dispatch?.requires_acknowledgement ||
+                    stage === 'operator_review';
+            }
+            if (filter === 'manual') {
+                return track === 'manual_dns' || readinessLevel === 'manual_repair' || stage === 'manual_repair';
+            }
+            if (filter === 'reputation') {
+                return track === 'reputation_review' || readinessLevel === 'needs_reputation_review' || stage === 'reputation_review';
+            }
+            return true;
+        },
+
+        remediationQueueFilterCount(filter) {
+            return this.filteredRemediationQueueItems(filter).length;
         },
 
         remediationDecisionLabel(value) {
@@ -1695,7 +1843,9 @@ function domainDetailsApp(domainId = '') {
 
         resetRemediationQueue() {
             this.showAllVerifiedRemediationItems = false;
+            this.showAllRemediationQueueItems = false;
             this.remediationQueueLoadedAt = '';
+            this.remediationQueueRefreshError = '';
             this.remediationQueue = {
                 status: 'unavailable',
                 loop: {
@@ -1741,10 +1891,23 @@ function domainDetailsApp(domainId = '') {
             };
         },
 
-        async fetchRemediationQueue() {
-            this.remediationQueueLoading = true;
+        hasRemediationQueueData() {
+            return Boolean(
+                (this.remediationQueue.items || []).length ||
+                (this.remediationQueue.verified_items || []).length ||
+                this.remediationQueueLoadedAt
+            );
+        },
+
+        async fetchRemediationQueue(options = {}) {
+            const refresh = Boolean(options.refresh);
+            const keepExistingQueueVisible = refresh && this.hasRemediationQueueData();
+            this.remediationQueueLoading = !keepExistingQueueVisible;
+            this.remediationQueueRefreshing = refresh;
             this.remediationQueueError = '';
+            this.remediationQueueRefreshError = '';
             this.showAllVerifiedRemediationItems = false;
+            this.showAllRemediationQueueItems = false;
             try {
                 const response = await this.fetchWithTimeout(
                     `/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation`
@@ -1755,18 +1918,27 @@ function domainDetailsApp(domainId = '') {
                         status: response.status,
                         statusText: response.statusText
                     });
-                    this.remediationQueueError = 'Remediation queue could not be loaded.';
-                    this.resetRemediationQueue();
+                    if (keepExistingQueueVisible) {
+                        this.remediationQueueRefreshError = 'Remediation queue refresh failed. Keeping the current queue visible.';
+                    } else {
+                        this.remediationQueueError = 'Remediation queue could not be loaded.';
+                        this.resetRemediationQueue();
+                    }
                     return;
                 }
                 this.remediationQueue = await response.json();
                 this.remediationQueueLoadedAt = new Date().toISOString();
             } catch (error) {
                 console.error('Error fetching remediation queue:', error);
-                this.remediationQueueError = error.message || 'Remediation queue could not be loaded.';
-                this.resetRemediationQueue();
+                if (keepExistingQueueVisible) {
+                    this.remediationQueueRefreshError = error.message || 'Remediation queue refresh failed. Keeping the current queue visible.';
+                } else {
+                    this.remediationQueueError = error.message || 'Remediation queue could not be loaded.';
+                    this.resetRemediationQueue();
+                }
             } finally {
                 this.remediationQueueLoading = false;
+                this.remediationQueueRefreshing = false;
             }
         },
 
@@ -2180,15 +2352,17 @@ function domainDetailsApp(domainId = '') {
         },
         
         async fetchSources(options = {}) {
-            this.sourcesLoading = true;
+            const refresh = Boolean(options.refresh);
+            const keepExistingSourcesVisible = refresh && (this.sources || []).length > 0;
+            this.sourcesLoading = !keepExistingSourcesVisible;
             this.sourcesError = '';
             try {
                 const params = new URLSearchParams({ days: this.sourceDateWindow() });
-                if (options.refresh) params.set('refresh', 'true');
+                if (refresh) params.set('refresh', 'true');
                 const response = await this.fetchWithTimeout(
                     `/api/v1/domains/${encodeURIComponent(this.domainId)}/sources?${params.toString()}`,
                     {},
-                    options.refresh ? 60000 : 45000
+                    refresh ? 60000 : 45000
                 );
                 if (!response.ok) {
                     const data = await response.json().catch(() => ({}));

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -118,7 +118,10 @@
                                 </div>
                                 <div class="rounded-md bg-white p-3">
                                     <div class="flex flex-wrap items-center justify-between gap-2">
-                                        <p class="text-xs font-semibold uppercase text-[#5f5c78]">Readiness</p>
+                                        <p class="text-xs font-semibold uppercase text-[#5f5c78]">Repair readiness</p>
+                                        <span class="rounded px-2 py-1 text-xs font-semibold"
+                                              :class="repairReadinessClass(primaryRemediationItem.repair_progression)"
+                                              x-text="repairReadinessLabel(primaryRemediationItem.repair_progression)"></span>
                                         <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]">
                                             <span x-text="repairReadinessScore(primaryRemediationItem.repair_progression)"></span><span>/100</span>
                                         </span>
@@ -432,9 +435,10 @@
                             </span>
                             <button type="button"
                                     class="btn btn-outline btn-xs"
-                                    :disabled="remediationQueueLoading"
+                                    :disabled="remediationQueueLoading || remediationQueueRefreshing"
                                     data-domain-detail-remediation-refresh>
-                                Refresh queue
+                                <span x-show="remediationQueueRefreshing" class="loading loading-spinner loading-xs"></span>
+                                <span x-text="remediationQueueRefreshing ? 'Refreshing...' : 'Refresh queue'"></span>
                             </button>
                         </div>
                     </div>
@@ -457,6 +461,10 @@
                             </div>
                         </div>
                     </template>
+                    <p x-show="remediationQueueRefreshError"
+                       x-cloak
+                       class="mt-4 rounded border border-[#ffcfbd] bg-[#fff2ec] px-3 py-2 text-sm text-[#8a2d0d]"
+                       x-text="remediationQueueRefreshError"></p>
                     <template x-if="!remediationQueueLoading && !remediationQueueError && (remediationQueue.verified_items || []).length > 0">
                         <div class="mt-4 rounded-lg border border-[#d8ebe8] bg-[#f2fbf9] p-3">
                             <div class="flex flex-wrap items-start justify-between gap-3">
@@ -605,8 +613,40 @@
                     <template x-if="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length === 0">
                         <p class="mt-4 text-sm text-[#5f5c78]">No remediation items are queued for this domain.</p>
                     </template>
+                    <div class="mt-4 flex flex-wrap gap-2"
+                         x-show="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length > 0">
+                        <label class="flex items-center gap-2 rounded border border-[#e6e3e1] bg-white px-3 py-2 text-xs font-semibold text-[#5f5c78]">
+                            <span>Sort</span>
+                            <select x-model="remediationQueueSort"
+                                    class="bg-transparent font-semibold text-[#272a5f] outline-none"
+                                    aria-label="Remediation queue sort">
+                                <option value="priority">Priority</option>
+                                <option value="readiness">Repair readiness</option>
+                                <option value="severity">Severity</option>
+                            </select>
+                        </label>
+                        <template x-for="filter in remediationQueueFilterOptions" :key="'remediation-filter-' + filter.value">
+                            <button type="button"
+                                    class="rounded border px-3 py-2 text-xs font-semibold transition"
+                                    :class="remediationQueueFilter === filter.value ? 'border-[#2f9da5] bg-[#f2fbf9] text-[#1f7c83]' : 'border-[#e6e3e1] bg-white text-[#5f5c78] hover:border-[#2f9da5]'"
+                                    :aria-pressed="remediationQueueFilter === filter.value ? 'true' : 'false'"
+                                    :data-domain-detail-remediation-filter="filter.value">
+                                <span x-text="filter.label"></span>
+                                <span class="ml-1 rounded bg-[#f4f3f2] px-1.5 py-0.5 text-[0.65rem] text-[#45505f]"
+                                      x-text="remediationQueueFilterCount(filter.value)"></span>
+                            </button>
+                        </template>
+                    </div>
+                    <p class="mt-3 text-xs font-semibold text-[#5f5c78]"
+                       role="status"
+                       x-show="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length > 0">
+                        <span>Showing </span><span x-text="visibleRemediationQueueItems().length"></span>
+                        <span> of </span><span x-text="remediationQueueFilteredCount()"></span>
+                        <span> matching remediation items in </span><span x-text="remediationQueueFilterLabel()"></span>
+                        <span> view (</span><span x-text="remediationQueueTotalCount()"></span><span> total).</span>
+                    </p>
                     <div class="mt-4 grid gap-3 xl:grid-cols-2">
-                        <template x-for="item in (!remediationQueueLoading && !remediationQueueError ? remediationQueue.items.slice(0, 6) : [])" :key="item.id">
+                        <template x-for="item in (!remediationQueueLoading && !remediationQueueError ? visibleRemediationQueueItems() : [])" :key="item.id">
                             <div class="rounded-lg border border-[#e6e3e1] bg-white p-4">
                                 <div class="flex items-start justify-between gap-3">
                                     <div class="min-w-0">
@@ -937,10 +977,24 @@
                             </div>
                         </template>
                     </div>
-                    <template x-if="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length > 6">
-                        <p class="mt-3 text-xs font-semibold text-[#5f5c78]">
-                            <span>+</span><span x-text="remediationQueue.items.length - 6"></span><span> more remediation items</span>
-                        </p>
+                    <p class="mt-4 rounded border border-[#e6e3e1] bg-white p-4 text-sm text-[#5f5c78]"
+                       x-show="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length > 0 && visibleRemediationQueueItems().length === 0">
+                        No remediation items match this filter. Choose another queue view or refresh the queue after new evidence is available.
+                    </p>
+                    <template x-if="!remediationQueueLoading && !remediationQueueError && (remediationQueueHiddenCount() > 0 || showAllRemediationQueueItems)">
+                        <div class="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs font-semibold text-[#5f5c78]">
+                            <p x-show="remediationQueueHiddenCount() > 0">
+                                <span>+</span><span x-text="remediationQueueHiddenCount()"></span><span> more remediation items in this view.</span>
+                            </p>
+                            <p x-show="showAllRemediationQueueItems && remediationQueueHiddenCount() === 0">
+                                <span>Showing all </span><span x-text="remediationQueueFilteredCount()"></span><span> matching remediation items.</span>
+                            </p>
+                            <button type="button"
+                                    class="btn btn-outline btn-xs"
+                                    data-domain-detail-remediation-toggle-all
+                                    x-text="showAllRemediationQueueItems ? 'Show compact queue' : 'Show all matching items'">
+                            </button>
+                        </div>
                     </template>
                 </div>
 

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -32,6 +32,14 @@
         <p class="mt-1" x-text="dashboardError"></p>
     </div>
 
+    <div x-show="!dashboardLoading && dashboardRefreshError && hasDomainData"
+         x-cloak
+         class="rounded-lg border border-[#ffcfbd] bg-[#fff2ec] p-4 text-sm text-[#8a2d0d]"
+         role="status">
+        <p class="font-semibold">Dashboard refresh failed</p>
+        <p class="mt-1" x-text="dashboardRefreshError"></p>
+    </div>
+
     <div class="rounded-lg bg-white p-4 shadow-sm" x-show="hasDomainData" x-cloak data-tour="date-filter">
         <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div class="grid gap-1">
@@ -212,8 +220,27 @@
             <div>
                 <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]">Remediation Loop</p>
                 <h2 class="mt-1 text-2xl font-semibold tracking-normal text-[#07071f]">Current fix queue</h2>
+                <p class="mt-2 text-sm text-[#5f5c78]" x-text="remediationLoop().next_action || 'Keep importing reports and monitoring DNS.'"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]" x-show="domainSummaryLoadedAt">
+                    <span>Updated </span><span x-text="domainSummaryLoadedAtLabel"></span>
+                </p>
             </div>
-            <a href="/domains" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open domain worklist</a>
+            <div class="flex flex-wrap items-center gap-2">
+                <span class="rounded px-2 py-1 text-xs font-semibold"
+                      :class="remediationLoopStatusClass(remediationLoop().status || remediationLoop().loop_status)"
+                      x-text="remediationLoopStatusLabel(remediationLoop().status || remediationLoop().loop_status)"></span>
+                <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]">
+                    <span>Top: </span><span x-text="remediationIncidentLabel(remediationLoop().top_incident_type)"></span>
+                </span>
+                <button type="button"
+                        class="rounded border border-[#dfdfdf] bg-white px-3 py-2 text-sm font-semibold text-[#272a5f] hover:border-[#2f9da5] disabled:opacity-60"
+                        :disabled="dashboardLoading || remediationRefreshRunning"
+                        data-dashboard-remediation-refresh>
+                    <span x-show="remediationRefreshRunning" class="loading loading-spinner loading-xs"></span>
+                    <span x-text="remediationRefreshRunning ? 'Refreshing...' : 'Refresh queue'"></span>
+                </button>
+                <a href="/domains" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open domain worklist</a>
+            </div>
         </div>
         <div class="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
             <div class="rounded-md border border-[#e6e3e1] p-4">
@@ -321,6 +348,13 @@
                                 <span x-text="repairReadinessScore(item.repair_progression)"></span><span>/100 readiness</span>
                             </span>
                         </div>
+                        <p class="mt-2 rounded bg-white px-2 py-1 text-[#120d36]">
+                            <span class="font-semibold">Next safe action: </span>
+                            <span x-text="repairProgressionNextSafeAction(item.repair_progression)"></span>
+                        </p>
+                        <p class="mt-2 text-[#45505f]" x-text="repairReadinessReason(item.repair_progression)"></p>
+                        <p class="mt-1 text-[#7a4a00]" x-show="repairReadinessBlockedText(item.repair_progression)"
+                           x-text="repairReadinessBlockedText(item.repair_progression)"></p>
                     </div>
                     <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3 text-xs">
                         <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Next verification</p>
@@ -332,6 +366,14 @@
                     </p>
                 </a>
             </template>
+        </div>
+        <div class="mt-5 rounded-md border border-[#d8ebe8] bg-[#f2fbf9] p-4 text-sm"
+             x-show="!hasRemediationLoopItems()">
+            <p class="font-semibold text-[#120d36]">No active remediation work queued</p>
+            <p class="mt-1 text-[#5f5c78]">
+                DMARQ did not find a current fix that needs approval, manual action, or sender investigation.
+                Keep importing reports and refreshing DNS evidence so new issues appear here.
+            </p>
         </div>
     </section>
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -348,6 +348,27 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "Need fresh evidence" in template
     assert "Waiting on operator" in template
     assert "Blocked before repair" in template
+    assert "remediationLoop().next_action" in template
+    assert "remediationLoopStatusClass(remediationLoop().status || remediationLoop().loop_status)" in template
+    assert "remediationLoopStatusLabel(remediationLoop().status || remediationLoop().loop_status)" in template
+    assert "remediationIncidentLabel(remediationLoop().top_incident_type)" in template
+    assert "data-dashboard-remediation-refresh" in template
+    assert "data-dashboard-remediation-refresh" in script
+    assert "remediationRefreshRunning" in script
+    assert "dashboardRefreshError" in script
+    assert "Showing the previously loaded dashboard data." in script
+    assert "fetchDomainSummary({ refresh: true })" in script
+    assert "dashboardLoading = !refresh || !this.hasDomainData" in script
+    assert "remediationRefreshRunning ? 'Refreshing...' : 'Refresh queue'" in template
+    assert "Dashboard refresh failed" in template
+    assert "dashboardRefreshError && hasDomainData" in template
+    assert '@click="fetchDomainSummary()"' not in template
+    assert "domainSummaryLoadedAt" in script
+    assert "domainSummaryLoadedAtLabel" in script
+    assert "domainSummaryLoadedAtLabel" in template
+    assert "No active remediation work queued" in template
+    assert "Keep importing reports and refreshing DNS evidence" in template
+    assert 'x-show="!hasRemediationLoopItems()"' in template
     assert (
         "remediationLoop().repair_ready_for_preview || remediationLoop().repair_preview_ready || 0"
         in template
@@ -362,14 +383,27 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "repairProgressionClass(item.repair_progression)" in template
     assert "repairProgressionLabel(item.repair_progression)" in template
     assert "repairProgressionNextStep(item.repair_progression)" in template
+    assert "repairProgressionNextSafeAction(item.repair_progression)" in template
+    assert "repairReadinessReason(item.repair_progression)" in template
+    assert "repairReadinessBlockedText(item.repair_progression)" in template
+    assert "Next safe action" in template
     assert "repairReadinessClass(item.repair_progression)" in template
     assert "repairReadinessLabel(item.repair_progression)" in template
     assert "repairReadinessScore(item.repair_progression)" in template
     assert "remediationRiskClass(risk)" in script
     assert "remediationTrackLabel(track)" in script
+    assert "remediationLoopStatusLabel(status)" in script
+    assert "remediationLoopStatusClass(status)" in script
+    assert "remediationIncidentLabel(value)" in script
+    assert "remediationLoopItemRank(item)" in script
+    assert "[...items].sort" in script
+    assert "this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b)" in script
     assert "repairProgressionClass(progression)" in script
     assert "repairProgressionLabel(progression)" in script
     assert "repairProgressionNextStep(progression)" in script
+    assert "repairProgressionNextSafeAction(progression)" in script
+    assert "repairReadinessReason(progression)" in script
+    assert "repairReadinessBlockedText(progression)" in script
     assert "repairReadinessClass(progression)" in script
     assert "repairReadinessLabel(progression)" in script
     assert "repairReadinessScore(progression)" in script
@@ -385,7 +419,50 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "visibleVerifiedItems()" in template
     assert "data-domain-detail-remediation-refresh" in template
     assert "data-domain-detail-verified-repairs-toggle" in template
-    assert "fetchRemediationQueue()" in script
+    assert "fetchRemediationQueue({ refresh: true })" in script
+    assert "remediationQueueRefreshing" in script
+    assert "remediationQueueRefreshError" in script
+    assert "hasRemediationQueueData()" in script
+    assert "keepExistingQueueVisible" in script
+    assert "Remediation queue refresh failed. Keeping the current queue visible." in script
+    assert "remediationQueueRefreshing ? 'Refreshing...' : 'Refresh queue'" in template
+    assert "remediationQueueRefreshError" in template
+    assert "remediationQueueFilterOptions" in script
+    assert "remediationQueueFilter: 'all'" in script
+    assert "{ value: 'notify_ready', label: 'Ready to notify' }" in script
+    assert "{ value: 'waiting_operator', label: 'Waiting' }" in script
+    assert "remediationQueueSort: 'priority'" in script
+    assert "sortedRemediationQueueItems(items)" in script
+    assert "visibleRemediationQueueItems()" in script
+    assert "filteredRemediationQueueItems(filterValue)" in script
+    assert "remediationQueueFilterMatches(item, filter)" in script
+    assert "filter === 'notify_ready'" in script
+    assert "filter === 'waiting_operator'" in script
+    assert "item.notification?.dispatch?.eligible" in script
+    assert "remediationQueueFilterCount(filter)" in script
+    assert "remediationQueueFilteredCount()" in script
+    assert "remediationQueueTotalCount()" in script
+    assert "showAllRemediationQueueItems" in script
+    assert "remediationQueueHiddenCount()" in script
+    assert "remediationQueueFilterLabel()" in script
+    assert "remediationQueueFilterOptions" in template
+    assert 'x-model="remediationQueueSort"' in template
+    assert "Repair readiness" in template
+    assert "Remediation queue sort" in template
+    assert "data-domain-detail-remediation-filter" in template
+    assert "aria-pressed" in template
+    assert 'role="status"' in template
+    assert "domainDetailRemediationFilter" in script
+    assert "remediationQueueFilterCount(filter.value)" in template
+    assert "remediationQueueFilteredCount()" in template
+    assert "remediationQueueTotalCount()" in template
+    assert "remediationQueueFilterLabel()" in template
+    assert "visibleRemediationQueueItems()" in template
+    assert "data-domain-detail-remediation-toggle-all" in template
+    assert "Show all matching items" in template
+    assert "Show compact queue" in template
+    assert "remediationQueueHiddenCount()" in template
+    assert "No remediation items match this filter" in template
     assert "showAllVerifiedRemediationItems = !this.showAllVerifiedRemediationItems" in script
     assert "remediationQueueLoadedAt" in template
     assert "formatIsoDate(remediationQueueLoadedAt)" in template
@@ -1395,6 +1472,8 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "sourceReputationRefreshing" in template
     assert "sourceReputationRefreshError" in template
     assert "this.sourceReputationRefreshError = '';" in script
+    assert "keepExistingSourcesVisible" in script
+    assert "this.sourcesLoading = !keepExistingSourcesVisible;" in script
     assert "if (!options.preserveOnFailure) {\n                    this.sources = [];" in script
     assert "sourceSeenLabel" in script
     assert "sourceVolumeBars" in script
@@ -1466,6 +1545,12 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "repairReadinessScore(primaryRemediationItem.repair_progression)" in template
     assert "Next safe action" in template
     assert "item.state.split('_').join(' ')" in template
+    assert "Repair readiness" in template
+    assert "primaryRepairReadinessReasonText" in script
+    assert "repairReadinessLabel(primaryRemediationItem.repair_progression)" in template
+    assert "repairReadinessScore(primaryRemediationItem.repair_progression)" in template
+    assert "repairReadinessReason(progression)" in script
+    assert "repairReadinessBlockedText(progression)" in script
     assert 'href="#remediation-queue"' in template
     assert 'id="remediation-queue"' in template
     assert "Loading remediation queue..." in template
@@ -1489,7 +1574,7 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "(!sourcesLoading && !sourcesError ? filteredSources : [])" in template
     assert "(!reportsLoading && !reportsError ? reports : [])" in template
     assert (
-        "(!remediationQueueLoading && !remediationQueueError ? remediationQueue.items.slice(0, 6) : [])"
+        "(!remediationQueueLoading && !remediationQueueError ? visibleRemediationQueueItems() : [])"
         in template
     )
     assert (
@@ -1736,6 +1821,7 @@ def test_dashboard_distinguishes_loading_error_and_empty_states():
     assert "Dashboard could not be loaded" in template
     assert "dashboardLoading" in script
     assert "dashboardError" in script
+    assert "dashboardRefreshError" in script
     assert "Dashboard data could not be loaded." in script
     assert 'x-show="!dashboardLoading && !dashboardError && !hasDomainData"' in template
 

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -73,9 +73,17 @@ Repair-gate counters distinguish provider previews that are ready for review,
 items that still need fresh evidence before closure, and findings that are
 blocked before repair. The dashboard also separates items waiting on an operator
 for sender classification, manual repair, reputation review, or general operator
-review. Each card shows the same readiness label and 0-100 score used on the
-domain remediation queue, then links to the selected domain for the full
-evidence, approval, and verification flow.
+review. The section header shows the loop status, top incident family, next
+action, and the last successful summary refresh time so operators can triage the
+queue before reading every card. Use **Refresh queue** when new reports, DNS
+refreshes, or operator markers should be reflected immediately. A failed manual
+refresh keeps the previously loaded dashboard visible and shows a refresh warning
+instead of replacing the page with an empty state. Cards are sorted so provider
+previews and approval-ready work appear before blocked, reputation,
+investigation, and manual work. Each card shows the same readiness label and
+0-100 score used on the domain remediation queue. Cards also show the next safe
+action, first readiness reason, and blocker summary before linking to the
+selected domain for the full evidence, approval, and verification flow.
 
 ### Demo Mode
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -93,7 +93,17 @@ blast radius, prerequisites, and expected health-score impact. Approval-ready
 DNS items link back to the DNS change-plan review area; they still require an
 operator preview and explicit approval before any provider write is sent.
 Use **Refresh queue** to reload the remediation queue from the backend after
-new reports, DNS checks, or operator lifecycle changes are available.
+new reports, DNS checks, or operator lifecycle changes are available. If a
+manual refresh fails, DMARQ keeps the currently loaded queue on screen and shows
+a refresh warning so an operator does not lose context during a transient API or
+network problem.
+Use the queue filters to focus on all work, preview-ready repairs, blocked
+repairs, evidence-gated items, notification-ready work, operator-waiting items,
+manual work, or reputation review without losing the underlying prioritized
+queue. The filter bar shows how many matching items are visible, how many match
+the selected view, and how many remain in the full queue. Operators can sort the
+same filtered queue by priority, repair readiness, or severity, and expand the
+compact six-item list to show every matching item.
 Each item now also shows the remediation track, priority band, owner, risk
 level, safe-automation flag, and the exact operator decision DMARQ expects next.
 Action plans include decision checkpoints and a rollback or fallback note so an
@@ -112,8 +122,9 @@ must be classified first, whether the work is manual DNS, or whether fresh
 reputation/report/DNS evidence is still required before closure. This panel is
 read-only; it does not apply DNS changes or send provider requests. The top
 **Next remediation** panel mirrors the same repair-gate status so the operator
-can see the current blocker, readiness label, readiness score, and next safe
-action before opening the full queue.
+can see the current blocker, readiness label, readiness score, next safe action,
+and first readiness reason before
+opening the full queue.
 Repair progression also includes a readiness label, 0-100 readiness score,
 human-readable reasons, and blocker keys. Use this to separate work that is
 ready for provider preview from work that is blocked by missing provider values,
@@ -184,6 +195,10 @@ prefix data explains who appears to operate the sending infrastructure; optional
 reputation feeds can add DNSBL, blocklist, or abuse-confidence evidence when an
 administrator has enabled those providers. A clean Geo/ASN lookup is not the
 same thing as a clean reputation result.
+When you use **Refresh reputation**, DMARQ recalculates cached IP reputation
+evidence. If the refresh times out or a provider is unavailable, the page keeps
+the previously loaded sending-source rows visible and shows the refresh error
+separately.
 
 Known sender matching recognizes common provider evidence from DMARC reports,
 reverse DNS, and authentication domains. The built-in profiles include Google


### PR DESCRIPTION
## Summary
- keep dashboard, domain remediation queue, and source reputation evidence visible during manual refreshes and transient refresh failures
- add domain remediation queue sorting, extra operator filters, and expandable filtered results
- align the top next-remediation panel with repair readiness, next-safe-action, and blocker context
- update user docs and changelog for the operator workflow

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py -q --tb=short
- node --check backend/app/static/js/dashboard-page.js
- node --check backend/app/static/js/domain-details-page.js
- .venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py
- git diff --check origin/main...HEAD

## Safety
- No DNS/provider writes changed
- No notification dispatch behavior changed
- Operator refresh and queue UI only

Closes part of #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remediation queue sorting, filtering, and expandable views for easier triage.
  * Added clearer remediation guidance, including next action, readiness, and blocker details.
  * Added updated refresh status indicators and timestamps for dashboard and domain pages.

* **Bug Fixes**
  * Manual refreshes now keep previously loaded dashboard, queue, and source data visible when errors occur.
  * Fixed transient refresh failures from clearing already available operator information.

* **Documentation**
  * Expanded user guide content for dashboard and domain remediation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->