### PR TITLE
fix: address remediation operator review gaps

### DIFF
--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -952,7 +952,7 @@ function dashboardApp() {
             const state = String(item?.state || '');
             const track = String(item?.remediation_track || '');
             if (readinessLevel === 'ready_for_preview' || stage === 'preview_ready') return 0;
-            if (state === 'needs_approval') return 1;
+            if (state === 'needs_approval' || state === 'approval_ready') return 1;
             if (readinessLevel === 'blocked' || stage === 'blocked') return 2;
             if (readinessLevel === 'needs_reputation_review' || track === 'reputation_review') return 3;
             if (state === 'investigate') return 4;
@@ -978,6 +978,13 @@ function dashboardApp() {
                 manual_action_required: 'bg-[#fff7df] text-[#8a6418]',
                 investigation_required: 'bg-[#fff1ea] text-[#b8431d]'
             }[String(status || '')] || 'bg-[#f8f7f6] text-[#5f5c78]';
+        },
+
+        remediationLoopEffectiveStatus(loop) {
+            if (!loop) return '';
+            const status = String(loop.status || '');
+            const loopStatus = String(loop.loop_status || '');
+            return status === 'needs_attention' && loopStatus ? loopStatus : (status || loopStatus);
         },
 
         remediationIncidentLabel(value) {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -2354,7 +2354,7 @@ function domainDetailsApp(domainId = '') {
         async fetchSources(options = {}) {
             const refresh = Boolean(options.refresh);
             const keepExistingSourcesVisible = refresh && (this.sources || []).length > 0;
-            const preserveOnFailure = Boolean(options.preserveOnFailure || keepExistingSourcesVisible);
+            const preserveOnFailure = Boolean(options.preserveOnFailure ?? keepExistingSourcesVisible);
             this.sourcesLoading = !keepExistingSourcesVisible;
             this.sourcesError = '';
             try {
@@ -2376,7 +2376,7 @@ function domainDetailsApp(domainId = '') {
             } catch (error) {
                 if (!preserveOnFailure) {
                     this.sources = [];
-                    this.sourcesError = error.message || 'Sending sources could not be loaded.';
+                    this.sourcesError = error.message || 'Sources could not be loaded.';
                 }
                 if (preserveOnFailure) {
                     this.sourceReputationRefreshError = error.message || 'Source reputation could not be refreshed.';

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1248,10 +1248,10 @@ function domainDetailsApp(domainId = '') {
                 return readinessLevel === 'ready_for_preview' || stage === 'preview_ready';
             }
             if (filter === 'blocked') {
-                return readinessLevel === 'blocked' || stage === 'blocked' || (progression.blocked_by || []).length > 0;
+                return readinessLevel === 'blocked' || stage === 'blocked';
             }
             if (filter === 'needs_evidence') {
-                return Boolean(progression.verification_required) || stage === 'operator_review' || readinessLevel === 'needs_operator_review';
+                return stage === 'operator_review' || readinessLevel === 'needs_operator_review';
             }
             if (filter === 'notify_ready') {
                 return Boolean(item.notification?.dispatch?.eligible);
@@ -2354,6 +2354,7 @@ function domainDetailsApp(domainId = '') {
         async fetchSources(options = {}) {
             const refresh = Boolean(options.refresh);
             const keepExistingSourcesVisible = refresh && (this.sources || []).length > 0;
+            const preserveOnFailure = Boolean(options.preserveOnFailure || keepExistingSourcesVisible);
             this.sourcesLoading = !keepExistingSourcesVisible;
             this.sourcesError = '';
             try {
@@ -2373,11 +2374,11 @@ function domainDetailsApp(domainId = '') {
                 this.sources = (data.sources || []).map(source => this.normalizeSource(source));
                 this.sourceReputationRefreshError = '';
             } catch (error) {
-                if (!options.preserveOnFailure) {
+                if (!preserveOnFailure) {
                     this.sources = [];
                     this.sourcesError = error.message || 'Sending sources could not be loaded.';
                 }
-                if (options.preserveOnFailure) {
+                if (preserveOnFailure) {
                     this.sourceReputationRefreshError = error.message || 'Source reputation could not be refreshed.';
                 }
                 console.error('Error fetching sources:', error);

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -614,6 +614,8 @@
                         <p class="mt-4 text-sm text-[#5f5c78]">No remediation items are queued for this domain.</p>
                     </template>
                     <div class="mt-4 flex flex-wrap gap-2"
+                         role="group"
+                         aria-label="Remediation queue filters"
                          x-show="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length > 0">
                         <label class="flex items-center gap-2 rounded border border-[#e6e3e1] bg-white px-3 py-2 text-xs font-semibold text-[#5f5c78]">
                             <span>Sort</span>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -227,8 +227,8 @@
             </div>
             <div class="flex flex-wrap items-center gap-2">
                 <span class="rounded px-2 py-1 text-xs font-semibold"
-                      :class="remediationLoopStatusClass(remediationLoop().status || remediationLoop().loop_status)"
-                      x-text="remediationLoopStatusLabel(remediationLoop().status || remediationLoop().loop_status)"></span>
+                      :class="remediationLoopStatusClass(remediationLoopEffectiveStatus(remediationLoop()))"
+                      x-text="remediationLoopStatusLabel(remediationLoopEffectiveStatus(remediationLoop()))"></span>
                 <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]">
                     <span>Top: </span><span x-text="remediationIncidentLabel(remediationLoop().top_incident_type)"></span>
                 </span>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -349,8 +349,8 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "Waiting on operator" in template
     assert "Blocked before repair" in template
     assert "remediationLoop().next_action" in template
-    assert "remediationLoopStatusClass(remediationLoop().status || remediationLoop().loop_status)" in template
-    assert "remediationLoopStatusLabel(remediationLoop().status || remediationLoop().loop_status)" in template
+    assert "remediationLoopStatusClass(remediationLoopEffectiveStatus(remediationLoop()))" in template
+    assert "remediationLoopStatusLabel(remediationLoopEffectiveStatus(remediationLoop()))" in template
     assert "remediationIncidentLabel(remediationLoop().top_incident_type)" in template
     assert "data-dashboard-remediation-refresh" in template
     assert "data-dashboard-remediation-refresh" in script
@@ -394,6 +394,7 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "remediationTrackLabel(track)" in script
     assert "remediationLoopStatusLabel(status)" in script
     assert "remediationLoopStatusClass(status)" in script
+    assert "remediationLoopEffectiveStatus(loop)" in script
     assert "remediationIncidentLabel(value)" in script
     assert "remediationLoopItemRank(item)" in script
     assert "[...items].sort" in script
@@ -451,6 +452,8 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "Remediation queue sort" in template
     assert "data-domain-detail-remediation-filter" in template
     assert "aria-pressed" in template
+    assert 'role="group"' in template
+    assert 'aria-label="Remediation queue filters"' in template
     assert 'role="status"' in template
     assert "domainDetailRemediationFilter" in script
     assert "remediationQueueFilterCount(filter.value)" in template
@@ -1473,8 +1476,9 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "sourceReputationRefreshError" in template
     assert "this.sourceReputationRefreshError = '';" in script
     assert "keepExistingSourcesVisible" in script
+    assert "preserveOnFailure = Boolean(options.preserveOnFailure || keepExistingSourcesVisible)" in script
     assert "this.sourcesLoading = !keepExistingSourcesVisible;" in script
-    assert "if (!options.preserveOnFailure) {\n                    this.sources = [];" in script
+    assert "if (!preserveOnFailure) {\n                    this.sources = [];" in script
     assert "sourceSeenLabel" in script
     assert "sourceVolumeBars" in script
     assert "source.reputation.status" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1476,9 +1476,10 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "sourceReputationRefreshError" in template
     assert "this.sourceReputationRefreshError = '';" in script
     assert "keepExistingSourcesVisible" in script
-    assert "preserveOnFailure = Boolean(options.preserveOnFailure || keepExistingSourcesVisible)" in script
+    assert "preserveOnFailure = Boolean(options.preserveOnFailure ?? keepExistingSourcesVisible)" in script
     assert "this.sourcesLoading = !keepExistingSourcesVisible;" in script
     assert "if (!preserveOnFailure) {\n                    this.sources = [];" in script
+    assert "Sources could not be loaded." in script
     assert "sourceSeenLabel" in script
     assert "sourceVolumeBars" in script
     assert "source.reputation.status" in template


### PR DESCRIPTION
## Summary
- keep source evidence visible when manual source refreshes fail
- tighten remediation queue filters so blocked/evidence views stay discriminating
- surface specific remediation loop statuses and group queue filters semantically

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py