### PR TITLE
feat: surface remediation evidence refresh paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.
 - Added domain remediation queue sorting by priority, repair readiness, or severity, plus filters for notification-ready and operator-waiting work.
 - Added an expandable domain remediation queue view so operators can open every matching item instead of only seeing the compact six-item list.
+- Added fresh-evidence refresh paths to remediation items so operators can see whether DNS, reports, source intelligence, reputation, or provider values must be refreshed before closure.
+- Added dashboard fresh-evidence counters and remediation-card refresh paths so workspace triage shows whether DNS, reports, reputation, or provider prerequisites should be handled next.
 
 ### Changed
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.
@@ -48,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard remediation-loop cards now expose the same repair-gate language and workspace counters for preview-ready, evidence-gated, and blocked repair work.
 - Dashboard and domain remediation views now show repair-readiness counters and per-item readiness scores before an operator opens or dispatches remediation work.
 - Dashboard, domain remediation queue, and sending-source reputation refreshes now keep previously loaded evidence visible while a manual refresh runs.
+- Dashboard remediation rows now expose the top incident and fresh-evidence action directly in the workspace view, and the domain-compliance refresh control reloads the backend summary again.
+- Domain remediation cards now offer focused read-only evidence refresh actions that reload the relevant backend data and rebuild the queue without applying DNS or provider writes.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -111,6 +111,7 @@ from app.services.remediation_dispatch import (
     attach_remediation_dispatch_previews,
     summarize_remediation_activity,
 )
+from app.services.remediation_evidence import evidence_refresh_for_remediation_item
 from app.services.remediation_queue import build_remediation_queue
 from app.services.remediation_readiness import (
     OPERATOR_REVIEW_READINESS_LEVELS,
@@ -1240,6 +1241,22 @@ class RemediationRepairProgression(BaseModel):
     verification_status: str = ""
 
 
+class RemediationEvidenceRefresh(BaseModel):
+    """Read-only refresh path for the evidence needed to close one remediation item."""
+
+    required: bool = True
+    source: str = ""
+    refresh_key: str = ""
+    label: str = ""
+    safe_to_run: bool = True
+    recommended_action: str = ""
+    completion_signal: str = ""
+    stale_warning: str = ""
+    next_check: str = ""
+    ui_anchor: str = ""
+    endpoint_hint: str = ""
+
+
 class RemediationNotification(BaseModel):
     """Read-only notification routing metadata for one remediation item."""
 
@@ -1278,6 +1295,7 @@ class RemediationQueueItem(BaseModel):
     action_plan: RemediationActionPlan
     verification_plan: RemediationVerificationPlan
     repair_progression: RemediationRepairProgression
+    evidence_refresh: RemediationEvidenceRefresh = Field(default_factory=RemediationEvidenceRefresh)
     automation: RemediationAutomation
     notification: RemediationNotification
 
@@ -2205,12 +2223,14 @@ def _dashboard_remediation_item(
         "operator_decisions": _remediation_operator_decisions(state),
         "repair_progression": _dashboard_repair_progression(state, action),
         "severity": str(action.get("severity") or "info"),
+        "source": str(action.get("source") or "domain_health"),
         "title": str(action.get("title") or "Review remediation item"),
         "next_step": str(action.get("next_step") or "Review the domain evidence."),
         "score_impact": int(action.get("score_impact") or 0),
         "type": str(action.get("type") or "health_action"),
         **context,
     }
+    item["evidence_refresh"] = evidence_refresh_for_remediation_item(domain_name, item)
     if include_detail:
         item["detail"] = str(action.get("detail") or "")
     return item
@@ -2238,6 +2258,25 @@ def _increment_repair_counters(counters: Dict[str, int], item: Dict[str, Any]) -
     )
 
 
+def _increment_evidence_refresh_counters(
+    counters: Dict[str, int],
+    item: Dict[str, Any],
+) -> None:
+    """Count read-only evidence refresh paths for dashboard summaries."""
+    evidence_refresh = item.get("evidence_refresh") or {}
+    if evidence_refresh.get("required"):
+        counters["evidence_refresh_required"] += 1
+    refresh_key = str(evidence_refresh.get("refresh_key") or "")
+    if refresh_key == "dns":
+        counters["evidence_refresh_dns"] += 1
+    if refresh_key in {"reports", "reports_and_sources"}:
+        counters["evidence_refresh_reports"] += 1
+    if refresh_key == "source_reputation":
+        counters["evidence_refresh_reputation"] += 1
+    if refresh_key == "provider_value":
+        counters["evidence_refresh_prerequisite"] += 1
+
+
 def _build_dashboard_remediation_loop(
     domains: List[Dict[str, Any]],
     remediation_activity: Dict[str, Any],
@@ -2260,6 +2299,11 @@ def _build_dashboard_remediation_loop(
         "repair_waiting_on_operator": 0,
         "repair_readiness_blocked": 0,
         "repair_readiness_score": 0,
+        "evidence_refresh_required": 0,
+        "evidence_refresh_dns": 0,
+        "evidence_refresh_reports": 0,
+        "evidence_refresh_reputation": 0,
+        "evidence_refresh_prerequisite": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2272,6 +2316,7 @@ def _build_dashboard_remediation_loop(
             counters[state] += 1
             item = _dashboard_remediation_item(domain_name, action)
             _increment_repair_counters(counters, item)
+            _increment_evidence_refresh_counters(counters, item)
             track_counters[f"track_{item['remediation_track']}"] += 1
             items.append(item)
 
@@ -2309,6 +2354,7 @@ def _build_dashboard_remediation_loop(
         "dispatch_enqueued": int(activity_summary.get("dispatch_enqueued") or 0),
         "operator_follow_up": int(activity_summary.get("needs_operator_follow_up") or 0),
         "status": "clear" if total_open == 0 else "needs_attention",
+        "top_incident_type": str(items[0].get("incident_type") or "") if items else "",
         "items": items[:5],
     }
 
@@ -2326,6 +2372,11 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         "repair_waiting_on_operator": 0,
         "repair_readiness_blocked": 0,
         "repair_readiness_score": 0,
+        "evidence_refresh_required": 0,
+        "evidence_refresh_dns": 0,
+        "evidence_refresh_reports": 0,
+        "evidence_refresh_reputation": 0,
+        "evidence_refresh_prerequisite": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2335,6 +2386,7 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         counters[state] += 1
         item = _dashboard_remediation_item(domain_name, action, include_detail=False)
         _increment_repair_counters(counters, item)
+        _increment_evidence_refresh_counters(counters, item)
         track_counters[f"track_{item['remediation_track']}"] += 1
         items.append(item)
 

--- a/backend/app/services/remediation_evidence.py
+++ b/backend/app/services/remediation_evidence.py
@@ -1,0 +1,119 @@
+"""Shared remediation evidence refresh helpers."""
+
+from typing import Any, Dict
+
+
+def _fallback_remediation_track(item: Dict[str, Any]) -> str:
+    """Infer a conservative remediation track when callers have not set one."""
+    if (item.get("automation") or {}).get("eligible"):
+        return "provider_preview"
+    if item.get("state") == "investigate":
+        return "sender_investigation"
+    if str(item.get("incident_type") or "") == "sending_ip_reputation_risk":
+        return "reputation_review"
+    if str(item.get("source") or "") == "dns_lint":
+        if any(
+            "provider-specific" in str(prerequisite).lower()
+            for prerequisite in item.get("prerequisites", [])
+        ):
+            return "blocked_by_prerequisite"
+        return "manual_dns"
+    return "manual_only"
+
+
+def evidence_refresh_for_remediation_item(domain: str, item: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the safe read-only refresh path before a remediation item is closed."""
+    track = str(item.get("remediation_track") or _fallback_remediation_track(item))
+    source = str(item.get("source") or "remediation")
+    state = str(item.get("state") or "")
+    verification = item.get("verification_plan") or {}
+    stale_warning = str(verification.get("stale_evidence_warning") or "")
+    next_check = str(verification.get("next_check") or "")
+
+    if track == "blocked_by_prerequisite":
+        return {
+            "required": True,
+            "source": "mail_provider",
+            "refresh_key": "provider_value",
+            "label": "Provider value required",
+            "safe_to_run": False,
+            "recommended_action": (
+                "Collect the exact DKIM, SPF, DMARC, or CNAME target from the mail provider, "
+                "then refresh DNS evidence."
+            ),
+            "completion_signal": "The prerequisite is present and the item can move to manual DNS or provider preview.",
+            "stale_warning": stale_warning,
+            "next_check": next_check,
+            "ui_anchor": "#dns-guidance",
+            "endpoint_hint": "",
+        }
+
+    if source == "dns_lint" or track in {"provider_preview", "manual_dns"}:
+        return {
+            "required": True,
+            "source": "dns",
+            "refresh_key": "dns",
+            "label": "Refresh DNS evidence",
+            "safe_to_run": True,
+            "recommended_action": (
+                "Refresh DNS records, DNS lint, posture, and the remediation queue after the DNS TTL."
+            ),
+            "completion_signal": "The original DNS finding is absent from the refreshed queue.",
+            "stale_warning": stale_warning,
+            "next_check": next_check,
+            "ui_anchor": "#dns-records",
+            "endpoint_hint": f"/api/v1/domains/{domain}/dns?refresh=true",
+        }
+
+    if (
+        track == "reputation_review"
+        or str(item.get("incident_type") or "") == "sending_ip_reputation_risk"
+    ):
+        return {
+            "required": True,
+            "source": "source_reputation",
+            "refresh_key": "source_reputation",
+            "label": "Refresh source reputation",
+            "safe_to_run": True,
+            "recommended_action": (
+                "Refresh sending-source rows and reputation feeds, then rebuild the remediation queue."
+            ),
+            "completion_signal": "Current reputation evidence is clean, accepted, or documented as intentionally blocked.",
+            "stale_warning": stale_warning,
+            "next_check": next_check,
+            "ui_anchor": "#sending-sources",
+            "endpoint_hint": f"/api/v1/domains/{domain}/sources?refresh=true",
+        }
+
+    if state == "investigate":
+        return {
+            "required": True,
+            "source": "dmarc_reports_and_sources",
+            "refresh_key": "reports_and_sources",
+            "label": "Refresh report and source evidence",
+            "safe_to_run": True,
+            "recommended_action": (
+                "Reload reports and sending-source intelligence after the next receiver report window."
+            ),
+            "completion_signal": "Fresh report rows show the source is passing, blocked, or no longer active.",
+            "stale_warning": stale_warning,
+            "next_check": next_check,
+            "ui_anchor": "#sending-sources",
+            "endpoint_hint": f"/api/v1/domains/{domain}/sources?refresh=true",
+        }
+
+    return {
+        "required": True,
+        "source": "dmarc_reports",
+        "refresh_key": "reports",
+        "label": "Refresh report evidence",
+        "safe_to_run": True,
+        "recommended_action": (
+            "Reload reports and rebuild domain health after the operator action has had time to appear."
+        ),
+        "completion_signal": "The same health action no longer appears in the refreshed remediation queue.",
+        "stale_warning": stale_warning,
+        "next_check": next_check,
+        "ui_anchor": "#reports",
+        "endpoint_hint": f"/api/v1/domains/{domain}/reports",
+    }

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Optional, Set
 
+from app.services.remediation_evidence import evidence_refresh_for_remediation_item
 from app.services.remediation_readiness import (
     OPERATOR_REVIEW_READINESS_LEVELS,
     repair_readiness_for_stage,
@@ -186,6 +187,28 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
         ),
         "notify_summary_only": sum(
             1 for item in items if item.get("notification", {}).get("state") == "summary_only"
+        ),
+        "evidence_refresh_required": sum(
+            1 for item in items if (item.get("evidence_refresh") or {}).get("required")
+        ),
+        "evidence_refresh_dns": sum(
+            1 for item in items if (item.get("evidence_refresh") or {}).get("refresh_key") == "dns"
+        ),
+        "evidence_refresh_reports": sum(
+            1
+            for item in items
+            if (item.get("evidence_refresh") or {}).get("refresh_key")
+            in {"reports", "reports_and_sources"}
+        ),
+        "evidence_refresh_reputation": sum(
+            1
+            for item in items
+            if (item.get("evidence_refresh") or {}).get("refresh_key") == "source_reputation"
+        ),
+        "evidence_refresh_prerequisite": sum(
+            1
+            for item in items
+            if (item.get("evidence_refresh") or {}).get("refresh_key") == "provider_value"
         ),
     }
     for track in TRACKS:
@@ -455,7 +478,12 @@ def _repair_progression_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
     )
 
 
-def _apply_loop_metadata(items: List[Dict[str, Any]]) -> None:
+def _evidence_refresh_for_item(domain: str, item: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the safe read-only refresh path before a remediation item is closed."""
+    return evidence_refresh_for_remediation_item(domain, item)
+
+
+def _apply_loop_metadata(domain: str, items: List[Dict[str, Any]]) -> None:
     for item in items:
         item["incident_type"] = _incident_type_for_item(item)
         item["loop_state"] = _loop_state_for_item(item)
@@ -465,6 +493,7 @@ def _apply_loop_metadata(items: List[Dict[str, Any]]) -> None:
         item["priority_band"] = _priority_band(item, score=priority_score)
         item["operator_decisions"] = _operator_decision_options(item)
         item["repair_progression"] = _repair_progression_for_item(item)
+        item["evidence_refresh"] = _evidence_refresh_for_item(domain, item)
 
 
 def _loop_summary(domain: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
@@ -514,6 +543,11 @@ def _loop_summary(domain: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
         "rollback_guidance": summary["rollback_guidance"],
         "closure_gate_required": summary["closure_gate_required"],
         "stale_evidence_warning": summary["stale_evidence_warning"],
+        "evidence_refresh_required": summary["evidence_refresh_required"],
+        "evidence_refresh_dns": summary["evidence_refresh_dns"],
+        "evidence_refresh_reports": summary["evidence_refresh_reports"],
+        "evidence_refresh_reputation": summary["evidence_refresh_reputation"],
+        "evidence_refresh_prerequisite": summary["evidence_refresh_prerequisite"],
         "top_item_id": next_item.get("id") if next_item else None,
         "top_incident_type": next_item.get("incident_type") if next_item else None,
         "top_loop_state": next_item.get("loop_state") if next_item else None,
@@ -575,6 +609,7 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
     action_plan = item.get("action_plan") or {}
     verification_plan = item.get("verification_plan") or {}
     repair_progression = item.get("repair_progression") or {}
+    evidence_refresh = item.get("evidence_refresh") or {}
     return {
         "schema_version": "dmarq.remediation.notification.v1",
         "domain": domain,
@@ -610,6 +645,19 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
             "manual_fallback": bool(repair_progression.get("manual_fallback")),
             "verification_required": bool(repair_progression.get("verification_required")),
             "verification_status": str(repair_progression.get("verification_status") or ""),
+        },
+        "evidence_refresh": {
+            "required": bool(evidence_refresh.get("required")),
+            "source": str(evidence_refresh.get("source") or ""),
+            "refresh_key": str(evidence_refresh.get("refresh_key") or ""),
+            "label": str(evidence_refresh.get("label") or ""),
+            "safe_to_run": bool(evidence_refresh.get("safe_to_run")),
+            "recommended_action": str(evidence_refresh.get("recommended_action") or ""),
+            "completion_signal": str(evidence_refresh.get("completion_signal") or ""),
+            "stale_warning": str(evidence_refresh.get("stale_warning") or ""),
+            "next_check": str(evidence_refresh.get("next_check") or ""),
+            "ui_anchor": str(evidence_refresh.get("ui_anchor") or ""),
+            "endpoint_hint": str(evidence_refresh.get("endpoint_hint") or ""),
         },
         "title": str(item.get("title") or ""),
         "detail": str(item.get("detail") or ""),
@@ -1227,7 +1275,7 @@ def build_remediation_queue(
             continue
         items.append(_health_item(domain, action))
 
-    _apply_loop_metadata(items)
+    _apply_loop_metadata(domain, items)
     _attach_notification_profiles(domain, items)
     items.sort(
         key=lambda item: (

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -227,6 +227,12 @@ function dashboardApp() {
                     return;
                 }
 
+                const dashboardRefresh = event.target.closest('[data-dashboard-refresh]');
+                if (dashboardRefresh && root.contains(dashboardRefresh)) {
+                    this.fetchDomainSummary({ refresh: true });
+                    return;
+                }
+
                 const triggerPoll = event.target.closest('[data-dashboard-trigger-poll]');
                 if (triggerPoll && root.contains(triggerPoll)) {
                     this.triggerPollNow();
@@ -1075,6 +1081,26 @@ function dashboardApp() {
             return Number.isFinite(score) ? Math.max(0, Math.min(100, Math.round(score))) : 0;
         },
 
+        evidenceRefreshLabel(refresh) {
+            const key = String(refresh?.refresh_key || refresh?.source || '');
+            return {
+                dns: 'Refresh DNS evidence',
+                reports: 'Refresh report evidence',
+                reports_and_sources: 'Refresh report and source evidence',
+                source_reputation: 'Refresh source reputation',
+                provider_value: 'Provider value required'
+            }[key] || 'Refresh evidence';
+        },
+
+        evidenceRefreshClass(refresh) {
+            const key = String(refresh?.refresh_key || '');
+            if (refresh?.safe_to_run === false || key === 'provider_value') return 'bg-red-100 text-red-700';
+            if (key === 'dns') return 'bg-blue-100 text-blue-700';
+            if (key === 'source_reputation') return 'bg-purple-100 text-purple-700';
+            if (key === 'reports_and_sources') return 'bg-green-100 text-green-700';
+            return 'bg-white text-[#5f5c78]';
+        },
+
         domainActionHref(action) {
             return action && action.domain
                 ? `/domains/${encodeURIComponent(action.domain)}#remediation-queue`
@@ -1774,6 +1800,15 @@ function dashboardApp() {
                 action.className = 'max-w-48 truncate text-xs text-muted-foreground';
                 action.textContent = workload.primary.title;
                 wrapper.appendChild(action);
+            }
+
+            if (workload?.primary?.evidence_refresh?.required) {
+                const evidence = document.createElement('span');
+                evidence.className = 'max-w-56 truncate text-xs font-semibold text-[#247982]';
+                evidence.textContent = workload.primary.evidence_refresh.safe_to_run === false
+                    ? 'Evidence: provider value required'
+                    : `Evidence: ${this.evidenceRefreshLabel(workload.primary.evidence_refresh)}`;
+                wrapper.appendChild(evidence);
             }
 
             cell.appendChild(wrapper);

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -87,6 +87,11 @@ function domainDetailsApp(domainId = '') {
                 repair_approval_pending: 0,
                 repair_blocked: 0,
                 repair_needs_evidence: 0,
+                evidence_refresh_required: 0,
+                evidence_refresh_dns: 0,
+                evidence_refresh_reports: 0,
+                evidence_refresh_reputation: 0,
+                evidence_refresh_prerequisite: 0,
                 dispatch_ready: 0,
                 dispatch_blocked: 0,
                 dispatch_disabled: 0,
@@ -299,6 +304,12 @@ function domainDetailsApp(domainId = '') {
                 } else if (button.matches('[data-domain-detail-remediation-action]')) {
                     event.preventDefault();
                     this.handleRemediationAction(button);
+                } else if (button.matches('[data-domain-detail-remediation-refresh-evidence]')) {
+                    event.preventDefault();
+                    const item = this.findRemediationItem(button.dataset.remediationItemId);
+                    if (item) {
+                        this.refreshRemediationEvidence(item);
+                    }
                 } else if (button.matches('[data-domain-detail-remediation-filter]')) {
                     event.preventDefault();
                     this.remediationQueueFilter = button.dataset.domainDetailRemediationFilter || 'all';
@@ -1139,6 +1150,25 @@ function domainDetailsApp(domainId = '') {
             return Number.isFinite(score) ? Math.max(0, Math.min(100, Math.round(score))) : 0;
         },
 
+        remediationEvidenceRefreshClass(refresh) {
+            const key = String(refresh?.refresh_key || '');
+            if (key === 'dns') return 'bg-blue-100 text-blue-700';
+            if (key === 'source_reputation') return 'bg-purple-100 text-purple-700';
+            if (key === 'reports' || key === 'reports_and_sources') return 'bg-green-100 text-green-700';
+            if (key === 'provider_value') return 'bg-yellow-100 text-yellow-800';
+            return 'bg-base-200 text-base-content/70';
+        },
+
+        remediationEvidenceRefreshActionLabel(refresh) {
+            const key = String(refresh?.refresh_key || '');
+            if (key === 'dns') return 'Refresh DNS evidence';
+            if (key === 'source_reputation') return 'Refresh reputation';
+            if (key === 'reports_and_sources') return 'Refresh reports and sources';
+            if (key === 'reports') return 'Refresh reports';
+            if (key === 'provider_value') return 'Collect provider value';
+            return 'Refresh evidence';
+        },
+
         remediationRiskClass(value) {
             const risk = String(value || '').toLowerCase();
             if (risk === 'high') return 'bg-red-100 text-red-700';
@@ -1871,6 +1901,11 @@ function domainDetailsApp(domainId = '') {
                     repair_approval_pending: 0,
                     repair_blocked: 0,
                     repair_needs_evidence: 0,
+                    evidence_refresh_required: 0,
+                    evidence_refresh_dns: 0,
+                    evidence_refresh_reports: 0,
+                    evidence_refresh_reputation: 0,
+                    evidence_refresh_prerequisite: 0,
                     dispatch_ready: 0,
                     dispatch_blocked: 0,
                     dispatch_disabled: 0,
@@ -1939,6 +1974,67 @@ function domainDetailsApp(domainId = '') {
             } finally {
                 this.remediationQueueLoading = false;
                 this.remediationQueueRefreshing = false;
+            }
+        },
+
+        async refreshRemediationEvidence(item) {
+            const refresh = item?.evidence_refresh || {};
+            const key = String(refresh.refresh_key || '');
+            if (!item?.id) return;
+            if (refresh.safe_to_run === false || key === 'provider_value') {
+                this.remediationAction = {
+                    itemId: item.id,
+                    action: 'refresh_evidence',
+                    loading: false,
+                    message: refresh.recommended_action || 'Collect the missing prerequisite before refreshing evidence.',
+                    error: ''
+                };
+                return;
+            }
+            this.remediationAction = {
+                itemId: item.id,
+                action: 'refresh_evidence',
+                loading: true,
+                message: '',
+                error: ''
+            };
+            try {
+                if (key === 'dns') {
+                    await this.refreshDNSData();
+                } else if (key === 'source_reputation') {
+                    await Promise.allSettled([
+                        this.refreshSourceReputation(),
+                        this.fetchSourceIntelligence()
+                    ]);
+                } else if (key === 'reports_and_sources') {
+                    await Promise.allSettled([
+                        this.fetchReports(),
+                        this.fetchSources({ refresh: true, preserveOnFailure: true }),
+                        this.fetchSourceIntelligence()
+                    ]);
+                } else if (key === 'reports') {
+                    await Promise.allSettled([
+                        this.fetchReports(),
+                        this.fetchPosture({ refresh: true })
+                    ]);
+                }
+                await this.fetchRemediationQueue({ refresh: true });
+                this.remediationAction = {
+                    itemId: item.id,
+                    action: 'refresh_evidence',
+                    loading: false,
+                    message: 'Evidence refreshed. Review whether the item still appears in the queue.',
+                    error: ''
+                };
+            } catch (error) {
+                console.error('Error refreshing remediation evidence:', error);
+                this.remediationAction = {
+                    itemId: item.id,
+                    action: 'refresh_evidence',
+                    loading: false,
+                    message: '',
+                    error: error.message || 'Evidence refresh failed.'
+                };
             }
         },
 

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1423,6 +1423,26 @@ function domainDetailsApp(domainId = '') {
             return this.remediationAction.error ? 'text-red-700' : 'text-green-700';
         },
 
+        remediationEvidenceRefreshError(key) {
+            const errors = [];
+            if (key === 'dns') {
+                errors.push(this.dnsRecordsError);
+            } else if (key === 'source_reputation') {
+                errors.push(this.sourceReputationRefreshError, this.sourceIntelligence?.error);
+            } else if (key === 'reports_and_sources') {
+                errors.push(
+                    this.reportsError,
+                    this.sourcesError,
+                    this.sourceReputationRefreshError,
+                    this.sourceIntelligence?.error
+                );
+            } else if (key === 'reports') {
+                errors.push(this.reportsError);
+            }
+            errors.push(this.remediationQueueRefreshError, this.remediationQueueError);
+            return errors.find(error => Boolean(error)) || '';
+        },
+
         remediationHistoryDotClass(entry) {
             if (entry?.delivery_enqueued) return 'bg-teal-500';
             if (['acknowledged', 'resolved'].includes(entry?.state)) return 'bg-green-500';
@@ -2019,6 +2039,17 @@ function domainDetailsApp(domainId = '') {
                     ]);
                 }
                 await this.fetchRemediationQueue({ refresh: true });
+                const refreshError = this.remediationEvidenceRefreshError(key);
+                if (refreshError) {
+                    this.remediationAction = {
+                        itemId: item.id,
+                        action: 'refresh_evidence',
+                        loading: false,
+                        message: '',
+                        error: `Evidence refresh incomplete: ${refreshError}`
+                    };
+                    return;
+                }
                 this.remediationAction = {
                     itemId: item.id,
                     action: 'refresh_evidence',

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -574,6 +574,12 @@
                                         <span x-text="remediationQueue.loop?.repair_needs_evidence || 0"></span><span> require fresh evidence</span>
                                     </span>
                                     <span class="rounded bg-[#eef7ff] px-2 py-1 font-semibold text-[#24507a]">
+                                        <span x-text="remediationQueue.loop?.evidence_refresh_dns || remediationQueue.summary?.evidence_refresh_dns || 0"></span><span> DNS refreshes</span>
+                                    </span>
+                                    <span class="rounded bg-[#f2fbf9] px-2 py-1 font-semibold text-[#1f7c83]">
+                                        <span x-text="remediationQueue.loop?.evidence_refresh_reports || remediationQueue.summary?.evidence_refresh_reports || 0"></span><span> report refreshes</span>
+                                    </span>
+                                    <span class="rounded bg-[#eef7ff] px-2 py-1 font-semibold text-[#24507a]">
                                         <span x-text="remediationQueue.loop?.repair_waiting_on_operator || 0"></span><span> waiting on operator</span>
                                     </span>
                                     <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
@@ -862,6 +868,46 @@
                                         <p class="mt-2 text-xs text-[#7a4a00]"
                                            x-show="item.verification_plan.stale_evidence_warning"
                                            x-text="item.verification_plan.stale_evidence_warning"></p>
+                                    </div>
+                                </template>
+                                <template x-if="item.evidence_refresh">
+                                    <div class="mt-3 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-3">
+                                        <div class="flex flex-wrap items-center justify-between gap-2">
+                                            <div>
+                                                <p class="text-xs font-semibold uppercase text-[#1f7c83]">Fresh evidence path</p>
+                                                <p class="mt-1 text-sm font-semibold text-[#120d36]" x-text="item.evidence_refresh.label || 'Refresh evidence'"></p>
+                                            </div>
+                                            <span class="rounded px-2 py-1 text-xs font-semibold"
+                                                  :class="remediationEvidenceRefreshClass(item.evidence_refresh)"
+                                                  x-text="humanizeToken(item.evidence_refresh.source || item.evidence_refresh.refresh_key || 'evidence')"></span>
+                                        </div>
+                                        <p class="mt-2 text-sm text-[#45505f]" x-text="item.evidence_refresh.recommended_action"></p>
+                                        <p class="mt-2 rounded bg-white px-3 py-2 text-xs text-[#45505f]">
+                                            <span class="font-semibold">Done when: </span>
+                                            <span x-text="item.evidence_refresh.completion_signal || item.verification_plan?.closure_gate || 'Fresh evidence no longer shows this finding.'"></span>
+                                        </p>
+                                        <p class="mt-2 text-xs text-[#7a4a00]"
+                                           x-show="item.evidence_refresh.stale_warning"
+                                           x-text="item.evidence_refresh.stale_warning"></p>
+                                        <div class="mt-3 flex flex-wrap items-center gap-2">
+                                            <button type="button"
+                                                    class="btn btn-xs btn-outline"
+                                                    :disabled="item.evidence_refresh.safe_to_run === false || remediationActionBusy(item)"
+                                                    :data-remediation-item-id="item.id"
+                                                    data-domain-detail-remediation-refresh-evidence>
+                                                <span x-show="remediationActionBusy(item, 'refresh_evidence')" class="loading loading-spinner loading-xs"></span>
+                                                <span x-text="remediationEvidenceRefreshActionLabel(item.evidence_refresh)"></span>
+                                            </button>
+                                            <a x-show="item.evidence_refresh.ui_anchor"
+                                               :href="item.evidence_refresh.ui_anchor"
+                                               class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#1f7c83]">
+                                                Open evidence section
+                                            </a>
+                                            <span class="text-xs text-[#5f5c78]"
+                                                  x-show="item.evidence_refresh.safe_to_run === false">
+                                                Manual prerequisite first
+                                            </span>
+                                        </div>
                                     </div>
                                 </template>
                                 <template x-if="item.notification && item.notification.dispatch">

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -283,6 +283,13 @@
                 <p class="mt-2 text-2xl font-bold text-[#8a6418]"
                    x-text="remediationLoop().repair_needs_evidence || 0"></p>
                 <p class="mt-1 text-xs text-[#5f5c78]">Items that must be verified before closure</p>
+                <p class="mt-2 text-xs text-[#7a4a00]">
+                    <span x-text="remediationLoop().evidence_refresh_dns || 0"></span><span> DNS</span>
+                    <span> · </span>
+                    <span x-text="remediationLoop().evidence_refresh_reports || 0"></span><span> reports</span>
+                    <span> · </span>
+                    <span x-text="remediationLoop().evidence_refresh_reputation || 0"></span><span> reputation</span>
+                </p>
             </div>
             <div class="rounded-md border border-[#d5e9f8] bg-[#f7fbff] p-4">
                 <p class="text-sm text-[#5f5c78]">Waiting on operator</p>
@@ -359,6 +366,20 @@
                     <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3 text-xs">
                         <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Next verification</p>
                         <p class="mt-1 text-[#120d36]" x-text="item.verification_next_check"></p>
+                    </div>
+                    <div class="mt-3 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-3 text-xs"
+                         x-show="item.evidence_refresh?.required">
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                            <p class="font-semibold uppercase tracking-wide text-[#247982]">Fresh evidence path</p>
+                            <span class="rounded px-2 py-1 font-semibold"
+                                  :class="evidenceRefreshClass(item.evidence_refresh)"
+                                  x-text="item.evidence_refresh?.label || evidenceRefreshLabel(item.evidence_refresh)"></span>
+                        </div>
+                        <p class="mt-2 text-[#120d36]" x-text="item.evidence_refresh?.recommended_action"></p>
+                        <p class="mt-1 text-[#45505f]">
+                            <span class="font-semibold">Done when: </span>
+                            <span x-text="item.evidence_refresh?.completion_signal || item.completion_criteria"></span>
+                        </p>
                     </div>
                     <p class="mt-2 text-xs text-[#5f5c78]">
                         <span x-text="item.domain"></span>
@@ -520,10 +541,13 @@
             {% call card_header() %}
                 <div class="flex items-center justify-between">
                     {% call card_title() %}Domain Compliance{% endcall %}
-                    {% call button(variant="outline", size="sm") %}
+                    <button type="button"
+                            class="btn btn-outline btn-sm"
+                            :disabled="dashboardLoading || remediationRefreshRunning"
+                            data-dashboard-refresh>
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"></path><path d="M21 3v5h-5"></path></svg>
-                        Refresh
-                    {% endcall %}
+                        <span x-text="remediationRefreshRunning ? 'Refreshing...' : 'Refresh'"></span>
+                    </button>
                 </div>
                 {% call card_description() %}
                     Overview of domains and their DMARC compliance status

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1397,6 +1397,8 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "handleRemediationAction" in script
     assert "remediationDecisionLabel" in script
     assert "remediationActionNote(action)" in script
+    assert "remediationEvidenceRefreshError(key)" in script
+    assert "Evidence refresh incomplete:" in script
     assert "approve_after_preview" in script
     assert "mark_unknown" in script
     assert "humanizeToken" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -349,11 +349,22 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "Waiting on operator" in template
     assert "Blocked before repair" in template
     assert "remediationLoop().next_action" in template
-    assert "remediationLoopStatusClass(remediationLoop().status || remediationLoop().loop_status)" in template
-    assert "remediationLoopStatusLabel(remediationLoop().status || remediationLoop().loop_status)" in template
+    assert (
+        "remediationLoopStatusClass(remediationLoop().status || remediationLoop().loop_status)"
+        in template
+    )
+    assert (
+        "remediationLoopStatusLabel(remediationLoop().status || remediationLoop().loop_status)"
+        in template
+    )
     assert "remediationIncidentLabel(remediationLoop().top_incident_type)" in template
+    assert "data-dashboard-refresh" in template
+    assert "data-dashboard-refresh" in script
     assert "data-dashboard-remediation-refresh" in template
     assert "data-dashboard-remediation-refresh" in script
+    assert "Fresh evidence path" in template
+    assert "evidenceRefreshLabel(workload.primary.evidence_refresh)" in script
+    assert "Evidence: provider value required" in script
     assert "remediationRefreshRunning" in script
     assert "dashboardRefreshError" in script
     assert "Showing the previously loaded dashboard data." in script

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2288,9 +2288,13 @@ def test_summary_includes_current_remediation_loop(
     assert "approve_after_preview" in loop["items"][0]["operator_decisions"]
     assert loop["repair_preview_ready"] >= 2
     assert loop["repair_needs_evidence"] >= 2
+    assert loop["evidence_refresh_required"] >= 2
+    assert loop["evidence_refresh_dns"] >= 2
     assert loop["repair_blocked"] == 0
     assert loop["items"][0]["repair_progression"]["stage"] == "preview_ready"
     assert loop["items"][0]["repair_progression"]["can_preview"] is True
+    assert loop["items"][0]["evidence_refresh"]["refresh_key"] == "dns"
+    assert loop["items"][0]["evidence_refresh"]["safe_to_run"] is True
     assert loop["items"][0]["state_label"] == "Needs approval"
     assert loop["items"][0]["owner"] == "Domain DNS operator"
     assert loop["items"][0]["automation_path"] == "provider_preview"
@@ -2306,6 +2310,7 @@ def test_summary_includes_current_remediation_loop(
     assert domain["remediation_workload"]["needs_approval"] >= 2
     assert domain["remediation_workload"]["repair_preview_ready"] >= 2
     assert domain["remediation_workload"]["repair_needs_evidence"] >= 2
+    assert domain["remediation_workload"]["evidence_refresh_dns"] >= 2
     assert domain["remediation_workload"]["total_open"] >= 2
     assert domain["remediation_workload"]["primary"]["state"] == "needs_approval"
     assert domain["remediation_workload"]["primary"]["loop_state"] == (
@@ -2315,6 +2320,7 @@ def test_summary_includes_current_remediation_loop(
         "preview_ready"
     )
     assert domain["remediation_workload"]["primary"]["remediation_track"] == ("provider_preview")
+    assert domain["remediation_workload"]["primary"]["evidence_refresh"]["refresh_key"] == "dns"
     assert domain["remediation_workload"]["primary"]["state_label"] == "Needs approval"
     assert domain["remediation_workload"]["primary"]["owner"] == "Domain DNS operator"
     assert domain["remediation_workload"]["primary"]["automation_path"] == "provider_preview"

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -905,6 +905,11 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["track_reputation_review"] == 1
     assert loop["repair_preview_ready"] == 1
     assert loop["repair_needs_evidence"] == 2
+    assert loop["evidence_refresh_required"] == 2
+    assert loop["evidence_refresh_dns"] == 1
+    assert loop["evidence_refresh_reputation"] == 1
+    assert loop["evidence_refresh_reports"] == 0
+    assert loop["top_incident_type"] == "dmarc_policy_missing_or_weak"
     assert loop["repair_blocked"] == 0
     assert loop["repair_ready_for_preview"] == 1
     assert loop["repair_waiting_on_operator"] == 1
@@ -917,10 +922,13 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["items"][0]["repair_progression"]["can_preview"] is True
     assert loop["items"][0]["repair_progression"]["readiness_level"] == "ready_for_preview"
     assert loop["items"][0]["repair_progression"]["readiness_score"] == 80
+    assert loop["items"][0]["evidence_refresh"]["refresh_key"] == "dns"
+    assert loop["items"][0]["evidence_refresh"]["safe_to_run"] is True
     assert "Preview the exact DNS" in loop["items"][0]["operator_decision_summary"]
     assert loop["items"][1]["remediation_track"] == "reputation_review"
     assert loop["items"][1]["repair_progression"]["stage"] == "reputation_review"
     assert loop["items"][1]["repair_progression"]["readiness_level"] == "needs_reputation_review"
+    assert loop["items"][1]["evidence_refresh"]["refresh_key"] == "source_reputation"
     assert loop["items"][1]["risk_level"] == "high"
     assert loop["items"][1]["safe_to_automate"] is False
 
@@ -956,6 +964,8 @@ def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks
     assert loop["repair_blocked"] == 1
     assert loop["repair_preview_ready"] == 0
     assert loop["repair_needs_evidence"] == 1
+    assert loop["evidence_refresh_required"] == 1
+    assert loop["evidence_refresh_prerequisite"] == 1
     assert loop["repair_ready_for_preview"] == 0
     assert loop["repair_waiting_on_operator"] == 0
     assert loop["repair_readiness_blocked"] == 1
@@ -964,6 +974,8 @@ def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks
     assert loop["items"][0]["repair_progression"]["stage"] == "blocked"
     assert loop["items"][0]["repair_progression"]["can_preview"] is False
     assert loop["items"][0]["repair_progression"]["readiness_level"] == "blocked"
+    assert loop["items"][0]["evidence_refresh"]["refresh_key"] == "provider_value"
+    assert loop["items"][0]["evidence_refresh"]["safe_to_run"] is False
     assert "provider-specific value" in loop["items"][0]["repair_progression"]["summary"]
 
 

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -95,6 +95,11 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "rollback_guidance": 2,
         "closure_gate_required": 2,
         "stale_evidence_warning": 2,
+        "evidence_refresh_required": 2,
+        "evidence_refresh_dns": 1,
+        "evidence_refresh_reports": 1,
+        "evidence_refresh_reputation": 0,
+        "evidence_refresh_prerequisite": 0,
         "notify_approval_required": 1,
         "notify_action_required": 0,
         "notify_investigation_required": 1,
@@ -134,6 +139,11 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "rollback_guidance": 2,
         "closure_gate_required": 2,
         "stale_evidence_warning": 2,
+        "evidence_refresh_required": 2,
+        "evidence_refresh_dns": 1,
+        "evidence_refresh_reports": 1,
+        "evidence_refresh_reputation": 0,
+        "evidence_refresh_prerequisite": 0,
         "top_item_id": "dns:dmarc-missing",
         "top_incident_type": "dmarc_policy_missing_or_weak",
         "top_loop_state": "proposal_ready_for_approval",
@@ -220,8 +230,27 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "provider preview was approved" in evidence
         for evidence in queue["items"][0]["verification_plan"]["evidence_needed"]
     )
+    assert queue["items"][0]["evidence_refresh"] == {
+        "required": True,
+        "source": "dns",
+        "refresh_key": "dns",
+        "label": "Refresh DNS evidence",
+        "safe_to_run": True,
+        "recommended_action": (
+            "Refresh DNS records, DNS lint, posture, and the remediation queue after the DNS TTL."
+        ),
+        "completion_signal": "The original DNS finding is absent from the refreshed queue.",
+        "stale_warning": (
+            "Do not mark this fixed from the preview alone; DNS propagation evidence is required."
+        ),
+        "next_check": "Refresh DNS posture after provider propagation, then rebuild the queue.",
+        "ui_anchor": "#dns-records",
+        "endpoint_hint": "/api/v1/domains/example.com/dns?refresh=true",
+    }
     assert queue["items"][1]["verification_plan"]["status"] == "pending_sender_review"
     assert "next receiver report window" in queue["items"][1]["verification_plan"]["next_check"]
+    assert queue["items"][1]["evidence_refresh"]["refresh_key"] == "reports_and_sources"
+    assert queue["items"][1]["evidence_refresh"]["ui_anchor"] == "#sending-sources"
     notification = queue["items"][0]["notification"]
     assert notification == {
         "state": "approval_required",
@@ -282,6 +311,23 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
             "next_safe_action": (
                 "Open the provider preview, compare old and new DNS values, then approve or reject."
             ),
+        },
+        "evidence_refresh": {
+            "required": True,
+            "source": "dns",
+            "refresh_key": "dns",
+            "label": "Refresh DNS evidence",
+            "safe_to_run": True,
+            "recommended_action": (
+                "Refresh DNS records, DNS lint, posture, and the remediation queue after the DNS TTL."
+            ),
+            "completion_signal": "The original DNS finding is absent from the refreshed queue.",
+            "stale_warning": (
+                "Do not mark this fixed from the preview alone; DNS propagation evidence is required."
+            ),
+            "next_check": "Refresh DNS posture after provider propagation, then rebuild the queue.",
+            "ui_anchor": "#dns-records",
+            "endpoint_hint": "/api/v1/domains/example.com/dns?refresh=true",
         },
         "title": "Publish DMARC",
         "detail": "No DMARC TXT record was found.",

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -815,6 +815,14 @@ TXT/CNAME provider write are marked `approval_ready` and point to the same
 explicit preview/apply endpoint used by the DNS change-plan UI. Placeholder
 DKIM/SPF records that still need provider-specific values are surfaced as
 blocked by prerequisite instead of being presented as one-click repairs.
+Each item also includes an `evidence_refresh` object. It tells clients which
+fresh evidence source is needed before closure (`dns`, `dmarc_reports`,
+`dmarc_reports_and_sources`, `source_reputation`, or `mail_provider`), whether
+the refresh is safe to run from the UI, the recommended read-only refresh
+action, the completion signal, the stale-evidence warning, and the UI anchor or
+read-only endpoint hint that should be used. Provider-specific prerequisites
+are marked `safe_to_run=false`; clients should show the instruction but avoid
+presenting it as an executable refresh.
 
 The top-level `loop` object summarizes what DMARQ can fix, what needs explicit
 approval, what needs manual action, what needs investigation, the current
@@ -826,7 +834,13 @@ track-specific counters like `track_provider_preview`, `track_manual_dns`,
 repair-progression counters such as `repair_preview_ready`, `repair_blocked`,
 and `repair_needs_evidence`, so clients can distinguish a ready provider
 preview from a finding that still needs sender classification, provider values,
-or fresh report/DNS evidence.
+or fresh report/DNS evidence. Fresh-evidence counters such as
+`evidence_refresh_dns`, `evidence_refresh_reports`,
+`evidence_refresh_reputation`, and `evidence_refresh_prerequisite` explain what
+kind of read-only refresh or prerequisite the operator should handle next.
+The workspace dashboard `health_summary.remediation_loop` and each domain row's
+`remediation_workload` expose the same `evidence_refresh` object and counters,
+so clients can present the correct refresh path before opening the detail queue.
 
 Notification metadata includes the event name, channel, dedupe key, reason, and
 next state transition that an operator workflow can use. Each notification also

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -112,6 +112,14 @@ before approving, closing, or converting a remediation item.
 Verification cards include a closure gate and stale-evidence warning. This is
 the rule DMARQ expects before an operator-resolved item should become an
 evidence-verified repair.
+Each remediation card also shows a **Fresh evidence path**. It names the
+evidence that must be refreshed before the item can be closed safely, such as
+DNS records, DMARC reports, sending-source intelligence, source reputation, or
+a provider-specific DKIM/SPF/CNAME value. When the action is safe and read-only,
+the card offers a focused refresh button that reloads the relevant backend
+evidence and then rebuilds the queue. If a missing provider value is the blocker,
+DMARQ shows that prerequisite instead of pretending it can refresh or repair the
+item automatically.
 The queue header also counts closure gates and rollback notes, so operators can
 spot how much work still needs fresh evidence or a recovery plan before opening
 every remediation card.
@@ -171,6 +179,10 @@ Dashboard action-plan cards and remediation-loop cards both deep-link into the
 selected domain's remediation queue. Use those links when triaging workspace
 health: they keep the operator on the evidence and approval surface instead of
 dropping them on a generic domain overview.
+The dashboard remediation loop also mirrors the Fresh Evidence path from the
+domain queue. Its evidence-gated counters split the queue into DNS, report, and
+reputation refreshes, and each remediation card states the concrete read-only
+evidence action that should happen before the operator marks an item fixed.
 
 ### Source Intelligence
 


### PR DESCRIPTION
## Summary
- add a shared read-only evidence refresh contract for remediation items
- show DNS/report/reputation/provider-prerequisite refresh paths on domain detail and dashboard remediation cards
- expose fresh-evidence counters, top incident type, domain-table evidence hints, and wire the dashboard refresh control
- update API/user docs and changelog

Part of #384.

## Local validation
- .venv/bin/python -m pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_dns_endpoints.py::test_summary_includes_current_remediation_loop -q --tb=short
- .venv/bin/python -m flake8 backend/app/services/remediation_evidence.py backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py
- node --check backend/app/static/js/dashboard-page.js
- node --check backend/app/static/js/domain-details-page.js
- git diff --check origin/main...HEAD