### PR TITLE
feat: add remediation dashboard triage controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an expandable domain remediation queue view so operators can open every matching item instead of only seeing the compact six-item list.
 - Added fresh-evidence refresh paths to remediation items so operators can see whether DNS, reports, source intelligence, reputation, or provider values must be refreshed before closure.
 - Added dashboard fresh-evidence counters and remediation-card refresh paths so workspace triage shows whether DNS, reports, reputation, or provider prerequisites should be handled next.
+- Added dashboard remediation filters, sorting, compact/show-all controls, and matching empty states so operators can triage large remediation workspaces by preview readiness, fresh evidence, blockers, manual work, or reputation review before opening a domain.
+- Added domain remediation fresh-evidence and provider-value queue filters plus freshness sorting so closure-blocking evidence work is easier to isolate on domain detail pages.
+- Added stale-evidence remediation filters and direct dashboard links into the relevant domain evidence section, such as DNS records or sending sources.
+- Fixed dashboard remediation state rendering so backend `approval_ready` queue items are labeled as needing approval and evidence anchors fall back safely if malformed.
 
 ### Changed
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -12,6 +12,19 @@ function dashboardApp() {
         dashboardRefreshError: '',
         domainSummaryLoadedAt: '',
         remediationRefreshRunning: false,
+        dashboardRemediationFilter: 'all',
+        dashboardRemediationSort: 'priority',
+        showAllDashboardRemediationItems: false,
+        dashboardRemediationFilterOptions: [
+            { value: 'all', label: 'All' },
+            { value: 'preview_ready', label: 'Preview ready' },
+            { value: 'fresh_evidence', label: 'Fresh evidence' },
+            { value: 'stale_evidence', label: 'Stale evidence' },
+            { value: 'blocked', label: 'Blocked' },
+            { value: 'waiting_operator', label: 'Waiting' },
+            { value: 'manual', label: 'Manual' },
+            { value: 'reputation', label: 'Reputation' }
+        ],
         selectedDnsDomain: '',
         triggerPollRunning: false,
         triggerPollStatus: '',
@@ -176,6 +189,11 @@ function dashboardApp() {
         
         init() {
             this.bindControls();
+            if (typeof this.$watch === 'function') {
+                this.$watch('dashboardRemediationSort', () => {
+                    this.showAllDashboardRemediationItems = false;
+                });
+            }
 
             // Fetch domain summary on page load
             this.fetchDomainSummary();
@@ -208,6 +226,13 @@ function dashboardApp() {
                 if (dnsDomain && root.contains(dnsDomain)) {
                     this.selectedDnsDomain = dnsDomain.value;
                     this.updateDnsHealth();
+                    return;
+                }
+
+                const remediationSort = event.target.closest('[data-dashboard-remediation-sort]');
+                if (remediationSort && root.contains(remediationSort)) {
+                    this.dashboardRemediationSort = remediationSort.value || 'priority';
+                    this.showAllDashboardRemediationItems = false;
                 }
             });
 
@@ -230,6 +255,20 @@ function dashboardApp() {
                 const dashboardRefresh = event.target.closest('[data-dashboard-refresh]');
                 if (dashboardRefresh && root.contains(dashboardRefresh)) {
                     this.fetchDomainSummary({ refresh: true });
+                    return;
+                }
+
+                const remediationFilter = event.target.closest('[data-dashboard-remediation-filter]');
+                if (remediationFilter && root.contains(remediationFilter)) {
+                    this.dashboardRemediationFilter =
+                        remediationFilter.dataset.dashboardRemediationFilter || 'all';
+                    this.showAllDashboardRemediationItems = false;
+                    return;
+                }
+
+                const remediationToggleAll = event.target.closest('[data-dashboard-remediation-toggle-all]');
+                if (remediationToggleAll && root.contains(remediationToggleAll)) {
+                    this.showAllDashboardRemediationItems = !this.showAllDashboardRemediationItems;
                     return;
                 }
 
@@ -937,8 +976,44 @@ function dashboardApp() {
             return this.healthSummary?.remediation_loop || {};
         },
 
-        remediationLoopItems() {
+        dashboardRemediationRawItems() {
             const items = this.remediationLoop().items;
+            return Array.isArray(items) ? items : [];
+        },
+
+        remediationLoopItems() {
+            const items = this.dashboardRemediationRawItems();
+            const filtered = items.filter(item =>
+                this.dashboardRemediationFilterMatches(item, this.dashboardRemediationFilter)
+            );
+            return this.sortedDashboardRemediationItems(filtered);
+        },
+
+        sortedDashboardRemediationItems(items) {
+            const list = Array.isArray(items) ? [...items] : [];
+            if (this.dashboardRemediationSort === 'readiness') {
+                return list.sort((a, b) => (
+                    this.repairReadinessScore(b?.repair_progression) -
+                    this.repairReadinessScore(a?.repair_progression) ||
+                    this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b) ||
+                    (Number(b?.priority_score) || 0) - (Number(a?.priority_score) || 0)
+                ));
+            }
+            if (this.dashboardRemediationSort === 'freshness') {
+                return list.sort((a, b) => (
+                    this.dashboardRemediationEvidenceRank(a) -
+                    this.dashboardRemediationEvidenceRank(b) ||
+                    this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b) ||
+                    (Number(b?.priority_score) || 0) - (Number(a?.priority_score) || 0)
+                ));
+            }
+            if (this.dashboardRemediationSort === 'severity') {
+                return list.sort((a, b) => (
+                    this.remediationSeverityWeight(b?.severity) - this.remediationSeverityWeight(a?.severity) ||
+                    this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b) ||
+                    (Number(b?.priority_score) || 0) - (Number(a?.priority_score) || 0)
+                ));
+            }
             return Array.isArray(items)
                 ? [...items].sort((a, b) => (
                     this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b) ||
@@ -948,7 +1023,89 @@ function dashboardApp() {
         },
 
         hasRemediationLoopItems() {
+            return this.dashboardRemediationRawItems().length > 0;
+        },
+
+        hasVisibleDashboardRemediationItems() {
             return this.remediationLoopItems().length > 0;
+        },
+
+        visibleDashboardRemediationItems() {
+            const items = this.remediationLoopItems();
+            return this.showAllDashboardRemediationItems ? items : items.slice(0, 6);
+        },
+
+        dashboardRemediationTotalCount() {
+            return this.dashboardRemediationRawItems().length;
+        },
+
+        dashboardRemediationFilteredCount() {
+            return this.remediationLoopItems().length;
+        },
+
+        dashboardRemediationHiddenCount() {
+            return Math.max(
+                this.dashboardRemediationFilteredCount() - this.visibleDashboardRemediationItems().length,
+                0
+            );
+        },
+
+        dashboardRemediationFilterLabel() {
+            const match = this.dashboardRemediationFilterOptions.find(
+                option => option.value === this.dashboardRemediationFilter
+            );
+            return match?.label || 'All';
+        },
+
+        dashboardRemediationFilterCount(filter) {
+            return this.dashboardRemediationRawItems().filter(item =>
+                this.dashboardRemediationFilterMatches(item, filter)
+            ).length;
+        },
+
+        dashboardRemediationFilterMatches(item, filterValue) {
+            if (!item || !filterValue || filterValue === 'all') return true;
+            const progression = item?.repair_progression || {};
+            const readinessLevel = String(progression.readiness_level || '');
+            const stage = String(progression.stage || '');
+            const track = String(item?.remediation_track || '');
+            const refresh = item?.evidence_refresh || {};
+            const refreshKey = String(refresh.refresh_key || '');
+            if (filterValue === 'preview_ready') {
+                return readinessLevel === 'ready_for_preview' || stage === 'preview_ready';
+            }
+            if (filterValue === 'fresh_evidence') {
+                return Boolean(refresh.required) ||
+                    Boolean(progression.verification_required) ||
+                    Boolean(item?.action_plan?.requires_fresh_evidence);
+            }
+            if (filterValue === 'stale_evidence') {
+                return Boolean(this.remediationStaleEvidenceText(item));
+            }
+            if (filterValue === 'blocked') {
+                return readinessLevel === 'blocked' ||
+                    stage === 'blocked' ||
+                    refresh.safe_to_run === false ||
+                    refreshKey === 'provider_value' ||
+                    (progression.blocked_by || []).length > 0;
+            }
+            if (filterValue === 'waiting_operator') {
+                return ['manual_action', 'investigate'].includes(String(item?.state || '')) ||
+                    readinessLevel === 'needs_operator_review' ||
+                    stage === 'operator_review';
+            }
+            if (filterValue === 'manual') {
+                return track === 'manual_dns' ||
+                    readinessLevel === 'manual_repair' ||
+                    stage === 'manual_repair';
+            }
+            if (filterValue === 'reputation') {
+                return track === 'reputation_review' ||
+                    readinessLevel === 'needs_reputation_review' ||
+                    stage === 'reputation_review' ||
+                    refreshKey === 'source_reputation';
+            }
+            return true;
         },
 
         remediationLoopItemRank(item) {
@@ -958,12 +1115,40 @@ function dashboardApp() {
             const state = String(item?.state || '');
             const track = String(item?.remediation_track || '');
             if (readinessLevel === 'ready_for_preview' || stage === 'preview_ready') return 0;
-            if (state === 'needs_approval') return 1;
+            if (state === 'approval_ready' || state === 'needs_approval') return 1;
             if (readinessLevel === 'blocked' || stage === 'blocked') return 2;
             if (readinessLevel === 'needs_reputation_review' || track === 'reputation_review') return 3;
             if (state === 'investigate') return 4;
             if (readinessLevel === 'manual_repair' || track === 'manual_dns' || state === 'manual_action') return 5;
             return 6;
+        },
+
+        dashboardRemediationEvidenceRank(item) {
+            const refresh = item?.evidence_refresh || {};
+            const key = String(refresh.refresh_key || '');
+            if (refresh.safe_to_run === false || key === 'provider_value') return 0;
+            if (refresh.required && key === 'dns') return 1;
+            if (refresh.required && key === 'source_reputation') return 2;
+            if (refresh.required) return 3;
+            return 4;
+        },
+
+        remediationSeverityWeight(severity) {
+            return {
+                critical: 5,
+                high: 4,
+                error: 4,
+                medium: 3,
+                warning: 3,
+                low: 2,
+                info: 1
+            }[String(severity || '').toLowerCase()] || 0;
+        },
+
+        remediationStaleEvidenceText(item) {
+            return item?.evidence_refresh?.stale_warning ||
+                item?.verification_plan?.stale_evidence_warning ||
+                '';
         },
 
         remediationLoopStatusLabel(status) {
@@ -992,6 +1177,7 @@ function dashboardApp() {
 
         remediationLoopStateLabel(state) {
             return {
+                approval_ready: 'Needs approval',
                 needs_approval: 'Needs approval',
                 manual_action: 'Manual action',
                 investigate: 'Investigate'
@@ -1000,6 +1186,7 @@ function dashboardApp() {
 
         remediationLoopStateClass(state) {
             return {
+                approval_ready: 'bg-[#edf7f7] text-[#247982]',
                 needs_approval: 'bg-[#edf7f7] text-[#247982]',
                 manual_action: 'bg-[#fff7df] text-[#8a6418]',
                 investigate: 'bg-[#fff1ea] text-[#b8431d]'
@@ -1110,6 +1297,15 @@ function dashboardApp() {
         domainRemediationHref(domainName) {
             return domainName
                 ? `/domains/${encodeURIComponent(domainName)}#remediation-queue`
+                : '/domains';
+        },
+
+        domainEvidenceHref(item) {
+            const domainName = item?.domain || '';
+            const rawAnchor = String(item?.evidence_refresh?.ui_anchor || '#remediation-queue');
+            const anchor = rawAnchor.startsWith('#') ? rawAnchor : '#remediation-queue';
+            return domainName
+                ? `/domains/${encodeURIComponent(domainName)}${anchor}`
                 : '/domains';
         },
 

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -124,6 +124,9 @@ function domainDetailsApp(domainId = '') {
             { value: 'preview_ready', label: 'Preview ready' },
             { value: 'blocked', label: 'Blocked' },
             { value: 'needs_evidence', label: 'Needs evidence' },
+            { value: 'fresh_evidence', label: 'Fresh evidence' },
+            { value: 'stale_evidence', label: 'Stale evidence' },
+            { value: 'provider_value', label: 'Provider value' },
             { value: 'notify_ready', label: 'Ready to notify' },
             { value: 'waiting_operator', label: 'Waiting' },
             { value: 'manual', label: 'Manual' },
@@ -1246,6 +1249,7 @@ function domainDetailsApp(domainId = '') {
             const score = item => Number(item?.priority_score || 0);
             const readiness = item => this.repairReadinessScore(item?.repair_progression);
             const severity = item => severityWeight[String(item?.severity || '').toLowerCase()] || 0;
+            const freshness = item => this.remediationEvidenceRefreshRank(item);
             const list = [...(items || [])];
             if (this.remediationQueueSort === 'readiness') {
                 return list.sort((left, right) => (
@@ -1261,11 +1265,28 @@ function domainDetailsApp(domainId = '') {
                     readiness(right) - readiness(left)
                 ));
             }
+            if (this.remediationQueueSort === 'freshness') {
+                return list.sort((left, right) => (
+                    freshness(left) - freshness(right) ||
+                    score(right) - score(left) ||
+                    severity(right) - severity(left)
+                ));
+            }
             return list.sort((left, right) => (
                 score(right) - score(left) ||
                 severity(right) - severity(left) ||
                 readiness(right) - readiness(left)
             ));
+        },
+
+        remediationEvidenceRefreshRank(item) {
+            const refresh = item?.evidence_refresh || {};
+            const key = String(refresh.refresh_key || '');
+            if (refresh.safe_to_run === false || key === 'provider_value') return 0;
+            if (refresh.required && key === 'dns') return 1;
+            if (refresh.required && key === 'source_reputation') return 2;
+            if (refresh.required) return 3;
+            return 4;
         },
 
         remediationQueueFilterMatches(item, filter) {
@@ -1274,14 +1295,35 @@ function domainDetailsApp(domainId = '') {
             const readinessLevel = String(progression.readiness_level || '');
             const stage = String(progression.stage || '');
             const track = String(item.remediation_track || '');
+            const refresh = item.evidence_refresh || {};
+            const refreshKey = String(refresh.refresh_key || '');
             if (filter === 'preview_ready') {
                 return readinessLevel === 'ready_for_preview' || stage === 'preview_ready';
             }
             if (filter === 'blocked') {
-                return readinessLevel === 'blocked' || stage === 'blocked' || (progression.blocked_by || []).length > 0;
+                return readinessLevel === 'blocked' ||
+                    stage === 'blocked' ||
+                    refresh.safe_to_run === false ||
+                    refreshKey === 'provider_value' ||
+                    (progression.blocked_by || []).length > 0;
             }
             if (filter === 'needs_evidence') {
-                return Boolean(progression.verification_required) || stage === 'operator_review' || readinessLevel === 'needs_operator_review';
+                return Boolean(refresh.required) ||
+                    Boolean(progression.verification_required) ||
+                    Boolean(item.action_plan?.requires_fresh_evidence) ||
+                    stage === 'operator_review' ||
+                    readinessLevel === 'needs_operator_review';
+            }
+            if (filter === 'fresh_evidence') {
+                return Boolean(refresh.required);
+            }
+            if (filter === 'stale_evidence') {
+                return Boolean(
+                    refresh.stale_warning || item.verification_plan?.stale_evidence_warning
+                );
+            }
+            if (filter === 'provider_value') {
+                return refresh.safe_to_run === false || refreshKey === 'provider_value';
             }
             if (filter === 'notify_ready') {
                 return Boolean(item.notification?.dispatch?.eligible);
@@ -1296,7 +1338,10 @@ function domainDetailsApp(domainId = '') {
                 return track === 'manual_dns' || readinessLevel === 'manual_repair' || stage === 'manual_repair';
             }
             if (filter === 'reputation') {
-                return track === 'reputation_review' || readinessLevel === 'needs_reputation_review' || stage === 'reputation_review';
+                return track === 'reputation_review' ||
+                    readinessLevel === 'needs_reputation_review' ||
+                    stage === 'reputation_review' ||
+                    refreshKey === 'source_reputation';
             }
             return true;
         },

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1289,6 +1289,11 @@ function domainDetailsApp(domainId = '') {
             return 4;
         },
 
+        remediationEvidenceAnchorHref(item) {
+            const rawAnchor = String(item?.evidence_refresh?.ui_anchor || '#remediation-queue');
+            return rawAnchor.startsWith('#') ? rawAnchor : '#remediation-queue';
+        },
+
         remediationQueueFilterMatches(item, filter) {
             if (!item || filter === 'all') return true;
             const progression = item.repair_progression || {};

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -628,6 +628,7 @@
                                     aria-label="Remediation queue sort">
                                 <option value="priority">Priority</option>
                                 <option value="readiness">Repair readiness</option>
+                                <option value="freshness">Fresh evidence</option>
                                 <option value="severity">Severity</option>
                             </select>
                         </label>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -900,7 +900,7 @@
                                                 <span x-text="remediationEvidenceRefreshActionLabel(item.evidence_refresh)"></span>
                                             </button>
                                             <a x-show="item.evidence_refresh.ui_anchor"
-                                               :href="item.evidence_refresh.ui_anchor"
+                                               :href="remediationEvidenceAnchorHref(item)"
                                                class="rounded bg-white px-2 py-1 text-xs font-semibold text-[#1f7c83]">
                                                 Open evidence section
                                             </a>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -304,8 +304,41 @@
                 <p class="mt-1 text-xs text-[#5f5c78]">Missing provider values or prerequisites</p>
             </div>
         </div>
-        <div class="mt-5 grid gap-3 lg:grid-cols-2" x-show="hasRemediationLoopItems()">
-            <template x-for="item in remediationLoopItems()" :key="item.domain + item.type + item.title">
+        <div class="mt-5 flex flex-wrap items-center gap-2" x-show="hasRemediationLoopItems()">
+            <label class="flex items-center gap-2 rounded border border-[#e6e3e1] bg-white px-3 py-2 text-xs font-semibold text-[#5f5c78]">
+                <span>Sort</span>
+                <select x-model="dashboardRemediationSort"
+                        class="bg-transparent font-semibold text-[#272a5f] outline-none"
+                        aria-label="Dashboard remediation sort"
+                        data-dashboard-remediation-sort>
+                    <option value="priority">Priority</option>
+                    <option value="readiness">Repair readiness</option>
+                    <option value="freshness">Fresh evidence</option>
+                    <option value="severity">Severity</option>
+                </select>
+            </label>
+            <template x-for="filter in dashboardRemediationFilterOptions" :key="'dashboard-remediation-filter-' + filter.value">
+                <button type="button"
+                        class="rounded border px-3 py-2 text-xs font-semibold transition"
+                        :class="dashboardRemediationFilter === filter.value ? 'border-[#2f9da5] bg-[#f2fbf9] text-[#1f7c83]' : 'border-[#e6e3e1] bg-white text-[#5f5c78] hover:border-[#2f9da5]'"
+                        :aria-pressed="dashboardRemediationFilter === filter.value ? 'true' : 'false'"
+                        :data-dashboard-remediation-filter="filter.value">
+                    <span x-text="filter.label"></span>
+                    <span class="ml-1 rounded bg-[#f4f3f2] px-1.5 py-0.5 text-[0.65rem] text-[#45505f]"
+                          x-text="dashboardRemediationFilterCount(filter.value)"></span>
+                </button>
+            </template>
+        </div>
+        <p class="mt-3 text-xs font-semibold text-[#5f5c78]"
+           role="status"
+           x-show="hasRemediationLoopItems()">
+            <span>Showing </span><span x-text="visibleDashboardRemediationItems().length"></span>
+            <span> of </span><span x-text="dashboardRemediationFilteredCount()"></span>
+            <span> remediation cards in </span><span x-text="dashboardRemediationFilterLabel()"></span>
+            <span> view (</span><span x-text="dashboardRemediationTotalCount()"></span><span> total).</span>
+        </p>
+        <div class="mt-5 grid gap-3 lg:grid-cols-2" x-show="hasVisibleDashboardRemediationItems()">
+            <template x-for="item in visibleDashboardRemediationItems()" :key="item.domain + item.type + item.title">
                 <a class="rounded-md border border-[#e6e3e1] p-4 transition hover:border-[#2f9da5] hover:shadow-sm"
                    :href="domainRemediationHref(item.domain)">
                     <div class="flex items-start justify-between gap-3">
@@ -380,6 +413,14 @@
                             <span class="font-semibold">Done when: </span>
                             <span x-text="item.evidence_refresh?.completion_signal || item.completion_criteria"></span>
                         </p>
+                        <p class="mt-2 text-[#7a4a00]"
+                           x-show="remediationStaleEvidenceText(item)"
+                           x-text="remediationStaleEvidenceText(item)"></p>
+                        <a x-show="item.evidence_refresh?.ui_anchor"
+                           :href="domainEvidenceHref(item)"
+                           class="mt-2 inline-flex rounded bg-white px-2 py-1 font-semibold text-[#1f7c83]">
+                            Open evidence section
+                        </a>
                     </div>
                     <p class="mt-2 text-xs text-[#5f5c78]">
                         <span x-text="item.domain"></span>
@@ -388,6 +429,25 @@
                 </a>
             </template>
         </div>
+        <p class="mt-4 rounded border border-[#e6e3e1] bg-white p-4 text-sm text-[#5f5c78]"
+           x-show="hasRemediationLoopItems() && !hasVisibleDashboardRemediationItems()">
+            No remediation cards match this dashboard filter. Choose another queue view or refresh after new evidence is available.
+        </p>
+        <template x-if="hasRemediationLoopItems() && (dashboardRemediationHiddenCount() > 0 || showAllDashboardRemediationItems)">
+            <div class="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs font-semibold text-[#5f5c78]">
+                <p x-show="dashboardRemediationHiddenCount() > 0">
+                    <span>+</span><span x-text="dashboardRemediationHiddenCount()"></span><span> more remediation cards in this view.</span>
+                </p>
+                <p x-show="showAllDashboardRemediationItems && dashboardRemediationHiddenCount() === 0">
+                    <span>Showing all </span><span x-text="dashboardRemediationFilteredCount()"></span><span> matching remediation cards.</span>
+                </p>
+                <button type="button"
+                        class="btn btn-outline btn-xs"
+                        data-dashboard-remediation-toggle-all
+                        x-text="showAllDashboardRemediationItems ? 'Show compact cards' : 'Show all matching cards'">
+                </button>
+            </div>
+        </template>
         <div class="mt-5 rounded-md border border-[#d8ebe8] bg-[#f2fbf9] p-4 text-sm"
              x-show="!hasRemediationLoopItems()">
             <p class="font-semibold text-[#120d36]">No active remediation work queued</p>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -339,8 +339,7 @@
         </p>
         <div class="mt-5 grid gap-3 lg:grid-cols-2" x-show="hasVisibleDashboardRemediationItems()">
             <template x-for="item in visibleDashboardRemediationItems()" :key="item.domain + item.type + item.title">
-                <a class="rounded-md border border-[#e6e3e1] p-4 transition hover:border-[#2f9da5] hover:shadow-sm"
-                   :href="domainRemediationHref(item.domain)">
+                <article class="rounded-md border border-[#e6e3e1] p-4 transition hover:border-[#2f9da5] hover:shadow-sm">
                     <div class="flex items-start justify-between gap-3">
                         <div class="min-w-0">
                             <span class="inline-flex rounded-md px-2 py-1 text-xs font-semibold"
@@ -424,9 +423,13 @@
                     </div>
                     <p class="mt-2 text-xs text-[#5f5c78]">
                         <span x-text="item.domain"></span>
-                        <span> · Open remediation queue</span>
+                        <span> · </span>
+                        <a class="font-semibold text-[#1f7c83]"
+                           :href="domainRemediationHref(item.domain)">
+                            Open remediation queue
+                        </a>
                     </p>
-                </a>
+                </article>
             </template>
         </div>
         <p class="mt-4 rounded border border-[#e6e3e1] bg-white p-4 text-sm text-[#5f5c78]"

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -362,6 +362,27 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "data-dashboard-refresh" in script
     assert "data-dashboard-remediation-refresh" in template
     assert "data-dashboard-remediation-refresh" in script
+    assert "dashboardRemediationFilterOptions" in script
+    assert "{ value: 'fresh_evidence', label: 'Fresh evidence' }" in script
+    assert "{ value: 'stale_evidence', label: 'Stale evidence' }" in script
+    assert "dashboardRemediationSort: 'priority'" in script
+    assert "showAllDashboardRemediationItems" in script
+    assert "data-dashboard-remediation-sort" in template
+    assert "data-dashboard-remediation-sort" in script
+    assert "data-dashboard-remediation-filter" in template
+    assert "data-dashboard-remediation-filter" in script
+    assert "data-dashboard-remediation-toggle-all" in template
+    assert "data-dashboard-remediation-toggle-all" in script
+    assert "visibleDashboardRemediationItems()" in template
+    assert "visibleDashboardRemediationItems()" in script
+    assert "dashboardRemediationFilterCount(filter.value)" in template
+    assert "dashboardRemediationFilteredCount()" in template
+    assert "dashboardRemediationTotalCount()" in template
+    assert "dashboardRemediationFilterLabel()" in template
+    assert "dashboardRemediationHiddenCount()" in template
+    assert "No remediation cards match this dashboard filter" in template
+    assert "Show all matching cards" in template
+    assert "Show compact cards" in template
     assert "Fresh evidence path" in template
     assert "evidenceRefreshLabel(workload.primary.evidence_refresh)" in script
     assert "Evidence: provider value required" in script
@@ -405,10 +426,20 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "remediationTrackLabel(track)" in script
     assert "remediationLoopStatusLabel(status)" in script
     assert "remediationLoopStatusClass(status)" in script
+    assert "approval_ready: 'Needs approval'" in script
+    assert "state === 'approval_ready' || state === 'needs_approval'" in script
     assert "remediationIncidentLabel(value)" in script
     assert "remediationLoopItemRank(item)" in script
     assert "[...items].sort" in script
     assert "this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b)" in script
+    assert "dashboardRemediationFilterMatches(item, filterValue)" in script
+    assert "dashboardRemediationEvidenceRank(item)" in script
+    assert "remediationSeverityWeight(severity)" in script
+    assert "remediationStaleEvidenceText(item)" in script
+    assert "domainEvidenceHref(item)" in script
+    assert "rawAnchor.startsWith('#')" in script
+    assert ':href="domainEvidenceHref(item)"' in template
+    assert "Open evidence section" in template
     assert "repairProgressionClass(progression)" in script
     assert "repairProgressionLabel(progression)" in script
     assert "repairProgressionNextStep(progression)" in script
@@ -418,6 +449,98 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "repairReadinessClass(progression)" in script
     assert "repairReadinessLabel(progression)" in script
     assert "repairReadinessScore(progression)" in script
+
+
+def test_dashboard_remediation_filters_and_sorts_cards():
+    result = _run_dashboard_expression("""(() => {
+            app.healthSummary = { remediation_loop: { items: [
+                {
+                    domain: 'manual.example',
+                    state: 'manual_action',
+                    remediation_track: 'manual_dns',
+                    priority_score: 5,
+                    severity: 'low',
+                    repair_progression: {
+                        readiness_level: 'manual_repair',
+                        readiness_score: 40
+                    },
+                    evidence_refresh: {
+                        required: true,
+                        refresh_key: 'dns',
+                        safe_to_run: true
+                    }
+                },
+                {
+                    domain: 'blocked.example',
+                    state: 'approval_ready',
+                    remediation_track: 'blocked_by_prerequisite',
+                    priority_score: 9,
+                    severity: 'high',
+                    repair_progression: {
+                        readiness_level: 'blocked',
+                        readiness_score: 10,
+                        blocked_by: ['provider value']
+                    },
+                    evidence_refresh: {
+                        required: true,
+                        refresh_key: 'provider_value',
+                        safe_to_run: false
+                    }
+                },
+                {
+                    domain: 'reputation.example',
+                    state: 'investigate',
+                    remediation_track: 'reputation_review',
+                    priority_score: 4,
+                    severity: 'medium',
+                    repair_progression: {
+                        readiness_level: 'needs_reputation_review',
+                        stage: 'reputation_review',
+                        readiness_score: 30
+                    },
+                    evidence_refresh: {
+                        required: true,
+                        refresh_key: 'source_reputation',
+                        safe_to_run: true
+                    }
+                }
+            ] } };
+            app.dashboardRemediationFilter = 'fresh_evidence';
+            app.dashboardRemediationSort = 'freshness';
+            return [
+                app.dashboardRemediationFilterCount('blocked'),
+                app.dashboardRemediationFilterCount('reputation'),
+                app.dashboardRemediationFilteredCount(),
+                app.visibleDashboardRemediationItems()[0].domain
+            ].join('|');
+        })()""")
+
+    assert result == "1|1|3|blocked.example"
+
+
+def test_dashboard_remediation_stale_evidence_links_to_evidence_anchor():
+    result = _run_dashboard_expression("""(() => {
+            const item = {
+                domain: 'mail.example/a b',
+                evidence_refresh: {
+                    required: true,
+                    refresh_key: 'dns',
+                    ui_anchor: '#dns-records',
+                    stale_warning: 'DNS evidence is older than the TTL window.'
+                }
+            };
+            app.healthSummary = { remediation_loop: { items: [item] } };
+            return [
+                app.dashboardRemediationFilterCount('stale_evidence'),
+                app.domainEvidenceHref(item),
+                app.remediationStaleEvidenceText(item)
+            ].join('|');
+        })()""")
+
+    assert (
+        result
+        == "1|/domains/mail.example%2Fa%20b#dns-records|DNS evidence is older than the TTL window."
+    )
 
 
 def test_domain_details_remediation_queue_shows_verification_context():
@@ -442,13 +565,20 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "remediationQueueFilter: 'all'" in script
     assert "{ value: 'notify_ready', label: 'Ready to notify' }" in script
     assert "{ value: 'waiting_operator', label: 'Waiting' }" in script
+    assert "{ value: 'fresh_evidence', label: 'Fresh evidence' }" in script
+    assert "{ value: 'stale_evidence', label: 'Stale evidence' }" in script
+    assert "{ value: 'provider_value', label: 'Provider value' }" in script
     assert "remediationQueueSort: 'priority'" in script
     assert "sortedRemediationQueueItems(items)" in script
+    assert "remediationEvidenceRefreshRank(item)" in script
     assert "visibleRemediationQueueItems()" in script
     assert "filteredRemediationQueueItems(filterValue)" in script
     assert "remediationQueueFilterMatches(item, filter)" in script
     assert "filter === 'notify_ready'" in script
     assert "filter === 'waiting_operator'" in script
+    assert "filter === 'fresh_evidence'" in script
+    assert "filter === 'stale_evidence'" in script
+    assert "filter === 'provider_value'" in script
     assert "item.notification?.dispatch?.eligible" in script
     assert "remediationQueueFilterCount(filter)" in script
     assert "remediationQueueFilteredCount()" in script
@@ -459,6 +589,7 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "remediationQueueFilterOptions" in template
     assert 'x-model="remediationQueueSort"' in template
     assert "Repair readiness" in template
+    assert "Fresh evidence" in template
     assert "Remediation queue sort" in template
     assert "data-domain-detail-remediation-filter" in template
     assert "aria-pressed" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -571,6 +571,9 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "remediationQueueSort: 'priority'" in script
     assert "sortedRemediationQueueItems(items)" in script
     assert "remediationEvidenceRefreshRank(item)" in script
+    assert "remediationEvidenceAnchorHref(item)" in script
+    assert "rawAnchor.startsWith('#')" in script
+    assert ':href="remediationEvidenceAnchorHref(item)"' in template
     assert "visibleRemediationQueueItems()" in script
     assert "filteredRemediationQueueItems(filterValue)" in script
     assert "remediationQueueFilterMatches(item, filter)" in script

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -183,6 +183,13 @@ The dashboard remediation loop also mirrors the Fresh Evidence path from the
 domain queue. Its evidence-gated counters split the queue into DNS, report, and
 reputation refreshes, and each remediation card states the concrete read-only
 evidence action that should happen before the operator marks an item fixed.
+Use the dashboard remediation filters and sort control when the workspace has
+many active items. The dashboard can focus on preview-ready work, fresh evidence
+requirements, blocked items, manual repairs, or reputation review, and the
+compact card list can expand to show every matching item.
+Items with stale DNS, report, or reputation evidence can be filtered separately.
+When a remediation card knows the relevant evidence section, the dashboard links
+directly to that part of the domain detail page.
 
 ### Source Intelligence
 


### PR DESCRIPTION
## Summary
- add dashboard remediation filtering, sorting, compact/show-all controls, and filter-specific empty states
- mirror fresh/stale evidence triage on dashboard and domain remediation queues, including direct links into the relevant domain evidence section
- treat approval_ready remediation items as approval work in the dashboard and harden malformed evidence anchors to a safe queue fallback

Part of #384.

## Local validation
- node --check backend/app/static/js/dashboard-page.js
- node --check backend/app/static/js/domain-details-page.js
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q --tb=short
- .venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py
- git diff --check origin/main...HEAD

## Safety
- read-only UI/API surface; no DNS/provider writes
- no notification dispatch behavior changes