### PR TITLE
feat: surface source reputation triage filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added domain remediation fresh-evidence and provider-value queue filters plus freshness sorting so closure-blocking evidence work is easier to isolate on domain detail pages.
 - Added stale-evidence remediation filters and direct dashboard links into the relevant domain evidence section, such as DNS records or sending sources.
 - Fixed dashboard remediation state rendering so backend `approval_ready` queue items are labeled as needing approval and evidence anchors fall back safely if malformed.
+- Added report-detail reputation filters and record-level reputation next steps so risky, listed, authentication-review, unchecked, and clean source records can be isolated without leaving the report.
+- Added sending-source risk filters, compact reputation counters, activity badges, and logarithmic recent-volume bars on domain detail pages so current risky senders stand out from stale or low-volume history.
 
 ### Changed
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.
@@ -69,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Docker release metadata so the in-product build SHA, ref, and date come from the checked-out image source instead of the workflow trigger commit.
 - Fixed Cloudflare OAuth recovery so invalid-scope callbacks offer a read-only retry path and stale legacy scopes such as `user.read` are filtered from DMARQ-generated requests.
 - Fixed report detail views so sender-IP reputation appears as a dedicated score and assessment column instead of being buried in source metadata.
+- Fixed sending-source reputation visibility so checked age, listed/feed evidence, and recommended next steps are shown beside the source rows operators already review.
 - Fixed DNS fallback behavior so independent public resolvers are checked in parallel before a transient timeout can make records appear missing.
 - Fixed domain sending-source loading so PTR and network enrichment run in parallel instead of pushing report-backed source rows past the UI timeout.
 - Fixed the remediation queue API schema so `repair_progression` is preserved in typed domain remediation responses.

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1619,17 +1619,24 @@ function domainDetailsApp(domainId = '') {
             return `risk ${reputation.risk_score}/100`;
         },
 
-        reputationCheckedLabel(reputation) {
-            if (!reputation?.checked_at) return 'not checked yet';
+        parsedReputationCheckedAt(reputation) {
+            if (!reputation?.checked_at) return null;
             const date = new Date(reputation.checked_at);
-            if (Number.isNaN(date.getTime())) return reputation.checked_at;
+            return Number.isNaN(date.getTime()) ? null : date;
+        },
+
+        reputationCheckedLabel(reputation) {
+            const checkedAt = reputation?.checked_at;
+            const date = this.parsedReputationCheckedAt(reputation);
+            if (!checkedAt) return 'not checked yet';
+            if (!date) return checkedAt;
             return `checked ${date.toLocaleString()}`;
         },
 
         reputationAgeLabel(reputation) {
             if (!reputation?.checked_at) return 'reputation not checked';
-            const checked = new Date(reputation.checked_at);
-            if (Number.isNaN(checked.getTime())) return 'reputation timestamp unknown';
+            const checked = this.parsedReputationCheckedAt(reputation);
+            if (!checked) return 'reputation timestamp unknown';
             const ageHours = Math.max(0, Math.floor((Date.now() - checked.getTime()) / 3600000));
             if (ageHours < 1) return 'checked recently';
             if (ageHours < 24) return `checked ${ageHours}h ago`;

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -245,6 +245,7 @@ function domainDetailsApp(domainId = '') {
         filters: {
             dateRange: '30',
             sourceFilter: '',
+            sourceRiskFilter: 'all',
             exportStartDate: '',
             exportEndDate: ''
         },
@@ -545,10 +546,26 @@ function domainDetailsApp(domainId = '') {
             return Number(regionSources || this.sources.length || 0);
         },
 
+        get sourceRiskCounts() {
+            return (this.sources || []).reduce(
+                (counts, source) => {
+                    counts.total += 1;
+                    if (this.sourceReputationNeedsReview(source)) counts.risky += 1;
+                    if (source?.reputation?.status === 'listed') counts.listed += 1;
+                    if (!source?.reputation) counts.unchecked += 1;
+                    if (source?.dmarc === 'fail' || source?.dmarc === 'mixed') counts.authReview += 1;
+                    if (this.sourceActivityBucket(source) === 'recent') counts.recent += 1;
+                    return counts;
+                },
+                { total: 0, risky: 0, listed: 0, unchecked: 0, authReview: 0, recent: 0 }
+            );
+        },
+
         get filteredSources() {
             if (!this.sources) return [];
 
             return this.sources.filter(source => {
+                if (!this.sourceRiskMatches(source, this.filters.sourceRiskFilter)) return false;
                 if (!this.filters.sourceFilter) return true;
                 const needle = this.filters.sourceFilter.toLowerCase();
                 return [
@@ -574,6 +591,50 @@ function domainDetailsApp(domainId = '') {
                     ...(source.reputation?.listings || []),
                 ].some(value => String(value || '').toLowerCase().includes(needle));
             });
+        },
+
+        sourceRiskMatches(source, filter) {
+            if (!source || filter === 'all') return true;
+            if (filter === 'risky') return this.sourceReputationNeedsReview(source);
+            if (filter === 'listed') return source.reputation?.status === 'listed';
+            if (filter === 'auth_review') return source.dmarc === 'fail' || source.dmarc === 'mixed';
+            if (filter === 'unchecked') return !source.reputation;
+            if (filter === 'recent') return this.sourceActivityBucket(source) === 'recent';
+            if (filter === 'stale') return this.sourceActivityBucket(source) === 'stale';
+            if (filter === 'clean') return source.reputation?.status === 'clean';
+            return true;
+        },
+
+        sourceReputationNeedsReview(source) {
+            const status = source?.reputation?.status || '';
+            const risk = Number(source?.reputation?.risk_score || 0);
+            return ['listed', 'critical', 'suspicious'].includes(status) || risk >= 50;
+        },
+
+        sourceActivityBucket(source) {
+            if (!source?.last_seen) return 'unknown';
+            const date = new Date(Number(source.last_seen) * 1000);
+            if (Number.isNaN(date.getTime())) return 'unknown';
+            const diffDays = Math.floor((Date.now() - date.getTime()) / 86400000);
+            if (diffDays <= 14) return 'recent';
+            if (diffDays <= 90) return 'older';
+            return 'stale';
+        },
+
+        sourceActivityLabel(source) {
+            const bucket = this.sourceActivityBucket(source);
+            if (bucket === 'recent') return 'recent sender';
+            if (bucket === 'older') return 'older sender';
+            if (bucket === 'stale') return 'stale sender';
+            return 'activity unknown';
+        },
+
+        sourceActivityClass(source) {
+            const bucket = this.sourceActivityBucket(source);
+            if (bucket === 'recent') return 'bg-green-50 text-green-800';
+            if (bucket === 'older') return 'bg-amber-50 text-amber-800';
+            if (bucket === 'stale') return 'bg-base-200 text-base-content/70';
+            return 'bg-base-200 text-base-content/70';
         },
 
         get exportReportsUrl() {
@@ -1565,6 +1626,17 @@ function domainDetailsApp(domainId = '') {
             return `checked ${date.toLocaleString()}`;
         },
 
+        reputationAgeLabel(reputation) {
+            if (!reputation?.checked_at) return 'reputation not checked';
+            const checked = new Date(reputation.checked_at);
+            if (Number.isNaN(checked.getTime())) return 'reputation timestamp unknown';
+            const ageHours = Math.max(0, Math.floor((Date.now() - checked.getTime()) / 3600000));
+            if (ageHours < 1) return 'checked recently';
+            if (ageHours < 24) return `checked ${ageHours}h ago`;
+            const ageDays = Math.floor(ageHours / 24);
+            return `checked ${ageDays}d ago`;
+        },
+
         reputationEvidencePreview(reputation) {
             return (reputation?.evidence || []).slice(0, 3);
         },
@@ -1603,12 +1675,14 @@ function domainDetailsApp(domainId = '') {
         sourceVolumeBars(source) {
             const history = (source.volume_history || []).slice(-14);
             const max = Math.max(...history.map(point => Number(point.count || 0)), 1);
+            const logMax = Math.log10(max + 1);
             const slotWidth = 140 / Math.max(history.length, 1);
             const barWidth = Math.max(4, slotWidth - 2);
             return history.map((point, index) => {
                 const count = Number(point.count || 0);
                 const failed = Number(point.failed || 0);
-                const height = Math.max(12, Math.round((count / max) * 100));
+                const scaled = logMax > 0 ? Math.log10(count + 1) / logMax : 0;
+                const height = count > 0 ? Math.max(12, Math.round(scaled * 100)) : 4;
                 return {
                     ...point,
                     failed,

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -6,6 +6,7 @@ function reportDetailApp(reportId = '') {
         error: null,
         reputationRefreshing: false,
         reputationRefreshError: '',
+        recordRiskFilter: 'all',
 
         async init() {
             this.reportId = this.$el?.dataset?.reportId || this.reportId;
@@ -150,6 +151,50 @@ function reportDetailApp(reportId = '') {
             return 'text-error';
         },
 
+        get filteredRecords() {
+            const records = this.report?.records || [];
+            return records.filter((record) => this.recordRiskMatches(record, this.recordRiskFilter));
+        },
+
+        get recordRiskCounts() {
+            const records = this.report?.records || [];
+            return records.reduce(
+                (counts, record) => {
+                    counts.total += 1;
+                    if (this.recordReputationNeedsReview(record)) counts.risky += 1;
+                    if (record.reputation?.status === 'listed') counts.listed += 1;
+                    if (!record.reputation) counts.unchecked += 1;
+                    if (record.review_status === 'needs_review') counts.authReview += 1;
+                    return counts;
+                },
+                { total: 0, risky: 0, listed: 0, unchecked: 0, authReview: 0 }
+            );
+        },
+
+        recordRiskMatches(record, filter) {
+            if (!record || filter === 'all') return true;
+            if (filter === 'listed') return record.reputation?.status === 'listed';
+            if (filter === 'risky') return this.recordReputationNeedsReview(record);
+            if (filter === 'auth_review') return record.review_status === 'needs_review';
+            if (filter === 'unchecked') return !record.reputation;
+            if (filter === 'clean') return record.reputation?.status === 'clean';
+            return true;
+        },
+
+        recordReputationNeedsReview(record) {
+            const status = record?.reputation?.status || '';
+            const risk = Number(record?.reputation?.risk_score || 0);
+            return ['listed', 'critical', 'suspicious'].includes(status) || risk >= 50;
+        },
+
+        recordRiskLabel() {
+            const counts = this.recordRiskCounts;
+            if (this.recordRiskFilter === 'all') {
+                return `${counts.total} source record${counts.total === 1 ? '' : 's'}`;
+            }
+            return `${this.filteredRecords.length} of ${counts.total} source record${counts.total === 1 ? '' : 's'}`;
+        },
+
         resultClass(result) {
             if (result === 'pass') return 'bg-green-100 text-green-800';
             if (result === 'fail') return 'bg-red-100 text-red-800';
@@ -171,6 +216,44 @@ function reportDetailApp(reportId = '') {
         reviewStatusLabel(status) {
             if (status === 'needs_review') return 'Needs review';
             return 'Pass';
+        },
+
+        senderStatusClass(status) {
+            if (status === 'known') return 'bg-green-100 text-green-800';
+            if (status === 'ambiguous') return 'bg-yellow-100 text-yellow-800';
+            if (status === 'suspicious') return 'bg-red-100 text-red-800';
+            return 'bg-gray-100 text-gray-700';
+        },
+
+        recordSender(record) {
+            return record?.source_details?.sender || {};
+        },
+
+        recordSenderName(record) {
+            const sender = this.recordSender(record);
+            return sender.name || sender.label || 'Unknown sender';
+        },
+
+        recordSenderStatus(record) {
+            return this.recordSender(record).status || 'unknown';
+        },
+
+        recordSenderProvider(record) {
+            const sender = this.recordSender(record);
+            return sender.provider || sender.category || 'Unclassified';
+        },
+
+        recordSenderConfidence(record) {
+            return `${this.recordSender(record).confidence || 0}% confidence`;
+        },
+
+        recordSenderEvidence(record) {
+            const evidence = this.recordSender(record).evidence || [];
+            return evidence.length ? evidence[0] : '';
+        },
+
+        recordSenderRemediationHint(record) {
+            return this.recordSender(record).remediation_hint || '';
         },
 
         sourceLocation(record) {
@@ -238,8 +321,36 @@ function reportDetailApp(reportId = '') {
             return `checked ${date.toLocaleString()}`;
         },
 
+        reputationAgeLabel(reputation) {
+            if (!reputation?.checked_at) return 'reputation not checked';
+            const checked = new Date(reputation.checked_at);
+            if (Number.isNaN(checked.getTime())) return 'reputation timestamp unknown';
+            const ageHours = Math.max(0, Math.floor((Date.now() - checked.getTime()) / 3600000));
+            if (ageHours < 1) return 'reputation checked recently';
+            if (ageHours < 24) return `reputation checked ${ageHours}h ago`;
+            const ageDays = Math.floor(ageHours / 24);
+            return `reputation checked ${ageDays}d ago`;
+        },
+
         reputationEvidencePreview(reputation) {
             return (reputation?.evidence || []).slice(0, 3);
+        },
+
+        reputationNextSteps(reputation) {
+            return (reputation?.recommendations || []).slice(0, 2);
+        },
+
+        seenLabel(timestamp) {
+            if (!timestamp) return '';
+            const date = new Date(Number(timestamp) * 1000);
+            if (Number.isNaN(date.getTime())) return String(timestamp);
+            const diffDays = Math.floor((Date.now() - date.getTime()) / 86400000);
+            if (Number.isFinite(diffDays) && diffDays >= 0) {
+                if (diffDays === 0) return 'today';
+                if (diffDays === 1) return 'yesterday';
+                if (diffDays < 90) return `${diffDays} days ago`;
+            }
+            return date.toLocaleDateString();
         },
     };
 }

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2155,6 +2155,16 @@
                             placeholder="Filter sources..." 
                             class="input input-sm input-bordered max-w-xs"
                         >
+                        <select x-model="filters.sourceRiskFilter" class="select select-sm select-bordered">
+                            <option value="all">All sources</option>
+                            <option value="risky">Reputation review</option>
+                            <option value="listed">Listed only</option>
+                            <option value="auth_review">Authentication review</option>
+                            <option value="unchecked">Unchecked reputation</option>
+                            <option value="recent">Recently active</option>
+                            <option value="stale">Stale senders</option>
+                            <option value="clean">Clean reputation</option>
+                        </select>
                         <button type="button"
                                 class="btn btn-sm btn-default"
                                 data-domain-detail-refresh-reputation
@@ -2170,6 +2180,26 @@
                    x-cloak
                    class="mb-4 rounded-md border border-[#ffcfbd] bg-[#fff2ec] px-3 py-2 text-sm text-[#8a2d0d]"
                    x-text="sourceReputationRefreshError"></p>
+                <div class="mb-4 flex flex-wrap gap-2 text-xs" x-show="!sourcesLoading && !sourcesError">
+                    <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-semibold text-base-content/80">
+                        <span x-text="sourceRiskCounts.total"></span><span class="ml-1">sources</span>
+                    </span>
+                    <span class="inline-flex items-center rounded-full bg-[#fff2ec] px-2 py-0.5 font-semibold text-[#8a2d0d]">
+                        <span x-text="sourceRiskCounts.risky"></span><span class="ml-1">reputation review</span>
+                    </span>
+                    <span class="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 font-semibold text-red-800">
+                        <span x-text="sourceRiskCounts.listed"></span><span class="ml-1">listed</span>
+                    </span>
+                    <span class="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 font-semibold text-amber-800">
+                        <span x-text="sourceRiskCounts.authReview"></span><span class="ml-1">auth review</span>
+                    </span>
+                    <span class="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 font-semibold text-green-800">
+                        <span x-text="sourceRiskCounts.recent"></span><span class="ml-1">recent</span>
+                    </span>
+                    <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-semibold text-base-content/70">
+                        <span x-text="sourceRiskCounts.unchecked"></span><span class="ml-1">unchecked reputation</span>
+                    </span>
+                </div>
                 {% call table() %}
                     {% call thead() %}
                         {% call tr() %}
@@ -2228,6 +2258,9 @@
                                                   :class="source.anomalies.some(anomaly => anomaly.severity === 'error') ? 'bg-red-100 text-red-800' : 'bg-amber-100 text-amber-800'"
                                                   x-text="source.anomalies.length === 1 ? '1 anomaly' : source.anomalies.length + ' anomalies'"></span>
                                         </template>
+                                        <span class="mt-1 inline-flex w-fit rounded-full px-2 py-0.5 text-xs font-semibold"
+                                              :class="sourceActivityClass(source)"
+                                              x-text="sourceActivityLabel(source)"></span>
                                     </div>
                                 {% endcall %}
                                 {% call td() %}
@@ -2313,7 +2346,11 @@
                                                     ></span>
                                                 </div>
                                                 <p class="text-muted-foreground" x-text="source.reputation.status_detail || source.reputation.summary"></p>
-                                                <p class="text-muted-foreground" x-text="reputationCheckedLabel(source.reputation)"></p>
+                                                <p class="text-muted-foreground">
+                                                    <span x-text="reputationCheckedLabel(source.reputation)"></span>
+                                                    <span> · </span>
+                                                    <span x-text="reputationAgeLabel(source.reputation)"></span>
+                                                </p>
                                                 <template x-if="source.reputation?.listings?.length">
                                                     <p class="font-medium text-[#ff6f3c]">
                                                         <span>Listed on </span>

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -251,7 +251,7 @@
                 {% call card_header() %}
                     {% call card_title() %}Records{% endcall %}
                     {% call card_description() %}
-                        <span x-text="report.records.length"></span> IP source(s) in this report
+                        <span x-text="recordRiskLabel()"></span> in this report
                     {% endcall %}
                 {% endcall %}
                 {% call card_content() %}
@@ -259,6 +259,36 @@
                        x-cloak
                        class="mb-4 rounded-md border border-[#ffcfbd] bg-[#fff2ec] px-3 py-2 text-sm text-[#8a2d0d]"
                        x-text="reputationRefreshError"></p>
+                    <div class="mb-4 flex flex-col gap-3 rounded-md border border-[#e6e3e1] bg-[#fbfbfb] p-3 lg:flex-row lg:items-center lg:justify-between">
+                        <div class="flex flex-wrap gap-2 text-xs">
+                            <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-semibold text-base-content/80">
+                                <span x-text="recordRiskCounts.total"></span><span class="ml-1">records</span>
+                            </span>
+                            <span class="inline-flex items-center rounded-full bg-[#fff2ec] px-2 py-0.5 font-semibold text-[#8a2d0d]">
+                                <span x-text="recordRiskCounts.risky"></span><span class="ml-1">reputation review</span>
+                            </span>
+                            <span class="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 font-semibold text-red-800">
+                                <span x-text="recordRiskCounts.listed"></span><span class="ml-1">listed</span>
+                            </span>
+                            <span class="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 font-semibold text-amber-800">
+                                <span x-text="recordRiskCounts.authReview"></span><span class="ml-1">auth review</span>
+                            </span>
+                            <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-semibold text-base-content/70">
+                                <span x-text="recordRiskCounts.unchecked"></span><span class="ml-1">unchecked</span>
+                            </span>
+                        </div>
+                        <label class="flex items-center gap-2 text-sm text-[#5f5c78]">
+                            <span class="font-medium">View</span>
+                            <select x-model="recordRiskFilter" class="select select-sm select-bordered">
+                                <option value="all">All records</option>
+                                <option value="risky">Reputation review</option>
+                                <option value="listed">Listed only</option>
+                                <option value="auth_review">Authentication review</option>
+                                <option value="unchecked">Unchecked reputation</option>
+                                <option value="clean">Clean reputation</option>
+                            </select>
+                        </label>
+                    </div>
                     {% call table() %}
                         {% call thead() %}
                             {% call tr() %}
@@ -281,14 +311,33 @@
                                     </td>
                                 </tr>
                             </template>
-                            <template x-for="(record, index) in report.records" :key="index">
+                            <template x-if="report.records.length > 0 && filteredRecords.length === 0">
+                                <tr>
+                                    <td colspan="9" class="text-center py-4">
+                                        <div class="text-muted-foreground">No records match this reputation view.</div>
+                                    </td>
+                                </tr>
+                            </template>
+                            <template x-for="(record, index) in filteredRecords" :key="index">
                                 {% call tr() %}
                                     {% call td() %}
                                         <span class="font-mono text-sm" x-text="record.source_ip"></span>
                                     {% endcall %}
                                     {% call td() %}
                                         <div class="min-w-64 max-w-sm space-y-1 text-xs text-[#5f5c78]">
-                                            <div class="font-semibold text-[#120d36]" x-text="record.source_details?.sender?.name || record.source_details?.sender?.label || 'Unknown sender'"></div>
+                                            <div class="flex flex-wrap items-center gap-2">
+                                                <span class="font-semibold text-[#120d36]" x-text="recordSenderName(record)"></span>
+                                                <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold"
+                                                      :class="senderStatusClass(recordSenderStatus(record))"
+                                                      x-text="recordSenderStatus(record)"></span>
+                                            </div>
+                                            <div>
+                                                <span x-text="recordSenderProvider(record)"></span>
+                                                <span> · </span>
+                                                <span x-text="recordSenderConfidence(record)"></span>
+                                            </div>
+                                            <p x-show="recordSenderEvidence(record)" x-text="recordSenderEvidence(record)"></p>
+                                            <p x-show="recordSenderRemediationHint(record)" class="text-[#120d36]" x-text="recordSenderRemediationHint(record)"></p>
                                             <div x-show="record.source_details?.hostname">
                                                 PTR: <span class="font-mono" x-text="record.source_details.hostname"></span>
                                             </div>
@@ -329,6 +378,11 @@
                                                class="inline-flex text-primary hover:underline">Open in Cloudflare Radar</a>
                                             <div x-show="record.source_details?.network_error && !record.source_details?.asn && !record.source_details?.network"
                                                  x-text="record.source_details.network_error"></div>
+                                            <div x-show="record.reputation?.first_seen || record.reputation?.last_seen">
+                                                <span x-show="record.reputation?.last_seen">Last sent <span x-text="seenLabel(record.reputation.last_seen)"></span></span>
+                                                <span x-show="record.reputation?.first_seen && record.reputation?.last_seen"> · </span>
+                                                <span x-show="record.reputation?.first_seen">First seen <span x-text="seenLabel(record.reputation.first_seen)"></span></span>
+                                            </div>
                                         </div>
                                     {% endcall %}
                                     {% call td() %}
@@ -348,11 +402,22 @@
                                                               x-text="record.reputation.feed_summary || 'Local reputation evidence only'"></span>
                                                     </div>
                                                     <div class="leading-relaxed" x-text="reputationDetail(record.reputation)"></div>
-                                                    <div class="text-muted-foreground" x-text="reputationCheckedLabel(record.reputation)"></div>
+                                                    <div class="text-muted-foreground">
+                                                        <span x-text="reputationCheckedLabel(record.reputation)"></span>
+                                                        <span> · </span>
+                                                        <span x-text="reputationAgeLabel(record.reputation)"></span>
+                                                    </div>
                                                     <template x-if="record.reputation.listings?.length">
                                                         <div class="font-semibold text-[#ff6f3c]">
                                                             DNSBL: <span x-text="record.reputation.listings.join(', ')"></span>
                                                         </div>
+                                                    </template>
+                                                    <template x-if="reputationNextSteps(record.reputation).length">
+                                                        <ul class="space-y-1 text-[#5f5c78]">
+                                                            <template x-for="step in reputationNextSteps(record.reputation)" :key="step">
+                                                                <li x-text="step"></li>
+                                                            </template>
+                                                        </ul>
                                                     </template>
                                                     <div class="flex flex-wrap gap-1" x-show="reputationEvidencePreview(record.reputation).length">
                                                         <template x-for="item in reputationEvidencePreview(record.reputation)" :key="item.label + item.value">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1131,10 +1131,24 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "this.report = null;" in script
     assert "record.reputation.feed_status" in template
     assert "record.reputation.feed_summary" in template
+    assert "recordRiskFilter" in template
+    assert "filteredRecords" in template
+    assert "recordRiskCounts" in template
+    assert "recordRiskMatches(record, this.recordRiskFilter)" in script
+    assert "reputationAgeLabel(record.reputation)" in template
+    assert "reputationNextSteps(record.reputation)" in template
+    assert "recordSenderName(record)" in template
+    assert "recordSenderStatus(record)" in template
+    assert "recordSenderProvider(record)" in template
+    assert "recordSenderConfidence(record)" in template
+    assert "recordSenderEvidence(record)" in template
+    assert "recordSenderRemediationHint(record)" in template
+    assert "seenLabel(record.reputation.last_seen)" in template
     assert "Use Recalculate reputation" in template
     assert "reputationFeedClass" in script
     assert "reputationLabel" in script
     assert "reputationEvidencePreview" in script
+    assert "senderStatusClass" in script
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
 
 
@@ -1710,6 +1724,13 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "remediationQueue.summary.approval_ready" in template
     assert "remediationQueue.summary.manual_action" in template
     assert "No sending sources match this filter." in template
+    assert "filters.sourceRiskFilter" in template
+    assert "sourceRiskCounts" in template
+    assert "sourceRiskMatches(source, this.filters.sourceRiskFilter)" in script
+    assert "sourceActivityLabel(source)" in template
+    assert "sourceActivityClass(source)" in template
+    assert "reputationAgeLabel(source.reputation)" in template
+    assert "Math.log10(count + 1)" in script
     assert (
         "(!sourceIntelligence.loading && !sourceIntelligence.error ? sourceIntelligence.regions.slice(0, 4) : [])"
         in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1135,6 +1135,7 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "filteredRecords" in template
     assert "recordRiskCounts" in template
     assert "recordRiskMatches(record, this.recordRiskFilter)" in script
+    assert "recordRiskLabel()" in template
     assert "reputationAgeLabel(record.reputation)" in template
     assert "reputationNextSteps(record.reputation)" in template
     assert "recordSenderName(record)" in template

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -204,6 +204,14 @@ that host, how many distinct report days include the source, and a compact
 recent volume history. Use this to separate current infrastructure from stale
 legacy traffic: a source that last sent yesterday deserves different treatment
 than a one-off sender that appeared three months ago.
+The recent-volume bars use a logarithmic scale so an occasional large outbound
+day does not hide smaller but still recent sender activity.
+
+Use the source filters to switch from all sources to reputation-review,
+listed-only, authentication-review, unchecked reputation, recently active, stale,
+or clean-reputation views. The source table also shows compact counters for the
+same categories, so an operator can see whether the page is mostly historical
+noise or has current risky senders that need action.
 
 Use these findings before editing DNS. A new source is not automatically a
 trusted sender; confirm the service owner first, then update SPF or DKIM only

--- a/docs/user_guide/reports.md
+++ b/docs/user_guide/reports.md
@@ -55,6 +55,17 @@ To view details of a specific aggregate report:
    - Sending sources (by domain and IP)
    - Pass/fail rates by source
 
+The report detail page also shows sender-IP reputation next to each source
+record when reputation evidence has been calculated. Use the record view filter
+to focus on listed sources, reputation-review items, authentication-review
+items, unchecked reputation, or clean sources. This keeps a report with many
+passing records usable when only one IP needs deliverability or blacklist
+attention.
+Each record also shows the sender-recognition status, confidence, matching
+evidence, and first/last observed dates when that context is available. Treat a
+low-confidence sender match as a prompt to verify PTR, ASN, authenticated
+domains, and provider account evidence before changing SPF or DKIM.
+
 ### Forensic Reports
 
 To view forensic reports (when available):


### PR DESCRIPTION
## Summary
- add report-detail filters for risky, listed, authentication-review, unchecked, and clean source records
- show sender recognition status, confidence, evidence, first/last seen dates, reputation age, and next steps in report records
- add domain sending-source risk filters, compact source counters, activity badges, and logarithmic recent-volume bars
- update changelog and user docs for the new reputation/source triage flow

## Validation
- node --check backend/app/static/js/report-detail-page.js
- node --check backend/app/static/js/domain-details-page.js
- .venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q --tb=short
- .venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py
- git diff --check origin/main...HEAD

## Safety
- read-only UI and documentation changes only
- no DNS/provider writes
- no notification dispatch behavior changes

Part of #384.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reputation-based filters and summary counters for report records and sending sources.
  * Added richer sender/reputation details, including last/first seen, age, evidence, next steps, and activity indicators.

* **Bug Fixes**
  * Improved reputation age and date labels for clearer, more reliable status display.
  * Made source activity volume bars easier to read by better scaling smaller values.

* **Documentation**
  * Updated user guides and changelog entries to match the new report and source review views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->