### PR TITLE
[codex] improve DNS refresh performance and stale-data resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the remediation queue API schema so `repair_progression` is preserved in typed domain remediation responses.
 - Fixed dashboard and domain remediation refresh failures so transient backend errors no longer blank already-loaded operator evidence.
 - Fixed domain-list refresh failures so a transient DNS/API error no longer clears the previously loaded domain rows.
+- Fixed source-intelligence refresh failures so previously loaded region and anomaly evidence stays visible while the retry warning is shown.
 - Fixed the Cloudflare permissions picker so selecting the full DNS repair profile no longer falls back to read-only scopes.
 - Fixed the release modal coverage so recent operator-facing work is visible from inside the app.
 - Fixed the remaining Settings page startup hook so CSP hardening no longer depends on template-level page initialization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the remediation queue API schema so `repair_progression` is preserved in typed domain remediation responses.
 - Fixed dashboard and domain remediation refresh failures so transient backend errors no longer blank already-loaded operator evidence.
 - Fixed domain-list refresh failures so a transient DNS/API error no longer clears the previously loaded domain rows.
+- Fixed sending-source refresh failures so existing source rows remain visible during date-window or reputation refresh retries.
 - Fixed source-intelligence refresh failures so previously loaded region and anomaly evidence stays visible while the retry warning is shown.
 - Fixed the Cloudflare permissions picker so selecting the full DNS repair profile no longer falls back to read-only scopes.
 - Fixed the release modal coverage so recent operator-facing work is visible from inside the app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed dashboard remediation state rendering so backend `approval_ready` queue items are labeled as needing approval and evidence anchors fall back safely if malformed.
 - Added report-detail reputation filters and record-level reputation next steps so risky, listed, authentication-review, unchecked, and clean source records can be isolated without leaving the report.
 - Added sending-source risk filters, compact reputation counters, activity badges, and logarithmic recent-volume bars on domain detail pages so current risky senders stand out from stale or low-volume history.
+- Added domain-list DNS state badges for queued, cached, fallback, partial, stale, and failed DNS evidence so resolver uncertainty is visible instead of silently degrading scores.
 
 ### Changed
+- Domain summary DNS refreshes now run with bounded concurrency instead of resolving each domain sequentially.
+- Startup DNS cache prewarming now prioritizes domains with observed reports and message volume before empty monitored domains.
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.
 - The full Cloudflare DNS repair profile now requests DNS write access plus Radar read access so one-click repair and IP enrichment can work from the same consent flow.
 - Dashboard and domain detail pages now expose more actionable remediation context around DNS, DMARC, source authentication, and ownership state.
@@ -76,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed domain sending-source loading so PTR and network enrichment run in parallel instead of pushing report-backed source rows past the UI timeout.
 - Fixed the remediation queue API schema so `repair_progression` is preserved in typed domain remediation responses.
 - Fixed dashboard and domain remediation refresh failures so transient backend errors no longer blank already-loaded operator evidence.
+- Fixed domain-list refresh failures so a transient DNS/API error no longer clears the previously loaded domain rows.
 - Fixed the Cloudflare permissions picker so selecting the full DNS repair profile no longer falls back to read-only scopes.
 - Fixed the release modal coverage so recent operator-facing work is visible from inside the app.
 - Fixed the remaining Settings page startup hook so CSP hardening no longer depends on template-level page initialization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up root directory for clarity
 
 ### Fixed
+- Aggregate and TLS report pages now keep the last loaded data visible when a manual refresh or API retry fails.
 - Retired stale roadmap issue-generator guidance and made the docs-site
   changelog point at the canonical root changelog.
 - Fixed remediation verified-repair totals so older resolved items are counted

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
-from app.core.database import get_db
+from app.core.database import SessionLocal, get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
@@ -3859,6 +3859,7 @@ async def _resolve_summary_dns_result(
     selectors: List[str],
     *,
     refresh: bool,
+    timeout_seconds: float = 10.0,
 ) -> DomainDNSResult:
     if not refresh:
         cached_result, cached, checked_at = get_cached_domain_dns_result(
@@ -3899,7 +3900,7 @@ async def _resolve_summary_dns_result(
                 selectors=selectors,
                 refresh=refresh,
             ),
-            timeout=10.0,
+            timeout=timeout_seconds,
         )
         return _with_dns_summary_metadata(
             result,
@@ -3910,6 +3911,91 @@ async def _resolve_summary_dns_result(
     except (asyncio.TimeoutError, LookupError, OSError) as exc:
         logger.warning("DNS check failed for %s: %s", domain_name, exc)
         return _failed_dns_summary_result(f"DNS lookup failed: {exc}")
+
+
+def _dns_summary_refresh_timeout(settings: Any) -> float:
+    return max(1.0, float(settings.DNS_SUMMARY_REFRESH_TIMEOUT_SECONDS or 10.0))
+
+
+def _dns_summary_refresh_concurrency(settings: Any) -> int:
+    return max(1, int(settings.DNS_SUMMARY_REFRESH_CONCURRENCY or 1))
+
+
+def _reuse_request_session_for_dns(db: Session) -> bool:
+    # Test suites often override the request session with an in-memory SQLite
+    # connection. That database is not visible from the global SessionLocal
+    # factory, so keep those calls on the request session.
+    return str(db.get_bind().url) == "sqlite://"
+
+
+async def _resolve_summary_dns_result_for_domain(
+    db: Session,
+    provider: Any,
+    domain_name: str,
+    selectors: List[str],
+    *,
+    refresh: bool,
+    timeout_seconds: float,
+) -> DomainDNSResult:
+    if not refresh:
+        return await _resolve_summary_dns_result(
+            db,
+            provider,
+            domain_name,
+            selectors,
+            refresh=False,
+            timeout_seconds=timeout_seconds,
+        )
+
+    use_request_session = _reuse_request_session_for_dns(db)
+    dns_db = db if use_request_session else SessionLocal()
+    try:
+        return await _resolve_summary_dns_result(
+            dns_db,
+            provider,
+            domain_name,
+            selectors,
+            refresh=True,
+            timeout_seconds=timeout_seconds,
+        )
+    finally:
+        if not use_request_session:
+            dns_db.close()
+
+
+async def _resolve_summary_dns_results(
+    db: Session,
+    provider: Any,
+    domains: List[str],
+    selectors_by_domain: Dict[str, List[str]],
+    *,
+    refresh: bool,
+    timeout_seconds: float,
+    concurrency: int,
+) -> List[DomainDNSResult]:
+    async def _resolve_one(domain_name: str) -> DomainDNSResult:
+        return await _resolve_summary_dns_result_for_domain(
+            db,
+            provider,
+            domain_name,
+            selectors_by_domain.get(domain_name, []),
+            refresh=refresh,
+            timeout_seconds=timeout_seconds,
+        )
+
+    if not refresh:
+        results = []
+        for domain_name in domains:
+            results.append(await _resolve_one(domain_name))
+        return results
+
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _bounded(domain_name: str) -> DomainDNSResult:
+        async with semaphore:
+            return await _resolve_one(domain_name)
+
+    return await asyncio.gather(*(_bounded(domain_name) for domain_name in domains))
 
 
 @router.get("/summary", response_model=DomainSummaryResponse)
@@ -3932,7 +4018,8 @@ async def get_domains_summary(
     """
     selected_workspace_id = parse_selected_workspace_id(selected_workspace)
     workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
-    demo_mode = get_settings().DEMO_MODE
+    settings = get_settings()
+    demo_mode = settings.DEMO_MODE
     store: Optional[ReportStore] = None
     report_selectors_by_domain: Dict[str, List[str]] = {}
     if demo_mode:
@@ -3980,24 +4067,26 @@ async def get_domains_summary(
         for domain in workspace_domain_query(db, workspace).filter(Domain.name.in_(domains)).all()
     }
 
-    async def _dns_for_domain(domain_name: str) -> DomainDNSResult:
+    selectors_by_summary_domain: Dict[str, List[str]] = {}
+    for domain_name in domains:
         manual_selectors = manual_selectors_by_domain.get(domain_name, [])
         if demo_mode and store is not None:
             report_selectors = _get_selectors_from_reports(store, domain_name)
         else:
             report_selectors = report_selectors_by_domain.get(domain_name, [])
-        combined = list(dict.fromkeys(manual_selectors + report_selectors))
-        return await _resolve_summary_dns_result(
-            db,
-            provider,
-            domain_name,
-            combined,
-            refresh=refresh,
+        selectors_by_summary_domain[domain_name] = list(
+            dict.fromkeys(manual_selectors + report_selectors)
         )
 
-    dns_results = []
-    for domain_name in domains:
-        dns_results.append(await _dns_for_domain(domain_name))
+    dns_results = await _resolve_summary_dns_results(
+        db,
+        provider,
+        domains,
+        selectors_by_summary_domain,
+        refresh=refresh,
+        timeout_seconds=_dns_summary_refresh_timeout(settings),
+        concurrency=_dns_summary_refresh_concurrency(settings),
+    )
 
     # Calculate overall statistics
     total_domains = len(domains)

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3914,11 +3914,13 @@ async def _resolve_summary_dns_result(
 
 
 def _dns_summary_refresh_timeout(settings: Any) -> float:
-    return max(1.0, float(settings.DNS_SUMMARY_REFRESH_TIMEOUT_SECONDS or 10.0))
+    timeout = getattr(settings, "DNS_SUMMARY_REFRESH_TIMEOUT_SECONDS", 10.0)
+    return max(1.0, float(timeout or 10.0))
 
 
 def _dns_summary_refresh_concurrency(settings: Any) -> int:
-    return max(1, int(settings.DNS_SUMMARY_REFRESH_CONCURRENCY or 1))
+    concurrency = getattr(settings, "DNS_SUMMARY_REFRESH_CONCURRENCY", 1)
+    return max(1, int(concurrency or 1))
 
 
 def _reuse_request_session_for_dns(db: Session) -> bool:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -123,6 +123,8 @@ class Settings(BaseSettings):
     DNS_STARTUP_PREWARM_ENABLED: bool = True
     DNS_STARTUP_PREWARM_LIMIT: int = 50
     DNS_STARTUP_PREWARM_CONCURRENCY: int = 4
+    DNS_SUMMARY_REFRESH_CONCURRENCY: int = 6
+    DNS_SUMMARY_REFRESH_TIMEOUT_SECONDS: float = 10.0
 
     # Optional Stripe Billing integration. Self-hosted and provider-billed
     # deployments work without these values.

--- a/backend/app/services/dns_prewarm.py
+++ b/backend/app/services/dns_prewarm.py
@@ -6,18 +6,25 @@ import asyncio
 import logging
 from typing import List
 
+from sqlalchemy import func
+
 from app.core.config import get_settings
 from app.core.database import SessionLocal
 from app.models.domain import Domain
+from app.models.report import DMARCReport, ReportRecord
 from app.services.dns_cache import resolve_domain_dns_cached
 from app.services.dns_resolver import get_default_provider
 
 logger = logging.getLogger(__name__)
 
 
-def _domain_selectors(domain: Domain) -> List[str]:
-    raw = domain.dkim_selectors or ""
+def _selectors_from_raw(raw_selectors: str | None) -> List[str]:
+    raw = raw_selectors or ""
     return [selector.strip() for selector in raw.split(",") if selector.strip()]
+
+
+def _domain_selectors(domain: Domain) -> List[str]:
+    return _selectors_from_raw(domain.dkim_selectors)
 
 
 def _canonical_domain_name(name: str) -> str:
@@ -60,17 +67,35 @@ async def prewarm_dns_cache() -> None:
 
     db = SessionLocal()
     try:
-        domains = (
-            db.query(Domain)
+        report_count = func.count(func.distinct(DMARCReport.id))
+        message_count = func.coalesce(func.sum(ReportRecord.count), 0)
+        activity_score = message_count + (report_count * 1000)
+        last_report_end = func.max(DMARCReport.end_date)
+        rows = (
+            db.query(
+                Domain.id,
+                Domain.name,
+                Domain.dkim_selectors,
+                activity_score.label("activity_score"),
+                last_report_end.label("last_report_end"),
+            )
+            .outerjoin(DMARCReport, DMARCReport.domain_id == Domain.id)
+            .outerjoin(ReportRecord, ReportRecord.report_id == DMARCReport.id)
             .filter(Domain.active.is_(True))
-            .order_by(Domain.updated_at.desc(), Domain.id.asc())
+            .group_by(Domain.id, Domain.name, Domain.dkim_selectors, Domain.updated_at)
+            .order_by(
+                activity_score.desc(),
+                last_report_end.desc(),
+                Domain.updated_at.desc(),
+                Domain.id.asc(),
+            )
             .limit(limit)
             .all()
         )
         candidates = [
-            (domain.id, canonical_name, _domain_selectors(domain))
-            for domain in domains
-            if domain.name and (canonical_name := _canonical_domain_name(domain.name))
+            (row.id, canonical_name, _selectors_from_raw(row.dkim_selectors))
+            for row in rows
+            if row.name and (canonical_name := _canonical_domain_name(row.name))
         ]
     finally:
         db.close()

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -2633,11 +2633,12 @@ function domainDetailsApp(domainId = '') {
                 this.sources = (data.sources || []).map(source => this.normalizeSource(source));
                 this.sourceReputationRefreshError = '';
             } catch (error) {
-                if (!options.preserveOnFailure) {
+                const hasExistingSources = (this.sources || []).length > 0;
+                if (!options.preserveOnFailure || !hasExistingSources) {
                     this.sources = [];
                     this.sourcesError = error.message || 'Sending sources could not be loaded.';
                 }
-                if (options.preserveOnFailure) {
+                if (options.preserveOnFailure && hasExistingSources) {
                     this.sourceReputationRefreshError =
                         (error.message || 'Sending sources could not be refreshed.') +
                         ' Showing the last loaded sending sources.';
@@ -2673,8 +2674,9 @@ function domainDetailsApp(domainId = '') {
                 const message = error.message || 'Source intelligence could not be loaded.';
                 const hasExistingEvidence =
                     (this.sourceIntelligence.regions || []).length > 0 ||
-                    (this.sourceIntelligence.anomalies || []).length > 0;
-                if (options.preserveOnFailure || hasExistingEvidence) {
+                    (this.sourceIntelligence.anomalies || []).length > 0 ||
+                    Object.keys(this.sourceIntelligence.summary || {}).length > 0;
+                if (hasExistingEvidence) {
                     this.sourceIntelligence = {
                         ...this.sourceIntelligence,
                         loading: false,

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -266,7 +266,7 @@ function domainDetailsApp(domainId = '') {
             this.loadInitialData();
 
             this.$watch('filters.dateRange', () => {
-                this.fetchSources();
+                this.fetchSources({ preserveOnFailure: true });
                 this.fetchSourceIntelligence({ preserveOnFailure: true });
             });
             this.$watch('remediationQueueSort', () => {
@@ -429,7 +429,7 @@ function domainDetailsApp(domainId = '') {
             ]);
 
             Promise.allSettled([
-                this.fetchSources(),
+                this.fetchSources({ preserveOnFailure: true }),
                 this.fetchSourceIntelligence({ preserveOnFailure: true })
             ]);
 
@@ -488,7 +488,7 @@ function domainDetailsApp(domainId = '') {
                     this.fetchBimi({ refresh: true }),
                     this.fetchSelectors(),
                     this.fetchReports(),
-                    this.fetchSources({ refresh: true }),
+                    this.fetchSources({ refresh: true, preserveOnFailure: true }),
                     this.fetchSourceIntelligence({ preserveOnFailure: true })
                 ]);
             } finally {
@@ -2612,7 +2612,8 @@ function domainDetailsApp(domainId = '') {
         
         async fetchSources(options = {}) {
             const refresh = Boolean(options.refresh);
-            const keepExistingSourcesVisible = refresh && (this.sources || []).length > 0;
+            const keepExistingSourcesVisible =
+                (refresh || options.preserveOnFailure) && (this.sources || []).length > 0;
             this.sourcesLoading = !keepExistingSourcesVisible;
             this.sourcesError = '';
             try {
@@ -2637,7 +2638,9 @@ function domainDetailsApp(domainId = '') {
                     this.sourcesError = error.message || 'Sending sources could not be loaded.';
                 }
                 if (options.preserveOnFailure) {
-                    this.sourceReputationRefreshError = error.message || 'Source reputation could not be refreshed.';
+                    this.sourceReputationRefreshError =
+                        (error.message || 'Sending sources could not be refreshed.') +
+                        ' Showing the last loaded sending sources.';
                 }
                 console.error('Error fetching sources:', error);
             } finally {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -177,6 +177,7 @@ function domainDetailsApp(domainId = '') {
             loading: true,
             error: ''
         },
+        sourceIntelligenceRefreshError: '',
         ownership: {
             loading: false,
             error: '',
@@ -266,7 +267,7 @@ function domainDetailsApp(domainId = '') {
 
             this.$watch('filters.dateRange', () => {
                 this.fetchSources();
-                this.fetchSourceIntelligence();
+                this.fetchSourceIntelligence({ preserveOnFailure: true });
             });
             this.$watch('remediationQueueSort', () => {
                 this.showAllRemediationQueueItems = false;
@@ -429,7 +430,7 @@ function domainDetailsApp(domainId = '') {
 
             Promise.allSettled([
                 this.fetchSources(),
-                this.fetchSourceIntelligence()
+                this.fetchSourceIntelligence({ preserveOnFailure: true })
             ]);
 
             window.setTimeout(() => {
@@ -488,7 +489,7 @@ function domainDetailsApp(domainId = '') {
                     this.fetchSelectors(),
                     this.fetchReports(),
                     this.fetchSources({ refresh: true }),
-                    this.fetchSourceIntelligence()
+                    this.fetchSourceIntelligence({ preserveOnFailure: true })
                 ]);
             } finally {
                 this.refreshingPage = false;
@@ -2155,13 +2156,13 @@ function domainDetailsApp(domainId = '') {
                 } else if (key === 'source_reputation') {
                     await Promise.allSettled([
                         this.refreshSourceReputation(),
-                        this.fetchSourceIntelligence()
+                        this.fetchSourceIntelligence({ preserveOnFailure: true })
                     ]);
                 } else if (key === 'reports_and_sources') {
                     await Promise.allSettled([
                         this.fetchReports(),
                         this.fetchSources({ refresh: true, preserveOnFailure: true }),
-                        this.fetchSourceIntelligence()
+                        this.fetchSourceIntelligence({ preserveOnFailure: true })
                     ]);
                 } else if (key === 'reports') {
                     await Promise.allSettled([
@@ -2644,9 +2645,10 @@ function domainDetailsApp(domainId = '') {
             }
         },
 
-        async fetchSourceIntelligence() {
+        async fetchSourceIntelligence(options = {}) {
             this.sourceIntelligence.loading = true;
             this.sourceIntelligence.error = '';
+            this.sourceIntelligenceRefreshError = '';
             try {
                 const response = await this.fetchWithTimeout(
                     `/api/v1/domains/${encodeURIComponent(this.domainId)}/source-intelligence?days=${this.sourceDateWindow()}`,
@@ -2665,13 +2667,27 @@ function domainDetailsApp(domainId = '') {
                     error: ''
                 };
             } catch (error) {
-                this.sourceIntelligence = {
-                    regions: [],
-                    anomalies: [],
-                    summary: {},
-                    loading: false,
-                    error: error.message || 'Source intelligence could not be loaded.'
-                };
+                const message = error.message || 'Source intelligence could not be loaded.';
+                const hasExistingEvidence =
+                    (this.sourceIntelligence.regions || []).length > 0 ||
+                    (this.sourceIntelligence.anomalies || []).length > 0;
+                if (options.preserveOnFailure || hasExistingEvidence) {
+                    this.sourceIntelligence = {
+                        ...this.sourceIntelligence,
+                        loading: false,
+                        error: ''
+                    };
+                    this.sourceIntelligenceRefreshError =
+                        `${message} Showing the last loaded source intelligence.`;
+                } else {
+                    this.sourceIntelligence = {
+                        regions: [],
+                        anomalies: [],
+                        summary: {},
+                        loading: false,
+                        error: message
+                    };
+                }
                 console.error('Error fetching source intelligence:', error);
             } finally {
                 this.sourceIntelligence.loading = false;

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -127,10 +127,15 @@ function domainsApp() {
                 this.emptyDomainsCount = Number(data.empty_domains_count || 0);
                 this.emptyDomainsHidden = Number(data.empty_domains_hidden || 0);
             } catch (error) {
-                this.domains = [];
-                this.emptyDomainsCount = 0;
-                this.emptyDomainsHidden = 0;
-                this.loadError = error.message || 'Domains could not be loaded.';
+                if (!refresh || this.domains.length === 0) {
+                    this.domains = [];
+                    this.emptyDomainsCount = 0;
+                    this.emptyDomainsHidden = 0;
+                    this.loadError = error.message || 'Domains could not be loaded.';
+                } else {
+                    this.loadError =
+                        'Domain refresh failed; showing the last loaded domain data.';
+                }
                 console.error('Error fetching domains:', error);
             } finally {
                 this.loading = false;
@@ -286,6 +291,10 @@ function domainsApp() {
                 spf_status: domain.spf_status ?? false,
                 dkim_status: domain.dkim_status ?? false,
                 dns_pending: Boolean(domain.dns_pending),
+                dns_lookup_status: domain.dns_lookup_status || 'ok',
+                dns_lookup_error: domain.dns_lookup_error || '',
+                dns_evidence_source: domain.dns_evidence_source || '',
+                dmarc_policy_source: domain.dmarc_policy_source || '',
                 dns_cached: Boolean(domain.dns_cached),
                 dns_checked_at: domain.dns_checked_at || null,
                 reports_count: domain.report_count,
@@ -307,6 +316,9 @@ function domainsApp() {
                 dmarc_status_class: this.dnsStatusClass(normalized, 'dmarc_status'),
                 spf_status_class: this.dnsStatusClass(normalized, 'spf_status'),
                 dkim_status_class: this.dnsStatusClass(normalized, 'dkim_status'),
+                dns_state_label: this.dnsStateLabel(normalized),
+                dns_state_class: this.dnsStateClass(normalized),
+                dns_checked_label: this.dnsCheckedLabel(normalized),
             };
         },
 
@@ -318,6 +330,34 @@ function domainsApp() {
         dmarcStatusText(domain) {
             if (domain.dns_pending) return 'Pending DNS refresh';
             return domain.dmarc_policy || 'Not configured';
+        },
+
+        dnsStateLabel(domain) {
+            if (domain.dns_pending) return 'DNS queued';
+            if (domain.dns_lookup_status === 'failed') return 'DNS failed';
+            if (domain.dns_lookup_status === 'stale_cache') return 'Last known DNS';
+            if (domain.dns_lookup_status === 'fallback') return 'Fallback DNS';
+            if (domain.dns_lookup_status === 'partial') return 'Partial DNS';
+            if (domain.dns_cached) return 'Cached DNS';
+            if (domain.dns_checked_at) return 'Fresh DNS';
+            return '';
+        },
+
+        dnsStateClass(domain) {
+            if (domain.dns_lookup_status === 'failed') return 'badge-error';
+            if (domain.dns_lookup_status === 'stale_cache') return 'badge-warning';
+            if (domain.dns_lookup_status === 'fallback' || domain.dns_lookup_status === 'partial') {
+                return 'badge-info';
+            }
+            if (domain.dns_pending) return 'badge-ghost';
+            return 'badge-outline';
+        },
+
+        dnsCheckedLabel(domain) {
+            if (!domain.dns_checked_at) return '';
+            const date = new Date(domain.dns_checked_at);
+            if (Number.isNaN(date.getTime())) return '';
+            return `checked ${date.toLocaleString()}`;
         },
 
         visibleDomains() {

--- a/backend/app/static/js/reports-page.js
+++ b/backend/app/static/js/reports-page.js
@@ -164,7 +164,8 @@ function reportsApp() {
             } catch (error) {
                 const message = error.message || 'Reports could not be loaded.';
                 if (preserveOnFailure && hadReports) {
-                    this.warning = `${message} Showing the last loaded reports.`;
+                    const separator = /[.!?]$/.test(message.trim()) ? ' ' : '. ';
+                    this.warning = `${message}${separator}Showing the last loaded reports.`;
                 } else {
                     this.reports = [];
                     this.domains = [];

--- a/backend/app/static/js/reports-page.js
+++ b/backend/app/static/js/reports-page.js
@@ -8,6 +8,7 @@ function reportsApp() {
         reports: [],
         loading: true,
         error: '',
+        warning: '',
 
         init() {
             this.bindPageControls();
@@ -34,7 +35,13 @@ function reportsApp() {
 
                 const retryButton = event.target.closest('[data-report-retry-load]');
                 if (retryButton && root.contains(retryButton)) {
-                    this.fetchReports();
+                    this.fetchReports({ preserveOnFailure: true });
+                    return;
+                }
+
+                const refreshButton = event.target.closest('[data-report-refresh]');
+                if (refreshButton && root.contains(refreshButton)) {
+                    this.fetchReports({ preserveOnFailure: true });
                     return;
                 }
 
@@ -56,6 +63,10 @@ function reportsApp() {
 
         get showError() {
             return !this.loading && Boolean(this.error);
+        },
+
+        get showWarning() {
+            return !this.loading && Boolean(this.warning);
         },
 
         get showReportCount() {
@@ -136,9 +147,12 @@ function reportsApp() {
             return 'bg-red-100 text-red-800';
         },
 
-        async fetchReports() {
+        async fetchReports(options = {}) {
+            const preserveOnFailure = Boolean(options.preserveOnFailure);
+            const hadReports = this.reports.length > 0;
             this.loading = true;
             this.error = '';
+            this.warning = '';
             try {
                 const response = await fetch('/api/v1/reports');
                 if (!response.ok) {
@@ -148,9 +162,14 @@ function reportsApp() {
                 this.reports = reports.map((report) => this.normalizeReport(report));
                 this.domains = [...new Set(this.reports.map((report) => report.domain))].sort();
             } catch (error) {
-                this.reports = [];
-                this.domains = [];
-                this.error = error.message || 'Reports could not be loaded.';
+                const message = error.message || 'Reports could not be loaded.';
+                if (preserveOnFailure && hadReports) {
+                    this.warning = `${message} Showing the last loaded reports.`;
+                } else {
+                    this.reports = [];
+                    this.domains = [];
+                    this.error = message;
+                }
                 console.error('Error fetching reports:', error);
             } finally {
                 this.loading = false;

--- a/backend/app/static/js/tls-reports-page.js
+++ b/backend/app/static/js/tls-reports-page.js
@@ -16,12 +16,16 @@ function tlsReportsApp() {
         selectedFile: null,
         filters: { domain: '', days: '30' },
         summary: emptySummary,
+        warning: '',
         init() {
             this.bindControls();
             this.refresh();
         },
         get showError() {
             return !this.loading && Boolean(this.error);
+        },
+        get showWarning() {
+            return !this.loading && Boolean(this.warning);
         },
         get showEmptyTrends() {
             return !this.loading && !this.error && this.summary.trends.length === 0;
@@ -108,8 +112,10 @@ function tlsReportsApp() {
             });
         },
         async refresh() {
+            const hadSummaryData = this.hasSummaryData(this.summary);
             this.loading = true;
             this.error = '';
+            this.warning = '';
             const params = new URLSearchParams({ days: this.filters.days, limit: '10' });
             if (this.filters.domain.trim()) params.set('domain', this.filters.domain.trim());
             try {
@@ -117,7 +123,12 @@ function tlsReportsApp() {
                 if (!response.ok) throw new Error('Unable to load TLS report summary');
                 this.summary = this.normalizeSummary(await response.json());
             } catch (err) {
-                this.error = err.message || 'Unable to load TLS report summary';
+                const message = err.message || 'Unable to load TLS report summary';
+                if (hadSummaryData) {
+                    this.warning = `${message}. Showing the last loaded TLS report summary.`;
+                } else {
+                    this.error = message;
+                }
             } finally {
                 this.loading = false;
             }
@@ -185,6 +196,16 @@ function tlsReportsApp() {
                 affected_domains: affectedDomains,
                 privacy: { ...emptySummary.privacy, ...(summary.privacy || {}) },
             };
+        },
+        hasSummaryData(summary) {
+            return Boolean(
+                summary?.totals?.reports
+                || summary?.totals?.successful_sessions
+                || summary?.totals?.failed_sessions
+                || summary?.trends?.length
+                || summary?.top_failures?.length
+                || summary?.affected_domains?.length
+            );
         },
         joinValues(values) {
             const joined = (values || []).filter(Boolean).join(', ');

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2058,6 +2058,10 @@
                 </div>
             {% endcall %}
             {% call card_content() %}
+                <p x-show="sourceIntelligenceRefreshError"
+                   x-cloak
+                   class="mb-4 rounded-md border border-[#f2d18c] bg-[#fff8e8] p-3 text-sm text-[#7a4d05]"
+                   x-text="sourceIntelligenceRefreshError"></p>
                 <div class="grid gap-4 lg:grid-cols-2">
                     <div>
                         <h3 class="mb-3 text-sm font-semibold uppercase tracking-wide text-[#5f5c78]">Top regions</h3>

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -111,6 +111,14 @@
                                         <span>·</span>
                                         <span x-text="formatCount(domain.emails_count, 'message')"></span>
                                         <span x-show="!domain.has_activity" class="badge badge-ghost badge-xs">empty</span>
+                                        <span x-show="domain.dns_state_label"
+                                              class="badge badge-xs"
+                                              :class="domain.dns_state_class"
+                                              x-text="domain.dns_state_label"></span>
+                                        <span x-show="domain.dns_checked_label" x-text="domain.dns_checked_label"></span>
+                                        <span x-show="domain.dns_lookup_error && domain.dns_lookup_status !== 'ok'"
+                                              class="max-w-md truncate"
+                                              x-text="domain.dns_lookup_error"></span>
                                     </div>
                                 {% endcall %}
                                 {% call td() %}

--- a/backend/app/templates/reports.html
+++ b/backend/app/templates/reports.html
@@ -39,6 +39,11 @@
                             Reset Filters
                         </button>
                     </div>
+                    <div class="w-full sm:w-auto flex items-end">
+                        <button type="button" class="btn btn-outline btn-md" data-report-refresh>
+                            Refresh
+                        </button>
+                    </div>
                 </div>
             {% endcall %}
         {% endcall %}
@@ -58,6 +63,9 @@
                 {% endcall %}
             {% endcall %}
             {% call card_content() %}
+                <template x-if="showWarning">
+                    <div class="alert alert-warning mb-4" x-text="warning"></div>
+                </template>
                 {% call table() %}
                     {% call thead() %}
                         {% call tr() %}

--- a/backend/app/templates/tls_reports.html
+++ b/backend/app/templates/tls_reports.html
@@ -61,6 +61,9 @@
                 </div>
             {% endcall %}
             {% call card_content() %}
+                <template x-if="showWarning">
+                    <div class="alert alert-warning mb-4" x-text="warning"></div>
+                </template>
                 <template x-if="loading">
                     <div class="py-12 text-center"><span class="loading loading-spinner loading-lg"></span></div>
                 </template>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -755,6 +755,8 @@ def test_reports_uses_external_page_script_for_csp_migration():
     assert '@click="deleteReport' not in template
     assert "data-report-delete" in template
     assert "data-report-delete" in script
+    assert "data-report-refresh" in template
+    assert "data-report-refresh" in script
     assert "bindPageControls()" in script
     assert "event.target instanceof Element" in script
     assert "Number.isNaN(date.getTime())" in script
@@ -773,6 +775,9 @@ def test_reports_page_distinguishes_loading_error_and_empty_states():
     assert "Reports could not be loaded." in script
     assert "No reports match this filter." in template
     assert "Retry loading reports" in template
+    assert "Showing the last loaded reports." in script
+    assert 'x-if="showWarning"' in template
+    assert "warning: ''" in script
     assert '@click="fetchReports()"' not in template
     assert '@click="resetFilters()"' not in template
     assert "data-report-retry-load" in template
@@ -1085,6 +1090,9 @@ def test_tls_reports_uses_external_page_script_for_csp_migration():
     assert "data-tls-upload-file" in template
     assert "data-tls-reports-page" in template
     assert "data-tls-refresh" in script
+    assert "Showing the last loaded TLS report summary." in script
+    assert "hasSummaryData(summary)" in script
+    assert 'x-if="showWarning"' in template
     assert "bindControls()" in script
     assert "normalizeSummary" in script
     assert "event.target instanceof Element" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -815,9 +815,18 @@ def test_domains_uses_external_page_script_for_csp_migration():
     assert "visibleDomains()" in script
     assert "hiddenEmptyDomainCount()" in script
     assert "showEmptyDomainHint()" in script
+    assert "dnsStateLabel(domain)" in script
+    assert "dnsStateClass(domain)" in script
+    assert "dnsCheckedLabel(domain)" in script
+    assert "dns_lookup_status" in script
+    assert "dns_lookup_error" in script
     assert "visibleDomains()" in template
     assert "without reports or volume hidden" in template
     assert "Show empty domains" in template
+    assert "domain.dns_state_label" in template
+    assert "domain.dns_state_class" in template
+    assert "domain.dns_checked_label" in template
+    assert "domain.dns_lookup_error" in template
     assert "data-domain-create-open" in template
     assert "data-domain-create-open" in script
     assert "data-domain-create-dialog" in template
@@ -864,6 +873,8 @@ def test_domains_page_distinguishes_loading_error_and_empty_states():
 
     assert "Loading monitored domains..." in template
     assert "Domains could not be loaded." in script
+    assert "Domain refresh failed; showing the last loaded domain data." in script
+    assert "if (!refresh || this.domains.length === 0)" in script
     assert "No domains found. Add a domain to get started." in template
     assert "Retry loading domains" in template
     assert "All monitored domains are currently hidden" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1647,6 +1647,7 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "this.sourceReputationRefreshError = '';" in script
     assert "keepExistingSourcesVisible" in script
     assert "this.sourcesLoading = !keepExistingSourcesVisible;" in script
+    assert "Showing the last loaded sending sources." in script
     assert "if (!options.preserveOnFailure) {\n                    this.sources = [];" in script
     assert "sourceSeenLabel" in script
     assert "sourceVolumeBars" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1701,6 +1701,10 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "sourceIntelligence.loading" in template
     assert "Loading source intelligence..." in template
     assert "Source intelligence could not be loaded." in script
+    assert "sourceIntelligenceRefreshError" in script
+    assert "sourceIntelligenceRefreshError" in template
+    assert "Showing the last loaded source intelligence." in script
+    assert "preserveOnFailure: true" in script
     assert "remediationQueueLoading" in script
     assert "remediationQueueError" in script
     assert "primaryRemediationItem" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1656,7 +1656,9 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "keepExistingSourcesVisible" in script
     assert "this.sourcesLoading = !keepExistingSourcesVisible;" in script
     assert "Showing the last loaded sending sources." in script
-    assert "if (!options.preserveOnFailure) {\n                    this.sources = [];" in script
+    assert "const hasExistingSources = (this.sources || []).length > 0;" in script
+    assert "if (!options.preserveOnFailure || !hasExistingSources) {" in script
+    assert "if (options.preserveOnFailure && hasExistingSources) {" in script
     assert "sourceSeenLabel" in script
     assert "sourceVolumeBars" in script
     assert "source.reputation.status" in template

--- a/backend/app/tests/test_dns_prewarm.py
+++ b/backend/app/tests/test_dns_prewarm.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.models.domain import Domain
+from app.models.report import DMARCReport, ReportRecord
 from app.services import dns_prewarm
 
 
@@ -58,3 +59,57 @@ def test_canonical_domain_name_normalizes_imported_values():
         )
         == "example.com"
     )
+
+
+@pytest.mark.asyncio
+async def test_prewarm_dns_cache_prioritizes_domains_with_report_activity(db_session, monkeypatch):
+    active_empty = Domain(name="empty.example", active=True)
+    active_reported = Domain(
+        name="reported.example",
+        active=True,
+        dkim_selectors="selector1",
+    )
+    db_session.add_all([active_empty, active_reported])
+    db_session.flush()
+    report = DMARCReport(
+        domain_id=active_reported.id,
+        report_id="report-1",
+        org_name="google.com",
+        begin_date=1783000000,
+        end_date=1783086400,
+    )
+    db_session.add(report)
+    db_session.flush()
+    db_session.add(
+        ReportRecord(
+            report_id=report.id,
+            source_ip="203.0.113.10",
+            count=25,
+            disposition="none",
+            dkim="pass",
+            spf="pass",
+            header_from="reported.example",
+        )
+    )
+    db_session.commit()
+    resolver = AsyncMock()
+
+    monkeypatch.setattr(
+        dns_prewarm,
+        "get_default_provider",
+        lambda _db: resolver,
+    )
+    monkeypatch.setattr(dns_prewarm, "SessionLocal", lambda: db_session)
+    resolve = AsyncMock()
+    monkeypatch.setattr(dns_prewarm, "resolve_domain_dns_cached", resolve)
+    settings = dns_prewarm.get_settings()
+    monkeypatch.setattr(settings, "DNS_STARTUP_PREWARM_ENABLED", True)
+    monkeypatch.setattr(settings, "DNS_STARTUP_PREWARM_LIMIT", 1)
+    monkeypatch.setattr(settings, "DNS_STARTUP_PREWARM_CONCURRENCY", 1)
+
+    await dns_prewarm.prewarm_dns_cache()
+
+    resolve.assert_awaited_once()
+    _, _, domain, *args = resolve.await_args.args
+    assert domain == "reported.example"
+    assert resolve.await_args.kwargs["selectors"] == ["selector1"]

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -401,6 +401,11 @@ operational policy if long-term storage size matters.
 | `DMARQ_DNS_CUSTOM_SERVERS` | Comma-separated custom recursive resolver IP addresses for this deployment | - | `op://...` |
 | `DMARQ_DNS_CUSTOM_DOH_HOSTNAME` | Optional custom DNS-over-HTTPS hostname used when DNS server IPs are not configured or as fallback after resolver failure | - | `op://...` |
 | `DMARQ_DNS_CUSTOM_DOT_HOSTNAME` | Optional custom DNS-over-TLS hostname for operator context | - | `op://...` |
+| `DNS_STARTUP_PREWARM_ENABLED` | Refresh DNS cache rows shortly after startup without blocking the app boot path | `true` | `true` |
+| `DNS_STARTUP_PREWARM_LIMIT` | Maximum monitored domains prewarmed at startup; domains with observed reports and volume are prioritized first | `50` | `100` |
+| `DNS_STARTUP_PREWARM_CONCURRENCY` | Maximum concurrent startup DNS prewarm lookups | `4` | `6` |
+| `DNS_SUMMARY_REFRESH_CONCURRENCY` | Maximum concurrent live DNS refreshes when the domain list reload button recomputes DNS evidence | `6` | `8` |
+| `DNS_SUMMARY_REFRESH_TIMEOUT_SECONDS` | Per-domain timeout for live DNS summary refreshes | `10` | `8` |
 
 The `op://...` examples are intentional 1Password secret-reference placeholders
 for deployment environments that inject tenant-specific DNS resolver details at

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -14,6 +14,18 @@ To add a new domain for DMARC monitoring in DMARQ:
 
 DMARQ will add the domain to your account and begin monitoring for DMARC reports related to this domain.
 
+The domain list hides domains with no reports and no observed message volume by
+default so historical or newly imported empty zones do not dominate daily
+triage. Use **Show empty domains** when you intentionally want to audit those
+domains.
+
+The list also shows compact DNS evidence badges. **Cached DNS** and
+**Fresh DNS** indicate normal evidence, **Fallback DNS** or **Partial DNS**
+means an independent resolver had to be used, **Last known DNS** means DMARQ is
+protecting the UI from a transient resolver failure with recently cached
+evidence, and **DNS failed** means the latest explicit refresh could not produce
+usable evidence.
+
 ## Domain Settings
 
 For each domain, you can configure several settings:
@@ -69,6 +81,11 @@ DMARQ provides a health check feature for each domain:
    - MTA-STS TXT and HTTPS policy validation
    - MX record confirmation
    - BIMI record validation (if applicable)
+
+The Domains page **Reload** action recomputes DNS evidence with bounded
+parallelism, so larger workspaces do not wait for every domain one after
+another. At application startup, DMARQ also prewarms DNS cache rows in the
+background and prioritizes domains that already have reports or message volume.
 
 ### Posture Dashboard
 

--- a/docs/user_guide/reports.md
+++ b/docs/user_guide/reports.md
@@ -43,6 +43,10 @@ The report list shows:
 - Pass/fail statistics
 - DMARC policy applied
 
+Use **Refresh** to reload the aggregate report list from the backend. If the
+backend cannot answer temporarily, DMARQ keeps the last loaded reports visible
+and shows a warning instead of replacing the table with an empty state.
+
 ### Aggregate Report Details
 
 To view details of a specific aggregate report:

--- a/docs/user_guide/tls_reports.md
+++ b/docs/user_guide/tls_reports.md
@@ -17,6 +17,10 @@ Imported reports appear in the same page as:
 - affected policy domains with failure rates
 - receiving MX hostnames and reason codes when reporters include them
 
+Use **Refresh** after importing new TLS-RPT attachments or changing the filter.
+If the summary refresh fails while data is already visible, DMARQ keeps the last
+loaded summary on screen and marks it as stale with a warning.
+
 ## API
 
 TLS reporting endpoints require the same admin authentication as other


### PR DESCRIPTION
## What changed
- Run domain-summary DNS refreshes with bounded concurrency and per-task DB sessions so large domain lists do not serialize every resolver call.
- Surface DNS evidence state badges on the domain list, including queued, cached, fallback, partial, stale, and failed resolver states.
- Prioritize startup DNS cache prewarming for domains with real report and message activity before empty monitored domains.
- Keep previously loaded domain, source-intelligence, sending-source, aggregate-report, and TLS-report data visible when refreshes fail temporarily.
- Document the new DNS refresh/prewarm configuration and stale-data UI behavior in the user/deployment docs and changelog.

## Why
Live app smoke tests showed slow DNS refresh paths and jarring empty states when backend refreshes timed out. This keeps useful evidence visible and makes DNS uncertainty explicit instead of silently clearing data or degrading scores.

## Validation
- `node --check backend/app/static/js/domains-page.js && node --check backend/app/static/js/domain-details-page.js && node --check backend/app/static/js/reports-page.js && node --check backend/app/static/js/tls-reports-page.js`
- `.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/core/config.py backend/app/services/dns_prewarm.py backend/app/tests/test_dns_prewarm.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python -m pytest backend/app/tests/test_dns_prewarm.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_resolver.py backend/app/tests/test_dns_fallbacks.py backend/app/tests/test_api.py -q --tb=short` (286 passed)