### PR TITLE
[codex] align remediation verification surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added remediation verification closure gates and stale-evidence warnings so resolved items are not confused with evidence-verified repairs.
 - Added queue-level closure-gate and rollback-guidance counters to highlight remediation items that still need fresh evidence or a recovery path.
 - Added remediation repair-readiness levels, scores, reasons, and blockers so operators can distinguish preview-ready work from manual, blocked, classification, and reputation-review work.
+- Added first-screen remediation freshness and closure-gate context so the top domain action panel shows what evidence must be current before closure.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 - Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added dashboard remediation verification freshness and closure gates so workspace cards match domain-level repair semantics.
 - Added dashboard remediation verification plans in the API so workspace cards and domain queue cards share the same closure semantics.
 - Added dashboard remediation verification counters for operator approval, sender review, reputation review, fresh-evidence checks, and missing provider values.
+- Added dashboard remediation verification badges, failure modes, and evidence-needed summaries to keep closure guidance visible on each card.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 - Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added queue-level closure-gate and rollback-guidance counters to highlight remediation items that still need fresh evidence or a recovery path.
 - Added remediation repair-readiness levels, scores, reasons, and blockers so operators can distinguish preview-ready work from manual, blocked, classification, and reputation-review work.
 - Added first-screen remediation freshness and closure-gate context so the top domain action panel shows what evidence must be current before closure.
+- Added top-panel remediation evidence controls so operators can open the relevant evidence section or run the safe read-only evidence refresh without scrolling.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 - Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added top-panel remediation evidence controls so operators can open the relevant evidence section or run the safe read-only evidence refresh without scrolling.
 - Added verified-repair freshness counters so stale or unknown repair-history evidence is visible before opening individual entries.
 - Added dashboard remediation verification freshness and closure gates so workspace cards match domain-level repair semantics.
+- Added dashboard remediation verification plans in the API so workspace cards and domain queue cards share the same closure semantics.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 - Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added remediation repair-readiness levels, scores, reasons, and blockers so operators can distinguish preview-ready work from manual, blocked, classification, and reputation-review work.
 - Added first-screen remediation freshness and closure-gate context so the top domain action panel shows what evidence must be current before closure.
 - Added top-panel remediation evidence controls so operators can open the relevant evidence section or run the safe read-only evidence refresh without scrolling.
+- Added verified-repair freshness counters so stale or unknown repair-history evidence is visible before opening individual entries.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 - Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added dashboard remediation verification counters for operator approval, sender review, reputation review, fresh-evidence checks, and missing provider values.
 - Added dashboard remediation verification badges, failure modes, and evidence-needed summaries to keep closure guidance visible on each card.
 - Added dashboard remediation summary breakdowns for approval waits, sender/reputation review, manual evidence checks, and missing provider values.
+- Added explicit domain-detail remediation state labels so approval-ready items do not expose raw internal state names.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 - Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added dashboard remediation verification badges, failure modes, and evidence-needed summaries to keep closure guidance visible on each card.
 - Added dashboard remediation summary breakdowns for approval waits, sender/reputation review, manual evidence checks, and missing provider values.
 - Added explicit domain-detail remediation state labels so approval-ready items do not expose raw internal state names.
+- Added top-level domain remediation verification status, evidence-needed, and failure-mode context before the full remediation queue.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 - Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added dashboard remediation verification counters for operator approval, sender review, reputation review, fresh-evidence checks, and missing provider values.
 - Added dashboard remediation verification badges, failure modes, and evidence-needed summaries to keep closure guidance visible on each card.
 - Added dashboard remediation summary breakdowns for approval waits, sender/reputation review, manual evidence checks, and missing provider values.
+- Added dashboard remediation filters for approval verification, sender review, and report-evidence follow-up work.
 - Added explicit domain-detail remediation state labels so approval-ready items do not expose raw internal state names.
 - Added top-level domain remediation verification status, evidence-needed, and failure-mode context before the full remediation queue.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added dashboard remediation verification plans in the API so workspace cards and domain queue cards share the same closure semantics.
 - Added dashboard remediation verification counters for operator approval, sender review, reputation review, fresh-evidence checks, and missing provider values.
 - Added dashboard remediation verification badges, failure modes, and evidence-needed summaries to keep closure guidance visible on each card.
+- Added dashboard remediation summary breakdowns for approval waits, sender/reputation review, manual evidence checks, and missing provider values.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 - Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added first-screen remediation freshness and closure-gate context so the top domain action panel shows what evidence must be current before closure.
 - Added top-panel remediation evidence controls so operators can open the relevant evidence section or run the safe read-only evidence refresh without scrolling.
 - Added verified-repair freshness counters so stale or unknown repair-history evidence is visible before opening individual entries.
+- Added dashboard remediation verification freshness and closure gates so workspace cards match domain-level repair semantics.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 - Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added verified-repair freshness counters so stale or unknown repair-history evidence is visible before opening individual entries.
 - Added dashboard remediation verification freshness and closure gates so workspace cards match domain-level repair semantics.
 - Added dashboard remediation verification plans in the API so workspace cards and domain queue cards share the same closure semantics.
+- Added dashboard remediation verification counters for operator approval, sender review, reputation review, fresh-evidence checks, and missing provider values.
 - Added next-remediation readiness context and verified-repair freshness gates so operators see the next safe action before opening or closing remediation work.
 - Added dashboard remediation-card readiness reasons, blockers, and next-safe-action text so operators can triage fixes before opening the domain queue.
 - Added dashboard remediation sorting, last-refresh context, a queue refresh control, and domain remediation filters for preview-ready, blocked, evidence-gated, manual, and reputation-review work.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2065,7 +2065,8 @@ def _dashboard_verification_plan(
     context: Dict[str, str],
 ) -> Dict[str, Any]:
     """Return dashboard-safe read-only evidence checks before closure."""
-    if _remediation_track_for_action(state, action) == "blocked_by_prerequisite":
+    track = _remediation_track_for_action(state, action)
+    if track == "blocked_by_prerequisite":
         return {
             "label": "Collect provider value first",
             "status": "blocked_by_prerequisite",
@@ -2085,6 +2086,27 @@ def _dashboard_verification_plan(
                 "Provider-specific target value",
                 "Fresh DNS posture after publishing",
                 "Finding disappears from the remediation queue",
+            ],
+            "next_check": context["verification_next_check"],
+        }
+    if track == "reputation_review":
+        return {
+            "label": "Verify reputation evidence",
+            "status": "pending_reputation_review",
+            "verification_method": "fresh_reputation_evidence",
+            "freshness_requirement": "Fresh reputation or blacklist evidence for this source.",
+            "failure_mode": "Keep investigating if the source remains listed, risky, or unchecked.",
+            "closure_gate": (
+                "Close only after fresh reputation evidence and newer reports support the treatment."
+            ),
+            "stale_evidence_warning": (
+                "Old blacklist or reputation checks can be wrong after provider remediation."
+            ),
+            "summary": "Reputation items need fresh source-intelligence evidence before closure.",
+            "evidence_needed": [
+                "Fresh source reputation lookup",
+                "Current blacklist or risk result",
+                "Newer report evidence for the sender",
             ],
             "next_check": context["verification_next_check"],
         }
@@ -2365,6 +2387,25 @@ def _increment_evidence_refresh_counters(
         counters["evidence_refresh_prerequisite"] += 1
 
 
+def _increment_verification_plan_counters(
+    counters: Dict[str, int],
+    item: Dict[str, Any],
+) -> None:
+    """Count the closure-proof state each dashboard remediation item requires."""
+    verification = item.get("verification_plan") or {}
+    status = str(verification.get("status") or "")
+    if status == "pending_operator_approval":
+        counters["verification_pending_operator_approval"] += 1
+    elif status == "pending_sender_review":
+        counters["verification_pending_sender_review"] += 1
+    elif status == "pending_reputation_review":
+        counters["verification_pending_reputation_review"] += 1
+    elif status == "pending_report_evidence":
+        counters["verification_pending_report_evidence"] += 1
+    elif status == "blocked_by_prerequisite":
+        counters["verification_blocked_by_prerequisite"] += 1
+
+
 def _build_dashboard_remediation_loop(
     domains: List[Dict[str, Any]],
     remediation_activity: Dict[str, Any],
@@ -2392,6 +2433,11 @@ def _build_dashboard_remediation_loop(
         "evidence_refresh_reports": 0,
         "evidence_refresh_reputation": 0,
         "evidence_refresh_prerequisite": 0,
+        "verification_pending_operator_approval": 0,
+        "verification_pending_sender_review": 0,
+        "verification_pending_reputation_review": 0,
+        "verification_pending_report_evidence": 0,
+        "verification_blocked_by_prerequisite": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2405,6 +2451,7 @@ def _build_dashboard_remediation_loop(
             item = _dashboard_remediation_item(domain_name, action)
             _increment_repair_counters(counters, item)
             _increment_evidence_refresh_counters(counters, item)
+            _increment_verification_plan_counters(counters, item)
             track_counters[f"track_{item['remediation_track']}"] += 1
             items.append(item)
 
@@ -2465,6 +2512,11 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         "evidence_refresh_reports": 0,
         "evidence_refresh_reputation": 0,
         "evidence_refresh_prerequisite": 0,
+        "verification_pending_operator_approval": 0,
+        "verification_pending_sender_review": 0,
+        "verification_pending_reputation_review": 0,
+        "verification_pending_report_evidence": 0,
+        "verification_blocked_by_prerequisite": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2475,6 +2527,7 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         item = _dashboard_remediation_item(domain_name, action, include_detail=False)
         _increment_repair_counters(counters, item)
         _increment_evidence_refresh_counters(counters, item)
+        _increment_verification_plan_counters(counters, item)
         track_counters[f"track_{item['remediation_track']}"] += 1
         items.append(item)
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2059,6 +2059,93 @@ def _remediation_operator_decision_summary(state: str) -> str:
     return "Complete the manual action, refresh evidence, then mark the item resolved."
 
 
+def _dashboard_verification_plan(
+    state: str,
+    action: Dict[str, Any],
+    context: Dict[str, str],
+) -> Dict[str, Any]:
+    """Return dashboard-safe read-only evidence checks before closure."""
+    if _remediation_track_for_action(state, action) == "blocked_by_prerequisite":
+        return {
+            "label": "Collect provider value first",
+            "status": "blocked_by_prerequisite",
+            "verification_method": "provider_specific_value_then_health_rebuild",
+            "freshness_requirement": (
+                "The exact provider-specific DKIM, SPF, DMARC, or CNAME target value."
+            ),
+            "failure_mode": "Keep the item blocked until the missing provider value is known.",
+            "closure_gate": (
+                "Close only after the provider value is published and fresh evidence removes the finding."
+            ),
+            "stale_evidence_warning": (
+                "Do not approve or close this until the provider-specific target value is known."
+            ),
+            "summary": "This repair is blocked until DMARQ has the exact provider value.",
+            "evidence_needed": [
+                "Provider-specific target value",
+                "Fresh DNS posture after publishing",
+                "Finding disappears from the remediation queue",
+            ],
+            "next_check": context["verification_next_check"],
+        }
+    if state == "needs_approval":
+        return {
+            "label": "Verify after approved repair",
+            "status": "pending_operator_approval",
+            "verification_method": "provider_write_then_dns_refresh",
+            "freshness_requirement": "Fresh DNS evidence after provider propagation.",
+            "failure_mode": "Keep the item open if the expected record is not visible.",
+            "closure_gate": "Close only after approved provider apply and fresh DNS evidence agree.",
+            "stale_evidence_warning": (
+                "Do not close this from the preview alone; DNS propagation evidence is required."
+            ),
+            "summary": "Provider-backed repairs require explicit approval and fresh DNS evidence.",
+            "evidence_needed": [
+                "Operator-approved provider preview",
+                "Fresh DNS posture after propagation",
+                "Finding disappears from the remediation queue",
+            ],
+            "next_check": context["verification_next_check"],
+        }
+    if state == "investigate":
+        return {
+            "label": "Verify with fresh sender evidence",
+            "status": "pending_sender_review",
+            "verification_method": "fresh_dmarc_report_window",
+            "freshness_requirement": "A newer receiver report covering the active sender.",
+            "failure_mode": "Keep investigating if the source remains unknown, failing, or stale.",
+            "closure_gate": (
+                "Close only after sender classification and newer reports confirm the treatment."
+            ),
+            "stale_evidence_warning": (
+                "Old report rows can describe senders that no longer send mail for this domain."
+            ),
+            "summary": "Investigation items need sender classification and fresh report evidence.",
+            "evidence_needed": [
+                "Sender classification decision",
+                "Fresh receiver report window",
+                "Expected DMARC pass or intentional block",
+            ],
+            "next_check": context["verification_next_check"],
+        }
+    return {
+        "label": "Verify after manual action",
+        "status": "pending_report_evidence",
+        "verification_method": "fresh_health_rebuild",
+        "freshness_requirement": "Fresh DMARC reports or DNS checks after the operator action.",
+        "failure_mode": "Keep the item open if the same health action is still present.",
+        "closure_gate": "Close only after fresh health evidence removes the same finding.",
+        "stale_evidence_warning": "Do not close from an operator note alone; refresh evidence first.",
+        "summary": "Manual remediation needs fresh report or DNS evidence before closure.",
+        "evidence_needed": [
+            "Operator action is complete",
+            "Fresh domain health rebuild",
+            "Finding disappears from the remediation queue",
+        ],
+        "next_check": context["verification_next_check"],
+    }
+
+
 def _dashboard_repair_progression_with_readiness(
     progression: Dict[str, Any],
     *,
@@ -2221,6 +2308,7 @@ def _dashboard_remediation_item(
         "safe_to_automate": _remediation_safe_to_automate(state),
         "operator_decision_summary": _remediation_operator_decision_summary(state),
         "operator_decisions": _remediation_operator_decisions(state),
+        "verification_plan": _dashboard_verification_plan(state, action, context),
         "repair_progression": _dashboard_repair_progression(state, action),
         "severity": str(action.get("severity") or "info"),
         "source": str(action.get("source") or "domain_health"),

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1151,6 +1151,40 @@ function dashboardApp() {
                 '';
         },
 
+        verificationPlanStatusLabel(plan) {
+            const status = typeof plan === 'string' ? plan : plan?.status;
+            return {
+                pending_operator_approval: 'Needs approval',
+                pending_sender_review: 'Sender review',
+                pending_reputation_review: 'Reputation review',
+                pending_report_evidence: 'Fresh evidence',
+                blocked_by_prerequisite: 'Blocked'
+            }[String(status || '')] || 'Verification needed';
+        },
+
+        verificationPlanStatusClass(plan) {
+            const status = typeof plan === 'string' ? plan : plan?.status;
+            return {
+                pending_operator_approval: 'bg-[#edf7f7] text-[#247982]',
+                pending_sender_review: 'bg-blue-100 text-blue-700',
+                pending_reputation_review: 'bg-purple-100 text-purple-700',
+                pending_report_evidence: 'bg-yellow-100 text-yellow-800',
+                blocked_by_prerequisite: 'bg-red-100 text-red-700'
+            }[String(status || '')] || 'bg-[#f8f7f6] text-[#5f5c78]';
+        },
+
+        verificationPlanFailureMode(plan) {
+            return plan?.failure_mode || 'Keep this open until fresh evidence confirms the finding is gone.';
+        },
+
+        verificationPlanEvidenceNeededText(plan) {
+            const evidence = plan?.evidence_needed || [];
+            if (Array.isArray(evidence) && evidence.length) {
+                return evidence.slice(0, 3).join(' · ');
+            }
+            return 'Fresh DNS, report, or source evidence.';
+        },
+
         remediationLoopStatusLabel(status) {
             return {
                 clear: 'Clear',

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -19,6 +19,9 @@ function dashboardApp() {
             { value: 'all', label: 'All' },
             { value: 'preview_ready', label: 'Preview ready' },
             { value: 'fresh_evidence', label: 'Fresh evidence' },
+            { value: 'approval_verification', label: 'Approval' },
+            { value: 'sender_review', label: 'Sender review' },
+            { value: 'report_evidence', label: 'Report evidence' },
             { value: 'stale_evidence', label: 'Stale evidence' },
             { value: 'blocked', label: 'Blocked' },
             { value: 'waiting_operator', label: 'Waiting' },
@@ -1071,6 +1074,7 @@ function dashboardApp() {
             const track = String(item?.remediation_track || '');
             const refresh = item?.evidence_refresh || {};
             const refreshKey = String(refresh.refresh_key || '');
+            const verificationStatus = String(item?.verification_plan?.status || '');
             if (filterValue === 'preview_ready') {
                 return readinessLevel === 'ready_for_preview' || stage === 'preview_ready';
             }
@@ -1078,6 +1082,17 @@ function dashboardApp() {
                 return Boolean(refresh.required) ||
                     Boolean(progression.verification_required) ||
                     Boolean(item?.action_plan?.requires_fresh_evidence);
+            }
+            if (filterValue === 'approval_verification') {
+                return verificationStatus === 'pending_operator_approval' ||
+                    (!verificationStatus &&
+                        ['approval_ready', 'needs_approval'].includes(String(item?.state || '')));
+            }
+            if (filterValue === 'sender_review') {
+                return verificationStatus === 'pending_sender_review';
+            }
+            if (filterValue === 'report_evidence') {
+                return verificationStatus === 'pending_report_evidence';
             }
             if (filterValue === 'stale_evidence') {
                 return Boolean(this.remediationStaleEvidenceText(item));

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -695,6 +695,30 @@ function domainDetailsApp(domainId = '') {
             return this.remediationDispatchNextStep(dispatch);
         },
 
+        get primaryRemediationFreshnessText() {
+            const item = this.primaryRemediationItem;
+            if (!item) return '';
+            return item.verification_plan?.freshness_requirement ||
+                item.evidence_refresh?.label ||
+                'Fresh report, DNS, or source evidence is required before closure.';
+        },
+
+        get primaryRemediationClosureGateText() {
+            const item = this.primaryRemediationItem;
+            if (!item) return '';
+            return item.verification_plan?.closure_gate ||
+                item.evidence_refresh?.completion_signal ||
+                'Keep this item open until fresh evidence removes the finding.';
+        },
+
+        get primaryRemediationStaleWarningText() {
+            const item = this.primaryRemediationItem;
+            if (!item) return '';
+            return item.verification_plan?.stale_evidence_warning ||
+                item.evidence_refresh?.stale_warning ||
+                '';
+        },
+
         get primaryRepairProgressionText() {
             const progression = this.primaryRemediationItem?.repair_progression;
             if (!progression) return 'Repair status will appear after the remediation queue finishes loading.';
@@ -1213,6 +1237,25 @@ function domainDetailsApp(domainId = '') {
         repairReadinessScore(progression) {
             const score = Number(progression?.readiness_score || 0);
             return Number.isFinite(score) ? Math.max(0, Math.min(100, Math.round(score))) : 0;
+        },
+
+        verifiedFreshnessClass(verified) {
+            const status = String(verified?.freshness_status || '');
+            if (status === 'current_queue_absence') return 'bg-teal-100 text-teal-700';
+            if (status === 'stale_queue_absence') return 'bg-yellow-100 text-yellow-800';
+            if (status === 'unknown_queue_absence_age') return 'bg-orange-100 text-orange-700';
+            return 'bg-[#f6f8fb] text-[#45505f]';
+        },
+
+        verifiedFreshnessWarning(verified) {
+            const status = String(verified?.freshness_status || '');
+            if (status === 'stale_queue_absence') {
+                return 'Refresh the remediation queue and evidence before relying on this repair as still fixed.';
+            }
+            if (status === 'unknown_queue_absence_age') {
+                return 'Queue absence age is unknown; refresh evidence before treating this as current.';
+            }
+            return '';
         },
 
         remediationEvidenceRefreshClass(refresh) {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1121,10 +1121,20 @@ function domainDetailsApp(domainId = '') {
         },
 
         remediationStateClass(state) {
-            if (state === 'approval_ready') return 'bg-green-100 text-green-700';
+            if (state === 'approval_ready' || state === 'needs_approval') return 'bg-green-100 text-green-700';
             if (state === 'manual_action') return 'bg-yellow-100 text-yellow-800';
             if (state === 'investigate') return 'bg-blue-100 text-blue-700';
             return 'bg-base-200 text-base-content/70';
+        },
+
+        remediationStateLabel(state) {
+            const labels = {
+                approval_ready: 'Needs approval',
+                needs_approval: 'Needs approval',
+                manual_action: 'Manual action',
+                investigate: 'Investigate'
+            };
+            return labels[state] || this.humanizeToken(state || 'review');
         },
 
         remediationNotificationClass(state) {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1317,6 +1317,19 @@ function domainDetailsApp(domainId = '') {
             return this.showAllVerifiedRemediationItems ? items : items.slice(0, VERIFIED_ITEMS_COMPACT_LIMIT);
         },
 
+        verifiedFreshnessCounts() {
+            return (this.remediationQueue.verified_items || []).reduce(
+                (counts, item) => {
+                    const status = String(item?.freshness_status || '');
+                    if (status === 'current_queue_absence') counts.current += 1;
+                    else if (status === 'stale_queue_absence') counts.stale += 1;
+                    else counts.unknown += 1;
+                    return counts;
+                },
+                { current: 0, stale: 0, unknown: 0 }
+            );
+        },
+
         visibleRemediationQueueItems() {
             const items = this.filteredRemediationQueueItems(this.remediationQueueFilter);
             return this.showAllRemediationQueueItems ? items : items.slice(0, 6);

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -695,6 +695,23 @@ function domainDetailsApp(domainId = '') {
             return this.remediationDispatchNextStep(dispatch);
         },
 
+        get primaryRemediationVerificationStatusLabel() {
+            return this.verificationPlanStatusLabel(this.primaryRemediationItem?.verification_plan);
+        },
+
+        get primaryRemediationVerificationStatusClass() {
+            return this.verificationPlanStatusClass(this.primaryRemediationItem?.verification_plan);
+        },
+
+        get primaryRemediationEvidenceNeededText() {
+            return this.verificationPlanEvidenceNeededText(this.primaryRemediationItem?.verification_plan);
+        },
+
+        get primaryRemediationFailureModeText() {
+            return this.primaryRemediationItem?.verification_plan?.failure_mode ||
+                'Keep this item open until fresh evidence confirms the finding is gone.';
+        },
+
         get primaryRemediationFreshnessText() {
             const item = this.primaryRemediationItem;
             if (!item) return '';
@@ -1135,6 +1152,38 @@ function domainDetailsApp(domainId = '') {
                 investigate: 'Investigate'
             };
             return labels[state] || this.humanizeToken(state || 'review');
+        },
+
+        verificationPlanStatusLabel(plan) {
+            const status = typeof plan === 'string' ? plan : plan?.status;
+            const labels = {
+                pending_operator_approval: 'Needs approval',
+                pending_sender_review: 'Sender review',
+                pending_reputation_review: 'Reputation review',
+                pending_report_evidence: 'Fresh evidence',
+                blocked_by_prerequisite: 'Blocked'
+            };
+            return labels[status] || 'Verification needed';
+        },
+
+        verificationPlanStatusClass(plan) {
+            const status = typeof plan === 'string' ? plan : plan?.status;
+            const classes = {
+                pending_operator_approval: 'bg-green-100 text-green-700',
+                pending_sender_review: 'bg-blue-100 text-blue-700',
+                pending_reputation_review: 'bg-purple-100 text-purple-700',
+                pending_report_evidence: 'bg-yellow-100 text-yellow-800',
+                blocked_by_prerequisite: 'bg-red-100 text-red-700'
+            };
+            return classes[status] || 'bg-base-200 text-base-content/70';
+        },
+
+        verificationPlanEvidenceNeededText(plan) {
+            const evidence = plan?.evidence_needed || [];
+            if (Array.isArray(evidence) && evidence.length) {
+                return evidence.slice(0, 3).join(' · ');
+            }
+            return 'Fresh DNS, report, or source evidence.';
         },
 
         remediationNotificationClass(state) {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -719,6 +719,12 @@ function domainDetailsApp(domainId = '') {
                 '';
         },
 
+        get primaryRemediationEvidenceHref() {
+            const item = this.primaryRemediationItem;
+            if (!item?.evidence_refresh?.ui_anchor) return '';
+            return this.remediationEvidenceAnchorHref(item);
+        },
+
         get primaryRepairProgressionText() {
             const progression = this.primaryRemediationItem?.repair_progression;
             if (!progression) return 'Repair status will appear after the remediation queue finishes loading.';

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -99,6 +99,9 @@
                                 <span class="rounded px-2 py-1 text-xs font-semibold"
                                       :class="repairReadinessClass(primaryRemediationItem.repair_progression)"
                                       x-text="repairReadinessLabel(primaryRemediationItem.repair_progression)"></span>
+                                <span class="rounded px-2 py-1 text-xs font-semibold"
+                                      :class="primaryRemediationVerificationStatusClass"
+                                      x-text="primaryRemediationVerificationStatusLabel"></span>
                             </div>
                             <h2 class="mt-2 text-lg font-semibold text-[#07071f]" x-text="primaryRemediationItem.title"></h2>
                             <p class="mt-1 text-sm text-[#5f5c78]" x-text="primaryRemediationItem.detail"></p>
@@ -145,6 +148,16 @@
                             <p class="mt-3 rounded border border-[#f3d2a4] bg-[#fff8ed] px-3 py-2 text-xs font-semibold text-[#7a4a00]"
                                x-show="primaryRemediationStaleWarningText"
                                x-text="primaryRemediationStaleWarningText"></p>
+                            <div class="mt-3 grid gap-2 text-xs md:grid-cols-2">
+                                <p class="rounded border border-[#e6e3e1] bg-white px-3 py-2 text-[#45505f]">
+                                    <span class="font-semibold text-[#120d36]">Evidence needed: </span>
+                                    <span x-text="primaryRemediationEvidenceNeededText"></span>
+                                </p>
+                                <p class="rounded border border-[#e6e3e1] bg-white px-3 py-2 text-[#45505f]">
+                                    <span class="font-semibold text-[#120d36]">If not fixed: </span>
+                                    <span x-text="primaryRemediationFailureModeText"></span>
+                                </p>
+                            </div>
                         </div>
                         <div class="flex flex-wrap gap-2">
                             <a x-show="primaryRemediationEvidenceHref"

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -102,7 +102,7 @@
                             </div>
                             <h2 class="mt-2 text-lg font-semibold text-[#07071f]" x-text="primaryRemediationItem.title"></h2>
                             <p class="mt-1 text-sm text-[#5f5c78]" x-text="primaryRemediationItem.detail"></p>
-                            <div class="mt-3 grid gap-3 md:grid-cols-4">
+                            <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-6">
                                 <div class="rounded-md bg-white p-3">
                                     <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next safe action</p>
                                     <p class="mt-1 text-sm text-[#120d36]" x-text="primaryRemediationNextSafeAction"></p>
@@ -130,10 +130,21 @@
                                     <p class="mt-1 text-xs text-[#5f5c78]" x-text="primaryRemediationBlockedText"></p>
                                 </div>
                                 <div class="rounded-md bg-white p-3">
+                                    <p class="text-xs font-semibold uppercase text-[#5f5c78]">Freshness required</p>
+                                    <p class="mt-1 text-sm text-[#120d36]" x-text="primaryRemediationFreshnessText"></p>
+                                </div>
+                                <div class="rounded-md bg-white p-3">
+                                    <p class="text-xs font-semibold uppercase text-[#5f5c78]">Closure gate</p>
+                                    <p class="mt-1 text-sm text-[#120d36]" x-text="primaryRemediationClosureGateText"></p>
+                                </div>
+                                <div class="rounded-md bg-white p-3">
                                     <p class="text-xs font-semibold uppercase text-[#5f5c78]">Operator dispatch</p>
                                     <p class="mt-1 text-sm text-[#120d36]" x-text="primaryRemediationDispatchText"></p>
                                 </div>
                             </div>
+                            <p class="mt-3 rounded border border-[#f3d2a4] bg-[#fff8ed] px-3 py-2 text-xs font-semibold text-[#7a4a00]"
+                               x-show="primaryRemediationStaleWarningText"
+                               x-text="primaryRemediationStaleWarningText"></p>
                         </div>
                         <a href="#remediation-queue" class="btn btn-sm border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f]">
                             Open queue
@@ -487,7 +498,8 @@
                                             <span class="flex flex-wrap items-center gap-1">
                                                 <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700"
                                                       x-text="verified.label"></span>
-                                                <span class="rounded bg-[#f6f8fb] px-2 py-1 font-semibold text-[#45505f]"
+                                                <span class="rounded px-2 py-1 font-semibold"
+                                                      :class="verifiedFreshnessClass(verified)"
                                                       x-text="verified.freshness_label || 'Queue absence'"></span>
                                             </span>
                                         </div>
@@ -518,6 +530,13 @@
                                             <span class="font-semibold">Closure gate: </span>
                                             <span x-text="verified.closure_gate || 'Keep this item closed only while fresh evidence keeps it absent.'"></span>
                                         </p>
+                                        <p class="mt-1 rounded bg-[#f6f8fb] px-2 py-1 text-[#45505f]">
+                                            <span class="font-semibold">Freshness gate: </span>
+                                            <span x-text="verified.freshness_label || 'Queue absence age unknown'"></span>
+                                        </p>
+                                        <p class="mt-1 rounded border border-[#f3d2a4] bg-[#fff8ed] px-2 py-1 font-semibold text-[#7a4a00]"
+                                           x-show="verifiedFreshnessWarning(verified)"
+                                           x-text="verifiedFreshnessWarning(verified)"></p>
                                         <p class="mt-1 rounded bg-[#f6f8fb] px-2 py-1 text-[#45505f]">
                                             <span class="font-semibold">Next safe action: </span>
                                             <span x-text="verified.next_safe_action || verified.next_check || 'Keep monitoring fresh evidence.'"></span>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -505,6 +505,17 @@
                                     <span x-text="verifiedItemsTotalCount()"></span><span> no longer observed</span>
                                 </span>
                             </div>
+                            <div class="mt-2 flex flex-wrap gap-2 text-xs">
+                                <span class="rounded bg-teal-100 px-2 py-1 font-semibold text-teal-700">
+                                    <span x-text="verifiedFreshnessCounts().current"></span><span> fresh</span>
+                                </span>
+                                <span class="rounded bg-yellow-100 px-2 py-1 font-semibold text-yellow-800">
+                                    <span x-text="verifiedFreshnessCounts().stale"></span><span> stale</span>
+                                </span>
+                                <span class="rounded bg-orange-100 px-2 py-1 font-semibold text-orange-700">
+                                    <span x-text="verifiedFreshnessCounts().unknown"></span><span> unknown age</span>
+                                </span>
+                            </div>
                             <div class="mt-2 grid gap-2 md:grid-cols-2">
                                 <template x-for="verified in visibleVerifiedItems()"
                                           :key="'verified-' + verified.item_id">

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -90,7 +90,7 @@
                                 <p class="text-xs font-semibold uppercase text-[#5f5c78]">Next remediation</p>
                                 <span class="rounded px-2 py-1 text-xs font-semibold capitalize"
                                       :class="remediationStateClass(primaryRemediationItem.state)"
-                                      x-text="primaryRemediationItem.state.split('_').join(' ')"></span>
+                                      x-text="remediationStateLabel(primaryRemediationItem.state)"></span>
                                 <span class="inline-flex items-center gap-1 text-xs font-semibold uppercase text-[#5f5c78]">
                                     <span class="h-2 w-2 rounded-full"
                                           :class="remediationSeverityDotClass(primaryRemediationItem.severity)"></span>
@@ -706,7 +706,7 @@
                                         <div class="flex flex-wrap items-center gap-2">
                                             <span class="rounded px-2 py-1 text-xs font-semibold capitalize"
                                                   :class="remediationStateClass(item.state)"
-                                                  x-text="item.state.split('_').join(' ')"></span>
+                                                  x-text="remediationStateLabel(item.state)"></span>
                                             <span class="inline-flex items-center gap-1 text-xs font-semibold uppercase text-[#5f5c78]">
                                                 <span class="h-2 w-2 rounded-full"
                                                       :class="remediationSeverityDotClass(item.severity)"></span>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -146,9 +146,25 @@
                                x-show="primaryRemediationStaleWarningText"
                                x-text="primaryRemediationStaleWarningText"></p>
                         </div>
-                        <a href="#remediation-queue" class="btn btn-sm border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f]">
-                            Open queue
-                        </a>
+                        <div class="flex flex-wrap gap-2">
+                            <a x-show="primaryRemediationEvidenceHref"
+                               :href="primaryRemediationEvidenceHref"
+                               class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5]">
+                                Open evidence
+                            </a>
+                            <button type="button"
+                                    x-show="primaryRemediationItem.evidence_refresh"
+                                    class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5]"
+                                    :disabled="primaryRemediationItem.evidence_refresh?.safe_to_run === false || remediationActionBusy(primaryRemediationItem)"
+                                    :data-remediation-item-id="primaryRemediationItem.id"
+                                    data-domain-detail-remediation-refresh-evidence>
+                                <span x-show="remediationActionBusy(primaryRemediationItem, 'refresh_evidence')" class="loading loading-spinner loading-xs"></span>
+                                <span x-text="remediationEvidenceRefreshActionLabel(primaryRemediationItem.evidence_refresh)"></span>
+                            </button>
+                            <a href="#remediation-queue" class="btn btn-sm border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f]">
+                                Open queue
+                            </a>
+                        </div>
                     </div>
                 </template>
                 <template x-if="!remediationQueueLoading && !remediationQueueError && !primaryRemediationItem">

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -398,6 +398,16 @@
                     <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3 text-xs">
                         <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Next verification</p>
                         <p class="mt-1 text-[#120d36]" x-text="item.verification_next_check"></p>
+                        <div class="mt-2 grid gap-2 sm:grid-cols-2">
+                            <div class="rounded bg-white px-2 py-1 text-[#45505f]">
+                                <span class="font-semibold">Freshness: </span>
+                                <span x-text="item.verification_plan?.freshness_requirement || 'fresh report or DNS evidence'"></span>
+                            </div>
+                            <div class="rounded bg-white px-2 py-1 text-[#45505f]">
+                                <span class="font-semibold">Closure gate: </span>
+                                <span x-text="item.verification_plan?.closure_gate || item.completion_criteria"></span>
+                            </div>
+                        </div>
                     </div>
                     <div class="mt-3 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-3 text-xs"
                          x-show="item.evidence_refresh?.required">

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -259,6 +259,10 @@
                 <p class="text-sm text-[#5f5c78]">Needs approval</p>
                 <p class="mt-2 text-3xl font-bold text-[#120d36]" x-text="remediationLoop().needs_approval || 0"></p>
                 <p class="mt-1 text-xs text-[#5f5c78]">DNS or policy changes to review</p>
+                <p class="mt-2 text-xs text-[#45505f]">
+                    <span x-text="remediationLoop().verification_pending_operator_approval || 0"></span>
+                    <span> waiting for explicit approval</span>
+                </p>
             </div>
             <div class="rounded-md border border-[#e6e3e1] p-4">
                 <p class="text-sm text-[#5f5c78]">Manual action</p>
@@ -289,6 +293,8 @@
                     <span x-text="remediationLoop().evidence_refresh_reports || 0"></span><span> reports</span>
                     <span> · </span>
                     <span x-text="remediationLoop().evidence_refresh_reputation || 0"></span><span> reputation</span>
+                    <span> · </span>
+                    <span x-text="remediationLoop().verification_pending_report_evidence || 0"></span><span> manual evidence</span>
                 </p>
             </div>
             <div class="rounded-md border border-[#d5e9f8] bg-[#f7fbff] p-4">
@@ -296,12 +302,21 @@
                 <p class="mt-2 text-2xl font-bold text-[#24507a]"
                    x-text="remediationLoop().repair_waiting_on_operator || 0"></p>
                 <p class="mt-1 text-xs text-[#5f5c78]">Classification, manual repair, reputation, or review</p>
+                <p class="mt-2 text-xs text-[#24507a]">
+                    <span x-text="remediationLoop().verification_pending_sender_review || 0"></span><span> sender</span>
+                    <span> · </span>
+                    <span x-text="remediationLoop().verification_pending_reputation_review || 0"></span><span> reputation</span>
+                </p>
             </div>
             <div class="rounded-md border border-[#e6e3e1] p-4">
                 <p class="text-sm text-[#5f5c78]">Blocked before repair</p>
                 <p class="mt-2 text-2xl font-bold text-[#5f5c78]"
                    x-text="remediationLoop().repair_readiness_blocked || remediationLoop().repair_blocked || 0"></p>
                 <p class="mt-1 text-xs text-[#5f5c78]">Missing provider values or prerequisites</p>
+                <p class="mt-2 text-xs text-[#5f5c78]">
+                    <span x-text="remediationLoop().verification_blocked_by_prerequisite || 0"></span>
+                    <span> provider values required</span>
+                </p>
             </div>
         </div>
         <div class="mt-5 flex flex-wrap items-center gap-2" x-show="hasRemediationLoopItems()">

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -396,7 +396,12 @@
                            x-text="repairReadinessBlockedText(item.repair_progression)"></p>
                     </div>
                     <div class="mt-3 rounded border border-[#e6e3e1] bg-[#fbfaf9] p-3 text-xs">
-                        <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Next verification</p>
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                            <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Next verification</p>
+                            <span class="rounded px-2 py-1 font-semibold"
+                                  :class="verificationPlanStatusClass(item.verification_plan)"
+                                  x-text="verificationPlanStatusLabel(item.verification_plan)"></span>
+                        </div>
                         <p class="mt-1 text-[#120d36]" x-text="item.verification_next_check"></p>
                         <div class="mt-2 grid gap-2 sm:grid-cols-2">
                             <div class="rounded bg-white px-2 py-1 text-[#45505f]">
@@ -406,6 +411,14 @@
                             <div class="rounded bg-white px-2 py-1 text-[#45505f]">
                                 <span class="font-semibold">Closure gate: </span>
                                 <span x-text="item.verification_plan?.closure_gate || item.completion_criteria"></span>
+                            </div>
+                            <div class="rounded bg-white px-2 py-1 text-[#45505f]">
+                                <span class="font-semibold">Failure mode: </span>
+                                <span x-text="verificationPlanFailureMode(item.verification_plan)"></span>
+                            </div>
+                            <div class="rounded bg-white px-2 py-1 text-[#45505f]">
+                                <span class="font-semibold">Evidence needed: </span>
+                                <span x-text="verificationPlanEvidenceNeededText(item.verification_plan)"></span>
                             </div>
                         </div>
                     </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -421,6 +421,10 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "Next safe action" in template
     assert "item.verification_plan?.freshness_requirement" in template
     assert "item.verification_plan?.closure_gate" in template
+    assert "verificationPlanStatusClass(item.verification_plan)" in template
+    assert "verificationPlanStatusLabel(item.verification_plan)" in template
+    assert "verificationPlanFailureMode(item.verification_plan)" in template
+    assert "verificationPlanEvidenceNeededText(item.verification_plan)" in template
     assert "repairReadinessClass(item.repair_progression)" in template
     assert "repairReadinessLabel(item.repair_progression)" in template
     assert "repairReadinessScore(item.repair_progression)" in template
@@ -451,6 +455,11 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "repairReadinessClass(progression)" in script
     assert "repairReadinessLabel(progression)" in script
     assert "repairReadinessScore(progression)" in script
+    assert "verificationPlanStatusLabel(plan)" in script
+    assert "pending_reputation_review: 'Reputation review'" in script
+    assert "verificationPlanStatusClass(plan)" in script
+    assert "verificationPlanFailureMode(plan)" in script
+    assert "verificationPlanEvidenceNeededText(plan)" in script
 
 
 def test_dashboard_remediation_filters_and_sorts_cards():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -411,6 +411,12 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
         "remediationLoop().repair_readiness_blocked || remediationLoop().repair_blocked || 0"
         in template
     )
+    assert "remediationLoop().verification_pending_operator_approval || 0" in template
+    assert "remediationLoop().verification_pending_report_evidence || 0" in template
+    assert "remediationLoop().verification_pending_sender_review || 0" in template
+    assert "remediationLoop().verification_pending_reputation_review || 0" in template
+    assert "remediationLoop().verification_blocked_by_prerequisite || 0" in template
+    assert "provider values required" in template
     assert "Repair gate" in template
     assert "repairProgressionClass(item.repair_progression)" in template
     assert "repairProgressionLabel(item.repair_progression)" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1754,8 +1754,15 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "primaryRemediationClosureGateText" in script
     assert "primaryRemediationStaleWarningText" in script
     assert "primaryRemediationEvidenceHref" in script
+    assert "primaryRemediationVerificationStatusLabel" in script
+    assert "primaryRemediationVerificationStatusClass" in script
+    assert "primaryRemediationEvidenceNeededText" in script
+    assert "primaryRemediationFailureModeText" in script
     assert "remediationStateLabel(state)" in script
     assert "needs_approval: 'Needs approval'" in script
+    assert "verificationPlanStatusLabel(plan)" in script
+    assert "verificationPlanStatusClass(plan)" in script
+    assert "verificationPlanEvidenceNeededText(plan)" in script
     assert "Next remediation" in template
     assert "Loading next remediation..." in template
     assert "Next remediation could not be loaded." in template
@@ -1772,6 +1779,12 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "primaryRemediationClosureGateText" in template
     assert "primaryRemediationStaleWarningText" in template
     assert "primaryRemediationEvidenceHref" in template
+    assert "primaryRemediationVerificationStatusClass" in template
+    assert "primaryRemediationVerificationStatusLabel" in template
+    assert "primaryRemediationEvidenceNeededText" in template
+    assert "primaryRemediationFailureModeText" in template
+    assert "Evidence needed:" in template
+    assert "If not fixed:" in template
     assert "Open evidence" in template
     assert 'data-domain-detail-remediation-refresh-evidence' in template
     assert "remediationEvidenceRefreshActionLabel(primaryRemediationItem.evidence_refresh)" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1617,6 +1617,9 @@ def test_domain_details_distinguishes_evidence_verified_repairs_without_html_inj
     assert "verifiedFreshnessWarning(verified)" in template
     assert "verifiedFreshnessClass(verified)" in script
     assert "verifiedFreshnessWarning(verified)" in script
+    assert "verifiedFreshnessCounts()" in template
+    assert "verifiedFreshnessCounts()" in script
+    assert "unknown age" in template
     assert "Freshness gate" in template
     assert "Refresh the remediation queue and evidence before relying on this repair" in script
     assert "verified.detail" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1733,6 +1733,7 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "primaryRemediationFreshnessText" in script
     assert "primaryRemediationClosureGateText" in script
     assert "primaryRemediationStaleWarningText" in script
+    assert "primaryRemediationEvidenceHref" in script
     assert "Next remediation" in template
     assert "Loading next remediation..." in template
     assert "Next remediation could not be loaded." in template
@@ -1745,6 +1746,10 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "primaryRemediationFreshnessText" in template
     assert "primaryRemediationClosureGateText" in template
     assert "primaryRemediationStaleWarningText" in template
+    assert "primaryRemediationEvidenceHref" in template
+    assert "Open evidence" in template
+    assert 'data-domain-detail-remediation-refresh-evidence' in template
+    assert "remediationEvidenceRefreshActionLabel(primaryRemediationItem.evidence_refresh)" in template
     assert "item.state.split('_').join(' ')" in template
     assert "Repair readiness" in template
     assert "primaryRepairReadinessReasonText" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1754,11 +1754,16 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "primaryRemediationClosureGateText" in script
     assert "primaryRemediationStaleWarningText" in script
     assert "primaryRemediationEvidenceHref" in script
+    assert "remediationStateLabel(state)" in script
+    assert "needs_approval: 'Needs approval'" in script
     assert "Next remediation" in template
     assert "Loading next remediation..." in template
     assert "Next remediation could not be loaded." in template
     assert "No remediation queued" in template
-    assert "primaryRemediationItem.state.split('_').join(' ')" in template
+    assert "remediationStateLabel(primaryRemediationItem.state)" in template
+    assert "remediationStateLabel(item.state)" in template
+    assert "primaryRemediationItem.state.split('_').join(' ')" not in template
+    assert "item.state.split('_').join(' ')" not in template
     assert "repairReadinessLabel(primaryRemediationItem.repair_progression)" in template
     assert "repairReadinessScore(primaryRemediationItem.repair_progression)" in template
     assert "Next safe action" in template
@@ -1770,7 +1775,6 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "Open evidence" in template
     assert 'data-domain-detail-remediation-refresh-evidence' in template
     assert "remediationEvidenceRefreshActionLabel(primaryRemediationItem.evidence_refresh)" in template
-    assert "item.state.split('_').join(' ')" in template
     assert "Repair readiness" in template
     assert "primaryRepairReadinessReasonText" in script
     assert "repairReadinessLabel(primaryRemediationItem.repair_progression)" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -419,6 +419,8 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "repairReadinessReason(item.repair_progression)" in template
     assert "repairReadinessBlockedText(item.repair_progression)" in template
     assert "Next safe action" in template
+    assert "item.verification_plan?.freshness_requirement" in template
+    assert "item.verification_plan?.closure_gate" in template
     assert "repairReadinessClass(item.repair_progression)" in template
     assert "repairReadinessLabel(item.repair_progression)" in template
     assert "repairReadinessScore(item.repair_progression)" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1613,6 +1613,12 @@ def test_domain_details_distinguishes_evidence_verified_repairs_without_html_inj
     assert "verified.item_id" in template
     assert "verified.label" in template
     assert "verified.freshness_label" in template
+    assert "verifiedFreshnessClass(verified)" in template
+    assert "verifiedFreshnessWarning(verified)" in template
+    assert "verifiedFreshnessClass(verified)" in script
+    assert "verifiedFreshnessWarning(verified)" in script
+    assert "Freshness gate" in template
+    assert "Refresh the remediation queue and evidence before relying on this repair" in script
     assert "verified.detail" in template
     assert "Closure gate" in template
     assert "verified.closure_gate" in template
@@ -1724,6 +1730,9 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "primaryRemediationReadinessContext" in script
     assert "primaryRemediationBlockedText" in script
     assert "primaryRemediationDispatchText" in script
+    assert "primaryRemediationFreshnessText" in script
+    assert "primaryRemediationClosureGateText" in script
+    assert "primaryRemediationStaleWarningText" in script
     assert "Next remediation" in template
     assert "Loading next remediation..." in template
     assert "Next remediation could not be loaded." in template
@@ -1732,6 +1741,10 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "repairReadinessLabel(primaryRemediationItem.repair_progression)" in template
     assert "repairReadinessScore(primaryRemediationItem.repair_progression)" in template
     assert "Next safe action" in template
+    assert "Freshness required" in template
+    assert "primaryRemediationFreshnessText" in template
+    assert "primaryRemediationClosureGateText" in template
+    assert "primaryRemediationStaleWarningText" in template
     assert "item.state.split('_').join(' ')" in template
     assert "Repair readiness" in template
     assert "primaryRepairReadinessReasonText" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -364,6 +364,9 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "data-dashboard-remediation-refresh" in script
     assert "dashboardRemediationFilterOptions" in script
     assert "{ value: 'fresh_evidence', label: 'Fresh evidence' }" in script
+    assert "{ value: 'approval_verification', label: 'Approval' }" in script
+    assert "{ value: 'sender_review', label: 'Sender review' }" in script
+    assert "{ value: 'report_evidence', label: 'Report evidence' }" in script
     assert "{ value: 'stale_evidence', label: 'Stale evidence' }" in script
     assert "dashboardRemediationSort: 'priority'" in script
     assert "showAllDashboardRemediationItems" in script
@@ -445,6 +448,9 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "[...items].sort" in script
     assert "this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b)" in script
     assert "dashboardRemediationFilterMatches(item, filterValue)" in script
+    assert "verificationStatus === 'pending_operator_approval'" in script
+    assert "verificationStatus === 'pending_sender_review'" in script
+    assert "verificationStatus === 'pending_report_evidence'" in script
     assert "dashboardRemediationEvidenceRank(item)" in script
     assert "remediationSeverityWeight(severity)" in script
     assert "remediationStaleEvidenceText(item)" in script
@@ -502,7 +508,8 @@ def test_dashboard_remediation_filters_and_sorts_cards():
                         required: true,
                         refresh_key: 'provider_value',
                         safe_to_run: false
-                    }
+                    },
+                    verification_plan: { status: 'blocked_by_prerequisite' }
                 },
                 {
                     domain: 'reputation.example',
@@ -519,7 +526,51 @@ def test_dashboard_remediation_filters_and_sorts_cards():
                         required: true,
                         refresh_key: 'source_reputation',
                         safe_to_run: true
-                    }
+                    },
+                    verification_plan: { status: 'pending_reputation_review' }
+                },
+                {
+                    domain: 'approval.example',
+                    state: 'needs_approval',
+                    priority_score: 5,
+                    severity: 'high',
+                    repair_progression: {
+                        readiness_level: 'ready_for_preview',
+                        stage: 'preview_ready',
+                        readiness_score: 90
+                    },
+                    evidence_refresh: {
+                        required: true,
+                        refresh_key: 'dns',
+                        safe_to_run: true
+                    },
+                    verification_plan: { status: 'pending_operator_approval' }
+                },
+                {
+                    domain: 'sender.example',
+                    state: 'investigate',
+                    remediation_track: 'sender_classification',
+                    priority_score: 3,
+                    severity: 'medium',
+                    repair_progression: {
+                        readiness_level: 'needs_classification',
+                        stage: 'classification_required',
+                        readiness_score: 20
+                    },
+                    verification_plan: { status: 'pending_sender_review' }
+                },
+                {
+                    domain: 'report.example',
+                    state: 'manual_action',
+                    remediation_track: 'manual_dns',
+                    priority_score: 2,
+                    severity: 'low',
+                    repair_progression: {
+                        readiness_level: 'manual_repair',
+                        stage: 'manual_repair',
+                        readiness_score: 45
+                    },
+                    verification_plan: { status: 'pending_report_evidence' }
                 }
             ] } };
             app.dashboardRemediationFilter = 'fresh_evidence';
@@ -527,12 +578,15 @@ def test_dashboard_remediation_filters_and_sorts_cards():
             return [
                 app.dashboardRemediationFilterCount('blocked'),
                 app.dashboardRemediationFilterCount('reputation'),
+                app.dashboardRemediationFilterCount('approval_verification'),
+                app.dashboardRemediationFilterCount('sender_review'),
+                app.dashboardRemediationFilterCount('report_evidence'),
                 app.dashboardRemediationFilteredCount(),
                 app.visibleDashboardRemediationItems()[0].domain
             ].join('|');
         })()""")
 
-    assert result == "1|1|3|blocked.example"
+    assert result == "1|1|1|1|1|4|blocked.example"
 
 
 def test_dashboard_remediation_stale_evidence_links_to_evidence_anchor():

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -924,11 +924,28 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["items"][0]["repair_progression"]["readiness_score"] == 80
     assert loop["items"][0]["evidence_refresh"]["refresh_key"] == "dns"
     assert loop["items"][0]["evidence_refresh"]["safe_to_run"] is True
+    assert loop["items"][0]["verification_plan"]["status"] == "pending_operator_approval"
+    assert loop["items"][0]["verification_plan"]["verification_method"] == (
+        "provider_write_then_dns_refresh"
+    )
+    assert "Fresh DNS evidence" in loop["items"][0]["verification_plan"]["freshness_requirement"]
+    assert "approved provider apply" in loop["items"][0]["verification_plan"]["closure_gate"]
+    assert "DNS propagation evidence" in (
+        loop["items"][0]["verification_plan"]["stale_evidence_warning"]
+    )
     assert "Preview the exact DNS" in loop["items"][0]["operator_decision_summary"]
     assert loop["items"][1]["remediation_track"] == "reputation_review"
     assert loop["items"][1]["repair_progression"]["stage"] == "reputation_review"
     assert loop["items"][1]["repair_progression"]["readiness_level"] == "needs_reputation_review"
     assert loop["items"][1]["evidence_refresh"]["refresh_key"] == "source_reputation"
+    assert loop["items"][1]["verification_plan"]["status"] == "pending_sender_review"
+    assert loop["items"][1]["verification_plan"]["verification_method"] == (
+        "fresh_dmarc_report_window"
+    )
+    assert "newer receiver report" in (
+        loop["items"][1]["verification_plan"]["freshness_requirement"]
+    )
+    assert "sender classification" in loop["items"][1]["verification_plan"]["closure_gate"]
     assert loop["items"][1]["risk_level"] == "high"
     assert loop["items"][1]["safe_to_automate"] is False
 
@@ -976,6 +993,13 @@ def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks
     assert loop["items"][0]["repair_progression"]["readiness_level"] == "blocked"
     assert loop["items"][0]["evidence_refresh"]["refresh_key"] == "provider_value"
     assert loop["items"][0]["evidence_refresh"]["safe_to_run"] is False
+    assert loop["items"][0]["verification_plan"]["status"] == "blocked_by_prerequisite"
+    assert loop["items"][0]["verification_plan"]["verification_method"] == (
+        "provider_specific_value_then_health_rebuild"
+    )
+    assert "provider-specific target value" in (
+        loop["items"][0]["verification_plan"]["stale_evidence_warning"]
+    )
     assert "provider-specific value" in loop["items"][0]["repair_progression"]["summary"]
 
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -909,6 +909,10 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["evidence_refresh_dns"] == 1
     assert loop["evidence_refresh_reputation"] == 1
     assert loop["evidence_refresh_reports"] == 0
+    assert loop["verification_pending_operator_approval"] == 1
+    assert loop["verification_pending_sender_review"] == 0
+    assert loop["verification_pending_reputation_review"] == 1
+    assert loop["verification_blocked_by_prerequisite"] == 0
     assert loop["top_incident_type"] == "dmarc_policy_missing_or_weak"
     assert loop["repair_blocked"] == 0
     assert loop["repair_ready_for_preview"] == 1
@@ -938,14 +942,14 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["items"][1]["repair_progression"]["stage"] == "reputation_review"
     assert loop["items"][1]["repair_progression"]["readiness_level"] == "needs_reputation_review"
     assert loop["items"][1]["evidence_refresh"]["refresh_key"] == "source_reputation"
-    assert loop["items"][1]["verification_plan"]["status"] == "pending_sender_review"
+    assert loop["items"][1]["verification_plan"]["status"] == "pending_reputation_review"
     assert loop["items"][1]["verification_plan"]["verification_method"] == (
-        "fresh_dmarc_report_window"
+        "fresh_reputation_evidence"
     )
-    assert "newer receiver report" in (
+    assert "Fresh reputation" in (
         loop["items"][1]["verification_plan"]["freshness_requirement"]
     )
-    assert "sender classification" in loop["items"][1]["verification_plan"]["closure_gate"]
+    assert "fresh reputation evidence" in loop["items"][1]["verification_plan"]["closure_gate"]
     assert loop["items"][1]["risk_level"] == "high"
     assert loop["items"][1]["safe_to_automate"] is False
 
@@ -983,6 +987,8 @@ def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks
     assert loop["repair_needs_evidence"] == 1
     assert loop["evidence_refresh_required"] == 1
     assert loop["evidence_refresh_prerequisite"] == 1
+    assert loop["verification_pending_operator_approval"] == 0
+    assert loop["verification_blocked_by_prerequisite"] == 1
     assert loop["repair_ready_for_preview"] == 0
     assert loop["repair_waiting_on_operator"] == 0
     assert loop["repair_readiness_blocked"] == 1

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -844,7 +844,12 @@ so clients can present the correct refresh path before opening the detail queue.
 Dashboard remediation items also include `verification_plan` with the method,
 freshness requirement, failure mode, closure gate, stale-evidence warning,
 needed evidence, and next check; clients should show it as read-only closure
-guidance before treating an item as fixed.
+guidance before treating an item as fixed. The same dashboard summaries include
+verification counters such as `verification_pending_operator_approval`,
+`verification_pending_sender_review`, `verification_pending_reputation_review`,
+`verification_pending_report_evidence`, and `verification_blocked_by_prerequisite`
+so clients can distinguish approval, sender review, reputation evidence, manual
+fresh-evidence checks, and missing provider values.
 
 Notification metadata includes the event name, channel, dedupe key, reason, and
 next state transition that an operator workflow can use. Each notification also

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -841,6 +841,10 @@ kind of read-only refresh or prerequisite the operator should handle next.
 The workspace dashboard `health_summary.remediation_loop` and each domain row's
 `remediation_workload` expose the same `evidence_refresh` object and counters,
 so clients can present the correct refresh path before opening the detail queue.
+Dashboard remediation items also include `verification_plan` with the method,
+freshness requirement, failure mode, closure gate, stale-evidence warning,
+needed evidence, and next check; clients should show it as read-only closure
+guidance before treating an item as fixed.
 
 Notification metadata includes the event name, channel, dedupe key, reason, and
 next state transition that an operator workflow can use. Each notification also

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -84,7 +84,10 @@ investigation, and manual work. Each card shows the same readiness label and
 0-100 score used on the domain remediation queue. Cards also show the next safe
 action, first readiness reason, freshness requirement, closure gate, and blocker
 summary before linking to the selected domain for the full evidence, approval,
-and verification flow.
+and verification flow. Filter chips let you isolate preview-ready repairs,
+approval verification, sender review, report-evidence follow-up, blocked work,
+manual work, reputation review, and stale-evidence cases without opening every
+domain.
 
 ### Demo Mode
 

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -82,8 +82,9 @@ instead of replacing the page with an empty state. Cards are sorted so provider
 previews and approval-ready work appear before blocked, reputation,
 investigation, and manual work. Each card shows the same readiness label and
 0-100 score used on the domain remediation queue. Cards also show the next safe
-action, first readiness reason, and blocker summary before linking to the
-selected domain for the full evidence, approval, and verification flow.
+action, first readiness reason, freshness requirement, closure gate, and blocker
+summary before linking to the selected domain for the full evidence, approval,
+and verification flow.
 
 ### Demo Mode
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -149,7 +149,10 @@ read-only; it does not apply DNS changes or send provider requests. The top
 **Next remediation** panel mirrors the same repair-gate status so the operator
 can see the current blocker, readiness label, readiness score, next safe action,
 freshness requirement, closure gate, stale-evidence warning, and first
-readiness reason before opening the full queue.
+readiness reason before opening the full queue. When a focused read-only
+evidence refresh is available, the panel also links directly to the relevant
+evidence section and exposes the same safe refresh action as the full queue
+card.
 Repair progression also includes a readiness label, 0-100 readiness score,
 human-readable reasons, and blocker keys. Use this to separate work that is
 ready for provider preview from work that is blocked by missing provider values,

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -148,8 +148,8 @@ reputation/report/DNS evidence is still required before closure. This panel is
 read-only; it does not apply DNS changes or send provider requests. The top
 **Next remediation** panel mirrors the same repair-gate status so the operator
 can see the current blocker, readiness label, readiness score, next safe action,
-and first readiness reason before
-opening the full queue.
+freshness requirement, closure gate, stale-evidence warning, and first
+readiness reason before opening the full queue.
 Repair progression also includes a readiness label, 0-100 readiness score,
 human-readable reasons, and blocker keys. Use this to separate work that is
 ready for provider preview from work that is blocked by missing provider values,
@@ -181,7 +181,9 @@ fresh reports or DNS checks should keep monitoring the fix. It also shows the
 closure gate and next safe action so an operator can tell that a resolved marker
 is still conditional on fresh evidence staying clean. The compact view shows
 the newest verified repairs first and can be expanded to show every verified
-repair returned by the backend response.
+repair returned by the backend response. Stale or unknown queue-absence
+evidence is called out so operators refresh evidence before relying on an old
+verified marker.
 
 After a remediation notification is previewed or acknowledged, an operator can
 explicitly enqueue the notification through the dispatch API with


### PR DESCRIPTION
## Summary
- align remediation verification semantics across dashboard cards, domain detail next-remediation panel, and evidence-verified repair history
- add API-level dashboard verification plans and counters for approval waits, sender review, reputation review, report evidence, and provider-value prerequisites
- add dashboard filters for approval verification, sender review, report-evidence follow-up, and richer closure/freshness guidance
- update user docs, API reference, and changelog for the remediation verification wave

Refs #384.

## Validation
- `node --check backend/app/static/js/domain-details-page.js && node --check backend/app/static/js/dashboard-page.js && node --check backend/app/static/js/reports-page.js`
- `.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `.venv/bin/python -m pytest backend/app/tests/test_dns_endpoints.py::test_summary_endpoint_returns_demo_domains_in_demo_mode backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_domain_detail_endpoints.py::test_dashboard_remediation_loop_exposes_operator_decision_context backend/app/tests/test_domain_detail_endpoints.py::test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks backend/app/tests/test_remediation_dispatch.py -q --tb=short`
- `.venv/bin/python -m pytest backend/app/tests -q --tb=short` (1855 passed)
