### PR TITLE
[codex] add remediation provider repair checklists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added sending-source risk filters, compact reputation counters, activity badges, and logarithmic recent-volume bars on domain detail pages so current risky senders stand out from stale or low-volume history.
 - Added domain-list DNS state badges for queued, cached, fallback, partial, stale, and failed DNS evidence so resolver uncertainty is visible instead of silently degrading scores.
 - Added explicit remediation provider-repair plans so DNS queue items show preview availability, apply-after-approval readiness, apply blockers, provider-value prerequisites, record metadata, and manual fallback without changing live DNS behavior.
+- Added remediation provider repair checklists so DNS repair items show before-apply checks, after-apply evidence checks, blast radius, and operator warnings before any provider write path is exposed.
+- Added a domain remediation filter and summary counter for provider repair checklists so operator-review work can be isolated quickly.
 
 ### Changed
 - Domain summary DNS refreshes now run with bounded concurrency instead of resolving each domain sequentially.
@@ -74,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard remediation rows now expose the top incident and fresh-evidence action directly in the workspace view, and the domain-compliance refresh control reloads the backend summary again.
 - Domain remediation cards now offer focused read-only evidence refresh actions that reload the relevant backend data and rebuild the queue without applying DNS or provider writes.
 - Public API and read-only MCP remediation queues now strip provider preview/apply endpoints from both item data and notification payload previews while keeping read-only provider-repair context visible.
+- Public API and read-only MCP remediation queues now label provider repair approval gates as read-only and warn that provider write endpoints are intentionally omitted.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -613,6 +613,13 @@ def read_only_remediation_queue_response(payload: Any) -> "RemediationQueueRespo
             provider_repair_plan["apply_endpoint"] = ""
             provider_repair_plan["can_apply_after_approval"] = False
             provider_repair_plan["apply_blocked"] = True
+            provider_repair_plan["approval_gate"] = (
+                "Public and MCP responses are read-only; open the authenticated domain "
+                "workflow for provider approval."
+            )
+            provider_repair_plan["operator_warning"] = (
+                "This response intentionally omits provider write endpoints."
+            )
             blocked = list(provider_repair_plan.get("blocked_reasons") or [])
             blocked.append("public_read_only_response")
             provider_repair_plan["blocked_reasons"] = list(dict.fromkeys(blocked))
@@ -674,6 +681,13 @@ def read_only_remediation_queue_response(payload: Any) -> "RemediationQueueRespo
             preview_provider_plan["apply_endpoint"] = ""
             preview_provider_plan["can_apply_after_approval"] = False
             preview_provider_plan["apply_blocked"] = True
+            preview_provider_plan["approval_gate"] = (
+                "Public and MCP responses are read-only; open the authenticated domain "
+                "workflow for provider approval."
+            )
+            preview_provider_plan["operator_warning"] = (
+                "This response intentionally omits provider write endpoints."
+            )
             blocked = list(preview_provider_plan.get("blocked_reasons") or [])
             blocked.append("public_read_only_response")
             preview_provider_plan["blocked_reasons"] = list(dict.fromkeys(blocked))
@@ -1285,6 +1299,11 @@ class RemediationProviderRepairPlan(BaseModel):
     record_name: str = ""
     record_type: str = ""
     capability: str = "manual_review"
+    approval_gate: str = ""
+    pre_apply_checks: List[str] = Field(default_factory=list)
+    post_apply_checks: List[str] = Field(default_factory=list)
+    blast_radius: str = ""
+    operator_warning: str = ""
     next_step: str = ""
     completion_gate: str = ""
 

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -189,6 +189,16 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
             if (item.get("provider_repair_plan") or {}).get("kind") == "dns_provider_repair"
             and (item.get("provider_repair_plan") or {}).get("manual_fallback")
         ),
+        "provider_pre_apply_checks": sum(
+            1
+            for item in items
+            if (item.get("provider_repair_plan") or {}).get("pre_apply_checks")
+        ),
+        "provider_post_apply_checks": sum(
+            1
+            for item in items
+            if (item.get("provider_repair_plan") or {}).get("post_apply_checks")
+        ),
         "requires_fresh_evidence": sum(
             1 for item in items if (item.get("action_plan") or {}).get("requires_fresh_evidence")
         ),
@@ -517,6 +527,19 @@ def _provider_repair_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
     source = str(item.get("source") or "")
     stage = str(repair.get("stage") or "operator_review")
     blocked_reasons = list(repair.get("blocked_by") or [])
+    verification = item.get("verification_plan") or {}
+    blast_radius = str(item.get("blast_radius") or "")
+    pre_apply_checks = [
+        "Confirm the authoritative zone and record owner.",
+        "Compare the current DNS value, proposed value, record type, and TTL.",
+        "Confirm a human operator explicitly approved this repair.",
+    ]
+    post_apply_checks = [
+        verification.get("closure_gate")
+        or "Refresh DNS evidence after propagation and rebuild the remediation queue.",
+        verification.get("next_check") or "Keep the item open until fresh evidence is available.",
+    ]
+    post_apply_checks = [str(check) for check in post_apply_checks if str(check)]
 
     if source != "dns_lint":
         return {
@@ -537,9 +560,14 @@ def _provider_repair_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
             "record_name": "",
             "record_type": "",
             "capability": "manual_review",
+            "approval_gate": "No provider DNS apply gate for this item.",
+            "pre_apply_checks": [],
+            "post_apply_checks": post_apply_checks[:3],
+            "blast_radius": blast_radius,
+            "operator_warning": "Do not change DNS from this item without a matching DNS finding.",
             "next_step": repair.get("next_safe_action")
             or "Review sender, report, reputation, or policy evidence before DNS changes.",
-            "completion_gate": (item.get("verification_plan") or {}).get("closure_gate") or "",
+            "completion_gate": verification.get("closure_gate") or "",
         }
 
     if not provider:
@@ -582,12 +610,23 @@ def _provider_repair_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         "record_name": str(automation.get("record_name") or ""),
         "record_type": str(automation.get("record_type") or ""),
         "capability": "provider_preview" if safe_preview else "manual_dns",
+        "approval_gate": (
+            "Provider apply is available only after explicit operator approval."
+            if can_apply
+            else "Provider apply is blocked; use manual fallback or resolve blockers first."
+        ),
+        "pre_apply_checks": pre_apply_checks[:5],
+        "post_apply_checks": post_apply_checks[:5],
+        "blast_radius": blast_radius,
+        "operator_warning": (
+            "Preview does not mean fixed; close only after fresh DNS evidence confirms the change."
+        ),
         "next_step": str(
             repair.get("next_safe_action")
             or repair.get("next_step")
             or "Review the DNS record change and collect fresh evidence before closure."
         ),
-        "completion_gate": (item.get("verification_plan") or {}).get("closure_gate") or "",
+        "completion_gate": verification.get("closure_gate") or "",
     }
 
 
@@ -658,6 +697,8 @@ def _loop_summary(domain: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
         "provider_apply_blocked": summary["provider_apply_blocked"],
         "provider_value_missing": summary["provider_value_missing"],
         "provider_manual_fallback": summary["provider_manual_fallback"],
+        "provider_pre_apply_checks": summary["provider_pre_apply_checks"],
+        "provider_post_apply_checks": summary["provider_post_apply_checks"],
         "requires_fresh_evidence": summary["requires_fresh_evidence"],
         "rollback_guidance": summary["rollback_guidance"],
         "closure_gate_required": summary["closure_gate_required"],
@@ -790,6 +831,15 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
             "record_name": str(provider_repair_plan.get("record_name") or ""),
             "record_type": str(provider_repair_plan.get("record_type") or ""),
             "capability": str(provider_repair_plan.get("capability") or ""),
+            "approval_gate": str(provider_repair_plan.get("approval_gate") or ""),
+            "pre_apply_checks": [
+                str(check) for check in provider_repair_plan.get("pre_apply_checks", [])
+            ][:5],
+            "post_apply_checks": [
+                str(check) for check in provider_repair_plan.get("post_apply_checks", [])
+            ][:5],
+            "blast_radius": str(provider_repair_plan.get("blast_radius") or ""),
+            "operator_warning": str(provider_repair_plan.get("operator_warning") or ""),
             "next_step": str(provider_repair_plan.get("next_step") or ""),
             "completion_gate": str(provider_repair_plan.get("completion_gate") or ""),
         },

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -92,6 +92,8 @@ function domainDetailsApp(domainId = '') {
                 provider_apply_blocked: 0,
                 provider_value_missing: 0,
                 provider_manual_fallback: 0,
+                provider_pre_apply_checks: 0,
+                provider_post_apply_checks: 0,
                 evidence_refresh_required: 0,
                 evidence_refresh_dns: 0,
                 evidence_refresh_reports: 0,
@@ -128,6 +130,7 @@ function domainDetailsApp(domainId = '') {
             { value: 'all', label: 'All' },
             { value: 'preview_ready', label: 'Preview ready' },
             { value: 'provider_apply', label: 'Provider apply' },
+            { value: 'provider_checks', label: 'Provider checks' },
             { value: 'apply_blocked', label: 'Apply blocked' },
             { value: 'blocked', label: 'Blocked' },
             { value: 'needs_evidence', label: 'Needs evidence' },
@@ -1363,6 +1366,13 @@ function domainDetailsApp(domainId = '') {
             return `Blocked by ${blocked.slice(0, 4).map(value => this.humanizeToken(value)).join(', ')}.`;
         },
 
+        providerRepairPlanHasChecks(plan) {
+            return Boolean(
+                (plan?.pre_apply_checks || []).length ||
+                (plan?.post_apply_checks || []).length
+            );
+        },
+
         verifiedFreshnessClass(verified) {
             const status = String(verified?.freshness_status || '');
             if (status === 'current_queue_absence') return 'bg-teal-100 text-teal-700';
@@ -1550,6 +1560,9 @@ function domainDetailsApp(domainId = '') {
             if (filter === 'provider_apply') {
                 return Boolean(item.provider_repair_plan?.can_apply_after_approval) ||
                     Boolean(item.provider_repair_plan?.safe_preview_available);
+            }
+            if (filter === 'provider_checks') {
+                return this.providerRepairPlanHasChecks(item.provider_repair_plan);
             }
             if (filter === 'apply_blocked') {
                 return Boolean(item.provider_repair_plan?.apply_blocked);
@@ -2245,6 +2258,8 @@ function domainDetailsApp(domainId = '') {
                     provider_apply_blocked: 0,
                     provider_value_missing: 0,
                     provider_manual_fallback: 0,
+                    provider_pre_apply_checks: 0,
+                    provider_post_apply_checks: 0,
                     evidence_refresh_required: 0,
                     evidence_refresh_dns: 0,
                     evidence_refresh_reports: 0,

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -476,6 +476,9 @@
                             <span class="rounded bg-yellow-100 px-2 py-1 font-semibold text-yellow-800">
                                 <span x-text="remediationQueue.summary.provider_apply_blocked || 0"></span><span> apply blocked</span>
                             </span>
+                            <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
+                                <span x-text="remediationQueue.summary.provider_pre_apply_checks || 0"></span><span> provider checklists</span>
+                            </span>
                             <span class="rounded bg-[#fff8ed] px-2 py-1 font-semibold text-[#7a4a00]">
                                 <span x-text="remediationQueue.summary.repair_needs_evidence || 0"></span><span> need evidence</span>
                             </span>
@@ -860,6 +863,36 @@
                                         <p class="mt-2 text-xs font-semibold text-[#7a4a00]"
                                            x-show="providerRepairPlanBlockedText(item.provider_repair_plan)"
                                            x-text="providerRepairPlanBlockedText(item.provider_repair_plan)"></p>
+                                        <div class="mt-3 grid gap-3 text-xs text-[#5f5c78] md:grid-cols-2"
+                                             x-show="providerRepairPlanHasChecks(item.provider_repair_plan)">
+                                            <div x-show="(item.provider_repair_plan.pre_apply_checks || []).length">
+                                                <p class="font-semibold uppercase text-[#272a5f]">Before apply</p>
+                                                <ul class="mt-1 space-y-1">
+                                                    <template x-for="(check, index) in (item.provider_repair_plan.pre_apply_checks || []).slice(0, 3)"
+                                                              :key="item.id + '-provider-pre-' + index">
+                                                        <li class="flex gap-2">
+                                                            <span class="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-[#2f9da5]"></span>
+                                                            <span x-text="check"></span>
+                                                        </li>
+                                                    </template>
+                                                </ul>
+                                            </div>
+                                            <div x-show="(item.provider_repair_plan.post_apply_checks || []).length">
+                                                <p class="font-semibold uppercase text-[#272a5f]">After apply</p>
+                                                <ul class="mt-1 space-y-1">
+                                                    <template x-for="(check, index) in (item.provider_repair_plan.post_apply_checks || []).slice(0, 3)"
+                                                              :key="item.id + '-provider-post-' + index">
+                                                        <li class="flex gap-2">
+                                                            <span class="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-[#272a5f]"></span>
+                                                            <span x-text="check"></span>
+                                                        </li>
+                                                    </template>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                        <p class="mt-3 text-xs font-semibold text-[#7c5a1a]"
+                                           x-show="item.provider_repair_plan.operator_warning"
+                                           x-text="item.provider_repair_plan.operator_warning"></p>
                                     </div>
                                 </template>
                                 <template x-if="item.action_plan">

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -1252,6 +1252,11 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
         "public_read_only_response"
         in remediation_result.items[0].provider_repair_plan.blocked_reasons
     )
+    assert "read-only" in remediation_result.items[0].provider_repair_plan.approval_gate
+    assert (
+        "omits provider write endpoints"
+        in remediation_result.items[0].provider_repair_plan.operator_warning
+    )
     assert (
         remediation_result.items[0].notification.payload_preview["automation"]["apply_endpoint"]
         is None

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1578,6 +1578,15 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
     assert "target_spf" in script
     assert "target_dkim" in script
     assert "Provider repair readiness" in template
+    assert "Before apply" in template
+    assert "After apply" in template
+    assert "item.provider_repair_plan.pre_apply_checks" in template
+    assert "item.provider_repair_plan.post_apply_checks" in template
+    assert "item.provider_repair_plan.operator_warning" in template
+    assert "providerRepairPlanHasChecks" in script
+    assert "{ value: 'provider_checks', label: 'Provider checks' }" in script
+    assert "filter === 'provider_checks'" in script
+    assert "remediationQueue.summary.provider_pre_apply_checks" in template
     assert "providerContextStatusLabel" in script
     assert "providerContextSummary" in script
     assert "providerContextSteps" in script

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -679,6 +679,8 @@ def test_public_remediation_queue_is_read_only_and_posture_scoped(
     assert item["provider_repair_plan"]["preview_endpoint"] == ""
     assert item["provider_repair_plan"]["apply_endpoint"] == ""
     assert "public_read_only_response" in item["provider_repair_plan"]["blocked_reasons"]
+    assert "read-only" in item["provider_repair_plan"]["approval_gate"]
+    assert "omits provider write endpoints" in item["provider_repair_plan"]["operator_warning"]
     assert item["notification"]["payload_preview"]["automation"]["apply_endpoint"] is None
 
 

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -96,6 +96,8 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "provider_apply_blocked": 0,
         "provider_value_missing": 0,
         "provider_manual_fallback": 1,
+        "provider_pre_apply_checks": 1,
+        "provider_post_apply_checks": 2,
         "requires_fresh_evidence": 2,
         "rollback_guidance": 2,
         "closure_gate_required": 2,
@@ -145,6 +147,8 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "provider_apply_blocked": 0,
         "provider_value_missing": 0,
         "provider_manual_fallback": 1,
+        "provider_pre_apply_checks": 1,
+        "provider_post_apply_checks": 2,
         "requires_fresh_evidence": 2,
         "rollback_guidance": 2,
         "closure_gate_required": 2,
@@ -218,6 +222,20 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
         "record_name": "_dmarc.example.com",
         "record_type": "TXT",
         "capability": "provider_preview",
+        "approval_gate": "Provider apply is available only after explicit operator approval.",
+        "pre_apply_checks": [
+            "Confirm the authoritative zone and record owner.",
+            "Compare the current DNS value, proposed value, record type, and TTL.",
+            "Confirm a human operator explicitly approved this repair.",
+        ],
+        "post_apply_checks": [
+            "Close only after approved provider apply and fresh DNS evidence agree.",
+            "Refresh DNS posture after provider propagation, then rebuild the queue.",
+        ],
+        "blast_radius": "DNS record _dmarc.example.com (TXT)",
+        "operator_warning": (
+            "Preview does not mean fixed; close only after fresh DNS evidence confirms the change."
+        ),
         "next_step": (
             "Open the provider preview, compare old and new DNS values, then approve or reject."
         ),
@@ -398,6 +416,20 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
             "record_name": "_dmarc.example.com",
             "record_type": "TXT",
             "capability": "provider_preview",
+            "approval_gate": "Provider apply is available only after explicit operator approval.",
+            "pre_apply_checks": [
+                "Confirm the authoritative zone and record owner.",
+                "Compare the current DNS value, proposed value, record type, and TTL.",
+                "Confirm a human operator explicitly approved this repair.",
+            ],
+            "post_apply_checks": [
+                "Close only after approved provider apply and fresh DNS evidence agree.",
+                "Refresh DNS posture after provider propagation, then rebuild the queue.",
+            ],
+            "blast_radius": "DNS record _dmarc.example.com (TXT)",
+            "operator_warning": (
+                "Preview does not mean fixed; close only after fresh DNS evidence confirms the change."
+            ),
             "next_step": (
                 "Open the provider preview, compare old and new DNS values, then approve or reject."
             ),

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -821,9 +821,13 @@ post-change closure verification. Clients can show `safe_preview_available`,
 `can_apply_after_approval`, `apply_blocked`, `blocked_reasons`, `provider`,
 `plan_id`, `operation`, `record_name`, `record_type`, and
 `manual_fallback` without inferring that a DNS mutation has already happened.
+The object also includes `approval_gate`, `pre_apply_checks`,
+`post_apply_checks`, `blast_radius`, and `operator_warning` so clients can
+render the human review and evidence gates before any apply request exists.
 Read-only public API and MCP responses keep this context but remove
 `preview_endpoint` and `apply_endpoint`, set `can_apply_after_approval=false`,
-and add `public_read_only_response` as an apply blocker.
+add `public_read_only_response` as an apply blocker, and label the approval
+gate as read-only.
 Each item also includes an `evidence_refresh` object. It tells clients which
 fresh evidence source is needed before closure (`dns`, `dmarc_reports`,
 `dmarc_reports_and_sources`, `source_reputation`, or `mail_provider`), whether

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -91,7 +91,9 @@ domain.
 Open the domain detail queue for the full provider-repair plan. That view shows
 whether a DNS item has a safe provider preview, can be applied only after
 explicit approval, is blocked by missing provider values, or should fall back to
-manual DNS work.
+manual DNS work. Provider repair items also expose before-apply and after-apply
+checklists so operators can review the blast radius and required evidence before
+approving or closing a repair.
 
 ### Demo Mode
 

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -164,8 +164,11 @@ whether DMARQ can prepare a safe provider preview, whether the change could be
 applied after explicit approval, and whether fresh evidence is still required
 before the repair is considered closed. It shows the connected provider,
 operation, record name/type, apply blockers, provider-value prerequisites, and
-manual fallback. Public API and read-only MCP consumers see the same context
-without preview/apply links.
+manual fallback. It also lists before-apply checks, after-apply evidence
+checks, blast radius, and an operator warning so a preview cannot be mistaken
+for a completed repair. Public API and read-only MCP consumers see the same
+context without preview/apply links and with an explicit read-only approval
+gate.
 Each item also shows a notification profile such as approval required, action
 required, investigation required, or summary only. These labels explain how
 DMARQ would route the item into alerting or ticketing workflows; viewing the


### PR DESCRIPTION
## Summary
- add read-only provider repair before/after apply checklists, blast radius, approval gate, and operator warnings to remediation queue items
- surface provider repair checklists in the domain queue UI with a provider-checks filter and summary counter
- keep public API and MCP provider repair responses explicitly read-only by removing write endpoints and replacing approval-gate wording
- update API docs, user guides, and changelog

## Local validation
- node --check backend/app/static/js/domain-details-page.js
- .venv/bin/python -m flake8 backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py backend/app/tests/test_dashboard_template_security.py
- .venv/bin/python -m pytest backend/app/tests/test_remediation_queue.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py backend/app/tests/test_dashboard_template_security.py -q (268 passed)

Safety: read-only remediation guidance only; no DNS/provider write behavior and no notification dispatch behavior changed.

Refs #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider repair checklists with before/after apply steps, blast-radius context, and operator warnings in remediation queues.
  * Added a new “Provider checks” filter and summary counters to help identify items with checklists.
* **Bug Fixes**
  * Public API and read-only MCP responses now clearly label provider repair approvals as read-only and omit write actions from preview data.
* **Documentation**
  * Updated API and user guides to describe the new checklist-based review flow and read-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->