### PR TITLE
feat: add remediation provider apply history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added explicit remediation provider-repair plans so DNS queue items show preview availability, apply-after-approval readiness, apply blockers, provider-value prerequisites, record metadata, and manual fallback without changing live DNS behavior.
 - Added remediation provider repair checklists so DNS repair items show before-apply checks, after-apply evidence checks, blast radius, and operator warnings before any provider write path is exposed.
 - Added a domain remediation filter and summary counter for provider repair checklists so operator-review work can be isolated quickly.
+- Added remediation provider apply-confirmation metadata and attempt-history placeholders so future live DNS repair controls have an explicit confirmation phrase, blocker list, and audit-trail slot before any write behavior is enabled.
 
 ### Changed
 - Domain summary DNS refreshes now run with bounded concurrency instead of resolving each domain sequentially.
@@ -77,6 +78,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain remediation cards now offer focused read-only evidence refresh actions that reload the relevant backend data and rebuild the queue without applying DNS or provider writes.
 - Public API and read-only MCP remediation queues now strip provider preview/apply endpoints from both item data and notification payload previews while keeping read-only provider-repair context visible.
 - Public API and read-only MCP remediation queues now label provider repair approval gates as read-only and warn that provider write endpoints are intentionally omitted.
+- Public API and read-only MCP remediation queues now also clear provider apply confirmation phrases and mark confirmation metadata as read-only blocked.
+- Domain remediation provider-repair cards now show the operator confirmation prompt and current provider-apply history state alongside the existing pre/post apply checks.
+- Domain remediation provider-repair cards now render provider apply audit entries with provider, record, timestamp, verification status, and detail when history exists.
+- Domain remediation queues now include a provider-history filter so previously recorded provider apply attempts can be isolated from preview-only work.
+- Domain remediation queue summaries now count provider apply attempts and verified provider applies from audit history.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`
 - Cleaned up root directory for clarity

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -596,6 +596,48 @@ def read_only_dns_change_plan_response(payload: Any) -> DNSChangePlanResponse:
     )
 
 
+def _read_only_provider_repair_plan(plan: Dict[str, Any]) -> Dict[str, Any]:
+    """Strip provider write affordances from public and MCP remediation data."""
+    sanitized = dict(plan)
+    sanitized["preview_endpoint"] = ""
+    sanitized["apply_endpoint"] = ""
+    sanitized["can_apply_after_approval"] = False
+    sanitized["apply_blocked"] = True
+    sanitized["approval_gate"] = (
+        "Public and MCP responses are read-only; open the authenticated domain "
+        "workflow for provider approval."
+    )
+    sanitized["operator_warning"] = (
+        "This response intentionally omits provider write endpoints."
+    )
+    blocked = list(sanitized.get("blocked_reasons") or [])
+    blocked.append("public_read_only_response")
+    sanitized["blocked_reasons"] = list(dict.fromkeys(blocked))
+    confirmation = dict(sanitized.get("apply_confirmation") or {})
+    confirmation.update(
+        {
+            "required": bool(confirmation.get("required")),
+            "status": "read_only_blocked",
+            "label": "Read-only response",
+            "confirm_phrase": "",
+            "operator_prompt": (
+                "Open the authenticated domain workflow to review the provider preview "
+                "and collect operator approval."
+            ),
+            "blocked_reasons": list(
+                dict.fromkeys(
+                    [*(confirmation.get("blocked_reasons") or []), "public_read_only_response"]
+                )
+            ),
+            "next_step": (
+                "Use the authenticated domain workflow for any provider write action."
+            ),
+        }
+    )
+    sanitized["apply_confirmation"] = confirmation
+    return sanitized
+
+
 def read_only_remediation_queue_response(payload: Any) -> "RemediationQueueResponse":
     """Return remediation queue data without public write affordances."""
     data = payload.model_dump() if hasattr(payload, "model_dump") else copy.deepcopy(payload)
@@ -609,21 +651,9 @@ def read_only_remediation_queue_response(payload: Any) -> "RemediationQueueRespo
         item["automation"] = automation
         provider_repair_plan = item.get("provider_repair_plan") or {}
         if provider_repair_plan:
-            provider_repair_plan["preview_endpoint"] = ""
-            provider_repair_plan["apply_endpoint"] = ""
-            provider_repair_plan["can_apply_after_approval"] = False
-            provider_repair_plan["apply_blocked"] = True
-            provider_repair_plan["approval_gate"] = (
-                "Public and MCP responses are read-only; open the authenticated domain "
-                "workflow for provider approval."
+            item["provider_repair_plan"] = _read_only_provider_repair_plan(
+                provider_repair_plan
             )
-            provider_repair_plan["operator_warning"] = (
-                "This response intentionally omits provider write endpoints."
-            )
-            blocked = list(provider_repair_plan.get("blocked_reasons") or [])
-            blocked.append("public_read_only_response")
-            provider_repair_plan["blocked_reasons"] = list(dict.fromkeys(blocked))
-            item["provider_repair_plan"] = provider_repair_plan
 
         if "repair_progression" not in item:
             verification = item.get("verification_plan") or {}
@@ -677,21 +707,9 @@ def read_only_remediation_queue_response(payload: Any) -> "RemediationQueueRespo
             preview["automation"] = preview_automation
         preview_provider_plan = preview.get("provider_repair_plan") or {}
         if preview_provider_plan:
-            preview_provider_plan["preview_endpoint"] = ""
-            preview_provider_plan["apply_endpoint"] = ""
-            preview_provider_plan["can_apply_after_approval"] = False
-            preview_provider_plan["apply_blocked"] = True
-            preview_provider_plan["approval_gate"] = (
-                "Public and MCP responses are read-only; open the authenticated domain "
-                "workflow for provider approval."
+            preview["provider_repair_plan"] = _read_only_provider_repair_plan(
+                preview_provider_plan
             )
-            preview_provider_plan["operator_warning"] = (
-                "This response intentionally omits provider write endpoints."
-            )
-            blocked = list(preview_provider_plan.get("blocked_reasons") or [])
-            blocked.append("public_read_only_response")
-            preview_provider_plan["blocked_reasons"] = list(dict.fromkeys(blocked))
-            preview["provider_repair_plan"] = preview_provider_plan
         if preview:
             notification["payload_preview"] = preview
         item["notification"] = notification
@@ -1302,6 +1320,8 @@ class RemediationProviderRepairPlan(BaseModel):
     approval_gate: str = ""
     pre_apply_checks: List[str] = Field(default_factory=list)
     post_apply_checks: List[str] = Field(default_factory=list)
+    apply_confirmation: Dict[str, Any] = Field(default_factory=dict)
+    attempt_history: Dict[str, Any] = Field(default_factory=dict)
     blast_radius: str = ""
     operator_warning: str = ""
     next_step: str = ""

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -443,13 +443,16 @@ def _provider_repair_attempt_entry(row: WorkspaceAuditLog) -> Optional[Dict[str,
         return None
     verified = bool(verification.get("verified"))
     applied = bool(details.get("applied"))
-    state = "verified_after_apply" if applied and verified else "apply_recorded"
+    applied_and_verified = applied and verified
+    state = "verified_after_apply" if applied_and_verified else "apply_recorded"
     if applied and not verified:
         state = "apply_needs_verification"
     return {
         "plan_id": plan_id,
         "state": state,
-        "label": "Verified provider apply" if verified else "Provider apply recorded",
+        "label": (
+            "Verified provider apply" if applied_and_verified else "Provider apply recorded"
+        ),
         "created_at": _audit_timestamp(row.created_at),
         "provider": provider,
         "record_name": str(mutation.get("name") or ""),
@@ -457,7 +460,7 @@ def _provider_repair_attempt_entry(row: WorkspaceAuditLog) -> Optional[Dict[str,
         "verification_status": str(verification.get("status") or ""),
         "detail": (
             "Provider readback verified the applied DNS value."
-            if verified
+            if applied_and_verified
             else "Provider apply was recorded; keep the item open until readback and fresh DNS evidence pass."
         ),
     }
@@ -974,7 +977,8 @@ def _attach_dispatch_summary(
             "provider_apply_verified": sum(
                 1
                 for history in provider_attempt_histories
-                if history.get("status") == "verified_after_apply"
+                for entry in history.get("entries") or []
+                if entry.get("state") == "verified_after_apply"
             ),
         }
     )

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -13,6 +13,7 @@ from app.models.setting import Setting
 from app.models.webhook import WebhookEndpoint
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
+from app.services.remediation_queue import _remediation_notification_payload
 from app.services.webhook_events import SUPPORTED_EVENT_TYPES, endpoint_matches_event
 from app.utils.domain_validator import normalize_domain_name
 
@@ -445,24 +446,34 @@ def _provider_repair_attempt_entry(row: WorkspaceAuditLog) -> Optional[Dict[str,
     applied = bool(details.get("applied"))
     applied_and_verified = applied and verified
     state = "verified_after_apply" if applied_and_verified else "apply_recorded"
+    label = "Verified provider apply" if applied_and_verified else "Provider apply recorded"
+    detail = (
+        "Provider readback verified the applied DNS value."
+        if applied_and_verified
+        else (
+            "Provider apply was recorded; keep the item open until readback "
+            "and fresh DNS evidence pass."
+        )
+    )
     if applied and not verified:
         state = "apply_needs_verification"
+    elif not applied and not verified:
+        state = "apply_not_recorded"
+        label = "Provider apply not recorded"
+        detail = (
+            "Provider apply was not recorded; keep the remediation item open "
+            "until a successful apply and readback evidence are available."
+        )
     return {
         "plan_id": plan_id,
         "state": state,
-        "label": (
-            "Verified provider apply" if applied_and_verified else "Provider apply recorded"
-        ),
+        "label": label,
         "created_at": _audit_timestamp(row.created_at),
         "provider": provider,
         "record_name": str(mutation.get("name") or ""),
         "record_type": str(mutation.get("record_type") or ""),
         "verification_status": str(verification.get("status") or ""),
-        "detail": (
-            "Provider readback verified the applied DNS value."
-            if applied_and_verified
-            else "Provider apply was recorded; keep the item open until readback and fresh DNS evidence pass."
-        ),
+        "detail": detail,
     }
 
 
@@ -887,6 +898,8 @@ def attach_remediation_dispatch_previews(
             item,
             provider_attempts.get(provider_plan_id, []),
         )
+        if "payload_preview" in notification:
+            notification["payload_preview"] = _remediation_notification_payload(domain, item)
         notification["history"] = item_history
         notification["dispatch"] = build_remediation_dispatch_preview(
             db,

--- a/backend/app/services/remediation_dispatch.py
+++ b/backend/app/services/remediation_dispatch.py
@@ -83,6 +83,7 @@ HISTORY_ACTIONS = {
     "remediation.notification_lifecycle_recorded",
     "remediation.notification_dispatch_enqueued",
 }
+PROVIDER_REPAIR_HISTORY_ACTION = "domain.dns_change_applied"
 VERIFIED_FIXED_STALE_AFTER = timedelta(days=7)
 
 
@@ -430,6 +431,100 @@ def _notification_histories(
     return histories
 
 
+def _provider_repair_attempt_entry(row: WorkspaceAuditLog) -> Optional[Dict[str, Any]]:
+    details = _audit_details(row)
+    mutation = details.get("mutation") if isinstance(details.get("mutation"), dict) else {}
+    verification = (
+        details.get("verification") if isinstance(details.get("verification"), dict) else {}
+    )
+    provider = str(details.get("provider") or mutation.get("provider") or "")
+    plan_id = str(details.get("plan_id") or "")
+    if not plan_id:
+        return None
+    verified = bool(verification.get("verified"))
+    applied = bool(details.get("applied"))
+    state = "verified_after_apply" if applied and verified else "apply_recorded"
+    if applied and not verified:
+        state = "apply_needs_verification"
+    return {
+        "plan_id": plan_id,
+        "state": state,
+        "label": "Verified provider apply" if verified else "Provider apply recorded",
+        "created_at": _audit_timestamp(row.created_at),
+        "provider": provider,
+        "record_name": str(mutation.get("name") or ""),
+        "record_type": str(mutation.get("record_type") or ""),
+        "verification_status": str(verification.get("status") or ""),
+        "detail": (
+            "Provider readback verified the applied DNS value."
+            if verified
+            else "Provider apply was recorded; keep the item open until readback and fresh DNS evidence pass."
+        ),
+    }
+
+
+def _provider_repair_attempt_histories(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domain: str,
+    plan_ids: Iterable[str],
+    limit_per_plan: int = 3,
+) -> Dict[str, List[Dict[str, Any]]]:
+    ids = {str(plan_id or "") for plan_id in plan_ids if str(plan_id or "").strip()}
+    if not ids:
+        return {}
+    normalized_domain = normalize_domain_name(domain)
+    normalized_entity_name = func.lower(func.rtrim(func.trim(WorkspaceAuditLog.entity_name), "."))
+    rows = (
+        db.query(WorkspaceAuditLog)
+        .filter(
+            WorkspaceAuditLog.workspace_id == workspace.id,
+            WorkspaceAuditLog.action == PROVIDER_REPAIR_HISTORY_ACTION,
+            WorkspaceAuditLog.entity_type == "domain",
+            normalized_entity_name == normalized_domain,
+        )
+        .order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc())
+        .limit(max(len(ids) * limit_per_plan * 3, limit_per_plan))
+        .all()
+    )
+    histories: Dict[str, List[Dict[str, Any]]] = {plan_id: [] for plan_id in ids}
+    for row in rows:
+        entry = _provider_repair_attempt_entry(row)
+        if entry is None:
+            continue
+        plan_id = str(entry.get("plan_id") or "")
+        if plan_id not in histories or len(histories[plan_id]) >= limit_per_plan:
+            continue
+        histories[plan_id].append(entry)
+    return histories
+
+
+def _attach_provider_repair_attempt_history(
+    item: Dict[str, Any],
+    history: Sequence[Dict[str, Any]],
+) -> None:
+    plan = item.get("provider_repair_plan") or {}
+    if plan.get("kind") != "dns_provider_repair":
+        return
+    entries = [dict(entry) for entry in history][:3]
+    if not entries:
+        return
+    latest = entries[0]
+    plan["attempt_history"] = {
+        "source": "workspace_audit.domain.dns_change_applied",
+        "status": str(latest.get("state") or "apply_recorded"),
+        "label": str(latest.get("label") or "Provider apply recorded"),
+        "latest_at": str(latest.get("created_at") or ""),
+        "entries": entries,
+        "next_step": str(
+            latest.get("detail")
+            or "Refresh DNS evidence and keep the remediation item open until verification passes."
+        ),
+    }
+    item["provider_repair_plan"] = plan
+
+
 def _verified_fixed_items(
     db: Session,
     *,
@@ -762,6 +857,17 @@ def attach_remediation_dispatch_previews(
         domain=domain,
         item_ids=item_ids,
     )
+    provider_plan_ids = [
+        str((item.get("provider_repair_plan") or {}).get("plan_id") or "")
+        for item in items
+        if (item.get("provider_repair_plan") or {}).get("kind") == "dns_provider_repair"
+    ]
+    provider_attempts = _provider_repair_attempt_histories(
+        db,
+        workspace=workspace,
+        domain=domain,
+        plan_ids=provider_plan_ids,
+    )
     webhook_event_counts = _webhook_event_counts(
         endpoints,
         configured_events | event_types,
@@ -773,6 +879,11 @@ def attach_remediation_dispatch_previews(
     for item in items:
         notification = item.setdefault("notification", {})
         item_history = histories.get(str(item.get("id") or ""), [])
+        provider_plan_id = str((item.get("provider_repair_plan") or {}).get("plan_id") or "")
+        _attach_provider_repair_attempt_history(
+            item,
+            provider_attempts.get(provider_plan_id, []),
+        )
         notification["history"] = item_history
         notification["dispatch"] = build_remediation_dispatch_preview(
             db,
@@ -810,6 +921,10 @@ def _attach_dispatch_summary(
     ]
     dispatches = [notification.get("dispatch") or {} for notification in notifications]
     blocked = [dispatch for dispatch in dispatches if dispatch.get("blocked_reasons")]
+    provider_attempt_histories = [
+        (item.get("provider_repair_plan") or {}).get("attempt_history") or {}
+        for item in items
+    ]
     awaiting_ack = [
         dispatch
         for dispatch in blocked
@@ -852,6 +967,14 @@ def _attach_dispatch_summary(
                 )
                 - len(verified_fixed_items or []),
                 0,
+            ),
+            "provider_apply_attempts": sum(
+                len(history.get("entries") or []) for history in provider_attempt_histories
+            ),
+            "provider_apply_verified": sum(
+                1
+                for history in provider_attempt_histories
+                if history.get("status") == "verified_after_apply"
             ),
         }
     )

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -826,6 +826,8 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
     repair_progression = item.get("repair_progression") or {}
     evidence_refresh = item.get("evidence_refresh") or {}
     provider_repair_plan = item.get("provider_repair_plan") or {}
+    apply_confirmation = provider_repair_plan.get("apply_confirmation") or {}
+    attempt_history = provider_repair_plan.get("attempt_history") or {}
     return {
         "schema_version": "dmarq.remediation.notification.v1",
         "domain": domain,
@@ -894,51 +896,22 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
                 str(check) for check in provider_repair_plan.get("post_apply_checks", [])
             ][:5],
             "apply_confirmation": {
-                "required": bool(
-                    (provider_repair_plan.get("apply_confirmation") or {}).get("required")
-                ),
-                "status": str(
-                    (provider_repair_plan.get("apply_confirmation") or {}).get("status") or ""
-                ),
-                "label": str(
-                    (provider_repair_plan.get("apply_confirmation") or {}).get("label") or ""
-                ),
-                "confirm_phrase": str(
-                    (provider_repair_plan.get("apply_confirmation") or {}).get(
-                        "confirm_phrase"
-                    )
-                    or ""
-                ),
-                "operator_prompt": str(
-                    (provider_repair_plan.get("apply_confirmation") or {}).get(
-                        "operator_prompt"
-                    )
-                    or ""
-                ),
+                "required": bool(apply_confirmation.get("required")),
+                "status": str(apply_confirmation.get("status") or ""),
+                "label": str(apply_confirmation.get("label") or ""),
+                "confirm_phrase": str(apply_confirmation.get("confirm_phrase") or ""),
+                "operator_prompt": str(apply_confirmation.get("operator_prompt") or ""),
                 "blocked_reasons": [
                     str(reason)
-                    for reason in (provider_repair_plan.get("apply_confirmation") or {}).get(
-                        "blocked_reasons", []
-                    )
+                    for reason in apply_confirmation.get("blocked_reasons", [])
                 ][:6],
-                "next_step": str(
-                    (provider_repair_plan.get("apply_confirmation") or {}).get("next_step")
-                    or ""
-                ),
+                "next_step": str(apply_confirmation.get("next_step") or ""),
             },
             "attempt_history": {
-                "source": str(
-                    (provider_repair_plan.get("attempt_history") or {}).get("source") or ""
-                ),
-                "status": str(
-                    (provider_repair_plan.get("attempt_history") or {}).get("status") or ""
-                ),
-                "label": str(
-                    (provider_repair_plan.get("attempt_history") or {}).get("label") or ""
-                ),
-                "latest_at": str(
-                    (provider_repair_plan.get("attempt_history") or {}).get("latest_at") or ""
-                ),
+                "source": str(attempt_history.get("source") or ""),
+                "status": str(attempt_history.get("status") or ""),
+                "label": str(attempt_history.get("label") or ""),
+                "latest_at": str(attempt_history.get("latest_at") or ""),
                 "entries": [
                     {
                         "state": str(entry.get("state") or ""),
@@ -946,14 +919,10 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
                         "created_at": str(entry.get("created_at") or ""),
                         "detail": str(entry.get("detail") or ""),
                     }
-                    for entry in (provider_repair_plan.get("attempt_history") or {}).get(
-                        "entries", []
-                    )
+                    for entry in attempt_history.get("entries", [])
                     if isinstance(entry, dict)
                 ][:5],
-                "next_step": str(
-                    (provider_repair_plan.get("attempt_history") or {}).get("next_step") or ""
-                ),
+                "next_step": str(attempt_history.get("next_step") or ""),
             },
             "blast_radius": str(provider_repair_plan.get("blast_radius") or ""),
             "operator_warning": str(provider_repair_plan.get("operator_warning") or ""),

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -542,6 +542,14 @@ def _provider_repair_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         verification.get("next_check") or "Keep the item open until fresh evidence is available.",
     ]
     post_apply_checks = [str(check) for check in post_apply_checks if str(check)]
+    attempt_history = {
+        "source": "workspace_audit.domain.dns_change_applied",
+        "status": "no_provider_attempt_recorded",
+        "label": "No provider apply attempt recorded",
+        "latest_at": "",
+        "entries": [],
+        "next_step": "After a future approved provider apply, keep the audit trail attached to this remediation item.",
+    }
 
     if source != "dns_lint":
         return {
@@ -565,6 +573,16 @@ def _provider_repair_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
             "approval_gate": "No provider DNS apply gate for this item.",
             "pre_apply_checks": [],
             "post_apply_checks": [],
+            "apply_confirmation": {
+                "required": False,
+                "status": "not_applicable",
+                "label": "No provider apply",
+                "confirm_phrase": "",
+                "operator_prompt": "Provider apply is not available for this remediation item.",
+                "blocked_reasons": [],
+                "next_step": "Review the manual action plan and evidence instead.",
+            },
+            "attempt_history": attempt_history,
             "blast_radius": blast_radius,
             "operator_warning": "Do not change DNS from this item without a matching DNS finding.",
             "next_step": repair.get("next_safe_action")
@@ -593,6 +611,15 @@ def _provider_repair_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
             }
         ]
     apply_blocked = bool(not can_apply or blocked_reasons)
+    record_name = str(automation.get("record_name") or "")
+    record_type = str(automation.get("record_type") or "")
+    confirm_phrase = ""
+    if can_apply and not apply_blocked:
+        confirm_phrase = "APPLY"
+        if record_type:
+            confirm_phrase = f"{confirm_phrase} {record_type}"
+        if record_name:
+            confirm_phrase = f"{confirm_phrase} {record_name}"
 
     return {
         "kind": "dns_provider_repair",
@@ -609,8 +636,8 @@ def _provider_repair_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         "preview_endpoint": str(automation.get("apply_endpoint") or "") if safe_preview else "",
         "apply_endpoint": str(automation.get("apply_endpoint") or "") if can_apply else "",
         "operation": str(automation.get("operation") or ""),
-        "record_name": str(automation.get("record_name") or ""),
-        "record_type": str(automation.get("record_type") or ""),
+        "record_name": record_name,
+        "record_type": record_type,
         "capability": "provider_preview" if safe_preview else "manual_dns",
         "approval_gate": (
             "Provider apply is available only after explicit operator approval."
@@ -619,6 +646,32 @@ def _provider_repair_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         ),
         "pre_apply_checks": pre_apply_checks[:5],
         "post_apply_checks": post_apply_checks[:5],
+        "apply_confirmation": {
+            "required": True,
+            "status": (
+                "ready_for_operator_confirmation"
+                if can_apply and not apply_blocked
+                else "blocked"
+            ),
+            "label": (
+                "Operator confirmation required"
+                if can_apply and not apply_blocked
+                else "Confirmation blocked"
+            ),
+            "confirm_phrase": confirm_phrase,
+            "operator_prompt": (
+                "Review the provider preview, complete the before-apply checklist, then type the confirmation phrase before any live write."
+                if can_apply and not apply_blocked
+                else "Resolve provider blockers before asking an operator to confirm a live write."
+            ),
+            "blocked_reasons": blocked_reasons[:6],
+            "next_step": (
+                "Collect explicit operator approval after preview; do not close until the after-apply evidence checks pass."
+                if can_apply and not apply_blocked
+                else "Use the manual fallback or clear the blocked reasons before provider apply."
+            ),
+        },
+        "attempt_history": attempt_history,
         "blast_radius": blast_radius,
         "operator_warning": (
             "Preview does not mean fixed; close only after fresh DNS evidence confirms the change."
@@ -840,6 +893,68 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
             "post_apply_checks": [
                 str(check) for check in provider_repair_plan.get("post_apply_checks", [])
             ][:5],
+            "apply_confirmation": {
+                "required": bool(
+                    (provider_repair_plan.get("apply_confirmation") or {}).get("required")
+                ),
+                "status": str(
+                    (provider_repair_plan.get("apply_confirmation") or {}).get("status") or ""
+                ),
+                "label": str(
+                    (provider_repair_plan.get("apply_confirmation") or {}).get("label") or ""
+                ),
+                "confirm_phrase": str(
+                    (provider_repair_plan.get("apply_confirmation") or {}).get(
+                        "confirm_phrase"
+                    )
+                    or ""
+                ),
+                "operator_prompt": str(
+                    (provider_repair_plan.get("apply_confirmation") or {}).get(
+                        "operator_prompt"
+                    )
+                    or ""
+                ),
+                "blocked_reasons": [
+                    str(reason)
+                    for reason in (provider_repair_plan.get("apply_confirmation") or {}).get(
+                        "blocked_reasons", []
+                    )
+                ][:6],
+                "next_step": str(
+                    (provider_repair_plan.get("apply_confirmation") or {}).get("next_step")
+                    or ""
+                ),
+            },
+            "attempt_history": {
+                "source": str(
+                    (provider_repair_plan.get("attempt_history") or {}).get("source") or ""
+                ),
+                "status": str(
+                    (provider_repair_plan.get("attempt_history") or {}).get("status") or ""
+                ),
+                "label": str(
+                    (provider_repair_plan.get("attempt_history") or {}).get("label") or ""
+                ),
+                "latest_at": str(
+                    (provider_repair_plan.get("attempt_history") or {}).get("latest_at") or ""
+                ),
+                "entries": [
+                    {
+                        "state": str(entry.get("state") or ""),
+                        "label": str(entry.get("label") or ""),
+                        "created_at": str(entry.get("created_at") or ""),
+                        "detail": str(entry.get("detail") or ""),
+                    }
+                    for entry in (provider_repair_plan.get("attempt_history") or {}).get(
+                        "entries", []
+                    )
+                    if isinstance(entry, dict)
+                ][:5],
+                "next_step": str(
+                    (provider_repair_plan.get("attempt_history") or {}).get("next_step") or ""
+                ),
+            },
             "blast_radius": str(provider_repair_plan.get("blast_radius") or ""),
             "operator_warning": str(provider_repair_plan.get("operator_warning") or ""),
             "next_step": str(provider_repair_plan.get("next_step") or ""),

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1220,6 +1220,13 @@ function dashboardApp() {
             }[String(status || '')] || 'bg-[#f8f7f6] text-[#5f5c78]';
         },
 
+        remediationLoopEffectiveStatus(loop) {
+            if (!loop) return '';
+            const status = String(loop.status || '');
+            const loopStatus = String(loop.loop_status || '');
+            return status === 'needs_attention' && loopStatus ? loopStatus : (status || loopStatus);
+        },
+
         remediationIncidentLabel(value) {
             return this.formatDemoLabel(value || 'none');
         },

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1223,6 +1223,13 @@ function domainDetailsApp(domainId = '') {
             }[status] || 'Needs review';
         },
 
+        remediationLoopEffectiveStatus(loop) {
+            if (!loop) return '';
+            const status = String(loop.status || '');
+            const loopStatus = String(loop.loop_status || '');
+            return status === 'needs_attention' && loopStatus ? loopStatus : (status || loopStatus);
+        },
+
         humanizeToken(value) {
             return String(value || '')
                 .split('_')
@@ -1401,11 +1408,12 @@ function domainDetailsApp(domainId = '') {
                 const record = [entry.record_type, entry.record_name].filter(Boolean).join(' ');
                 const provider = entry.provider || 'provider';
                 const status = entry.verification_status || entry.state || 'recorded';
+                const createdAt = this.formatIsoDate(entry.created_at);
                 return {
                     label: [entry.label || this.humanizeToken(entry.state || 'recorded'), provider, record]
                         .filter(Boolean)
                         .join(' - '),
-                    meta: [entry.created_at, status].filter(Boolean).join(' - '),
+                    meta: [createdAt, status].filter(Boolean).join(' - '),
                     detail: entry.detail || '',
                 };
             });

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -94,6 +94,8 @@ function domainDetailsApp(domainId = '') {
                 provider_manual_fallback: 0,
                 provider_pre_apply_checks: 0,
                 provider_post_apply_checks: 0,
+                provider_apply_attempts: 0,
+                provider_apply_verified: 0,
                 evidence_refresh_required: 0,
                 evidence_refresh_dns: 0,
                 evidence_refresh_reports: 0,
@@ -131,6 +133,7 @@ function domainDetailsApp(domainId = '') {
             { value: 'preview_ready', label: 'Preview ready' },
             { value: 'provider_apply', label: 'Provider apply' },
             { value: 'provider_checks', label: 'Provider checks' },
+            { value: 'provider_history', label: 'Provider history' },
             { value: 'apply_blocked', label: 'Apply blocked' },
             { value: 'blocked', label: 'Blocked' },
             { value: 'needs_evidence', label: 'Needs evidence' },
@@ -1374,6 +1377,40 @@ function domainDetailsApp(domainId = '') {
             );
         },
 
+        providerRepairConfirmationText(plan) {
+            const confirmation = plan?.apply_confirmation || {};
+            if (!confirmation.required) return 'No live provider apply confirmation is available for this item.';
+            if (confirmation.status === 'ready_for_operator_confirmation') {
+                const phrase = confirmation.confirm_phrase ? ` Confirmation phrase: ${confirmation.confirm_phrase}.` : '';
+                return `${confirmation.operator_prompt || 'Operator confirmation is required before live provider apply.'}${phrase}`;
+            }
+            return confirmation.operator_prompt || confirmation.next_step || 'Provider apply confirmation is blocked.';
+        },
+
+        providerRepairAttemptHistoryText(plan) {
+            const history = plan?.attempt_history || {};
+            if ((history.entries || []).length) {
+                return history.label || 'Provider repair attempt history available';
+            }
+            return history.label || 'No provider apply attempt recorded';
+        },
+
+        providerRepairAttemptEntries(plan) {
+            const entries = plan?.attempt_history?.entries || [];
+            return entries.slice(0, 3).map(entry => {
+                const record = [entry.record_type, entry.record_name].filter(Boolean).join(' ');
+                const provider = entry.provider || 'provider';
+                const status = entry.verification_status || entry.state || 'recorded';
+                return {
+                    label: [entry.label || this.humanizeToken(entry.state || 'recorded'), provider, record]
+                        .filter(Boolean)
+                        .join(' - '),
+                    meta: [entry.created_at, status].filter(Boolean).join(' - '),
+                    detail: entry.detail || '',
+                };
+            });
+        },
+
         verifiedFreshnessClass(verified) {
             const status = String(verified?.freshness_status || '');
             if (status === 'current_queue_absence') return 'bg-teal-100 text-teal-700';
@@ -1564,6 +1601,9 @@ function domainDetailsApp(domainId = '') {
             }
             if (filter === 'provider_checks') {
                 return this.providerRepairPlanHasChecks(item.provider_repair_plan);
+            }
+            if (filter === 'provider_history') {
+                return (item.provider_repair_plan?.attempt_history?.entries || []).length > 0;
             }
             if (filter === 'apply_blocked') {
                 return Boolean(item.provider_repair_plan?.apply_blocked);
@@ -2261,6 +2301,8 @@ function domainDetailsApp(domainId = '') {
                     provider_manual_fallback: 0,
                     provider_pre_apply_checks: 0,
                     provider_post_apply_checks: 0,
+                    provider_apply_attempts: 0,
+                    provider_apply_verified: 0,
                     evidence_refresh_required: 0,
                     evidence_refresh_dns: 0,
                     evidence_refresh_reports: 0,

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -648,7 +648,7 @@
                                 <div class="flex flex-wrap items-start justify-between gap-3">
                                     <div>
                                         <p class="text-xs font-semibold uppercase text-[#5f5c78]">Remediation loop</p>
-                                        <p class="mt-1 text-sm font-semibold text-[#120d36]" x-text="remediationLoopStatusLabel(remediationQueue.loop?.status)"></p>
+                                        <p class="mt-1 text-sm font-semibold text-[#120d36]" x-text="remediationLoopStatusLabel(remediationLoopEffectiveStatus(remediationQueue.loop))"></p>
                                         <p class="mt-1 text-sm text-[#5f5c78]" x-text="remediationQueue.loop?.next_action || 'Review the highest priority remediation item.'"></p>
                                     </div>
                                     <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]">

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -479,6 +479,12 @@
                             <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
                                 <span x-text="remediationQueue.summary.provider_pre_apply_checks || 0"></span><span> provider checklists</span>
                             </span>
+                            <span class="rounded bg-[#f2fbf9] px-2 py-1 font-semibold text-[#1f7c83]">
+                                <span x-text="remediationQueue.summary.provider_apply_verified || 0"></span><span> verified provider applies</span>
+                            </span>
+                            <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
+                                <span x-text="remediationQueue.summary.provider_apply_attempts || 0"></span><span> provider apply history</span>
+                            </span>
                             <span class="rounded bg-[#fff8ed] px-2 py-1 font-semibold text-[#7a4a00]">
                                 <span x-text="remediationQueue.summary.repair_needs_evidence || 0"></span><span> need evidence</span>
                             </span>
@@ -703,6 +709,8 @@
                         <p class="mt-4 text-sm text-[#5f5c78]">No remediation items are queued for this domain.</p>
                     </template>
                     <div class="mt-4 flex flex-wrap gap-2"
+                         role="group"
+                         aria-label="Remediation queue filters"
                          x-show="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length > 0">
                         <label class="flex items-center gap-2 rounded border border-[#e6e3e1] bg-white px-3 py-2 text-xs font-semibold text-[#5f5c78]">
                             <span>Sort</span>
@@ -860,6 +868,28 @@
                                             <span class="font-semibold">Completion gate: </span>
                                             <span x-text="item.provider_repair_plan.completion_gate"></span>
                                         </p>
+                                        <div class="mt-2 grid gap-2 text-xs md:grid-cols-2">
+                                            <div class="rounded bg-white px-3 py-2 text-[#45505f]">
+                                                <p class="font-semibold text-[#120d36]">Apply confirmation</p>
+                                                <p class="mt-1" x-text="providerRepairConfirmationText(item.provider_repair_plan)"></p>
+                                            </div>
+                                            <div class="rounded bg-white px-3 py-2 text-[#45505f]">
+                                                <p class="font-semibold text-[#120d36]">Attempt history</p>
+                                                <p class="mt-1" x-text="providerRepairAttemptHistoryText(item.provider_repair_plan)"></p>
+                                                <ul class="mt-2 space-y-1" x-show="providerRepairAttemptEntries(item.provider_repair_plan).length">
+                                                    <template x-for="(entry, index) in providerRepairAttemptEntries(item.provider_repair_plan)"
+                                                              :key="`provider-attempt-${item.id}-${index}`">
+                                                        <li class="rounded border border-[#e3e0f4] bg-[#f8f7ff] px-2 py-1">
+                                                            <p class="font-semibold text-[#120d36]" x-text="entry.label"></p>
+                                                            <p class="text-[#5f5c78]" x-show="entry.meta" x-text="entry.meta"></p>
+                                                            <p class="text-[#5f5c78]" x-show="entry.detail" x-text="entry.detail"></p>
+                                                        </li>
+                                                    </template>
+                                                </ul>
+                                                <p class="mt-1 text-[#5f5c78]" x-show="item.provider_repair_plan.attempt_history?.next_step"
+                                                   x-text="item.provider_repair_plan.attempt_history?.next_step"></p>
+                                            </div>
+                                        </div>
                                         <p class="mt-2 text-xs font-semibold text-[#7a4a00]"
                                            x-show="providerRepairPlanBlockedText(item.provider_repair_plan)"
                                            x-text="providerRepairPlanBlockedText(item.provider_repair_plan)"></p>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -227,8 +227,8 @@
             </div>
             <div class="flex flex-wrap items-center gap-2">
                 <span class="rounded px-2 py-1 text-xs font-semibold"
-                      :class="remediationLoopStatusClass(remediationLoop().status || remediationLoop().loop_status)"
-                      x-text="remediationLoopStatusLabel(remediationLoop().status || remediationLoop().loop_status)"></span>
+                      :class="remediationLoopStatusClass(remediationLoopEffectiveStatus(remediationLoop()))"
+                      x-text="remediationLoopStatusLabel(remediationLoopEffectiveStatus(remediationLoop()))"></span>
                 <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]">
                     <span>Top: </span><span x-text="remediationIncidentLabel(remediationLoop().top_incident_type)"></span>
                 </span>

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -143,6 +143,15 @@ def _sample_remediation_queue(domain=DOMAIN):
                     "record_name": "_dmarc.example.com",
                     "record_type": "TXT",
                     "capability": "provider_preview",
+                    "apply_confirmation": {
+                        "required": True,
+                        "status": "ready_for_operator_confirmation",
+                        "label": "Operator confirmation required",
+                        "confirm_phrase": "APPLY TXT _dmarc.example.com",
+                        "operator_prompt": "Type the phrase before applying.",
+                        "blocked_reasons": [],
+                        "next_step": "Collect explicit operator approval.",
+                    },
                     "next_step": "Open the provider preview, compare old and new DNS values, then approve or reject.",
                     "completion_gate": "Close only after approved provider apply and fresh DNS evidence agree.",
                 },
@@ -1253,6 +1262,20 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
         in remediation_result.items[0].provider_repair_plan.blocked_reasons
     )
     assert "read-only" in remediation_result.items[0].provider_repair_plan.approval_gate
+    assert (
+        remediation_result.items[0].provider_repair_plan.apply_confirmation["status"]
+        == "read_only_blocked"
+    )
+    assert (
+        remediation_result.items[0].provider_repair_plan.apply_confirmation["confirm_phrase"]
+        == ""
+    )
+    assert (
+        "public_read_only_response"
+        in remediation_result.items[0].provider_repair_plan.apply_confirmation[
+            "blocked_reasons"
+        ]
+    )
     assert (
         "omits provider write endpoints"
         in remediation_result.items[0].provider_repair_plan.operator_warning

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -350,11 +350,11 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "Blocked before repair" in template
     assert "remediationLoop().next_action" in template
     assert (
-        "remediationLoopStatusClass(remediationLoop().status || remediationLoop().loop_status)"
+        "remediationLoopStatusClass(remediationLoopEffectiveStatus(remediationLoop()))"
         in template
     )
     assert (
-        "remediationLoopStatusLabel(remediationLoop().status || remediationLoop().loop_status)"
+        "remediationLoopStatusLabel(remediationLoopEffectiveStatus(remediationLoop()))"
         in template
     )
     assert "remediationIncidentLabel(remediationLoop().top_incident_type)" in template
@@ -441,6 +441,7 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "remediationTrackLabel(track)" in script
     assert "remediationLoopStatusLabel(status)" in script
     assert "remediationLoopStatusClass(status)" in script
+    assert "remediationLoopEffectiveStatus(loop)" in script
     assert "approval_ready: 'Needs approval'" in script
     assert "state === 'approval_ready' || state === 'needs_approval'" in script
     assert "remediationIncidentLabel(value)" in script
@@ -667,6 +668,8 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "Remediation queue sort" in template
     assert "data-domain-detail-remediation-filter" in template
     assert "aria-pressed" in template
+    assert 'role="group"' in template
+    assert 'aria-label="Remediation queue filters"' in template
     assert 'role="status"' in template
     assert "domainDetailRemediationFilter" in script
     assert "remediationQueueFilterCount(filter.value)" in template
@@ -1583,10 +1586,20 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
     assert "item.provider_repair_plan.pre_apply_checks" in template
     assert "item.provider_repair_plan.post_apply_checks" in template
     assert "item.provider_repair_plan.operator_warning" in template
+    assert "Apply confirmation" in template
+    assert "Attempt history" in template
+    assert "remediationQueue.summary.provider_apply_verified" in template
+    assert "remediationQueue.summary.provider_apply_attempts" in template
     assert "providerRepairPlanHasChecks" in script
     assert "plan?.kind !== 'dns_provider_repair'" in script
+    assert "providerRepairConfirmationText" in script
+    assert "providerRepairAttemptHistoryText" in script
+    assert "providerRepairAttemptEntries" in script
+    assert "provider-attempt-" in template
     assert "{ value: 'provider_checks', label: 'Provider checks' }" in script
     assert "filter === 'provider_checks'" in script
+    assert "{ value: 'provider_history', label: 'Provider history' }" in script
+    assert "filter === 'provider_history'" in script
     assert "remediationQueue.summary.provider_pre_apply_checks" in template
     assert "providerContextStatusLabel" in script
     assert "providerContextSummary" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1595,6 +1595,7 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
     assert "providerRepairConfirmationText" in script
     assert "providerRepairAttemptHistoryText" in script
     assert "providerRepairAttemptEntries" in script
+    assert "formatIsoDate(entry.created_at)" in script
     assert "provider-attempt-" in template
     assert "{ value: 'provider_checks', label: 'Provider checks' }" in script
     assert "filter === 'provider_checks'" in script
@@ -1645,7 +1646,8 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "'-dispatch-blocker-' + index" in template
     assert "blocked_reasons[0]" not in template
     assert "Remediation loop" in template
-    assert "remediationLoopStatusLabel" in template
+    assert "remediationLoopStatusLabel(remediationLoopEffectiveStatus(remediationQueue.loop))" in template
+    assert "remediationLoopEffectiveStatus(loop)" in script
     assert "remediationIncidentLabel" in template
     assert "remediationTrackLabel" in template
     assert "visibleRemediationDecisions(item)" in template

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -224,6 +224,15 @@ def _sample_remediation_queue(domain=DOMAIN):
                     "record_name": "_dmarc.example.com",
                     "record_type": "TXT",
                     "capability": "provider_preview",
+                    "apply_confirmation": {
+                        "required": True,
+                        "status": "ready_for_operator_confirmation",
+                        "label": "Operator confirmation required",
+                        "confirm_phrase": "APPLY TXT _dmarc.example.com",
+                        "operator_prompt": "Type the phrase before applying.",
+                        "blocked_reasons": [],
+                        "next_step": "Collect explicit operator approval.",
+                    },
                     "next_step": "Open the provider preview, compare old and new DNS values, then approve or reject.",
                     "completion_gate": "Close only after approved provider apply and fresh DNS evidence agree.",
                 },
@@ -248,6 +257,15 @@ def _sample_remediation_queue(domain=DOMAIN):
                             "blocked_reasons": [],
                             "preview_endpoint": "/api/v1/domains/example.com/dns/change-plan/apply",
                             "apply_endpoint": "/api/v1/domains/example.com/dns/change-plan/apply",
+                            "apply_confirmation": {
+                                "required": True,
+                                "status": "ready_for_operator_confirmation",
+                                "label": "Operator confirmation required",
+                                "confirm_phrase": "APPLY TXT _dmarc.example.com",
+                                "operator_prompt": "Type the phrase before applying.",
+                                "blocked_reasons": [],
+                                "next_step": "Collect explicit operator approval.",
+                            },
                         },
                     },
                     "history": [],
@@ -691,6 +709,12 @@ def test_public_remediation_queue_is_read_only_and_posture_scoped(
     assert "public_read_only_response" in item["provider_repair_plan"]["blocked_reasons"]
     assert "read-only" in item["provider_repair_plan"]["approval_gate"]
     assert "omits provider write endpoints" in item["provider_repair_plan"]["operator_warning"]
+    assert item["provider_repair_plan"]["apply_confirmation"]["status"] == "read_only_blocked"
+    assert item["provider_repair_plan"]["apply_confirmation"]["confirm_phrase"] == ""
+    assert (
+        "public_read_only_response"
+        in item["provider_repair_plan"]["apply_confirmation"]["blocked_reasons"]
+    )
     assert item["notification"]["payload_preview"]["automation"]["apply_endpoint"] is None
     preview_plan = item["notification"]["payload_preview"]["provider_repair_plan"]
     assert preview_plan["can_apply_after_approval"] is False
@@ -698,6 +722,8 @@ def test_public_remediation_queue_is_read_only_and_posture_scoped(
     assert preview_plan["preview_endpoint"] == ""
     assert preview_plan["apply_endpoint"] == ""
     assert "public_read_only_response" in preview_plan["blocked_reasons"]
+    assert preview_plan["apply_confirmation"]["status"] == "read_only_blocked"
+    assert preview_plan["apply_confirmation"]["confirm_phrase"] == ""
 
 
 def test_read_only_remediation_queue_keeps_missing_provider_plan_not_applicable():

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -642,6 +642,33 @@ def test_attach_remediation_dispatch_previews_adds_provider_apply_history(db_ses
             created_at=datetime(2026, 7, 1, 9, 0, 0),
         )
     )
+    db_session.add(
+        WorkspaceAuditLog(
+            workspace_id=workspace.id,
+            actor_type="user",
+            actor_id="operator-1",
+            action="domain.dns_change_applied",
+            entity_type="domain",
+            entity_name="Example.COM.",
+            details=json.dumps(
+                {
+                    "provider": "cloudflare",
+                    "plan_id": "dmarc-missing",
+                    "applied": False,
+                    "mutation": {
+                        "provider": "cloudflare",
+                        "record_type": "TXT",
+                        "name": "_dmarc.example.com",
+                    },
+                    "verification": {
+                        "status": "verified",
+                        "verified": True,
+                    },
+                }
+            ),
+            created_at=datetime(2026, 7, 1, 10, 0, 0),
+        )
+    )
     db_session.commit()
 
     queue = {
@@ -667,13 +694,15 @@ def test_attach_remediation_dispatch_previews_adds_provider_apply_history(db_ses
     )
 
     history = result["items"][0]["provider_repair_plan"]["attempt_history"]
-    assert history["status"] == "verified_after_apply"
-    assert history["label"] == "Verified provider apply"
+    assert history["status"] == "apply_recorded"
+    assert history["label"] == "Provider apply recorded"
     assert history["entries"][0]["provider"] == "cloudflare"
     assert history["entries"][0]["record_name"] == "_dmarc.example.com"
     assert history["entries"][0]["verification_status"] == "verified"
+    assert history["entries"][0]["state"] == "apply_recorded"
+    assert history["entries"][1]["state"] == "verified_after_apply"
     assert "actor_id" not in history["entries"][0]
-    assert result["summary"]["provider_apply_attempts"] == 1
+    assert result["summary"]["provider_apply_attempts"] == 2
     assert result["summary"]["provider_apply_verified"] == 1
 
 

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -706,6 +706,43 @@ def test_attach_remediation_dispatch_previews_adds_provider_apply_history(db_ses
     assert result["summary"]["provider_apply_verified"] == 1
 
 
+def test_provider_repair_attempt_entry_handles_missing_plan_and_unverified_apply():
+    missing_plan = WorkspaceAuditLog(
+        workspace_id=1,
+        actor_type="user",
+        action="domain.dns_change_applied",
+        entity_type="domain",
+        entity_name="example.com",
+        details=json.dumps({"applied": True}),
+        created_at=datetime(2026, 7, 1, 9, 0, 0),
+    )
+    assert remediation_dispatch._provider_repair_attempt_entry(missing_plan) is None
+
+    unverified_apply = WorkspaceAuditLog(
+        workspace_id=1,
+        actor_type="user",
+        action="domain.dns_change_applied",
+        entity_type="domain",
+        entity_name="example.com",
+        details=json.dumps(
+            {
+                "provider": "cloudflare",
+                "plan_id": "dmarc-missing",
+                "applied": True,
+                "verification": {"status": "pending", "verified": False},
+            }
+        ),
+        created_at=datetime(2026, 7, 1, 9, 5, 0),
+    )
+
+    entry = remediation_dispatch._provider_repair_attempt_entry(unverified_apply)
+
+    assert entry is not None
+    assert entry["state"] == "apply_needs_verification"
+    assert entry["label"] == "Provider apply recorded"
+    assert entry["detail"].startswith("Provider apply was recorded")
+
+
 def test_summarize_remediation_activity_handles_empty_domain_inputs(db_session):
     workspace = get_or_create_default_workspace(db_session)
 

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -677,7 +677,14 @@ def test_attach_remediation_dispatch_previews_adds_provider_apply_history(db_ses
         "items": [
             {
                 "id": "dns:dmarc-missing",
-                "notification": {"event": EVENT_REMEDIATION_APPROVAL_REQUIRED},
+                "notification": {
+                    "event": EVENT_REMEDIATION_APPROVAL_REQUIRED,
+                    "payload_preview": {
+                        "provider_repair_plan": {
+                            "attempt_history": {"status": "stale_before_attach"}
+                        }
+                    },
+                },
                 "provider_repair_plan": {
                     "kind": "dns_provider_repair",
                     "plan_id": "dmarc-missing",
@@ -702,6 +709,11 @@ def test_attach_remediation_dispatch_previews_adds_provider_apply_history(db_ses
     assert history["entries"][0]["state"] == "apply_recorded"
     assert history["entries"][1]["state"] == "verified_after_apply"
     assert "actor_id" not in history["entries"][0]
+    preview_history = result["items"][0]["notification"]["payload_preview"][
+        "provider_repair_plan"
+    ]["attempt_history"]
+    assert preview_history["status"] == "apply_recorded"
+    assert preview_history["entries"][0]["state"] == "apply_recorded"
     assert result["summary"]["provider_apply_attempts"] == 2
     assert result["summary"]["provider_apply_verified"] == 1
 
@@ -741,6 +753,30 @@ def test_provider_repair_attempt_entry_handles_missing_plan_and_unverified_apply
     assert entry["state"] == "apply_needs_verification"
     assert entry["label"] == "Provider apply recorded"
     assert entry["detail"].startswith("Provider apply was recorded")
+
+    no_apply = WorkspaceAuditLog(
+        workspace_id=1,
+        actor_type="user",
+        action="domain.dns_change_applied",
+        entity_type="domain",
+        entity_name="example.com",
+        details=json.dumps(
+            {
+                "provider": "cloudflare",
+                "plan_id": "dmarc-missing",
+                "applied": False,
+                "verification": {"status": "failed", "verified": False},
+            }
+        ),
+        created_at=datetime(2026, 7, 1, 9, 10, 0),
+    )
+
+    no_apply_entry = remediation_dispatch._provider_repair_attempt_entry(no_apply)
+
+    assert no_apply_entry is not None
+    assert no_apply_entry["state"] == "apply_not_recorded"
+    assert no_apply_entry["label"] == "Provider apply not recorded"
+    assert no_apply_entry["detail"].startswith("Provider apply was not recorded")
 
 
 def test_summarize_remediation_activity_handles_empty_domain_inputs(db_session):

--- a/backend/app/tests/test_remediation_dispatch.py
+++ b/backend/app/tests/test_remediation_dispatch.py
@@ -305,6 +305,8 @@ def test_attach_remediation_dispatch_previews_skips_empty_queues(monkeypatch):
         "dispatch_verified_fixed": 0,
         "dispatch_verified_fixed_visible": 0,
         "dispatch_verified_fixed_hidden": 0,
+        "provider_apply_attempts": 0,
+        "provider_apply_verified": 0,
     }
     assert result["verified_items"] == []
     assert result["verified_items_total"] == 0
@@ -609,6 +611,70 @@ def test_notification_histories_return_sanitized_recent_audit_events(db_session)
     assert history[1]["state"] == "acknowledged"
     assert history[1]["label"] == "Marked acknowledged"
     assert history[1]["operator_note"] == "Reviewed with DNS owner"
+
+
+def test_attach_remediation_dispatch_previews_adds_provider_apply_history(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add(
+        WorkspaceAuditLog(
+            workspace_id=workspace.id,
+            actor_type="user",
+            actor_id="operator-1",
+            action="domain.dns_change_applied",
+            entity_type="domain",
+            entity_name="Example.COM.",
+            details=json.dumps(
+                {
+                    "provider": "cloudflare",
+                    "plan_id": "dmarc-missing",
+                    "applied": True,
+                    "mutation": {
+                        "provider": "cloudflare",
+                        "record_type": "TXT",
+                        "name": "_dmarc.example.com",
+                    },
+                    "verification": {
+                        "status": "verified",
+                        "verified": True,
+                    },
+                }
+            ),
+            created_at=datetime(2026, 7, 1, 9, 0, 0),
+        )
+    )
+    db_session.commit()
+
+    queue = {
+        "domain": "example.com",
+        "summary": {},
+        "items": [
+            {
+                "id": "dns:dmarc-missing",
+                "notification": {"event": EVENT_REMEDIATION_APPROVAL_REQUIRED},
+                "provider_repair_plan": {
+                    "kind": "dns_provider_repair",
+                    "plan_id": "dmarc-missing",
+                    "attempt_history": {"status": "no_provider_attempt_recorded"},
+                },
+            }
+        ],
+    }
+
+    result = remediation_dispatch.attach_remediation_dispatch_previews(
+        db_session,
+        workspace=workspace,
+        queue=queue,
+    )
+
+    history = result["items"][0]["provider_repair_plan"]["attempt_history"]
+    assert history["status"] == "verified_after_apply"
+    assert history["label"] == "Verified provider apply"
+    assert history["entries"][0]["provider"] == "cloudflare"
+    assert history["entries"][0]["record_name"] == "_dmarc.example.com"
+    assert history["entries"][0]["verification_status"] == "verified"
+    assert "actor_id" not in history["entries"][0]
+    assert result["summary"]["provider_apply_attempts"] == 1
+    assert result["summary"]["provider_apply_verified"] == 1
 
 
 def test_summarize_remediation_activity_handles_empty_domain_inputs(db_session):

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -232,6 +232,32 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
             "Close only after approved provider apply and fresh DNS evidence agree.",
             "Refresh DNS posture after provider propagation, then rebuild the queue.",
         ],
+        "apply_confirmation": {
+            "required": True,
+            "status": "ready_for_operator_confirmation",
+            "label": "Operator confirmation required",
+            "confirm_phrase": "APPLY TXT _dmarc.example.com",
+            "operator_prompt": (
+                "Review the provider preview, complete the before-apply checklist, "
+                "then type the confirmation phrase before any live write."
+            ),
+            "blocked_reasons": [],
+            "next_step": (
+                "Collect explicit operator approval after preview; do not close until "
+                "the after-apply evidence checks pass."
+            ),
+        },
+        "attempt_history": {
+            "source": "workspace_audit.domain.dns_change_applied",
+            "status": "no_provider_attempt_recorded",
+            "label": "No provider apply attempt recorded",
+            "latest_at": "",
+            "entries": [],
+            "next_step": (
+                "After a future approved provider apply, keep the audit trail attached "
+                "to this remediation item."
+            ),
+        },
         "blast_radius": "DNS record _dmarc.example.com (TXT)",
         "operator_warning": (
             "Preview does not mean fixed; close only after fresh DNS evidence confirms the change."
@@ -426,6 +452,32 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
                 "Close only after approved provider apply and fresh DNS evidence agree.",
                 "Refresh DNS posture after provider propagation, then rebuild the queue.",
             ],
+            "apply_confirmation": {
+                "required": True,
+                "status": "ready_for_operator_confirmation",
+                "label": "Operator confirmation required",
+                "confirm_phrase": "APPLY TXT _dmarc.example.com",
+                "operator_prompt": (
+                    "Review the provider preview, complete the before-apply checklist, "
+                    "then type the confirmation phrase before any live write."
+                ),
+                "blocked_reasons": [],
+                "next_step": (
+                    "Collect explicit operator approval after preview; do not close until "
+                    "the after-apply evidence checks pass."
+                ),
+            },
+            "attempt_history": {
+                "source": "workspace_audit.domain.dns_change_applied",
+                "status": "no_provider_attempt_recorded",
+                "label": "No provider apply attempt recorded",
+                "latest_at": "",
+                "entries": [],
+                "next_step": (
+                    "After a future approved provider apply, keep the audit trail attached "
+                    "to this remediation item."
+                ),
+            },
             "blast_radius": "DNS record _dmarc.example.com (TXT)",
             "operator_warning": (
                 "Preview does not mean fixed; close only after fresh DNS evidence confirms the change."
@@ -588,6 +640,25 @@ def test_remediation_queue_keeps_placeholder_plan_manual():
     assert queue["items"][0]["provider_repair_plan"]["safe_preview_available"] is False
     assert queue["items"][0]["provider_repair_plan"]["apply_blocked"] is True
     assert "provider_specific_value" in queue["items"][0]["provider_repair_plan"]["blocked_reasons"]
+    assert queue["items"][0]["provider_repair_plan"]["apply_confirmation"] == {
+        "required": True,
+        "status": "blocked",
+        "label": "Confirmation blocked",
+        "confirm_phrase": "",
+        "operator_prompt": (
+            "Resolve provider blockers before asking an operator to confirm a live write."
+        ),
+        "blocked_reasons": [
+            "provider_specific_value",
+            "fresh_evidence_before_closure",
+            "pending_dns_refresh",
+            "provider_preview_not_available",
+        ],
+        "next_step": "Use the manual fallback or clear the blocked reasons before provider apply.",
+    }
+    assert queue["items"][0]["provider_repair_plan"]["attempt_history"]["status"] == (
+        "no_provider_attempt_recorded"
+    )
     assert queue["items"][0]["provider_repair_plan"]["record_name"] == (
         "pm._domainkey.example.com"
     )

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -824,10 +824,19 @@ post-change closure verification. Clients can show `safe_preview_available`,
 The object also includes `approval_gate`, `pre_apply_checks`,
 `post_apply_checks`, `blast_radius`, and `operator_warning` so clients can
 render the human review and evidence gates before any apply request exists.
+`apply_confirmation` describes the live-write confirmation status, confirmation
+phrase, operator prompt, blockers, and next step. `attempt_history` is the
+read-only audit slot for provider apply attempts; current read-only queues
+return an empty history when no approved apply has been recorded.
+Queue summaries include `provider_apply_attempts` and
+`provider_apply_verified` when provider apply audit history is attached.
 Read-only public API and MCP responses keep this context but remove
 `preview_endpoint` and `apply_endpoint`, set `can_apply_after_approval=false`,
 add `public_read_only_response` as an apply blocker, and label the approval
-gate as read-only.
+gate as read-only. They also clear `apply_confirmation.confirm_phrase`, set
+`apply_confirmation.status=read_only_blocked`, and include
+`public_read_only_response` in the confirmation blockers so external
+automation cannot reuse a live-write phrase from a read-only response.
 Each item also includes an `evidence_refresh` object. It tells clients which
 fresh evidence source is needed before closure (`dns`, `dmarc_reports`,
 `dmarc_reports_and_sources`, `source_reputation`, or `mail_provider`), whether

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -166,9 +166,18 @@ before the repair is considered closed. It shows the connected provider,
 operation, record name/type, apply blockers, provider-value prerequisites, and
 manual fallback. It also lists before-apply checks, after-apply evidence
 checks, blast radius, and an operator warning so a preview cannot be mistaken
-for a completed repair. Public API and read-only MCP consumers see the same
-context without preview/apply links and with an explicit read-only approval
-gate.
+for a completed repair. The panel also shows the current apply-confirmation
+state. Ready provider repairs include the confirmation phrase an operator would
+need after reviewing the preview; blocked repairs explain which blockers must
+clear before a live-write confirmation should even be requested. Attempt
+history is shown separately so future provider apply audit entries can be
+reviewed without treating a preview as an apply. Public API and read-only MCP
+consumers see the same context without preview/apply links and with an explicit
+read-only approval gate. Those read-only responses also clear the confirmation
+phrase and mark `apply_confirmation` as blocked so external automation cannot
+mistake advisory context for a live-write affordance.
+When provider apply audit entries exist, the queue summary counts both recorded
+provider apply attempts and entries whose provider readback was verified.
 Each item also shows a notification profile such as approval required, action
 required, investigation required, or summary only. These labels explain how
 DMARQ would route the item into alerting or ticketing workflows; viewing the


### PR DESCRIPTION
## Summary
- add provider apply confirmation metadata, blocked/ready confirmation text, and audit-history slots to remediation provider repair plans
- attach historical provider apply audit entries to matching remediation items and surface provider apply attempt/verified counters
- render provider apply history on domain remediation cards and add a provider-history filter
- harden public API and MCP read-only remediation responses so apply endpoints and confirmation phrases are stripped from item and notification payloads
- update API docs, user guide, and changelog

## Validation
- .venv/bin/python -m pytest backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py backend/app/tests/test_dashboard_template_security.py -q
- node --check backend/app/static/js/domain-details-page.js
- node --check backend/app/static/js/dashboard-page.js
- .venv/bin/python -m flake8 backend/app/services/remediation_queue.py backend/app/services/remediation_dispatch.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_remediation_queue.py backend/app/tests/test_remediation_dispatch.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_public_api.py backend/app/tests/test_ai_mcp.py
- git diff --check

## Safety
- No live DNS/provider write behavior is added or changed.
- Public API and MCP responses remain read-only and now also clear provider apply confirmation phrases.
- Provider apply history is read from existing workspace audit logs only.

Refs #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider repair apply confirmation details and attempt history to remediation queue views.
  * Added a provider history filter and new queue summary metrics for apply attempts and verified applies.
  * Improved dashboard status display to show the most relevant remediation loop state.

* **Bug Fixes**
  * Read-only public and MCP responses now clearly block live apply actions and remove writable repair controls.
  * Provider repair cards now show clearer next-step guidance and audit-style history details when available.

* **Documentation**
  * Updated API and user guide documentation for the new remediation queue behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->