### PR TITLE
feat: align dashboard provider remediation states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain remediation provider-repair cards now show the operator confirmation prompt and current provider-apply history state alongside the existing pre/post apply checks.
 - Domain remediation provider-repair cards now render provider apply audit entries with provider, record, timestamp, verification status, and detail when history exists.
 - Domain remediation queues now include a provider-history filter so previously recorded provider apply attempts can be isolated from preview-only work.
+- Dashboard remediation filters now mirror provider apply, apply-blocked, and provider-history states from domain remediation queues.
+- Dashboard remediation summaries now count provider previews, apply-after-approval items, blocked applies, and missing provider values.
 - Domain remediation queue summaries now count provider apply attempts and verified provider applies from audit history.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2431,9 +2431,50 @@ def _dashboard_remediation_item(
         **context,
     }
     item["evidence_refresh"] = evidence_refresh_for_remediation_item(domain_name, item)
+    _attach_dashboard_provider_repair_state(item, action)
     if include_detail:
         item["detail"] = str(action.get("detail") or "")
     return item
+
+
+def _attach_dashboard_provider_repair_state(
+    item: Dict[str, Any],
+    action: Dict[str, Any],
+) -> None:
+    """Attach provider repair signals to the progression fields used by the dashboard."""
+    repair_progression = item.get("repair_progression") or {}
+    evidence_refresh = item.get("evidence_refresh") or {}
+    readiness_level = str(repair_progression.get("readiness_level") or "")
+    stage = str(repair_progression.get("stage") or "")
+    track = str(item.get("remediation_track") or "")
+    blocked_by = {str(value) for value in repair_progression.get("blocked_by") or []}
+    provider_blockers = {"provider_specific_value", "provider_value", "provider value"}
+    provider_value_missing = (
+        evidence_refresh.get("refresh_key") == "provider_value"
+        or bool(blocked_by & provider_blockers)
+        or track == "blocked_by_prerequisite"
+    )
+    provider_apply_blocked = readiness_level == "blocked" or stage == "blocked"
+    plan = action.get("provider_repair_plan") or {}
+    history = plan.get("attempt_history") or {}
+    history_entries = history.get("entries") or []
+    if not isinstance(history_entries, list):
+        history_entries = []
+
+    repair_progression.update(
+        {
+            "provider_preview_available": (
+                readiness_level == "ready_for_preview" or stage == "preview_ready"
+            ),
+            "provider_apply_after_approval": bool(
+                repair_progression.get("can_apply_after_approval")
+            ),
+            "provider_apply_blocked": provider_apply_blocked,
+            "provider_value_missing": provider_value_missing,
+            "provider_apply_history": len(history_entries),
+        }
+    )
+    item["repair_progression"] = repair_progression
 
 
 def _increment_repair_counters(counters: Dict[str, int], item: Dict[str, Any]) -> None:
@@ -2461,29 +2502,13 @@ def _increment_repair_counters(counters: Dict[str, int], item: Dict[str, Any]) -
 def _increment_provider_repair_counters(counters: Dict[str, int], item: Dict[str, Any]) -> None:
     """Count dashboard-safe provider repair states without exposing write controls."""
     repair_progression = item.get("repair_progression") or {}
-    evidence_refresh = item.get("evidence_refresh") or {}
-    readiness_level = str(repair_progression.get("readiness_level") or "")
-    stage = str(repair_progression.get("stage") or "")
-    track = str(item.get("remediation_track") or "")
-    blocked_by = {str(value) for value in repair_progression.get("blocked_by") or []}
-    provider_blockers = {"provider_specific_value", "provider_value", "provider value"}
-    provider_value_missing = (
-        evidence_refresh.get("refresh_key") == "provider_value"
-        or bool(blocked_by & provider_blockers)
-        or track == "blocked_by_prerequisite"
-    )
-
-    if readiness_level == "ready_for_preview" or stage == "preview_ready":
+    if repair_progression.get("provider_preview_available"):
         counters["provider_preview_available"] += 1
-    if repair_progression.get("can_apply_after_approval"):
+    if repair_progression.get("provider_apply_after_approval"):
         counters["provider_apply_after_approval"] += 1
-    if provider_value_missing:
+    if repair_progression.get("provider_value_missing"):
         counters["provider_value_missing"] += 1
-    if (
-        readiness_level == "blocked"
-        or stage == "blocked"
-        or provider_value_missing
-    ):
+    if repair_progression.get("provider_apply_blocked"):
         counters["provider_apply_blocked"] += 1
 
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2458,6 +2458,35 @@ def _increment_repair_counters(counters: Dict[str, int], item: Dict[str, Any]) -
     )
 
 
+def _increment_provider_repair_counters(counters: Dict[str, int], item: Dict[str, Any]) -> None:
+    """Count dashboard-safe provider repair states without exposing write controls."""
+    repair_progression = item.get("repair_progression") or {}
+    evidence_refresh = item.get("evidence_refresh") or {}
+    readiness_level = str(repair_progression.get("readiness_level") or "")
+    stage = str(repair_progression.get("stage") or "")
+    track = str(item.get("remediation_track") or "")
+    blocked_by = {str(value) for value in repair_progression.get("blocked_by") or []}
+    provider_blockers = {"provider_specific_value", "provider_value", "provider value"}
+    provider_value_missing = (
+        evidence_refresh.get("refresh_key") == "provider_value"
+        or bool(blocked_by & provider_blockers)
+        or track == "blocked_by_prerequisite"
+    )
+
+    if readiness_level == "ready_for_preview" or stage == "preview_ready":
+        counters["provider_preview_available"] += 1
+    if repair_progression.get("can_apply_after_approval"):
+        counters["provider_apply_after_approval"] += 1
+    if provider_value_missing:
+        counters["provider_value_missing"] += 1
+    if (
+        readiness_level == "blocked"
+        or stage == "blocked"
+        or provider_value_missing
+    ):
+        counters["provider_apply_blocked"] += 1
+
+
 def _increment_evidence_refresh_counters(
     counters: Dict[str, int],
     item: Dict[str, Any],
@@ -2528,6 +2557,12 @@ def _build_dashboard_remediation_loop(
         "verification_pending_reputation_review": 0,
         "verification_pending_report_evidence": 0,
         "verification_blocked_by_prerequisite": 0,
+        "provider_preview_available": 0,
+        "provider_apply_after_approval": 0,
+        "provider_apply_blocked": 0,
+        "provider_value_missing": 0,
+        "provider_apply_history": int(activity_summary.get("provider_apply_attempts") or 0),
+        "provider_apply_verified": int(activity_summary.get("provider_apply_verified") or 0),
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2540,6 +2575,7 @@ def _build_dashboard_remediation_loop(
             counters[state] += 1
             item = _dashboard_remediation_item(domain_name, action)
             _increment_repair_counters(counters, item)
+            _increment_provider_repair_counters(counters, item)
             _increment_evidence_refresh_counters(counters, item)
             _increment_verification_plan_counters(counters, item)
             track_counters[f"track_{item['remediation_track']}"] += 1
@@ -2607,6 +2643,12 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         "verification_pending_reputation_review": 0,
         "verification_pending_report_evidence": 0,
         "verification_blocked_by_prerequisite": 0,
+        "provider_preview_available": 0,
+        "provider_apply_after_approval": 0,
+        "provider_apply_blocked": 0,
+        "provider_value_missing": 0,
+        "provider_apply_history": 0,
+        "provider_apply_verified": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2616,6 +2658,7 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         counters[state] += 1
         item = _dashboard_remediation_item(domain_name, action, include_detail=False)
         _increment_repair_counters(counters, item)
+        _increment_provider_repair_counters(counters, item)
         _increment_evidence_refresh_counters(counters, item)
         _increment_verification_plan_counters(counters, item)
         track_counters[f"track_{item['remediation_track']}"] += 1

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1092,21 +1092,14 @@ function dashboardApp() {
                         ['approval_ready', 'needs_approval'].includes(String(item?.state || '')));
             }
             if (filterValue === 'provider_apply') {
-                const plan = item?.provider_repair_plan || {};
-                return Boolean(plan.can_apply_after_approval) ||
-                    Boolean(plan.safe_preview_available) ||
-                    readinessLevel === 'ready_for_preview' ||
-                    stage === 'preview_ready';
+                return Boolean(progression.provider_apply_after_approval) ||
+                    Boolean(progression.provider_preview_available);
             }
             if (filterValue === 'apply_blocked') {
-                const plan = item?.provider_repair_plan || {};
-                return Boolean(plan.apply_blocked) ||
-                    readinessLevel === 'blocked' ||
-                    stage === 'blocked';
+                return Boolean(progression.provider_apply_blocked);
             }
             if (filterValue === 'provider_history') {
-                const entries = item?.provider_repair_plan?.attempt_history?.entries || [];
-                return entries.length > 0;
+                return Number(progression.provider_apply_history || 0) > 0;
             }
             if (filterValue === 'sender_review') {
                 return verificationStatus === 'pending_sender_review';

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -20,6 +20,9 @@ function dashboardApp() {
             { value: 'preview_ready', label: 'Preview ready' },
             { value: 'fresh_evidence', label: 'Fresh evidence' },
             { value: 'approval_verification', label: 'Approval' },
+            { value: 'provider_apply', label: 'Provider apply' },
+            { value: 'apply_blocked', label: 'Apply blocked' },
+            { value: 'provider_history', label: 'Provider history' },
             { value: 'sender_review', label: 'Sender review' },
             { value: 'report_evidence', label: 'Report evidence' },
             { value: 'stale_evidence', label: 'Stale evidence' },
@@ -1088,6 +1091,23 @@ function dashboardApp() {
                     (!verificationStatus &&
                         ['approval_ready', 'needs_approval'].includes(String(item?.state || '')));
             }
+            if (filterValue === 'provider_apply') {
+                const plan = item?.provider_repair_plan || {};
+                return Boolean(plan.can_apply_after_approval) ||
+                    Boolean(plan.safe_preview_available) ||
+                    readinessLevel === 'ready_for_preview' ||
+                    stage === 'preview_ready';
+            }
+            if (filterValue === 'apply_blocked') {
+                const plan = item?.provider_repair_plan || {};
+                return Boolean(plan.apply_blocked) ||
+                    readinessLevel === 'blocked' ||
+                    stage === 'blocked';
+            }
+            if (filterValue === 'provider_history') {
+                const entries = item?.provider_repair_plan?.attempt_history?.entries || [];
+                return entries.length > 0;
+            }
             if (filterValue === 'sender_review') {
                 return verificationStatus === 'pending_sender_review';
             }
@@ -2061,6 +2081,20 @@ function dashboardApp() {
                     ? 'Evidence: provider value required'
                     : `Evidence: ${this.evidenceRefreshLabel(workload.primary.evidence_refresh)}`;
                 wrapper.appendChild(evidence);
+            }
+
+            const providerPreview = Number(workload?.provider_preview_available || 0);
+            const providerApply = Number(workload?.provider_apply_after_approval || 0);
+            const providerBlocked = Number(workload?.provider_apply_blocked || 0);
+            if (providerPreview || providerApply || providerBlocked) {
+                const provider = document.createElement('span');
+                provider.className = 'max-w-56 truncate text-xs font-semibold text-[#24507a]';
+                const parts = [];
+                if (providerPreview) parts.push(`${this.formatLargeNumber(providerPreview)} provider preview`);
+                if (providerApply) parts.push(`${this.formatLargeNumber(providerApply)} apply-ready`);
+                if (providerBlocked) parts.push(`${this.formatLargeNumber(providerBlocked)} apply blocked`);
+                provider.textContent = parts.join(' · ');
+                wrapper.appendChild(provider);
             }
 
             cell.appendChild(wrapper);

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -281,6 +281,11 @@
                 <p class="mt-2 text-2xl font-bold text-[#247982]"
                    x-text="remediationLoop().repair_ready_for_preview || remediationLoop().repair_preview_ready || 0"></p>
                 <p class="mt-1 text-xs text-[#5f5c78]">Provider-backed proposals ready for review</p>
+                <p class="mt-2 text-xs text-[#247982]">
+                    <span x-text="remediationLoop().provider_preview_available || 0"></span><span> provider previews</span>
+                    <span> · </span>
+                    <span x-text="remediationLoop().provider_apply_after_approval || 0"></span><span> apply after approval</span>
+                </p>
             </div>
             <div class="rounded-md border border-[#f5dfbd] bg-[#fff8ed] p-4">
                 <p class="text-sm text-[#5f5c78]">Need fresh evidence</p>
@@ -316,6 +321,8 @@
                 <p class="mt-2 text-xs text-[#5f5c78]">
                     <span x-text="remediationLoop().verification_blocked_by_prerequisite || 0"></span>
                     <span> provider values required</span>
+                    <span> · </span>
+                    <span x-text="remediationLoop().provider_apply_blocked || 0"></span><span> apply blocked</span>
                 </p>
             </div>
         </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -408,12 +408,15 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
         "remediationLoop().repair_ready_for_preview || remediationLoop().repair_preview_ready || 0"
         in template
     )
+    assert "remediationLoop().provider_preview_available || 0" in template
+    assert "remediationLoop().provider_apply_after_approval || 0" in template
     assert "remediationLoop().repair_needs_evidence || 0" in template
     assert "remediationLoop().repair_waiting_on_operator || 0" in template
     assert (
         "remediationLoop().repair_readiness_blocked || remediationLoop().repair_blocked || 0"
         in template
     )
+    assert "remediationLoop().provider_apply_blocked || 0" in template
     assert "remediationLoop().verification_pending_operator_approval || 0" in template
     assert "remediationLoop().verification_pending_report_evidence || 0" in template
     assert "remediationLoop().verification_pending_sender_review || 0" in template
@@ -450,6 +453,13 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b)" in script
     assert "dashboardRemediationFilterMatches(item, filterValue)" in script
     assert "verificationStatus === 'pending_operator_approval'" in script
+    assert "{ value: 'provider_apply', label: 'Provider apply' }" in script
+    assert "{ value: 'apply_blocked', label: 'Apply blocked' }" in script
+    assert "{ value: 'provider_history', label: 'Provider history' }" in script
+    assert "filterValue === 'provider_apply'" in script
+    assert "filterValue === 'apply_blocked'" in script
+    assert "filterValue === 'provider_history'" in script
+    assert "item?.provider_repair_plan?.attempt_history?.entries" in script
     assert "verificationStatus === 'pending_sender_review'" in script
     assert "verificationStatus === 'pending_report_evidence'" in script
     assert "dashboardRemediationEvidenceRank(item)" in script
@@ -548,6 +558,26 @@ def test_dashboard_remediation_filters_and_sorts_cards():
                     verification_plan: { status: 'pending_operator_approval' }
                 },
                 {
+                    domain: 'provider-history.example',
+                    state: 'needs_approval',
+                    priority_score: 7,
+                    severity: 'medium',
+                    repair_progression: {
+                        readiness_level: 'ready_for_preview',
+                        stage: 'preview_ready',
+                        readiness_score: 85
+                    },
+                    provider_repair_plan: {
+                        safe_preview_available: true,
+                        can_apply_after_approval: false,
+                        apply_blocked: true,
+                        attempt_history: {
+                            entries: [{ state: 'apply_needs_verification' }]
+                        }
+                    },
+                    verification_plan: { status: 'pending_operator_approval' }
+                },
+                {
                     domain: 'sender.example',
                     state: 'investigate',
                     remediation_track: 'sender_classification',
@@ -580,6 +610,9 @@ def test_dashboard_remediation_filters_and_sorts_cards():
                 app.dashboardRemediationFilterCount('blocked'),
                 app.dashboardRemediationFilterCount('reputation'),
                 app.dashboardRemediationFilterCount('approval_verification'),
+                app.dashboardRemediationFilterCount('provider_apply'),
+                app.dashboardRemediationFilterCount('apply_blocked'),
+                app.dashboardRemediationFilterCount('provider_history'),
                 app.dashboardRemediationFilterCount('sender_review'),
                 app.dashboardRemediationFilterCount('report_evidence'),
                 app.dashboardRemediationFilteredCount(),
@@ -587,7 +620,7 @@ def test_dashboard_remediation_filters_and_sorts_cards():
             ].join('|');
         })()""")
 
-    assert result == "1|1|1|1|1|4|blocked.example"
+    assert result == "1|1|2|2|2|1|1|1|4|blocked.example"
 
 
 def test_dashboard_remediation_stale_evidence_links_to_evidence_anchor():
@@ -613,6 +646,58 @@ def test_dashboard_remediation_stale_evidence_links_to_evidence_anchor():
         result
         == "1|/domains/mail.example%2Fa%20b#dns-records|DNS evidence is older than the TTL window."
     )
+
+
+def test_domain_list_remediation_cell_shows_provider_workload_summary():
+    result = _run_dashboard_expression("""(() => {
+            global.document = {
+                createElement: (tagName) => {
+                    const element = {
+                        tagName,
+                        className: '',
+                        children: [],
+                        _textContent: '',
+                        appendChild(child) {
+                            this.children.push(child);
+                            return child;
+                        },
+                        set textContent(value) {
+                            this._textContent = String(value);
+                        },
+                        get textContent() {
+                            return [
+                                this._textContent,
+                                ...this.children.map((child) => child.textContent || '')
+                            ].join('');
+                        }
+                    };
+                    return element;
+                }
+            };
+            const cell = app.createRemediationCell(
+                { status: 'none' },
+                {
+                    total_open: 3,
+                    provider_preview_available: 2,
+                    provider_apply_after_approval: 1,
+                    provider_apply_blocked: 1,
+                    primary: {
+                        state: 'needs_approval',
+                        remediation_track: 'provider_preview',
+                        repair_progression: {
+                            readiness_label: 'Ready for preview'
+                        },
+                        title: 'Review provider repair'
+                    }
+                }
+            );
+            return cell.textContent.replace(/\\s+/g, ' ').trim();
+        })()""")
+
+    assert "3 open" in result
+    assert "2 provider preview" in result
+    assert "1 apply-ready" in result
+    assert "1 apply blocked" in result
 
 
 def test_domain_details_remediation_queue_shows_verification_context():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -459,7 +459,10 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "filterValue === 'provider_apply'" in script
     assert "filterValue === 'apply_blocked'" in script
     assert "filterValue === 'provider_history'" in script
-    assert "item?.provider_repair_plan?.attempt_history?.entries" in script
+    assert "progression.provider_apply_after_approval" in script
+    assert "progression.provider_preview_available" in script
+    assert "progression.provider_apply_blocked" in script
+    assert "progression.provider_apply_history" in script
     assert "verificationStatus === 'pending_sender_review'" in script
     assert "verificationStatus === 'pending_report_evidence'" in script
     assert "dashboardRemediationEvidenceRank(item)" in script
@@ -513,7 +516,9 @@ def test_dashboard_remediation_filters_and_sorts_cards():
                     repair_progression: {
                         readiness_level: 'blocked',
                         readiness_score: 10,
-                        blocked_by: ['provider value']
+                        blocked_by: ['provider value'],
+                        provider_apply_blocked: true,
+                        provider_value_missing: true
                     },
                     evidence_refresh: {
                         required: true,
@@ -548,7 +553,10 @@ def test_dashboard_remediation_filters_and_sorts_cards():
                     repair_progression: {
                         readiness_level: 'ready_for_preview',
                         stage: 'preview_ready',
-                        readiness_score: 90
+                        readiness_score: 90,
+                        provider_preview_available: true,
+                        provider_apply_after_approval: true,
+                        provider_apply_blocked: false
                     },
                     evidence_refresh: {
                         required: true,
@@ -565,15 +573,11 @@ def test_dashboard_remediation_filters_and_sorts_cards():
                     repair_progression: {
                         readiness_level: 'ready_for_preview',
                         stage: 'preview_ready',
-                        readiness_score: 85
-                    },
-                    provider_repair_plan: {
-                        safe_preview_available: true,
-                        can_apply_after_approval: false,
-                        apply_blocked: true,
-                        attempt_history: {
-                            entries: [{ state: 'apply_needs_verification' }]
-                        }
+                        readiness_score: 85,
+                        provider_preview_available: true,
+                        provider_apply_after_approval: false,
+                        provider_apply_blocked: false,
+                        provider_apply_history: 1
                     },
                     verification_plan: { status: 'pending_operator_approval' }
                 },
@@ -620,7 +624,7 @@ def test_dashboard_remediation_filters_and_sorts_cards():
             ].join('|');
         })()""")
 
-    assert result == "1|1|2|2|2|1|1|1|4|blocked.example"
+    assert result == "1|1|2|2|1|1|1|1|4|blocked.example"
 
 
 def test_dashboard_remediation_stale_evidence_links_to_evidence_anchor():

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2287,6 +2287,10 @@ def test_summary_includes_current_remediation_loop(
     assert loop["items"][0]["priority_score"] > 0
     assert "approve_after_preview" in loop["items"][0]["operator_decisions"]
     assert loop["repair_preview_ready"] >= 2
+    assert loop["provider_preview_available"] >= 2
+    assert loop["provider_apply_after_approval"] >= 2
+    assert loop["provider_apply_blocked"] == 0
+    assert loop["provider_value_missing"] == 0
     assert loop["repair_needs_evidence"] >= 2
     assert loop["evidence_refresh_required"] >= 2
     assert loop["evidence_refresh_dns"] >= 2
@@ -2309,6 +2313,9 @@ def test_summary_includes_current_remediation_loop(
     assert domain["remediation_workload"]["what_needs_approval"] >= 2
     assert domain["remediation_workload"]["needs_approval"] >= 2
     assert domain["remediation_workload"]["repair_preview_ready"] >= 2
+    assert domain["remediation_workload"]["provider_preview_available"] >= 2
+    assert domain["remediation_workload"]["provider_apply_after_approval"] >= 2
+    assert domain["remediation_workload"]["provider_apply_blocked"] == 0
     assert domain["remediation_workload"]["repair_needs_evidence"] >= 2
     assert domain["remediation_workload"]["evidence_refresh_dns"] >= 2
     assert domain["remediation_workload"]["total_open"] >= 2

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -977,6 +977,9 @@ def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks
                             "prerequisites": [
                                 "A provider-specific final value is required before automation is safe."
                             ],
+                            "provider_repair_plan": {
+                                "attempt_history": {"entries": {"unexpected": "shape"}}
+                            },
                         }
                     ]
                 },
@@ -1005,6 +1008,7 @@ def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks
     assert loop["items"][0]["repair_progression"]["stage"] == "blocked"
     assert loop["items"][0]["repair_progression"]["can_preview"] is False
     assert loop["items"][0]["repair_progression"]["readiness_level"] == "blocked"
+    assert loop["items"][0]["repair_progression"]["provider_apply_history"] == 0
     assert loop["items"][0]["evidence_refresh"]["refresh_key"] == "provider_value"
     assert loop["items"][0]["evidence_refresh"]["safe_to_run"] is False
     assert loop["items"][0]["verification_plan"]["status"] == "blocked_by_prerequisite"

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -904,6 +904,10 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["track_provider_preview"] == 1
     assert loop["track_reputation_review"] == 1
     assert loop["repair_preview_ready"] == 1
+    assert loop["provider_preview_available"] == 1
+    assert loop["provider_apply_after_approval"] == 1
+    assert loop["provider_apply_blocked"] == 0
+    assert loop["provider_value_missing"] == 0
     assert loop["repair_needs_evidence"] == 2
     assert loop["evidence_refresh_required"] == 2
     assert loop["evidence_refresh_dns"] == 1
@@ -983,6 +987,10 @@ def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks
 
     assert loop["track_blocked_by_prerequisite"] == 1
     assert loop["repair_blocked"] == 1
+    assert loop["provider_preview_available"] == 0
+    assert loop["provider_apply_after_approval"] == 0
+    assert loop["provider_apply_blocked"] == 1
+    assert loop["provider_value_missing"] == 1
     assert loop["repair_preview_ready"] == 0
     assert loop["repair_needs_evidence"] == 1
     assert loop["evidence_refresh_required"] == 1

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -227,8 +227,11 @@ reputation refreshes, and each remediation card states the concrete read-only
 evidence action that should happen before the operator marks an item fixed.
 Use the dashboard remediation filters and sort control when the workspace has
 many active items. The dashboard can focus on preview-ready work, fresh evidence
-requirements, blocked items, manual repairs, or reputation review, and the
-compact card list can expand to show every matching item.
+requirements, provider apply work, blocked applies, provider apply history,
+manual repairs, or reputation review, and the compact card list can expand to
+show every matching item. The dashboard summary cards also count provider
+previews, apply-after-approval work, blocked applies, and missing provider
+values so a workspace-level triage view matches the domain queue semantics.
 Items with stale DNS, report, or reputation evidence can be filtered separately.
 When a remediation card knows the relevant evidence section, the dashboard links
 directly to that part of the domain detail page.


### PR DESCRIPTION
## Summary
- align dashboard remediation filters with provider apply, apply-blocked, and provider-history states from the domain remediation queue
- expose provider preview/apply/blocker counters in the workspace dashboard and domain list remediation cells
- document the dashboard provider triage semantics and cover them with backend/template/JS tests

## Validation
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_domain_detail_endpoints.py::test_dashboard_remediation_loop_exposes_operator_decision_context backend/app/tests/test_domain_detail_endpoints.py::test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks backend/app/tests/test_dns_endpoints.py::test_summary_includes_current_remediation_loop -q`
- `node --check backend/app/static/js/dashboard-page.js`
- `/tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py`
- `git diff --check`

Fixes part of #384.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new remediation dashboard filters and badges for provider apply, blocked apply, and provider history states.
  * Expanded remediation summary cards to show provider preview, apply-after-approval, blocked apply, and missing-value counts.

* **Bug Fixes**
  * Dashboard remediation counts now align more closely with the underlying repair states shown in the queue.

* **Documentation**
  * Updated the domain health check guide to describe the new dashboard filter and summary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->