### PR TITLE
feat: surface provider apply history on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain remediation queues now include a provider-history filter so previously recorded provider apply attempts can be isolated from preview-only work.
 - Dashboard remediation filters now mirror provider apply, apply-blocked, and provider-history states from domain remediation queues.
 - Dashboard remediation summaries now count provider previews, apply-after-approval items, blocked applies, and missing provider values.
+- Dashboard remediation summaries and domain rows now also surface provider apply attempts and verified provider applies.
 - Domain remediation queue summaries now count provider apply attempts and verified provider applies from audit history.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2460,11 +2460,11 @@ def _attach_dashboard_provider_repair_state(
     history_entries = history.get("entries") or []
     if not isinstance(history_entries, list):
         history_entries = []
-    verified_history_entries = [
-        entry
+    verified_history_count = sum(
+        1
         for entry in history_entries
         if isinstance(entry, dict) and entry.get("state") == "verified_after_apply"
-    ]
+    )
 
     repair_progression.update(
         {
@@ -2477,7 +2477,7 @@ def _attach_dashboard_provider_repair_state(
             "provider_apply_blocked": provider_apply_blocked,
             "provider_value_missing": provider_value_missing,
             "provider_apply_history": len(history_entries),
-            "provider_apply_verified": len(verified_history_entries),
+            "provider_apply_verified": verified_history_count,
         }
     )
     item["repair_progression"] = repair_progression

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2460,6 +2460,11 @@ def _attach_dashboard_provider_repair_state(
     history_entries = history.get("entries") or []
     if not isinstance(history_entries, list):
         history_entries = []
+    verified_history_entries = [
+        entry
+        for entry in history_entries
+        if isinstance(entry, dict) and entry.get("state") == "verified_after_apply"
+    ]
 
     repair_progression.update(
         {
@@ -2472,6 +2477,7 @@ def _attach_dashboard_provider_repair_state(
             "provider_apply_blocked": provider_apply_blocked,
             "provider_value_missing": provider_value_missing,
             "provider_apply_history": len(history_entries),
+            "provider_apply_verified": len(verified_history_entries),
         }
     )
     item["repair_progression"] = repair_progression
@@ -2510,6 +2516,12 @@ def _increment_provider_repair_counters(counters: Dict[str, int], item: Dict[str
         counters["provider_value_missing"] += 1
     if repair_progression.get("provider_apply_blocked"):
         counters["provider_apply_blocked"] += 1
+    counters["provider_apply_history"] += int(
+        repair_progression.get("provider_apply_history") or 0
+    )
+    counters["provider_apply_verified"] += int(
+        repair_progression.get("provider_apply_verified") or 0
+    )
 
 
 def _increment_evidence_refresh_counters(

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1099,7 +1099,8 @@ function dashboardApp() {
                 return Boolean(progression.provider_apply_blocked);
             }
             if (filterValue === 'provider_history') {
-                return Number(progression.provider_apply_history || 0) > 0;
+                return Number(progression.provider_apply_history || 0) > 0 ||
+                    Number(progression.provider_apply_verified || 0) > 0;
             }
             if (filterValue === 'sender_review') {
                 return verificationStatus === 'pending_sender_review';
@@ -2079,13 +2080,17 @@ function dashboardApp() {
             const providerPreview = Number(workload?.provider_preview_available || 0);
             const providerApply = Number(workload?.provider_apply_after_approval || 0);
             const providerBlocked = Number(workload?.provider_apply_blocked || 0);
-            if (providerPreview || providerApply || providerBlocked) {
+            const providerHistory = Number(workload?.provider_apply_history || 0);
+            const providerVerified = Number(workload?.provider_apply_verified || 0);
+            if (providerPreview || providerApply || providerBlocked || providerHistory || providerVerified) {
                 const provider = document.createElement('span');
                 provider.className = 'max-w-56 truncate text-xs font-semibold text-[#24507a]';
                 const parts = [];
                 if (providerPreview) parts.push(`${this.formatLargeNumber(providerPreview)} provider preview`);
                 if (providerApply) parts.push(`${this.formatLargeNumber(providerApply)} apply-ready`);
                 if (providerBlocked) parts.push(`${this.formatLargeNumber(providerBlocked)} apply blocked`);
+                if (providerHistory) parts.push(`${this.formatLargeNumber(providerHistory)} apply history`);
+                if (providerVerified) parts.push(`${this.formatLargeNumber(providerVerified)} verified`);
                 provider.textContent = parts.join(' · ');
                 wrapper.appendChild(provider);
             }

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -286,6 +286,11 @@
                     <span> · </span>
                     <span x-text="remediationLoop().provider_apply_after_approval || 0"></span><span> apply after approval</span>
                 </p>
+                <p class="mt-1 text-xs text-[#45505f]">
+                    <span x-text="remediationLoop().provider_apply_history || 0"></span><span> apply attempts</span>
+                    <span> · </span>
+                    <span x-text="remediationLoop().provider_apply_verified || 0"></span><span> verified</span>
+                </p>
             </div>
             <div class="rounded-md border border-[#f5dfbd] bg-[#fff8ed] p-4">
                 <p class="text-sm text-[#5f5c78]">Need fresh evidence</p>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -410,6 +410,8 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     )
     assert "remediationLoop().provider_preview_available || 0" in template
     assert "remediationLoop().provider_apply_after_approval || 0" in template
+    assert "remediationLoop().provider_apply_history || 0" in template
+    assert "remediationLoop().provider_apply_verified || 0" in template
     assert "remediationLoop().repair_needs_evidence || 0" in template
     assert "remediationLoop().repair_waiting_on_operator || 0" in template
     assert (
@@ -463,6 +465,7 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "progression.provider_preview_available" in script
     assert "progression.provider_apply_blocked" in script
     assert "progression.provider_apply_history" in script
+    assert "progression.provider_apply_verified" in script
     assert "verificationStatus === 'pending_sender_review'" in script
     assert "verificationStatus === 'pending_report_evidence'" in script
     assert "dashboardRemediationEvidenceRank(item)" in script
@@ -577,7 +580,8 @@ def test_dashboard_remediation_filters_and_sorts_cards():
                         provider_preview_available: true,
                         provider_apply_after_approval: false,
                         provider_apply_blocked: false,
-                        provider_apply_history: 1
+                        provider_apply_history: 1,
+                        provider_apply_verified: 1
                     },
                     verification_plan: { status: 'pending_operator_approval' }
                 },
@@ -685,6 +689,8 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
                     provider_preview_available: 2,
                     provider_apply_after_approval: 1,
                     provider_apply_blocked: 1,
+                    provider_apply_history: 2,
+                    provider_apply_verified: 1,
                     primary: {
                         state: 'needs_approval',
                         remediation_track: 'provider_preview',
@@ -702,6 +708,8 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
     assert "2 provider preview" in result
     assert "1 apply-ready" in result
     assert "1 apply blocked" in result
+    assert "2 apply history" in result
+    assert "1 verified" in result
 
 
 def test_domain_details_remediation_queue_shows_verification_context():

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2291,6 +2291,8 @@ def test_summary_includes_current_remediation_loop(
     assert loop["provider_apply_after_approval"] >= 2
     assert loop["provider_apply_blocked"] == 0
     assert loop["provider_value_missing"] == 0
+    assert loop["provider_apply_history"] >= 0
+    assert loop["provider_apply_verified"] >= 0
     assert loop["repair_needs_evidence"] >= 2
     assert loop["evidence_refresh_required"] >= 2
     assert loop["evidence_refresh_dns"] >= 2
@@ -2316,6 +2318,8 @@ def test_summary_includes_current_remediation_loop(
     assert domain["remediation_workload"]["provider_preview_available"] >= 2
     assert domain["remediation_workload"]["provider_apply_after_approval"] >= 2
     assert domain["remediation_workload"]["provider_apply_blocked"] == 0
+    assert domain["remediation_workload"]["provider_apply_history"] >= 0
+    assert domain["remediation_workload"]["provider_apply_verified"] >= 0
     assert domain["remediation_workload"]["repair_needs_evidence"] >= 2
     assert domain["remediation_workload"]["evidence_refresh_dns"] >= 2
     assert domain["remediation_workload"]["total_open"] >= 2

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -883,6 +883,14 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
                             "detail": "No DMARC policy was found.",
                             "next_step": "Publish a DMARC TXT record.",
                             "score_impact": 30,
+                            "provider_repair_plan": {
+                                "attempt_history": {
+                                    "entries": [
+                                        {"state": "apply_needs_verification"},
+                                        {"state": "verified_after_apply"},
+                                    ]
+                                }
+                            },
                         },
                         {
                             "type": "source_reputation_review",
@@ -908,6 +916,8 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["provider_apply_after_approval"] == 1
     assert loop["provider_apply_blocked"] == 0
     assert loop["provider_value_missing"] == 0
+    assert loop["provider_apply_history"] == 2
+    assert loop["provider_apply_verified"] == 1
     assert loop["repair_needs_evidence"] == 2
     assert loop["evidence_refresh_required"] == 2
     assert loop["evidence_refresh_dns"] == 1
@@ -930,6 +940,8 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["items"][0]["repair_progression"]["can_preview"] is True
     assert loop["items"][0]["repair_progression"]["readiness_level"] == "ready_for_preview"
     assert loop["items"][0]["repair_progression"]["readiness_score"] == 80
+    assert loop["items"][0]["repair_progression"]["provider_apply_history"] == 2
+    assert loop["items"][0]["repair_progression"]["provider_apply_verified"] == 1
     assert loop["items"][0]["evidence_refresh"]["refresh_key"] == "dns"
     assert loop["items"][0]["evidence_refresh"]["safe_to_run"] is True
     assert loop["items"][0]["verification_plan"]["status"] == "pending_operator_approval"

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -862,9 +862,11 @@ or fresh report/DNS evidence. Fresh-evidence counters such as
 kind of read-only refresh or prerequisite the operator should handle next.
 Provider-repair counters such as `provider_preview_available`,
 `provider_apply_after_approval`, `provider_apply_blocked`,
-`provider_value_missing`, and `provider_manual_fallback` summarize where DNS
-repairs can progress through a connected provider and where a prerequisite or
-manual fallback still owns the next step.
+`provider_value_missing`, `provider_apply_history`,
+`provider_apply_verified`, and `provider_manual_fallback` summarize where DNS
+repairs can progress through a connected provider, which applies already have
+history or verified evidence, and where a prerequisite or manual fallback still
+owns the next step.
 The workspace dashboard `health_summary.remediation_loop` and each domain row's
 `remediation_workload` expose the same `evidence_refresh` object and counters,
 so clients can present the correct refresh path before opening the detail queue.

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -232,6 +232,8 @@ manual repairs, or reputation review, and the compact card list can expand to
 show every matching item. The dashboard summary cards also count provider
 previews, apply-after-approval work, blocked applies, and missing provider
 values so a workspace-level triage view matches the domain queue semantics.
+When provider apply history exists, the dashboard and domain rows show the
+attempt count and how many applies have been verified by follow-up evidence.
 Items with stale DNS, report, or reputation evidence can be filtered separately.
 When a remediation card knows the relevant evidence section, the dashboard links
 directly to that part of the domain detail page.


### PR DESCRIPTION
## Summary
- add normalized provider apply verified counts alongside provider apply history in dashboard repair progression
- surface provider apply attempts and verified applies in the workspace dashboard summary and domain-list remediation cells
- update API/user docs, changelog, and focused dashboard/domain tests

## Validation
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_domain_detail_endpoints.py::test_dashboard_remediation_loop_exposes_operator_decision_context backend/app/tests/test_domain_detail_endpoints.py::test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks backend/app/tests/test_dns_endpoints.py::test_summary_includes_current_remediation_loop -q`
- `node --check backend/app/static/js/dashboard-page.js`
- `/tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py`
- `git diff --check`

Continues #384.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard remediation views now show additional provider apply activity, including apply attempts and verified applies.
  * Domain rows and remediation cards display these extra counts when available.

* **Bug Fixes**
  * Dashboard filtering and summary counts now include verified apply history, improving consistency across remediation views.

* **Documentation**
  * Updated user and API documentation to reflect the new remediation counters and dashboard display details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->