### PR TITLE
feat: surface remediation dispatch activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard remediation filters now mirror provider apply, apply-blocked, and provider-history states from domain remediation queues.
 - Dashboard remediation summaries now count provider previews, apply-after-approval items, blocked applies, and missing provider values.
 - Dashboard remediation summaries and domain rows now also surface provider apply attempts and verified provider applies.
+- Dashboard remediation summaries and domain rows now surface notification dispatches and operator follow-up activity.
 - Domain remediation queue summaries now count provider apply attempts and verified provider applies from audit history.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -2095,6 +2095,18 @@ function dashboardApp() {
                 wrapper.appendChild(provider);
             }
 
+            const dispatched = Number(remediation?.dispatch_enqueued || 0);
+            const followUp = Number(remediation?.needs_operator_follow_up || 0);
+            if (dispatched || followUp) {
+                const dispatch = document.createElement('span');
+                dispatch.className = 'max-w-56 truncate text-xs font-semibold text-[#5f5c78]';
+                const parts = [];
+                if (dispatched) parts.push(`${this.formatLargeNumber(dispatched)} dispatched`);
+                if (followUp) parts.push(`${this.formatLargeNumber(followUp)} follow-up`);
+                dispatch.textContent = parts.join(' · ');
+                wrapper.appendChild(dispatch);
+            }
+
             cell.appendChild(wrapper);
             return cell;
         },

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -298,7 +298,7 @@
                    x-text="remediationLoop().dispatch_enqueued || 0"></p>
                 <p class="mt-1 text-xs text-[#5f5c78]">Confirmed notification dispatches</p>
                 <p class="mt-2 text-xs text-[#24507a]">
-                    <span x-text="remediationLoop().operator_follow_up || 0"></span><span> need follow-up</span>
+                    <span x-text="remediationLoop().operator_follow_up || 0"></span><span> domains need follow-up</span>
                 </p>
             </div>
             <div class="rounded-md border border-[#f5dfbd] bg-[#fff8ed] p-4">

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -275,7 +275,7 @@
                 <p class="mt-1 text-xs text-[#5f5c78]">Sender or report evidence to confirm</p>
             </div>
         </div>
-        <div class="mt-3 grid gap-3 md:grid-cols-4">
+        <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
             <div class="rounded-md border border-[#d8ebe8] bg-[#f2fbf9] p-4">
                 <p class="text-sm text-[#5f5c78]">Repair previews ready</p>
                 <p class="mt-2 text-2xl font-bold text-[#247982]"
@@ -290,6 +290,15 @@
                     <span x-text="remediationLoop().provider_apply_history || 0"></span><span> apply attempts</span>
                     <span> · </span>
                     <span x-text="remediationLoop().provider_apply_verified || 0"></span><span> verified</span>
+                </p>
+            </div>
+            <div class="rounded-md border border-[#d5e9f8] bg-[#f7fbff] p-4">
+                <p class="text-sm text-[#5f5c78]">Dispatch activity</p>
+                <p class="mt-2 text-2xl font-bold text-[#24507a]"
+                   x-text="remediationLoop().dispatch_enqueued || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Confirmed notification dispatches</p>
+                <p class="mt-2 text-xs text-[#24507a]">
+                    <span x-text="remediationLoop().operator_follow_up || 0"></span><span> need follow-up</span>
                 </p>
             </div>
             <div class="rounded-md border border-[#f5dfbd] bg-[#fff8ed] p-4">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -412,6 +412,9 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "remediationLoop().provider_apply_after_approval || 0" in template
     assert "remediationLoop().provider_apply_history || 0" in template
     assert "remediationLoop().provider_apply_verified || 0" in template
+    assert "Dispatch activity" in template
+    assert "remediationLoop().dispatch_enqueued || 0" in template
+    assert "remediationLoop().operator_follow_up || 0" in template
     assert "remediationLoop().repair_needs_evidence || 0" in template
     assert "remediationLoop().repair_waiting_on_operator || 0" in template
     assert (
@@ -683,7 +686,11 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
                 }
             };
             const cell = app.createRemediationCell(
-                { status: 'none' },
+                {
+                    status: 'dispatched',
+                    dispatch_enqueued: 1,
+                    needs_operator_follow_up: true
+                },
                 {
                     total_open: 3,
                     provider_preview_available: 2,
@@ -710,6 +717,8 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
     assert "1 apply blocked" in result
     assert "2 apply history" in result
     assert "1 verified" in result
+    assert "1 dispatched" in result
+    assert "1 follow-up" in result
 
 
 def test_domain_details_remediation_queue_shows_verification_context():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -415,6 +415,7 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "Dispatch activity" in template
     assert "remediationLoop().dispatch_enqueued || 0" in template
     assert "remediationLoop().operator_follow_up || 0" in template
+    assert "domains need follow-up" in template
     assert "remediationLoop().repair_needs_evidence || 0" in template
     assert "remediationLoop().repair_waiting_on_operator || 0" in template
     assert (

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -234,6 +234,9 @@ previews, apply-after-approval work, blocked applies, and missing provider
 values so a workspace-level triage view matches the domain queue semantics.
 When provider apply history exists, the dashboard and domain rows show the
 attempt count and how many applies have been verified by follow-up evidence.
+The same dashboard area also surfaces confirmed notification dispatches and
+operator follow-up activity so remediation work does not disappear after a
+webhook has been queued.
 Items with stale DNS, report, or reputation evidence can be filtered separately.
 When a remediation card knows the relevant evidence section, the dashboard links
 directly to that part of the domain detail page.


### PR DESCRIPTION
## Summary
- add a dashboard remediation card for confirmed dispatches and operator follow-up activity
- show per-domain dispatch/follow-up activity in the domain list remediation cell
- update dashboard tests, user docs, and changelog for the read-only dispatch visibility

## Validation
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q`
- `node --check backend/app/static/js/dashboard-page.js`
- `/tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py`
- `git diff --check`

Continues #384.
