### PR TITLE
feat: improve remediation dispatch dashboard follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard remediation summaries now count provider previews, apply-after-approval items, blocked applies, and missing provider values.
 - Dashboard remediation summaries and domain rows now also surface provider apply attempts and verified provider applies.
 - Dashboard remediation summaries and domain rows now surface notification dispatches and operator follow-up activity.
+- Dashboard remediation cards can now be filtered and sorted by notification dispatch readiness, dispatched work, operator follow-up, and dispatch blockers.
+- Dashboard remediation filters now receive a larger bounded working set from the backend instead of only the first compact card page.
+- Domain remediation rows now show the latest operator or dispatch activity label and timestamp beside the active remediation workload.
 - Domain remediation queue summaries now count provider apply attempts and verified provider applies from audit history.
 - Reorganized repository: moved development docs (`AGENTS.md`, `ROADMAP.md`, `ISSUE_GENERATION_SUMMARY.md`, `generated_issues/`) into `docs/`
 - Added root-level `CHANGELOG.md` and `TODO.md`

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1988,6 +1988,7 @@ REMEDIATION_SEVERITY_RANK = {
     "low": 1,
     "info": 0,
 }
+REMEDIATION_DASHBOARD_ITEM_LIMIT = 25
 REMEDIATION_STATE_PRIORITY = {
     "needs_approval": 40,
     "manual_action": 30,
@@ -2653,7 +2654,7 @@ def _build_dashboard_remediation_loop(
         "operator_follow_up": int(activity_summary.get("needs_operator_follow_up") or 0),
         "status": "clear" if total_open == 0 else "needs_attention",
         "top_incident_type": str(items[0].get("incident_type") or "") if items else "",
-        "items": items[:5],
+        "items": items[:REMEDIATION_DASHBOARD_ITEM_LIMIT],
     }
 
 

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -23,6 +23,10 @@ function dashboardApp() {
             { value: 'provider_apply', label: 'Provider apply' },
             { value: 'apply_blocked', label: 'Apply blocked' },
             { value: 'provider_history', label: 'Provider history' },
+            { value: 'notify_ready', label: 'Ready to notify' },
+            { value: 'dispatched', label: 'Dispatched' },
+            { value: 'follow_up', label: 'Follow-up' },
+            { value: 'dispatch_blocked', label: 'Dispatch blocked' },
             { value: 'sender_review', label: 'Sender review' },
             { value: 'report_evidence', label: 'Report evidence' },
             { value: 'stale_evidence', label: 'Stale evidence' },
@@ -1020,6 +1024,14 @@ function dashboardApp() {
                     (Number(b?.priority_score) || 0) - (Number(a?.priority_score) || 0)
                 ));
             }
+            if (this.dashboardRemediationSort === 'dispatch') {
+                return list.sort((a, b) => (
+                    this.dashboardRemediationDispatchRank(a) -
+                    this.dashboardRemediationDispatchRank(b) ||
+                    this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b) ||
+                    (Number(b?.priority_score) || 0) - (Number(a?.priority_score) || 0)
+                ));
+            }
             return Array.isArray(items)
                 ? [...items].sort((a, b) => (
                     this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b) ||
@@ -1102,6 +1114,26 @@ function dashboardApp() {
                 return Number(progression.provider_apply_history || 0) > 0 ||
                     Number(progression.provider_apply_verified || 0) > 0;
             }
+            if (filterValue === 'notify_ready') {
+                return Boolean(item?.notification?.dispatch?.eligible);
+            }
+            if (filterValue === 'dispatched') {
+                const activity = this.dashboardRemediationActivity(item);
+                return Number(activity.dispatch_enqueued || 0) > 0 ||
+                    Boolean(item?.notification?.dispatch?.delivery_enqueued);
+            }
+            if (filterValue === 'follow_up') {
+                const activity = this.dashboardRemediationActivity(item);
+                const dispatch = item?.notification?.dispatch || {};
+                return Boolean(activity.needs_operator_follow_up) ||
+                    Boolean(dispatch.requires_lifecycle_acknowledgement) ||
+                    Boolean(dispatch.operator_hold);
+            }
+            if (filterValue === 'dispatch_blocked') {
+                const dispatch = item?.notification?.dispatch || {};
+                return Boolean(dispatch.enabled && !dispatch.eligible) ||
+                    (dispatch.blocked_reasons || []).length > 0;
+            }
             if (filterValue === 'sender_review') {
                 return verificationStatus === 'pending_sender_review';
             }
@@ -1135,6 +1167,44 @@ function dashboardApp() {
                     refreshKey === 'source_reputation';
             }
             return true;
+        },
+
+        dashboardRemediationActivity(item) {
+            const domainName = typeof item === 'string' ? item : item?.domain;
+            if (!domainName) return {};
+            const domain = this.domains.find(
+                entry => entry.domain_name === domainName || entry.id === domainName
+            );
+            return domain?.remediation || {};
+        },
+
+        dashboardRemediationDispatchRank(item) {
+            const activity = this.dashboardRemediationActivity(item);
+            const dispatch = item?.notification?.dispatch || {};
+            if (Boolean(activity.needs_operator_follow_up) || Boolean(dispatch.operator_hold)) return 0;
+            if (Number(activity.dispatch_enqueued || 0) > 0 || dispatch.delivery_enqueued) return 1;
+            if (dispatch.enabled && !dispatch.eligible) return 2;
+            if (dispatch.eligible) return 3;
+            return 4;
+        },
+
+        dashboardRemediationDispatchText(item) {
+            const activity = this.dashboardRemediationActivity(item);
+            const dispatch = item?.notification?.dispatch || {};
+            const parts = [];
+            const dispatched = Number(activity.dispatch_enqueued || 0);
+            if (dispatched) {
+                parts.push(`${this.formatLargeNumber(dispatched)} notification${dispatched === 1 ? '' : 's'} dispatched`);
+            }
+            if (activity.needs_operator_follow_up || dispatch.requires_lifecycle_acknowledgement) {
+                parts.push('operator follow-up needed');
+            }
+            if (dispatch.eligible) {
+                parts.push('ready to notify');
+            } else if (dispatch.enabled && (dispatch.blocked_reasons || []).length) {
+                parts.push('dispatch blocked');
+            }
+            return parts.join(' · ');
         },
 
         remediationLoopItemRank(item) {
@@ -2055,11 +2125,19 @@ function dashboardApp() {
                 const readiness = this.repairReadinessLabel(workload.primary.repair_progression);
                 latest.textContent = `${this.remediationLoopStateLabel(workload.primary.state)} · ${track} · ${readiness}`;
             } else if (remediation?.latest_at) {
-                latest.textContent = new Date(remediation.latest_at).toLocaleString();
+                latest.textContent = this.remediationActivityText(remediation);
             } else {
                 latest.textContent = 'No operator action';
             }
             wrapper.appendChild(latest);
+
+            const activityText = this.remediationActivityText(remediation);
+            if (activityText && activityText !== latest.textContent) {
+                const activity = document.createElement('span');
+                activity.className = 'max-w-56 truncate text-xs text-muted-foreground';
+                activity.textContent = activityText;
+                wrapper.appendChild(activity);
+            }
 
             if (workload?.primary?.title) {
                 const action = document.createElement('span');
@@ -2109,6 +2187,13 @@ function dashboardApp() {
 
             cell.appendChild(wrapper);
             return cell;
+        },
+
+        remediationActivityText(remediation) {
+            if (!remediation || !remediation.latest_at) return '';
+            const label = remediation.latest_label || this.remediationStatusLabel(remediation.status);
+            const timestamp = new Date(remediation.latest_at).toLocaleString();
+            return `${label} · ${timestamp}`;
         },
 
         createPassRateCell(passRate) {

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -351,6 +351,7 @@
                     <option value="readiness">Repair readiness</option>
                     <option value="freshness">Fresh evidence</option>
                     <option value="severity">Severity</option>
+                    <option value="dispatch">Dispatch follow-up</option>
                 </select>
             </label>
             <template x-for="filter in dashboardRemediationFilterOptions" :key="'dashboard-remediation-filter-' + filter.value">
@@ -458,6 +459,9 @@
                             </div>
                         </div>
                     </div>
+                    <p class="mt-3 rounded border border-[#d5e9f8] bg-[#f7fbff] p-3 text-xs font-semibold text-[#24507a]"
+                       x-show="dashboardRemediationDispatchText(item)"
+                       x-text="dashboardRemediationDispatchText(item)"></p>
                     <div class="mt-3 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-3 text-xs"
                          x-show="item.evidence_refresh?.required">
                         <div class="flex flex-wrap items-center justify-between gap-2">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -365,6 +365,10 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "dashboardRemediationFilterOptions" in script
     assert "{ value: 'fresh_evidence', label: 'Fresh evidence' }" in script
     assert "{ value: 'approval_verification', label: 'Approval' }" in script
+    assert "{ value: 'notify_ready', label: 'Ready to notify' }" in script
+    assert "{ value: 'dispatched', label: 'Dispatched' }" in script
+    assert "{ value: 'follow_up', label: 'Follow-up' }" in script
+    assert "{ value: 'dispatch_blocked', label: 'Dispatch blocked' }" in script
     assert "{ value: 'sender_review', label: 'Sender review' }" in script
     assert "{ value: 'report_evidence', label: 'Report evidence' }" in script
     assert "{ value: 'stale_evidence', label: 'Stale evidence' }" in script
@@ -372,6 +376,7 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "showAllDashboardRemediationItems" in script
     assert "data-dashboard-remediation-sort" in template
     assert "data-dashboard-remediation-sort" in script
+    assert '<option value="dispatch">Dispatch follow-up</option>' in template
     assert "data-dashboard-remediation-filter" in template
     assert "data-dashboard-remediation-filter" in script
     assert "data-dashboard-remediation-toggle-all" in template
@@ -443,6 +448,9 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "verificationPlanStatusLabel(item.verification_plan)" in template
     assert "verificationPlanFailureMode(item.verification_plan)" in template
     assert "verificationPlanEvidenceNeededText(item.verification_plan)" in template
+    assert "dashboardRemediationDispatchText(item)" in template
+    assert "dashboardRemediationDispatchRank(item)" in script
+    assert "dashboardRemediationActivity(item)" in script
     assert "repairReadinessClass(item.repair_progression)" in template
     assert "repairReadinessLabel(item.repair_progression)" in template
     assert "repairReadinessScore(item.repair_progression)" in template
@@ -614,8 +622,39 @@ def test_dashboard_remediation_filters_and_sorts_cards():
                         readiness_score: 45
                     },
                     verification_plan: { status: 'pending_report_evidence' }
+                },
+                {
+                    domain: 'dispatch.example',
+                    state: 'manual_action',
+                    remediation_track: 'manual_dns',
+                    priority_score: 8,
+                    severity: 'high',
+                    repair_progression: {
+                        readiness_level: 'manual_repair',
+                        stage: 'operator_review',
+                        readiness_score: 50
+                    },
+                    verification_plan: { status: 'pending_report_evidence' },
+                    notification: {
+                        dispatch: {
+                            enabled: true,
+                            eligible: false,
+                            blocked_reasons: [
+                                'No enabled webhook endpoint is subscribed to this event.'
+                            ]
+                        }
+                    }
                 }
             ] } };
+            app.domains = [
+                {
+                    domain_name: 'dispatch.example',
+                    remediation: {
+                        dispatch_enqueued: 2,
+                        needs_operator_follow_up: true
+                    }
+                }
+            ];
             app.dashboardRemediationFilter = 'fresh_evidence';
             app.dashboardRemediationSort = 'freshness';
             return [
@@ -625,6 +664,10 @@ def test_dashboard_remediation_filters_and_sorts_cards():
                 app.dashboardRemediationFilterCount('provider_apply'),
                 app.dashboardRemediationFilterCount('apply_blocked'),
                 app.dashboardRemediationFilterCount('provider_history'),
+                app.dashboardRemediationFilterCount('notify_ready'),
+                app.dashboardRemediationFilterCount('dispatched'),
+                app.dashboardRemediationFilterCount('follow_up'),
+                app.dashboardRemediationFilterCount('dispatch_blocked'),
                 app.dashboardRemediationFilterCount('sender_review'),
                 app.dashboardRemediationFilterCount('report_evidence'),
                 app.dashboardRemediationFilteredCount(),
@@ -632,7 +675,67 @@ def test_dashboard_remediation_filters_and_sorts_cards():
             ].join('|');
         })()""")
 
-    assert result == "1|1|2|2|1|1|1|1|4|blocked.example"
+    assert result == "1|1|2|2|1|1|0|1|1|1|1|2|4|blocked.example"
+
+
+def test_dashboard_remediation_dispatch_activity_filters_and_labels():
+    result = _run_dashboard_expression("""(() => {
+            app.healthSummary = { remediation_loop: { items: [
+                {
+                    domain: 'follow.example',
+                    state: 'manual_action',
+                    priority_score: 7,
+                    severity: 'high',
+                    notification: { dispatch: { enabled: true, eligible: false } }
+                },
+                {
+                    domain: 'ready.example',
+                    state: 'needs_approval',
+                    priority_score: 9,
+                    severity: 'medium',
+                    notification: { dispatch: { enabled: true, eligible: true } }
+                },
+                {
+                    domain: 'blocked.example',
+                    state: 'investigate',
+                    priority_score: 6,
+                    severity: 'medium',
+                    notification: {
+                        dispatch: {
+                            enabled: true,
+                            eligible: false,
+                            blocked_reasons: [
+                                'No enabled webhook endpoint is subscribed to this event.'
+                            ]
+                        }
+                    }
+                }
+            ] } };
+            app.domains = [
+                {
+                    domain_name: 'follow.example',
+                    remediation: {
+                        dispatch_enqueued: 3,
+                        needs_operator_follow_up: true
+                    }
+                }
+            ];
+            app.dashboardRemediationFilter = 'follow_up';
+            app.dashboardRemediationSort = 'dispatch';
+            return [
+                app.dashboardRemediationFilterCount('notify_ready'),
+                app.dashboardRemediationFilterCount('dispatched'),
+                app.dashboardRemediationFilterCount('follow_up'),
+                app.dashboardRemediationFilterCount('dispatch_blocked'),
+                app.visibleDashboardRemediationItems()[0].domain,
+                app.dashboardRemediationDispatchText(app.visibleDashboardRemediationItems()[0])
+            ].join('|');
+        })()""")
+
+    assert result == (
+        "1|1|1|2|follow.example|"
+        "3 notifications dispatched · operator follow-up needed"
+    )
 
 
 def test_dashboard_remediation_stale_evidence_links_to_evidence_anchor():
@@ -689,6 +792,8 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
             const cell = app.createRemediationCell(
                 {
                     status: 'dispatched',
+                    latest_label: 'Dispatch enqueued',
+                    latest_at: '2026-07-06T03:00:00Z',
                     dispatch_enqueued: 1,
                     needs_operator_follow_up: true
                 },
@@ -720,6 +825,7 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
     assert "1 verified" in result
     assert "1 dispatched" in result
     assert "1 follow-up" in result
+    assert "Dispatch enqueued" in result
 
 
 def test_domain_details_remediation_queue_shows_verification_context():

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2363,6 +2363,34 @@ def test_dashboard_remediation_loop_is_clear_without_current_actions():
     assert loop["repair_blocked"] == 0
 
 
+def test_dashboard_remediation_loop_returns_filterable_working_set():
+    """Dashboard filters should receive more than the first compact-card page."""
+    loop = domains_endpoint._build_dashboard_remediation_loop(
+        domains=[
+            {
+                "domain_name": f"domain-{index}.example",
+                "health": {
+                    "actions": [
+                        {
+                            "type": "missing_dmarc",
+                            "severity": "high",
+                            "title": f"Publish DMARC {index}",
+                            "detail": "No DMARC policy was found.",
+                            "next_step": "Publish a DMARC TXT record.",
+                            "score_impact": 30,
+                        }
+                    ]
+                },
+            }
+            for index in range(8)
+        ],
+        remediation_activity={"summary": {}},
+    )
+
+    assert loop["total_open"] == 8
+    assert len(loop["items"]) == 8
+
+
 @pytest.mark.parametrize(
     "action_type",
     ["source_reputation_listed", "source_reputation_review"],

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -879,6 +879,11 @@ verification counters such as `verification_pending_operator_approval`,
 `verification_pending_report_evidence`, and `verification_blocked_by_prerequisite`
 so clients can distinguish approval, sender review, reputation evidence, manual
 fresh-evidence checks, and missing provider values.
+Dashboard clients can also combine `health_summary.remediation_loop.items` with
+each domain row's `remediation` activity to group cards by dispatched
+notifications and operator follow-up without rebuilding the domain queue. The
+dashboard loop returns a bounded working set rather than only the first compact
+page, so client-side filters can still find lower-priority items.
 
 Notification metadata includes the event name, channel, dedupe key, reason, and
 next state transition that an operator workflow can use. Each notification also

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -87,7 +87,9 @@ summary before linking to the selected domain for the full evidence, approval,
 and verification flow. Filter chips let you isolate preview-ready repairs,
 approval verification, sender review, report-evidence follow-up, blocked work,
 manual work, reputation review, and stale-evidence cases without opening every
-domain.
+domain. The same filter bar can now isolate remediation notifications that are
+ready to send, already dispatched, blocked by notification settings, or waiting
+for operator follow-up after dispatch.
 Open the domain detail queue for the full provider-repair plan. That view shows
 whether a DNS item has a safe provider preview, can be applied only after
 explicit approval, is blocked by missing provider values, or should fall back to

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -236,7 +236,11 @@ When provider apply history exists, the dashboard and domain rows show the
 attempt count and how many applies have been verified by follow-up evidence.
 The same dashboard area also surfaces confirmed notification dispatches and
 operator follow-up activity so remediation work does not disappear after a
-webhook has been queued.
+webhook has been queued. Use the dashboard dispatch filters to focus on items
+that are ready to notify, already dispatched, blocked before dispatch, or still
+waiting for acknowledgement or follow-up. Domain rows also show the latest
+operator or dispatch activity timestamp alongside the active remediation
+workload, so stale history is easier to separate from current work.
 Items with stale DNS, report, or reputation evidence can be filtered separately.
 When a remediation card knows the relevant evidence section, the dashboard links
 directly to that part of the domain detail page.


### PR DESCRIPTION
## Summary
- add dashboard remediation filters for notification-ready, dispatched, follow-up, and dispatch-blocked work
- add dispatch-follow-up sorting and visible dispatch/follow-up context on remediation cards
- return a bounded 25-item remediation working set to keep dashboard filters useful beyond the compact card page
- show latest operator/dispatch activity on domain remediation rows
- update changelog, API reference, and user docs

## Why
The dashboard already exposed remediation dispatch totals, but operators could not turn those totals into a working list. This keeps the workspace view actionable after notifications are queued and makes stale/operator activity easier to separate from current remediation work.

## Validation
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_dns_endpoints.py::test_summary_includes_remediation_activity backend/app/tests/test_dns_endpoints.py::test_summary_includes_current_remediation_loop backend/app/tests/test_dns_endpoints.py::test_dashboard_remediation_loop_returns_filterable_working_set -q`
- `node --check backend/app/static/js/dashboard-page.js`
- `/tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_dns_endpoints.py`
- `git diff --check`

## Safety
- No DNS/provider write behavior changed.
- No notification dispatch behavior changed.
- This is read-only dashboard/API visibility and filtering around already-recorded remediation activity.

Closes no issue; continues #384.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard filters and a new sort option to better track notification and dispatch progress.
  * Expanded remediation cards and domain rows to show the latest activity label and timestamp.
  * Increased the number of remediation items shown in the dashboard working set.

* **Documentation**
  * Updated user guides and API reference to explain the new remediation filtering and dashboard activity details.

* **Bug Fixes**
  * Improved dashboard results so filtering can work across a larger set of remediation items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->