### PR TITLE
feat: expose dashboard remediation notification profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added remediation provider repair checklists so DNS repair items show before-apply checks, after-apply evidence checks, blast radius, and operator warnings before any provider write path is exposed.
 - Added a domain remediation filter and summary counter for provider repair checklists so operator-review work can be isolated quickly.
 - Added remediation provider apply-confirmation metadata and attempt-history placeholders so future live DNS repair controls have an explicit confirmation phrase, blocker list, and audit-trail slot before any write behavior is enabled.
+- Added dashboard remediation notification profiles and payload previews so workspace filters can identify approval, manual-action, and investigation notifications from backend data before dispatch previews are attached.
 
 ### Changed
 - Domain summary DNS refreshes now run with bounded concurrency instead of resolving each domain sequentially.
@@ -78,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain remediation cards now offer focused read-only evidence refresh actions that reload the relevant backend data and rebuild the queue without applying DNS or provider writes.
 - Public API and read-only MCP remediation queues now strip provider preview/apply endpoints from both item data and notification payload previews while keeping read-only provider-repair context visible.
 - Public API and read-only MCP remediation queues now label provider repair approval gates as read-only and warn that provider write endpoints are intentionally omitted.
+- Dashboard remediation notification filters now treat backend notification profiles as ready-to-notify candidates instead of requiring a dispatch preview object on every workspace card.
 - Public API and read-only MCP remediation queues now also clear provider apply confirmation phrases and mark confirmation metadata as read-only blocked.
 - Domain remediation provider-repair cards now show the operator confirmation prompt and current provider-apply history state alongside the existing pre/post apply checks.
 - Domain remediation provider-repair cards now render provider apply audit entries with provider, record, timestamp, verification status, and detail when history exists.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2490,7 +2490,7 @@ def _dashboard_remediation_notification(domain: str, item: Dict[str, Any]) -> Di
             "next_transition": "resolved_or_escalated",
         }
     notification["payload_preview"] = {
-        "schema_version": "dmarq.remediation.notification.v1",
+        "schema_version": "dmarq.dashboard.remediation.notification_preview.v1",
         "domain": domain,
         "item_id": item_id,
         "source": source,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -141,7 +141,14 @@ from app.services.source_reputation import (
     source_reputation_by_ip,
 )
 from app.services.source_reputation_feeds import feed_registry
-from app.services.webhook_events import delivery_to_dict, enqueue_webhook_event
+from app.services.webhook_events import (
+    EVENT_REMEDIATION_APPROVAL_REQUIRED,
+    EVENT_REMEDIATION_INVESTIGATION_REQUIRED,
+    EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED,
+    EVENT_REMEDIATION_SUMMARY,
+    delivery_to_dict,
+    enqueue_webhook_event,
+)
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
     PERMISSION_REPORTS_READ,
@@ -2433,9 +2440,75 @@ def _dashboard_remediation_item(
     }
     item["evidence_refresh"] = evidence_refresh_for_remediation_item(domain_name, item)
     _attach_dashboard_provider_repair_state(item, action)
+    item["notification"] = _dashboard_remediation_notification(domain_name, item)
     if include_detail:
         item["detail"] = str(action.get("detail") or "")
     return item
+
+
+def _dashboard_remediation_notification(domain: str, item: Dict[str, Any]) -> Dict[str, Any]:
+    """Return read-only notification routing metadata for dashboard remediation cards."""
+    state = str(item.get("state") or "")
+    severity = str(item.get("severity") or "info")
+    source = str(item.get("source") or "domain_health")
+    item_id = f"health:{item.get('type') or 'health_action'}"
+    dedupe_key = f"dmarq:remediation:{domain}:{item_id}"
+    if state == "needs_approval":
+        notification = {
+            "state": "approval_required",
+            "event": EVENT_REMEDIATION_APPROVAL_REQUIRED,
+            "channel": "email_security",
+            "dedupe_key": dedupe_key,
+            "reason": "Notify an operator that a safe DNS repair is ready for preview.",
+            "next_transition": "verified_after_apply",
+        }
+    elif state == "manual_action" and REMEDIATION_SEVERITY_RANK.get(severity, 0) >= 3:
+        notification = {
+            "state": "action_required",
+            "event": EVENT_REMEDIATION_MANUAL_ACTION_REQUIRED,
+            "channel": "email_security",
+            "dedupe_key": dedupe_key,
+            "reason": "Escalate high-impact manual remediation work.",
+            "next_transition": "resolved_by_operator",
+        }
+    elif state == "investigate":
+        notification = {
+            "state": "investigation_required",
+            "event": EVENT_REMEDIATION_INVESTIGATION_REQUIRED,
+            "channel": "email_security",
+            "dedupe_key": dedupe_key,
+            "reason": "Ask an operator to confirm whether the sender or finding is legitimate.",
+            "next_transition": "manual_action_or_resolved",
+        }
+    else:
+        notification = {
+            "state": "summary_only",
+            "event": EVENT_REMEDIATION_SUMMARY,
+            "channel": "daily_summary" if source == "dns_lint" else "email_security",
+            "dedupe_key": dedupe_key,
+            "reason": "Include this lower-risk remediation item in summary reporting.",
+            "next_transition": "resolved_or_escalated",
+        }
+    notification["payload_preview"] = {
+        "schema_version": "dmarq.remediation.notification.v1",
+        "domain": domain,
+        "item_id": item_id,
+        "source": source,
+        "state": state,
+        "severity": severity,
+        "incident_type": str(item.get("incident_type") or ""),
+        "remediation_track": str(item.get("remediation_track") or ""),
+        "priority_score": int(item.get("priority_score") or 0),
+        "priority_band": str(item.get("priority_band") or "watch"),
+        "title": str(item.get("title") or "Review remediation item"),
+        "next_step": str(item.get("next_step") or "Review the domain evidence."),
+        "owner": str(item.get("owner") or ""),
+        "completion_criteria": str(item.get("completion_criteria") or ""),
+        "evidence_refresh": item.get("evidence_refresh") or {},
+        "verification_plan": item.get("verification_plan") or {},
+        "repair_progression": item.get("repair_progression") or {},
+    }
+    return notification
 
 
 def _attach_dashboard_provider_repair_state(
@@ -2563,6 +2636,28 @@ def _increment_verification_plan_counters(
         counters["verification_blocked_by_prerequisite"] += 1
 
 
+def _increment_notification_profile_counters(
+    counters: Dict[str, int],
+    item: Dict[str, Any],
+) -> None:
+    """Count notification profiles attached to dashboard remediation items."""
+    notification = item.get("notification") or {}
+    state = str(notification.get("state") or "")
+    if not state:
+        return
+    counters["notification_profiles"] += 1
+    if state in {"approval_required", "action_required", "investigation_required"}:
+        counters["notification_profile_ready"] += 1
+    if state == "approval_required":
+        counters["notification_approval_required"] += 1
+    elif state == "action_required":
+        counters["notification_action_required"] += 1
+    elif state == "investigation_required":
+        counters["notification_investigation_required"] += 1
+    elif state == "summary_only":
+        counters["notification_summary_only"] += 1
+
+
 def _build_dashboard_remediation_loop(
     domains: List[Dict[str, Any]],
     remediation_activity: Dict[str, Any],
@@ -2601,6 +2696,12 @@ def _build_dashboard_remediation_loop(
         "provider_value_missing": 0,
         "provider_apply_history": int(activity_summary.get("provider_apply_attempts") or 0),
         "provider_apply_verified": int(activity_summary.get("provider_apply_verified") or 0),
+        "notification_profiles": 0,
+        "notification_profile_ready": 0,
+        "notification_approval_required": 0,
+        "notification_action_required": 0,
+        "notification_investigation_required": 0,
+        "notification_summary_only": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2616,6 +2717,7 @@ def _build_dashboard_remediation_loop(
             _increment_provider_repair_counters(counters, item)
             _increment_evidence_refresh_counters(counters, item)
             _increment_verification_plan_counters(counters, item)
+            _increment_notification_profile_counters(counters, item)
             track_counters[f"track_{item['remediation_track']}"] += 1
             items.append(item)
 
@@ -2687,6 +2789,12 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         "provider_value_missing": 0,
         "provider_apply_history": 0,
         "provider_apply_verified": 0,
+        "notification_profiles": 0,
+        "notification_profile_ready": 0,
+        "notification_approval_required": 0,
+        "notification_action_required": 0,
+        "notification_investigation_required": 0,
+        "notification_summary_only": 0,
     }
     track_counters = {f"track_{track}": 0 for track in REMEDIATION_TRACKS}
     items: List[Dict[str, Any]] = []
@@ -2699,6 +2807,7 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         _increment_provider_repair_counters(counters, item)
         _increment_evidence_refresh_counters(counters, item)
         _increment_verification_plan_counters(counters, item)
+        _increment_notification_profile_counters(counters, item)
         track_counters[f"track_{item['remediation_track']}"] += 1
         items.append(item)
 

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1115,10 +1115,12 @@ function dashboardApp() {
                     Number(progression.provider_apply_verified || 0) > 0;
             }
             if (filterValue === 'notify_ready') {
-                return Boolean(item?.notification?.dispatch?.eligible) ||
-                    ['approval_required', 'action_required', 'investigation_required'].includes(
-                        String(item?.notification?.state || '')
-                    );
+                const dispatch = item?.notification?.dispatch;
+                const hasDispatchPreview = dispatch && typeof dispatch === 'object';
+                if (hasDispatchPreview) return Boolean(dispatch.eligible);
+                return ['approval_required', 'action_required', 'investigation_required'].includes(
+                    String(item?.notification?.state || '')
+                );
             }
             if (filterValue === 'dispatched') {
                 const activity = this.dashboardRemediationActivity(item);
@@ -1204,12 +1206,12 @@ function dashboardApp() {
             }
             if (dispatch.eligible) {
                 parts.push('ready to notify');
+            } else if (dispatch.enabled && (dispatch.blocked_reasons || []).length) {
+                parts.push('dispatch blocked');
             } else if (['approval_required', 'action_required', 'investigation_required'].includes(
                 String(item?.notification?.state || '')
             )) {
                 parts.push('notification profile ready');
-            } else if (dispatch.enabled && (dispatch.blocked_reasons || []).length) {
-                parts.push('dispatch blocked');
             }
             return parts.join(' · ');
         },

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1115,7 +1115,10 @@ function dashboardApp() {
                     Number(progression.provider_apply_verified || 0) > 0;
             }
             if (filterValue === 'notify_ready') {
-                return Boolean(item?.notification?.dispatch?.eligible);
+                return Boolean(item?.notification?.dispatch?.eligible) ||
+                    ['approval_required', 'action_required', 'investigation_required'].includes(
+                        String(item?.notification?.state || '')
+                    );
             }
             if (filterValue === 'dispatched') {
                 const activity = this.dashboardRemediationActivity(item);
@@ -1201,6 +1204,10 @@ function dashboardApp() {
             }
             if (dispatch.eligible) {
                 parts.push('ready to notify');
+            } else if (['approval_required', 'action_required', 'investigation_required'].includes(
+                String(item?.notification?.state || '')
+            )) {
+                parts.push('notification profile ready');
             } else if (dispatch.enabled && (dispatch.blocked_reasons || []).length) {
                 parts.push('dispatch blocked');
             }

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -883,7 +883,7 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "filter === 'fresh_evidence'" in script
     assert "filter === 'stale_evidence'" in script
     assert "filter === 'provider_value'" in script
-    assert "if (hasDispatchPreview) return Boolean(dispatch.eligible)" in script
+    assert "item.notification?.dispatch?.eligible" in script
     assert "remediationQueueFilterCount(filter)" in script
     assert "remediationQueueFilteredCount()" in script
     assert "remediationQueueTotalCount()" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -696,6 +696,13 @@ def test_dashboard_remediation_dispatch_activity_filters_and_labels():
                     notification: { dispatch: { enabled: true, eligible: true } }
                 },
                 {
+                    domain: 'profile.example',
+                    state: 'needs_approval',
+                    priority_score: 8,
+                    severity: 'high',
+                    notification: { state: 'approval_required' }
+                },
+                {
                     domain: 'blocked.example',
                     state: 'investigate',
                     priority_score: 6,
@@ -728,13 +735,15 @@ def test_dashboard_remediation_dispatch_activity_filters_and_labels():
                 app.dashboardRemediationFilterCount('follow_up'),
                 app.dashboardRemediationFilterCount('dispatch_blocked'),
                 app.visibleDashboardRemediationItems()[0].domain,
-                app.dashboardRemediationDispatchText(app.visibleDashboardRemediationItems()[0])
+                app.dashboardRemediationDispatchText(app.visibleDashboardRemediationItems()[0]),
+                app.dashboardRemediationDispatchText(app.healthSummary.remediation_loop.items[2])
             ].join('|');
         })()""")
 
     assert result == (
-        "1|1|1|2|follow.example|"
-        "3 notifications dispatched · operator follow-up needed"
+        "2|1|1|2|follow.example|"
+        "3 notifications dispatched · operator follow-up needed|"
+        "notification profile ready"
     )
 
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -686,7 +686,14 @@ def test_dashboard_remediation_dispatch_activity_filters_and_labels():
                     state: 'manual_action',
                     priority_score: 7,
                     severity: 'high',
-                    notification: { dispatch: { enabled: true, eligible: false } }
+                    notification: {
+                        state: 'action_required',
+                        dispatch: {
+                            enabled: true,
+                            eligible: false,
+                            blocked_reasons: ['No enabled webhook endpoint is subscribed to this event.']
+                        }
+                    }
                 },
                 {
                     domain: 'ready.example',
@@ -742,7 +749,7 @@ def test_dashboard_remediation_dispatch_activity_filters_and_labels():
 
     assert result == (
         "2|1|1|2|follow.example|"
-        "3 notifications dispatched · operator follow-up needed|"
+        "3 notifications dispatched · operator follow-up needed · dispatch blocked|"
         "notification profile ready"
     )
 
@@ -876,7 +883,7 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "filter === 'fresh_evidence'" in script
     assert "filter === 'stale_evidence'" in script
     assert "filter === 'provider_value'" in script
-    assert "item.notification?.dispatch?.eligible" in script
+    assert "if (hasDispatchPreview) return Boolean(dispatch.eligible)" in script
     assert "remediationQueueFilterCount(filter)" in script
     assert "remediationQueueFilteredCount()" in script
     assert "remediationQueueTotalCount()" in script

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2471,8 +2471,34 @@ def test_dashboard_remediation_item_exposes_summary_notification_profile():
     assert notification["event"] == "dmarq.remediation.summary"
     assert notification["channel"] == "daily_summary"
     assert notification["reason"] == "Include this lower-risk remediation item in summary reporting."
+    assert notification["payload_preview"]["schema_version"] == (
+        "dmarq.dashboard.remediation.notification_preview.v1"
+    )
     assert notification["payload_preview"]["source"] == "dns_lint"
     assert notification["payload_preview"]["severity"] == "low"
+
+
+def test_dashboard_remediation_item_exposes_manual_action_notification_profile():
+    """High-impact manual remediation should be visible as operator action work."""
+    item = domains_endpoint._dashboard_remediation_item(
+        DOMAIN,
+        {
+            "type": "tls_coverage_gap",
+            "severity": "high",
+            "title": "Review TLS coverage",
+            "next_step": "Coordinate a manual TLS fix.",
+        },
+    )
+
+    notification = item["notification"]
+    assert notification["state"] == "action_required"
+    assert notification["event"] == "dmarq.remediation.manual_action_required"
+    assert notification["channel"] == "email_security"
+    assert notification["reason"] == "Escalate high-impact manual remediation work."
+    assert notification["next_transition"] == "resolved_by_operator"
+    assert notification["payload_preview"]["schema_version"] == (
+        "dmarq.dashboard.remediation.notification_preview.v1"
+    )
 
 
 def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_session):

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2453,6 +2453,28 @@ def test_dashboard_remediation_item_includes_context_for_non_approval_states(
     assert item["why"]
 
 
+def test_dashboard_remediation_item_exposes_summary_notification_profile():
+    """Low-risk DNS lint items should be routed to summary reporting, not operator dispatch."""
+    item = domains_endpoint._dashboard_remediation_item(
+        DOMAIN,
+        {
+            "type": "minor_dns_lint",
+            "source": "dns_lint",
+            "severity": "low",
+            "title": "Review DNS lint advisory",
+            "next_step": "Keep monitoring DNS posture.",
+        },
+    )
+
+    notification = item["notification"]
+    assert notification["state"] == "summary_only"
+    assert notification["event"] == "dmarq.remediation.summary"
+    assert notification["channel"] == "daily_summary"
+    assert notification["reason"] == "Include this lower-risk remediation item in summary reporting."
+    assert notification["payload_preview"]["source"] == "dns_lint"
+    assert notification["payload_preview"]["severity"] == "low"
+
+
 def test_summary_dns_failure_defaults_false(authed_client: TestClient, db_session):
     """Empty DNS results stay false without being labeled resolver failures."""
     _persist_minimal_report(db_session)

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2296,6 +2296,9 @@ def test_summary_includes_current_remediation_loop(
     assert loop["repair_needs_evidence"] >= 2
     assert loop["evidence_refresh_required"] >= 2
     assert loop["evidence_refresh_dns"] >= 2
+    assert loop["notification_profiles"] >= 2
+    assert loop["notification_profile_ready"] >= 2
+    assert loop["notification_approval_required"] >= 2
     assert loop["repair_blocked"] == 0
     assert loop["items"][0]["repair_progression"]["stage"] == "preview_ready"
     assert loop["items"][0]["repair_progression"]["can_preview"] is True
@@ -2322,6 +2325,9 @@ def test_summary_includes_current_remediation_loop(
     assert domain["remediation_workload"]["provider_apply_verified"] >= 0
     assert domain["remediation_workload"]["repair_needs_evidence"] >= 2
     assert domain["remediation_workload"]["evidence_refresh_dns"] >= 2
+    assert domain["remediation_workload"]["notification_profiles"] >= 2
+    assert domain["remediation_workload"]["notification_profile_ready"] >= 2
+    assert domain["remediation_workload"]["notification_approval_required"] >= 2
     assert domain["remediation_workload"]["total_open"] >= 2
     assert domain["remediation_workload"]["primary"]["state"] == "needs_approval"
     assert domain["remediation_workload"]["primary"]["loop_state"] == (

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -927,6 +927,12 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["verification_pending_sender_review"] == 0
     assert loop["verification_pending_reputation_review"] == 1
     assert loop["verification_blocked_by_prerequisite"] == 0
+    assert loop["notification_profiles"] == 2
+    assert loop["notification_profile_ready"] == 2
+    assert loop["notification_approval_required"] == 1
+    assert loop["notification_action_required"] == 0
+    assert loop["notification_investigation_required"] == 1
+    assert loop["notification_summary_only"] == 0
     assert loop["top_incident_type"] == "dmarc_policy_missing_or_weak"
     assert loop["repair_blocked"] == 0
     assert loop["repair_ready_for_preview"] == 1
@@ -944,6 +950,18 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["items"][0]["repair_progression"]["provider_apply_verified"] == 1
     assert loop["items"][0]["evidence_refresh"]["refresh_key"] == "dns"
     assert loop["items"][0]["evidence_refresh"]["safe_to_run"] is True
+    assert loop["items"][0]["notification"]["state"] == "approval_required"
+    assert loop["items"][0]["notification"]["event"] == "dmarq.remediation.approval_required"
+    assert loop["items"][0]["notification"]["dedupe_key"] == (
+        "dmarq:remediation:example.com:health:missing_dmarc"
+    )
+    assert loop["items"][0]["notification"]["payload_preview"]["domain"] == "example.com"
+    assert loop["items"][0]["notification"]["payload_preview"]["item_id"] == (
+        "health:missing_dmarc"
+    )
+    assert loop["items"][0]["notification"]["payload_preview"]["repair_progression"][
+        "stage"
+    ] == "preview_ready"
     assert loop["items"][0]["verification_plan"]["status"] == "pending_operator_approval"
     assert loop["items"][0]["verification_plan"]["verification_method"] == (
         "provider_write_then_dns_refresh"
@@ -958,6 +976,10 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["items"][1]["repair_progression"]["stage"] == "reputation_review"
     assert loop["items"][1]["repair_progression"]["readiness_level"] == "needs_reputation_review"
     assert loop["items"][1]["evidence_refresh"]["refresh_key"] == "source_reputation"
+    assert loop["items"][1]["notification"]["state"] == "investigation_required"
+    assert loop["items"][1]["notification"]["event"] == (
+        "dmarq.remediation.investigation_required"
+    )
     assert loop["items"][1]["verification_plan"]["status"] == "pending_reputation_review"
     assert loop["items"][1]["verification_plan"]["verification_method"] == (
         "fresh_reputation_evidence"
@@ -1012,6 +1034,10 @@ def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks
     assert loop["evidence_refresh_prerequisite"] == 1
     assert loop["verification_pending_operator_approval"] == 0
     assert loop["verification_blocked_by_prerequisite"] == 1
+    assert loop["notification_profiles"] == 1
+    assert loop["notification_profile_ready"] == 1
+    assert loop["notification_approval_required"] == 1
+    assert loop["notification_summary_only"] == 0
     assert loop["repair_ready_for_preview"] == 0
     assert loop["repair_waiting_on_operator"] == 0
     assert loop["repair_readiness_blocked"] == 1

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -956,6 +956,9 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
         "dmarq:remediation:example.com:health:missing_dmarc"
     )
     assert loop["items"][0]["notification"]["payload_preview"]["domain"] == "example.com"
+    assert loop["items"][0]["notification"]["payload_preview"]["schema_version"] == (
+        "dmarq.dashboard.remediation.notification_preview.v1"
+    )
     assert loop["items"][0]["notification"]["payload_preview"]["item_id"] == (
         "health:missing_dmarc"
     )

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -879,6 +879,12 @@ verification counters such as `verification_pending_operator_approval`,
 `verification_pending_report_evidence`, and `verification_blocked_by_prerequisite`
 so clients can distinguish approval, sender review, reputation evidence, manual
 fresh-evidence checks, and missing provider values.
+The same summary includes notification-profile counters such as
+`notification_profiles`, `notification_profile_ready`,
+`notification_approval_required`, `notification_action_required`,
+`notification_investigation_required`, and `notification_summary_only` so
+dashboards can show which items already have operator notification routing
+metadata before any dispatch preview is requested.
 Dashboard clients can also combine `health_summary.remediation_loop.items` with
 each domain row's `remediation` activity to group cards by dispatched
 notifications and operator follow-up without rebuilding the domain queue. The
@@ -886,17 +892,21 @@ dashboard loop returns a bounded working set rather than only the first compact
 page, so client-side filters can still find lower-priority items.
 
 Notification metadata includes the event name, channel, dedupe key, reason, and
-next state transition that an operator workflow can use. Each notification also
-includes a read-only `dispatch` preview showing whether the item would be
-eligible for a future dispatch step, which channel would be used, whether a
-previewed or acknowledged lifecycle marker is still required, how many enabled
-webhook endpoints match the event, and why dispatch is currently blocked. The
-`blocked_reasons` list is ordered and may contain multiple actionable blockers;
-clients should display the full list rather than only the first item. Each item
-also includes a sanitized `payload_preview` using schema
-`dmarq.remediation.notification.v1`; it is the deterministic data shape a
-future webhook, ticketing, or chatops delivery would receive. The endpoint does
-not perform DNS writes, enqueue webhook deliveries, or send notifications.
+next state transition that an operator workflow can use. Dashboard remediation
+items include this read-only notification profile even before a dispatch preview
+is attached, so clients can group approval-required, manual-action, and
+investigation-required work without rebuilding the domain queue. Each
+notification also includes a sanitized `payload_preview` using schema
+`dmarq.remediation.notification.v1`; it is the deterministic data shape a future
+webhook, ticketing, or chatops delivery would receive. Domain detail remediation
+queues can additionally include a read-only `dispatch` preview showing whether
+the item would be eligible for a future dispatch step, which channel would be
+used, whether a previewed or acknowledged lifecycle marker is still required,
+how many enabled webhook endpoints match the event, and why dispatch is
+currently blocked. The `blocked_reasons` list is ordered and may contain
+multiple actionable blockers; clients should display the full list rather than
+only the first item. The endpoint does not perform DNS writes, enqueue webhook
+deliveries, or send notifications.
 After dispatch previews are attached, the queue `summary` also exposes dispatch
 readiness counters, including `dispatch_ready`, `dispatch_blocked`,
 `dispatch_disabled`, `dispatch_awaiting_acknowledgement`, and

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -896,9 +896,10 @@ next state transition that an operator workflow can use. Dashboard remediation
 items include this read-only notification profile even before a dispatch preview
 is attached, so clients can group approval-required, manual-action, and
 investigation-required work without rebuilding the domain queue. Each
-notification also includes a sanitized `payload_preview` using schema
-`dmarq.remediation.notification.v1`; it is the deterministic data shape a future
-webhook, ticketing, or chatops delivery would receive. Domain detail remediation
+notification also includes a sanitized dashboard `payload_preview` using schema
+`dmarq.dashboard.remediation.notification_preview.v1`; it is a compact,
+read-only preview for client grouping and operator review rather than the full
+webhook, ticketing, or chatops delivery envelope. Domain detail remediation
 queues can additionally include a read-only `dispatch` preview showing whether
 the item would be eligible for a future dispatch step, which channel would be
 used, whether a previewed or acknowledged lifecycle marker is still required,

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -87,9 +87,14 @@ summary before linking to the selected domain for the full evidence, approval,
 and verification flow. Filter chips let you isolate preview-ready repairs,
 approval verification, sender review, report-evidence follow-up, blocked work,
 manual work, reputation review, and stale-evidence cases without opening every
-domain. The same filter bar can now isolate remediation notifications that are
+domain. The same filter bar can now isolate remediation notifications that have
+a backend notification profile ready for operator action, notifications that are
 ready to send, already dispatched, blocked by notification settings, or waiting
-for operator follow-up after dispatch.
+for operator follow-up after dispatch. Notification-profile-ready cards have
+the event, channel, dedupe key, and payload preview prepared, but they still do
+not send anything until the operator uses the explicit dispatch flow. The
+dashboard and domain rows also expose separate counts for approval-required,
+manual-action, investigation-required, and summary-only notification profiles.
 Open the domain detail queue for the full provider-repair plan. That view shows
 whether a DNS item has a safe provider preview, can be applied only after
 explicit approval, is blocked by missing provider values, or should fall back to


### PR DESCRIPTION
## Summary
- attach read-only notification profiles and payload previews to dashboard remediation items
- expose notification-profile counters on workspace and domain remediation summaries
- let the dashboard "ready to notify" filter use backend notification state before a dispatch preview exists
- document the dashboard/API data shape and changelog entry

## Why
The dashboard had filters for notify-ready remediation work, but real workspace remediation items did not always include notification metadata. That meant the UI could rely on fabricated/test-only dispatch data instead of backend evidence. This makes the notification profile part of the dashboard remediation contract while keeping dispatch/send behavior explicit and operator-controlled.

## Validation
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_domain_detail_endpoints.py::test_dashboard_remediation_loop_exposes_operator_decision_context backend/app/tests/test_domain_detail_endpoints.py::test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_dispatch_activity_filters_and_labels backend/app/tests/test_dns_endpoints.py::test_summary_includes_current_remediation_loop -q`
- `node --check backend/app/static/js/dashboard-page.js`
- `/tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dns_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `git diff --check origin/main..HEAD`
