### PR TITLE
feat: clarify dashboard remediation filter chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added fresh-evidence refresh paths to remediation items so operators can see whether DNS, reports, source intelligence, reputation, or provider values must be refreshed before closure.
 - Added dashboard fresh-evidence counters and remediation-card refresh paths so workspace triage shows whether DNS, reports, reputation, or provider prerequisites should be handled next.
 - Added dashboard remediation filters, sorting, compact/show-all controls, and matching empty states so operators can triage large remediation workspaces by preview readiness, fresh evidence, blockers, manual work, or reputation review before opening a domain.
+- Added clearer dashboard remediation filter chips with compact counts, empty-filter affordances, and hover text that explains what each filtered queue would show.
 - Added domain remediation fresh-evidence and provider-value queue filters plus freshness sorting so closure-blocking evidence work is easier to isolate on domain detail pages.
 - Added stale-evidence remediation filters and direct dashboard links into the relevant domain evidence section, such as DNS records or sending sources.
 - Fixed dashboard remediation state rendering so backend `approval_ready` queue items are labeled as needing approval and evidence anchors fall back safely if malformed.

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -15,6 +15,7 @@ function dashboardApp() {
         dashboardRemediationFilter: 'all',
         dashboardRemediationSort: 'priority',
         showAllDashboardRemediationItems: false,
+        dashboardRemediationFilterCountCache: null,
         dashboardRemediationFilterOptions: [
             { value: 'all', label: 'All' },
             { value: 'preview_ready', label: 'Preview ready' },
@@ -1075,7 +1076,30 @@ function dashboardApp() {
             return match?.label || 'All';
         },
 
+        dashboardRemediationFilterCounts() {
+            const items = this.dashboardRemediationRawItems();
+            if (this.dashboardRemediationFilterCountCache?.items === items) {
+                return this.dashboardRemediationFilterCountCache.counts;
+            }
+            const counts = Object.fromEntries(
+                this.dashboardRemediationFilterOptions.map(option => [option.value, 0])
+            );
+            items.forEach(item => {
+                this.dashboardRemediationFilterOptions.forEach(option => {
+                    if (this.dashboardRemediationFilterMatches(item, option.value)) {
+                        counts[option.value] += 1;
+                    }
+                });
+            });
+            this.dashboardRemediationFilterCountCache = { items, counts };
+            return counts;
+        },
+
         dashboardRemediationFilterCount(filter) {
+            const counts = this.dashboardRemediationFilterCounts();
+            if (Object.prototype.hasOwnProperty.call(counts, filter)) {
+                return counts[filter];
+            }
             return this.dashboardRemediationRawItems().filter(item =>
                 this.dashboardRemediationFilterMatches(item, filter)
             ).length;

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1081,6 +1081,27 @@ function dashboardApp() {
             ).length;
         },
 
+        dashboardRemediationFilterClass(filter) {
+            if (this.dashboardRemediationFilter === filter) {
+                return 'border-[#2f9da5] bg-[#f2fbf9] text-[#1f7c83]';
+            }
+            if (this.dashboardRemediationFilterCount(filter) === 0 && filter !== 'all') {
+                return 'border-[#ece9e7] bg-[#fbfaf9] text-[#9a96a8]';
+            }
+            return 'border-[#e6e3e1] bg-white text-[#5f5c78] hover:border-[#2f9da5]';
+        },
+
+        dashboardRemediationFilterTitle(filter) {
+            const label = this.dashboardRemediationFilterOptions.find(
+                option => option.value === filter
+            )?.label || 'Remediation';
+            const count = this.dashboardRemediationFilterCount(filter);
+            if (count === 0 && filter !== 'all') {
+                return `No ${label.toLowerCase()} remediation cards in the current workspace summary`;
+            }
+            return `${this.formatLargeNumber(count)} ${label.toLowerCase()} remediation card${count === 1 ? '' : 's'}`;
+        },
+
         dashboardRemediationFilterMatches(item, filterValue) {
             if (!item || !filterValue || filterValue === 'all') return true;
             const progression = item?.repair_progression || {};

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -357,12 +357,13 @@
             <template x-for="filter in dashboardRemediationFilterOptions" :key="'dashboard-remediation-filter-' + filter.value">
                 <button type="button"
                         class="rounded border px-3 py-2 text-xs font-semibold transition"
-                        :class="dashboardRemediationFilter === filter.value ? 'border-[#2f9da5] bg-[#f2fbf9] text-[#1f7c83]' : 'border-[#e6e3e1] bg-white text-[#5f5c78] hover:border-[#2f9da5]'"
+                        :class="dashboardRemediationFilterClass(filter.value)"
                         :aria-pressed="dashboardRemediationFilter === filter.value ? 'true' : 'false'"
+                        :title="dashboardRemediationFilterTitle(filter.value)"
                         :data-dashboard-remediation-filter="filter.value">
                     <span x-text="filter.label"></span>
                     <span class="ml-1 rounded bg-[#f4f3f2] px-1.5 py-0.5 text-[0.65rem] text-[#45505f]"
-                          x-text="dashboardRemediationFilterCount(filter.value)"></span>
+                          x-text="formatLargeNumber(dashboardRemediationFilterCount(filter.value))"></span>
                 </button>
             </template>
         </div>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -360,6 +360,7 @@
                         :class="dashboardRemediationFilterClass(filter.value)"
                         :aria-pressed="dashboardRemediationFilter === filter.value ? 'true' : 'false'"
                         :title="dashboardRemediationFilterTitle(filter.value)"
+                        :aria-label="dashboardRemediationFilterTitle(filter.value)"
                         :data-dashboard-remediation-filter="filter.value">
                     <span x-text="filter.label"></span>
                     <span class="ml-1 rounded bg-[#f4f3f2] px-1.5 py-0.5 text-[0.65rem] text-[#45505f]"

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -379,6 +379,11 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert '<option value="dispatch">Dispatch follow-up</option>' in template
     assert "data-dashboard-remediation-filter" in template
     assert "data-dashboard-remediation-filter" in script
+    assert ":class=\"dashboardRemediationFilterClass(filter.value)\"" in template
+    assert ":title=\"dashboardRemediationFilterTitle(filter.value)\"" in template
+    assert "formatLargeNumber(dashboardRemediationFilterCount(filter.value))" in template
+    assert "dashboardRemediationFilterClass(filter)" in script
+    assert "dashboardRemediationFilterTitle(filter)" in script
     assert "data-dashboard-remediation-toggle-all" in template
     assert "data-dashboard-remediation-toggle-all" in script
     assert "visibleDashboardRemediationItems()" in template
@@ -751,6 +756,38 @@ def test_dashboard_remediation_dispatch_activity_filters_and_labels():
         "2|1|1|2|follow.example|"
         "3 notifications dispatched · operator follow-up needed · dispatch blocked|"
         "notification profile ready"
+    )
+
+
+def test_dashboard_remediation_filter_chips_explain_empty_states():
+    result = _run_dashboard_expression("""(() => {
+            app.healthSummary = { remediation_loop: { items: [
+                {
+                    domain: 'ready.example',
+                    state: 'needs_approval',
+                    priority_score: 9,
+                    severity: 'medium',
+                    repair_progression: { readiness_level: 'ready_for_preview' }
+                }
+            ] } };
+            app.dashboardRemediationFilter = 'preview_ready';
+            return [
+                app.dashboardRemediationFilterClass('preview_ready'),
+                app.dashboardRemediationFilterClass('reputation'),
+                app.dashboardRemediationFilterClass('all'),
+                app.dashboardRemediationFilterTitle('preview_ready'),
+                app.dashboardRemediationFilterTitle('reputation'),
+                app.dashboardRemediationFilterTitle('all')
+            ].join('|');
+        })()""")
+
+    assert result == (
+        "border-[#2f9da5] bg-[#f2fbf9] text-[#1f7c83]|"
+        "border-[#ece9e7] bg-[#fbfaf9] text-[#9a96a8]|"
+        "border-[#e6e3e1] bg-white text-[#5f5c78] hover:border-[#2f9da5]|"
+        "1 preview ready remediation card|"
+        "No reputation remediation cards in the current workspace summary|"
+        "1 all remediation card"
     )
 
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -381,9 +381,11 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "data-dashboard-remediation-filter" in script
     assert ":class=\"dashboardRemediationFilterClass(filter.value)\"" in template
     assert ":title=\"dashboardRemediationFilterTitle(filter.value)\"" in template
+    assert ":aria-label=\"dashboardRemediationFilterTitle(filter.value)\"" in template
     assert "formatLargeNumber(dashboardRemediationFilterCount(filter.value))" in template
     assert "dashboardRemediationFilterClass(filter)" in script
     assert "dashboardRemediationFilterTitle(filter)" in script
+    assert "dashboardRemediationFilterCounts()" in script
     assert "data-dashboard-remediation-toggle-all" in template
     assert "data-dashboard-remediation-toggle-all" in script
     assert "visibleDashboardRemediationItems()" in template

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -95,6 +95,9 @@ the event, channel, dedupe key, and payload preview prepared, but they still do
 not send anything until the operator uses the explicit dispatch flow. The
 dashboard and domain rows also expose separate counts for approval-required,
 manual-action, investigation-required, and summary-only notification profiles.
+Filter chips show compact counts, fade when the current workspace has no
+matching cards, and include hover text that explains whether the filtered queue
+is empty or how many cards it would show.
 Open the domain detail queue for the full provider-repair plan. That view shows
 whether a DNS item has a safe provider preview, can be applied only after
 explicit approval, is blocked by missing provider values, or should fall back to


### PR DESCRIPTION
## Summary
- make dashboard remediation filter chips use a small JS helper for active, normal, and empty states
- show compact filter counts and add hover text that explains empty filtered queues
- update dashboard docs and changelog for the filter-chip UX behavior

## Why
The remediation dashboard has many focused filters. Empty filters looked the same as populated filters, and large counts could make the chips harder to scan. This keeps the workspace triage surface easier to read without changing backend behavior or notification dispatch logic.

## Validation
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_filters_and_sorts_cards backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_filter_chips_explain_empty_states backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_dispatch_activity_filters_and_labels -q`
- `node --check backend/app/static/js/dashboard-page.js`
- `/tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py`
- `git diff --check origin/main..HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard remediation filter chips now show compact counts and clearer hover text.
  * Empty filter states are easier to spot, with visual fading for filters with no matching items.
* **Documentation**
  * Updated the dashboard guide and changelog to describe the improved filter chip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->