### PR TITLE
feat: show remediation notification summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a domain remediation filter and summary counter for provider repair checklists so operator-review work can be isolated quickly.
 - Added remediation provider apply-confirmation metadata and attempt-history placeholders so future live DNS repair controls have an explicit confirmation phrase, blocker list, and audit-trail slot before any write behavior is enabled.
 - Added dashboard remediation notification profiles and payload previews so workspace filters can identify approval, manual-action, and investigation notifications from backend data before dispatch previews are attached.
+- Added a dashboard remediation notification summary card so approval, action, investigation, and summary-only notification profiles are visible before dispatch activity exists.
 
 ### Changed
 - Domain summary DNS refreshes now run with bounded concurrency instead of resolving each domain sequentially.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a domain remediation filter and summary counter for provider repair checklists so operator-review work can be isolated quickly.
 - Added remediation provider apply-confirmation metadata and attempt-history placeholders so future live DNS repair controls have an explicit confirmation phrase, blocker list, and audit-trail slot before any write behavior is enabled.
 - Added dashboard remediation notification profiles and payload previews so workspace filters can identify approval, manual-action, and investigation notifications from backend data before dispatch previews are attached.
-- Added a dashboard remediation notification summary card so approval, action, investigation, and summary-only notification profiles are visible before dispatch activity exists.
+- Added a dashboard remediation notification summary card so approval, manual-action, investigation, and summary-only notification profiles are visible before dispatch activity exists.
 
 ### Changed
 - Domain summary DNS refreshes now run with bounded concurrency instead of resolving each domain sequentially.

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -300,7 +300,7 @@
                 <p class="mt-2 text-xs text-[#24507a]">
                     <span x-text="remediationLoop().notification_approval_required || 0"></span><span> approval</span>
                     <span> · </span>
-                    <span x-text="remediationLoop().notification_action_required || 0"></span><span> action</span>
+                    <span x-text="remediationLoop().notification_action_required || 0"></span><span> manual action</span>
                     <span> · </span>
                     <span x-text="remediationLoop().notification_investigation_required || 0"></span><span> investigate</span>
                 </p>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -275,7 +275,7 @@
                 <p class="mt-1 text-xs text-[#5f5c78]">Sender or report evidence to confirm</p>
             </div>
         </div>
-        <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-6">
             <div class="rounded-md border border-[#d8ebe8] bg-[#f2fbf9] p-4">
                 <p class="text-sm text-[#5f5c78]">Repair previews ready</p>
                 <p class="mt-2 text-2xl font-bold text-[#247982]"
@@ -290,6 +290,24 @@
                     <span x-text="remediationLoop().provider_apply_history || 0"></span><span> apply attempts</span>
                     <span> · </span>
                     <span x-text="remediationLoop().provider_apply_verified || 0"></span><span> verified</span>
+                </p>
+            </div>
+            <div class="rounded-md border border-[#d5e9f8] bg-[#f7fbff] p-4">
+                <p class="text-sm text-[#5f5c78]">Notifications ready</p>
+                <p class="mt-2 text-2xl font-bold text-[#24507a]"
+                   x-text="remediationLoop().notification_profile_ready || 0"></p>
+                <p class="mt-1 text-xs text-[#5f5c78]">Operator notification profiles prepared</p>
+                <p class="mt-2 text-xs text-[#24507a]">
+                    <span x-text="remediationLoop().notification_approval_required || 0"></span><span> approval</span>
+                    <span> · </span>
+                    <span x-text="remediationLoop().notification_action_required || 0"></span><span> action</span>
+                    <span> · </span>
+                    <span x-text="remediationLoop().notification_investigation_required || 0"></span><span> investigate</span>
+                </p>
+                <p class="mt-1 text-xs text-[#45505f]">
+                    <span x-text="remediationLoop().notification_profiles || 0"></span><span> total profiles</span>
+                    <span> · </span>
+                    <span x-text="remediationLoop().notification_summary_only || 0"></span><span> summary-only</span>
                 </p>
             </div>
             <div class="rounded-md border border-[#d5e9f8] bg-[#f7fbff] p-4">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -350,6 +350,7 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "remediationLoop().notification_profile_ready || 0" in template
     assert "remediationLoop().notification_approval_required || 0" in template
     assert "remediationLoop().notification_action_required || 0" in template
+    assert "manual action" in template
     assert "remediationLoop().notification_investigation_required || 0" in template
     assert "remediationLoop().notification_profiles || 0" in template
     assert "remediationLoop().notification_summary_only || 0" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -345,6 +345,14 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "item.priority_band || 'watch'" in template
     assert "item.operator_decision_summary" in template
     assert "Repair previews ready" in template
+    assert "Notifications ready" in template
+    assert "Operator notification profiles prepared" in template
+    assert "remediationLoop().notification_profile_ready || 0" in template
+    assert "remediationLoop().notification_approval_required || 0" in template
+    assert "remediationLoop().notification_action_required || 0" in template
+    assert "remediationLoop().notification_investigation_required || 0" in template
+    assert "remediationLoop().notification_profiles || 0" in template
+    assert "remediationLoop().notification_summary_only || 0" in template
     assert "Need fresh evidence" in template
     assert "Waiting on operator" in template
     assert "Blocked before repair" in template

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -96,7 +96,7 @@ not send anything until the operator uses the explicit dispatch flow. The
 dashboard and domain rows also expose separate counts for approval-required,
 manual-action, investigation-required, and summary-only notification profiles.
 The dashboard summary cards show those notification-profile counts before any
-delivery is dispatched, making queued operator communication visible even when
+dispatch activity exists, making queued operator communication visible even when
 webhook delivery is not yet enabled.
 Filter chips show compact counts, fade when the current workspace has no
 matching cards, and include hover text that explains whether the filtered queue

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -95,6 +95,9 @@ the event, channel, dedupe key, and payload preview prepared, but they still do
 not send anything until the operator uses the explicit dispatch flow. The
 dashboard and domain rows also expose separate counts for approval-required,
 manual-action, investigation-required, and summary-only notification profiles.
+The dashboard summary cards show those notification-profile counts before any
+delivery is dispatched, making queued operator communication visible even when
+webhook delivery is not yet enabled.
 Filter chips show compact counts, fade when the current workspace has no
 matching cards, and include hover text that explains whether the filtered queue
 is empty or how many cards it would show.


### PR DESCRIPTION
## Summary
- add a dashboard remediation summary card for notification profiles
- show approval-required, action-required, investigation-required, total, and summary-only notification counts before dispatch activity exists
- update dashboard docs and changelog for the new notification-summary surface

## Why
PR #698 made notification profiles part of the backend dashboard contract. This makes that signal visible in the workspace dashboard summary so operators can see queued communication work even when webhook delivery has not yet been enabled or dispatched.

## Validation
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_cards_show_owner_and_completion_context backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_filters_and_sorts_cards backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_filter_chips_explain_empty_states -q`
- `node --check backend/app/static/js/dashboard-page.js`
- `/tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py`
- `git diff --check origin/main..HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new dashboard remediation status card that highlights notification readiness before any dispatch activity exists.
  * Expanded the dashboard summary to show notification profile counts, required approvals/actions/investigations, and summary-only profiles.

* **Documentation**
  * Updated the user guide and release notes to explain that notification summary cards appear even before delivery is dispatched.

* **Tests**
  * Extended dashboard template coverage to verify the new notification-related summary fields render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->