### PR TITLE
feat: surface domain notification workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added remediation provider apply-confirmation metadata and attempt-history placeholders so future live DNS repair controls have an explicit confirmation phrase, blocker list, and audit-trail slot before any write behavior is enabled.
 - Added dashboard remediation notification profiles and payload previews so workspace filters can identify approval, manual-action, and investigation notifications from backend data before dispatch previews are attached.
 - Added a dashboard remediation notification summary card so approval, manual-action, investigation, and summary-only notification profiles are visible before dispatch activity exists.
+- Added domain-list remediation notification badges so per-domain approval, action, and investigation profiles are visible before dispatch activity exists.
+- Added domain-list remediation notification totals so profile and summary-only counts match the dashboard notification summary card.
 
 ### Changed
 - Domain summary DNS refreshes now run with bounded concurrency instead of resolving each domain sequentially.

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -2227,6 +2227,47 @@ function dashboardApp() {
                 wrapper.appendChild(provider);
             }
 
+            const notificationReady = Number(workload?.notification_profile_ready || 0);
+            const notificationApproval = Number(workload?.notification_approval_required || 0);
+            const notificationAction = Number(workload?.notification_action_required || 0);
+            const notificationInvestigation = Number(
+                workload?.notification_investigation_required || 0
+            );
+            const notificationProfiles = Number(workload?.notification_profiles || 0);
+            const notificationSummary = Number(workload?.notification_summary_only || 0);
+            if (
+                notificationReady ||
+                notificationApproval ||
+                notificationAction ||
+                notificationInvestigation ||
+                notificationProfiles ||
+                notificationSummary
+            ) {
+                const notification = document.createElement('span');
+                notification.className = 'max-w-56 truncate text-xs font-semibold text-[#24507a]';
+                const parts = [];
+                if (notificationReady) {
+                    parts.push(`${this.formatLargeNumber(notificationReady)} notify-ready`);
+                }
+                if (notificationApproval) {
+                    parts.push(`${this.formatLargeNumber(notificationApproval)} approval`);
+                }
+                if (notificationAction) {
+                    parts.push(`${this.formatLargeNumber(notificationAction)} action`);
+                }
+                if (notificationInvestigation) {
+                    parts.push(`${this.formatLargeNumber(notificationInvestigation)} investigate`);
+                }
+                if (notificationProfiles) {
+                    parts.push(`${this.formatLargeNumber(notificationProfiles)} profiles`);
+                }
+                if (notificationSummary) {
+                    parts.push(`${this.formatLargeNumber(notificationSummary)} summary-only`);
+                }
+                notification.textContent = parts.join(' · ');
+                wrapper.appendChild(notification);
+            }
+
             const dispatched = Number(remediation?.dispatch_enqueued || 0);
             const followUp = Number(remediation?.needs_operator_follow_up || 0);
             if (dispatched || followUp) {

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -2209,79 +2209,41 @@ function dashboardApp() {
                 wrapper.appendChild(evidence);
             }
 
-            const providerPreview = Number(workload?.provider_preview_available || 0);
-            const providerApply = Number(workload?.provider_apply_after_approval || 0);
-            const providerBlocked = Number(workload?.provider_apply_blocked || 0);
-            const providerHistory = Number(workload?.provider_apply_history || 0);
-            const providerVerified = Number(workload?.provider_apply_verified || 0);
-            if (providerPreview || providerApply || providerBlocked || providerHistory || providerVerified) {
-                const provider = document.createElement('span');
-                provider.className = 'max-w-56 truncate text-xs font-semibold text-[#24507a]';
-                const parts = [];
-                if (providerPreview) parts.push(`${this.formatLargeNumber(providerPreview)} provider preview`);
-                if (providerApply) parts.push(`${this.formatLargeNumber(providerApply)} apply-ready`);
-                if (providerBlocked) parts.push(`${this.formatLargeNumber(providerBlocked)} apply blocked`);
-                if (providerHistory) parts.push(`${this.formatLargeNumber(providerHistory)} apply history`);
-                if (providerVerified) parts.push(`${this.formatLargeNumber(providerVerified)} verified`);
-                provider.textContent = parts.join(' · ');
-                wrapper.appendChild(provider);
-            }
+            this.appendCountBadge(wrapper, [
+                [Number(workload?.provider_preview_available || 0), 'provider preview'],
+                [Number(workload?.provider_apply_after_approval || 0), 'apply-ready'],
+                [Number(workload?.provider_apply_blocked || 0), 'apply blocked'],
+                [Number(workload?.provider_apply_history || 0), 'apply history'],
+                [Number(workload?.provider_apply_verified || 0), 'verified'],
+            ], 'max-w-56 truncate text-xs font-semibold text-[#24507a]');
 
-            const notificationReady = Number(workload?.notification_profile_ready || 0);
-            const notificationApproval = Number(workload?.notification_approval_required || 0);
-            const notificationAction = Number(workload?.notification_action_required || 0);
-            const notificationInvestigation = Number(
-                workload?.notification_investigation_required || 0
-            );
-            const notificationProfiles = Number(workload?.notification_profiles || 0);
-            const notificationSummary = Number(workload?.notification_summary_only || 0);
-            if (
-                notificationReady ||
-                notificationApproval ||
-                notificationAction ||
-                notificationInvestigation ||
-                notificationProfiles ||
-                notificationSummary
-            ) {
-                const notification = document.createElement('span');
-                notification.className = 'max-w-56 truncate text-xs font-semibold text-[#24507a]';
-                const parts = [];
-                if (notificationReady) {
-                    parts.push(`${this.formatLargeNumber(notificationReady)} notify-ready`);
-                }
-                if (notificationApproval) {
-                    parts.push(`${this.formatLargeNumber(notificationApproval)} approval`);
-                }
-                if (notificationAction) {
-                    parts.push(`${this.formatLargeNumber(notificationAction)} action`);
-                }
-                if (notificationInvestigation) {
-                    parts.push(`${this.formatLargeNumber(notificationInvestigation)} investigate`);
-                }
-                if (notificationProfiles) {
-                    parts.push(`${this.formatLargeNumber(notificationProfiles)} profiles`);
-                }
-                if (notificationSummary) {
-                    parts.push(`${this.formatLargeNumber(notificationSummary)} summary-only`);
-                }
-                notification.textContent = parts.join(' · ');
-                wrapper.appendChild(notification);
-            }
+            this.appendCountBadge(wrapper, [
+                [Number(workload?.notification_profile_ready || 0), 'notify-ready'],
+                [Number(workload?.notification_approval_required || 0), 'approval'],
+                [Number(workload?.notification_action_required || 0), 'action'],
+                [Number(workload?.notification_investigation_required || 0), 'investigate'],
+                [Number(workload?.notification_profiles || 0), 'profiles'],
+                [Number(workload?.notification_summary_only || 0), 'summary-only'],
+            ], 'max-w-56 truncate text-xs font-semibold text-[#7a5a24]');
 
-            const dispatched = Number(remediation?.dispatch_enqueued || 0);
-            const followUp = Number(remediation?.needs_operator_follow_up || 0);
-            if (dispatched || followUp) {
-                const dispatch = document.createElement('span');
-                dispatch.className = 'max-w-56 truncate text-xs font-semibold text-[#5f5c78]';
-                const parts = [];
-                if (dispatched) parts.push(`${this.formatLargeNumber(dispatched)} dispatched`);
-                if (followUp) parts.push(`${this.formatLargeNumber(followUp)} follow-up`);
-                dispatch.textContent = parts.join(' · ');
-                wrapper.appendChild(dispatch);
-            }
+            this.appendCountBadge(wrapper, [
+                [Number(remediation?.dispatch_enqueued || 0), 'dispatched'],
+                [Number(remediation?.needs_operator_follow_up || 0), 'follow-up'],
+            ], 'max-w-56 truncate text-xs font-semibold text-[#5f5c78]');
 
             cell.appendChild(wrapper);
             return cell;
+        },
+
+        appendCountBadge(wrapper, entries, className) {
+            const parts = entries
+                .filter(([count]) => count)
+                .map(([count, label]) => `${this.formatLargeNumber(count)} ${label}`);
+            if (!parts.length) return;
+            const badge = document.createElement('span');
+            badge.className = className;
+            badge.textContent = parts.join(' · ');
+            wrapper.appendChild(badge);
         },
 
         remediationActivityText(remediation) {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -868,6 +868,12 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
                     provider_apply_blocked: 1,
                     provider_apply_history: 2,
                     provider_apply_verified: 1,
+                    notification_profile_ready: 3,
+                    notification_approval_required: 1,
+                    notification_action_required: 1,
+                    notification_investigation_required: 1,
+                    notification_profiles: 4,
+                    notification_summary_only: 1,
                     primary: {
                         state: 'needs_approval',
                         remediation_track: 'provider_preview',
@@ -887,6 +893,12 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
     assert "1 apply blocked" in result
     assert "2 apply history" in result
     assert "1 verified" in result
+    assert "3 notify-ready" in result
+    assert "1 approval" in result
+    assert "1 action" in result
+    assert "1 investigate" in result
+    assert "4 profiles" in result
+    assert "1 summary-only" in result
     assert "1 dispatched" in result
     assert "1 follow-up" in result
     assert "Dispatch enqueued" in result

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -98,6 +98,9 @@ manual-action, investigation-required, and summary-only notification profiles.
 The dashboard summary cards show those notification-profile counts before any
 dispatch activity exists, making queued operator communication visible even when
 webhook delivery is not yet enabled.
+The domain table repeats the same notification-ready signal, profile total, and
+summary-only counts on each affected domain row so operators can pick the next
+domain without opening every queue.
 Filter chips show compact counts, fade when the current workspace has no
 matching cards, and include hover text that explains whether the filtered queue
 is empty or how many cards it would show.


### PR DESCRIPTION
## Summary
- show notification-ready workload directly in each domain-list remediation cell
- include approval, action, and investigation profile counts before dispatch activity exists
- update dashboard docs and changelog for the domain-row notification signal

## Why
The dashboard summary now exposes notification-profile counts, but operators still need to choose which domain to open next. This surfaces the same notification-ready signal on affected domain rows so the domain list matches the remediation dashboard summary.

## Validation
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py::test_domain_list_remediation_cell_shows_provider_workload_summary backend/app/tests/test_dashboard_template_security.py::test_dashboard_remediation_cards_show_owner_and_completion_context -q`
- `node --check backend/app/static/js/dashboard-page.js`
- `/tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py`
- `git diff --check origin/main..HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification badges in the remediation table to show domain readiness and required follow-up states at a glance.
  * Domain rows now repeat the notification-ready signal so operators can identify the next domain without opening each queue.

* **Documentation**
  * Updated the dashboard guide and changelog to describe the new remediation notification indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->