### PR TITLE
feat: clarify remediation operator next actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a dashboard remediation notification summary card so approval, manual-action, investigation, and summary-only notification profiles are visible before dispatch activity exists.
 - Added domain-list remediation notification badges so per-domain approval, action, and investigation profiles are visible before dispatch activity exists.
 - Added domain-list remediation notification totals so profile and summary-only counts match the dashboard notification summary card.
+- Added dashboard stuck-work remediation filtering and next-action callouts so blocked provider values, apply prerequisites, dispatch blockers, and verification prerequisites are visible before opening a domain.
+- Added remediation follow-up aging on dashboard cards and domain rows so stale operator follow-up is visible before opening a queue.
+- Added domain remediation refresh result messages and clearer empty-queue states so operators can tell whether no work is open, recent verified repairs exist, or data has not loaded yet.
+- Added domain remediation filter chip counts, empty-filter styling, and explanatory labels so queue filters behave consistently with dashboard remediation filters.
 
 ### Changed
 - Domain summary DNS refreshes now run with bounded concurrency instead of resolving each domain sequentially.

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1270,7 +1270,7 @@ function dashboardApp() {
             const timestamp = new Date(value).getTime();
             if (!Number.isFinite(timestamp)) return '';
             const diffMs = Date.now() - timestamp;
-            if (diffMs < 0) return 'just now';
+            if (diffMs < 0) return '';
             const minutes = Math.floor(diffMs / 60000);
             if (minutes < 1) return 'just now';
             if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -28,6 +28,7 @@ function dashboardApp() {
             { value: 'dispatched', label: 'Dispatched' },
             { value: 'follow_up', label: 'Follow-up' },
             { value: 'dispatch_blocked', label: 'Dispatch blocked' },
+            { value: 'stuck', label: 'Stuck' },
             { value: 'sender_review', label: 'Sender review' },
             { value: 'report_evidence', label: 'Report evidence' },
             { value: 'stale_evidence', label: 'Stale evidence' },
@@ -1184,6 +1185,9 @@ function dashboardApp() {
                 return Boolean(dispatch.enabled && !dispatch.eligible) ||
                     (dispatch.blocked_reasons || []).length > 0;
             }
+            if (filterValue === 'stuck') {
+                return Boolean(this.dashboardRemediationStuckText(item));
+            }
             if (filterValue === 'sender_review') {
                 return verificationStatus === 'pending_sender_review';
             }
@@ -1259,6 +1263,82 @@ function dashboardApp() {
                 parts.push('notification profile ready');
             }
             return parts.join(' · ');
+        },
+
+        relativeAgeText(value) {
+            if (!value) return '';
+            const timestamp = new Date(value).getTime();
+            if (!Number.isFinite(timestamp)) return '';
+            const diffMs = Date.now() - timestamp;
+            if (diffMs < 0) return 'just now';
+            const minutes = Math.floor(diffMs / 60000);
+            if (minutes < 1) return 'just now';
+            if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+            const hours = Math.floor(minutes / 60);
+            if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+            const days = Math.floor(hours / 24);
+            if (days < 30) return `${days} day${days === 1 ? '' : 's'} ago`;
+            const months = Math.floor(days / 30);
+            if (months < 12) return `${months} month${months === 1 ? '' : 's'} ago`;
+            const years = Math.floor(months / 12);
+            return `${years} year${years === 1 ? '' : 's'} ago`;
+        },
+
+        dashboardRemediationFollowUpAgeText(item) {
+            const activity = item?.latest_at
+                ? item
+                : this.dashboardRemediationActivity(item);
+            const requiresFollowUp = Boolean(activity.needs_operator_follow_up) ||
+                Boolean(item?.notification?.dispatch?.requires_lifecycle_acknowledgement) ||
+                Boolean(item?.notification?.dispatch?.operator_hold);
+            if (!requiresFollowUp) return '';
+            const age = this.relativeAgeText(activity.latest_at);
+            return age ? `Follow-up waiting since ${age}` : 'Follow-up is waiting for operator review';
+        },
+
+        dashboardRemediationNextActionText(item) {
+            if (!item) return 'Open the remediation queue to review the next safe action.';
+            const refresh = item.evidence_refresh || {};
+            const progression = item.repair_progression || {};
+            const verification = item.verification_plan || {};
+            if (refresh.safe_to_run === false || refresh.refresh_key === 'provider_value') {
+                return refresh.recommended_action || 'Add the missing provider value before this repair can continue.';
+            }
+            if (refresh.required) {
+                return refresh.recommended_action || this.evidenceRefreshLabel(refresh);
+            }
+            if (progression.next_safe_action) return progression.next_safe_action;
+            if (progression.next_step) return progression.next_step;
+            if (verification.next_check) return verification.next_check;
+            return item.next_step || 'Open the remediation queue to review the next safe action.';
+        },
+
+        dashboardRemediationStuckText(item) {
+            if (!item) return '';
+            const refresh = item.evidence_refresh || {};
+            const dispatch = item.notification?.dispatch || {};
+            const progression = item.repair_progression || {};
+            const verificationStatus = String(item.verification_plan?.status || '');
+            const blockers = progression.blocked_by || [];
+            if (refresh.safe_to_run === false || refresh.refresh_key === 'provider_value') {
+                return 'Waiting on a provider value before DMARQ can refresh or prepare the repair.';
+            }
+            if (Boolean(progression.provider_apply_blocked)) {
+                return 'Provider apply is blocked until prerequisites are complete.';
+            }
+            if (dispatch.enabled && !dispatch.eligible) {
+                return 'Notification dispatch is blocked by settings, acknowledgement, or route availability.';
+            }
+            if ((dispatch.blocked_reasons || []).length) {
+                return `Dispatch blocked: ${dispatch.blocked_reasons.slice(0, 2).join(', ')}.`;
+            }
+            if (blockers.length) {
+                return `Repair blocked by ${blockers.slice(0, 2).map(value => this.formatDemoLabel(value)).join(', ')}.`;
+            }
+            if (verificationStatus === 'blocked_by_prerequisite') {
+                return 'Verification is blocked by a missing prerequisite.';
+            }
+            return '';
         },
 
         remediationLoopItemRank(item) {
@@ -2200,6 +2280,13 @@ function dashboardApp() {
                 wrapper.appendChild(action);
             }
 
+            if (workload?.primary) {
+                const nextAction = document.createElement('span');
+                nextAction.className = 'max-w-56 truncate text-xs font-semibold text-[#1f7c83]';
+                nextAction.textContent = this.dashboardRemediationNextActionText(workload.primary);
+                wrapper.appendChild(nextAction);
+            }
+
             if (workload?.primary?.evidence_refresh?.required) {
                 const evidence = document.createElement('span');
                 evidence.className = 'max-w-56 truncate text-xs font-semibold text-[#247982]';
@@ -2230,6 +2317,14 @@ function dashboardApp() {
                 [Number(remediation?.dispatch_enqueued || 0), 'dispatched'],
                 [Number(remediation?.needs_operator_follow_up || 0), 'follow-up'],
             ], 'max-w-56 truncate text-xs font-semibold text-[#5f5c78]');
+
+            const followUpAge = this.dashboardRemediationFollowUpAgeText(remediation);
+            if (followUpAge) {
+                const age = document.createElement('span');
+                age.className = 'max-w-56 truncate text-xs font-semibold text-[#8a6418]';
+                age.textContent = followUpAge;
+                wrapper.appendChild(age);
+            }
 
             cell.appendChild(wrapper);
             return cell;

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -123,6 +123,7 @@ function domainDetailsApp(domainId = '') {
         remediationQueueRefreshing: false,
         remediationQueueError: '',
         remediationQueueRefreshError: '',
+        remediationQueueRefreshMessage: '',
         showAllVerifiedRemediationItems: false,
         showAllRemediationQueueItems: false,
         remediationQueueLoadedAt: '',
@@ -1526,6 +1527,27 @@ function domainDetailsApp(domainId = '') {
             return match?.label || 'All';
         },
 
+        remediationQueueFilterClass(filter) {
+            if (this.remediationQueueFilter === filter) {
+                return 'border-[#2f9da5] bg-[#f2fbf9] text-[#1f7c83]';
+            }
+            if (filter !== 'all' && this.remediationQueueFilterCount(filter) === 0) {
+                return 'border-[#ece9e7] bg-[#fbfaf9] text-[#9a96a8]';
+            }
+            return 'border-[#e6e3e1] bg-white text-[#5f5c78] hover:border-[#2f9da5]';
+        },
+
+        remediationQueueFilterTitle(filter) {
+            const label = this.remediationQueueFilterOptions.find(
+                option => option.value === filter
+            )?.label || 'Remediation';
+            const count = this.remediationQueueFilterCount(filter);
+            if (count === 0 && filter !== 'all') {
+                return `No ${label.toLowerCase()} remediation items in this domain queue`;
+            }
+            return `${this.formatLargeNumber(count)} ${label.toLowerCase()} remediation item${count === 1 ? '' : 's'}`;
+        },
+
         filteredRemediationQueueItems(filterValue) {
             const filter = filterValue || 'all';
             const items = this.remediationQueue.items || [];
@@ -2277,6 +2299,7 @@ function domainDetailsApp(domainId = '') {
             this.showAllRemediationQueueItems = false;
             this.remediationQueueLoadedAt = '';
             this.remediationQueueRefreshError = '';
+            this.remediationQueueRefreshMessage = '';
             this.remediationQueue = {
                 status: 'unavailable',
                 loop: {
@@ -2351,6 +2374,7 @@ function domainDetailsApp(domainId = '') {
             this.remediationQueueRefreshing = refresh;
             this.remediationQueueError = '';
             this.remediationQueueRefreshError = '';
+            this.remediationQueueRefreshMessage = '';
             this.showAllVerifiedRemediationItems = false;
             this.showAllRemediationQueueItems = false;
             try {
@@ -2373,6 +2397,12 @@ function domainDetailsApp(domainId = '') {
                 }
                 this.remediationQueue = await response.json();
                 this.remediationQueueLoadedAt = new Date().toISOString();
+                if (refresh) {
+                    const total = Number(this.remediationQueue?.summary?.total || 0);
+                    this.remediationQueueRefreshMessage = total
+                        ? `Remediation queue refreshed. ${total} open item${total === 1 ? '' : 's'} still need review.`
+                        : 'Remediation queue refreshed. No open remediation items remain.';
+                }
             } catch (error) {
                 console.error('Error fetching remediation queue:', error);
                 if (keepExistingQueueVisible) {
@@ -2385,6 +2415,26 @@ function domainDetailsApp(domainId = '') {
                 this.remediationQueueLoading = false;
                 this.remediationQueueRefreshing = false;
             }
+        },
+
+        remediationQueueEmptyStateTitle() {
+            if (this.remediationQueueLoadedAt && (this.remediationQueue.verified_items || []).length) {
+                return 'No active remediation queued';
+            }
+            if (this.remediationQueueLoadedAt) {
+                return 'No remediation queued';
+            }
+            return 'No remediation data loaded yet';
+        },
+
+        remediationQueueEmptyStateText() {
+            if (this.remediationQueueLoadedAt && (this.remediationQueue.verified_items || []).length) {
+                return 'Recent repairs are listed above. Refresh the queue when new reports or DNS evidence arrive.';
+            }
+            if (this.remediationQueueLoadedAt) {
+                return 'DMARQ did not find an approval, manual action, or investigation item for this domain in the current evidence window.';
+            }
+            return 'Load or refresh the queue to check whether this domain has actionable remediation work.';
         },
 
         async refreshRemediationEvidence(item) {

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -535,6 +535,10 @@
                        x-cloak
                        class="mt-4 rounded border border-[#ffcfbd] bg-[#fff2ec] px-3 py-2 text-sm text-[#8a2d0d]"
                        x-text="remediationQueueRefreshError"></p>
+                    <p x-show="remediationQueueRefreshMessage"
+                       x-cloak
+                       class="mt-4 rounded border border-[#d8ebe8] bg-[#f2fbf9] px-3 py-2 text-sm font-semibold text-[#1f7c83]"
+                       x-text="remediationQueueRefreshMessage"></p>
                     <template x-if="!remediationQueueLoading && !remediationQueueError && (remediationQueue.verified_items || []).length > 0">
                         <div class="mt-4 rounded-lg border border-[#d8ebe8] bg-[#f2fbf9] p-3">
                             <div class="flex flex-wrap items-start justify-between gap-3">
@@ -706,7 +710,10 @@
                         </div>
                     </template>
                     <template x-if="!remediationQueueLoading && !remediationQueueError && remediationQueue.items.length === 0">
-                        <p class="mt-4 text-sm text-[#5f5c78]">No remediation items are queued for this domain.</p>
+                        <div class="mt-4 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-4 text-sm">
+                            <p class="font-semibold text-[#120d36]" x-text="remediationQueueEmptyStateTitle()"></p>
+                            <p class="mt-1 text-[#5f5c78]" x-text="remediationQueueEmptyStateText()"></p>
+                        </div>
                     </template>
                     <div class="mt-4 flex flex-wrap gap-2"
                          role="group"
@@ -726,8 +733,10 @@
                         <template x-for="filter in remediationQueueFilterOptions" :key="'remediation-filter-' + filter.value">
                             <button type="button"
                                     class="rounded border px-3 py-2 text-xs font-semibold transition"
-                                    :class="remediationQueueFilter === filter.value ? 'border-[#2f9da5] bg-[#f2fbf9] text-[#1f7c83]' : 'border-[#e6e3e1] bg-white text-[#5f5c78] hover:border-[#2f9da5]'"
+                                    :class="remediationQueueFilterClass(filter.value)"
                                     :aria-pressed="remediationQueueFilter === filter.value ? 'true' : 'false'"
+                                    :title="remediationQueueFilterTitle(filter.value)"
+                                    :aria-label="remediationQueueFilterTitle(filter.value)"
                                     :data-domain-detail-remediation-filter="filter.value">
                                 <span x-text="filter.label"></span>
                                 <span class="ml-1 rounded bg-[#f4f3f2] px-1.5 py-0.5 text-[0.65rem] text-[#45505f]"

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -416,6 +416,13 @@
                     </div>
                     <p class="mt-2 text-sm text-[#5f5c78]" x-text="item.detail"></p>
                     <p class="mt-2 text-sm font-semibold text-[#272a5f]" x-text="item.next_step"></p>
+                    <p class="mt-2 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-2 text-xs font-semibold text-[#1f7c83]">
+                        <span>Next action: </span>
+                        <span x-text="dashboardRemediationNextActionText(item)"></span>
+                    </p>
+                    <p class="mt-2 rounded border border-[#f5dfbd] bg-[#fff8ed] p-2 text-xs font-semibold text-[#7a4a00]"
+                       x-show="dashboardRemediationStuckText(item)"
+                       x-text="dashboardRemediationStuckText(item)"></p>
                     <div class="mt-3 grid gap-2 text-xs text-[#5f5c78] sm:grid-cols-2">
                         <div>
                             <p class="font-semibold uppercase tracking-wide text-[#8a879e]">Owner</p>
@@ -482,6 +489,9 @@
                     <p class="mt-3 rounded border border-[#d5e9f8] bg-[#f7fbff] p-3 text-xs font-semibold text-[#24507a]"
                        x-show="dashboardRemediationDispatchText(item)"
                        x-text="dashboardRemediationDispatchText(item)"></p>
+                    <p class="mt-2 rounded border border-[#f5dfbd] bg-[#fff8ed] p-2 text-xs font-semibold text-[#7a4a00]"
+                       x-show="dashboardRemediationFollowUpAgeText(item)"
+                       x-text="dashboardRemediationFollowUpAgeText(item)"></p>
                     <div class="mt-3 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-3 text-xs"
                          x-show="item.evidence_refresh?.required">
                         <div class="flex flex-wrap items-center justify-between gap-2">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -378,6 +378,7 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "{ value: 'dispatched', label: 'Dispatched' }" in script
     assert "{ value: 'follow_up', label: 'Follow-up' }" in script
     assert "{ value: 'dispatch_blocked', label: 'Dispatch blocked' }" in script
+    assert "{ value: 'stuck', label: 'Stuck' }" in script
     assert "{ value: 'sender_review', label: 'Sender review' }" in script
     assert "{ value: 'report_evidence', label: 'Report evidence' }" in script
     assert "{ value: 'stale_evidence', label: 'Stale evidence' }" in script
@@ -394,6 +395,12 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "formatLargeNumber(dashboardRemediationFilterCount(filter.value))" in template
     assert "dashboardRemediationFilterClass(filter)" in script
     assert "dashboardRemediationFilterTitle(filter)" in script
+    assert "dashboardRemediationNextActionText(item)" in script
+    assert "dashboardRemediationStuckText(item)" in script
+    assert "dashboardRemediationFollowUpAgeText(item)" in script
+    assert "relativeAgeText(value)" in script
+    assert "Next action:" in template
+    assert "dashboardRemediationFollowUpAgeText(item)" in template
     assert "dashboardRemediationFilterCounts()" in script
     assert "data-dashboard-remediation-toggle-all" in template
     assert "data-dashboard-remediation-toggle-all" in script
@@ -802,6 +809,54 @@ def test_dashboard_remediation_filter_chips_explain_empty_states():
     )
 
 
+def test_dashboard_remediation_stuck_filter_and_next_action_text():
+    result = _run_dashboard_expression("""(() => {
+            const item = {
+                domain: 'blocked.example',
+                state: 'needs_approval',
+                priority_score: 9,
+                severity: 'medium',
+                evidence_refresh: {
+                    required: true,
+                    refresh_key: 'provider_value',
+                    safe_to_run: false,
+                    recommended_action: 'Select a DNS provider connection first.'
+                },
+                repair_progression: {
+                    provider_apply_blocked: true,
+                    blocked_by: ['provider_value']
+                }
+            };
+            app.healthSummary = { remediation_loop: { items: [item] } };
+            return [
+                app.dashboardRemediationFilterCount('stuck'),
+                app.dashboardRemediationNextActionText(item),
+                app.dashboardRemediationStuckText(item)
+            ].join('|');
+        })()""")
+
+    assert result == (
+        "1|Select a DNS provider connection first.|"
+        "Waiting on a provider value before DMARQ can refresh or prepare the repair."
+    )
+
+
+def test_dashboard_remediation_follow_up_age_text_uses_activity_timestamp():
+    result = _run_dashboard_expression("""(() => {
+            const latest = new Date(Date.now() - (2 * 24 * 60 * 60 * 1000)).toISOString();
+            app.domains = [{
+                domain_name: 'follow.example',
+                remediation: {
+                    latest_at: latest,
+                    needs_operator_follow_up: true
+                }
+            }];
+            return app.dashboardRemediationFollowUpAgeText({ domain: 'follow.example' });
+        })()""")
+
+    assert result == "Follow-up waiting since 2 days ago"
+
+
 def test_dashboard_remediation_stale_evidence_links_to_evidence_anchor():
     result = _run_dashboard_expression("""(() => {
             const item = {
@@ -902,6 +957,8 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
     assert "1 dispatched" in result
     assert "1 follow-up" in result
     assert "Dispatch enqueued" in result
+    assert "Open the remediation queue" in result
+    assert "Follow-up waiting since" in result
 
 
 def test_domain_details_remediation_queue_shows_verification_context():
@@ -917,6 +974,13 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "fetchRemediationQueue({ refresh: true })" in script
     assert "remediationQueueRefreshing" in script
     assert "remediationQueueRefreshError" in script
+    assert "remediationQueueRefreshMessage" in script
+    assert "remediationQueueRefreshMessage" in template
+    assert "Remediation queue refreshed." in script
+    assert "remediationQueueEmptyStateTitle()" in script
+    assert "remediationQueueEmptyStateText()" in script
+    assert "remediationQueueEmptyStateTitle()" in template
+    assert "remediationQueueEmptyStateText()" in template
     assert "hasRemediationQueueData()" in script
     assert "keepExistingQueueVisible" in script
     assert "Remediation queue refresh failed. Keeping the current queue visible." in script
@@ -945,6 +1009,8 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "filter === 'provider_value'" in script
     assert "item.notification?.dispatch?.eligible" in script
     assert "remediationQueueFilterCount(filter)" in script
+    assert "remediationQueueFilterClass(filter)" in script
+    assert "remediationQueueFilterTitle(filter)" in script
     assert "remediationQueueFilteredCount()" in script
     assert "remediationQueueTotalCount()" in script
     assert "showAllRemediationQueueItems" in script
@@ -957,6 +1023,9 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "Remediation queue sort" in template
     assert "data-domain-detail-remediation-filter" in template
     assert "aria-pressed" in template
+    assert ":class=\"remediationQueueFilterClass(filter.value)\"" in template
+    assert ":title=\"remediationQueueFilterTitle(filter.value)\"" in template
+    assert ":aria-label=\"remediationQueueFilterTitle(filter.value)\"" in template
     assert 'role="group"' in template
     assert 'aria-label="Remediation queue filters"' in template
     assert 'role="status"' in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -857,6 +857,18 @@ def test_dashboard_remediation_follow_up_age_text_uses_activity_timestamp():
     assert result == "Follow-up waiting since 2 days ago"
 
 
+def test_dashboard_remediation_follow_up_age_text_ignores_future_timestamp():
+    result = _run_dashboard_expression("""(() => {
+            const latest = new Date(Date.now() + (10 * 60 * 1000)).toISOString();
+            return app.dashboardRemediationFollowUpAgeText({
+                latest_at: latest,
+                needs_operator_follow_up: true
+            });
+        })()""")
+
+    assert result == "Follow-up is waiting for operator review"
+
+
 def test_dashboard_remediation_stale_evidence_links_to_evidence_anchor():
     result = _run_dashboard_expression("""(() => {
             const item = {

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -87,10 +87,14 @@ summary before linking to the selected domain for the full evidence, approval,
 and verification flow. Filter chips let you isolate preview-ready repairs,
 approval verification, sender review, report-evidence follow-up, blocked work,
 manual work, reputation review, and stale-evidence cases without opening every
-domain. The same filter bar can now isolate remediation notifications that have
+domain. A dedicated stuck-work filter highlights cards blocked by missing
+provider values, provider apply prerequisites, dispatch routing, or verification
+prerequisites. The same filter bar can now isolate remediation notifications that have
 a backend notification profile ready for operator action, notifications that are
 ready to send, already dispatched, blocked by notification settings, or waiting
-for operator follow-up after dispatch. Notification-profile-ready cards have
+for operator follow-up after dispatch. Follow-up cards show how long the latest
+operator or dispatch activity has been waiting, so old manual work is easier to
+separate from fresh findings. Notification-profile-ready cards have
 the event, channel, dedupe key, and payload preview prepared, but they still do
 not send anything until the operator uses the explicit dispatch flow. The
 dashboard and domain rows also expose separate counts for approval-required,
@@ -100,7 +104,9 @@ dispatch activity exists, making queued operator communication visible even when
 webhook delivery is not yet enabled.
 The domain table repeats the same notification-ready signal, profile total, and
 summary-only counts on each affected domain row so operators can pick the next
-domain without opening every queue.
+domain without opening every queue. Rows also repeat the current next safe
+action from the top remediation item so obvious refresh, approval, or provider
+value work is visible before opening the domain.
 Filter chips show compact counts, fade when the current workspace has no
 matching cards, and include hover text that explains whether the filtered queue
 is empty or how many cards it would show.
@@ -110,6 +116,12 @@ explicit approval, is blocked by missing provider values, or should fall back to
 manual DNS work. Provider repair items also expose before-apply and after-apply
 checklists so operators can review the blast radius and required evidence before
 approving or closing a repair.
+When the domain remediation queue is refreshed, the page keeps the existing
+evidence visible and reports whether open items remain or the queue is now
+empty. Empty queue states distinguish a clean current queue from historical
+verified repairs or data that has not loaded yet. Domain queue filters use the
+same count and empty-filter affordances as the dashboard, so a faded filter means
+there is no matching item in that domain's current queue.
 
 ### Demo Mode
 


### PR DESCRIPTION
## Summary
- add dashboard remediation next-action callouts and a stuck-work filter for blocked provider values, apply prerequisites, dispatch blockers, and verification prerequisites
- show remediation follow-up age on dashboard cards and domain rows
- improve domain remediation refresh success messaging, empty-queue states, and domain queue filter chip affordances
- update dashboard user docs and changelog

## Local validation
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q`
- `node --check backend/app/static/js/dashboard-page.js && node --check backend/app/static/js/domain-details-page.js`
- `/tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py`
- `git diff --check origin/main..HEAD`

## Safety
- read-only UI/UX slice only
- no DNS/provider write behavior changed
- no notification dispatch behavior changed

Refs #384
