### PR TITLE
feat: surface aging remediation follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added domain-list remediation notification totals so profile and summary-only counts match the dashboard notification summary card.
 - Added dashboard stuck-work remediation filtering and next-action callouts so blocked provider values, apply prerequisites, dispatch blockers, and verification prerequisites are visible before opening a domain.
 - Added remediation follow-up aging on dashboard cards and domain rows so stale operator follow-up is visible before opening a queue.
+- Added an aging follow-up remediation filter and overdue styling so operator follow-up older than 24 hours or 7 days is easier to triage.
+- Added aging follow-up counts to the dashboard health summary, dispatch activity card, and domain rows so stale manual work is visible without opening the remediation queue.
 - Added domain remediation refresh result messages and clearer empty-queue states so operators can tell whether no work is open, recent verified repairs exist, or data has not loaded yet.
 - Added domain remediation filter chip counts, empty-filter styling, and explanatory labels so queue filters behave consistently with dashboard remediation filters.
 

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1322,8 +1322,7 @@ function dashboardApp() {
         dashboardRemediationFollowUpAgeClass(item) {
             const days = this.dashboardRemediationFollowUpAgeDays(item);
             if (days >= 7) return 'border-[#ffcfbd] bg-[#fff2ec] text-[#8a2d0d]';
-            if (days >= 1) return 'border-[#f5dfbd] bg-[#fff8ed] text-[#7a4a00]';
-            return 'border-[#d5e9f8] bg-[#f7fbff] text-[#24507a]';
+            return 'border-[#f5dfbd] bg-[#fff8ed] text-[#7a4a00]';
         },
 
         dashboardRemediationNextActionText(item) {

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -27,6 +27,7 @@ function dashboardApp() {
             { value: 'notify_ready', label: 'Ready to notify' },
             { value: 'dispatched', label: 'Dispatched' },
             { value: 'follow_up', label: 'Follow-up' },
+            { value: 'aging_follow_up', label: 'Aging follow-up' },
             { value: 'dispatch_blocked', label: 'Dispatch blocked' },
             { value: 'stuck', label: 'Stuck' },
             { value: 'sender_review', label: 'Sender review' },
@@ -1180,6 +1181,9 @@ function dashboardApp() {
                     Boolean(dispatch.requires_lifecycle_acknowledgement) ||
                     Boolean(dispatch.operator_hold);
             }
+            if (filterValue === 'aging_follow_up') {
+                return this.dashboardRemediationFollowUpAgeDays(item) >= 1;
+            }
             if (filterValue === 'dispatch_blocked') {
                 const dispatch = item?.notification?.dispatch || {};
                 return Boolean(dispatch.enabled && !dispatch.eligible) ||
@@ -1284,6 +1288,15 @@ function dashboardApp() {
             return `${years} year${years === 1 ? '' : 's'} ago`;
         },
 
+        ageDays(value) {
+            if (!value) return -1;
+            const timestamp = new Date(value).getTime();
+            if (!Number.isFinite(timestamp)) return -1;
+            const diffMs = Date.now() - timestamp;
+            if (diffMs < 0) return -1;
+            return Math.floor(diffMs / (24 * 60 * 60 * 1000));
+        },
+
         dashboardRemediationFollowUpAgeText(item) {
             const activity = item?.latest_at
                 ? item
@@ -1294,6 +1307,23 @@ function dashboardApp() {
             if (!requiresFollowUp) return '';
             const age = this.relativeAgeText(activity.latest_at);
             return age ? `Follow-up waiting since ${age}` : 'Follow-up is waiting for operator review';
+        },
+
+        dashboardRemediationFollowUpAgeDays(item) {
+            const activity = item?.latest_at
+                ? item
+                : this.dashboardRemediationActivity(item);
+            const requiresFollowUp = Boolean(activity.needs_operator_follow_up) ||
+                Boolean(item?.notification?.dispatch?.requires_lifecycle_acknowledgement) ||
+                Boolean(item?.notification?.dispatch?.operator_hold);
+            return requiresFollowUp ? this.ageDays(activity.latest_at) : -1;
+        },
+
+        dashboardRemediationFollowUpAgeClass(item) {
+            const days = this.dashboardRemediationFollowUpAgeDays(item);
+            if (days >= 7) return 'border-[#ffcfbd] bg-[#fff2ec] text-[#8a2d0d]';
+            if (days >= 1) return 'border-[#f5dfbd] bg-[#fff8ed] text-[#7a4a00]';
+            return 'border-[#d5e9f8] bg-[#f7fbff] text-[#24507a]';
         },
 
         dashboardRemediationNextActionText(item) {
@@ -2316,12 +2346,17 @@ function dashboardApp() {
             this.appendCountBadge(wrapper, [
                 [Number(remediation?.dispatch_enqueued || 0), 'dispatched'],
                 [Number(remediation?.needs_operator_follow_up || 0), 'follow-up'],
+                [this.dashboardRemediationFollowUpAgeDays(remediation) >= 1 ? 1 : 0, 'aging follow-up'],
             ], 'max-w-56 truncate text-xs font-semibold text-[#5f5c78]');
 
             const followUpAge = this.dashboardRemediationFollowUpAgeText(remediation);
             if (followUpAge) {
                 const age = document.createElement('span');
-                age.className = 'max-w-56 truncate text-xs font-semibold text-[#8a6418]';
+                age.className = `max-w-56 truncate text-xs font-semibold ${
+                    this.dashboardRemediationFollowUpAgeDays(remediation) >= 7
+                        ? 'text-[#8a2d0d]'
+                        : 'text-[#8a6418]'
+                }`;
                 age.textContent = followUpAge;
                 wrapper.appendChild(age);
             }

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -113,6 +113,11 @@
                               x-text="remediationTotals().needs_operator_follow_up || 0"></span>
                     </div>
                     <div class="flex items-center justify-between gap-3">
+                        <span class="text-[#5f5c78]">Aging follow-up</span>
+                        <span class="font-semibold text-[#8a2d0d]"
+                              x-text="dashboardRemediationFilterCount('aging_follow_up')"></span>
+                    </div>
+                    <div class="flex items-center justify-between gap-3">
                         <span class="text-[#5f5c78]">Resolved markers</span>
                         <span class="font-semibold text-[#247982]"
                               x-text="remediationTotals().resolved || 0"></span>
@@ -318,6 +323,9 @@
                 <p class="mt-2 text-xs text-[#24507a]">
                     <span x-text="remediationLoop().operator_follow_up || 0"></span><span> domains need follow-up</span>
                 </p>
+                <p class="mt-1 text-xs text-[#8a2d0d]">
+                    <span x-text="dashboardRemediationFilterCount('aging_follow_up')"></span><span> aging follow-ups</span>
+                </p>
             </div>
             <div class="rounded-md border border-[#f5dfbd] bg-[#fff8ed] p-4">
                 <p class="text-sm text-[#5f5c78]">Need fresh evidence</p>
@@ -489,7 +497,8 @@
                     <p class="mt-3 rounded border border-[#d5e9f8] bg-[#f7fbff] p-3 text-xs font-semibold text-[#24507a]"
                        x-show="dashboardRemediationDispatchText(item)"
                        x-text="dashboardRemediationDispatchText(item)"></p>
-                    <p class="mt-2 rounded border border-[#f5dfbd] bg-[#fff8ed] p-2 text-xs font-semibold text-[#7a4a00]"
+                    <p class="mt-2 rounded border p-2 text-xs font-semibold"
+                       :class="dashboardRemediationFollowUpAgeClass(item)"
                        x-show="dashboardRemediationFollowUpAgeText(item)"
                        x-text="dashboardRemediationFollowUpAgeText(item)"></p>
                     <div class="mt-3 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-3 text-xs"

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -885,6 +885,27 @@ def test_dashboard_remediation_aging_follow_up_filter_and_class():
     assert result == "1|8|border-[#ffcfbd] bg-[#fff2ec] text-[#8a2d0d]"
 
 
+def test_dashboard_remediation_follow_up_age_class_handles_unknown_age():
+    result = _run_dashboard_expression("""(() => {
+            const future = new Date(Date.now() + (10 * 60 * 1000)).toISOString();
+            return [
+                app.dashboardRemediationFollowUpAgeClass({
+                    latest_at: future,
+                    needs_operator_follow_up: true
+                }),
+                app.dashboardRemediationFollowUpAgeClass({
+                    latest_at: 'not-a-date',
+                    needs_operator_follow_up: true
+                })
+            ].join('|');
+        })()""")
+
+    assert result == (
+        "border-[#f5dfbd] bg-[#fff8ed] text-[#7a4a00]|"
+        "border-[#f5dfbd] bg-[#fff8ed] text-[#7a4a00]"
+    )
+
+
 def test_dashboard_remediation_follow_up_age_text_ignores_future_timestamp():
     result = _run_dashboard_expression("""(() => {
             const latest = new Date(Date.now() + (10 * 60 * 1000)).toISOString();

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -354,6 +354,8 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "remediationLoop().notification_investigation_required || 0" in template
     assert "remediationLoop().notification_profiles || 0" in template
     assert "remediationLoop().notification_summary_only || 0" in template
+    assert "Aging follow-up" in template
+    assert "dashboardRemediationFilterCount('aging_follow_up')" in template
     assert "Need fresh evidence" in template
     assert "Waiting on operator" in template
     assert "Blocked before repair" in template
@@ -377,6 +379,7 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "{ value: 'notify_ready', label: 'Ready to notify' }" in script
     assert "{ value: 'dispatched', label: 'Dispatched' }" in script
     assert "{ value: 'follow_up', label: 'Follow-up' }" in script
+    assert "{ value: 'aging_follow_up', label: 'Aging follow-up' }" in script
     assert "{ value: 'dispatch_blocked', label: 'Dispatch blocked' }" in script
     assert "{ value: 'stuck', label: 'Stuck' }" in script
     assert "{ value: 'sender_review', label: 'Sender review' }" in script
@@ -398,9 +401,12 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "dashboardRemediationNextActionText(item)" in script
     assert "dashboardRemediationStuckText(item)" in script
     assert "dashboardRemediationFollowUpAgeText(item)" in script
+    assert "dashboardRemediationFollowUpAgeClass(item)" in script
+    assert "dashboardRemediationFollowUpAgeDays(item)" in script
     assert "relativeAgeText(value)" in script
     assert "Next action:" in template
     assert "dashboardRemediationFollowUpAgeText(item)" in template
+    assert ":class=\"dashboardRemediationFollowUpAgeClass(item)\"" in template
     assert "dashboardRemediationFilterCounts()" in script
     assert "data-dashboard-remediation-toggle-all" in template
     assert "data-dashboard-remediation-toggle-all" in script
@@ -857,6 +863,28 @@ def test_dashboard_remediation_follow_up_age_text_uses_activity_timestamp():
     assert result == "Follow-up waiting since 2 days ago"
 
 
+def test_dashboard_remediation_aging_follow_up_filter_and_class():
+    result = _run_dashboard_expression("""(() => {
+            const latest = new Date(Date.now() - (8 * 24 * 60 * 60 * 1000)).toISOString();
+            const item = { domain: 'old.example' };
+            app.domains = [{
+                domain_name: 'old.example',
+                remediation: {
+                    latest_at: latest,
+                    needs_operator_follow_up: true
+                }
+            }];
+            app.healthSummary = { remediation_loop: { items: [item] } };
+            return [
+                app.dashboardRemediationFilterCount('aging_follow_up'),
+                app.dashboardRemediationFollowUpAgeDays(item),
+                app.dashboardRemediationFollowUpAgeClass(item)
+            ].join('|');
+        })()""")
+
+    assert result == "1|8|border-[#ffcfbd] bg-[#fff2ec] text-[#8a2d0d]"
+
+
 def test_dashboard_remediation_follow_up_age_text_ignores_future_timestamp():
     result = _run_dashboard_expression("""(() => {
             const latest = new Date(Date.now() + (10 * 60 * 1000)).toISOString();
@@ -924,7 +952,7 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
                 {
                     status: 'dispatched',
                     latest_label: 'Dispatch enqueued',
-                    latest_at: '2026-07-06T03:00:00Z',
+                    latest_at: new Date(Date.now() - (2 * 24 * 60 * 60 * 1000)).toISOString(),
                     dispatch_enqueued: 1,
                     needs_operator_follow_up: true
                 },
@@ -968,6 +996,7 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
     assert "1 summary-only" in result
     assert "1 dispatched" in result
     assert "1 follow-up" in result
+    assert "1 aging follow-up" in result
     assert "Dispatch enqueued" in result
     assert "Open the remediation queue" in result
     assert "Follow-up waiting since" in result

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -93,8 +93,12 @@ prerequisites. The same filter bar can now isolate remediation notifications tha
 a backend notification profile ready for operator action, notifications that are
 ready to send, already dispatched, blocked by notification settings, or waiting
 for operator follow-up after dispatch. Follow-up cards show how long the latest
-operator or dispatch activity has been waiting, so old manual work is easier to
-separate from fresh findings. Notification-profile-ready cards have
+operator or dispatch activity has been waiting, and a separate aging follow-up
+filter isolates work older than 24 hours. The dashboard health summary,
+dispatch activity card, and domain rows expose the same aging follow-up count so
+old manual work is visible before the operator opens the full queue. Follow-ups
+older than a week use the stronger overdue styling so old manual work is easier
+to separate from fresh findings. Notification-profile-ready cards have
 the event, channel, dedupe key, and payload preview prepared, but they still do
 not send anything until the operator uses the explicit dispatch flow. The
 dashboard and domain rows also expose separate counts for approval-required,


### PR DESCRIPTION
## Summary
- add an Aging follow-up dashboard remediation filter for operator follow-up older than 24 hours
- style overdue follow-up cards and domain-row ages more strongly after 7 days
- surface aging follow-up counts in the dashboard health summary, dispatch activity card, and domain rows
- update dashboard user guide and changelog

## Local validation
- PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q
- node --check backend/app/static/js/dashboard-page.js
- /tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py
- git diff --check

## Safety
- UI/read-only remediation visibility changes only; no provider writes or dispatch side effects.

Refs #384