### PR TITLE
feat: prioritize stale remediation follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added remediation follow-up aging on dashboard cards and domain rows so stale operator follow-up is visible before opening a queue.
 - Added an aging follow-up remediation filter and overdue styling so operator follow-up older than 24 hours or 7 days is easier to triage.
 - Added aging follow-up counts to the dashboard health summary, dispatch activity card, and domain rows so stale manual work is visible without opening the remediation queue.
+- Changed the dashboard dispatch follow-up sort to put older operator follow-ups ahead of fresher follow-ups within the same dispatch state.
 - Added domain remediation refresh result messages and clearer empty-queue states so operators can tell whether no work is open, recent verified repairs exist, or data has not loaded yet.
 - Added domain remediation filter chip counts, empty-filter styling, and explanatory labels so queue filters behave consistently with dashboard remediation filters.
 

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1249,7 +1249,7 @@ function dashboardApp() {
             return 4;
         },
 
-        dashboardRemediationFollowUpAgeMs(item, nowMs = Date.now()) {
+        dashboardRemediationFollowUpActivity(item) {
             const activity = item?.latest_at
                 ? item
                 : this.dashboardRemediationActivity(item);
@@ -1257,6 +1257,11 @@ function dashboardApp() {
             const requiresFollowUp = Boolean(activity.needs_operator_follow_up) ||
                 Boolean(dispatch.requires_lifecycle_acknowledgement) ||
                 Boolean(dispatch.operator_hold);
+            return { activity, requiresFollowUp };
+        },
+
+        dashboardRemediationFollowUpAgeMs(item, nowMs = Date.now()) {
+            const { activity, requiresFollowUp } = this.dashboardRemediationFollowUpActivity(item);
             if (!requiresFollowUp || !activity.latest_at) return 0;
             const timestamp = new Date(activity.latest_at).getTime();
             if (!Number.isFinite(timestamp)) return 0;
@@ -1316,24 +1321,14 @@ function dashboardApp() {
         },
 
         dashboardRemediationFollowUpAgeText(item) {
-            const activity = item?.latest_at
-                ? item
-                : this.dashboardRemediationActivity(item);
-            const requiresFollowUp = Boolean(activity.needs_operator_follow_up) ||
-                Boolean(item?.notification?.dispatch?.requires_lifecycle_acknowledgement) ||
-                Boolean(item?.notification?.dispatch?.operator_hold);
+            const { activity, requiresFollowUp } = this.dashboardRemediationFollowUpActivity(item);
             if (!requiresFollowUp) return '';
             const age = this.relativeAgeText(activity.latest_at);
             return age ? `Follow-up waiting since ${age}` : 'Follow-up is waiting for operator review';
         },
 
         dashboardRemediationFollowUpAgeDays(item) {
-            const activity = item?.latest_at
-                ? item
-                : this.dashboardRemediationActivity(item);
-            const requiresFollowUp = Boolean(activity.needs_operator_follow_up) ||
-                Boolean(item?.notification?.dispatch?.requires_lifecycle_acknowledgement) ||
-                Boolean(item?.notification?.dispatch?.operator_hold);
+            const { activity, requiresFollowUp } = this.dashboardRemediationFollowUpActivity(item);
             return requiresFollowUp ? this.ageDays(activity.latest_at) : -1;
         },
 

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1031,6 +1031,8 @@ function dashboardApp() {
                 return list.sort((a, b) => (
                     this.dashboardRemediationDispatchRank(a) -
                     this.dashboardRemediationDispatchRank(b) ||
+                    this.dashboardRemediationFollowUpAgeMs(b) -
+                    this.dashboardRemediationFollowUpAgeMs(a) ||
                     this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b) ||
                     (Number(b?.priority_score) || 0) - (Number(a?.priority_score) || 0)
                 ));
@@ -1244,6 +1246,21 @@ function dashboardApp() {
             if (dispatch.enabled && !dispatch.eligible) return 2;
             if (dispatch.eligible) return 3;
             return 4;
+        },
+
+        dashboardRemediationFollowUpAgeMs(item) {
+            const activity = item?.latest_at
+                ? item
+                : this.dashboardRemediationActivity(item);
+            const dispatch = item?.notification?.dispatch || {};
+            const requiresFollowUp = Boolean(activity.needs_operator_follow_up) ||
+                Boolean(dispatch.requires_lifecycle_acknowledgement) ||
+                Boolean(dispatch.operator_hold);
+            if (!requiresFollowUp || !activity.latest_at) return 0;
+            const timestamp = new Date(activity.latest_at).getTime();
+            if (!Number.isFinite(timestamp)) return 0;
+            const diffMs = Date.now() - timestamp;
+            return diffMs > 0 ? diffMs : 0;
         },
 
         dashboardRemediationDispatchText(item) {

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1028,11 +1028,12 @@ function dashboardApp() {
                 ));
             }
             if (this.dashboardRemediationSort === 'dispatch') {
+                const nowMs = Date.now();
                 return list.sort((a, b) => (
                     this.dashboardRemediationDispatchRank(a) -
                     this.dashboardRemediationDispatchRank(b) ||
-                    this.dashboardRemediationFollowUpAgeMs(b) -
-                    this.dashboardRemediationFollowUpAgeMs(a) ||
+                    this.dashboardRemediationFollowUpAgeMs(b, nowMs) -
+                    this.dashboardRemediationFollowUpAgeMs(a, nowMs) ||
                     this.remediationLoopItemRank(a) - this.remediationLoopItemRank(b) ||
                     (Number(b?.priority_score) || 0) - (Number(a?.priority_score) || 0)
                 ));
@@ -1248,7 +1249,7 @@ function dashboardApp() {
             return 4;
         },
 
-        dashboardRemediationFollowUpAgeMs(item) {
+        dashboardRemediationFollowUpAgeMs(item, nowMs = Date.now()) {
             const activity = item?.latest_at
                 ? item
                 : this.dashboardRemediationActivity(item);
@@ -1259,7 +1260,7 @@ function dashboardApp() {
             if (!requiresFollowUp || !activity.latest_at) return 0;
             const timestamp = new Date(activity.latest_at).getTime();
             if (!Number.isFinite(timestamp)) return 0;
-            const diffMs = Date.now() - timestamp;
+            const diffMs = nowMs - timestamp;
             return diffMs > 0 ? diffMs : 0;
         },
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -783,6 +783,43 @@ def test_dashboard_remediation_dispatch_activity_filters_and_labels():
     )
 
 
+def test_dashboard_remediation_dispatch_sort_prioritizes_old_follow_up():
+    result = _run_dashboard_expression("""(() => {
+            const oldLatest = new Date(Date.now() - (6 * 24 * 60 * 60 * 1000)).toISOString();
+            const freshLatest = new Date(Date.now() - (2 * 60 * 60 * 1000)).toISOString();
+            app.healthSummary = { remediation_loop: { items: [
+                { domain: 'fresh.example', state: 'needs_approval', priority_score: 10, severity: 'high' },
+                { domain: 'old.example', state: 'needs_approval', priority_score: 3, severity: 'medium' }
+            ] } };
+            app.domains = [
+                {
+                    domain_name: 'fresh.example',
+                    remediation: {
+                        latest_at: freshLatest,
+                        needs_operator_follow_up: true
+                    }
+                },
+                {
+                    domain_name: 'old.example',
+                    remediation: {
+                        latest_at: oldLatest,
+                        needs_operator_follow_up: true
+                    }
+                }
+            ];
+            app.dashboardRemediationFilter = 'follow_up';
+            app.dashboardRemediationSort = 'dispatch';
+            return [
+                app.visibleDashboardRemediationItems()[0].domain,
+                app.visibleDashboardRemediationItems()[1].domain,
+                app.dashboardRemediationFollowUpAgeMs(app.visibleDashboardRemediationItems()[0]) >
+                    app.dashboardRemediationFollowUpAgeMs(app.visibleDashboardRemediationItems()[1])
+            ].join('|');
+        })()""")
+
+    assert result == "old.example|fresh.example|true"
+
+
 def test_dashboard_remediation_filter_chips_explain_empty_states():
     result = _run_dashboard_expression("""(() => {
             app.healthSummary = { remediation_loop: { items: [

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -785,8 +785,9 @@ def test_dashboard_remediation_dispatch_activity_filters_and_labels():
 
 def test_dashboard_remediation_dispatch_sort_prioritizes_old_follow_up():
     result = _run_dashboard_expression("""(() => {
-            const oldLatest = new Date(Date.now() - (6 * 24 * 60 * 60 * 1000)).toISOString();
-            const freshLatest = new Date(Date.now() - (2 * 60 * 60 * 1000)).toISOString();
+            const nowMs = Date.parse('2026-07-06T09:00:00Z');
+            const oldLatest = new Date(nowMs - (6 * 24 * 60 * 60 * 1000)).toISOString();
+            const freshLatest = new Date(nowMs - (2 * 60 * 60 * 1000)).toISOString();
             app.healthSummary = { remediation_loop: { items: [
                 { domain: 'fresh.example', state: 'needs_approval', priority_score: 10, severity: 'high' },
                 { domain: 'old.example', state: 'needs_approval', priority_score: 3, severity: 'medium' }
@@ -812,8 +813,8 @@ def test_dashboard_remediation_dispatch_sort_prioritizes_old_follow_up():
             return [
                 app.visibleDashboardRemediationItems()[0].domain,
                 app.visibleDashboardRemediationItems()[1].domain,
-                app.dashboardRemediationFollowUpAgeMs(app.visibleDashboardRemediationItems()[0]) >
-                    app.dashboardRemediationFollowUpAgeMs(app.visibleDashboardRemediationItems()[1])
+                app.dashboardRemediationFollowUpAgeMs(app.visibleDashboardRemediationItems()[0], nowMs) >
+                    app.dashboardRemediationFollowUpAgeMs(app.visibleDashboardRemediationItems()[1], nowMs)
             ].join('|');
         })()""")
 

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -98,7 +98,9 @@ filter isolates work older than 24 hours. The dashboard health summary,
 dispatch activity card, and domain rows expose the same aging follow-up count so
 old manual work is visible before the operator opens the full queue. Follow-ups
 older than a week use the stronger overdue styling so old manual work is easier
-to separate from fresh findings. Notification-profile-ready cards have
+to separate from fresh findings. The dispatch follow-up sort also places older
+operator follow-ups ahead of fresher follow-ups, even when the fresher item has a
+higher remediation score. Notification-profile-ready cards have
 the event, channel, dedupe key, and payload preview prepared, but they still do
 not send anything until the operator uses the explicit dispatch flow. The
 dashboard and domain rows also expose separate counts for approval-required,


### PR DESCRIPTION
## Summary
- make the dashboard Dispatch follow-up sort prioritize older operator follow-ups inside the same dispatch state
- add a regression test proving older follow-up work wins over fresher higher-score work
- update dashboard user guide and changelog

## Local validation
- PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q
- node --check backend/app/static/js/dashboard-page.js
- /tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py
- git diff --check origin/main..HEAD

## Safety
- UI/read-only sorting change only; no DNS/provider writes and no notification dispatch behavior changes.

Refs #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard follow-up sorting now shows older operator follow-ups before newer ones when items are in the same dispatch state.
  * Overdue manual work guidance in the dashboard help text was clarified to reflect this ordering.

* **Bug Fixes**
  * Improved consistency in follow-up age handling so dashboard sorting is more stable and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->