### PR TITLE
feat: clarify empty remediation filter states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an aging follow-up remediation filter and overdue styling so operator follow-up older than 24 hours or 7 days is easier to triage.
 - Added aging follow-up counts to the dashboard health summary, dispatch activity card, and domain rows so stale manual work is visible without opening the remediation queue.
 - Changed the dashboard dispatch follow-up sort to put older operator follow-ups ahead of fresher follow-ups within the same dispatch state.
+- Added filter-specific empty states to the dashboard remediation cards so empty filter views explain the next useful operator action.
 - Added domain remediation refresh result messages and clearer empty-queue states so operators can tell whether no work is open, recent verified repairs exist, or data has not loaded yet.
 - Added domain remediation filter chip counts, empty-filter styling, and explanatory labels so queue filters behave consistently with dashboard remediation filters.
 

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1131,6 +1131,40 @@ function dashboardApp() {
             return `${this.formatLargeNumber(count)} ${label.toLowerCase()} remediation card${count === 1 ? '' : 's'}`;
         },
 
+        dashboardRemediationEmptyStateTitle() {
+            const label = this.dashboardRemediationFilterOptions.find(
+                option => option.value === this.dashboardRemediationFilter
+            )?.label;
+            if (!label) return 'No remediation cards';
+            return `No ${label.toLowerCase()} remediation cards`;
+        },
+
+        dashboardRemediationEmptyStateText() {
+            const messages = {
+                preview_ready: 'No provider-backed repair preview is ready yet. Check blocked or fresh-evidence work first.',
+                fresh_evidence: 'No remediation item currently asks for fresh evidence. Keep importing reports and refresh DNS when new sender or policy data changes.',
+                approval_verification: 'No approval verification is pending. Review ready-to-notify or manual work next.',
+                provider_apply: 'No provider apply path is ready. Check apply-blocked work or confirm the DNS provider connection first.',
+                apply_blocked: 'No provider apply is blocked right now. Provider-backed repairs can continue through preview or approval review.',
+                provider_history: 'No provider apply history is attached to the current queue. Apply attempts will appear here after an operator-approved repair flow records them.',
+                notify_ready: 'No remediation notification is ready to send. Check dispatch-blocked items or items that still need approval.',
+                dispatched: 'No remediation notification has been dispatched for the visible queue yet.',
+                follow_up: 'No remediation item is waiting on operator follow-up after dispatch.',
+                aging_follow_up: 'No operator follow-up has been waiting longer than 24 hours.',
+                dispatch_blocked: 'No remediation notification is blocked by dispatch settings or webhook routing.',
+                stuck: 'No stuck remediation work is visible. Provider values, apply prerequisites, and verification blockers are clear for this view.',
+                sender_review: 'No sender-classification review is pending in the current workspace summary.',
+                report_evidence: 'No item currently needs report evidence. Import or poll DMARC reports when sender activity changes.',
+                stale_evidence: 'No stale evidence warning is active for this dashboard filter.',
+                blocked: 'No remediation card is blocked by prerequisites in this view.',
+                waiting_operator: 'No manual operator decision is waiting in this view.',
+                manual: 'No manual repair card is visible in this filter.',
+                reputation: 'No source reputation remediation card is visible in the current workspace summary.'
+            };
+            return messages[this.dashboardRemediationFilter] ||
+                'Choose another queue view or refresh after new evidence is available.';
+        },
+
         dashboardRemediationFilterMatches(item, filterValue) {
             if (!item || !filterValue || filterValue === 'all') return true;
             const progression = item?.repair_progression || {};

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1159,7 +1159,7 @@ function dashboardApp() {
                 blocked: 'No remediation card is blocked by prerequisites in this view.',
                 waiting_operator: 'No manual operator decision is waiting in this view.',
                 manual: 'No manual repair card is visible in this filter.',
-                reputation: 'No source reputation remediation card is visible in the current workspace summary.'
+                reputation: 'No source reputation remediation cards are visible in the current workspace summary.'
             };
             return messages[this.dashboardRemediationFilter] ||
                 'Choose another queue view or refresh after new evidence is available.';

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -534,10 +534,11 @@
                 </article>
             </template>
         </div>
-        <p class="mt-4 rounded border border-[#e6e3e1] bg-white p-4 text-sm text-[#5f5c78]"
-           x-show="hasRemediationLoopItems() && !hasVisibleDashboardRemediationItems()">
-            No remediation cards match this dashboard filter. Choose another queue view or refresh after new evidence is available.
-        </p>
+        <div class="mt-4 rounded border border-[#e6e3e1] bg-white p-4 text-sm"
+             x-show="hasRemediationLoopItems() && !hasVisibleDashboardRemediationItems()">
+            <p class="font-semibold text-[#120d36]" x-text="dashboardRemediationEmptyStateTitle()"></p>
+            <p class="mt-1 text-[#5f5c78]" x-text="dashboardRemediationEmptyStateText()"></p>
+        </div>
         <template x-if="hasRemediationLoopItems() && (dashboardRemediationHiddenCount() > 0 || showAllDashboardRemediationItems)">
             <div class="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs font-semibold text-[#5f5c78]">
                 <p x-show="dashboardRemediationHiddenCount() > 0">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -398,6 +398,10 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "formatLargeNumber(dashboardRemediationFilterCount(filter.value))" in template
     assert "dashboardRemediationFilterClass(filter)" in script
     assert "dashboardRemediationFilterTitle(filter)" in script
+    assert "dashboardRemediationEmptyStateTitle()" in script
+    assert "dashboardRemediationEmptyStateText()" in script
+    assert "dashboardRemediationEmptyStateTitle()" in template
+    assert "dashboardRemediationEmptyStateText()" in template
     assert "dashboardRemediationNextActionText(item)" in script
     assert "dashboardRemediationStuckText(item)" in script
     assert "dashboardRemediationFollowUpAgeText(item)" in script
@@ -417,7 +421,6 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "dashboardRemediationTotalCount()" in template
     assert "dashboardRemediationFilterLabel()" in template
     assert "dashboardRemediationHiddenCount()" in template
-    assert "No remediation cards match this dashboard filter" in template
     assert "Show all matching cards" in template
     assert "Show compact cards" in template
     assert "Fresh evidence path" in template
@@ -850,6 +853,46 @@ def test_dashboard_remediation_filter_chips_explain_empty_states():
         "1 preview ready remediation card|"
         "No reputation remediation cards in the current workspace summary|"
         "1 all remediation card"
+    )
+
+
+def test_dashboard_remediation_empty_state_copy_matches_selected_filter():
+    result = _run_dashboard_expression("""(() => {
+            app.healthSummary = { remediation_loop: { items: [
+                {
+                    domain: 'ready.example',
+                    state: 'needs_approval',
+                    priority_score: 9,
+                    severity: 'medium',
+                    repair_progression: { readiness_level: 'ready_for_preview' }
+                }
+            ] } };
+            app.dashboardRemediationFilter = 'dispatch_blocked';
+            return [
+                app.hasVisibleDashboardRemediationItems(),
+                app.dashboardRemediationEmptyStateTitle(),
+                app.dashboardRemediationEmptyStateText()
+            ].join('|');
+        })()""")
+
+    assert result == (
+        "false|No dispatch blocked remediation cards|"
+        "No remediation notification is blocked by dispatch settings or webhook routing."
+    )
+
+
+def test_dashboard_remediation_empty_state_copy_has_default_fallback():
+    result = _run_dashboard_expression("""(() => {
+            app.dashboardRemediationFilter = 'unknown_future_filter';
+            return [
+                app.dashboardRemediationEmptyStateTitle(),
+                app.dashboardRemediationEmptyStateText()
+            ].join('|');
+        })()""")
+
+    assert result == (
+        "No remediation cards|"
+        "Choose another queue view or refresh after new evidence is available."
     )
 
 

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -100,7 +100,9 @@ old manual work is visible before the operator opens the full queue. Follow-ups
 older than a week use the stronger overdue styling so old manual work is easier
 to separate from fresh findings. The dispatch follow-up sort also places older
 operator follow-ups ahead of fresher follow-ups, even when the fresher item has a
-higher remediation score. Notification-profile-ready cards have
+higher remediation score. Empty remediation filter views explain the selected
+filter and the next useful operator action instead of showing a generic no-match
+message. Notification-profile-ready cards have
 the event, channel, dedupe key, and payload preview prepared, but they still do
 not send anything until the operator uses the explicit dispatch flow. The
 dashboard and domain rows also expose separate counts for approval-required,


### PR DESCRIPTION
## Summary
- replace the generic empty dashboard remediation filter message with filter-specific empty-state titles and next actions
- cover dispatch-blocked and fallback empty-state behavior in dashboard tests
- update dashboard user guide and changelog

## Local validation
- PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q
- node --check backend/app/static/js/dashboard-page.js
- /tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py
- git diff --check origin/main..HEAD

## Safety
- UI/read-only empty-state copy only; no DNS/provider writes and no notification dispatch behavior changes.

Refs #384