### PR TITLE
feat: add remediation empty-state reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added aging follow-up counts to the dashboard health summary, dispatch activity card, and domain rows so stale manual work is visible without opening the remediation queue.
 - Changed the dashboard dispatch follow-up sort to put older operator follow-ups ahead of fresher follow-ups within the same dispatch state.
 - Added filter-specific empty states to the dashboard remediation cards so empty filter views explain the next useful operator action.
+- Added a dashboard remediation empty-state reset control so operators can return from an empty filtered view to the full remediation card list.
 - Added domain remediation refresh result messages and clearer empty-queue states so operators can tell whether no work is open, recent verified repairs exist, or data has not loaded yet.
 - Added domain remediation filter chip counts, empty-filter styling, and explanatory labels so queue filters behave consistently with dashboard remediation filters.
 

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -279,6 +279,12 @@ function dashboardApp() {
                     return;
                 }
 
+                const remediationResetFilter = event.target.closest('[data-dashboard-remediation-reset-filter]');
+                if (remediationResetFilter && root.contains(remediationResetFilter)) {
+                    this.resetDashboardRemediationFilter();
+                    return;
+                }
+
                 const remediationToggleAll = event.target.closest('[data-dashboard-remediation-toggle-all]');
                 if (remediationToggleAll && root.contains(remediationToggleAll)) {
                     this.showAllDashboardRemediationItems = !this.showAllDashboardRemediationItems;
@@ -1168,6 +1174,7 @@ function dashboardApp() {
         resetDashboardRemediationFilter() {
             this.dashboardRemediationFilter = 'all';
             this.dashboardRemediationFilterCountCache = null;
+            this.showAllDashboardRemediationItems = false;
         },
 
         dashboardRemediationFilterMatches(item, filterValue) {

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1165,6 +1165,11 @@ function dashboardApp() {
                 'Choose another queue view or refresh after new evidence is available.';
         },
 
+        resetDashboardRemediationFilter() {
+            this.dashboardRemediationFilter = 'all';
+            this.dashboardRemediationFilterCountCache = null;
+        },
+
         dashboardRemediationFilterMatches(item, filterValue) {
             if (!item || !filterValue || filterValue === 'all') return true;
             const progression = item?.repair_progression || {};

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -538,6 +538,12 @@
              x-show="hasRemediationLoopItems() && !hasVisibleDashboardRemediationItems()">
             <p class="font-semibold text-[#120d36]" x-text="dashboardRemediationEmptyStateTitle()"></p>
             <p class="mt-1 text-[#5f5c78]" x-text="dashboardRemediationEmptyStateText()"></p>
+            <button type="button"
+                    class="btn btn-outline btn-xs mt-3 border-[#2f9da5] text-[#1f7c83] hover:border-[#272a5f]"
+                    data-dashboard-remediation-reset-filter
+                    @click="resetDashboardRemediationFilter()">
+                Show all remediation cards
+            </button>
         </div>
         <template x-if="hasRemediationLoopItems() && (dashboardRemediationHiddenCount() > 0 || showAllDashboardRemediationItems)">
             <div class="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs font-semibold text-[#5f5c78]">

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -538,12 +538,11 @@
              x-show="hasRemediationLoopItems() && !hasVisibleDashboardRemediationItems()">
             <p class="font-semibold text-[#120d36]" x-text="dashboardRemediationEmptyStateTitle()"></p>
             <p class="mt-1 text-[#5f5c78]" x-text="dashboardRemediationEmptyStateText()"></p>
-            <button type="button"
-                    class="btn btn-outline btn-xs mt-3 border-[#2f9da5] text-[#1f7c83] hover:border-[#272a5f]"
-                    data-dashboard-remediation-reset-filter
-                    @click="resetDashboardRemediationFilter()">
-                Show all remediation cards
-            </button>
+                <button type="button"
+                        class="btn btn-outline btn-xs mt-3 border-[#2f9da5] text-[#1f7c83] hover:border-[#272a5f]"
+                        data-dashboard-remediation-reset-filter>
+                    Show all remediation cards
+                </button>
         </div>
         <template x-if="hasRemediationLoopItems() && (dashboardRemediationHiddenCount() > 0 || showAllDashboardRemediationItems)">
             <div class="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs font-semibold text-[#5f5c78]">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -404,7 +404,8 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "dashboardRemediationEmptyStateTitle()" in template
     assert "dashboardRemediationEmptyStateText()" in template
     assert "data-dashboard-remediation-reset-filter" in template
-    assert "@click=\"resetDashboardRemediationFilter()\"" in template
+    assert "data-dashboard-remediation-reset-filter" in script
+    assert "@click=\"resetDashboardRemediationFilter()\"" not in template
     assert "Show all remediation cards" in template
     assert "dashboardRemediationNextActionText(item)" in script
     assert "dashboardRemediationStuckText(item)" in script
@@ -912,17 +913,19 @@ def test_dashboard_remediation_empty_state_reset_shows_all_cards():
                 }
             ] } };
             app.dashboardRemediationFilter = 'dispatch_blocked';
+            app.showAllDashboardRemediationItems = true;
             const before = app.visibleDashboardRemediationItems().length;
             app.resetDashboardRemediationFilter();
             return [
                 before,
                 app.dashboardRemediationFilter,
                 app.visibleDashboardRemediationItems().length,
-                app.dashboardRemediationFilterCountCache === null
+                app.dashboardRemediationFilterCountCache === null,
+                app.showAllDashboardRemediationItems
             ].join('|');
         })()""")
 
-    assert result == "0|all|1|true"
+    assert result == "0|all|1|true|false"
 
 
 def test_dashboard_remediation_stuck_filter_and_next_action_text():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -400,8 +400,12 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "dashboardRemediationFilterTitle(filter)" in script
     assert "dashboardRemediationEmptyStateTitle()" in script
     assert "dashboardRemediationEmptyStateText()" in script
+    assert "resetDashboardRemediationFilter()" in script
     assert "dashboardRemediationEmptyStateTitle()" in template
     assert "dashboardRemediationEmptyStateText()" in template
+    assert "data-dashboard-remediation-reset-filter" in template
+    assert "@click=\"resetDashboardRemediationFilter()\"" in template
+    assert "Show all remediation cards" in template
     assert "dashboardRemediationNextActionText(item)" in script
     assert "dashboardRemediationStuckText(item)" in script
     assert "dashboardRemediationFollowUpAgeText(item)" in script
@@ -894,6 +898,31 @@ def test_dashboard_remediation_empty_state_copy_has_default_fallback():
         "No remediation cards|"
         "Choose another queue view or refresh after new evidence is available."
     )
+
+
+def test_dashboard_remediation_empty_state_reset_shows_all_cards():
+    result = _run_dashboard_expression("""(() => {
+            app.healthSummary = { remediation_loop: { items: [
+                {
+                    domain: 'ready.example',
+                    state: 'needs_approval',
+                    priority_score: 9,
+                    severity: 'medium',
+                    repair_progression: { readiness_level: 'ready_for_preview' }
+                }
+            ] } };
+            app.dashboardRemediationFilter = 'dispatch_blocked';
+            const before = app.visibleDashboardRemediationItems().length;
+            app.resetDashboardRemediationFilter();
+            return [
+                before,
+                app.dashboardRemediationFilter,
+                app.visibleDashboardRemediationItems().length,
+                app.dashboardRemediationFilterCountCache === null
+            ].join('|');
+        })()""")
+
+    assert result == "0|all|1|true"
 
 
 def test_dashboard_remediation_stuck_filter_and_next_action_text():

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -102,7 +102,8 @@ to separate from fresh findings. The dispatch follow-up sort also places older
 operator follow-ups ahead of fresher follow-ups, even when the fresher item has a
 higher remediation score. Empty remediation filter views explain the selected
 filter and the next useful operator action instead of showing a generic no-match
-message. Notification-profile-ready cards have
+message, and they include a reset control to return to the full remediation
+card list. Notification-profile-ready cards have
 the event, channel, dedupe key, and payload preview prepared, but they still do
 not send anything until the operator uses the explicit dispatch flow. The
 dashboard and domain rows also expose separate counts for approval-required,


### PR DESCRIPTION
## Summary
- add a reset control to empty dashboard remediation filter states so operators can return to the full card list
- reset the dashboard remediation filter and count cache through a small frontend helper
- update dashboard tests, user guide, and changelog

## Local validation
- PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_dashboard_template_security.py -q
- node --check backend/app/static/js/dashboard-page.js
- /tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/tests/test_dashboard_template_security.py
- git diff --check origin/main..HEAD

## Safety
- UI/read-only filter reset only; no DNS/provider writes and no notification dispatch behavior changes.

Refs #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reset control in the remediation dashboard that returns you to the full list when a filter leaves the view empty.
* **Bug Fixes**
  * Improved empty filtered states so operators can quickly recover and see all remediation cards again.
* **Documentation**
  * Updated the dashboard guide and changelog to describe the new reset option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->