### PR TITLE
[codex] Surface remediation and mail source recovery states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added mail-source authorization health signals to poll status, operations health, and dashboard intake status so expired or incomplete Gmail OAuth connections request reauthorization instead of appearing simply connected.
+- Added recovery diagnostics to manual dashboard mail polling results so failed Gmail/Microsoft 365 imports surface the likely action, such as reconnecting the mailbox.
+- Added early Gmail backfill reauthorization checks when a source has no refresh token, preventing long-running backfills from failing later with opaque provider errors.
 - Documented shipped mail-health surfaces separately from future roadmap work
   so health scoring, evidence exports, read-only API/MCP access, and sender
   reputation no longer read as purely future features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the dashboard dispatch follow-up sort to put older operator follow-ups ahead of fresher follow-ups within the same dispatch state.
 - Added filter-specific empty states to the dashboard remediation cards so empty filter views explain the next useful operator action.
 - Added a dashboard remediation empty-state reset control so operators can return from an empty filtered view to the full remediation card list.
+- Added remediation empty-state context showing how many dashboard remediation cards exist outside the selected empty filter.
 - Added domain remediation refresh result messages and clearer empty-queue states so operators can tell whether no work is open, recent verified repairs exist, or data has not loaded yet.
 - Added domain remediation filter chip counts, empty-filter styling, and explanatory labels so queue filters behave consistently with dashboard remediation filters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added remediation empty-state context showing how many dashboard remediation cards exist outside the selected empty filter.
 - Added domain remediation refresh result messages and clearer empty-queue states so operators can tell whether no work is open, recent verified repairs exist, or data has not loaded yet.
 - Added domain remediation filter chip counts, empty-filter styling, and explanatory labels so queue filters behave consistently with dashboard remediation filters.
+- Added remediation-loop completion gates on the dashboard and domain queue so parent roadmap issues are only considered ready after priority, evidence, action-plan, automation, approval, verification, notification, and summary criteria are represented.
 
 ### Changed
 - Domain summary DNS refreshes now run with bounded concurrency instead of resolving each domain sequentially.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -112,7 +112,10 @@ from app.services.remediation_dispatch import (
     summarize_remediation_activity,
 )
 from app.services.remediation_evidence import evidence_refresh_for_remediation_item
-from app.services.remediation_queue import build_remediation_queue
+from app.services.remediation_queue import (
+    build_remediation_queue,
+    remediation_completion_assessment,
+)
 from app.services.remediation_readiness import (
     OPERATOR_REVIEW_READINESS_LEVELS,
     repair_readiness_for_stage,
@@ -614,9 +617,7 @@ def _read_only_provider_repair_plan(plan: Dict[str, Any]) -> Dict[str, Any]:
         "Public and MCP responses are read-only; open the authenticated domain "
         "workflow for provider approval."
     )
-    sanitized["operator_warning"] = (
-        "This response intentionally omits provider write endpoints."
-    )
+    sanitized["operator_warning"] = "This response intentionally omits provider write endpoints."
     blocked = list(sanitized.get("blocked_reasons") or [])
     blocked.append("public_read_only_response")
     sanitized["blocked_reasons"] = list(dict.fromkeys(blocked))
@@ -636,9 +637,7 @@ def _read_only_provider_repair_plan(plan: Dict[str, Any]) -> Dict[str, Any]:
                     [*(confirmation.get("blocked_reasons") or []), "public_read_only_response"]
                 )
             ),
-            "next_step": (
-                "Use the authenticated domain workflow for any provider write action."
-            ),
+            "next_step": ("Use the authenticated domain workflow for any provider write action."),
         }
     )
     sanitized["apply_confirmation"] = confirmation
@@ -658,9 +657,7 @@ def read_only_remediation_queue_response(payload: Any) -> "RemediationQueueRespo
         item["automation"] = automation
         provider_repair_plan = item.get("provider_repair_plan") or {}
         if provider_repair_plan:
-            item["provider_repair_plan"] = _read_only_provider_repair_plan(
-                provider_repair_plan
-            )
+            item["provider_repair_plan"] = _read_only_provider_repair_plan(provider_repair_plan)
 
         if "repair_progression" not in item:
             verification = item.get("verification_plan") or {}
@@ -714,9 +711,7 @@ def read_only_remediation_queue_response(payload: Any) -> "RemediationQueueRespo
             preview["automation"] = preview_automation
         preview_provider_plan = preview.get("provider_repair_plan") or {}
         if preview_provider_plan:
-            preview["provider_repair_plan"] = _read_only_provider_repair_plan(
-                preview_provider_plan
-            )
+            preview["provider_repair_plan"] = _read_only_provider_repair_plan(preview_provider_plan)
         if preview:
             notification["payload_preview"] = preview
         item["notification"] = notification
@@ -1365,6 +1360,31 @@ class RemediationNotification(BaseModel):
     dispatch: Dict[str, Any] = Field(default_factory=dict)
 
 
+class RemediationCompletionCriterion(BaseModel):
+    """One parent-issue completion gate represented by the remediation loop."""
+
+    key: str
+    label: str
+    met: bool = False
+    evidence: str = ""
+    next_step: str = ""
+
+
+class RemediationCompletionGate(BaseModel):
+    """Product-level completion status for the autonomous remediation loop."""
+
+    status: str = "needs_work"
+    ready_to_close_parent_issue: bool = False
+    total_items_evaluated: int = 0
+    criteria_met: int = 0
+    criteria_total: int = 0
+    remaining_slices: int = 0
+    criteria: List[RemediationCompletionCriterion] = Field(default_factory=list)
+    blockers: List[Dict[str, str]] = Field(default_factory=list)
+    next_step: str = ""
+    safety_boundary: str = ""
+
+
 class RemediationQueueItem(BaseModel):
     """One prioritized operator action for a domain."""
 
@@ -1404,6 +1424,7 @@ class RemediationQueueResponse(BaseModel):
     status: str
     summary: Dict[str, int]
     loop: Dict[str, Any] = Field(default_factory=dict)
+    completion: RemediationCompletionGate = Field(default_factory=RemediationCompletionGate)
     items: List[RemediationQueueItem]
     verified_items: List[Dict[str, Any]] = Field(default_factory=list)
     verified_items_total: int = 0
@@ -2416,6 +2437,15 @@ def _dashboard_remediation_item(
     state = _remediation_loop_state(action)
     context = _remediation_loop_context(state, action)
     priority_score = _remediation_priority_score(state, action)
+    next_step = str(action.get("next_step") or "Review the domain evidence.")
+    evidence = _dashboard_remediation_evidence(action)
+    action_plan = _dashboard_remediation_action_plan(
+        state=state,
+        action=action,
+        context=context,
+        next_step=next_step,
+    )
+    automation = _dashboard_remediation_automation(state, action)
     item = {
         "domain": domain_name,
         "state": state,
@@ -2433,7 +2463,12 @@ def _dashboard_remediation_item(
         "severity": str(action.get("severity") or "info"),
         "source": str(action.get("source") or "domain_health"),
         "title": str(action.get("title") or "Review remediation item"),
-        "next_step": str(action.get("next_step") or "Review the domain evidence."),
+        "next_step": next_step,
+        "next_steps": [next_step],
+        "evidence": evidence,
+        "action_plan": action_plan,
+        "automation": automation,
+        "provider_repair_plan": _dashboard_provider_repair_plan(state, action, automation),
         "score_impact": int(action.get("score_impact") or 0),
         "type": str(action.get("type") or "health_action"),
         **context,
@@ -2444,6 +2479,126 @@ def _dashboard_remediation_item(
     if include_detail:
         item["detail"] = str(action.get("detail") or "")
     return item
+
+
+def _dashboard_remediation_evidence(action: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Return compact evidence rows for dashboard completion checks."""
+    evidence_rows: List[Dict[str, str]] = []
+    for row in action.get("evidence") or []:
+        if isinstance(row, dict):
+            label = str(row.get("label") or row.get("key") or "evidence")
+            value = str(row.get("value") or row.get("summary") or row.get("detail") or "")
+            if value:
+                evidence_rows.append({"label": label, "value": value})
+        elif row:
+            evidence_rows.append({"label": "evidence", "value": str(row)})
+    if evidence_rows:
+        return evidence_rows[:5]
+    fallback = str(
+        action.get("detail") or action.get("title") or action.get("type") or "Domain health action"
+    )
+    return [{"label": "finding", "value": fallback}]
+
+
+def _dashboard_remediation_action_plan(
+    *,
+    state: str,
+    action: Dict[str, Any],
+    context: Dict[str, str],
+    next_step: str,
+) -> Dict[str, Any]:
+    """Expose dashboard-safe action metadata without write controls."""
+    track = _remediation_track_for_action(state, action)
+    if track == "provider_preview":
+        guidance_summary = "Use the domain remediation queue to preview provider DNS changes."
+    elif track == "blocked_by_prerequisite":
+        guidance_summary = "Collect the provider-specific value before any DNS change."
+    elif track == "reputation_review":
+        guidance_summary = "Review fresh source reputation evidence before closing."
+    elif track == "sender_investigation":
+        guidance_summary = "Classify the sender before changing DNS or policy."
+    elif track == "manual_dns":
+        guidance_summary = "Apply the DNS fix manually, then refresh DNS evidence."
+    else:
+        guidance_summary = "Follow the self-hosted or provider-specific remediation path."
+    return {
+        "owner": context["owner"],
+        "steps": [next_step],
+        "guidance_paths": [
+            {
+                "key": track,
+                "label": context["state_label"],
+                "summary": guidance_summary,
+                "owner": context["owner"],
+            }
+        ],
+        "completion_criteria": context["completion_criteria"],
+        "safe_to_automate": _remediation_safe_to_automate(state),
+        "requires_fresh_evidence": True,
+    }
+
+
+def _dashboard_remediation_automation(
+    state: str,
+    action: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return dashboard-safe automation eligibility metadata."""
+    eligible = _remediation_safe_to_automate(state)
+    if eligible:
+        reason = "A provider repair can be previewed, but apply requires approval."
+    elif _remediation_track_for_action(state, action) == "blocked_by_prerequisite":
+        reason = "Provider-specific target values are missing."
+    elif state == "investigate":
+        reason = "Sender classification is required before automation."
+    else:
+        reason = "Manual operator action and fresh evidence are required."
+    return {
+        "eligible": eligible,
+        "requires_approval": eligible,
+        "reason": reason,
+    }
+
+
+def _dashboard_provider_repair_plan(
+    state: str,
+    action: Dict[str, Any],
+    automation: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return read-only provider repair state required by completion gates."""
+    plan = action.get("provider_repair_plan")
+    if isinstance(plan, dict) and plan:
+        normalized = dict(plan)
+        confirmation = dict(normalized.get("apply_confirmation") or {})
+        if automation.get("eligible"):
+            confirmation.setdefault("required", True)
+            confirmation.setdefault("label", "Human approval required before apply")
+        normalized["apply_confirmation"] = confirmation
+        normalized.setdefault("available", bool(automation.get("eligible")))
+        normalized.setdefault("state", state)
+        normalized.setdefault(
+            "completion_gate",
+            (
+                "Close only after preview approval, apply, and fresh DNS evidence."
+                if automation.get("eligible")
+                else "Close only after operator action and fresh evidence."
+            ),
+        )
+        return normalized
+    confirmation_required = bool(automation.get("eligible"))
+    return {
+        "available": confirmation_required,
+        "apply_confirmation": {
+            "required": confirmation_required,
+            "label": "Human approval required before apply",
+        },
+        "completion_gate": (
+            "Close only after preview approval, apply, and fresh DNS evidence."
+            if confirmation_required
+            else "Close only after operator action and fresh evidence."
+        ),
+        "status": "preview_available" if confirmation_required else "manual_or_blocked",
+        "state": state,
+    }
 
 
 def _dashboard_remediation_notification(domain: str, item: Dict[str, Any]) -> Dict[str, Any]:
@@ -2590,9 +2745,7 @@ def _increment_provider_repair_counters(counters: Dict[str, int], item: Dict[str
         counters["provider_value_missing"] += 1
     if repair_progression.get("provider_apply_blocked"):
         counters["provider_apply_blocked"] += 1
-    counters["provider_apply_history"] += int(
-        repair_progression.get("provider_apply_history") or 0
-    )
+    counters["provider_apply_history"] += int(repair_progression.get("provider_apply_history") or 0)
     counters["provider_apply_verified"] += int(
         repair_progression.get("provider_apply_verified") or 0
     )
@@ -2623,6 +2776,10 @@ def _increment_verification_plan_counters(
 ) -> None:
     """Count the closure-proof state each dashboard remediation item requires."""
     verification = item.get("verification_plan") or {}
+    if verification.get("closure_gate"):
+        counters["closure_gate_required"] += 1
+    if verification.get("stale_evidence_warning"):
+        counters["stale_evidence_warning"] += 1
     status = str(verification.get("status") or "")
     if status == "pending_operator_approval":
         counters["verification_pending_operator_approval"] += 1
@@ -2690,6 +2847,8 @@ def _build_dashboard_remediation_loop(
         "verification_pending_reputation_review": 0,
         "verification_pending_report_evidence": 0,
         "verification_blocked_by_prerequisite": 0,
+        "closure_gate_required": 0,
+        "stale_evidence_warning": 0,
         "provider_preview_available": 0,
         "provider_apply_after_approval": 0,
         "provider_apply_blocked": 0,
@@ -2742,6 +2901,16 @@ def _build_dashboard_remediation_loop(
     else:
         loop_status = "clear"
         next_action = "No current remediation work; keep importing reports and monitoring DNS."
+    completion_summary = {
+        "total": len(items),
+        "approval_ready": counters["needs_approval"],
+        "manual_action": counters["manual_action"],
+        "investigate": counters["investigate"],
+        "provider_apply_after_approval": counters["provider_apply_after_approval"],
+        "provider_apply_blocked": counters["provider_apply_blocked"],
+        "closure_gate_required": counters["closure_gate_required"],
+        "stale_evidence_warning": counters["stale_evidence_warning"],
+    }
     return {
         **counters,
         **track_counters,
@@ -2756,6 +2925,10 @@ def _build_dashboard_remediation_loop(
         "operator_follow_up": int(activity_summary.get("needs_operator_follow_up") or 0),
         "status": "clear" if total_open == 0 else "needs_attention",
         "top_incident_type": str(items[0].get("incident_type") or "") if items else "",
+        "completion": remediation_completion_assessment(
+            items=items,
+            summary=completion_summary,
+        ),
         "items": items[:REMEDIATION_DASHBOARD_ITEM_LIMIT],
     }
 
@@ -2783,6 +2956,8 @@ def _domain_remediation_workload(domain: Dict[str, Any]) -> Dict[str, Any]:
         "verification_pending_reputation_review": 0,
         "verification_pending_report_evidence": 0,
         "verification_blocked_by_prerequisite": 0,
+        "closure_gate_required": 0,
+        "stale_evidence_warning": 0,
         "provider_preview_available": 0,
         "provider_apply_after_approval": 0,
         "provider_apply_blocked": 0,

--- a/backend/app/api/api_v1/endpoints/health.py
+++ b/backend/app/api/api_v1/endpoints/health.py
@@ -46,8 +46,104 @@ def _iso(value):
     return value.isoformat() if value else None
 
 
+def _latest_imports_by_source(db: Session, source_ids):
+    if not source_ids:
+        return {}
+    rows = (
+        db.query(MailSourceImport)
+        .filter(MailSourceImport.mail_source_id.in_(source_ids))
+        .order_by(
+            MailSourceImport.mail_source_id.asc(),
+            MailSourceImport.started_at.desc(),
+            MailSourceImport.id.desc(),
+        )
+        .all()
+    )
+    latest = {}
+    for row in rows:
+        latest.setdefault(int(row.mail_source_id), row)
+    return latest
+
+
+def _source_label(source: MailSource) -> str:
+    method = (source.method or "IMAP").upper()
+    if method == "GMAIL_API":
+        return f"Gmail API: {source.gmail_email or source.name}"
+    if method == "M365_GRAPH":
+        return f"Microsoft 365: {source.m365_email or source.m365_mailbox or source.name}"
+    if method == "IMAP":
+        return f"IMAP: {source.username or source.name}"
+    return f"{method}: {source.name}"
+
+
+def _source_health(source: MailSource, latest_import=None):
+    method = (source.method or "IMAP").upper()
+    if method == "GMAIL_API" and not source.gmail_access_token:
+        return {
+            "source_id": source.id,
+            "label": _source_label(source),
+            "method": method,
+            "status": "not_authorized",
+            "attention": True,
+            "message": "Gmail is not authorised yet.",
+            "action_label": "Connect Gmail",
+            "diagnostic_category": "auth_required",
+        }
+    if method == "GMAIL_API" and not source.gmail_refresh_token:
+        return {
+            "source_id": source.id,
+            "label": _source_label(source),
+            "method": method,
+            "status": "reauth_required",
+            "attention": True,
+            "message": "Gmail is connected without a refresh token.",
+            "action_label": "Reconnect Gmail",
+            "diagnostic_category": "auth_expired",
+        }
+    if method == "M365_GRAPH" and not source.m365_access_token:
+        return {
+            "source_id": source.id,
+            "label": _source_label(source),
+            "method": method,
+            "status": "not_authorized",
+            "attention": True,
+            "message": "Microsoft 365 is not authorised yet.",
+            "action_label": "Connect Microsoft 365",
+            "diagnostic_category": "auth_required",
+        }
+
+    diagnostic = import_row_diagnostic(latest_import)
+    category = (diagnostic or {}).get("category")
+    if latest_import and latest_import.status == "failed" and category in {
+        "auth_expired",
+        "authentication",
+        "permissions",
+    }:
+        return {
+            "source_id": source.id,
+            "label": _source_label(source),
+            "method": method,
+            "status": "reauth_required",
+            "attention": True,
+            "message": diagnostic["summary"],
+            "action_label": "Reconnect mailbox",
+            "diagnostic_category": category,
+        }
+
+    return {
+        "source_id": source.id,
+        "label": _source_label(source),
+        "method": method,
+        "status": "connected" if method in {"GMAIL_API", "M365_GRAPH"} else "configured",
+        "attention": False,
+        "message": None,
+        "action_label": None,
+        "diagnostic_category": category or "ok",
+    }
+
+
 @router.get("/health/operations", status_code=200)
-async def operations_health(
+async def operations_health(  # noqa: C901
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -64,11 +160,13 @@ async def operations_health(
     latest_report = None
     latest_import = None
     latest_successful_import = None
+    mail_source_health = []
     if database["ok"]:
+        enabled_source_rows = (
+            db.query(MailSource).filter(MailSource.enabled == True).all()  # noqa: E712
+        )
         enabled_sources = (
-            db.query(func.count(MailSource.id))
-            .filter(MailSource.enabled == True)  # noqa: E712
-            .scalar()
+            len(enabled_source_rows)
         )
         total_sources = db.query(func.count(MailSource.id)).scalar()
         report_count = db.query(func.count(DMARCReport.id)).scalar()
@@ -84,6 +182,14 @@ async def operations_health(
             .order_by(MailSourceImport.finished_at.desc(), MailSourceImport.id.desc())
             .first()
         )
+        latest_by_source = _latest_imports_by_source(
+            db,
+            [int(source.id) for source in enabled_source_rows],
+        )
+        mail_source_health = [
+            _source_health(source, latest_by_source.get(int(source.id)))
+            for source in enabled_source_rows
+        ]
 
     scheduler = get_scheduler_status()
     status = "ok"
@@ -97,6 +203,20 @@ async def operations_health(
     if total_sources and enabled_sources == 0:
         status = "degraded"
         checks.append("All mail sources are disabled.")
+    attention_sources = [source for source in mail_source_health if source["attention"]]
+    if attention_sources:
+        status = "degraded"
+        checks.append(f"{len(attention_sources)} mail source needs authorization attention.")
+        for source in attention_sources:
+            mailbox_recovery.append(
+                {
+                    "category": source["diagnostic_category"],
+                    "summary": source["message"] or "Mail source needs attention.",
+                    "recovery_steps": [source["action_label"]] if source["action_label"] else [],
+                    "source_label": source["label"],
+                    "source_id": source["source_id"],
+                }
+            )
     if scheduler.get("last_error"):
         status = "degraded"
         checks.append("The scheduler reported a recent error.")
@@ -117,6 +237,11 @@ async def operations_health(
             **scheduler,
             "enabled_sources": int(enabled_sources or 0),
             "total_sources": int(total_sources or 0),
+            "attention_sources": len(attention_sources),
+            "reauth_required_sources": len(
+                [source for source in mail_source_health if source["status"] == "reauth_required"]
+            ),
+            "sources": mail_source_health,
         },
         "imports": {
             "latest": {

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -37,6 +37,7 @@ from app.services.mailbox_recovery import (
     connection_diagnostic,
     connection_test_response,
     diagnostic_category,
+    import_row_diagnostic,
     import_result_diagnostic,
     redact_recovery_text,
 )
@@ -129,6 +130,11 @@ class MailSourceResponse(MailSourceBase):
     gmail_email: Optional[str] = None
     # Indicate whether OAuth tokens are present (without exposing them)
     gmail_connected: bool = False
+    connection_status: str = "unknown"
+    connection_attention: bool = False
+    connection_message: Optional[str] = None
+    connection_action_label: Optional[str] = None
+    connection_diagnostic_category: Optional[str] = None
     # Microsoft 365: show the authorised account and token state, but not tokens
     m365_email: Optional[str] = None
     m365_connected: bool = False
@@ -448,8 +454,120 @@ def _safe_attr(source: MailSource, name: str, default: Any = None) -> Any:
     return value
 
 
-def _source_to_response(source: MailSource) -> MailSourceResponse:
+def _latest_import_for_source(db: Session, source_id: int) -> Optional[MailSourceImport]:
+    """Return the latest persisted import attempt for one source, if available."""
+    return (
+        db.query(MailSourceImport)
+        .filter(MailSourceImport.mail_source_id == source_id)
+        .order_by(MailSourceImport.started_at.desc(), MailSourceImport.id.desc())
+        .first()
+    )
+
+
+def _latest_imports_by_source(
+    db: Session,
+    source_ids: List[int],
+) -> Dict[int, MailSourceImport]:
+    """Return latest import attempts keyed by source ID."""
+    if not source_ids:
+        return {}
+    rows = (
+        db.query(MailSourceImport)
+        .filter(MailSourceImport.mail_source_id.in_(source_ids))
+        .order_by(
+            MailSourceImport.mail_source_id.asc(),
+            MailSourceImport.started_at.desc(),
+            MailSourceImport.id.desc(),
+        )
+        .all()
+    )
+    latest: Dict[int, MailSourceImport] = {}
+    for row in rows:
+        latest.setdefault(int(row.mail_source_id), row)
+    return latest
+
+
+def _connection_state_for_source(
+    source: MailSource,
+    latest_import: Optional[MailSourceImport] = None,
+) -> Dict[str, Any]:
+    """Build a non-secret connection state for list/detail views."""
+    method = (source.method or "IMAP").upper()
+    if method == "GMAIL_API":
+        if not source.gmail_access_token:
+            return {
+                "connection_status": "not_authorized",
+                "connection_attention": True,
+                "connection_message": "Gmail is not authorised yet. Connect Gmail before relying on imports.",
+                "connection_action_label": "Connect Gmail",
+                "connection_diagnostic_category": "auth_required",
+            }
+        if not source.gmail_refresh_token:
+            return {
+                "connection_status": "reauth_required",
+                "connection_attention": True,
+                "connection_message": (
+                    "Gmail is connected without a refresh token. Reconnect Gmail so scheduled "
+                    "imports can keep refreshing access."
+                ),
+                "connection_action_label": "Reconnect Gmail",
+                "connection_diagnostic_category": "auth_expired",
+            }
+
+        diagnostic = import_row_diagnostic(latest_import)
+        category = (diagnostic or {}).get("category")
+        if latest_import and latest_import.status == "failed" and category in {
+            "auth_expired",
+            "authentication",
+            "permissions",
+        }:
+            return {
+                "connection_status": "reauth_required",
+                "connection_attention": True,
+                "connection_message": diagnostic["summary"],
+                "connection_action_label": "Reconnect Gmail",
+                "connection_diagnostic_category": category,
+            }
+        return {
+            "connection_status": "connected",
+            "connection_attention": False,
+            "connection_message": "Gmail authorization is present.",
+            "connection_action_label": None,
+            "connection_diagnostic_category": category or "ok",
+        }
+
+    if method == "M365_GRAPH":
+        if not _safe_attr(source, "m365_access_token"):
+            return {
+                "connection_status": "not_authorized",
+                "connection_attention": True,
+                "connection_message": "Microsoft 365 is not authorised yet.",
+                "connection_action_label": "Connect Microsoft 365",
+                "connection_diagnostic_category": "auth_required",
+            }
+        return {
+            "connection_status": "connected",
+            "connection_attention": False,
+            "connection_message": "Microsoft 365 authorization is present.",
+            "connection_action_label": None,
+            "connection_diagnostic_category": "ok",
+        }
+
+    return {
+        "connection_status": "configured" if source.username else "missing_config",
+        "connection_attention": not bool(source.username),
+        "connection_message": None,
+        "connection_action_label": None,
+        "connection_diagnostic_category": None,
+    }
+
+
+def _source_to_response(
+    source: MailSource,
+    latest_import: Optional[MailSourceImport] = None,
+) -> MailSourceResponse:
     """Convert ORM row to response schema, masking the stored password."""
+    connection_state = _connection_state_for_source(source, latest_import)
     return MailSourceResponse(
         id=source.id,
         name=source.name,
@@ -469,6 +587,7 @@ def _source_to_response(source: MailSource) -> MailSourceResponse:
         gmail_client_secret="**redacted**" if source.gmail_client_secret else None,
         gmail_email=source.gmail_email,
         gmail_connected=bool(source.gmail_access_token),
+        **connection_state,
         m365_tenant_id=_safe_attr(source, "m365_tenant_id", "common") or "common",
         m365_client_id=_safe_attr(source, "m365_client_id"),
         m365_client_secret=("**redacted**" if _safe_attr(source, "m365_client_secret") else None),
@@ -975,7 +1094,8 @@ async def list_mail_sources(
     sources = workspace_mail_source_query(db, workspace).order_by(MailSource.id).all()
     if not sources and get_settings().DEMO_MODE:
         return [_demo_mail_source_response(row) for row in build_demo_mail_sources()]
-    return [_source_to_response(s) for s in sources]
+    latest_imports = _latest_imports_by_source(db, [int(source.id) for source in sources])
+    return [_source_to_response(s, latest_imports.get(int(s.id))) for s in sources]
 
 
 @router.post("", response_model=MailSourceResponse, status_code=status.HTTP_201_CREATED)
@@ -1044,7 +1164,7 @@ async def get_mail_source(
         _selected_workspace_id(selected_workspace),
     )
     source = _get_source_or_404(source_id, db, workspace)
-    return _source_to_response(source)
+    return _source_to_response(source, _latest_import_for_source(db, int(source.id)))
 
 
 @router.get("/{source_id}/imports", response_model=List[MailSourceImportResponse])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -33,10 +33,13 @@ from app.middleware.demo import DemoReadOnlyMiddleware
 from app.middleware.security import SecurityHeadersMiddleware
 from app.models.domain import Domain
 from app.models.mail_source import MailSource  # noqa: F401 – ensure table is registered
+from app.models.mail_source_import import MailSourceImport
 from app.services.dns_prewarm import prewarm_dns_cache
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
+from app.services.mail_connector import initial_import_stats
+from app.services.mailbox_recovery import import_result_diagnostic, import_row_diagnostic
 from app.services.mail_service_imports import mail_service_context_from_domain
 from app.services.mail_source_backfill_worker import run_due_mail_source_backfill_jobs
 from app.services.microsoft_graph_client import MicrosoftGraphClient
@@ -125,11 +128,27 @@ def _poll_single_imap_source(source: MailSource) -> None:
         )
 
 
-def _poll_single_gmail_source(source: MailSource) -> None:
+def _poll_single_gmail_source(source: MailSource) -> None:  # noqa: C901
     """Fetch DMARC reports for a single GMAIL_API mail source."""
     global last_check_time  # pylint: disable=global-statement
 
     if not source.gmail_access_token:
+        db = SessionLocal()
+        try:
+            src = db.query(MailSource).get(source.id)
+            if src:
+                started_at = datetime.utcnow()
+                results = {
+                    **initial_import_stats(),
+                    "success": False,
+                    "errors": ["Gmail account not yet authorised. Complete OAuth2 flow first."],
+                }
+                src.last_checked = datetime.utcnow()
+                record_import_attempt(db, src, results, started_at=started_at, trigger="scheduled")
+                db.commit()
+        finally:
+            db.close()
+        last_check_time = datetime.now()
         logger.info(
             "Gmail polling (source id=%d): skipped – OAuth2 not yet authorised",
             source.id,
@@ -800,6 +819,28 @@ async def health():
 # ---------------------------------------------------------------------------
 
 
+def _trigger_poll_result(source: MailSource, method: str, results: Dict[str, Any]) -> dict:
+    """Return a non-secret manual poll result with operator recovery guidance."""
+    diagnostic = import_result_diagnostic(results)
+    return {
+        "source_id": source.id,
+        "name": source.name,
+        "method": method,
+        "success": bool(results.get("success", False)),
+        "processed": results.get("processed", 0),
+        "reports_found": results.get("reports_found", 0),
+        "forensic_reports_found": results.get("forensic_reports_found", 0),
+        "duplicate_reports": results.get("duplicate_reports", 0),
+        "duplicate_forensic_reports": results.get("duplicate_forensic_reports", 0),
+        "new_domains": results.get("new_domains", []),
+        "error_count": len(results.get("errors") or []),
+        "diagnostic": diagnostic,
+        "diagnostic_category": diagnostic["category"],
+        "diagnostic_summary": diagnostic["summary"],
+        "recovery_steps": diagnostic["recovery_steps"],
+    }
+
+
 def _trigger_poll_imap_source(source: MailSource, db, days: int = 7) -> dict:
     """Poll a single IMAP source and return a result dict for the API response."""
     global last_check_time  # pylint: disable=global-statement
@@ -819,17 +860,7 @@ def _trigger_poll_imap_source(source: MailSource, db, days: int = 7) -> dict:
     source.last_checked = datetime.utcnow()
     record_import_attempt(db, source, results, started_at=started_at, trigger="manual")
     db.commit()
-    return {
-        "source_id": source.id,
-        "name": source.name,
-        "method": "IMAP",
-        "success": results["success"],
-        "processed": results.get("processed", 0),
-        "reports_found": results.get("reports_found", 0),
-        "forensic_reports_found": results.get("forensic_reports_found", 0),
-        "duplicate_forensic_reports": results.get("duplicate_forensic_reports", 0),
-        "new_domains": results.get("new_domains", []),
-    }
+    return _trigger_poll_result(source, "IMAP", results)
 
 
 def _trigger_poll_gmail_source(source: MailSource, db) -> dict:
@@ -861,17 +892,7 @@ def _trigger_poll_gmail_source(source: MailSource, db) -> dict:
     source.last_checked = datetime.utcnow()
     record_import_attempt(db, source, results, started_at=started_at, trigger="manual")
     db.commit()
-    return {
-        "source_id": source.id,
-        "name": source.name,
-        "method": "GMAIL_API",
-        "success": results["success"],
-        "processed": results.get("processed", 0),
-        "reports_found": results.get("reports_found", 0),
-        "forensic_reports_found": results.get("forensic_reports_found", 0),
-        "duplicate_forensic_reports": results.get("duplicate_forensic_reports", 0),
-        "new_domains": results.get("new_domains", []),
-    }
+    return _trigger_poll_result(source, "GMAIL_API", results)
 
 
 def _trigger_poll_m365_source(source: MailSource, db, days: int = 7) -> dict:
@@ -907,17 +928,7 @@ def _trigger_poll_m365_source(source: MailSource, db, days: int = 7) -> dict:
     source.last_checked = datetime.utcnow()
     record_import_attempt(db, source, results, started_at=started_at, trigger="manual")
     db.commit()
-    return {
-        "source_id": source.id,
-        "name": source.name,
-        "method": "M365_GRAPH",
-        "success": results["success"],
-        "processed": results.get("processed", 0),
-        "reports_found": results.get("reports_found", 0),
-        "forensic_reports_found": results.get("forensic_reports_found", 0),
-        "duplicate_forensic_reports": results.get("duplicate_forensic_reports", 0),
-        "new_domains": results.get("new_domains", []),
-    }
+    return _trigger_poll_result(source, "M365_GRAPH", results)
 
 
 def _poll_source_for_trigger(source: MailSource, db, days: int = 7) -> dict:  # noqa: C901
@@ -927,10 +938,13 @@ def _poll_source_for_trigger(source: MailSource, db, days: int = 7) -> dict:  # 
     """
     if source.method == "GMAIL_API":
         if not source.gmail_access_token:
+            results = {
+                **initial_import_stats(),
+                "success": False,
+                "errors": ["Gmail account not yet authorised. Complete OAuth2 flow first."],
+            }
             return {
-                "source_id": source.id,
-                "name": source.name,
-                "method": "GMAIL_API",
+                **_trigger_poll_result(source, "GMAIL_API", results),
                 "skipped": True,
                 "reason": "Gmail account not yet authorised",
             }
@@ -947,10 +961,13 @@ def _poll_source_for_trigger(source: MailSource, db, days: int = 7) -> dict:  # 
             }
     if source.method == "M365_GRAPH":
         if not source.m365_access_token:
+            results = {
+                **initial_import_stats(),
+                "success": False,
+                "errors": ["Microsoft 365 account not yet authorised. Complete OAuth2 flow first."],
+            }
             return {
-                "source_id": source.id,
-                "name": source.name,
-                "method": "M365_GRAPH",
+                **_trigger_poll_result(source, "M365_GRAPH", results),
                 "skipped": True,
                 "reason": "Microsoft 365 account not yet authorised",
             }
@@ -1074,29 +1091,141 @@ def _source_display_label(source: MailSource) -> str:
     return f"{method}: {source.name}"
 
 
+def _latest_imports_by_source(db, source_ids: List[int]) -> Dict[int, MailSourceImport]:
+    """Return latest import attempts for status summaries."""
+    if not source_ids:
+        return {}
+    rows = (
+        db.query(MailSourceImport)
+        .filter(MailSourceImport.mail_source_id.in_(source_ids))
+        .order_by(
+            MailSourceImport.mail_source_id.asc(),
+            MailSourceImport.started_at.desc(),
+            MailSourceImport.id.desc(),
+        )
+        .all()
+    )
+    latest: Dict[int, MailSourceImport] = {}
+    for row in rows:
+        latest.setdefault(int(row.mail_source_id), row)
+    return latest
+
+
+def _mail_source_connection_state(
+    source: MailSource,
+    latest_import: Optional[MailSourceImport] = None,
+) -> Dict[str, Any]:
+    """Return a compact, non-secret source health state for dashboards."""
+    method = (source.method or "IMAP").upper()
+    if method == "GMAIL_API":
+        if not source.gmail_access_token:
+            return {
+                "status": "not_authorized",
+                "attention": True,
+                "message": "Gmail is not authorised yet.",
+                "action_label": "Connect Gmail",
+                "diagnostic_category": "auth_required",
+            }
+        if not source.gmail_refresh_token:
+            return {
+                "status": "reauth_required",
+                "attention": True,
+                "message": "Gmail is connected without a refresh token.",
+                "action_label": "Reconnect Gmail",
+                "diagnostic_category": "auth_expired",
+            }
+    if method == "M365_GRAPH" and not source.m365_access_token:
+        return {
+            "status": "not_authorized",
+            "attention": True,
+            "message": "Microsoft 365 is not authorised yet.",
+            "action_label": "Connect Microsoft 365",
+            "diagnostic_category": "auth_required",
+        }
+
+    diagnostic = import_row_diagnostic(latest_import)
+    category = (diagnostic or {}).get("category")
+    if latest_import and latest_import.status == "failed" and category in {
+        "auth_expired",
+        "authentication",
+        "permissions",
+    }:
+        return {
+            "status": "reauth_required",
+            "attention": True,
+            "message": diagnostic["summary"],
+            "action_label": "Reconnect mailbox",
+            "diagnostic_category": category,
+        }
+
+    return {
+        "status": "connected" if method in {"GMAIL_API", "M365_GRAPH"} else "configured",
+        "attention": False,
+        "message": None,
+        "action_label": None,
+        "diagnostic_category": category or "ok",
+    }
+
+
+def _source_status_payload(
+    source: MailSource,
+    latest_import: Optional[MailSourceImport] = None,
+) -> Dict[str, Any]:
+    state = _mail_source_connection_state(source, latest_import)
+    return {
+        "source_id": source.id,
+        "name": source.name,
+        "method": (source.method or "IMAP").upper(),
+        "label": _source_display_label(source),
+        "enabled": bool(source.enabled),
+        "last_checked": source.last_checked.isoformat() if source.last_checked else None,
+        "connection_status": state["status"],
+        "connection_attention": state["attention"],
+        "connection_message": state["message"],
+        "connection_action_label": state["action_label"],
+        "connection_diagnostic_category": state["diagnostic_category"],
+    }
+
+
 def _mail_source_status_summary() -> dict:
     """Summarize enabled report intake sources without exposing credentials."""
     db = SessionLocal()
     try:
+        total_sources = int(db.query(MailSource).count() or 0)
         enabled_sources = (
             db.query(MailSource).filter(MailSource.enabled == True).all()  # noqa: E712
         )
+        latest_imports = _latest_imports_by_source(db, [int(source.id) for source in enabled_sources])
         by_method: dict[str, int] = {}
         source_labels = []
+        source_statuses = []
         latest_checked = None
         for source in enabled_sources:
             method = (source.method or "IMAP").upper()
             by_method[method] = by_method.get(method, 0) + 1
             source_labels.append(_source_display_label(source))
+            source_statuses.append(_source_status_payload(source, latest_imports.get(int(source.id))))
             if source.last_checked and (
                 latest_checked is None or source.last_checked > latest_checked
             ):
                 latest_checked = source.last_checked
 
+        attention_sources = [
+            source for source in source_statuses if source.get("connection_attention")
+        ]
+        reauth_sources = [
+            source
+            for source in source_statuses
+            if source.get("connection_status") == "reauth_required"
+        ]
         return {
             "enabled_sources": len(enabled_sources),
+            "total_sources": total_sources,
             "sources_by_method": by_method,
             "source_labels": source_labels,
+            "sources": source_statuses,
+            "attention_sources": len(attention_sources),
+            "reauth_required_sources": len(reauth_sources),
             "latest_source_check": latest_checked.isoformat() if latest_checked else None,
         }
     finally:

--- a/backend/app/services/mail_source_backfill_worker.py
+++ b/backend/app/services/mail_source_backfill_worker.py
@@ -333,6 +333,8 @@ def _fetch_gmail_backfill_results(
 ) -> tuple[Dict[str, Any], Any]:
     if not source.gmail_access_token:
         raise ValueError("Gmail account not yet authorised. Complete OAuth2 flow first.")
+    if not source.gmail_refresh_token:
+        raise ValueError("Gmail authorization cannot be refreshed. Reconnect Gmail first.")
 
     already = GmailClient.load_ingested_ids(source.gmail_ingested_ids)
     client = GmailClient(

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -179,9 +179,8 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
         "provider_value_missing": sum(
             1
             for item in items
-            if "provider_specific_value" in (item.get("provider_repair_plan") or {}).get(
-                "blocked_reasons", []
-            )
+            if "provider_specific_value"
+            in (item.get("provider_repair_plan") or {}).get("blocked_reasons", [])
         ),
         "provider_manual_fallback": sum(
             1
@@ -257,6 +256,139 @@ def _summary(items: List[Dict[str, Any]]) -> Dict[str, int]:
             1 for item in items if item.get("remediation_track") == track
         )
     return summary
+
+
+def remediation_completion_assessment(
+    *,
+    items: List[Dict[str, Any]],
+    summary: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return the product-level completion gates for the remediation loop."""
+    total = int(summary.get("total") or len(items))
+    criteria = [
+        {
+            "key": "prioritized_queue",
+            "label": "Prioritized remediation queue",
+            "met": isinstance(items, list)
+            and all(item.get("priority_score") is not None for item in items),
+            "evidence": "Queue items include stable priority scores and severity/state ordering.",
+            "next_step": "Keep queue priority metadata attached to every remediation item.",
+        },
+        {
+            "key": "actionable_evidence",
+            "label": "Evidence and concrete next steps",
+            "met": all(
+                item.get("evidence")
+                and item.get("next_steps")
+                and (item.get("action_plan") or {}).get("steps")
+                for item in items
+            ),
+            "evidence": "Every open item must include evidence, steps, and an action plan.",
+            "next_step": "Add evidence, next steps, or an action plan to every open remediation item.",
+        },
+        {
+            "key": "provider_and_self_hosted_guidance",
+            "label": "Provider and self-hosted guidance",
+            "met": all((item.get("action_plan") or {}).get("guidance_paths") for item in items),
+            "evidence": "Action plans expose guidance paths for provider or self-hosted operators.",
+            "next_step": "Attach provider/manual/self-hosted guidance paths to every item.",
+        },
+        {
+            "key": "automation_eligibility",
+            "label": "Clear automation eligibility",
+            "met": all(
+                isinstance(item.get("automation"), dict)
+                and "eligible" in item.get("automation", {})
+                and isinstance(item.get("provider_repair_plan"), dict)
+                for item in items
+            ),
+            "evidence": "Items show whether DMARQ can preview provider repair and why.",
+            "next_step": "Attach automation eligibility and provider repair plans to each item.",
+        },
+        {
+            "key": "human_approved_write_boundary",
+            "label": "Human-approved write boundary",
+            "met": all(
+                not (item.get("automation") or {}).get("eligible")
+                or (
+                    (item.get("automation") or {}).get("requires_approval") is True
+                    and (
+                        (item.get("provider_repair_plan") or {}).get("apply_confirmation") or {}
+                    ).get("required")
+                    is True
+                )
+                for item in items
+            ),
+            "evidence": "Provider apply remains gated by explicit approval and confirmation.",
+            "next_step": "Block provider apply until approval and confirmation metadata is present.",
+        },
+        {
+            "key": "verification_closure_gates",
+            "label": "Fresh-evidence closure gates",
+            "met": all(
+                (item.get("verification_plan") or {}).get("closure_gate")
+                and (item.get("evidence_refresh") or {}).get("completion_signal")
+                for item in items
+            ),
+            "evidence": "Items state what fresh evidence is required before closure.",
+            "next_step": "Attach closure gates and safe evidence-refresh completion signals.",
+        },
+        {
+            "key": "notification_lifecycle",
+            "label": "Notification and operator lifecycle",
+            "met": all(
+                (item.get("notification") or {}).get("event")
+                and (item.get("notification") or {}).get("payload_preview")
+                for item in items
+            ),
+            "evidence": "Items include notification routing and a bounded payload preview.",
+            "next_step": "Attach notification event, dedupe key, and payload preview.",
+        },
+        {
+            "key": "dashboard_summary",
+            "label": "Dashboard summary counters",
+            "met": all(
+                key in summary
+                for key in (
+                    "approval_ready",
+                    "manual_action",
+                    "investigate",
+                    "provider_apply_after_approval",
+                    "provider_apply_blocked",
+                    "closure_gate_required",
+                    "stale_evidence_warning",
+                )
+            ),
+            "evidence": "Queue summaries expose approval, manual, provider, and verification counters.",
+            "next_step": "Expose missing summary counters before closing the parent issue.",
+        },
+    ]
+    unmet = [criterion for criterion in criteria if not criterion["met"]]
+    return {
+        "status": "ready" if not unmet else "needs_work",
+        "ready_to_close_parent_issue": not unmet,
+        "total_items_evaluated": total,
+        "criteria_met": sum(1 for criterion in criteria if criterion["met"]),
+        "criteria_total": len(criteria),
+        "remaining_slices": len(unmet),
+        "criteria": criteria,
+        "blockers": [
+            {
+                "key": criterion["key"],
+                "label": criterion["label"],
+                "next_step": criterion["next_step"],
+            }
+            for criterion in unmet
+        ],
+        "next_step": (
+            "All remediation-loop closure gates are represented. Close the parent issue only after the final PR is merged and deployed."
+            if not unmet
+            else unmet[0]["next_step"]
+        ),
+        "safety_boundary": (
+            "No unsupervised DNS, provider, or mail-server writes are implied by this completion gate."
+        ),
+    }
 
 
 def _incident_type_for_item(item: Dict[str, Any]) -> str:
@@ -649,9 +781,7 @@ def _provider_repair_plan_for_item(item: Dict[str, Any]) -> Dict[str, Any]:
         "apply_confirmation": {
             "required": True,
             "status": (
-                "ready_for_operator_confirmation"
-                if can_apply and not apply_blocked
-                else "blocked"
+                "ready_for_operator_confirmation" if can_apply and not apply_blocked else "blocked"
             ),
             "label": (
                 "Operator confirmation required"
@@ -871,9 +1001,7 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
             "plan_id": provider_repair_plan.get("plan_id"),
             "stage": str(provider_repair_plan.get("stage") or ""),
             "safe_preview_available": bool(provider_repair_plan.get("safe_preview_available")),
-            "can_apply_after_approval": bool(
-                provider_repair_plan.get("can_apply_after_approval")
-            ),
+            "can_apply_after_approval": bool(provider_repair_plan.get("can_apply_after_approval")),
             "apply_requires_approval": bool(
                 provider_repair_plan.get("apply_requires_approval", True)
             ),
@@ -902,8 +1030,7 @@ def _remediation_notification_payload(domain: str, item: Dict[str, Any]) -> Dict
                 "confirm_phrase": str(apply_confirmation.get("confirm_phrase") or ""),
                 "operator_prompt": str(apply_confirmation.get("operator_prompt") or ""),
                 "blocked_reasons": [
-                    str(reason)
-                    for reason in apply_confirmation.get("blocked_reasons", [])
+                    str(reason) for reason in apply_confirmation.get("blocked_reasons", [])
                 ][:6],
                 "next_step": str(apply_confirmation.get("next_step") or ""),
             },
@@ -1217,6 +1344,14 @@ def _health_playbook(domain: str, action: Dict[str, Any]) -> Dict[str, Any]:
 def _health_item(domain: str, action: Dict[str, Any]) -> Dict[str, Any]:
     state = "investigate" if action.get("type") == "low_compliance" else "manual_action"
     playbook = _health_playbook(domain, action)
+    evidence = _evidence_from_pairs(action.get("evidence") or [])
+    if not evidence:
+        evidence = [
+            {
+                "label": "finding",
+                "value": str(action.get("detail") or action.get("title") or "Domain health action"),
+            }
+        ]
     item = {
         "id": f"health:{action.get('type')}",
         "source": "health_score",
@@ -1226,7 +1361,7 @@ def _health_item(domain: str, action: Dict[str, Any]) -> Dict[str, Any]:
         "title": str(action.get("title") or "Review domain health"),
         "detail": str(action.get("detail") or ""),
         "next_steps": playbook["steps"],
-        "evidence": _evidence_from_pairs(action.get("evidence") or []),
+        "evidence": evidence,
         "blast_radius": f"Observed DMARC traffic for {domain}",
         "prerequisites": playbook["prerequisites"],
         "completion_criteria": playbook["completion_criteria"],
@@ -1574,10 +1709,12 @@ def build_remediation_queue(
             item["id"],
         )
     )
+    summary = _summary(items)
     return {
         "domain": domain,
         "status": _queue_status(items),
-        "summary": _summary(items),
+        "summary": summary,
         "loop": _loop_summary(domain, items),
+        "completion": remediation_completion_assessment(items=items, summary=summary),
         "items": items,
     }

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1560,6 +1560,18 @@ function dashboardApp() {
             }[String(status || '')] || 'bg-[#f8f7f6] text-[#5f5c78]';
         },
 
+        remediationCompletionLabel(completion) {
+            if (!completion) return 'Completion unknown';
+            if (completion.ready_to_close_parent_issue) return 'Completion gates ready';
+            const remaining = Number(completion.remaining_slices || 0);
+            return `${remaining} completion gate${remaining === 1 ? '' : 's'} open`;
+        },
+
+        remediationCompletionClass(completion) {
+            if (completion?.ready_to_close_parent_issue) return 'bg-green-100 text-green-700';
+            return 'bg-[#fff7df] text-[#8a6418]';
+        },
+
         remediationLoopEffectiveStatus(loop) {
             if (!loop) return '';
             const status = String(loop.status || '');

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -357,6 +357,10 @@ function dashboardApp() {
             );
             const skipped = sources.filter(source => source.skipped).length;
             const failed = sources.filter(source => source.success === false).length;
+            const attention = sources.filter(source => source.diagnostic_category && ![
+                'ok',
+                'duplicate_only'
+            ].includes(source.diagnostic_category));
 
             const parts = [
                 `Polling finished for ${count} source${count === 1 ? '' : 's'}${methodSuffix}`,
@@ -377,6 +381,10 @@ function dashboardApp() {
             if (failed) {
                 parts.push(`${failed} failed`);
             }
+            if (attention.length) {
+                const firstSummary = attention[0].diagnostic_summary || attention[0].reason || 'check Mail Sources';
+                parts.push(`attention: ${firstSummary}`);
+            }
             return `${parts.join('; ')}.`;
         },
 
@@ -392,8 +400,15 @@ function dashboardApp() {
                 const statusIcon = document.getElementById('imap-status-icon');
                 const statusText = document.getElementById('imap-status-text');
                 const lastCheck = document.getElementById('imap-last-check');
+                const attentionRow = document.getElementById('mail-source-attention-row');
+                const attentionText = document.getElementById('mail-source-attention');
+                const attentionCount = data.attention_sources || 0;
                 
-                if (data.is_running && (data.enabled_sources || 0) > 0) {
+                if (attentionCount > 0) {
+                    statusIcon.classList.remove('bg-green-500');
+                    statusIcon.classList.add('bg-red-500');
+                    statusText.textContent = 'Needs attention';
+                } else if (data.is_running && (data.enabled_sources || 0) > 0) {
                     statusIcon.classList.remove('bg-red-500');
                     statusIcon.classList.add('bg-green-500');
                     statusText.textContent = 'Running';
@@ -416,6 +431,18 @@ function dashboardApp() {
                         mailbox.textContent = data.source_labels.join(', ');
                     } else {
                         mailbox.textContent = 'No enabled mail sources configured';
+                    }
+                }
+                if (attentionRow && attentionText) {
+                    if (attentionCount > 0) {
+                        const sources = data.sources || [];
+                        const first = sources.find(source => source.connection_attention) || {};
+                        const label = first.label ? `${first.label}: ` : '';
+                        attentionText.textContent = `${attentionCount} source${attentionCount === 1 ? '' : 's'} need attention. ${label}${first.connection_message || ''}`.trim();
+                        attentionRow.hidden = false;
+                    } else {
+                        attentionRow.hidden = true;
+                        attentionText.textContent = '';
                     }
                 }
             } catch (error) {

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -1177,6 +1177,13 @@ function dashboardApp() {
             this.showAllDashboardRemediationItems = false;
         },
 
+        dashboardRemediationEmptyStateMeta() {
+            const total = this.dashboardRemediationTotalCount();
+            const label = this.dashboardRemediationFilterLabel();
+            const verb = total === 1 ? 'exists' : 'exist';
+            return `${this.formatLargeNumber(total)} remediation card${total === 1 ? '' : 's'} ${verb} outside the ${label} view.`;
+        },
+
         dashboardRemediationFilterMatches(item, filterValue) {
             if (!item || !filterValue || filterValue === 'all') return true;
             const progression = item?.repair_progression || {};

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -1224,6 +1224,18 @@ function domainDetailsApp(domainId = '') {
             }[status] || 'Needs review';
         },
 
+        remediationCompletionLabel(completion) {
+            if (!completion) return 'Completion unknown';
+            if (completion.ready_to_close_parent_issue) return 'Completion gates ready';
+            const remaining = Number(completion.remaining_slices || 0);
+            return `${remaining} completion gate${remaining === 1 ? '' : 's'} open`;
+        },
+
+        remediationCompletionClass(completion) {
+            if (completion?.ready_to_close_parent_issue) return 'bg-green-100 text-green-700';
+            return 'bg-[#fff7df] text-[#8a6418]';
+        },
+
         remediationLoopEffectiveStatus(loop) {
             if (!loop) return '';
             const status = String(loop.status || '');

--- a/backend/app/static/js/mail-sources-page.js
+++ b/backend/app/static/js/mail-sources-page.js
@@ -413,6 +413,9 @@ function mailSourcesApp() {
         },
 
         sourceStatusLabel(source) {
+            if (source.connection_attention && source.connection_action_label) {
+                return source.connection_action_label;
+            }
             if (source.method === 'GMAIL_API') {
                 return source.gmail_connected ? 'Connected' : 'Not authorised';
             }
@@ -420,6 +423,13 @@ function mailSourcesApp() {
                 return source.m365_connected ? 'Connected' : 'Not authorised';
             }
             return source.username || '—';
+        },
+
+        sourceStatusBadgeClass(source) {
+            if (source.connection_attention) return 'badge-warning';
+            if (source.connection_status === 'connected') return 'badge-success';
+            if (source.connection_status === 'not_authorized') return 'badge-outline';
+            return 'badge-outline';
         },
 
         formatList(value) {

--- a/backend/app/static/js/operations-page.js
+++ b/backend/app/static/js/operations-page.js
@@ -49,6 +49,24 @@ function operationsHealth() {
             return `${this.scheduler.enabled_sources || 0}/${this.scheduler.total_sources || 0}`;
         },
 
+        get mailSourcesAttentionLabel() {
+            const attention = this.scheduler.attention_sources || 0;
+            if (!attention) return 'No attention needed';
+            return `${attention} need attention`;
+        },
+
+        get hasMailSourceAttention() {
+            return (this.scheduler.attention_sources || 0) > 0;
+        },
+
+        get mailSourceHealth() {
+            return this.scheduler.sources || [];
+        },
+
+        get attentionMailSources() {
+            return this.mailSourceHealth.filter(source => source.attention);
+        },
+
         get reportsCountLabel() {
             return this.reports.count || 0;
         },

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -658,6 +658,9 @@
                                     <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]">
                                         <span>Top: </span><span x-text="remediationIncidentLabel(remediationQueue.loop?.top_incident_type)"></span>
                                     </span>
+                                    <span class="rounded px-2 py-1 text-xs font-semibold"
+                                          :class="remediationCompletionClass(remediationQueue.completion)"
+                                          x-text="remediationCompletionLabel(remediationQueue.completion)"></span>
                                 </div>
                                 <div class="mt-3 flex flex-wrap gap-2 text-xs">
                                     <span class="rounded bg-[#eef7ff] px-2 py-1 font-semibold text-[#24507a]">
@@ -687,6 +690,20 @@
                                     <span class="rounded bg-[#f4f3f2] px-2 py-1 font-semibold text-[#5f5c78]">
                                         <span x-text="remediationQueue.loop?.rollback_guidance || 0"></span><span> rollback notes</span>
                                     </span>
+                                </div>
+                                <div class="mt-3 rounded border border-[#d8ebe8] bg-[#f2fbf9] p-3 text-xs text-[#45505f]"
+                                     x-show="remediationQueue.completion">
+                                    <p class="font-semibold text-[#120d36]">Loop completion gate</p>
+                                    <p class="mt-1" x-text="remediationQueue.completion?.next_step || 'Keep this issue open until all completion gates are represented.'"></p>
+                                    <p class="mt-2 font-semibold">
+                                        <span x-text="remediationQueue.completion?.criteria_met || 0"></span>
+                                        <span>/</span>
+                                        <span x-text="remediationQueue.completion?.criteria_total || 0"></span>
+                                        <span> gates met</span>
+                                        <span> · </span>
+                                        <span x-text="remediationQueue.completion?.remaining_slices || 0"></span>
+                                        <span> remaining slices</span>
+                                    </p>
                                 </div>
                             </div>
                             <div class="rounded-lg bg-white p-3">

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -816,6 +816,13 @@
                         <span class="w-40 text-sm text-muted-foreground">Sources:</span>
                         <span id="imap-mailbox">Loading configured mail sources...</span>
                     </div>
+                    <div class="flex items-start" id="mail-source-attention-row" hidden>
+                        <span class="w-40 text-sm text-muted-foreground">Attention:</span>
+                        <div>
+                            <span id="mail-source-attention" class="text-sm font-medium text-[#8a2d0d]"></span>
+                            <a href="/mail-sources" class="ml-2 text-sm underline">Open Mail Sources</a>
+                        </div>
+                    </div>
                 </div>
             {% endcall %}
         {% endcall %}

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -237,6 +237,9 @@
                 <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#45505f]">
                     <span>Top: </span><span x-text="remediationIncidentLabel(remediationLoop().top_incident_type)"></span>
                 </span>
+                <span class="rounded px-2 py-1 text-xs font-semibold"
+                      :class="remediationCompletionClass(remediationLoop().completion)"
+                      x-text="remediationCompletionLabel(remediationLoop().completion)"></span>
                 <button type="button"
                         class="rounded border border-[#dfdfdf] bg-white px-3 py-2 text-sm font-semibold text-[#272a5f] hover:border-[#2f9da5] disabled:opacity-60"
                         :disabled="dashboardLoading || remediationRefreshRunning"
@@ -245,6 +248,24 @@
                     <span x-text="remediationRefreshRunning ? 'Refreshing...' : 'Refresh queue'"></span>
                 </button>
                 <a href="/domains" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open domain worklist</a>
+            </div>
+        </div>
+        <div class="mt-4 rounded-md border border-[#d8ebe8] bg-[#f2fbf9] p-4 text-sm"
+             x-show="remediationLoop().completion">
+            <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                <div>
+                    <p class="font-semibold text-[#120d36]">Remediation loop completion</p>
+                    <p class="mt-1 text-[#5f5c78]" x-text="remediationLoop().completion?.next_step || 'Keep the remediation loop open until every closure gate is represented.'"></p>
+                    <p class="mt-2 text-xs font-semibold text-[#45505f]">
+                        <span x-text="remediationLoop().completion?.criteria_met || 0"></span>
+                        <span>/</span>
+                        <span x-text="remediationLoop().completion?.criteria_total || 0"></span>
+                        <span> completion gates met</span>
+                    </p>
+                </div>
+                <p class="rounded px-2 py-1 text-xs font-semibold"
+                   :class="remediationCompletionClass(remediationLoop().completion)"
+                   x-text="remediationCompletionLabel(remediationLoop().completion)"></p>
             </div>
         </div>
         <div class="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -538,11 +538,13 @@
              x-show="hasRemediationLoopItems() && !hasVisibleDashboardRemediationItems()">
             <p class="font-semibold text-[#120d36]" x-text="dashboardRemediationEmptyStateTitle()"></p>
             <p class="mt-1 text-[#5f5c78]" x-text="dashboardRemediationEmptyStateText()"></p>
-                <button type="button"
-                        class="btn btn-outline btn-xs mt-3 border-[#2f9da5] text-[#1f7c83] hover:border-[#272a5f]"
-                        data-dashboard-remediation-reset-filter>
-                    Show all remediation cards
-                </button>
+            <p class="mt-2 text-xs font-semibold text-[#8a879e]"
+               x-text="dashboardRemediationEmptyStateMeta()"></p>
+            <button type="button"
+                    class="btn btn-outline btn-xs mt-3 border-[#2f9da5] text-[#1f7c83] hover:border-[#272a5f]"
+                    data-dashboard-remediation-reset-filter>
+                Show all remediation cards
+            </button>
         </div>
         <template x-if="hasRemediationLoopItems() && (dashboardRemediationHiddenCount() > 0 || showAllDashboardRemediationItems)">
             <div class="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs font-semibold text-[#5f5c78]">

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -93,7 +93,15 @@
                                         <span class="badge badge-outline" x-text="source.method"></span>
                                     </td>
                                     <td x-text="sourceAccountLabel(source)"></td>
-                                    <td x-text="sourceStatusLabel(source)"></td>
+                                    <td>
+                                        <div class="space-y-1">
+                                            <span class="badge badge-sm" :class="sourceStatusBadgeClass(source)"
+                                                x-text="sourceStatusLabel(source)"></span>
+                                            <p class="text-[11px] text-muted-foreground max-w-56"
+                                                x-show="source.connection_attention && source.connection_message"
+                                                x-text="source.connection_message"></p>
+                                        </div>
+                                    </td>
                                     <td x-text="source.last_checked ? new Date(source.last_checked).toLocaleString() : 'Never'"></td>
                                     <td class="min-w-72">
                                         <template x-if="backfillLoading[source.id]">

--- a/backend/app/templates/operations.html
+++ b/backend/app/templates/operations.html
@@ -36,6 +36,8 @@
             <div class="card-body">
                 <div class="text-sm text-base-content/60">Mail Sources</div>
                 <div class="text-2xl font-semibold" x-text="mailSourcesLabel"></div>
+                <div class="text-xs" :class="hasMailSourceAttention ? 'text-warning' : 'text-base-content/60'"
+                     x-text="mailSourcesAttentionLabel"></div>
             </div>
         </div>
         <div class="card bg-base-100 shadow">
@@ -123,6 +125,28 @@
                                 <li x-text="step"></li>
                             </template>
                         </ul>
+                    </div>
+                </template>
+            </div>
+        </div>
+    </section>
+
+    <section class="card bg-base-100 shadow" x-show="hasMailSourceAttention">
+        <div class="card-body">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <h2 class="card-title">Mail Source Attention</h2>
+                <a href="/mail-sources" class="btn btn-outline btn-sm">Reconnect Sources</a>
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+                <template x-for="source in attentionMailSources" :key="source.source_id">
+                    <div class="rounded-lg border border-warning/40 bg-warning/10 p-4">
+                        <div class="text-xs font-semibold uppercase tracking-wide text-base-content/60"
+                             x-text="source.method"></div>
+                        <p class="mt-1 text-sm font-medium" x-text="source.label"></p>
+                        <p class="mt-2 text-sm text-base-content/70" x-text="source.message"></p>
+                        <p class="mt-2 text-xs font-medium text-warning"
+                           x-show="source.action_label"
+                           x-text="source.action_label"></p>
                     </div>
                 </template>
             </div>

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -8,6 +8,7 @@ from starlette.requests import Request
 from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.main import app, health as root_health, members_page, settings
 from app.models.domain import Domain
+from app.models.mail_source import MailSource
 from app.models.report import DMARCReport, ReportRecord
 from app.services.workspaces import get_or_create_default_workspace
 
@@ -476,6 +477,35 @@ def test_operations_health_endpoint(authed_client: TestClient):
     assert "imports" in data
     assert "reports" in data
     assert data["mailbox_recovery"][0]["category"] == "not_configured"
+
+
+def test_operations_health_surfaces_gmail_reauth_attention(
+    authed_client: TestClient,
+    db_session,
+):
+    """Operational health flags enabled Gmail sources that cannot refresh tokens."""
+    workspace = get_or_create_default_workspace(db_session)
+    source = MailSource(
+        workspace_id=workspace.id,
+        name="Reports Gmail",
+        method="GMAIL_API",
+        enabled=True,
+        gmail_access_token="access-token",
+        gmail_refresh_token=None,
+        gmail_email="dmarc-reports@example.com",
+    )
+    db_session.add(source)
+    db_session.commit()
+
+    response = authed_client.get("/api/v1/health/operations")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "degraded"
+    assert data["scheduler"]["attention_sources"] == 1
+    assert data["scheduler"]["reauth_required_sources"] == 1
+    assert data["scheduler"]["sources"][0]["status"] == "reauth_required"
+    assert data["mailbox_recovery"][0]["category"] == "auth_expired"
 
 
 def test_setup_status_includes_mailbox_recovery_hint(authed_client: TestClient):

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -400,9 +400,11 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "dashboardRemediationFilterTitle(filter)" in script
     assert "dashboardRemediationEmptyStateTitle()" in script
     assert "dashboardRemediationEmptyStateText()" in script
+    assert "dashboardRemediationEmptyStateMeta()" in script
     assert "resetDashboardRemediationFilter()" in script
     assert "dashboardRemediationEmptyStateTitle()" in template
     assert "dashboardRemediationEmptyStateText()" in template
+    assert "dashboardRemediationEmptyStateMeta()" in template
     assert "data-dashboard-remediation-reset-filter" in template
     assert "data-dashboard-remediation-reset-filter" in script
     assert "@click=\"resetDashboardRemediationFilter()\"" not in template
@@ -876,13 +878,15 @@ def test_dashboard_remediation_empty_state_copy_matches_selected_filter():
             return [
                 app.hasVisibleDashboardRemediationItems(),
                 app.dashboardRemediationEmptyStateTitle(),
-                app.dashboardRemediationEmptyStateText()
+                app.dashboardRemediationEmptyStateText(),
+                app.dashboardRemediationEmptyStateMeta()
             ].join('|');
         })()""")
 
     assert result == (
         "false|No dispatch blocked remediation cards|"
-        "No remediation notification is blocked by dispatch settings or webhook routing."
+        "No remediation notification is blocked by dispatch settings or webhook routing.|"
+        "1 remediation card exists outside the Dispatch blocked view."
     )
 
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -358,15 +358,18 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "dashboardRemediationFilterCount('aging_follow_up')" in template
     assert "Need fresh evidence" in template
     assert "Waiting on operator" in template
+    assert "Remediation loop completion" in template
+    assert "remediationCompletionLabel(remediationLoop().completion)" in template
+    assert "remediationCompletionClass(remediationLoop().completion)" in template
+    assert "remediationCompletionLabel(completion)" in script
+    assert "remediationCompletionClass(completion)" in script
     assert "Blocked before repair" in template
     assert "remediationLoop().next_action" in template
     assert (
-        "remediationLoopStatusClass(remediationLoopEffectiveStatus(remediationLoop()))"
-        in template
+        "remediationLoopStatusClass(remediationLoopEffectiveStatus(remediationLoop()))" in template
     )
     assert (
-        "remediationLoopStatusLabel(remediationLoopEffectiveStatus(remediationLoop()))"
-        in template
+        "remediationLoopStatusLabel(remediationLoopEffectiveStatus(remediationLoop()))" in template
     )
     assert "remediationIncidentLabel(remediationLoop().top_incident_type)" in template
     assert "data-dashboard-refresh" in template
@@ -392,9 +395,9 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert '<option value="dispatch">Dispatch follow-up</option>' in template
     assert "data-dashboard-remediation-filter" in template
     assert "data-dashboard-remediation-filter" in script
-    assert ":class=\"dashboardRemediationFilterClass(filter.value)\"" in template
-    assert ":title=\"dashboardRemediationFilterTitle(filter.value)\"" in template
-    assert ":aria-label=\"dashboardRemediationFilterTitle(filter.value)\"" in template
+    assert ':class="dashboardRemediationFilterClass(filter.value)"' in template
+    assert ':title="dashboardRemediationFilterTitle(filter.value)"' in template
+    assert ':aria-label="dashboardRemediationFilterTitle(filter.value)"' in template
     assert "formatLargeNumber(dashboardRemediationFilterCount(filter.value))" in template
     assert "dashboardRemediationFilterClass(filter)" in script
     assert "dashboardRemediationFilterTitle(filter)" in script
@@ -407,7 +410,7 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "dashboardRemediationEmptyStateMeta()" in template
     assert "data-dashboard-remediation-reset-filter" in template
     assert "data-dashboard-remediation-reset-filter" in script
-    assert "@click=\"resetDashboardRemediationFilter()\"" not in template
+    assert '@click="resetDashboardRemediationFilter()"' not in template
     assert "Show all remediation cards" in template
     assert "dashboardRemediationNextActionText(item)" in script
     assert "dashboardRemediationStuckText(item)" in script
@@ -417,7 +420,7 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "relativeAgeText(value)" in script
     assert "Next action:" in template
     assert "dashboardRemediationFollowUpAgeText(item)" in template
-    assert ":class=\"dashboardRemediationFollowUpAgeClass(item)\"" in template
+    assert ':class="dashboardRemediationFollowUpAgeClass(item)"' in template
     assert "dashboardRemediationFilterCounts()" in script
     assert "data-dashboard-remediation-toggle-all" in template
     assert "data-dashboard-remediation-toggle-all" in script
@@ -1202,9 +1205,9 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "Remediation queue sort" in template
     assert "data-domain-detail-remediation-filter" in template
     assert "aria-pressed" in template
-    assert ":class=\"remediationQueueFilterClass(filter.value)\"" in template
-    assert ":title=\"remediationQueueFilterTitle(filter.value)\"" in template
-    assert ":aria-label=\"remediationQueueFilterTitle(filter.value)\"" in template
+    assert ':class="remediationQueueFilterClass(filter.value)"' in template
+    assert ':title="remediationQueueFilterTitle(filter.value)"' in template
+    assert ':aria-label="remediationQueueFilterTitle(filter.value)"' in template
     assert 'role="group"' in template
     assert 'aria-label="Remediation queue filters"' in template
     assert 'role="status"' in template
@@ -2163,6 +2166,11 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "item.action_plan.decision_checkpoints" in template
     assert "item.action_plan.requires_fresh_evidence" in template
     assert "item.action_plan.rollback_plan" in template
+    assert "Loop completion gate" in template
+    assert "remediationCompletionLabel(remediationQueue.completion)" in template
+    assert "remediationCompletionClass(remediationQueue.completion)" in template
+    assert "remediationCompletionLabel(completion)" in script
+    assert "remediationCompletionClass(completion)" in script
     assert "remediationQueue.summary.closure_gate_required" in template
     assert "remediationQueue.summary.rollback_guidance" in template
     assert "remediationQueue.loop?.closure_gate_required" in template
@@ -2183,7 +2191,10 @@ def test_domain_details_exposes_remediation_action_plans_without_html_injection(
     assert "'-dispatch-blocker-' + index" in template
     assert "blocked_reasons[0]" not in template
     assert "Remediation loop" in template
-    assert "remediationLoopStatusLabel(remediationLoopEffectiveStatus(remediationQueue.loop))" in template
+    assert (
+        "remediationLoopStatusLabel(remediationLoopEffectiveStatus(remediationQueue.loop))"
+        in template
+    )
     assert "remediationLoopEffectiveStatus(loop)" in script
     assert "remediationIncidentLabel" in template
     assert "remediationTrackLabel" in template
@@ -2402,8 +2413,10 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "Evidence needed:" in template
     assert "If not fixed:" in template
     assert "Open evidence" in template
-    assert 'data-domain-detail-remediation-refresh-evidence' in template
-    assert "remediationEvidenceRefreshActionLabel(primaryRemediationItem.evidence_refresh)" in template
+    assert "data-domain-detail-remediation-refresh-evidence" in template
+    assert (
+        "remediationEvidenceRefreshActionLabel(primaryRemediationItem.evidence_refresh)" in template
+    )
     assert "Repair readiness" in template
     assert "primaryRepairReadinessReasonText" in script
     assert "repairReadinessLabel(primaryRemediationItem.repair_progression)" in template

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -836,6 +836,10 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
     assert data["loop"]["what_dmarq_can_fix"] == 1
     assert data["loop"]["what_needs_investigation"] == 1
     assert data["loop"]["top_incident_type"] == "dmarc_policy_missing_or_weak"
+    assert data["completion"]["ready_to_close_parent_issue"] is True
+    assert data["completion"]["remaining_slices"] == 0
+    assert data["completion"]["criteria_met"] == data["completion"]["criteria_total"]
+    assert data["completion"]["safety_boundary"].startswith("No unsupervised DNS")
     assert data["items"][0]["id"] == "dns:dmarc-missing"
     assert data["items"][0]["incident_type"] == "dmarc_policy_missing_or_weak"
     assert data["items"][0]["loop_state"] == "proposal_ready_for_approval"
@@ -856,6 +860,7 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
     assert data["items"][1]["incident_type"] == "legitimate_sender_failing_alignment"
     assert data["items"][1]["loop_state"] == "evidence_review_required"
     assert data["items"][1]["remediation_track"] == "sender_investigation"
+    assert data["items"][1]["evidence"][0]["label"] == "finding"
     assert "receiver report window" in data["items"][1]["verification_plan"]["next_check"]
     dispatch = data["items"][0]["notification"]["dispatch"]
     assert dispatch["enabled"] is False
@@ -933,6 +938,9 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["notification_action_required"] == 0
     assert loop["notification_investigation_required"] == 1
     assert loop["notification_summary_only"] == 0
+    assert loop["completion"]["ready_to_close_parent_issue"] is True
+    assert loop["completion"]["remaining_slices"] == 0
+    assert loop["completion"]["criteria_met"] == loop["completion"]["criteria_total"]
     assert loop["top_incident_type"] == "dmarc_policy_missing_or_weak"
     assert loop["repair_blocked"] == 0
     assert loop["repair_ready_for_preview"] == 1
@@ -962,9 +970,10 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["items"][0]["notification"]["payload_preview"]["item_id"] == (
         "health:missing_dmarc"
     )
-    assert loop["items"][0]["notification"]["payload_preview"]["repair_progression"][
-        "stage"
-    ] == "preview_ready"
+    assert (
+        loop["items"][0]["notification"]["payload_preview"]["repair_progression"]["stage"]
+        == "preview_ready"
+    )
     assert loop["items"][0]["verification_plan"]["status"] == "pending_operator_approval"
     assert loop["items"][0]["verification_plan"]["verification_method"] == (
         "provider_write_then_dns_refresh"
@@ -980,16 +989,12 @@ def test_dashboard_remediation_loop_exposes_operator_decision_context():
     assert loop["items"][1]["repair_progression"]["readiness_level"] == "needs_reputation_review"
     assert loop["items"][1]["evidence_refresh"]["refresh_key"] == "source_reputation"
     assert loop["items"][1]["notification"]["state"] == "investigation_required"
-    assert loop["items"][1]["notification"]["event"] == (
-        "dmarq.remediation.investigation_required"
-    )
+    assert loop["items"][1]["notification"]["event"] == ("dmarq.remediation.investigation_required")
     assert loop["items"][1]["verification_plan"]["status"] == "pending_reputation_review"
     assert loop["items"][1]["verification_plan"]["verification_method"] == (
         "fresh_reputation_evidence"
     )
-    assert "Fresh reputation" in (
-        loop["items"][1]["verification_plan"]["freshness_requirement"]
-    )
+    assert "Fresh reputation" in (loop["items"][1]["verification_plan"]["freshness_requirement"])
     assert "fresh reputation evidence" in loop["items"][1]["verification_plan"]["closure_gate"]
     assert loop["items"][1]["risk_level"] == "high"
     assert loop["items"][1]["safe_to_automate"] is False
@@ -1041,6 +1046,8 @@ def test_dashboard_remediation_loop_counts_provider_specific_prerequisite_blocks
     assert loop["notification_profile_ready"] == 1
     assert loop["notification_approval_required"] == 1
     assert loop["notification_summary_only"] == 0
+    assert loop["completion"]["ready_to_close_parent_issue"] is True
+    assert loop["completion"]["remaining_slices"] == 0
     assert loop["repair_ready_for_preview"] == 0
     assert loop["repair_waiting_on_operator"] == 0
     assert loop["repair_readiness_blocked"] == 1

--- a/backend/app/tests/test_mail_source_backfill_worker.py
+++ b/backend/app/tests/test_mail_source_backfill_worker.py
@@ -273,6 +273,25 @@ def test_run_gmail_backfill_without_token_moves_to_backoff(db_session):
     assert attempt.status == "failed"
 
 
+def test_run_gmail_backfill_without_refresh_token_moves_to_backoff(db_session):
+    workspace, source = _source(db_session, method="GMAIL_API")
+    source.gmail_refresh_token = None
+    db_session.commit()
+    row = _job(db_session, workspace, source, max_attempts=3)
+
+    assert run_gmail_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    attempt = db_session.query(MailSourceImport).filter_by(mail_source_id=source.id).one()
+
+    assert row.status == "backoff"
+    assert row.attempt_count == 1
+    assert row.next_retry_at is not None
+    assert "Reconnect Gmail" in row.errors
+    assert attempt.trigger == "backfill"
+    assert attempt.status == "failed"
+
+
 def test_run_gmail_backfill_provider_failure_moves_to_backoff(db_session, monkeypatch):
     workspace, source = _source(db_session, method="GMAIL_API")
     row = _job(db_session, workspace, source, max_attempts=3)

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -3429,15 +3429,24 @@ class TestPollSingleGmailSource:
         return src
 
     def test_skips_when_no_access_token(self):
-        """Source without OAuth token → early return, no GmailClient created."""
+        """Source without OAuth token records a visible failure without creating GmailClient."""
         from app.main import _poll_single_gmail_source
 
         src = self._make_source(access_token=None)
+        mock_db_source = MagicMock()
+        mock_db = MagicMock()
+        mock_db.query.return_value.get.return_value = mock_db_source
 
-        with patch("app.main.GmailClient") as mock_gc:
+        with (
+            patch("app.main.GmailClient") as mock_gc,
+            patch("app.main.SessionLocal", return_value=mock_db),
+            patch("app.main.record_import_attempt") as mock_record,
+        ):
             _poll_single_gmail_source(src)
 
         mock_gc.assert_not_called()
+        mock_record.assert_called_once()
+        mock_db.commit.assert_called_once()
 
     def test_fetches_reports_and_persists_ids(self):
         """Happy-path: client is created, reports fetched, IDs saved to DB."""
@@ -3781,6 +3790,9 @@ class TestPollSourceForTrigger:
 
         assert result["skipped"] is True
         assert "authorised" in result["reason"].lower()
+        assert result["success"] is False
+        assert result["diagnostic_category"] == "auth_required"
+        assert result["recovery_steps"]
 
     def test_gmail_with_token_delegates_to_trigger_poll(self):
         from app.main import _poll_source_for_trigger
@@ -3826,6 +3838,8 @@ class TestPollSourceForTrigger:
 
         assert result["skipped"] is True
         assert "microsoft 365" in result["reason"].lower()
+        assert result["success"] is False
+        assert result["diagnostic_category"] == "auth_required"
 
     def test_m365_with_token_delegates_to_trigger_poll(self):
         from app.main import _poll_source_for_trigger
@@ -4128,10 +4142,55 @@ class TestTriggerPollEndpoint:
         assert resp.status_code == 200
         data = resp.json()
         assert data["enabled_sources"] == 1
+        assert data["attention_sources"] == 0
+        assert data["reauth_required_sources"] == 0
         assert data["sources_by_method"] == {"GMAIL_API": 1}
         assert data["source_labels"] == ["Gmail API: dmarc-reports@example.com"]
+        assert data["sources"][0]["connection_status"] == "connected"
         assert data["latest_source_check"] == "2026-07-02T12:00:00"
         assert data["authenticated_by"] == "session"
+
+    def test_poll_status_surfaces_gmail_reauth_attention(self):
+        """The dashboard status endpoint flags Gmail sources that cannot refresh."""
+        from app.core.security import require_admin_auth
+        from app.main import app as main_app
+
+        async def mock_auth():
+            return {"auth_type": "session"}
+
+        main_app.dependency_overrides[require_admin_auth] = mock_auth
+
+        mock_source = MagicMock()
+        mock_source.id = 42
+        mock_source.method = "GMAIL_API"
+        mock_source.name = "Reports Gmail"
+        mock_source.gmail_email = "dmarc-reports@example.com"
+        mock_source.gmail_access_token = "access-token"
+        mock_source.gmail_refresh_token = None
+        mock_source.last_checked = None
+        mock_source.enabled = True
+
+        source_query = MagicMock()
+        source_query.count.return_value = 1
+        source_query.filter.return_value.all.return_value = [mock_source]
+        import_query = MagicMock()
+        import_query.filter.return_value.order_by.return_value.all.return_value = []
+        mock_db = MagicMock()
+        mock_db.query.side_effect = [source_query, source_query, import_query]
+
+        try:
+            with TestClient(main_app) as tc:
+                with patch("app.main.SessionLocal", return_value=mock_db):
+                    resp = tc.get("/api/v1/poll-status")
+        finally:
+            main_app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["attention_sources"] == 1
+        assert data["reauth_required_sources"] == 1
+        assert data["sources"][0]["connection_status"] == "reauth_required"
+        assert data["sources"][0]["connection_action_label"] == "Reconnect Gmail"
 
     def test_trigger_poll_with_no_enabled_sources(self):
         """With no enabled sources, the endpoint returns an empty-success response."""

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -1570,6 +1570,53 @@ class TestMailSourcesAPIAuthed:
 class TestGmailAPIMailSource:
     """Tests for GMAIL_API mail source creation, OAuth flow, and fetching."""
 
+    def test_gmail_source_response_marks_missing_authorization(self):
+        source = MailSource(id=1, name="Gmail", method="GMAIL_API")
+
+        response = mail_sources_endpoint._source_to_response(source)
+
+        assert response.gmail_connected is False
+        assert response.connection_status == "not_authorized"
+        assert response.connection_attention is True
+        assert response.connection_diagnostic_category == "auth_required"
+
+    def test_gmail_source_response_requires_refresh_token_for_scheduled_imports(self):
+        source = MailSource(id=1, name="Gmail", method="GMAIL_API")
+        source.gmail_access_token = "access-token"
+
+        response = mail_sources_endpoint._source_to_response(source)
+
+        assert response.gmail_connected is True
+        assert response.connection_status == "reauth_required"
+        assert response.connection_attention is True
+        assert response.connection_action_label == "Reconnect Gmail"
+
+    def test_gmail_source_response_marks_latest_oauth_import_failure(self):
+        source = MailSource(id=1, name="Gmail", method="GMAIL_API")
+        source.gmail_access_token = "access-token"
+        source.gmail_refresh_token = "refresh-token"
+        latest_import = MailSourceImport(
+            mail_source_id=1,
+            trigger="scheduled",
+            status="failed",
+            processed=0,
+            reports_found=0,
+            duplicate_reports=0,
+            error_count=1,
+            new_domains="[]",
+            errors='["invalid_grant refresh token expired"]',
+            details="[]",
+            started_at=datetime.utcnow(),
+            finished_at=datetime.utcnow(),
+        )
+
+        response = mail_sources_endpoint._source_to_response(source, latest_import)
+
+        assert response.connection_status == "reauth_required"
+        assert response.connection_attention is True
+        assert response.connection_diagnostic_category == "auth_expired"
+        assert "expired" in response.connection_message
+
     def test_create_gmail_api_source(self, authed_client: TestClient):
         payload = {
             "name": "My Gmail",

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -120,6 +120,11 @@ Actions:
 4. Check whether the Google project or OAuth consent configuration changed.
 5. Retry after a few minutes if the failure looks like quota or throttling.
 
+DMARQ treats Gmail sources without a refresh token as requiring reauthorization.
+The Mail Sources page, Dashboard report-intake card, and System Health page show
+this as a reconnect action because scheduled polling and backfills need a refresh
+token to continue after the short-lived access token expires.
+
 ## Webhook Imports Fail
 
 Likely causes:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -867,6 +867,13 @@ Provider-repair counters such as `provider_preview_available`,
 repairs can progress through a connected provider, which applies already have
 history or verified evidence, and where a prerequisite or manual fallback still
 owns the next step.
+The top-level `completion` object is the parent-issue readiness gate for the
+remediation loop. It reports `status`, `ready_to_close_parent_issue`,
+`criteria_met`, `criteria_total`, `remaining_slices`, per-criterion evidence,
+current blockers, the next step, and an explicit safety boundary. Clients should
+treat this as release/readiness metadata only: it does not imply that DNS,
+provider, or mail-server writes have happened, and parent roadmap issues should
+stay open until the final PR is merged, deployed, and live-smoked.
 The workspace dashboard `health_summary.remediation_loop` and each domain row's
 `remediation_workload` expose the same `evidence_refresh` object and counters,
 so clients can present the correct refresh path before opening the detail queue.
@@ -879,6 +886,9 @@ verification counters such as `verification_pending_operator_approval`,
 `verification_pending_report_evidence`, and `verification_blocked_by_prerequisite`
 so clients can distinguish approval, sender review, reputation evidence, manual
 fresh-evidence checks, and missing provider values.
+The dashboard `health_summary.remediation_loop.completion` uses the same
+completion-gate shape so workspace-level views can show whether the active
+remediation wave is complete without opening every domain.
 The same summary includes notification-profile counters such as
 `notification_profiles`, `notification_profile_ready`,
 `notification_approval_required`, `notification_action_required`,

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -90,7 +90,11 @@ blocked before repair. The dashboard also separates items waiting on an operator
 for sender classification, manual repair, reputation review, or general operator
 review. The section header shows the loop status, top incident family, next
 action, and the last successful summary refresh time so operators can triage the
-queue before reading every card. Use **Refresh queue** when new reports, DNS
+queue before reading every card. The completion gate badge states whether every
+remediation-loop criterion is represented before the parent roadmap issue should
+be closed, including priority metadata, evidence, action plans, automation
+eligibility, explicit approval boundaries, closure evidence, notification
+routing, and summary counters. Use **Refresh queue** when new reports, DNS
 refreshes, or operator markers should be reflected immediately. A failed manual
 refresh keeps the previously loaded dashboard visible and shows a refresh warning
 instead of replacing the page with an empty state. Cards are sorted so provider

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -102,8 +102,9 @@ to separate from fresh findings. The dispatch follow-up sort also places older
 operator follow-ups ahead of fresher follow-ups, even when the fresher item has a
 higher remediation score. Empty remediation filter views explain the selected
 filter and the next useful operator action instead of showing a generic no-match
-message, and they include a reset control to return to the full remediation
-card list. Notification-profile-ready cards have
+message. They also show how many remediation cards exist outside the selected
+filter and include a reset control so operators can return to the full
+remediation card list. Notification-profile-ready cards have
 the event, channel, dedupe key, and payload preview prepared, but they still do
 not send anything until the operator uses the explicit dispatch flow. The
 dashboard and domain rows also expose separate counts for approval-required,

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -64,6 +64,21 @@ detected in the current reporting window. These entries are designed to point to
 the next DNS or sender-configuration action rather than act as a general alert
 feed.
 
+### Report Intake Status
+
+The report intake card shows whether the background scheduler is running, when a
+mail source last checked for reports, and which sources are enabled. Gmail and
+Microsoft 365 sources also expose authorization attention states. If an OAuth
+connection is missing, expired, revoked, or missing the refresh token required
+for scheduled imports, the dashboard shows **Needs attention** and links to Mail
+Sources so the operator can reconnect the mailbox before relying on automated
+imports.
+
+Manual **Trigger Poll Now** results include the number of sources, processed
+messages, discovered reports, and any recovery summary from the failing source.
+For example, a Gmail token problem is reported as a reconnect action instead of
+only saying that polling failed.
+
 ### Remediation Loop
 
 The remediation loop card turns current domain health findings into operator

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -139,7 +139,11 @@ DMARQ shows that prerequisite instead of pretending it can refresh or repair the
 item automatically.
 The queue header also counts closure gates and rollback notes, so operators can
 spot how much work still needs fresh evidence or a recovery plan before opening
-every remediation card.
+every remediation card. It also shows the loop completion gate for the domain:
+priority, evidence, action plans, automation eligibility, human-approved write
+boundaries, closure evidence, notification routing, and summary counters must
+all be present before a parent roadmap item is considered ready for final
+closure.
 The **Repair progression** panel separates the recommendation from the next
 safe gate. It tells the operator whether a connected provider preview is ready,
 whether a provider-specific value is still missing, whether a sending source


### PR DESCRIPTION
## Summary
- adds clearer remediation empty-state context for stuck filters and follow-up workflows
- surfaces Gmail/Microsoft 365 mail-source reauthorization state across Mail Sources, Dashboard intake status, and Operations Health
- returns actionable recovery diagnostics for manual and scheduled mail polling, including missing-token and expired-auth cases
- fails Gmail backfills early when reauthorization is required instead of letting them degrade into opaque provider failures
- adds remediation-loop completion gates on dashboard and domain queues so priority, evidence, action-plan, automation, approval, verification, notification, and summary criteria are visible before #384 can be closed

## User impact
Users can now see why report intake is not progressing, which mail source needs attention, which reconnect action is required, and whether the remediation-loop work is actually complete enough to close the parent roadmap item. Empty remediation states are less misleading when filters hide all rows.

## Validation
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m pytest backend/app/tests/test_mail_sources.py backend/app/tests/test_mail_source_backfill_worker.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py backend/app/tests/test_domain_detail_endpoints.py -q`
- `PYTHONPATH=backend /tmp/dmarq-public-remediation/.venv/bin/python -m flake8 backend/app/services/remediation_queue.py backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_dashboard_template_security.py`
- `node --check backend/app/static/js/dashboard-page.js && node --check backend/app/static/js/domain-details-page.js && node --check backend/app/static/js/operations-page.js && node --check backend/app/static/js/mail-sources-page.js`
- `git diff --check`

Part of #384. Do not close #384 until this PR is merged, deployed to prod/demo, and the live remediation-loop smoke test passes.