### PR TITLE
fix: polish mail source attention summaries

### DIFF
--- a/backend/app/api/api_v1/endpoints/health.py
+++ b/backend/app/api/api_v1/endpoints/health.py
@@ -206,7 +206,12 @@ async def operations_health(  # noqa: C901
     attention_sources = [source for source in mail_source_health if source["attention"]]
     if attention_sources:
         status = "degraded"
-        checks.append(f"{len(attention_sources)} mail source needs authorization attention.")
+        attention_count = len(attention_sources)
+        source_label = "source" if attention_count == 1 else "sources"
+        needs_label = "needs" if attention_count == 1 else "need"
+        checks.append(
+            f"{attention_count} mail {source_label} {needs_label} authorization attention."
+        )
         for source in attention_sources:
             mailbox_recovery.append(
                 {

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -356,7 +356,7 @@ function dashboardApp() {
                 new Set(sources.flatMap(source => source.new_domains || []))
             );
             const skipped = sources.filter(source => source.skipped).length;
-            const failed = sources.filter(source => source.success === false).length;
+            const failed = sources.filter(source => !source.skipped && source.success === false).length;
             const attention = sources.filter(source => source.diagnostic_category && ![
                 'ok',
                 'duplicate_only'

--- a/backend/app/static/js/operations-page.js
+++ b/backend/app/static/js/operations-page.js
@@ -52,7 +52,7 @@ function operationsHealth() {
         get mailSourcesAttentionLabel() {
             const attention = this.scheduler.attention_sources || 0;
             if (!attention) return 'No attention needed';
-            return `${attention} need attention`;
+            return attention === 1 ? '1 needs attention' : `${attention} need attention`;
         },
 
         get hasMailSourceAttention() {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2752,7 +2752,7 @@ def test_dashboard_poll_summary_reports_source_totals_and_outcomes():
     assert summary == (
         "Polling finished for 2 sources (Gmail API, Microsoft 365); "
         "4 emails processed; 2 aggregate reports found; 1 forensic report found; "
-        "new domains: example.com, example.net, example.org +1 more; 1 skipped; 1 failed."
+        "new domains: example.com, example.net, example.org +1 more; 1 skipped."
     )
 
 


### PR DESCRIPTION
## Summary
- pluralize mail-source attention copy in operations health surfaces
- avoid counting skipped poll sources as failed in dashboard summaries

## Validation
- node --check backend/app/static/js/operations-page.js
- node --check backend/app/static/js/dashboard-page.js
- python3 -m py_compile backend/app/api/api_v1/endpoints/health.py
- git diff --check

Follow-up for Copilot feedback on #707.