### PR TITLE
[codex] Surface account milestone readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a Settings account/access milestone readiness summary for #12, separating completed auth/workspace/billing/provider foundations from environment-specific setup gates.
 - Added mail-source authorization health signals to poll status, operations health, and dashboard intake status so expired or incomplete Gmail OAuth connections request reauthorization instead of appearing simply connected.
 - Added recovery diagnostics to manual dashboard mail polling results so failed Gmail/Microsoft 365 imports surface the likely action, such as reconnecting the mailbox.
 - Added early Gmail backfill reauthorization checks when a source has no refresh token, preventing long-running backfills from failing later with opaque provider errors.

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -24,10 +24,12 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.credential_encryption import decrypt_secret, encrypt_secret, is_encrypted_secret
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.setting import Setting
+from app.services.account_milestone import build_account_milestone_readiness
 from app.services.ai_assistance import AI_DEFAULTS
 from app.services.alert_history import (
     list_alert_config_audit,
@@ -672,6 +674,24 @@ class AIConnectionTestResponse(BaseModel):
     selected_model: Optional[str] = None
 
 
+class AccountReadinessResponse(BaseModel):
+    """Milestone #12 account/auth/provider readiness response."""
+
+    milestone: str
+    status: str
+    ready_to_close_parent_issue: bool
+    criteria_met: int
+    criteria_total: int
+    remaining_slices: int
+    setup_gates: int
+    criteria: List[Dict[str, Any]]
+    counts: Dict[str, int]
+    role_catalog: List[Dict[str, Any]]
+    deployment_modes: List[str]
+    safety_boundary: str
+    next_step: str
+
+
 AI_PROVIDER_PROFILES: List[Dict[str, Any]] = [
     {
         "id": "template",
@@ -1020,6 +1040,15 @@ async def test_ai_connection(
         models=models,
         selected_model=selected_model or None,
     )
+
+
+@router.get("/account-readiness", response_model=AccountReadinessResponse)
+async def get_account_milestone_readiness(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+) -> AccountReadinessResponse:
+    """Return the #12 account/auth/provider milestone readiness summary."""
+    return build_account_milestone_readiness(db, get_settings())
 
 
 @router.get("/{key:path}", response_model=SettingResponse)

--- a/backend/app/services/account_milestone.py
+++ b/backend/app/services/account_milestone.py
@@ -1,0 +1,270 @@
+"""Milestone readiness summary for account, auth, and provider foundations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings
+from app.models.api_token import APIToken
+from app.models.organization import (
+    BillingAccount,
+    BillingEvent,
+    Entitlement,
+    Organization,
+    OrganizationMembership,
+    Plan,
+    ProviderIntegration,
+    Subscription,
+    UsageRecord,
+)
+from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceAuditLog, WorkspaceMembership
+from app.services.api_tokens import (
+    PROVIDER_READ_SCOPE,
+    PROVIDER_WRITE_SCOPE,
+    SCIM_READ_SCOPE,
+    SCIM_WRITE_SCOPE,
+)
+from app.services.workspace_access import ROLE_PERMISSIONS, list_workspace_roles
+
+
+def _count(db: Session, model: Any) -> int:
+    return int(db.query(model).count())
+
+
+def _has_scope_token(db: Session, scope: str, *, global_token: bool | None = None) -> bool:
+    query = db.query(APIToken).filter(APIToken.active.is_(True), APIToken.scopes.contains(scope))
+    if global_token is True:
+        query = query.filter(APIToken.workspace_id.is_(None))
+    elif global_token is False:
+        query = query.filter(APIToken.workspace_id.is_not(None))
+    return db.query(query.exists()).scalar() is True
+
+
+def _auth_mode(settings: Settings) -> str:
+    configured = (settings.AUTH_MODE or "auto").strip().lower()
+    if settings.AUTH_DISABLED:
+        return "disabled"
+    if configured != "auto":
+        return configured
+    if settings.LOGTO_ENDPOINT and settings.LOGTO_APP_ID:
+        return "logto"
+    if settings.AUTHENTIK_ISSUER_URL and settings.AUTHENTIK_CLIENT_ID:
+        return "authentik"
+    if settings.OIDC_ISSUER_URL and settings.OIDC_CLIENT_ID:
+        return "oidc"
+    if settings.AUTH_TRUSTED_PROXY_ENABLED:
+        return "trusted_proxy"
+    return "auto"
+
+
+def _criterion(
+    key: str,
+    title: str,
+    ready: bool,
+    configured: bool,
+    status: str,
+    evidence: List[str],
+    next_step: str,
+) -> Dict[str, Any]:
+    return {
+        "key": key,
+        "title": title,
+        "ready": bool(ready),
+        "configured": bool(configured),
+        "setup_required": bool(ready and not configured),
+        "status": status,
+        "evidence": evidence,
+        "next_step": next_step,
+    }
+
+
+def build_account_milestone_readiness(db: Session, settings: Settings) -> Dict[str, Any]:
+    """Return a safe operator-facing #12 completion summary."""
+
+    counts = {
+        "organizations": _count(db, Organization),
+        "workspaces": _count(db, Workspace),
+        "organization_memberships": _count(db, OrganizationMembership),
+        "workspace_memberships": _count(db, WorkspaceMembership),
+        "plans": _count(db, Plan),
+        "billing_accounts": _count(db, BillingAccount),
+        "subscriptions": _count(db, Subscription),
+        "entitlements": _count(db, Entitlement),
+        "usage_records": _count(db, UsageRecord),
+        "provider_integrations": _count(db, ProviderIntegration),
+        "billing_events": _count(db, BillingEvent),
+        "workspace_audit_events": _count(db, WorkspaceAuditLog),
+    }
+
+    auth_mode = _auth_mode(settings)
+    role_count = len(ROLE_PERMISSIONS)
+    provider_read_token = _has_scope_token(db, PROVIDER_READ_SCOPE, global_token=True)
+    provider_write_token = _has_scope_token(db, PROVIDER_WRITE_SCOPE, global_token=True)
+    scim_token = _has_scope_token(db, SCIM_READ_SCOPE, global_token=False) or _has_scope_token(
+        db, SCIM_WRITE_SCOPE, global_token=False
+    )
+    stripe_configured = bool(settings.STRIPE_SECRET_KEY and settings.STRIPE_WEBHOOK_SECRET)
+    mfa_policy_configured = bool(settings.AUTH_REQUIRE_MFA)
+
+    criteria = [
+        _criterion(
+            "auth_modes",
+            "Production authentication modes",
+            True,
+            auth_mode != "disabled" or bool(settings.ALLOW_AUTH_DISABLED_IN_PRODUCTION),
+            auth_mode,
+            [
+                "OIDC, Authentik, Logto, trusted-proxy, and explicit auth-disabled modes are modeled.",
+                f"Current mode: {auth_mode}.",
+            ],
+            "Use OIDC/Logto/Authentik/trusted-proxy for internet-facing deployments.",
+        ),
+        _criterion(
+            "workspace_rbac",
+            "Workspace-scoped RBAC",
+            role_count >= 5,
+            role_count >= 5,
+            f"{role_count} roles",
+            [
+                "Role permissions are centralized in workspace access helpers.",
+                "Workspace owner, domain admin, operator, analyst, and auditor roles are available.",
+            ],
+            "Assign memberships or map IdP groups before enabling multi-workspace UI for a team.",
+        ),
+        _criterion(
+            "membership_management",
+            "Membership management and audit",
+            True,
+            counts["workspace_memberships"] > 0 or counts["organization_memberships"] > 0,
+            (
+                "implemented"
+                if counts["workspace_memberships"] or counts["organization_memberships"]
+                else "ready"
+            ),
+            [
+                "Organization and workspace membership models and APIs are available.",
+                f"Active database rows: {counts['organization_memberships']} org memberships, {counts['workspace_memberships']} workspace memberships.",
+            ],
+            "Invite or map the first non-admin user when operating as SaaS or provider tenant.",
+        ),
+        _criterion(
+            "workspace_switching",
+            "Workspace switching and tenant context",
+            True,
+            counts["workspaces"] > 0,
+            f"{counts['workspaces']} workspaces",
+            [
+                "Visible workspace API returns effective roles and permissions.",
+                "Workspace headers are used by workspace-scoped UI calls.",
+            ],
+            "Keep single-workspace UI disabled for self-hosted installs that do not need switching.",
+        ),
+        _criterion(
+            "onboarding_entitlements",
+            "SaaS onboarding and starter entitlements",
+            True,
+            counts["organizations"] > 0 and counts["entitlements"] > 0,
+            "materialized" if counts["entitlements"] else "ready",
+            [
+                "Onboarding can create organization, workspace, owner membership, and starter plan state.",
+                f"Database rows: {counts['organizations']} organizations, {counts['entitlements']} entitlements.",
+            ],
+            "Run browser onboarding for a new customer workspace before production use.",
+        ),
+        _criterion(
+            "direct_billing",
+            "Direct Stripe billing",
+            True,
+            stripe_configured or counts["subscriptions"] > 0,
+            "configured" if stripe_configured else "optional",
+            [
+                "Checkout, customer portal, webhook verification, and local entitlement materialization are implemented.",
+                "Stripe is optional for self-hosted and provider-billed deployments.",
+            ],
+            "Set Stripe secrets only for direct DMARQaaS billing.",
+        ),
+        _criterion(
+            "provider_billing",
+            "Provider lifecycle and external billing",
+            True,
+            provider_read_token or provider_write_token or counts["billing_accounts"] > 0,
+            "configured" if provider_read_token or provider_write_token else "ready",
+            [
+                "Provider-scoped tokens, customer provisioning, subscription state, and usage export endpoints are available.",
+                f"Provider tokens: read={provider_read_token}, write={provider_write_token}.",
+            ],
+            "Create provider machine tokens from a trusted admin session before WHMCS or ISP integration.",
+        ),
+        _criterion(
+            "plan_limits",
+            "Plan limits and grace states",
+            True,
+            counts["plans"] > 0 and counts["subscriptions"] > 0,
+            "active" if counts["subscriptions"] else "ready",
+            [
+                "Plans, subscriptions, entitlements, usage records, and grace/suspension states are local app concepts.",
+                f"Database rows: {counts['plans']} plans, {counts['subscriptions']} subscriptions.",
+            ],
+            "Review billing mode and entitlement warnings before enforcing hard limits.",
+        ),
+        _criterion(
+            "enterprise_identity",
+            "Enterprise identity controls",
+            True,
+            scim_token or mfa_policy_configured,
+            "configured" if scim_token or mfa_policy_configured else "ready",
+            [
+                "SCIM provisioning endpoints and MFA claim policy hooks are implemented.",
+                f"Configured controls: scim_token={scim_token}, mfa_required={mfa_policy_configured}.",
+            ],
+            "Create workspace-scoped SCIM tokens and enable MFA claims for enterprise tenants.",
+        ),
+        _criterion(
+            "support_access",
+            "Audited support access",
+            True,
+            True,
+            "approval-only",
+            [
+                "Support access grants are explicit, time-boxed, customer-visible, and written to workspace audit logs.",
+                f"Workspace audit events currently stored: {counts['workspace_audit_events']}.",
+            ],
+            "Use support-access grants for diagnostics; never impersonate silently.",
+        ),
+    ]
+
+    ready_count = sum(1 for item in criteria if item["ready"])
+    remaining = [item for item in criteria if not item["ready"]]
+    setup_gates = [item for item in criteria if item["setup_required"]]
+    return {
+        "milestone": "#12 User Authentication & Multi-User Support",
+        "status": "complete" if not remaining else "operational_with_setup_needed",
+        "ready_to_close_parent_issue": not remaining,
+        "criteria_met": ready_count,
+        "criteria_total": len(criteria),
+        "remaining_slices": len(remaining),
+        "setup_gates": len(setup_gates),
+        "criteria": criteria,
+        "counts": counts,
+        "role_catalog": list_workspace_roles(),
+        "deployment_modes": [
+            "self_hosted_single_workspace",
+            "self_hosted_multi_workspace",
+            "dmarq_saas_direct_billing",
+            "provider_resale",
+            "provider_whmcs",
+            "provider_tmf",
+        ],
+        "safety_boundary": (
+            "This readiness summary does not enable live writes, billing charges, or support access. "
+            "Those paths still require configured credentials, scoped tokens, and explicit operator action."
+        ),
+        "next_step": (
+            "Close #12 as implemented; review setup gates only when enabling SaaS, provider, or enterprise tenant modes."
+            if not remaining
+            else "Complete the remaining setup gates before closing #12 for this deployment."
+        ),
+    }

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -48,6 +48,8 @@ function settingsApp() {
         loadingWebhookDeliveries: false,
         loadingAIProfiles: false,
         testingAIConnection: false,
+        loadingAccountReadiness: false,
+        accountReadiness: null,
         aiProviderProfiles: [],
         aiConnectionResult: null,
         aiModels: [],
@@ -160,7 +162,8 @@ function settingsApp() {
                 load_webhooks: () => this.loadWebhooks(),
                 process_webhooks: () => this.processWebhooks(),
                 load_webhook_deliveries: () => this.loadWebhookDeliveries(),
-                test_ai_connection: () => this.testAIConnection()
+                test_ai_connection: () => this.testAIConnection(),
+                load_account_readiness: () => this.loadAccountReadiness()
             };
             actions[action]?.();
         },
@@ -211,9 +214,38 @@ function settingsApp() {
                 await this.loadCloudflareOAuthStatus(false);
                 await this.loadDNSProviders(false);
                 await this.loadAIProviderProfiles(false);
+                await this.loadAccountReadiness(false);
             } catch (err) {
                 this.showFlash('Error loading settings: ' + err.message, false);
             }
+        },
+
+        async loadAccountReadiness(showFlash = true) {
+            this.loadingAccountReadiness = true;
+            try {
+                const res = await fetch('/api/v1/settings/account-readiness', { headers: this.apiHeaders() });
+                if (!res.ok) {
+                    if (showFlash) this.showFlash('Failed to load account readiness: ' + res.statusText, false);
+                    return;
+                }
+                this.accountReadiness = await res.json();
+            } catch (err) {
+                if (showFlash) this.showFlash('Error loading account readiness: ' + err.message, false);
+            } finally {
+                this.loadingAccountReadiness = false;
+            }
+        },
+
+        accountReadinessStatusClass(status) {
+            if (status === 'complete') return 'badge-success';
+            if (status === 'operational_with_setup_needed') return 'badge-warning';
+            return 'badge-ghost';
+        },
+
+        accountReadinessStatusLabel(status) {
+            if (status === 'complete') return 'Complete';
+            if (status === 'operational_with_setup_needed') return 'Setup needed';
+            return status || 'Unknown';
         },
 
         applyCloudflareOAuthQueryState() {

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -22,6 +22,88 @@
         </div>
     </template>
 
+    <!-- ── Account/Auth Milestone ───────────────────────────────────────── -->
+    {% call card() %}
+        {% call card_header() %}
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                    {% call card_title() %}Account and Access Milestone{% endcall %}
+                    {% call card_description() %}
+                        Product readiness for authentication, workspace RBAC, billing ownership,
+                        provider lifecycle, enterprise provisioning, and audited support access.
+                    {% endcall %}
+                </div>
+                <button type="button" class="btn btn-outline btn-sm"
+                    data-settings-action="load_account_readiness"
+                    :disabled="loadingAccountReadiness">
+                    <template x-if="!loadingAccountReadiness">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+                            fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                            stroke-linejoin="round" class="mr-2">
+                            <polyline points="23 4 23 10 17 10"></polyline>
+                            <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+                        </svg>
+                    </template>
+                    <template x-if="loadingAccountReadiness"><span class="loading loading-spinner loading-xs mr-2"></span></template>
+                    Reload
+                </button>
+            </div>
+        {% endcall %}
+        {% call card_content() %}
+            <div x-show="loadingAccountReadiness && !accountReadiness" class="flex items-center gap-2 text-sm text-[#5f5c78]" role="status">
+                <span class="loading loading-spinner loading-sm"></span>
+                <span>Loading account readiness...</span>
+            </div>
+
+            <template x-if="accountReadiness">
+                <div class="space-y-4">
+                    <div class="flex flex-col gap-3 rounded-lg border border-[#dfdfdf] bg-[#f8f7f4] p-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <p class="text-sm font-semibold text-[#120d36]" x-text="accountReadiness.milestone"></p>
+                            <p class="mt-1 text-sm text-[#5f5c78]" x-text="accountReadiness.next_step"></p>
+                        </div>
+                        <div class="flex flex-wrap items-center gap-2">
+                            <span class="badge" :class="accountReadinessStatusClass(accountReadiness.status)"
+                                x-text="accountReadinessStatusLabel(accountReadiness.status)"></span>
+                            <span class="badge badge-ghost">
+                                <span x-text="accountReadiness.criteria_met"></span>/<span x-text="accountReadiness.criteria_total"></span> criteria
+                            </span>
+                            <span class="badge badge-ghost">
+                                <span x-text="accountReadiness.remaining_slices"></span> open slices
+                            </span>
+                            <span class="badge badge-ghost">
+                                <span x-text="accountReadiness.setup_gates"></span> setup gates
+                            </span>
+                        </div>
+                    </div>
+
+                    <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                        <template x-for="criterion in accountReadiness.criteria" :key="criterion.key">
+                            <article class="rounded-lg border border-[#dfdfdf] bg-white p-4">
+                                <div class="flex items-start justify-between gap-3">
+                                    <h3 class="text-sm font-semibold text-[#120d36]" x-text="criterion.title"></h3>
+                                    <span class="badge badge-sm" :class="criterion.ready ? (criterion.setup_required ? 'badge-warning' : 'badge-success') : 'badge-error'"
+                                        x-text="criterion.status"></span>
+                                </div>
+                                <ul class="mt-3 space-y-1 text-xs text-[#5f5c78]">
+                                    <template x-for="line in criterion.evidence" :key="line">
+                                        <li x-text="line"></li>
+                                    </template>
+                                </ul>
+                                <p class="mt-3 text-xs font-medium text-[#120d36]" x-text="criterion.next_step"></p>
+                            </article>
+                        </template>
+                    </div>
+
+                    <div class="rounded-lg border border-[#dfdfdf] bg-[#f8f7f4] p-4 text-xs text-[#5f5c78]">
+                        <p class="font-semibold text-[#120d36]">Safety boundary</p>
+                        <p class="mt-1" x-text="accountReadiness.safety_boundary"></p>
+                    </div>
+                </div>
+            </template>
+        {% endcall %}
+    {% endcall %}
+
     <!-- ── General ──────────────────────────────────────────────────────── -->
     {% call card() %}
         {% call card_header() %}

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -192,6 +192,14 @@ def _profile_script() -> str:
     return _read_project_file("static", "js", "profile-page.js")
 
 
+def _settings_template() -> str:
+    return _read_project_file("templates", "settings.html")
+
+
+def _settings_script() -> str:
+    return _read_project_file("static", "js", "settings-page.js")
+
+
 def _onboarding_template() -> str:
     return _read_project_file("templates", "onboarding.html")
 
@@ -230,14 +238,6 @@ def _report_detail_template() -> str:
 
 def _report_detail_script() -> str:
     return _read_project_file("static", "js", "report-detail-page.js")
-
-
-def _settings_template() -> str:
-    return _read_project_file("templates", "settings.html")
-
-
-def _settings_script() -> str:
-    return _read_project_file("static", "js", "settings-page.js")
 
 
 def test_settings_cloudflare_oauth_uses_popup_with_full_window_fallback():
@@ -1857,6 +1857,14 @@ def test_settings_controls_are_bound_from_external_script():
     template = _settings_template()
     script = _settings_script()
 
+    assert "Account and Access Milestone" in template
+    assert 'data-settings-action="load_account_readiness"' in template
+    assert "accountReadiness.remaining_slices" in template
+    assert "accountReadiness.setup_gates" in template
+    assert "loadAccountReadiness" in script
+    assert "accountReadinessStatusClass" in script
+    assert "accountReadinessStatusLabel" in script
+    assert "/api/v1/settings/account-readiness" in script
     assert "data-settings-save-category" in template
     assert "data-settings-save-automation" in template
     assert "data-settings-create-webhook" in template

--- a/backend/app/tests/test_settings.py
+++ b/backend/app/tests/test_settings.py
@@ -7,11 +7,16 @@ from datetime import datetime, timedelta, timezone
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.core.config import Settings
 from app.core.credential_encryption import decrypt_secret, is_encrypted_secret
 from app.models.alert import AlertConfigurationAudit, AlertHistory
+from app.models.api_token import APIToken
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
 from app.models.setting import Setting
+from app.models.workspace import Workspace
+from app.services.account_milestone import _auth_mode, _criterion, _has_scope_token
+from app.services.api_tokens import PROVIDER_READ_SCOPE, SCIM_READ_SCOPE
 from app.services.alert_history import list_alert_config_audit, record_alert_config_change
 from app.services.notifications import NotificationResult, send_notification
 from app.services.summary_notifications import send_due_scheduled_summaries
@@ -153,6 +158,101 @@ class TestSettingsAPI:
             "enterprise_identity",
             "support_access",
         }.issubset(keys)
+
+    def test_account_readiness_auth_mode_detection(self):
+        """The milestone summary reflects each supported auth mode signal."""
+        assert _auth_mode(Settings(AUTH_DISABLED=True)) == "disabled"
+        assert _auth_mode(Settings(AUTH_MODE="trusted_proxy")) == "trusted_proxy"
+        assert (
+            _auth_mode(
+                Settings(
+                    LOGTO_ENDPOINT="https://logto.example.test",
+                    LOGTO_APP_ID="app_123",
+                )
+            )
+            == "logto"
+        )
+        assert (
+            _auth_mode(
+                Settings(
+                    AUTHENTIK_ISSUER_URL="https://authentik.example.test/application/o/dmarq/",
+                    AUTHENTIK_CLIENT_ID="client_123",
+                )
+            )
+            == "authentik"
+        )
+        assert (
+            _auth_mode(
+                Settings(
+                    OIDC_ISSUER_URL="https://idp.example.test/realms/dmarq",
+                    OIDC_CLIENT_ID="client_123",
+                )
+            )
+            == "oidc"
+        )
+        assert _auth_mode(Settings(AUTH_TRUSTED_PROXY_ENABLED=True)) == "trusted_proxy"
+
+    def test_account_readiness_scope_token_filters(self, db_session: Session):
+        """Provider and SCIM readiness checks distinguish global and workspace tokens."""
+        workspace = Workspace(slug="tenant-a", name="Tenant A")
+        db_session.add(workspace)
+        db_session.flush()
+        db_session.add_all(
+            [
+                APIToken(
+                    name="provider",
+                    key_hash="provider-hash",
+                    key_prefix="dmq_provider",
+                    scopes=f"{PROVIDER_READ_SCOPE},other",
+                    active=True,
+                ),
+                APIToken(
+                    name="scim",
+                    key_hash="scim-hash",
+                    key_prefix="dmq_scim",
+                    scopes=SCIM_READ_SCOPE,
+                    workspace_id=workspace.id,
+                    active=True,
+                ),
+                APIToken(
+                    name="revoked",
+                    key_hash="revoked-hash",
+                    key_prefix="dmq_revoked",
+                    scopes=PROVIDER_READ_SCOPE,
+                    active=False,
+                ),
+            ]
+        )
+        db_session.commit()
+
+        assert _has_scope_token(db_session, PROVIDER_READ_SCOPE, global_token=True) is True
+        assert _has_scope_token(db_session, PROVIDER_READ_SCOPE, global_token=False) is False
+        assert _has_scope_token(db_session, SCIM_READ_SCOPE, global_token=False) is True
+        assert _has_scope_token(db_session, SCIM_READ_SCOPE) is True
+
+    def test_account_readiness_criterion_marks_setup_gates(self):
+        """Setup gates are only counted after implementation is ready."""
+        configured_gate = _criterion(
+            "enterprise_identity",
+            "Enterprise identity controls",
+            True,
+            True,
+            "configured",
+            ["SCIM and MFA are configured."],
+            "No setup required.",
+        )
+        pending_gate = _criterion(
+            "provider_billing",
+            "Provider lifecycle and external billing",
+            True,
+            False,
+            "ready",
+            ["Provider APIs are implemented."],
+            "Create provider tokens before integration.",
+        )
+
+        assert configured_gate["setup_required"] is False
+        assert pending_gate["setup_required"] is True
 
     def test_list_settings_filter_by_category(self, authed_client: TestClient):
         """GET /api/v1/settings?category=dmarc returns only dmarc settings."""

--- a/backend/app/tests/test_settings.py
+++ b/backend/app/tests/test_settings.py
@@ -126,6 +126,34 @@ class TestSettingsAPI:
         assert "forensics.redaction_mode" in keys
         assert "forensics.redact_long_tokens_enabled" in keys
 
+    def test_account_readiness_endpoint_summarizes_milestone_12(
+        self,
+        authed_client: TestClient,
+    ):
+        """GET /api/v1/settings/account-readiness returns the #12 rollup route."""
+        res = authed_client.get("/api/v1/settings/account-readiness")
+
+        assert res.status_code == 200
+        data = res.json()
+        assert data["milestone"] == "#12 User Authentication & Multi-User Support"
+        assert data["criteria_total"] == len(data["criteria"])
+        assert data["criteria_total"] >= 10
+        assert data["ready_to_close_parent_issue"] is True
+        assert data["remaining_slices"] == 0
+        assert data["setup_gates"] >= 0
+        assert data["safety_boundary"]
+        assert "workspace_owner" in {row["role"] for row in data["role_catalog"]}
+        assert all(row["ready"] is True for row in data["criteria"])
+        keys = {row["key"] for row in data["criteria"]}
+        assert {
+            "auth_modes",
+            "workspace_rbac",
+            "direct_billing",
+            "provider_billing",
+            "enterprise_identity",
+            "support_access",
+        }.issubset(keys)
+
     def test_list_settings_filter_by_category(self, authed_client: TestClient):
         """GET /api/v1/settings?category=dmarc returns only dmarc settings."""
         res = authed_client.get("/api/v1/settings?category=dmarc")

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -110,7 +110,7 @@ Strategic issue status:
 
 | Issue | Status | Notes |
 | --- | --- | --- |
-| [#12](https://github.com/christianlouis/dmarq/issues/12) | open | Broad user-auth, SaaS, ISP/OEM, subscription, and billing tracker. Keep this parked for the self-hosted demo unless auth work is explicitly reactivated. |
+| [#12](https://github.com/christianlouis/dmarq/issues/12) | ready to close | Parent tracker for user-auth, SaaS, ISP/OEM, subscription, and billing foundations. Child slices #236-#243 are complete, and Settings now exposes a readiness rollup that separates implemented foundations from environment setup gates. |
 | [#243](https://github.com/christianlouis/dmarq/issues/243) | complete | Enterprise identity, provisioning, and support-access hardening landed through focused child slices. |
 | [#305](https://github.com/christianlouis/dmarq/issues/305) | complete as roadmap parent | Competitive-parity direction is now captured here and in the referenced product docs. New work should use focused child issues instead of reopening the parent. |
 | [#309](https://github.com/christianlouis/dmarq/issues/309) | complete for current read-only API/MCP scope | Stable public API and MCP read-only surfaces exist for health, reports, DNS, sources, remediation, alerts, usage, and export discovery. Future write or provider-admin tools need separate scoped issues. |
@@ -550,6 +550,7 @@ Completed reference issues:
 
 - [Issue #206](https://github.com/christianlouis/dmarq/issues/206): Kubernetes
   host-loss high availability.
-- [Issues #236-#242](https://github.com/christianlouis/dmarq/issues?q=repo%3Achristianlouis%2Fdmarq+is%3Aissue+236..242):
+- [Issues #236-#243](https://github.com/christianlouis/dmarq/issues?q=repo%3Achristianlouis%2Fdmarq+is%3Aissue+236..243):
   #12 foundation slices for RBAC, membership, workspace switching, SaaS
-  onboarding, Stripe billing, provider lifecycle, and entitlement visibility.
+  onboarding, Stripe billing, provider lifecycle, entitlement visibility,
+  enterprise identity, and audited support access.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -240,6 +240,18 @@ DELETE /api-tokens/{token_id}
 Deactivates a token immediately. Revoked tokens can no longer access public API
 endpoints.
 
+### Settings Account Readiness
+
+```text
+GET /settings/account-readiness
+```
+
+Returns the administrator-facing #12 account/auth milestone summary used by
+Settings. The response separates completed implementation slices from
+environment setup gates, so self-hosted installs can stay simple while SaaS,
+provider-billed, SCIM, MFA, or support-access deployments still show their
+remaining configuration work.
+
 ### Workspace Audit
 
 #### List Workspace Roles

--- a/docs/user_guide/settings.md
+++ b/docs/user_guide/settings.md
@@ -4,6 +4,20 @@ This guide covers the various settings and configuration options available in DM
 
 ## General Settings
 
+### Account and Access Milestone
+
+Administrators see an **Account and Access Milestone** card at the top of
+Settings. It summarizes the #12 account/auth foundation in product terms:
+authentication modes, workspace RBAC, membership management, workspace
+switching, onboarding, billing ownership, provider lifecycle, plan limits,
+enterprise provisioning, and audited support access.
+
+The card separates implementation state from deployment setup. **Open slices**
+should be zero when the product foundation is complete. **Setup gates** identify
+environment-specific configuration still needed before using a mode, such as
+Stripe for direct billing, provider machine tokens for ISP/OEM integrations, or
+SCIM/MFA controls for enterprise tenants.
+
 ### User Profile
 
 To manage your user profile:


### PR DESCRIPTION
## Summary

Completes the #12 parent tracker locally by surfacing the account/auth readiness rollup in product and documentation instead of leaving the parent as a parked roadmap item.

Changes:
- adds a Settings account/access milestone card for authentication, workspace RBAC, membership, onboarding, billing, provider lifecycle, enterprise identity, and support access
- adds `GET /api/v1/settings/account-readiness`
- separates true remaining implementation slices from environment-specific setup gates such as Stripe, provider tokens, SCIM, and MFA
- updates roadmap, API docs, user guide, and changelog so #12 is documented as ready to close once the PR is merged

## Validation

Local validation completed before opening the PR:
- `node --check backend/app/static/js/settings-page.js`
- `python -m black --check backend/app/services/account_milestone.py backend/app/api/api_v1/endpoints/settings.py backend/app/tests/test_settings.py backend/app/tests/test_dashboard_template_security.py`
- `PYTHONPATH=backend python -m flake8 backend/app/services/account_milestone.py backend/app/api/api_v1/endpoints/settings.py backend/app/tests/test_settings.py backend/app/tests/test_dashboard_template_security.py`
- `PYTHONPATH=backend python -m pytest backend/app/tests/test_settings.py backend/app/tests/test_dashboard_template_security.py -q` -> 127 passed
- `PYTHONPATH=backend python -m pytest backend/app/tests/test_workspaces.py backend/app/tests/test_workspace_context_api.py backend/app/tests/test_memberships_api.py backend/app/tests/test_workspace_audit.py backend/app/tests/test_organization_foundations.py backend/app/tests/test_provider_billing_usage.py backend/app/tests/test_stripe_billing.py backend/app/tests/test_workspace_onboarding.py backend/app/tests/test_demo_multi_user_deployment.py backend/app/tests/test_demo_read_only.py backend/app/tests/test_settings.py -q` -> 192 passed
- `git diff --check`
