### PR TITLE
[codex] Clarify account readiness setup gates

### DIFF
--- a/backend/app/services/account_milestone.py
+++ b/backend/app/services/account_milestone.py
@@ -239,9 +239,14 @@ def build_account_milestone_readiness(db: Session, settings: Settings) -> Dict[s
     ready_count = sum(1 for item in criteria if item["ready"])
     remaining = [item for item in criteria if not item["ready"]]
     setup_gates = [item for item in criteria if item["setup_required"]]
+    status = (
+        "incomplete"
+        if remaining
+        else "operational_with_setup_needed" if setup_gates else "complete"
+    )
     return {
         "milestone": "#12 User Authentication & Multi-User Support",
-        "status": "complete" if not remaining else "operational_with_setup_needed",
+        "status": status,
         "ready_to_close_parent_issue": not remaining,
         "criteria_met": ready_count,
         "criteria_total": len(criteria),

--- a/backend/app/tests/test_settings.py
+++ b/backend/app/tests/test_settings.py
@@ -15,7 +15,12 @@ from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
 from app.models.setting import Setting
 from app.models.workspace import Workspace
-from app.services.account_milestone import _auth_mode, _criterion, _has_scope_token
+from app.services.account_milestone import (
+    _auth_mode,
+    _criterion,
+    _has_scope_token,
+    build_account_milestone_readiness,
+)
 from app.services.api_tokens import PROVIDER_READ_SCOPE, SCIM_READ_SCOPE
 from app.services.alert_history import list_alert_config_audit, record_alert_config_change
 from app.services.notifications import NotificationResult, send_notification
@@ -141,11 +146,12 @@ class TestSettingsAPI:
         assert res.status_code == 200
         data = res.json()
         assert data["milestone"] == "#12 User Authentication & Multi-User Support"
+        assert data["status"] == "operational_with_setup_needed"
         assert data["criteria_total"] == len(data["criteria"])
         assert data["criteria_total"] >= 10
         assert data["ready_to_close_parent_issue"] is True
         assert data["remaining_slices"] == 0
-        assert data["setup_gates"] >= 0
+        assert data["setup_gates"] > 0
         assert data["safety_boundary"]
         assert "workspace_owner" in {row["role"] for row in data["role_catalog"]}
         assert all(row["ready"] is True for row in data["criteria"])
@@ -253,6 +259,18 @@ class TestSettingsAPI:
 
         assert configured_gate["setup_required"] is False
         assert pending_gate["setup_required"] is True
+
+    def test_account_readiness_marks_setup_needed_without_reopening_parent(
+        self,
+        db_session: Session,
+    ):
+        """Deployment setup gates influence status without reopening #12 implementation."""
+        data = build_account_milestone_readiness(db_session, Settings())
+
+        assert data["status"] == "operational_with_setup_needed"
+        assert data["ready_to_close_parent_issue"] is True
+        assert data["remaining_slices"] == 0
+        assert data["setup_gates"] > 0
 
     def test_list_settings_filter_by_category(self, authed_client: TestClient):
         """GET /api/v1/settings?category=dmarc returns only dmarc settings."""

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -243,7 +243,7 @@ endpoints.
 ### Settings Account Readiness
 
 ```text
-GET /settings/account-readiness
+GET /api/v1/settings/account-readiness
 ```
 
 Returns the administrator-facing #12 account/auth milestone summary used by


### PR DESCRIPTION
## Summary

Fixes #710 after the #12 readiness rollout.

Changes:
- makes account readiness return `operational_with_setup_needed` when all implementation slices are ready but environment setup gates remain
- keeps `ready_to_close_parent_issue=true` and `remaining_slices=0` for that state so #12 is not reopened by deployment-specific setup
- corrects the API reference path to `GET /api/v1/settings/account-readiness`
- adds focused tests for setup-gate semantics

## Validation

Local validation completed before opening the PR:
- `python -m black --check backend/app/services/account_milestone.py backend/app/tests/test_settings.py`
- `PYTHONPATH=backend python -m flake8 backend/app/services/account_milestone.py backend/app/tests/test_settings.py`
- `PYTHONPATH=backend python -m pytest backend/app/tests/test_settings.py -q` -> 40 passed
- `git diff --check`
