### PR TITLE
Improve setup query paths and parser coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added focused regression coverage for reputation-feed configuration,
+  TLS-report serialization, and TLSA parsing edge cases.
 - Added a Settings account/access milestone readiness summary for #12, separating completed auth/workspace/billing/provider foundations from environment-specific setup gates.
 - Added mail-source authorization health signals to poll status, operations health, and dashboard intake status so expired or incomplete Gmail OAuth connections request reauthorization instead of appearing simply connected.
 - Added recovery diagnostics to manual dashboard mail polling results so failed Gmail/Microsoft 365 imports surface the likely action, such as reconnecting the mailbox.
@@ -77,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added remediation-loop completion gates on the dashboard and domain queue so parent roadmap issues are only considered ready after priority, evidence, action-plan, automation, approval, verification, notification, and summary criteria are represented.
 
 ### Changed
+- Settings and workspace onboarding defaults now load existing rows in bulk,
+  avoiding per-item database lookups while preserving idempotent setup behavior.
 - Domain summary DNS refreshes now run with bounded concurrency instead of resolving each domain sequentially.
 - Startup DNS cache prewarming now prioritizes domains with observed reports and message volume before empty monitored domains.
 - Cloudflare OAuth profile selection now controls the requested scopes instead of being overridden by the legacy static scope setting.
@@ -116,6 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up root directory for clarity
 
 ### Fixed
+- TLSA parsing now preserves association data that contains whitespace after the
+  first three TLSA fields, with focused tests for malformed and warning cases.
 - Aggregate and TLS report pages now keep the last loaded data visible when a manual refresh or API retry fails.
 - Retired stale roadmap issue-generator guidance and made the docs-site
   changelog point at the canonical root changelog.

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -455,9 +455,13 @@ _SECRET_KEYS = {
 
 def _seed_defaults(db: Session) -> None:
     """Insert any missing default settings rows (idempotent)."""
+    keys = [defaults["key"] for defaults in SETTING_DEFAULTS]
+    existing_settings = db.query(Setting.key).filter(Setting.key.in_(keys)).all()
+    existing_keys = {s[0] for s in existing_settings}
+
     for defaults in SETTING_DEFAULTS:
         key = defaults["key"]
-        if db.query(Setting).filter(Setting.key == key).first() is None:
+        if key not in existing_keys:
             db.add(
                 Setting(
                     key=key,

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -149,7 +149,7 @@ def parse_tlsa_record(record: str, *, query_name: str, mx_host: str) -> TLSAReco
     usage = _safe_int(parts[0])
     selector = _safe_int(parts[1])
     matching_type = _safe_int(parts[2])
-    association_data = "".join(parts[3:]).strip()
+    association_data = re.sub(r"\s+", "", parts[3])
     result.certificate_usage = usage
     result.selector = selector
     result.matching_type = matching_type

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -139,7 +139,7 @@ def _safe_int(value: str) -> Optional[int]:
 def parse_tlsa_record(record: str, *, query_name: str, mx_host: str) -> TLSARecord:
     """Parse a TLSA record and return normalized lint evidence."""
     result = TLSARecord(query_name=query_name, mx_host=mx_host, record=record)
-    parts = record.split()
+    parts = record.split(maxsplit=3)
     if len(parts) < 4:
         result.errors.append(
             "TLSA records must contain certificate usage, selector, matching type, and data."

--- a/backend/app/services/workspace_onboarding.py
+++ b/backend/app/services/workspace_onboarding.py
@@ -685,12 +685,22 @@ def _apply_mail_sources(
     source_plans: Iterable[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
     results: List[Dict[str, Any]] = []
-    for item in source_plans:
-        existing = (
+
+    source_plans_list = list(source_plans)
+    source_names = [item["name"] for item in source_plans_list]
+    existing_sources = (
+        (
             db.query(MailSource)
-            .filter(MailSource.workspace_id == workspace.id, MailSource.name == item["name"])
-            .first()
+            .filter(MailSource.workspace_id == workspace.id, MailSource.name.in_(source_names))
+            .all()
         )
+        if source_names
+        else []
+    )
+    existing_by_name = {source.name: source for source in existing_sources}
+
+    for item in source_plans_list:
+        existing = existing_by_name.get(item["name"])
         if existing:
             results.append({"name": item["name"], "status": "existing", "id": existing.id})
             continue
@@ -717,6 +727,8 @@ def _apply_mail_sources(
         db.add(source)
         db.flush()
         results.append({"name": source.name, "status": "created", "id": source.id})
+        # Add to existing_by_name in case there are duplicates in the source_plans_list
+        existing_by_name[source.name] = source
     return results
 
 
@@ -727,8 +739,15 @@ def _apply_notification_defaults(
     overwrite_existing: bool,
 ) -> List[Dict[str, Any]]:
     results: List[Dict[str, Any]] = []
+
+    if not defaults:
+        return results
+
+    existing_settings = db.query(Setting).filter(Setting.key.in_(defaults.keys())).all()
+    existing_map = {setting.key: setting for setting in existing_settings}
+
     for key, value in defaults.items():
-        row = db.query(Setting).filter(Setting.key == key).first()
+        row = existing_map.get(key)
         if row and not overwrite_existing:
             results.append({"key": key, "status": "existing"})
             continue

--- a/backend/app/tests/services/test_tls_report_persistence.py
+++ b/backend/app/tests/services/test_tls_report_persistence.py
@@ -1,14 +1,13 @@
 from datetime import datetime
-from importlib import import_module
 
-import_module("app.models.dns_cache")
-import_module("app.models.mail_source_backfill")
+import app.models.dns_cache  # noqa
+import app.models.mail_source_backfill  # noqa
 
 # Import all models to ensure SQLAlchemy's mapper registries are properly populated
-import_module("app.models.mail_source_import")
-import_module("app.models.organization")
-import_module("app.models.webhook")
-import_module("app.models.workspace_access")
+import app.models.mail_source_import  # noqa
+import app.models.organization  # noqa
+import app.models.webhook  # noqa
+import app.models.workspace_access  # noqa
 from app.models.domain import Domain
 from app.models.report import TLSReport, TLSReportFailure
 from app.services.tls_report_persistence import tls_report_to_dict

--- a/backend/app/tests/services/test_tls_report_persistence.py
+++ b/backend/app/tests/services/test_tls_report_persistence.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+
+import app.models.dns_cache  # noqa
+import app.models.mail_source_backfill  # noqa
+
+# Import all models to ensure SQLAlchemy's mapper registries are properly populated
+import app.models.mail_source_import  # noqa
+import app.models.organization  # noqa
+import app.models.webhook  # noqa
+import app.models.workspace_access  # noqa
+from app.models.domain import Domain
+from app.models.report import TLSReport, TLSReportFailure
+from app.services.tls_report_persistence import tls_report_to_dict
+
+
+def test_tls_report_to_dict_fully_populated():
+    """Test that a fully populated TLSReport serializes correctly."""
+    domain = Domain(name="example.com")
+    now = datetime(2023, 1, 1, 12, 0, 0)
+
+    failure = TLSReportFailure(
+        result_type="certificate-expired",
+        failed_session_count=5,
+        sending_mta_ip="192.0.2.1",
+        receiving_mx_hostname="mx.example.com",
+        receiving_mx_helo="mx.example.com",
+        receiving_ip="198.51.100.1",
+        failure_reason_code="tls",
+        additional_information="Expired cert",
+    )
+
+    report = TLSReport(
+        id=1,
+        report_id="test-report-1",
+        domain=domain,
+        org_name="Test Org",
+        contact_info="test@example.com",
+        policy_domain="example.com",
+        policy_type="sts",
+        begin_date=now,
+        end_date=now,
+        total_successful_sessions=10,
+        total_failure_sessions=5,
+        processed_at=now,
+        failures=[failure],
+    )
+
+    result = tls_report_to_dict(report)
+
+    assert result == {
+        "id": 1,
+        "report_id": "test-report-1",
+        "domain": "example.com",
+        "org_name": "Test Org",
+        "contact_info": "test@example.com",
+        "policy_domain": "example.com",
+        "policy_type": "sts",
+        "begin_date": "2023-01-01T12:00:00",
+        "end_date": "2023-01-01T12:00:00",
+        "total_successful_sessions": 10,
+        "total_failure_sessions": 5,
+        "processed_at": "2023-01-01T12:00:00",
+        "failures": [
+            {
+                "result_type": "certificate-expired",
+                "failed_session_count": 5,
+                "sending_mta_ip": "192.0.2.1",
+                "receiving_mx_hostname": "mx.example.com",
+                "receiving_mx_helo": "mx.example.com",
+                "receiving_ip": "198.51.100.1",
+                "failure_reason_code": "tls",
+                "additional_information": "Expired cert",
+            }
+        ],
+    }
+
+
+def test_tls_report_to_dict_sparse():
+    """Test that a sparse TLSReport (missing optional fields) serializes correctly."""
+    report = TLSReport(
+        id=2,
+        report_id="test-report-2",
+        domain=None,
+        org_name=None,
+        contact_info=None,
+        policy_domain="sparse.example.com",
+        policy_type=None,
+        begin_date=None,
+        end_date=None,
+        total_successful_sessions=0,
+        total_failure_sessions=0,
+        processed_at=None,
+        failures=[],
+    )
+
+    result = tls_report_to_dict(report)
+
+    assert result == {
+        "id": 2,
+        "report_id": "test-report-2",
+        "domain": "sparse.example.com",
+        "org_name": None,
+        "contact_info": None,
+        "policy_domain": "sparse.example.com",
+        "policy_type": None,
+        "begin_date": None,
+        "end_date": None,
+        "total_successful_sessions": 0,
+        "total_failure_sessions": 0,
+        "processed_at": None,
+        "failures": [],
+    }

--- a/backend/app/tests/services/test_tls_report_persistence.py
+++ b/backend/app/tests/services/test_tls_report_persistence.py
@@ -1,13 +1,14 @@
 from datetime import datetime
+from importlib import import_module
 
-import app.models.dns_cache  # noqa
-import app.models.mail_source_backfill  # noqa
+import_module("app.models.dns_cache")
+import_module("app.models.mail_source_backfill")
 
 # Import all models to ensure SQLAlchemy's mapper registries are properly populated
-import app.models.mail_source_import  # noqa
-import app.models.organization  # noqa
-import app.models.webhook  # noqa
-import app.models.workspace_access  # noqa
+import_module("app.models.mail_source_import")
+import_module("app.models.organization")
+import_module("app.models.webhook")
+import_module("app.models.workspace_access")
 from app.models.domain import Domain
 from app.models.report import TLSReport, TLSReportFailure
 from app.services.tls_report_persistence import tls_report_to_dict

--- a/backend/app/tests/test_dane.py
+++ b/backend/app/tests/test_dane.py
@@ -40,6 +40,21 @@ def test_parse_tlsa_record_accepts_valid_dane_ee_spki_hash():
     assert record.errors == []
 
 
+def test_parse_tlsa_record_accepts_grouped_association_data():
+    record = parse_tlsa_record(
+        "3 1 1 0123456789abcdef 0123456789abcdef 0123456789abcdef 0123456789abcdef",
+        query_name="_25._tcp.mx.example.com",
+        mx_host="mx.example.com",
+    )
+
+    assert record.valid is True
+    assert (
+        record.association_data
+        == "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    )
+    assert record.errors == []
+
+
 def test_parse_tlsa_record_rejects_bad_fields():
     record = parse_tlsa_record(
         "9 4 8 not-hex",

--- a/backend/app/tests/test_dane.py
+++ b/backend/app/tests/test_dane.py
@@ -305,3 +305,60 @@ async def test_check_dane_cached_keeps_live_suggestions_in_separate_cache(
     assert live_cached is False
     assert plain.suggested_records == []
     assert live.suggested_records[0].association_data == "a" * 64
+
+
+def test_parse_tlsa_record_missing_parts():
+    record = parse_tlsa_record(
+        "3 1 1",
+        query_name="_25._tcp.mx.example.com",
+        mx_host="mx.example.com",
+    )
+
+    assert record.valid is False
+    assert (
+        "TLSA records must contain certificate usage, selector, matching type, and data."
+        in record.errors
+    )
+
+
+def test_parse_tlsa_record_incomplete_bytes():
+    record = parse_tlsa_record(
+        "3 1 1 123",
+        query_name="_25._tcp.mx.example.com",
+        mx_host="mx.example.com",
+    )
+
+    assert record.valid is False
+    assert "TLSA association data must contain complete bytes." in record.errors
+
+
+def test_parse_tlsa_record_warnings():
+    record = parse_tlsa_record(
+        "0 1 0 0123456789abcdef",
+        query_name="_25._tcp.mx.example.com",
+        mx_host="mx.example.com",
+    )
+
+    assert record.valid is True
+    assert (
+        "PKIX TLSA usages still depend on public CA validation; usage 3 is common for DANE-EE."
+        in record.warnings
+    )
+    assert (
+        "Full-certificate TLSA values are bulky and rotate whenever the certificate changes."
+        in record.warnings
+    )
+
+
+def test_parse_tlsa_record_empty_association_data():
+    record = parse_tlsa_record(
+        "3 1 1  ",
+        query_name="_25._tcp.mx.example.com",
+        mx_host="mx.example.com",
+    )
+
+    assert record.valid is False
+    assert (
+        "TLSA records must contain certificate usage, selector, matching type, and data."
+        in record.errors
+    )

--- a/backend/app/tests/test_source_reputation_feeds.py
+++ b/backend/app/tests/test_source_reputation_feeds.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import dns.resolver
 import httpx
@@ -294,3 +295,54 @@ async def test_lookup_sources_reputation_filters_ineligible_ips_before_max_limit
 
     assert list(results) == ["8.8.8.8"]
     assert results["8.8.8.8"].listed is True
+
+
+def test_provider_configs_from_settings_all_enabled():
+    settings = _settings(
+        SOURCE_REPUTATION_FEEDS_ENABLED=True,
+        SOURCE_REPUTATION_FEEDS="spamhaus_dqs,abusix_mail,spamcop_scbl,barracuda_brbl,abuseipdb",
+        SOURCE_REPUTATION_SPAMHAUS_DQS_ZONE="example.dq.spamhaus.net",
+        SOURCE_REPUTATION_ABUSIX_ZONE="combined.mail.abusix.zone",
+        SOURCE_REPUTATION_ABUSEIPDB_API_KEY="secret-key",
+        SOURCE_REPUTATION_ABUSEIPDB_MAX_AGE_DAYS=90,
+        SOURCE_REPUTATION_ABUSEIPDB_LISTED_THRESHOLD=75,
+    )
+
+    configs = provider_configs_from_settings(settings)
+
+    assert len(configs) == 5
+
+    spamhaus = next(c for c in configs if c.provider_id == "spamhaus_dqs")
+    assert spamhaus.enabled is True
+    assert spamhaus.query_zone == "example.dq.spamhaus.net"
+
+    abusix = next(c for c in configs if c.provider_id == "abusix_mail")
+    assert abusix.enabled is True
+    assert abusix.query_zone == "combined.mail.abusix.zone"
+
+    spamcop = next(c for c in configs if c.provider_id == "spamcop_scbl")
+    assert spamcop.enabled is True
+    assert spamcop.query_zone == "bl.spamcop.net"
+
+    barracuda = next(c for c in configs if c.provider_id == "barracuda_brbl")
+    assert barracuda.enabled is True
+    assert barracuda.query_zone == "b.barracudacentral.org"
+
+    abuseipdb = next(c for c in configs if c.provider_id == "abuseipdb")
+    assert abuseipdb.enabled is True
+    assert abuseipdb.kind == "api"
+    assert abuseipdb.api_key == "secret-key"
+    assert abuseipdb.max_age_days == 90
+    assert abuseipdb.listed_threshold == 75
+
+
+@patch("app.services.source_reputation_feeds.get_settings")
+def test_provider_configs_from_settings_uses_get_settings_when_none(mock_get_settings):
+    settings = _settings()
+    mock_get_settings.return_value = settings
+
+    configs = provider_configs_from_settings(None)
+
+    mock_get_settings.assert_called_once()
+    assert len(configs) == 5
+    assert all(c.enabled is False for c in configs)


### PR DESCRIPTION
## Summary
- batch settings and workspace onboarding default lookups to avoid per-item database queries
- preserve TLSA association data with spaces after the first three fields
- add focused regression coverage for reputation feed config, TLSA parsing, and TLS report serialization
- update the changelog for the consolidated quality/performance wave

## Supersedes
- incorporates the useful parts of #713, #714, #716, #718, #721, and #725
- intentionally excludes #717 because it removes selector chunking and breaks existing tests
- intentionally excludes #720 because it changes locale semantics and breaks German guidance
- leaves pure code-health/no-op PRs to be closed as superseded

## Local validation
- `/tmp/dmarq-quality-venv/bin/black --check` on changed backend files
- `/tmp/dmarq-quality-venv/bin/isort --check-only` on changed backend files
- `/tmp/dmarq-quality-venv/bin/flake8` on changed backend files
- `cd backend && /tmp/dmarq-quality-venv/bin/pytest app/tests/test_source_reputation_feeds.py app/tests/test_dane.py app/tests/services/test_tls_report_persistence.py app/tests/test_workspace_onboarding.py app/tests/test_settings.py`
