### PR TITLE
Add gated provider demo surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a separately gated `/provider-demo` surface for ISP/MSP and multi-tenant demo workflows, keeping the self-hosted dashboard demo focused on the single-user story.
 - Added focused regression coverage for reputation-feed configuration,
   TLS-report serialization, and TLSA parsing edge cases.
 - Added a Settings account/access milestone readiness summary for #12, separating completed auth/workspace/billing/provider foundations from environment-specific setup gates.

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Protocol boundary:
 - Demo data fills the dashboard, domain details, DNS posture, aggregate reports,
   forensic reports, TLS reports, exports, and linting views
 - The public demo presents the self-hosted, single-user, multi-domain experience
-- Account-management, ISP, and multi-tenant demos are intended for a separate
-  admin/provider demo surface
+- Account-management, ISP, and multi-tenant demos live behind the separate
+  `/provider-demo` surface and require `PROVIDER_DEMO_ENABLED=true`
 - A guided dashboard tour walks through the opinionated product flow from domain
   posture to sender evidence and DNS remediation
 - The public demo is read-only so visitors can explore without modifying data

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     # Self-hosted installs default to a single workspace. Enable this for SaaS,
     # ISP/MSP, or admin deployments that need explicit workspace switching.
     MULTI_WORKSPACE_UI_ENABLED: bool = False
+    # Separate synthetic ISP/MSP demo surface. Keep disabled for the public
+    # self-hosted demo unless a dedicated provider-demo deployment enables it.
+    PROVIDER_DEMO_ENABLED: bool = False
 
     # Database
     # Default to a sub-directory so the SQLite file lives in a location that

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,9 +39,9 @@ from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
 from app.services.mail_connector import initial_import_stats
-from app.services.mailbox_recovery import import_result_diagnostic, import_row_diagnostic
 from app.services.mail_service_imports import mail_service_context_from_domain
 from app.services.mail_source_backfill_worker import run_due_mail_source_backfill_jobs
+from app.services.mailbox_recovery import import_result_diagnostic, import_row_diagnostic
 from app.services.microsoft_graph_client import MicrosoftGraphClient
 from app.services.release_info import build_release_info
 from app.services.report_persistence import hydrate_report_store_from_db
@@ -792,6 +792,14 @@ async def operations_page(request: Request):
     return templates.TemplateResponse(request, "operations.html")
 
 
+@app.get("/provider-demo", response_class=HTMLResponse)
+async def provider_demo_page(request: Request):
+    """Render the separate ISP/MSP/provider demo surface when explicitly enabled."""
+    if not settings.PROVIDER_DEMO_ENABLED:
+        raise HTTPException(status_code=404, detail="Provider demo is not enabled")
+    return templates.TemplateResponse(request, "provider_demo.html")
+
+
 @app.get("/upload", response_class=HTMLResponse)
 async def upload_page(request: Request):
     return templates.TemplateResponse(request, "upload.html")
@@ -1145,11 +1153,16 @@ def _mail_source_connection_state(
 
     diagnostic = import_row_diagnostic(latest_import)
     category = (diagnostic or {}).get("category")
-    if latest_import and latest_import.status == "failed" and category in {
-        "auth_expired",
-        "authentication",
-        "permissions",
-    }:
+    if (
+        latest_import
+        and latest_import.status == "failed"
+        and category
+        in {
+            "auth_expired",
+            "authentication",
+            "permissions",
+        }
+    ):
         return {
             "status": "reauth_required",
             "attention": True,
@@ -1195,7 +1208,9 @@ def _mail_source_status_summary() -> dict:
         enabled_sources = (
             db.query(MailSource).filter(MailSource.enabled == True).all()  # noqa: E712
         )
-        latest_imports = _latest_imports_by_source(db, [int(source.id) for source in enabled_sources])
+        latest_imports = _latest_imports_by_source(
+            db, [int(source.id) for source in enabled_sources]
+        )
         by_method: dict[str, int] = {}
         source_labels = []
         source_statuses = []
@@ -1204,7 +1219,9 @@ def _mail_source_status_summary() -> dict:
             method = (source.method or "IMAP").upper()
             by_method[method] = by_method.get(method, 0) + 1
             source_labels.append(_source_display_label(source))
-            source_statuses.append(_source_status_payload(source, latest_imports.get(int(source.id))))
+            source_statuses.append(
+                _source_status_payload(source, latest_imports.get(int(source.id)))
+            )
             if source.last_checked and (
                 latest_checked is None or source.last_checked > latest_checked
             ):

--- a/backend/app/static/js/provider-demo-page.js
+++ b/backend/app/static/js/provider-demo-page.js
@@ -13,7 +13,7 @@ function providerDemo() {
         },
 
         bindControls() {
-            const root = document.querySelector('[data-provider-demo]');
+            const root = this.$root || this.$el;
             if (!root) return;
             root.addEventListener('click', event => {
                 const refresh = event.target.closest('[data-provider-demo-refresh]');
@@ -39,9 +39,12 @@ function providerDemo() {
             this.loading = true;
             this.error = '';
             try {
+                const controller = new AbortController();
+                const timeout = setTimeout(() => controller.abort(), 10000);
                 const response = await fetch('/api/v1/operator/demo/multi-user', {
                     headers: {Accept: 'application/json'},
-                });
+                    signal: controller.signal,
+                }).finally(() => clearTimeout(timeout));
                 if (!response.ok) {
                     throw new Error('Provider demo data is not available in this deployment.');
                 }
@@ -50,7 +53,9 @@ function providerDemo() {
                 const firstStep = this.journeySteps[0] || {};
                 this.selectStep(firstStep.step || 1);
             } catch (error) {
-                this.error = error.message || 'Provider demo could not be loaded.';
+                this.error = error.name === 'AbortError'
+                    ? 'Provider demo data request timed out.'
+                    : error.message || 'Provider demo could not be loaded.';
                 this.deployment = null;
             } finally {
                 this.loading = false;

--- a/backend/app/static/js/provider-demo-page.js
+++ b/backend/app/static/js/provider-demo-page.js
@@ -267,3 +267,7 @@ function providerDemo() {
         },
     };
 }
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('providerDemo', providerDemo);
+});

--- a/backend/app/static/js/provider-demo-page.js
+++ b/backend/app/static/js/provider-demo-page.js
@@ -1,0 +1,269 @@
+function providerDemo() {
+    return {
+        loading: false,
+        error: '',
+        deployment: null,
+        selectedStepNumber: 1,
+        selectedScenarioId: '',
+        selectedWorkspaceSlug: '',
+
+        init() {
+            this.bindControls();
+            this.load();
+        },
+
+        bindControls() {
+            const root = document.querySelector('[data-provider-demo]');
+            if (!root) return;
+            root.addEventListener('click', event => {
+                const refresh = event.target.closest('[data-provider-demo-refresh]');
+                if (refresh) {
+                    this.load();
+                    return;
+                }
+
+                const stepButton = event.target.closest('[data-provider-demo-step]');
+                if (stepButton) {
+                    this.selectStep(Number(stepButton.dataset.providerDemoStep));
+                    return;
+                }
+
+                const workspaceButton = event.target.closest('[data-provider-demo-workspace]');
+                if (workspaceButton) {
+                    this.selectWorkspace(workspaceButton.dataset.providerDemoWorkspace);
+                }
+            });
+        },
+
+        async load() {
+            this.loading = true;
+            this.error = '';
+            try {
+                const response = await fetch('/api/v1/operator/demo/multi-user', {
+                    headers: {Accept: 'application/json'},
+                });
+                if (!response.ok) {
+                    throw new Error('Provider demo data is not available in this deployment.');
+                }
+                const payload = await response.json();
+                this.deployment = payload.deployment || {};
+                const firstStep = this.journeySteps[0] || {};
+                this.selectStep(firstStep.step || 1);
+            } catch (error) {
+                this.error = error.message || 'Provider demo could not be loaded.';
+                this.deployment = null;
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        get ready() {
+            return Boolean(this.deployment) && !this.loading;
+        },
+
+        get organizations() {
+            return this.deployment?.organizations || [];
+        },
+
+        get journeySteps() {
+            return this.deployment?.journey_steps || [];
+        },
+
+        get viewerScenarios() {
+            return this.deployment?.viewer_scenarios || [];
+        },
+
+        get zoomLevels() {
+            return this.deployment?.zoom_levels || [];
+        },
+
+        get impersonationPolicy() {
+            return this.deployment?.impersonation_policy || {};
+        },
+
+        get selectedStep() {
+            return this.journeySteps.find(step => step.step === this.selectedStepNumber)
+                || this.journeySteps[0]
+                || {};
+        },
+
+        get selectedScenario() {
+            return this.viewerScenarios.find(scenario => scenario.id === this.selectedScenarioId)
+                || this.viewerScenarios.find(scenario => scenario.id === this.selectedStep.scenario_id)
+                || this.viewerScenarios[0]
+                || {};
+        },
+
+        get selectedOrganization() {
+            return this.organizations.find(
+                organization => organization.slug === this.selectedStep.organization_slug,
+            ) || this.organizations[0] || {};
+        },
+
+        get selectedWorkspaces() {
+            return this.selectedOrganization.workspaces || [];
+        },
+
+        get selectedWorkspace() {
+            return this.selectedWorkspaces.find(
+                workspace => workspace.slug === this.selectedWorkspaceSlug,
+            ) || this.selectedWorkspaces[0] || {};
+        },
+
+        get providerOrganization() {
+            return this.organizations.find(
+                organization => organization.billing_mode === 'provider_resale',
+            ) || {};
+        },
+
+        get providerCustomers() {
+            return this.providerOrganization.provider_customers || [];
+        },
+
+        get billingProfile() {
+            return this.selectedOrganization.billing_profile || {};
+        },
+
+        get organizationCount() {
+            return this.organizations.length;
+        },
+
+        get workspaceCount() {
+            return this.organizations.reduce(
+                (total, organization) => total + (organization.workspaces || []).length,
+                0,
+            );
+        },
+
+        get messageVolumeLabel() {
+            const total = this.organizations.reduce((sum, organization) => {
+                return sum + (organization.usage || [])
+                    .filter(row => row.metric === 'aggregate_messages')
+                    .reduce((usageSum, row) => usageSum + Number(row.quantity || 0), 0);
+            }, 0);
+            return this.compactNumber(total);
+        },
+
+        get providerRevenueLabel() {
+            const cents = this.providerCustomers.reduce(
+                (sum, customer) => sum + Number(customer.monthly_charge_cents || 0),
+                0,
+            );
+            return this.formatMoney(cents);
+        },
+
+        get selectedScenarioLabel() {
+            return this.selectedScenario.label || this.selectedStep.label || 'Demo scenario';
+        },
+
+        get selectedStepAction() {
+            return this.selectedStep.action || '';
+        },
+
+        get selectedStepTakeaway() {
+            return this.selectedStep.expected_takeaway || '';
+        },
+
+        get selectedStepDomain() {
+            return this.selectedStep.domain || this.selectedScenario.default_domain || 'No domain';
+        },
+
+        get selectedOrganizationName() {
+            return this.selectedOrganization.name || 'Unknown organization';
+        },
+
+        get selectedOrganizationStory() {
+            return this.selectedOrganization.demo_story || '';
+        },
+
+        get selectedOrganizationBilling() {
+            return this.humanize(this.selectedOrganization.billing_mode || 'unknown');
+        },
+
+        get currentStepZoomLabel() {
+            const zoom = this.zoomLevels.find(level => level.level === this.selectedStep.zoom_level);
+            return zoom?.label || this.humanize(this.selectedStep.zoom_level || 'workspace');
+        },
+
+        get providerCustomerCountLabel() {
+            return `${this.providerCustomers.length} customers`;
+        },
+
+        get impersonationScope() {
+            return this.impersonationPolicy.scope || 'Support access is unavailable.';
+        },
+
+        get supportOperatorLabel() {
+            const org = this.providerOrganization;
+            const user = (org.users || []).find(item => (item.roles || []).includes('provider_operator'));
+            return user ? `${user.name} (${user.email})` : 'Provider operator';
+        },
+
+        get targetUserLabel() {
+            const org = this.providerOrganization;
+            const user = (org.users || []).find(item => item.demo_persona === 'customer-admin');
+            return user ? `${user.name} (${user.email})` : 'Customer admin';
+        },
+
+        selectStep(stepNumber) {
+            const step = this.journeySteps.find(item => item.step === stepNumber) || this.journeySteps[0];
+            if (!step) return;
+            this.selectedStepNumber = step.step;
+            this.selectedScenarioId = step.scenario_id;
+            this.selectedWorkspaceSlug = step.workspace_slug;
+        },
+
+        selectWorkspace(workspaceSlug) {
+            if (!workspaceSlug) return;
+            const matchingStep = this.journeySteps.find(step => step.workspace_slug === workspaceSlug);
+            if (matchingStep) {
+                this.selectStep(matchingStep.step);
+                return;
+            }
+            this.selectedWorkspaceSlug = workspaceSlug;
+        },
+
+        isSelectedStep(step) {
+            return step.step === this.selectedStepNumber;
+        },
+
+        isSelectedWorkspace(workspace) {
+            return workspace.slug === this.selectedWorkspaceSlug;
+        },
+
+        healthClass(health) {
+            return {
+                healthy: 'bg-[#eefaf6] text-[#0f6b4d]',
+                monitoring: 'bg-[#eef3ff] text-[#272a5f]',
+                warning: 'bg-[#fff8e5] text-[#8a5a00]',
+                attention: 'bg-[#fff8e5] text-[#8a5a00]',
+                critical: 'bg-[#fff2ec] text-[#8a2d0d]',
+            }[health] || 'bg-base-200 text-base-content/70';
+        },
+
+        humanize(value) {
+            return String(value || '')
+                .replace(/[_-]+/g, ' ')
+                .replace(/\b\w/g, char => char.toUpperCase());
+        },
+
+        formatNumber(value) {
+            return new Intl.NumberFormat('en-US').format(Number(value || 0));
+        },
+
+        compactNumber(value) {
+            return new Intl.NumberFormat('en-US', {
+                notation: 'compact',
+                maximumFractionDigits: 1,
+            }).format(Number(value || 0));
+        },
+
+        formatMoney(cents) {
+            return new Intl.NumberFormat('en-US', {
+                style: 'currency',
+                currency: 'EUR',
+                maximumFractionDigits: 0,
+            }).format(Number(cents || 0) / 100);
+        },
+    };
+}

--- a/backend/app/templates/provider_demo.html
+++ b/backend/app/templates/provider_demo.html
@@ -66,6 +66,7 @@
                         <button type="button"
                                 class="w-full rounded-md border px-3 py-3 text-left text-sm transition"
                                 :class="isSelectedStep(step) ? 'border-[#272a5f] bg-[#272a5f] text-white' : 'border-base-300 bg-base-100 hover:border-[#39a0aa]'"
+                                :aria-pressed="isSelectedStep(step)"
                                 :data-provider-demo-step="step.step">
                             <span class="block text-xs font-semibold uppercase tracking-wide" x-text="`Step ${step.step}`"></span>
                             <span class="mt-1 block font-semibold" x-text="step.label"></span>
@@ -103,6 +104,7 @@
                                 <button type="button"
                                         class="rounded-lg border p-4 text-left transition"
                                         :class="isSelectedWorkspace(workspace) ? 'border-[#272a5f] bg-[#f3f4ff]' : 'border-base-300 bg-white hover:border-[#39a0aa]'"
+                                        :aria-pressed="isSelectedWorkspace(workspace)"
                                         :data-provider-demo-workspace="workspace.slug">
                                     <div class="flex items-center justify-between gap-3">
                                         <span class="font-semibold" x-text="workspace.name"></span>

--- a/backend/app/templates/provider_demo.html
+++ b/backend/app/templates/provider_demo.html
@@ -1,0 +1,218 @@
+{% extends "layouts/base.html" %}
+
+{% block title %}DMARQ - Provider Demo{% endblock %}
+
+{% block content %}
+<div class="mx-auto max-w-7xl space-y-6" x-data="providerDemo" data-provider-demo>
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+            <p class="text-xs font-semibold uppercase tracking-wide text-[#39a0aa]">Provider demo</p>
+            <h1 class="mt-2 text-3xl font-bold text-[#07071f]">ISP, MSP, and tenant operations</h1>
+            <p class="mt-2 max-w-3xl text-sm text-base-content/70">
+                Separate demo surface for provider operations, customer drill-downs, billing ownership, and audited support access.
+            </p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+            <button type="button"
+                    class="btn btn-outline btn-sm"
+                    data-provider-demo-refresh
+                    :disabled="loading">
+                <span x-show="loading" class="loading loading-spinner loading-xs"></span>
+                Reload
+            </button>
+            <a href="/" class="btn btn-ghost btn-sm">Self-hosted demo</a>
+        </div>
+    </div>
+
+    <div x-show="error"
+         x-cloak
+         role="alert"
+         class="rounded-lg border border-[#ff6f3c]/40 bg-[#fff2ec] p-4 text-sm text-[#8a2d0d]">
+        <span x-text="error"></span>
+    </div>
+
+    <div x-show="loading" class="grid gap-4 md:grid-cols-4">
+        <div class="h-28 animate-pulse rounded-lg bg-base-200"></div>
+        <div class="h-28 animate-pulse rounded-lg bg-base-200"></div>
+        <div class="h-28 animate-pulse rounded-lg bg-base-200"></div>
+        <div class="h-28 animate-pulse rounded-lg bg-base-200"></div>
+    </div>
+
+    <div x-show="ready" x-cloak class="space-y-6">
+        <section class="grid gap-4 md:grid-cols-4">
+            <div class="rounded-lg border border-base-300 bg-base-100 p-5 shadow-sm">
+                <div class="text-sm text-base-content/60">Organizations</div>
+                <div class="mt-2 text-3xl font-semibold" x-text="organizationCount"></div>
+            </div>
+            <div class="rounded-lg border border-base-300 bg-base-100 p-5 shadow-sm">
+                <div class="text-sm text-base-content/60">Workspaces</div>
+                <div class="mt-2 text-3xl font-semibold" x-text="workspaceCount"></div>
+            </div>
+            <div class="rounded-lg border border-base-300 bg-base-100 p-5 shadow-sm">
+                <div class="text-sm text-base-content/60">Monthly usage</div>
+                <div class="mt-2 text-3xl font-semibold" x-text="messageVolumeLabel"></div>
+            </div>
+            <div class="rounded-lg border border-base-300 bg-base-100 p-5 shadow-sm">
+                <div class="text-sm text-base-content/60">Provider ledger</div>
+                <div class="mt-2 text-3xl font-semibold" x-text="providerRevenueLabel"></div>
+            </div>
+        </section>
+
+        <section class="grid gap-6 xl:grid-cols-[18rem_1fr]">
+            <div class="rounded-lg border border-base-300 bg-base-100 p-4 shadow-sm">
+                <h2 class="text-sm font-semibold uppercase tracking-wide text-base-content/60">Demo path</h2>
+                <div class="mt-4 space-y-2">
+                    <template x-for="step in journeySteps" :key="step.step">
+                        <button type="button"
+                                class="w-full rounded-md border px-3 py-3 text-left text-sm transition"
+                                :class="isSelectedStep(step) ? 'border-[#272a5f] bg-[#272a5f] text-white' : 'border-base-300 bg-base-100 hover:border-[#39a0aa]'"
+                                :data-provider-demo-step="step.step">
+                            <span class="block text-xs font-semibold uppercase tracking-wide" x-text="`Step ${step.step}`"></span>
+                            <span class="mt-1 block font-semibold" x-text="step.label"></span>
+                            <span class="mt-1 block text-xs opacity-80" x-text="step.domain"></span>
+                        </button>
+                    </template>
+                </div>
+            </div>
+
+            <div class="space-y-6">
+                <section class="rounded-lg border border-base-300 bg-base-100 p-5 shadow-sm">
+                    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                        <div>
+                            <div class="text-xs font-semibold uppercase tracking-wide text-[#39a0aa]" x-text="currentStepZoomLabel"></div>
+                            <h2 class="mt-1 text-2xl font-semibold" x-text="selectedScenarioLabel"></h2>
+                            <p class="mt-2 max-w-3xl text-sm text-base-content/70" x-text="selectedStepAction"></p>
+                        </div>
+                        <div class="rounded-md bg-base-200 px-3 py-2 text-sm font-semibold" x-text="selectedStepDomain"></div>
+                    </div>
+                    <p class="mt-4 rounded-md border border-[#d7efe8] bg-[#eefaf6] p-3 text-sm text-[#0f6b4d]" x-text="selectedStepTakeaway"></p>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-[1fr_22rem]">
+                    <div class="rounded-lg border border-base-300 bg-base-100 p-5 shadow-sm">
+                        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                                <h2 class="text-lg font-semibold" x-text="selectedOrganizationName"></h2>
+                                <p class="text-sm text-base-content/60" x-text="selectedOrganizationStory"></p>
+                            </div>
+                            <div class="rounded-md bg-base-200 px-3 py-2 text-sm font-semibold" x-text="selectedOrganizationBilling"></div>
+                        </div>
+
+                        <div class="mt-5 grid gap-3 lg:grid-cols-2">
+                            <template x-for="workspace in selectedWorkspaces" :key="workspace.slug">
+                                <button type="button"
+                                        class="rounded-lg border p-4 text-left transition"
+                                        :class="isSelectedWorkspace(workspace) ? 'border-[#272a5f] bg-[#f3f4ff]' : 'border-base-300 bg-white hover:border-[#39a0aa]'"
+                                        :data-provider-demo-workspace="workspace.slug">
+                                    <div class="flex items-center justify-between gap-3">
+                                        <span class="font-semibold" x-text="workspace.name"></span>
+                                        <span class="rounded-full px-2 py-1 text-xs font-semibold"
+                                              :class="healthClass(workspace.health)"
+                                              x-text="workspace.health"></span>
+                                    </div>
+                                    <p class="mt-2 text-xs text-base-content/60" x-text="workspace.domains.join(', ')"></p>
+                                    <ul class="mt-3 list-disc space-y-1 pl-4 text-sm text-base-content/70">
+                                        <template x-for="finding in workspace.primary_findings" :key="finding">
+                                            <li x-text="finding"></li>
+                                        </template>
+                                    </ul>
+                                </button>
+                            </template>
+                        </div>
+                    </div>
+
+                    <aside class="rounded-lg border border-base-300 bg-base-100 p-5 shadow-sm">
+                        <h2 class="text-lg font-semibold">Billing ownership</h2>
+                        <dl class="mt-4 space-y-3 text-sm">
+                            <div>
+                                <dt class="text-base-content/60">Invoice owner</dt>
+                                <dd class="font-semibold" x-text="billingProfile.invoice_owner || 'Unknown'"></dd>
+                            </div>
+                            <div>
+                                <dt class="text-base-content/60">Collection model</dt>
+                                <dd class="font-semibold" x-text="humanize(billingProfile.collection_model)"></dd>
+                            </div>
+                            <div>
+                                <dt class="text-base-content/60">Payment rail</dt>
+                                <dd class="font-semibold" x-text="humanize(billingProfile.payment_rail)"></dd>
+                            </div>
+                            <div>
+                                <dt class="text-base-content/60">Reference</dt>
+                                <dd class="font-mono text-xs" x-text="billingProfile.invoice_reference || 'None'"></dd>
+                            </div>
+                        </dl>
+                    </aside>
+                </section>
+            </div>
+        </section>
+
+        <section class="grid gap-6 xl:grid-cols-2">
+            <div class="rounded-lg border border-base-300 bg-base-100 p-5 shadow-sm">
+                <div class="flex items-center justify-between gap-3">
+                    <h2 class="text-lg font-semibold">Provider customers</h2>
+                    <span class="rounded-full bg-base-200 px-3 py-1 text-xs font-semibold" x-text="providerCustomerCountLabel"></span>
+                </div>
+                <div class="mt-4 overflow-x-auto">
+                    <table class="table table-sm">
+                        <thead>
+                            <tr>
+                                <th>Customer</th>
+                                <th>Status</th>
+                                <th>Plan</th>
+                                <th class="text-right">Messages</th>
+                                <th class="text-right">Monthly</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <template x-for="customer in providerCustomers" :key="customer.external_customer_id">
+                                <tr>
+                                    <td>
+                                        <button type="button"
+                                                class="font-semibold text-[#272a5f] underline-offset-2 hover:underline"
+                                                :data-provider-demo-workspace="customer.workspace_slug"
+                                                x-text="customer.name"></button>
+                                    </td>
+                                    <td x-text="humanize(customer.billing_status)"></td>
+                                    <td x-text="customer.subscription_tier"></td>
+                                    <td class="text-right" x-text="formatNumber(customer.aggregate_messages)"></td>
+                                    <td class="text-right" x-text="formatMoney(customer.monthly_charge_cents)"></td>
+                                </tr>
+                            </template>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="rounded-lg border border-base-300 bg-base-100 p-5 shadow-sm">
+                <h2 class="text-lg font-semibold">Audited support access</h2>
+                <p class="mt-2 text-sm text-base-content/70" x-text="impersonationScope"></p>
+                <div class="mt-4 rounded-md border border-[#f5d38a] bg-[#fff8e5] p-4">
+                    <div class="text-xs font-semibold uppercase tracking-wide text-[#8a5a00]">Demo audit event</div>
+                    <dl class="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+                        <div>
+                            <dt class="text-base-content/60">Operator</dt>
+                            <dd class="font-semibold" x-text="supportOperatorLabel"></dd>
+                        </div>
+                        <div>
+                            <dt class="text-base-content/60">Target user</dt>
+                            <dd class="font-semibold" x-text="targetUserLabel"></dd>
+                        </div>
+                        <div>
+                            <dt class="text-base-content/60">Reason</dt>
+                            <dd class="font-semibold">Customer support walkthrough</dd>
+                        </div>
+                        <div>
+                            <dt class="text-base-content/60">Mode</dt>
+                            <dd class="font-semibold" x-text="humanize(impersonationPolicy.mode)"></dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </section>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/provider-demo-page.js"></script>
+{% endblock %}

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -1,12 +1,16 @@
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 from starlette.requests import Request
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
-from app.main import app, health as root_health, members_page, settings
+from app.main import app
+from app.main import health as root_health
+from app.main import members_page, provider_demo_page, settings
 from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.report import DMARCReport, ReportRecord
@@ -25,8 +29,8 @@ def test_health_check(authed_client: TestClient):
 def test_release_info_endpoint_exposes_safe_build_metadata(authed_client: TestClient, monkeypatch):
     """Release metadata is available for support without exposing secrets."""
     from app.api.api_v1.endpoints import (
-        health as health_endpoint,
-    )  # pylint: disable=import-outside-toplevel
+        health as health_endpoint,  # pylint: disable=import-outside-toplevel
+    )
     from app.core.config import Settings  # pylint: disable=import-outside-toplevel
 
     monkeypatch.setattr(
@@ -70,8 +74,8 @@ def test_release_info_endpoint_exposes_safe_build_metadata(authed_client: TestCl
 def test_release_info_ignores_digest_only_image_references(authed_client: TestClient, monkeypatch):
     """Digest-pinned images do not expose a misleading digest as a tag."""
     from app.api.api_v1.endpoints import (
-        health as health_endpoint,
-    )  # pylint: disable=import-outside-toplevel
+        health as health_endpoint,  # pylint: disable=import-outside-toplevel
+    )
     from app.core.config import Settings  # pylint: disable=import-outside-toplevel
 
     monkeypatch.setattr(
@@ -98,8 +102,8 @@ def test_release_info_ignores_digest_only_image_references(authed_client: TestCl
 def test_release_info_extracts_tag_from_digest_pinned_tag(authed_client: TestClient, monkeypatch):
     """Tag-plus-digest image references still expose the tag for rollout checks."""
     from app.api.api_v1.endpoints import (
-        health as health_endpoint,
-    )  # pylint: disable=import-outside-toplevel
+        health as health_endpoint,  # pylint: disable=import-outside-toplevel
+    )
     from app.core.config import Settings  # pylint: disable=import-outside-toplevel
 
     monkeypatch.setattr(
@@ -126,8 +130,8 @@ def test_release_info_extracts_tag_from_digest_pinned_tag(authed_client: TestCli
 def test_api_health_includes_release_summary(authed_client: TestClient, monkeypatch):
     """The simple API health endpoint exposes the same release metadata family."""
     from app.api.api_v1.endpoints import (
-        health as health_endpoint,
-    )  # pylint: disable=import-outside-toplevel
+        health as health_endpoint,  # pylint: disable=import-outside-toplevel
+    )
     from app.core.config import Settings  # pylint: disable=import-outside-toplevel
 
     monkeypatch.setattr(
@@ -542,6 +546,34 @@ def test_members_page_renders_when_multi_workspace_ui_enabled(monkeypatch):
 
     assert response.status_code == 200
     assert response.template.name == "members.html"
+
+
+def test_provider_demo_page_route_is_registered():
+    """The separate provider demo page is available as a direct route."""
+    assert any(getattr(route, "path", None) == "/provider-demo" for route in app.routes)
+
+
+def test_provider_demo_page_is_hidden_without_feature_flag(monkeypatch):
+    """The provider/MSP demo must not leak into the self-hosted public demo."""
+    monkeypatch.setattr(settings, "PROVIDER_DEMO_ENABLED", False)
+
+    request = Request({"type": "http", "method": "GET", "path": "/provider-demo", "headers": []})
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(provider_demo_page(request))
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Provider demo is not enabled"
+
+
+def test_provider_demo_page_renders_when_feature_flag_enabled(monkeypatch):
+    """Dedicated provider-demo deployments can render the ISP/MSP surface."""
+    monkeypatch.setattr(settings, "PROVIDER_DEMO_ENABLED", True)
+
+    request = Request({"type": "http", "method": "GET", "path": "/provider-demo", "headers": []})
+    response = asyncio.run(provider_demo_page(request))
+
+    assert response.status_code == 200
+    assert response.template.name == "provider_demo.html"
 
 
 def test_reports_upload_invalid_extension(authed_client: TestClient):

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -152,6 +152,14 @@ def _operations_script() -> str:
     return _read_project_file("static", "js", "operations-page.js")
 
 
+def _provider_demo_template() -> str:
+    return _read_project_file("templates", "provider_demo.html")
+
+
+def _provider_demo_script() -> str:
+    return _read_project_file("static", "js", "provider-demo-page.js")
+
+
 def _reports_template() -> str:
     return _read_project_file("templates", "reports.html")
 
@@ -2698,6 +2706,21 @@ def test_dashboard_hides_multi_user_demo_mode_controls():
     assert "Provider billing samples" not in template
     assert "/api/v1/operator/demo/multi-user" not in template
     assert "x-html" not in template
+
+
+def test_provider_demo_is_separate_from_dashboard_controls():
+    template = _provider_demo_template()
+    script = _provider_demo_script()
+    dashboard = _dashboard_template()
+
+    assert "data-provider-demo" in template
+    assert "/api/v1/operator/demo/multi-user" in script
+    assert "/api/v1/operator/demo/multi-user" not in dashboard
+    assert "Provider demo" in template
+    assert "Audited support access" in template
+    assert "providerDemo" in script
+    assert "x-html" not in template
+    assert "innerHTML" not in script
 
 
 def test_dashboard_distinguishes_loading_error_and_empty_states():

--- a/docs/provider-demo.md
+++ b/docs/provider-demo.md
@@ -1,0 +1,29 @@
+# Provider Demo
+
+DMARQ keeps the public demo focused on the self-hosted, single-user, multiple-domain story.
+ISP, MSP, account-management, and multi-tenant workflows are shown through a separate
+provider demo surface.
+
+## Enablement
+
+Set `PROVIDER_DEMO_ENABLED=true` on a dedicated demo deployment and expose `/provider-demo`
+through the desired hostname. The page reads synthetic deployment data from
+`/api/v1/operator/demo/multi-user`, so the deployment must also be configured for demo data.
+
+Do not enable this surface on the standard public demo unless the desired visitor journey is
+the provider/operator story.
+
+## Included Personas
+
+- Single-user account owner managing `dmarq.org` and `dmarq.com`.
+- Managed-service analyst reviewing account, billing, and workspace context.
+- ISP operator reviewing customer workspaces and provider-billed usage.
+- Customer admin shown through explicit demo-only support access.
+- Self-hosted admin comparing local billing ownership and workspace operations.
+
+## Safety Boundaries
+
+- The page is read-only.
+- Support impersonation is displayed as synthetic audited state only.
+- Customer and billing data are generated demo fixtures, not real tenants.
+- DNS/provider writes remain outside this demo surface.


### PR DESCRIPTION
## Summary
- add a separately gated `/provider-demo` page for ISP/MSP and multi-tenant demo workflows
- keep the existing dashboard/self-hosted demo clean by requiring `PROVIDER_DEMO_ENABLED=true` for the new surface
- document the dedicated provider demo deployment mode and add CSP/template separation tests

## Local validation
- `cd backend && /tmp/dmarq-quality-venv/bin/pytest app/tests/test_demo_multi_user_deployment.py app/tests/test_api.py::test_provider_demo_page_route_is_registered app/tests/test_api.py::test_provider_demo_page_is_hidden_without_feature_flag app/tests/test_api.py::test_provider_demo_page_renders_when_feature_flag_enabled app/tests/test_dashboard_template_security.py::test_templates_do_not_reintroduce_csp_blocking_inline_markup app/tests/test_dashboard_template_security.py::test_dashboard_hides_multi_user_demo_mode_controls app/tests/test_dashboard_template_security.py::test_provider_demo_is_separate_from_dashboard_controls`
- `/tmp/dmarq-quality-venv/bin/black --check backend/app/core/config.py backend/app/main.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py`
- `/tmp/dmarq-quality-venv/bin/isort --check-only backend/app/core/config.py backend/app/main.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py`
- `/tmp/dmarq-quality-venv/bin/flake8 backend/app/core/config.py backend/app/main.py backend/app/tests/test_api.py backend/app/tests/test_dashboard_template_security.py`
- `node --check backend/app/static/js/provider-demo-page.js`

Closes part of #312.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a separate provider demo surface at `/provider-demo` for ISP/MSP and multi-tenant workflows.
  * Introduced a feature flag to keep this demo hidden unless explicitly enabled.
  * Added a dedicated demo experience with summary metrics, workflow steps, and support/billing views.

* **Documentation**
  * Updated setup and demo guidance to reflect the new provider demo path and enablement requirements.

* **Bug Fixes**
  * Kept the standard self-hosted demo focused on the single-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->