### PR TITLE
fix: support drill-down for every provider customer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up root directory for clarity
 
 ### Fixed
+- Fixed provider drill-down for suspended customers so an exactly scoped,
+  read-only support session can still inspect customer domains, organizations,
+  and members without reactivating the tenant or permitting mutations.
+- Fixed support-target defaults and labels so the console prefers a primary
+  workspace owner and shows the role that will actually govern the customer
+  session, instead of defaulting to a limited billing or analyst identity.
 - Fixed provider support sessions leaking standalone demo statistics, TLS,
   forensic, mail-source, and DNS-policy fixtures into customer-scoped views.
 - Fixed provider customer provisioning lookups after organization slug

--- a/backend/app/api/api_v1/endpoints/memberships.py
+++ b/backend/app/api/api_v1/endpoints/memberships.py
@@ -29,6 +29,7 @@ from app.services.workspace_access import (
     ROLE_WORKSPACE_OWNER,
     require_organization_permission,
     require_workspace_permission,
+    support_session_allows_inactive_tenant_read,
 )
 from app.services.workspace_audit import record_workspace_audit_log
 
@@ -117,12 +118,18 @@ def _ensure_workspace_accepts_mutation(workspace: Workspace) -> None:
     )
 
 
-def _organization_or_404(db: Session, organization_id: int) -> Organization:
-    organization = (
-        db.query(Organization)
-        .filter(Organization.id == organization_id, Organization.active.is_(True))
-        .first()
-    )
+def _organization_or_404(
+    db: Session,
+    organization_id: int,
+    auth_context: dict,
+) -> Organization:
+    query = db.query(Organization).filter(Organization.id == organization_id)
+    if not support_session_allows_inactive_tenant_read(
+        auth_context,
+        organization_id=organization_id,
+    ):
+        query = query.filter(Organization.active.is_(True))
+    organization = query.first()
     if organization is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -557,7 +564,7 @@ async def list_organization_memberships(
     _auth: dict = Depends(require_admin_auth),
 ) -> MembershipListResponse:
     """List users assigned across one organization."""
-    organization = _organization_or_404(db, organization_id)
+    organization = _organization_or_404(db, organization_id, _auth)
     require_organization_permission(_auth, PERMISSION_MEMBERS_READ, db, organization)
     query = (
         db.query(OrganizationMembership)
@@ -591,7 +598,7 @@ async def upsert_organization_membership(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Payload user_id must match path user_id",
         )
-    organization = _organization_or_404(db, organization_id)
+    organization = _organization_or_404(db, organization_id, _auth)
     require_organization_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, organization)
     user = _user_or_404(db, user_id)
     role = _normalize_role(payload.role, ORGANIZATION_ROLES)
@@ -616,7 +623,7 @@ async def invite_organization_member(
     _auth: dict = Depends(require_admin_auth),
 ) -> MembershipResponse:
     """Invite or link a user by email and assign an organization role."""
-    organization = _organization_or_404(db, organization_id)
+    organization = _organization_or_404(db, organization_id, _auth)
     require_organization_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, organization)
     role = _normalize_role(payload.role, ORGANIZATION_ROLES)
     _require_sso_identity_linking(db, organization, payload)
@@ -646,7 +653,7 @@ async def deactivate_organization_membership(
     _auth: dict = Depends(require_admin_auth),
 ) -> MembershipResponse:
     """Deactivate one organization membership without deleting audit history."""
-    organization = _organization_or_404(db, organization_id)
+    organization = _organization_or_404(db, organization_id, _auth)
     require_organization_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, organization)
     membership = (
         db.query(OrganizationMembership)

--- a/backend/app/api/api_v1/endpoints/operator.py
+++ b/backend/app/api/api_v1/endpoints/operator.py
@@ -241,6 +241,12 @@ async def start_support_session(
         .order_by(BillingAccount.id.asc())
         .first()
     )
+    read_only = (
+        get_settings().DEMO_MODE
+        or payload.access_mode == "read_only"
+        or not workspace.active
+        or (workspace.organization is not None and not workspace.organization.active)
+    )
     token, session = create_support_session_token(
         workspace_id=workspace.id,
         organization_id=workspace.organization_id,
@@ -255,7 +261,7 @@ async def start_support_session(
         ),
         plan_code=(subscription.plan.code if subscription is not None else None),
         plan_label=(subscription.plan.name if subscription is not None else None),
-        read_only=get_settings().DEMO_MODE or payload.access_mode == "read_only",
+        read_only=read_only,
     )
     audit = record_workspace_audit_log(
         db,
@@ -270,6 +276,7 @@ async def start_support_session(
             "target_user_id": target_user.id,
             "target_role": membership.role,
             "reason": payload.reason.strip(),
+            "access_mode": "read_only" if read_only else "role_scoped",
             "expires_at": session["expires_at"],
             "customer_visible": True,
         },

--- a/backend/app/api/api_v1/endpoints/organizations.py
+++ b/backend/app/api/api_v1/endpoints/organizations.py
@@ -18,6 +18,7 @@ from app.services.workspace_access import (
     PERMISSION_AUDIT_READ,
     organization_ids_for_permission,
     require_organization_permission,
+    support_session_allows_inactive_tenant_read,
 )
 
 router = APIRouter()
@@ -53,11 +54,13 @@ async def get_organization(
 ) -> OrganizationResponse:
     """Return one organization summary."""
     bootstrap_default_commercial_foundation(db)
-    organization = (
-        db.query(Organization)
-        .filter(Organization.id == organization_id, Organization.active.is_(True))
-        .first()
-    )
+    query = db.query(Organization).filter(Organization.id == organization_id)
+    if not support_session_allows_inactive_tenant_read(
+        _auth,
+        organization_id=organization_id,
+    ):
+        query = query.filter(Organization.active.is_(True))
+    organization = query.first()
     if organization is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/services/demo_provider_seed.py
+++ b/backend/app/services/demo_provider_seed.py
@@ -168,6 +168,7 @@ def _workspace_role(role: str) -> str:
         "organization_owner": "workspace_owner",
         "organization_admin": "workspace_owner",
         "workspace_admin": "workspace_owner",
+        "security_analyst": "analyst",
         "billing_admin": "auditor",
     }.get(role, role)
 

--- a/backend/app/services/provider_console.py
+++ b/backend/app/services/provider_console.py
@@ -24,6 +24,27 @@ from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog, WorkspaceMembership
 
+SUPPORT_ROLE_PRIORITY = {
+    "workspace_owner": 0,
+    "domain_admin": 1,
+    "operator": 2,
+    "analyst": 3,
+    "auditor": 4,
+}
+ACCOUNT_ROLE_PRIORITY = {
+    "organization_owner": 0,
+    "organization_admin": 1,
+    "workspace_owner": 2,
+    "workspace_admin": 3,
+    "billing_admin": 4,
+    "security_analyst": 5,
+    "domain_admin": 6,
+    "operator": 7,
+    "analyst": 8,
+    "auditor": 9,
+    "organization_auditor": 10,
+}
+
 
 def _iso(value: Optional[datetime]) -> Optional[str]:
     if value is None:
@@ -122,7 +143,9 @@ def _user_rows(
     workspace_memberships: Dict[int, List[WorkspaceMembership]],
 ) -> List[Dict[str, Any]]:
     roles: Dict[int, str] = {}
+    support_roles: Dict[int, str] = {}
     users_by_id: Dict[int, User] = {}
+    primary_workspace_id = workspaces[0].id if workspaces else None
     for membership in organization.memberships:
         if not membership.active or membership.user is None:
             continue
@@ -134,11 +157,17 @@ def _user_rows(
                 continue
             roles.setdefault(membership.user_id, membership.role)
             users_by_id[membership.user_id] = membership.user
+            if workspace.id == primary_workspace_id:
+                support_roles[membership.user_id] = membership.role
     if not roles:
         return []
     users = sorted(
         (users_by_id[user_id] for user_id in roles if user_id in users_by_id),
-        key=lambda user: user.email,
+        key=lambda user: (
+            SUPPORT_ROLE_PRIORITY.get(support_roles.get(user.id, ""), 99),
+            ACCOUNT_ROLE_PRIORITY.get(roles[user.id], 99),
+            user.email,
+        ),
     )
     return [
         {
@@ -146,11 +175,14 @@ def _user_rows(
             "name": user.full_name or user.email,
             "email": user.email,
             "role": roles[user.id],
+            "support_role": support_roles.get(user.id),
             "status": "active" if user.is_active else "inactive",
             "last_active_at": _iso(user.updated_at or user.created_at),
             "mfa_enabled": bool(user.is_verified),
             "can_impersonate": bool(
-                user.is_active and roles[user.id] not in {"auditor", "organization_auditor"}
+                user.is_active
+                and support_roles.get(user.id)
+                and roles[user.id] not in {"auditor", "organization_auditor"}
             ),
         }
         for user in users
@@ -563,7 +595,7 @@ def build_provider_console(
             "target_user_id": user["id"],
             "target_user": user["email"],
             "target_user_name": user["name"],
-            "target_role": user["role"],
+            "target_role": user.get("support_role") or user["role"],
             "health": account["health"],
         }
         for account in accounts

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -372,6 +372,8 @@ def support_session_allows_inactive_tenant_read(
         "support_read_only"
     ):
         return False
+    if workspace_id is None and organization_id is None:
+        return False
     if workspace_id is not None and _workspace_id_from_auth_context(auth_context) != workspace_id:
         return False
     if (

--- a/backend/app/services/workspace_access.py
+++ b/backend/app/services/workspace_access.py
@@ -361,6 +361,27 @@ def _organization_id_from_auth_context(auth_context: dict) -> Optional[int]:
     return organization_id if organization_id > 0 else None
 
 
+def support_session_allows_inactive_tenant_read(
+    auth_context: dict,
+    *,
+    workspace_id: Optional[int] = None,
+    organization_id: Optional[int] = None,
+) -> bool:
+    """Allow read-only support sessions to inspect their exact inactive tenant scope."""
+    if (auth_context or {}).get("auth_type") != "support_session" or not (auth_context or {}).get(
+        "support_read_only"
+    ):
+        return False
+    if workspace_id is not None and _workspace_id_from_auth_context(auth_context) != workspace_id:
+        return False
+    if (
+        organization_id is not None
+        and _organization_id_from_auth_context(auth_context) != organization_id
+    ):
+        return False
+    return True
+
+
 def resolve_authorized_workspace(
     db: Session,
     auth_context: dict,
@@ -377,14 +398,13 @@ def resolve_authorized_workspace(
     if selected_workspace_id is None:
         workspace = assign_default_workspace_to_unscoped_rows(db)
     else:
-        workspace = (
-            db.query(Workspace)
-            .filter(
-                Workspace.id == selected_workspace_id,
-                Workspace.active.is_(True),
-            )
-            .first()
-        )
+        workspace_query = db.query(Workspace).filter(Workspace.id == selected_workspace_id)
+        if not support_session_allows_inactive_tenant_read(
+            auth_context,
+            workspace_id=selected_workspace_id,
+        ):
+            workspace_query = workspace_query.filter(Workspace.active.is_(True))
+        workspace = workspace_query.first()
         if workspace is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -464,15 +484,17 @@ def _support_session_role_for_organization(
     bound_workspace_id = _workspace_id_from_auth_context(auth_context)
     if bound_organization_id != organization.id or bound_workspace_id is None:
         return ""
-    workspace = (
-        db.query(Workspace)
-        .filter(
-            Workspace.id == bound_workspace_id,
-            Workspace.organization_id == organization.id,
-            Workspace.active.is_(True),
-        )
-        .first()
+    workspace_query = db.query(Workspace).filter(
+        Workspace.id == bound_workspace_id,
+        Workspace.organization_id == organization.id,
     )
+    if not support_session_allows_inactive_tenant_read(
+        auth_context,
+        workspace_id=bound_workspace_id,
+        organization_id=organization.id,
+    ):
+        workspace_query = workspace_query.filter(Workspace.active.is_(True))
+    workspace = workspace_query.first()
     if workspace is None:
         return ""
     role = role_for_workspace(db, auth_context, workspace)
@@ -562,11 +584,13 @@ def _support_session_organization_ids_for_permission(
     organization_id = _organization_id_from_auth_context(auth_context)
     if organization_id is None:
         return []
-    organization = (
-        db.query(Organization)
-        .filter(Organization.id == organization_id, Organization.active.is_(True))
-        .first()
-    )
+    organization_query = db.query(Organization).filter(Organization.id == organization_id)
+    if not support_session_allows_inactive_tenant_read(
+        auth_context,
+        organization_id=organization_id,
+    ):
+        organization_query = organization_query.filter(Organization.active.is_(True))
+    organization = organization_query.first()
     if organization is None:
         return []
     role = role_for_organization(db, auth_context, organization, permission)
@@ -597,6 +621,13 @@ def require_organization_permission(
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="This support session is scoped to a different organization",
+            )
+        if (auth_context or {}).get(
+            "support_read_only"
+        ) and permission in TENANT_MUTATION_PERMISSIONS:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="This support session is read-only",
             )
     if role_for_organization(db, auth_context, organization, permission):
         return

--- a/backend/app/static/js/provider-demo-page.js
+++ b/backend/app/static/js/provider-demo-page.js
@@ -995,8 +995,13 @@ function providerDemo() {
         roleLabel(value) {
             return {
                 organization_owner: 'Organisationsinhaber',
+                organization_admin: 'Organisations-Admin',
+                workspace_owner: 'Workspace-Inhaber',
                 workspace_admin: 'Workspace-Admin',
                 security_analyst: 'Security-Analyst',
+                domain_admin: 'Domain-Admin',
+                analyst: 'Analyst',
+                operator: 'Operator',
                 auditor: 'Auditor',
                 billing_admin: 'Billing-Admin',
                 site_manager: 'Site Manager',
@@ -1016,7 +1021,8 @@ function providerDemo() {
         },
 
         impersonationUserOptionLabel(user) {
-            return `${user.name} · ${this.roleLabel(user.role)} · ${user.email}`;
+            const supportRole = user.support_role || user.role;
+            return `${user.name} · ${this.roleLabel(supportRole)} · ${user.email}`;
         },
 
         dateLabel(value) {

--- a/backend/app/tests/test_provider_console.py
+++ b/backend/app/tests/test_provider_console.py
@@ -188,6 +188,33 @@ def test_all_write_permissions_are_registered_as_tenant_mutations():
     assert write_permissions <= workspace_access.TENANT_MUTATION_PERMISSIONS
 
 
+def test_inactive_tenant_support_read_requires_an_exact_scope():
+    auth_context = {
+        "auth_type": "support_session",
+        "support_read_only": True,
+        "workspace_id": 42,
+        "organization_id": 7,
+    }
+
+    assert not workspace_access.support_session_allows_inactive_tenant_read(auth_context)
+    assert workspace_access.support_session_allows_inactive_tenant_read(
+        auth_context,
+        workspace_id=42,
+    )
+    assert workspace_access.support_session_allows_inactive_tenant_read(
+        auth_context,
+        organization_id=7,
+    )
+    assert not workspace_access.support_session_allows_inactive_tenant_read(
+        auth_context,
+        workspace_id=41,
+    )
+    assert not workspace_access.support_session_allows_inactive_tenant_read(
+        auth_context,
+        organization_id=8,
+    )
+
+
 def test_read_only_support_session_scopes_normal_customer_apis(
     client: TestClient,
     db_session: Session,

--- a/backend/app/tests/test_provider_console.py
+++ b/backend/app/tests/test_provider_console.py
@@ -84,6 +84,20 @@ def test_provider_demo_seed_is_idempotent_and_builds_console(db_session: Session
         account for account in console["accounts"] if account["slug"] == "praxis-stadtpark"
     )
     assert praxis["billing"]["status"] == "past_due"
+    retail = next(account for account in console["accounts"] if account["slug"] == "retail-example")
+    assert retail["users"][0]["email"] == "ops@retail.example"
+    assert (
+        next(user for user in retail["users"] if user["email"] == "finance@retail.example")[
+            "support_role"
+        ]
+        == "auditor"
+    )
+    assert (
+        next(user for user in lawfirm["users"] if user["email"] == "security@lawfirm.example")[
+            "support_role"
+        ]
+        == "analyst"
+    )
 
 
 def test_provider_console_uses_a_fixed_bulk_query_budget(db_session: Session):
@@ -311,6 +325,70 @@ def test_operator_can_start_and_end_audited_role_scoped_session(
     )
     assert ended_audit.actor_type == "provider_operator"
     assert ended_audit.actor_id == str(started.json()["session"]["operator"]["id"])
+
+
+def test_every_seeded_customer_support_session_can_read_its_tenant_scope(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch,
+):
+    seed_demo_provider_database(db_session)
+    console = build_provider_console(db_session, demo_mode=True)
+    api_key = "provider-console-all-customer-support-test-key"
+    add_api_key(api_key)
+    monkeypatch.setattr(get_settings(), "DEMO_MODE", False)
+
+    for account in console["accounts"]:
+        target = next(user for user in account["users"] if user["can_impersonate"])
+        started = client.post(
+            "/api/v1/operator/support-session",
+            headers={"X-API-Key": api_key},
+            json={
+                "workspace_id": account["workspace_id"],
+                "target_user_id": target["id"],
+                "reason": f"Verify support scope for {account['slug']}",
+                "access_mode": "role_scoped",
+            },
+        )
+        assert started.status_code == 200, account["slug"]
+        assert started.json()["session"]["read_only"] is (account["slug"] == "praxis-stadtpark")
+
+        workspaces = client.get("/api/v1/workspaces")
+        organizations = client.get("/api/v1/organizations")
+        organization = client.get(f"/api/v1/organizations/{account['organization_id']}")
+        domains = client.get("/api/v1/domains/summary")
+        members = client.get(f"/api/v1/memberships/organizations/{account['organization_id']}")
+
+        assert workspaces.status_code == 200, account["slug"]
+        assert [row["slug"] for row in workspaces.json()["workspaces"]] == [account["slug"]]
+        assert organizations.status_code == 200, account["slug"]
+        assert [row["slug"] for row in organizations.json()["organizations"]] == [account["slug"]]
+        assert organization.status_code == 200, account["slug"]
+        assert organization.json()["organization"]["slug"] == account["slug"]
+        assert domains.status_code == 200, account["slug"]
+        assert {row["domain_name"] for row in domains.json()["domains"]} == {
+            domain["name"] for domain in account["domains"]
+        }
+        assert members.status_code == 200, account["slug"]
+        assert members.json()["memberships"]
+
+        if account["slug"] == "praxis-stadtpark":
+            blocked_mutation = client.post(
+                f"/api/v1/memberships/organizations/{account['organization_id']}/invites",
+                json={
+                    "email": "blocked@praxis.example",
+                    "role": "organization_owner",
+                },
+            )
+            assert blocked_mutation.status_code == 403
+            assert blocked_mutation.json()["detail"] == "This support session is read-only"
+
+        ended = client.delete(
+            "/api/v1/operator/support-session",
+            headers={"X-API-Key": api_key},
+        )
+        assert ended.status_code == 200, account["slug"]
+        assert ended.json()["active"] is False
 
 
 def test_support_session_cookie_is_cleared_when_workspace_was_removed(client: TestClient):

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -1341,6 +1341,56 @@ test('provider demo supports site-manager account management and full customer i
   await expect(page.locator('[data-provider-demo-expression-error]')).toBeHidden();
 });
 
+test('provider demo can enter every seeded customer support scope', async ({ page }) => {
+  test.setTimeout(120_000);
+  test.skip(!realProviderBackend, 'requires the relational provider-demo backend');
+
+  const expectedAccounts = {
+    'bakery-example': { domains: ['bakery.example'], owner: 'anna@bakery.example' },
+    'feldwerk-logistics': { domains: ['feldwerk.example'], owner: 'jonas@feldwerk.example' },
+    'lawfirm-example': {
+      domains: ['lawfirm.example', 'secure.lawfirm.example'],
+      owner: 'admin@lawfirm.example',
+    },
+    'retail-example': {
+      domains: ['retail.example', 'shop.retail.example'],
+      owner: 'ops@retail.example',
+    },
+    'studio-example': {
+      domains: ['alerts.studio.example', 'studio.example'],
+      owner: 'elena@studio.example',
+    },
+    'praxis-stadtpark': { domains: ['praxis.example'], owner: 'nele@praxis.example' },
+  };
+
+  for (const [accountSlug, expected] of Object.entries(expectedAccounts)) {
+    await page.goto('/provider-demo#accounts');
+    const accountRow = page.locator(`[data-provider-account-row="${accountSlug}"]`);
+    await expect(accountRow).toBeVisible();
+    await accountRow.getByRole('button', { name: 'Account öffnen', exact: true }).click();
+    await page.getByRole('button', { name: 'Kundenansicht öffnen' }).click();
+
+    const supportDialog = page.getByRole('dialog', { name: 'Kundenansicht öffnen' });
+    await expect(supportDialog.getByLabel('Ansicht als')).not.toHaveValue('');
+    await supportDialog.getByLabel('Grund').fill(`Support-Scope für ${accountSlug} prüfen`);
+    await supportDialog.getByRole('button', { name: 'Support-Sitzung starten' }).click();
+
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.locator('[data-support-session-banner]')).toBeVisible();
+    await page.goto('/domains');
+    for (const domain of expected.domains) {
+      const domainRow = page.getByRole('row').filter({
+        has: page.getByText(domain, { exact: true }),
+      });
+      await expect(domainRow).toBeVisible();
+    }
+    await page.goto('/members');
+    await expect(page.getByRole('table').getByText(expected.owner, { exact: true })).toBeVisible();
+    await page.locator('[data-support-session-exit]').click();
+    await expect(page).toHaveURL(/\/provider-demo#accounts$/);
+  }
+});
+
 test('production provider mode persists a customer and opens its role-scoped product view', async ({ page }) => {
   test.setTimeout(60_000);
   test.skip(!productProviderBackend, 'requires a fresh production provider backend');

--- a/docs/provider-demo.md
+++ b/docs/provider-demo.md
@@ -97,6 +97,15 @@ Public provider demos force read-only access. A production provider operator may
 request role-scoped access; the target user's normal RBAC still applies. Read-only
 sessions can inspect membership and mail-source status but cannot invite users,
 change roles, alter connectors, mutate domains, or perform provider/DNS writes.
+The target selector prefers an eligible owner of the account's primary workspace
+and labels each option with the effective workspace role used by the session.
+Selecting a more limited user deliberately preserves that user's narrower RBAC.
+
+Suspended or inactive customer accounts remain available for diagnosis through
+an exactly bound read-only support session. DMARQ does not reactivate the account:
+it permits scoped reads of the inactive organization and workspace, forces the
+session to read-only even if role-scoped access was requested, and rejects tenant
+mutations before any account data can change.
 
 ## Safety Boundaries
 


### PR DESCRIPTION
## Summary

- allow exactly scoped read-only support sessions to inspect suspended customer workspaces and organizations without reactivating them
- force inactive-customer support sessions to read-only and block organization mutations as well as workspace mutations
- prefer a primary workspace owner as the default support target and expose the effective support role in the selector
- align seeded security-analyst memberships with the product's analyst role mapping
- add backend and real-browser coverage across all six seeded provider customers

## Root cause

The provider console offered the suspended Praxis account as a valid support target, but normal workspace resolution filtered inactive workspaces after the session started. The account therefore entered support mode but failed on customer APIs with `Selected workspace not found`. Separately, support targets were sorted by email and displayed their organization role, so Retail defaulted to a billing user whose effective workspace role was auditor and could not open the complete customer management view.

## Safety

Inactive customers remain inactive. Their support sessions are forced to read-only, remain bound to one signed organization/workspace/user scope, and reject tenant mutations before data can change.

## Validation

- `1921 passed` full backend suite
- `78 passed` focused organization/workspace/membership/provider suite
- `2 passed` relational provider-demo browser flows, including Domains and Members for every seeded customer
- `1 passed` fresh production CKLNet provider browser flow
- `11 passed, 3 skipped` general Chromium smoke
- Black, Flake8, JavaScript syntax check, CSS build, and `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Support sessions can now inspect suspended customer accounts without reactivating them.
  * Suspended-account sessions are automatically read-only, preventing changes to customer data.
  * Customer support targets now prioritize the primary workspace owner.
  * Support-session labels now show the effective workspace role, improving clarity when selecting access.
* **Documentation**
  * Clarified support-session behavior for inactive accounts and role-based access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->