### PR TITLE
ci: include multi demo in GitOps promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,7 +395,8 @@ jobs:
           cmd: |
             for manifest in \
               k8s-cluster-state/apps/dmarq/greenfield-preprod/dmarq-stack.yaml \
-              k8s-cluster-state/apps/dmarq/greenfield-demo/dmarq-stack.yaml
+              k8s-cluster-state/apps/dmarq/greenfield-demo/dmarq-stack.yaml \
+              k8s-cluster-state/apps/dmarq/greenfield-demo-multi/dmarq-stack.yaml
             do
               test -f "$manifest"
               yq -i '(.. | select(tag == "!!str") | select(test(strenv(IMAGE_PATTERN)))) = strenv(IMAGE)' \
@@ -413,7 +414,8 @@ jobs:
           git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${{ env.K8S_STATE_REPO }}.git"
           git add \
             apps/dmarq/greenfield-preprod/dmarq-stack.yaml \
-            apps/dmarq/greenfield-demo/dmarq-stack.yaml
+            apps/dmarq/greenfield-demo/dmarq-stack.yaml \
+            apps/dmarq/greenfield-demo-multi/dmarq-stack.yaml
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -93,6 +93,23 @@ def test_release_workflow_skips_gitops_for_stale_main_runs():
     ) in workflow
 
 
+def test_release_workflow_promotes_multi_user_demo_with_nonprod():
+    """Every release must keep the separate provider demo on the current image."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    manifest = "apps/dmarq/greenfield-demo-multi/dmarq-stack.yaml"
+
+    update_step = workflow.split("- name: Update image tags in GitOps manifests", maxsplit=1)[
+        1
+    ].split("- name: Commit and push manifest update", maxsplit=1)[0]
+    commit_step = workflow.split("- name: Commit and push manifest update", maxsplit=1)[1].split(
+        "promote-prod:", maxsplit=1
+    )[0]
+
+    assert manifest in update_step
+    assert manifest in commit_step
+    assert workflow.count(manifest) == 2
+
+
 def test_release_workflow_dispatches_gitops_deploy_after_release():
     """Semantic-release commits must trigger the deploy workflow explicitly."""
     workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed
- include the provider/multi-user demo manifest in non-production image promotion
- stage the manifest in the automated GitOps commit
- add a regression test covering both workflow steps

## Why
Release v1.169.1 exposed that demo-multi remained on an older image while the single-user demo and preprod manifests advanced. The workflow knew only the original two non-production manifests.

## Validation
- `.venv/bin/pytest backend/app/tests/test_release_rollout_script.py -q` (6 passed)
- workflow YAML parse
- Black and Flake8
- `git diff --check`