### PR TITLE
test(main): drive shutdown handler inside event loop (#755)

### DIFF
--- a/backend/app/tests/test_shutdown.py
+++ b/backend/app/tests/test_shutdown.py
@@ -1,0 +1,57 @@
+"""Tests for the FastAPI shutdown event handler in app.main."""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from app import main
+from app.main import app
+
+
+class _RaisingTask:
+    """Awaitable stand-in for the polling task whose await raises exc."""
+
+    def __init__(self, exc):
+        self._exc = exc
+        self.cancel_called = False
+
+    def cancel(self):
+        self.cancel_called = True
+
+    def __await__(self):
+        raise self._exc
+        yield
+
+
+def _shutdown_handler():
+    return next(
+        handler
+        for handler in app.router.on_shutdown
+        if getattr(handler, "__name__", "") == "shutdown_event"
+    )
+
+
+def test_shutdown_event_logs_cancelled_error(monkeypatch, caplog):
+    monkeypatch.setattr(main, "_cancel_background_task", AsyncMock())
+    monkeypatch.setattr(main, "mark_scheduler_stopped", MagicMock())
+    task = _RaisingTask(asyncio.CancelledError())
+    monkeypatch.setattr(main, "background_task", task)
+
+    handler = _shutdown_handler()
+    with caplog.at_level("INFO"):
+        asyncio.run(handler())
+
+    assert task.cancel_called
+    assert "cancelled successfully" in caplog.text
+
+
+def test_shutdown_event_logs_unexpected_exception(monkeypatch, caplog):
+    monkeypatch.setattr(main, "_cancel_background_task", AsyncMock())
+    monkeypatch.setattr(main, "mark_scheduler_stopped", MagicMock())
+    task = _RaisingTask(RuntimeError("boom"))
+    monkeypatch.setattr(main, "background_task", task)
+
+    handler = _shutdown_handler()
+    with caplog.at_level("INFO"):
+        asyncio.run(handler())
+
+    assert task.cancel_called
+    assert "Unexpected error" in caplog.text


### PR DESCRIPTION
## Description
Fixes the two failing shutdown tests in test_shutdown.py. They were failing with "no current event loop" because the async shutdown handler was being run without an event loop. Now the tests run it properly using asyncio.run, and both branches (cancelled task and unexpected error) are checked.

## Related Issue
Part of #755

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Rewrote test_shutdown.py to run the shutdown handler inside a real event loop
- Added a test for the CancelledError case
- Added a test for the unexpected-exception case

## Testing
- Ran the full backend test suite: 1926 passed, 0 failed
- No app code changed, only the test file

## Notes
- Verified two things from #755 are NOT bugs: the billing_contact_email column (model + migration both exist) and the "empty except" (it already logs errors).
- The N+1 query and the datetime/Starlette deprecation warnings are left for separate follow-up issues, as the issue asked.