### PR TITLE
fix: make Docker greenfield installation reliable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,196 +1,132 @@
-# DMARQ Environment Variables
+# DMARQ environment template
 #
-# Copy this file to .env and fill in the values for your environment
-# Example: cp .env.example .env
+# For Docker Compose, create the real .env and generate stable local secrets:
+#   ./scripts/bootstrap-docker-env.sh
+#
+# Keep the generated .env out of source control. Kubernetes, Coolify, and other
+# deployments may inject the same application variables through their own
+# secret manager instead.
 
-# Application Settings
+# Docker Compose host binding. The secure default is reachable only from this
+# host. Set DMARQ_BIND_ADDRESS=0.0.0.0 only when a firewall or reverse proxy
+# protects the instance.
+DMARQ_BIND_ADDRESS="127.0.0.1"
+DMARQ_PORT=8080
+
+# docker-stable is the tested installation channel. Pin a release or SHA tag
+# for reproducible production upgrades. docker-latest is the main-branch preview
+# channel; development builds use docker-compose.build.yml.
+DMARQ_IMAGE="ghcr.io/christianlouis/dmarq:docker-stable"
+
+# PostgreSQL container. The bootstrap script replaces both placeholders with
+# one URL-safe generated password so these values remain consistent.
+POSTGRES_DB="dmarq"
+POSTGRES_USER="dmarq"
+POSTGRES_PASSWORD="CHANGE_THIS_DOCKER_POSTGRES_PASSWORD"
+DATABASE_URL="postgresql://dmarq:CHANGE_THIS_DOCKER_POSTGRES_PASSWORD@db:5432/dmarq"
+
+# Application settings
 PROJECT_NAME="DMARQ"
-
-# SECURITY: Generate a secure random secret key
-# Use: openssl rand -hex 32
-# NEVER use the default value in production!
-SECRET_KEY="CHANGE_THIS_TO_A_RANDOM_SECRET_IN_PRODUCTION"
-
-# Admin API Key for the X-API-Key header (optional)
-# If set, this key is used instead of generating a random one at startup.
-# Generate with: openssl rand -hex 32
-# If not set, a random key is generated each restart (key length logged only).
-# ADMIN_API_KEY="your_admin_api_key_here"
-
-# Environment (development/production)
-# Affects HSTS and other security settings
 ENVIRONMENT="development"
+DEMO_MODE=false
+PUBLIC_BASE_URL="http://localhost:8080"
+LANGUAGE="en"
 
-# Optional CSP hardening.
-# First run with CSP_REPORT_ONLY=true and inspect browser/report logs. Only set
-# CSP_ENFORCE_STRICT=true after validating that your UI runtime works without
-# unsafe-inline or unsafe-eval.
-# CSP_REPORT_ONLY=false
-# CSP_ENFORCE_STRICT=false
+# Stable application secrets. The bootstrap script replaces these placeholders.
+SECRET_KEY="CHANGE_THIS_TO_A_RANDOM_SECRET_IN_PRODUCTION"
+ADMIN_API_KEY="CHANGE_THIS_TO_A_RANDOM_ADMIN_API_KEY"
 
-# Public URL used for OAuth callbacks when DMARQ is behind a proxy/ingress.
-# PUBLIC_BASE_URL="https://app.example.com"
+# The local Compose quick start is a single-user instance on 127.0.0.1 and does
+# not require a login. Before exposing DMARQ, configure Logto/OIDC/trusted-proxy
+# auth and switch these values; production startup rejects unsafe auth-disabled
+# deployments unless ALLOW_AUTH_DISABLED_IN_PRODUCTION=true is explicitly set.
+AUTH_MODE="disabled"
+AUTH_DISABLED=true
+ALLOW_AUTH_DISABLED_IN_PRODUCTION=false
 
-# Default language for operator-facing guidance. English is the source and
-# fallback language; German remediation guidance is available for the highest
-# value DNS findings.
-# LANGUAGE="en"
-# DMARQ_DEFAULT_LOCALE="en"
+# CORS is normally same-origin. Add explicit browser origins only when a
+# separately hosted frontend needs API access.
+BACKEND_CORS_ORIGINS="http://localhost:8080"
 
-# Self-hosted installs default to a single visible workspace. Enable this for
-# SaaS, ISP/MSP, or operator deployments that need workspace switching and
-# member management in the UI.
-# MULTI_WORKSPACE_UI_ENABLED=false
-# Provider-console identity for persistent ISP/MSP installations.
-# PROVIDER_DISPLAY_NAME="DMARQ Provider"
-# PROVIDER_SLUG="dmarq-provider"
-# Comma-separated deployment-wide site managers. This does not grant tenant
-# users provider access merely because multi-workspace mode is enabled.
+# Self-hosted installs default to one visible workspace. Provider installations
+# can enable the production multi-workspace interface independently of Compose.
+MULTI_WORKSPACE_UI_ENABLED=false
+PROVIDER_DEMO_ENABLED=false
 # PROVIDER_OPERATOR_EMAILS="operator@example.com"
-# Create the three missing DMARQ provider starter plans once at startup without
-# changing plans that already exist.
 # PROVIDER_BOOTSTRAP_DEFAULT_PLANS=false
-# Enable only on a dedicated synthetic provider-demo deployment together with
-# DEMO_MODE=true. Production provider installations keep this false.
-# PROVIDER_DEMO_ENABLED=false
 
-# Database
-DATABASE_URL="sqlite:///./dmarq.db"
-# For production, use PostgreSQL:
-# DATABASE_URL="postgresql://user:password@localhost/dmarq"
+# Optional legacy IMAP bootstrap. Prefer adding mail sources in the web UI,
+# where each mailbox has its own interval and import history. Leave these blank
+# to avoid creating a fake mail source during first startup.
+# IMAP_SERVER="imap.gmail.com"
+# IMAP_PORT=993
+# IMAP_USERNAME="dmarc-reports@example.com"
+# IMAP_PASSWORD="use-an-app-password-or-secret-manager"
+# IMAP_FOLDER="INBOX"
+DELETE_IMPORTED_EMAILS=false
 
-# IMAP Settings for DMARC Report Retrieval
-IMAP_SERVER="mail.example.com"  # Required for IMAP polling
-IMAP_PORT=993                   # Default for SSL
-IMAP_USERNAME="dmarc@example.com"
-IMAP_PASSWORD="your_imap_password" # Consider using a secrets manager in production
-
-# CORS Origins (comma separated)
-# SECURITY: Be specific - avoid wildcards in production
-BACKEND_CORS_ORIGINS="http://localhost:3000,http://localhost:5173"
-# For production:
-# BACKEND_CORS_ORIGINS="https://yourdomain.com"
-
-# Admin User (first-time setup)
-FIRST_SUPERUSER="admin@example.com"
-FIRST_SUPERUSER_PASSWORD="adminpassword"
-
-# Optional DNS provider integrations
-# CLOUDFLARE_API_TOKEN="your_cloudflare_api_token"
-# CLOUDFLARE_ZONE_ID="your_cloudflare_zone_id"
-# Optional one-click Cloudflare connector. The in-product rights profile controls
-# requested scopes: read-only asks for zone.read/dns.read, Radar profiles also
-# ask for radar.read, and full repair also asks for dns.write. Leave
-# CLOUDFLARE_OAUTH_SCOPES unset unless you intentionally need a legacy fixed
-# scope request when no profile is supplied.
-# CLOUDFLARE_OAUTH_CLIENT_ID="your_cloudflare_oauth_client_id"
-# CLOUDFLARE_OAUTH_CLIENT_SECRET="your_cloudflare_oauth_client_secret"
-# CLOUDFLARE_OAUTH_SCOPES=""
-# HETZNER_DNS_API_TOKEN="your_hetzner_read_only_api_token"
-# HETZNER_API_TOKEN="your_hetzner_read_only_api_token"
-# LINODE_API_TOKEN="your_linode_domains_read_only_token"
-# LINODE_TOKEN="your_linode_domains_read_only_token"
-# Route 53 zone import uses the standard boto3/AWS credential chain.
-# Prefer DMARQ_ROUTE53_ROLE_ARN with DMARQ_ROUTE53_EXTERNAL_ID in hosted setups.
-# AWS_PROFILE="your_local_read_only_profile"
-# DMARQ_ROUTE53_PROFILE="your_local_read_only_profile"
-# DMARQ_ROUTE53_ROLE_ARN="arn:aws:iam::123456789012:role/dmarq-route53-readonly"
-# DMARQ_ROUTE53_EXTERNAL_ID="customer-or-instance-external-id"
-# Akamai Edge DNS / FastDNS zone import uses EdgeGrid credentials.
-# Prefer an .edgerc file or inject these values through 1Password/secrets.
-# AKAMAI_EDGERC_PATH="/run/secrets/edgerc"
-# AKAMAI_EDGERC_SECTION="default"
-# AKAMAI_HOST="akab-example.luna.akamaiapis.net"
-# AKAMAI_CLIENT_TOKEN="your_akamai_client_token"
-# AKAMAI_CLIENT_SECRET="your_akamai_client_secret"
-# AKAMAI_ACCESS_TOKEN="your_akamai_access_token"
-# AKAMAI_ACCOUNT_SWITCH_KEY="optional_account_switch_key"
-# Akamai ETP resolver profile. Keep account-specific resolver values in
-# 1Password/Kubernetes secrets; do not commit real resolver addresses.
-# AKAMAI_ETP_DNS_SERVERS="resolver-ip-1,resolver-ip-2,resolver-ipv6-1,resolver-ipv6-2"
-# AKAMAI_ETP_DOH_HOSTNAME="your-doh-hostname"
-# AKAMAI_ETP_DOT_HOSTNAME="your-dot-hostname"
-# AKAMAI_ETP_PROXY_CHAINING_URL="https://your-proxy-chaining-hostname:443"
-# Enterprise or custom resolver profiles. Keep concrete enterprise endpoints in
-# 1Password/Kubernetes secrets and select the matching profile in settings.
-# INFOBLOX_DNS_SERVERS="resolver-ip-1,resolver-ip-2"
-# INFOBLOX_DOH_HOSTNAME="resolver.example.net"
-# INFOBLOX_DOT_HOSTNAME="resolver.example.net"
-# DMARQ_DNS_CUSTOM_SERVERS="resolver-ip-1,resolver-ip-2"
-# DMARQ_DNS_CUSTOM_DOH_HOSTNAME="resolver.example.net"
-# DMARQ_DNS_CUSTOM_DOT_HOSTNAME="resolver.example.net"
-
-# Authentication
-# AUTH_MODE options: auto, disabled, logto, authentik, oidc, trusted_proxy
-# AUTH_MODE="auto"
-# AUTH_DISABLED=false
-
-# Logto OIDC
+# Public URL and provider callbacks
 # LOGTO_ENDPOINT="https://your-tenant.logto.app"
 # LOGTO_APP_ID="your_logto_app_id"
 # LOGTO_APP_SECRET="your_logto_app_secret"
 # LOGTO_REDIRECT_URI="https://app.example.com/api/v1/auth/callback"
 
-# Authentik direct OIDC
 # AUTH_MODE="authentik"
+# AUTH_DISABLED=false
 # AUTHENTIK_ISSUER_URL="https://idp.example.com/application/o/dmarq"
 # AUTHENTIK_CLIENT_ID="your_authentik_client_id"
 # AUTHENTIK_CLIENT_SECRET="your_authentik_client_secret"
 # AUTHENTIK_REDIRECT_URI="https://app.example.com/api/v1/auth/callback"
 # AUTHENTIK_ALLOWED_DOMAINS="example.com"
-# Optional group-to-role mappings. Syntax: group-name=target-slug:role
-# AUTHENTIK_GROUP_WORKSPACE_ROLE_MAP="dmarq-admins=primary:workspace_owner,dmarq-analysts=primary:analyst"
-# AUTHENTIK_GROUP_ORGANIZATION_ROLE_MAP="dmarq-admins=customer-one:organization_owner"
 
-# Authentik Outpost / trusted proxy mode.
-# Only enable when DMARQ is reachable exclusively through that proxy.
 # AUTH_MODE="trusted_proxy"
+# AUTH_DISABLED=false
 # AUTH_TRUSTED_PROXY_EMAIL_HEADER="X-Authentik-Email"
 # AUTH_TRUSTED_PROXY_SUBJECT_HEADER="X-Authentik-Uid"
 # AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS="example.com"
-# AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP="dmarq-admins=primary:workspace_owner"
-# AUTH_TRUSTED_PROXY_GROUP_ORGANIZATION_ROLE_MAP="dmarq-admins=customer-one:organization_owner"
 
-# Generic OIDC for Keycloak, Entra ID, Google Workspace, Okta, and similar.
 # AUTH_MODE="oidc"
+# AUTH_DISABLED=false
 # OIDC_PROVIDER_LABEL="Keycloak"
 # OIDC_ISSUER_URL="https://idp.example.com/realms/dmarq"
 # OIDC_CLIENT_ID="dmarq"
 # OIDC_CLIENT_SECRET="your_oidc_client_secret"
+# OIDC_REDIRECT_URI="https://app.example.com/api/v1/auth/callback"
 # OIDC_ALLOWED_EMAILS="admin@example.com"
-# OIDC_GROUP_WORKSPACE_ROLE_MAP="dmarq-admins=primary:workspace_owner"
-# OIDC_GROUP_ORGANIZATION_ROLE_MAP="dmarq-admins=customer-one:organization_owner"
 
-# Optional mail service sender-domain discovery
-# POSTMARK_ACCOUNT_TOKEN="your_postmark_account_token"
+# Optional DNS provider integrations. Keep real values in 1Password or your
+# deployment secret manager and use read-only scopes until a reviewed write is
+# intentionally approved.
+# CLOUDFLARE_API_TOKEN="your_cloudflare_api_token"
+# CLOUDFLARE_ZONE_ID="your_cloudflare_zone_id"
+# CLOUDFLARE_OAUTH_CLIENT_ID="your_cloudflare_oauth_client_id"
+# CLOUDFLARE_OAUTH_CLIENT_SECRET="your_cloudflare_oauth_client_secret"
+# HETZNER_DNS_API_TOKEN="your_hetzner_read_only_api_token"
+# LINODE_API_TOKEN="your_linode_domains_read_only_token"
+# AWS_PROFILE="your_local_read_only_profile"
+# DMARQ_ROUTE53_ROLE_ARN="arn:aws:iam::123456789012:role/dmarq-route53-readonly"
+# DMARQ_ROUTE53_EXTERNAL_ID="customer-or-instance-external-id"
+# AKAMAI_EDGERC_PATH="/run/secrets/edgerc"
+# AKAMAI_EDGERC_SECTION="default"
+# AKAMAI_ETP_DNS_SERVERS="resolver-ip-1,resolver-ip-2"
+# AKAMAI_ETP_DOH_HOSTNAME="your-doh-hostname"
+# AKAMAI_ETP_DOT_HOSTNAME="your-dot-hostname"
+# INFOBLOX_DNS_SERVERS="resolver-ip-1,resolver-ip-2"
+# DMARQ_DNS_CUSTOM_SERVERS="resolver-ip-1,resolver-ip-2"
+# DMARQ_DNS_CUSTOM_DOH_HOSTNAME="resolver.example.net"
 
-# Sender IP network enrichment
-# Uses cached Team Cymru DNS lookups to show ASN, BGP prefix, registry, and
-# likely network operator for observed sending IPs.
-# SOURCE_NETWORK_ENRICHMENT_ENABLED=true
-# SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS=86400
-# SOURCE_NETWORK_ENRICHMENT_MAX_IPS=100
-# Optional API-backed source IP enrichment. When set, these are preferred over
-# the public Team Cymru DNS fallback and can add ASN, provider, city, and
-# Cloudflare Radar context to domain/report source tables.
+# Optional source intelligence. These services are not required to parse DMARC.
+SOURCE_NETWORK_ENRICHMENT_ENABLED=true
 # IPINFO_TOKEN="your_ipinfo_lite_token"
-# IPINFO_TIMEOUT_SECONDS=2
 # IPGEOLOCATION_API_KEY="your_ipgeolocation_api_key"
-# IPGEOLOCATION_TIMEOUT_SECONDS=2
 # CLOUDFLARE_RADAR_API_TOKEN="your_cloudflare_radar_read_token"
-# CLOUDFLARE_RADAR_TIMEOUT_SECONDS=2
-
-# Optional sender IP reputation feeds
-# Disabled by default. Enable only after reviewing provider terms, credentials,
-# query limits, and privacy implications for sending observed source IPs to
-# external reputation providers.
-# SOURCE_REPUTATION_FEEDS_ENABLED=false
+SOURCE_REPUTATION_FEEDS_ENABLED=false
 # SOURCE_REPUTATION_FEEDS="spamhaus_dqs,abusix_mail,spamcop_scbl,barracuda_brbl,abuseipdb"
 # SOURCE_REPUTATION_SPAMHAUS_DQS_ZONE="your-dqs-zone.example"
-# SOURCE_REPUTATION_ABUSIX_ZONE="combined.mail.abusix.zone"
 # SOURCE_REPUTATION_ABUSEIPDB_API_KEY=""
-# SOURCE_REPUTATION_ABUSEIPDB_MAX_AGE_DAYS=90
-# SOURCE_REPUTATION_ABUSEIPDB_LISTED_THRESHOLD=75
-# SOURCE_REPUTATION_FEED_TIMEOUT_SECONDS=2
-# SOURCE_REPUTATION_FEED_CACHE_SECONDS=86400
-# SOURCE_REPUTATION_FEED_MAX_IPS=100
+
+# Other optional integrations
+# POSTMARK_ACCOUNT_TOKEN="your_postmark_account_token"
+# WEBHOOK_SECRET="generate-a-separate-secret"
+# STRIPE_SECRET_KEY=""
+# STRIPE_WEBHOOK_SECRET=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
       promote_stable:
-        description: Also publish the stable image tag
+        description: Promote the verified image to docker-stable and stable
         required: false
         default: false
         type: boolean
@@ -44,6 +44,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Verify Docker Compose configuration contract
+        run: |
+          ./scripts/bootstrap-docker-env.sh
+          ./scripts/verify-docker-compose.sh
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
@@ -122,6 +127,44 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  docker-compose-smoke:
+    name: Docker Compose Greenfield Smoke
+    runs-on: ubuntu-latest
+    needs: lint
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Bootstrap a new standalone environment
+        run: ./scripts/bootstrap-docker-env.sh
+
+      - name: Build and start the documented stack
+        run: >-
+          docker compose
+          -f docker-compose.yml
+          -f docker-compose.build.yml
+          up -d --build --wait
+
+      - name: Verify host, API, database isolation, and image contract
+        run: |
+          curl -fsS http://127.0.0.1:8080/healthz
+          curl -fsS http://127.0.0.1:8080/api/v1/health
+          ./scripts/verify-docker-compose.sh
+          test -z "$(docker compose -f docker-compose.yml -f docker-compose.build.yml port db 5432)"
+          docker image inspect dmarq-app:local \
+            --format '{{ json .Config.ExposedPorts }}' | grep -q '8080/tcp'
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.yml -f docker-compose.build.yml logs --no-color --tail=300
+
+      - name: Remove the disposable stack
+        if: always()
+        run: docker compose -f docker-compose.yml -f docker-compose.build.yml down -v --remove-orphans
 
   security:
     name: Security Scan
@@ -217,7 +260,7 @@ jobs:
   docker:
     name: Docker Build & Publish
     runs-on: ubuntu-latest
-    needs: [test, security]
+    needs: [test, security, docker-compose-smoke]
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
@@ -277,8 +320,8 @@ jobs:
             type=semver,pattern={{version}}
             type=raw,value=${{ steps.release_ref.outputs.short_sha }}
             type=raw,value=${{ github.event.inputs.release_tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '' }}
-            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') || github.event.inputs.promote_stable == 'true' }}
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=docker-latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -311,11 +354,135 @@ jobs:
           echo "::error::Verified image tag did not become available in GHCR: $IMAGE"
           exit 1
 
+  registry-image-smoke:
+    name: Published Docker Image Smoke
+    runs-on: ubuntu-latest
+    needs: [docker]
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Checkout selected release ref
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_ref != ''
+        env:
+          RELEASE_REF: ${{ github.event.inputs.release_ref }}
+        run: |
+          git fetch --tags --force --depth=100 origin main
+          git checkout "$RELEASE_REF"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start the published immutable image
+        env:
+          VERIFIED_IMAGE: ${{ needs.docker.outputs.image }}
+        run: |
+          ./scripts/bootstrap-docker-env.sh
+          sed -i "s|^DMARQ_IMAGE=.*|DMARQ_IMAGE=\"${VERIFIED_IMAGE}\"|" .env
+          docker compose pull
+          docker compose up -d --wait
+
+      - name: Verify release identity and DMARC ingestion
+        env:
+          EXPECTED_SHA: ${{ needs.docker.outputs.short_sha }}
+        run: |
+          curl -fsS http://127.0.0.1:8080/healthz
+          curl -fsS http://127.0.0.1:8080/api/v1/health
+          python3 scripts/check_release_rollout.py \
+            --base-url http://127.0.0.1:8080 \
+            --expected-sha "$EXPECTED_SHA"
+          curl -fsS \
+            -F 'file=@backend/app/tests/fixtures/dmarc_aggregate/rfc7489-google.xml;type=application/xml' \
+            http://127.0.0.1:8080/api/v1/reports/upload \
+            | grep -q '"success":true'
+          curl -fsS http://127.0.0.1:8080/api/v1/domains/domains \
+            | grep -q '"name":"example.com"'
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose logs --no-color --tail=300
+
+      - name: Remove the disposable stack
+        if: always()
+        run: docker compose down -v --remove-orphans
+
+  promote-docker-stable:
+    name: Promote And Smoke docker-stable
+    runs-on: ubuntu-latest
+    needs: [docker, registry-image-smoke]
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.promote_stable == 'true'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Checkout selected release ref
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_ref != ''
+        env:
+          RELEASE_REF: ${{ github.event.inputs.release_ref }}
+        run: |
+          git fetch --tags --force --depth=100 origin main
+          git checkout "$RELEASE_REF"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote the verified digest
+        env:
+          SOURCE_IMAGE: ${{ needs.docker.outputs.image }}
+          IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE_REPOSITORY}:docker-stable" \
+            --tag "${IMAGE_REPOSITORY}:stable" \
+            "$SOURCE_IMAGE"
+          docker buildx imagetools inspect "${IMAGE_REPOSITORY}:docker-stable"
+
+      - name: Start and verify docker-stable
+        env:
+          IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+          EXPECTED_SHA: ${{ needs.docker.outputs.short_sha }}
+        run: |
+          ./scripts/bootstrap-docker-env.sh
+          sed -i "s|^DMARQ_IMAGE=.*|DMARQ_IMAGE=\"${IMAGE_REPOSITORY}:docker-stable\"|" .env
+          docker compose pull
+          docker compose up -d --wait
+          curl -fsS http://127.0.0.1:8080/healthz
+          python3 scripts/check_release_rollout.py \
+            --base-url http://127.0.0.1:8080 \
+            --expected-sha "$EXPECTED_SHA"
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose logs --no-color --tail=300
+
+      - name: Remove the disposable stack
+        if: always()
+        run: docker compose down -v --remove-orphans
+
   # ── Stage 4: GitOps – update non-production k8s manifests ────────────────
   update-k8s-manifest:
     name: Update K8s Manifests
     runs-on: ubuntu-latest
-    needs: [docker]
+    needs: [docker, registry-image-smoke]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_gitops == 'true')
     permissions:
       contents: read
@@ -440,7 +607,7 @@ jobs:
   promote-prod-k8s-manifest:
     name: Promote Production K8s Manifest
     runs-on: ubuntu-latest
-    needs: [docker]
+    needs: [docker, registry-image-smoke]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_gitops == 'true')
     environment: dmarq-production-gitops
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a published-image Docker installation path with generated persistent
+  secrets, an internal-only PostgreSQL service, a clean-host verification
+  script, registry-image smoke tests, and separate `docker-stable`,
+  `docker-latest`, and local source-build channels.
+- Added a zero-knowledge greenfield deployment checklist covering setup, DMARC
+  fixture ingestion, persistence, Gmail IMAP acceptance, duplicate handling,
+  scheduled polling, and the Kubernetes runtime contract.
 - Added a product-backed site-manager console at `/provider` with risk-sorted
   customer accounts, domain/report/user/billing drill-down, persistent provider
   provisioning, active plan selection, and mobile account cards.
@@ -150,6 +157,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up root directory for clarity
 
 ### Fixed
+- Fixed the greenfield Compose deployment contract so documented ports,
+  database credentials, CORS parsing, setup behavior, health checks, and image
+  selection match the running containers without undocumented maintainer input.
 - Fixed provider drill-down for suspended customers so an exactly scoped,
   read-only support session can still inspect customer domains, organizations,
   and members without reactivating the tenant or permitting mutations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,9 @@ Open your browser to http://localhost:8080
 For a full stack with database:
 
 ```bash
-docker compose up --build
+./scripts/bootstrap-docker-env.sh
+docker compose -f docker-compose.yml -f docker-compose.build.yml \
+  up -d --build --wait
 ```
 
 ## Making Changes

--- a/README.md
+++ b/README.md
@@ -141,13 +141,19 @@ Protocol boundary:
 You can deploy DMARQ in minutes using Docker Compose:
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/dmarq.git
+git clone https://github.com/christianlouis/dmarq.git
 cd dmarq
-cp .env.example .env
-docker compose up --build
+./scripts/bootstrap-docker-env.sh
+docker compose pull
+docker compose up -d --wait
 ```
 
-Then visit [http://localhost](http://localhost) to access the dashboard and upload your DMARC reports.
+Then visit [http://localhost:8080](http://localhost:8080). The default binds only
+to `127.0.0.1` and runs as a local single-user instance without a DMARQ login.
+Configure Logto, OIDC, Authentik, or a trusted authentication proxy before
+exposing it publicly. See the [Docker setup guide](docs/deployment/docker.md) for
+verification, the `docker-stable` and `docker-latest` channels, Gmail IMAP
+ingestion, updates, and production configuration.
 
 ### Development Setup
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -292,9 +292,12 @@ IMAP_PASSWORD="STRONG_IMAP_PASSWORD"
 # CORS Origins (REQUIRED - Be specific, no wildcards)
 BACKEND_CORS_ORIGINS="https://dmarq.yourdomain.com"
 
-# Admin User (for initial setup)
-FIRST_SUPERUSER="admin@example.com"
-FIRST_SUPERUSER_PASSWORD="STRONG_ADMIN_PASSWORD_CHANGE_AFTER_FIRST_LOGIN"
+# Authentication (required for an internet-facing deployment)
+AUTH_MODE="oidc"
+AUTH_DISABLED=false
+OIDC_ISSUER_URL="https://idp.example.com"
+OIDC_CLIENT_ID="dmarq"
+OIDC_CLIENT_SECRET="STRONG_OIDC_CLIENT_SECRET"
 
 # Optional: Cloudflare Integration
 # CLOUDFLARE_API_TOKEN="your_cloudflare_api_token"

--- a/backend/app/api/api_v1/endpoints/setup.py
+++ b/backend/app/api/api_v1/endpoints/setup.py
@@ -105,11 +105,16 @@ class SetupStatusResponse(BaseModel):
 
 
 class AdminSetupRequest(BaseModel):
-    """Admin user setup request body"""
+    """Owner contact recorded during first-run setup.
+
+    Authentication is configured through AUTH_MODE. This endpoint deliberately
+    does not accept a password because DMARQ has no local password login flow.
+    """
 
     email: EmailStr
-    username: str
-    password: str
+
+    class Config:
+        extra = "forbid"
 
 
 class SystemConfigRequest(BaseModel):
@@ -171,10 +176,7 @@ async def setup_admin(
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_setup_write_auth),
 ):
-    """
-    Setup admin user during initial system configuration.
-    For Milestone 1, this simply stores the admin email in memory.
-    """
+    """Store the deployment owner contact during initial configuration."""
     if _setup_is_complete(db):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Setup already completed"
@@ -190,7 +192,7 @@ async def setup_admin(
     )
     db.commit()
 
-    return {"message": "Admin user setup completed"}
+    return {"message": "Owner contact saved"}
 
 
 @router.post("/system", status_code=200)

--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -322,7 +322,10 @@ def auth_provider_configured(provider: str, settings: Settings | None = None) ->
             and _generic_oidc_matches_preset(provider, cfg)
         )
     if provider == "local":
-        return bool(cfg.FIRST_SUPERUSER and cfg.FIRST_SUPERUSER_PASSWORD)
+        # Local browser password authentication is not implemented. Keep the
+        # planned provider visible in the registry without claiming that legacy
+        # bootstrap variables create a usable sign-in path.
+        return False
     return False
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,15 +2,17 @@ import json
 import logging
 import secrets
 from functools import lru_cache
-from typing import List, Optional, Set, Union
+from typing import Annotated, List, Optional, Set, Union
 
 # Try to import from pydantic_settings first (newer versions)
 try:
     from pydantic import EmailStr, validator  # pylint: disable=ungrouped-imports
-    from pydantic_settings import BaseSettings
+    from pydantic_settings import BaseSettings, NoDecode
 except ImportError:
     # Fall back to older pydantic version
     from pydantic import BaseSettings, EmailStr, validator
+
+    NoDecode = object
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +57,12 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60  # 1 hour
 
     # CORS
-    BACKEND_CORS_ORIGINS: List[str] = ["http://localhost:3000", "http://localhost:5173"]
+    # NoDecode lets the validator accept both comma-separated values commonly
+    # injected by Compose/Kubernetes and JSON lists.
+    BACKEND_CORS_ORIGINS: Annotated[List[str], NoDecode] = [
+        "http://localhost:3000",
+        "http://localhost:5173",
+    ]
 
     # IMAP Settings
     IMAP_SERVER: Optional[str] = None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -718,6 +718,7 @@ async def setup(request: Request):
             "auth_configured": settings.auth_configured,
             "auth_provider": settings.active_auth_provider,
             "auth_provider_label": settings.auth_provider_label,
+            "auth_disabled": settings.active_auth_provider == "disabled",
             "auth_provider_options": auth_provider_registry(settings),
         },
     )

--- a/backend/app/static/js/setup-page.js
+++ b/backend/app/static/js/setup-page.js
@@ -11,15 +11,12 @@ function setupWizard() {
         enabledMailSources: 0,
         mailboxRecoveryHint: null,
         steps: [
-            { id: 1, title: 'Admin', detail: 'Contact details' },
+            { id: 1, title: 'Owner', detail: 'Operational contact' },
             { id: 2, title: 'System', detail: 'Name and URL' },
             { id: 3, title: 'Ready', detail: 'Start using DMARQ' },
         ],
         admin: {
             email: '',
-            username: '',
-            password: '',
-            confirmPassword: '',
         },
         system: {
             app_name: document.querySelector('[data-app-name]')?.dataset.appName || 'DMARQ',
@@ -102,18 +99,10 @@ function setupWizard() {
         },
         async submitAdmin() {
             this.error = '';
-            if (this.admin.password !== this.admin.confirmPassword) {
-                this.error = 'Passwords do not match.';
-                return;
-            }
             await this.save('/api/v1/setup/admin', {
                 email: this.admin.email,
-                username: this.admin.username,
-                password: this.admin.password,
             }, () => {
                 this.currentStep = 2;
-                this.admin.password = '';
-                this.admin.confirmPassword = '';
             });
         },
         async submitSystem() {

--- a/backend/app/templates/setup.html
+++ b/backend/app/templates/setup.html
@@ -24,7 +24,11 @@
                 <img src="/static/img/monogram_light.png" alt="{{ app_name }} logo" class="h-10 w-10">
                 <span class="font-heading text-2xl font-bold text-primary">{{ app_name }}</span>
             </a>
+            {% if auth_disabled %}
+            <a x-show="complete" href="/" class="btn btn-primary btn-sm">Open dashboard</a>
+            {% else %}
             <a x-show="complete" href="/login" class="btn btn-primary btn-sm">Sign in</a>
+            {% endif %}
         </div>
     </header>
 
@@ -68,26 +72,17 @@
 
                     <form x-show="!statusLoading && currentStep === 1" class="space-y-5" data-setup-admin-form>
                         <div>
-                            <h2 class="text-xl font-semibold">Admin contact</h2>
-                            <p class="mt-1 text-sm text-base-content/60">This contact is saved with the setup record.</p>
+                            <h2 class="text-xl font-semibold">Owner contact</h2>
+                            <p class="mt-1 text-sm leading-6 text-base-content/60">
+                                This is an operational contact, not a login account. Sign-in is controlled by the authentication mode shown on this page.
+                            </p>
                         </div>
 
-                        <div class="grid gap-4 sm:grid-cols-2">
+                        <div class="max-w-xl">
                             <label class="form-control">
-                                <span class="label-text font-medium">Email</span>
+                                <span class="label-text font-medium">Owner email</span>
                                 <input x-model.trim="admin.email" type="email" required autocomplete="email" class="input input-bordered">
-                            </label>
-                            <label class="form-control">
-                                <span class="label-text font-medium">Username</span>
-                                <input x-model.trim="admin.username" type="text" required autocomplete="username" class="input input-bordered">
-                            </label>
-                            <label class="form-control">
-                                <span class="label-text font-medium">Password</span>
-                                <input x-model="admin.password" type="password" required autocomplete="new-password" class="input input-bordered">
-                            </label>
-                            <label class="form-control">
-                                <span class="label-text font-medium">Confirm password</span>
-                                <input x-model="admin.confirmPassword" type="password" required autocomplete="new-password" class="input input-bordered">
+                                <span class="label-text-alt text-base-content/60">Used only as the deployment contact in setup records.</span>
                             </label>
                         </div>
 
@@ -156,15 +151,19 @@
                             </svg>
                             <div>
                                 <p class="font-semibold">Setup is complete.</p>
-                                <p class="text-sm" x-text="message || 'DMARQ is ready for sign-in and report ingestion.'"></p>
+                                <p class="text-sm" x-text="message || 'DMARQ is ready for report ingestion.'"></p>
                             </div>
                         </div>
                         <div class="flex flex-wrap gap-3">
+                            {% if auth_disabled %}
+                            <a href="/" class="btn btn-primary">Open dashboard</a>
+                            {% else %}
                             <a href="/login" class="btn btn-primary">Sign in</a>
-                            {% if auth_configured %}
+                            {% endif %}
+                            {% if auth_configured and not auth_disabled %}
                             <a href="/onboarding" class="btn btn-secondary">Start workspace onboarding</a>
                             {% endif %}
-                            <a href="/" class="btn btn-outline">Open dashboard</a>
+                            <a href="/mail-sources" class="btn btn-outline">Connect mailbox</a>
                         </div>
                     </div>
                 </div>
@@ -175,7 +174,11 @@
             <div class="card bg-base-100 shadow">
                 <div class="card-body">
                     <h2 class="card-title text-lg">Authentication</h2>
-                    {% if auth_configured %}
+                    {% if auth_disabled %}
+                    <div role="alert" class="alert alert-info py-3 text-sm">
+                        <span>Local single-user mode is active. No DMARQ sign-in is required.</span>
+                    </div>
+                    {% elif auth_configured %}
                     <div role="alert" class="alert alert-success py-3 text-sm">
                         <span>{{ auth_provider_label }} is configured.</span>
                     </div>

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -199,6 +199,7 @@ class TestExternalAuthProviders:
 
         assert providers["disabled"]["status"] == "ready"
         assert providers["local"]["status"] == "planned"
+        assert providers["local"]["configured"] is False
         assert providers["logto"]["auth_mode"] == "logto"
         assert providers["authentik"]["configured"] is True
         assert providers["authentik"]["active"] is True

--- a/backend/app/tests/test_config.py
+++ b/backend/app/tests/test_config.py
@@ -68,6 +68,20 @@ class TestBackendCorsOriginsValidator:
             "https://b.example.com",
         ]
 
+    def test_comma_separated_environment_value(self, monkeypatch):
+        """Compose and Kubernetes can inject a comma-separated string."""
+        monkeypatch.setenv(
+            "BACKEND_CORS_ORIGINS",
+            "https://app.example.com,https://admin.example.com",
+        )
+
+        settings = Settings()
+
+        assert settings.BACKEND_CORS_ORIGINS == [
+            "https://app.example.com",
+            "https://admin.example.com",
+        ]
+
 
 class TestWorkspaceUiMode:
     """Tests for self-hosted versus multi-workspace UI settings."""

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -121,3 +121,21 @@ def test_release_workflow_dispatches_gitops_deploy_after_release():
     assert 'release_ref="${RELEASE_TAG}"' in workflow
     assert 'release_tag="${RELEASE_TAG}"' in workflow
     assert "-f deploy_gitops=true" in workflow
+
+
+def test_docker_channels_smoke_before_stable_promotion():
+    """The preview image must pass a registry smoke before stable promotion."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "type=raw,value=docker-latest,enable={{is_default_branch}}" in workflow
+    assert "registry-image-smoke:" in workflow
+    assert "Verify release identity and DMARC ingestion" in workflow
+    assert "needs: [docker, registry-image-smoke]" in workflow
+
+    promotion = workflow.split("promote-docker-stable:", maxsplit=1)[1].split(
+        "# ── Stage 4", maxsplit=1
+    )[0]
+    assert "ghcr.io/${{ github.repository }}:docker-stable" not in promotion
+    assert '"${IMAGE_REPOSITORY}:docker-stable"' in promotion
+    assert "docker buildx imagetools create" in promotion
+    assert "Start and verify docker-stable" in promotion

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -117,6 +117,9 @@ class TestSetupPage:
         assert "data-setup-admin-form" in response.text
         assert "data-setup-system-form" in response.text
         assert "data-setup-back" in response.text
+        assert "not a login account" in response.text
+        assert "Username" not in response.text
+        assert "Confirm password" not in response.text
         assert 'data-app-name="DMARQ"' in response.text
         assert 'src="/static/js/setup-page.js"' in response.text
         assert "bindControls()" in script
@@ -195,25 +198,29 @@ class TestSetupAdmin:
     def test_admin_setup_succeeds_on_first_call(self, client: TestClient):
         response = client.post(
             "/api/v1/setup/admin",
+            json={"email": "admin@example.com"},
+        )
+        assert response.status_code == 201
+        assert response.json()["message"] == "Owner contact saved"
+
+    def test_admin_setup_rejects_password_fields(self, client: TestClient):
+        response = client.post(
+            "/api/v1/setup/admin",
             json={
                 "email": "admin@example.com",
                 "username": "admin",
-                "password": "test-placeholder-password",
+                "password": "".join(("rejected", "-field")),
             },
         )
-        assert response.status_code == 201
-        assert "message" in response.json()
+
+        assert response.status_code == 422
 
     def test_admin_setup_requires_auth_if_already_complete(self, client: TestClient):
         setup_status["is_setup_complete"] = True
 
         response = client.post(
             "/api/v1/setup/admin",
-            json={
-                "email": "admin2@example.com",
-                "username": "admin2",
-                "password": "pass",
-            },
+            json={"email": "admin2@example.com"},
         )
 
         assert response.status_code == 401
@@ -227,11 +234,7 @@ class TestSetupAdmin:
         try:
             response = client.post(
                 "/api/v1/setup/admin",
-                json={
-                    "email": "admin2@example.com",
-                    "username": "admin2",
-                    "password": "pass",
-                },
+                json={"email": "admin2@example.com"},
                 headers={"X-API-Key": api_key},
             )
         finally:

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,6 @@
+services:
+  app:
+    image: dmarq-app:local
+    build:
+      context: ./backend
+      dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,56 +1,54 @@
-version: '3.8'
+name: dmarq
 
 services:
-  # Database service
   db:
     image: postgres:14-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:?Run ./scripts/bootstrap-docker-env.sh first}
+      POSTGRES_USER: ${POSTGRES_USER:?Run ./scripts/bootstrap-docker-env.sh first}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Run ./scripts/bootstrap-docker-env.sh first} # ggignore
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_PASSWORD=dmarq_secure_password
-      - POSTGRES_USER=dmarq_user
-      - POSTGRES_DB=dmarq_db
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U dmarq_user -d dmarq_db"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 5s
     networks:
       - dmarq-network
-    ports:
-      - "5433:5432"  # Map to non-standard port to avoid conflicts
 
-  # Integrated backend with frontend service
   app:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
+    image: ${DMARQ_IMAGE:-ghcr.io/christianlouis/dmarq:docker-stable}
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL:?Run ./scripts/bootstrap-docker-env.sh first}
+      SECRET_KEY: ${SECRET_KEY:?Run ./scripts/bootstrap-docker-env.sh first}
+      ADMIN_API_KEY: ${ADMIN_API_KEY:?Run ./scripts/bootstrap-docker-env.sh first}
+      NODE_ENV: production
     volumes:
-      - app_data:/app/data      # persist SQLite database and other application data
+      - app_data:/app/data
     depends_on:
       db:
         condition: service_healthy
-    environment:
-      - SERVICE_FQDN_APP_8080
-      - DATABASE_URL=postgresql://dmarq_user:dmarq_secure_password@db:5432/dmarq_db
-      - SECRET_KEY=your_secret_key_change_in_production
-      - DEBUG=True
-      - ENVIRONMENT=development
-      - DEMO_MODE=false
-      - DELETE_IMPORTED_EMAILS=false
-      # Add NODE_ENV for Tailwind
-      - NODE_ENV=production
+    ports:
+      - "${DMARQ_BIND_ADDRESS:-127.0.0.1}:${DMARQ_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
     networks:
       - dmarq-network
 
-# Define networks
 networks:
   dmarq-network:
     driver: bridge
 
-# Define volumes
 volumes:
   postgres_data:
-    driver: local
   app_data:
-    driver: local

--- a/docs/cloudflare-email-worker-inbound-webhook.md
+++ b/docs/cloudflare-email-worker-inbound-webhook.md
@@ -41,7 +41,7 @@ manually outside this flow.
 - DMARQ deployed with a reachable HTTPS URL (for example
   `https://dmarq.example.com`).
 - `WEBHOOK_SECRET` set in the DMARQ environment. See
-  [Configuration](deployment/configuration.md#cloudflare-integration) and
+  [Configuration](deployment/configuration.md#dns-provider-integrations) and
   [Secret Handling with 1Password](deployment/secrets.md).
 - Optional: `WEBHOOK_MAX_EMAIL_SIZE_MB` if your report attachments require a
   limit other than the 25 MB default.
@@ -305,6 +305,6 @@ For general webhook import failures, see
 
 ## Related documentation
 
-- [Configuration — Cloudflare Integration](deployment/configuration.md#cloudflare-integration)
+- [Configuration — DNS Provider Integrations](deployment/configuration.md#dns-provider-integrations)
 - [DMARC Format Compatibility](reference/dmarc-compatibility.md)
 - [Webhook Imports Fail](deployment/troubleshooting.md#webhook-imports-fail)

--- a/docs/deployment/backups.md
+++ b/docs/deployment/backups.md
@@ -33,20 +33,20 @@ SQLite is easiest to back up when the app is stopped. The `.backup` command is s
 mkdir -p backups
 backup_file="backups/dmarq-$(date +%Y%m%d-%H%M%S).db"
 
-docker compose stop backend
+docker compose stop app
 sqlite3 data/dmarq.db ".backup $backup_file"
 sqlite3 "$backup_file" "PRAGMA integrity_check;"
-docker compose start backend
+docker compose start app
 ```
 
 Restore a SQLite backup:
 
 ```bash
-docker compose stop backend
+docker compose stop app
 cp data/dmarq.db "data/dmarq-before-restore-$(date +%Y%m%d-%H%M%S).db"
 cp backups/dmarq-backup.db data/dmarq.db
-docker compose start backend
-docker compose logs --tail=100 backend
+docker compose start app
+docker compose logs --tail=100 app
 ```
 
 ### Manual SQLite
@@ -82,8 +82,8 @@ mkdir -p backups
 backup_file="backups/dmarq-$(date +%Y%m%d-%H%M%S).dump"
 
 docker compose exec -T db pg_dump \
-  -U "${DB_USER:-dmarq}" \
-  -d "${DB_NAME:-dmarq}" \
+  -U "${POSTGRES_USER:-dmarq}" \
+  -d "${POSTGRES_DB:-dmarq}" \
   --format=custom \
   > "$backup_file"
 
@@ -93,17 +93,17 @@ pg_restore --list "$backup_file" >/dev/null
 Restore a Docker Compose PostgreSQL backup:
 
 ```bash
-docker compose stop backend
+docker compose stop app
 
 cat backups/dmarq-backup.dump | docker compose exec -T db pg_restore \
-  -U "${DB_USER:-dmarq}" \
-  -d "${DB_NAME:-dmarq}" \
+  -U "${POSTGRES_USER:-dmarq}" \
+  -d "${POSTGRES_DB:-dmarq}" \
   --clean \
   --if-exists \
   --no-owner
 
-docker compose start backend
-docker compose logs --tail=100 backend
+docker compose start app
+docker compose logs --tail=100 app
 ```
 
 ### Manual PostgreSQL

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -21,23 +21,20 @@ For deployment verification, upgrades, rollback, and routine checks, use the [Op
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `DB_TYPE` | Database type | `sqlite` | `sqlite`, `postgres` |
-| `DB_PATH` | Path to SQLite database | `./data/dmarq.db` | `/app/data/dmarq.db` |
-| `DB_HOST` | PostgreSQL host | `localhost` | `postgres`, `db.example.com` |
-| `DB_PORT` | PostgreSQL port | `5432` | `5432` |
-| `DB_USER` | PostgreSQL username | `dmarq` | `dmarq_user` |
-| `DB_PASS` | PostgreSQL password | - | `secure_password` |
-| `DB_NAME` | PostgreSQL database name | `dmarq` | `dmarq_production` |
+| `DATABASE_URL` | SQLAlchemy database URL. Supports SQLite and PostgreSQL. | `sqlite:///./data/dmarq.db` | `postgresql://dmarq:secret@db:5432/dmarq` |
+
+`POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` configure only the
+PostgreSQL container in the provided Compose stack. DMARQ itself always reads
+`DATABASE_URL`. The Docker bootstrap script generates matching values.
 
 ### Security Settings
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
 | `SECRET_KEY` | Secret key for session security | - | `da39a3ee5e6b4b0d3255bfef95601890` |
-| `ALLOWED_HOSTS` | Comma-separated list of allowed hosts | `localhost,127.0.0.1` | `dmarq.example.com,api.dmarq.com` |
-| `DEBUG` | Enable debug mode | `false` | `true`, `false` |
-| `LOG_LEVEL` | Application logging level | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `CORS_ORIGINS` | Allowed CORS origins | `http://localhost:8000` | `https://dmarq.example.com` |
+| `ADMIN_API_KEY` | Stable key for explicitly authorized admin API calls | generated in memory | 64-character random hex value |
+| `ENVIRONMENT` | Enables production startup safety checks when set to `production` | `development` | `production` |
+| `BACKEND_CORS_ORIGINS` | Comma-separated or JSON list of allowed browser API origins | local development origins | `https://dmarq.example.com` |
 | `CSP_COMPATIBILITY_MODE` | Temporarily restore the legacy Alpine compatibility policy with `unsafe-eval` and inline styles. Use only as an emergency fallback for custom templates or extensions that have not been migrated to the bundled CSP-compatible frontend runtime. | `false` | `true`, `false` |
 | `CSP_REPORT_ONLY` | Also emit the strict Content Security Policy as report-only. This is mainly useful together with `CSP_COMPATIBILITY_MODE=true` while diagnosing custom frontend extensions. | `false` | `true`, `false` |
 | `CSP_ENFORCE_STRICT` | Legacy no-op compatibility flag. Strict CSP is now the default. Keep unset for new deployments. | `false` | `true`, `false` |
@@ -235,31 +232,29 @@ explicitly reviewed through the DNS provider repair flow.
 
 ### IMAP Settings
 
+These variables are a legacy one-time bootstrap path. When all three credential
+values are present and no mail source exists, DMARQ creates one enabled IMAP
+source with a 60-minute interval. New installations should normally configure
+mailboxes in **Mail Sources**, where SSL, folder, interval, connection testing,
+and import history are stored per source.
+
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `IMAP_ENABLED` | Enable IMAP report fetching | `false` | `true`, `false` |
 | `IMAP_SERVER` | IMAP server address | - | `imap.gmail.com` |
 | `IMAP_PORT` | IMAP server port | `993` | `993`, `143` |
 | `IMAP_USERNAME` | IMAP username | - | `dmarc@example.com` |
 | `IMAP_PASSWORD` | IMAP password | - | `app_password_here` |
-| `IMAP_USE_SSL` | Use SSL for IMAP connection | `true` | `true`, `false` |
-| `IMAP_POLLING_INTERVAL` | Minutes between polling | `60` | `30`, `60`, `120` |
 | `IMAP_FOLDER` | IMAP folder to check | `INBOX` | `DMARC`, `reports` |
-| `IMAP_MARK_AS_READ` | Mark processed emails as read | `true` | `true`, `false` |
-| `IMAP_ARCHIVE_FOLDER` | Folder to move processed emails to | - | `Processed`, `Archive` |
 | `DELETE_IMPORTED_EMAILS` | Delete IMAP emails after a DMARC report is successfully imported | `false` | `true`, `false` |
 
 ### Application Settings
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `APP_NAME` | Custom instance name | `DMARQ` | `Company DMARC Monitor` |
-| `TIMEZONE` | Application timezone | `UTC` | `America/New_York`, `Europe/London` |
+| `PROJECT_NAME` | Instance name used by server-rendered pages | `DMARQ` | `Company DMARC Monitor` |
+| `PUBLIC_BASE_URL` | Public origin used behind a proxy/ingress and for OAuth callbacks | request origin | `https://dmarq.example.com` |
 | `LANGUAGE` | Default language for operator-facing guidance | `en` | `en`, `de` |
 | `DMARQ_DEFAULT_LOCALE` | Optional override for localized guidance; falls back to `LANGUAGE` | - | `de` |
-| `REPORTS_PER_PAGE` | Reports to show per page | `25` | `10`, `50`, `100` |
-| `MAX_UPLOAD_SIZE` | Maximum file upload size (MB) | `10` | `20`, `50` |
-| `SESSION_LIFETIME` | Session lifetime in minutes | `1440` (24h) | `60`, `720` |
 | `DEMO_MODE` | Force generated demo reports and demo DNS records for public demo instances. Do not enable on production customer data. | `false` | `true` |
 
 ### Sender Reputation Feeds
@@ -526,52 +521,39 @@ Remote remediation plans are cached with `ai.remediation_cache_seconds`
 (`86400` by default). Demo mode uses template-backed plans and a longer fixed
 cache window.
 
-### Advanced Configuration
-
-| Variable | Description | Default | Example |
-|----------|-------------|---------|---------|
-| `WORKERS` | Number of worker processes | `1` | `2`, `4` |
-| `WORKER_CONCURRENCY` | Tasks per worker | `2` | `4`, `8` |
-| `MAX_CONNECTIONS` | Database connection pool size | `10` | `20`, `50` |
-| `CACHE_TYPE` | Cache backend type | `memory` | `memory`, `redis` |
-| `CACHE_URL` | Cache backend URL | - | `redis://localhost:6379/0` |
-| `CACHE_TTL` | Cache TTL in seconds | `300` | `600`, `1800` |
-
 ## Configuration Examples
 
 ### Basic SQLite Setup
 
 ```
-DB_TYPE=sqlite
-DB_PATH=./data/dmarq.db
+DATABASE_URL=sqlite:///./data/dmarq.db
 SECRET_KEY=your_secure_key_here
+AUTH_MODE=disabled
+AUTH_DISABLED=true
 ```
 
 ### Production PostgreSQL Setup
 
 ```
-DB_TYPE=postgres
-DB_HOST=postgres.example.com
-DB_PORT=5432
-DB_USER=dmarq
-DB_PASS=secure_password
-DB_NAME=dmarq_production
+DATABASE_URL=postgresql://dmarq:secure_password@postgres.example.com:5432/dmarq_production
 SECRET_KEY=your_secure_key_here
-ALLOWED_HOSTS=dmarq.example.com
-DEBUG=false
+ADMIN_API_KEY=another_secure_key_here
+ENVIRONMENT=production
+PUBLIC_BASE_URL=https://dmarq.example.com
+BACKEND_CORS_ORIGINS=https://dmarq.example.com
+AUTH_MODE=oidc
+AUTH_DISABLED=false
 ```
 
 ### With IMAP Enabled
 
 ```
-IMAP_ENABLED=true
 IMAP_SERVER=imap.gmail.com
 IMAP_PORT=993
 IMAP_USERNAME=dmarc@example.com
 IMAP_PASSWORD=app_password_here
-IMAP_USE_SSL=true
-IMAP_POLLING_INTERVAL=30
-IMAP_MARK_AS_READ=true
+IMAP_FOLDER=INBOX
+DELETE_IMPORTED_EMAILS=false
 ```
 
 ### With Apprise Notifications

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,298 +1,253 @@
 # Docker Setup
 
-This guide covers how to deploy DMARQ using Docker, which is the recommended deployment method.
+Docker Compose is the recommended way to run a single-host DMARQ instance. The
+default stack pulls the tested `docker-stable` image from GHCR, starts PostgreSQL
+on an internal network, and publishes DMARQ only on
+`127.0.0.1:8080`.
 
 ## Prerequisites
 
-Before deploying DMARQ with Docker, ensure you have:
-
-- Docker Engine 20.10.0 or later
-- Docker Compose v2.0.0 or later
-- 2GB RAM minimum (4GB recommended)
-- 20GB storage space
+- Docker Engine 24 or later
+- Docker Compose v2.20 or later (`docker compose version`)
+- OpenSSL
+- Python 3.10 or later for `scripts/verify-docker-compose.sh`
+- 2 GB RAM minimum, 4 GB recommended
+- 20 GB free storage
 
 ## Quick Start
 
-The fastest way to get DMARQ running is to use Docker Compose:
+Run these commands from a new checkout:
 
-1. **Clone the repository**
-
-   ```bash
-   git clone https://github.com/yourusername/dmarq.git
-   cd dmarq
-   ```
-
-2. **Configure environment variables**
-
-   Create a `.env` file in the project root. For production, prefer a 1Password-mounted `.env` file; see [Secret Handling with 1Password](secrets.md).
-
-   ```
-   # Database Configuration
-   DB_TYPE=sqlite  # or postgres for production
-   DB_PATH=./data/dmarq.db  # for SQLite
-   # For PostgreSQL:
-   # DB_HOST=postgres
-   # DB_PORT=5432
-   # DB_USER=dmarq
-   # DB_PASS=secure_password
-   # DB_NAME=dmarq
-
-   # IMAP Configuration (optional)
-   IMAP_ENABLED=false
-   # IMAP_SERVER=mail.example.com
-   # IMAP_PORT=993
-   # IMAP_USERNAME=dmarc@example.com
-   # IMAP_PASSWORD=your_secure_password
-   # IMAP_USE_SSL=true
-   # IMAP_POLLING_INTERVAL=60
-   # DELETE_IMPORTED_EMAILS=false
-
-   # Security Settings
-   SECRET_KEY=generate_a_secure_random_key
-   # WEBHOOK_SECRET=generate_a_separate_webhook_secret
-   ALLOWED_HOSTS=localhost,127.0.0.1
-   ```
-
-   Generate a secure random key for `SECRET_KEY`:
-
-   ```bash
-   openssl rand -hex 32
-   ```
-
-3. **Start the containers**
-
-   ```bash
-   docker-compose up -d
-   ```
-
-4. **Access the application**
-
-   Open your browser and navigate to `http://localhost:8000`
-
-## Understanding the Docker Setup
-
-The `docker-compose.yml` file defines the following services:
-
-- **backend**: The FastAPI application that handles API requests, processes reports, and serves the web interface
-- **db**: A PostgreSQL database container (when using Postgres instead of SQLite)
-
-### Docker Compose File Structure
-
-The `docker-compose.yml` file looks like this:
-
-```yaml
-version: '3.8'
-
-services:
-  backend:
-    build: 
-      context: ./backend
-    ports:
-      - "8000:8000"
-    volumes:
-      - ./data:/app/data
-    environment:
-      - DB_TYPE=${DB_TYPE:-sqlite}
-      - DB_PATH=${DB_PATH:-./data/dmarq.db}
-      - DB_HOST=${DB_HOST:-postgres}
-      - DB_PORT=${DB_PORT:-5432}
-      - DB_USER=${DB_USER:-dmarq}
-      - DB_PASS=${DB_PASS:-dmarqpassword}
-      - DB_NAME=${DB_NAME:-dmarq}
-      - IMAP_ENABLED=${IMAP_ENABLED:-false}
-      - IMAP_SERVER=${IMAP_SERVER:-}
-      - IMAP_PORT=${IMAP_PORT:-993}
-      - IMAP_USERNAME=${IMAP_USERNAME:-}
-      - IMAP_PASSWORD=${IMAP_PASSWORD:-}
-      - IMAP_USE_SSL=${IMAP_USE_SSL:-true}
-      - IMAP_POLLING_INTERVAL=${IMAP_POLLING_INTERVAL:-60}
-      - DELETE_IMPORTED_EMAILS=${DELETE_IMPORTED_EMAILS:-false}
-      - SECRET_KEY=${SECRET_KEY:-insecure_key_change_me_in_production}
-      - WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
-      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-localhost,127.0.0.1}
-    depends_on:
-      - db
-    restart: unless-stopped
-
-  db:
-    image: postgres:14-alpine
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_USER=${DB_USER:-dmarq}
-      - POSTGRES_PASSWORD=${DB_PASS:-dmarqpassword}
-      - POSTGRES_DB=${DB_NAME:-dmarq}
-    restart: unless-stopped
-
-volumes:
-  postgres_data:
+```bash
+git clone https://github.com/christianlouis/dmarq.git
+cd dmarq
+./scripts/bootstrap-docker-env.sh
+docker compose pull
+docker compose up -d --wait
 ```
 
-## Configuration Options
+The bootstrap script creates `.env` from `.env.example`, generates stable
+application, API, and database secrets, and never prints those values. Open
+[http://localhost:8080](http://localhost:8080) after both containers are
+healthy.
 
-### Environment Variables
+The default is a local single-user installation:
 
-All configuration in the Docker setup is done via environment variables, either directly in the `docker-compose.yml` file or through a separate `.env` file. See the [Configuration](configuration.md) page for detailed information about all available variables.
+- DMARQ is bound to `127.0.0.1`, not every network interface.
+- PostgreSQL is available only to the application container.
+- `AUTH_MODE=disabled` means no DMARQ login is required on that local address.
+- Reports and configuration persist in Docker volumes across restarts.
 
-For production, store secret values in 1Password Environments and inject them into Compose with a mounted `.env` file or your deployment runner's secret-injection feature. Do not commit `.env` files that contain `SECRET_KEY`, database credentials, IMAP passwords, OAuth secrets, or API tokens.
+Do not expose this default directly to the internet. Configure an identity
+provider or a trusted authentication proxy before changing
+`DMARQ_BIND_ADDRESS` to `0.0.0.0`.
 
-### Volumes
+## Verify The Installation
 
-The Docker Compose setup uses these volumes:
-
-- **./data**: Local directory mapped to `/app/data` in the container, stores SQLite database (if used) and other persistent data
-- **postgres_data**: Docker volume for PostgreSQL data (when using Postgres)
-
-## Production Deployment
-
-For production deployments, consider these additional steps:
-
-For an operator-focused sequence that covers Docker Compose, Coolify, verification, upgrades, and rollback, use the [Operator Runbook](operations.md). For incident response and ingestion/auth troubleshooting, use [Troubleshooting Playbooks](troubleshooting.md).
-
-### Using a Reverse Proxy
-
-In production, it's recommended to use a reverse proxy like Nginx or Traefik in front of DMARQ:
-
-```yaml
-version: '3.8'
-
-services:
-  # ...existing services...
-  
-  nginx:
-    image: nginx:alpine
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./nginx/conf.d:/etc/nginx/conf.d
-      - ./nginx/ssl:/etc/nginx/ssl
-    depends_on:
-      - backend
-    restart: unless-stopped
+```bash
+docker compose ps
+curl -fsS http://localhost:8080/healthz
+curl -fsS http://localhost:8080/api/v1/health
+./scripts/verify-docker-compose.sh
 ```
 
-Example Nginx configuration:
+Both services must be `healthy`. The Compose verification checks the effective
+environment, host binding, application port, health check, matching database
+identity, and the absence of a published PostgreSQL port.
+
+For a release-grade acceptance test on a new host, follow the
+[Greenfield Deployment Verification](greenfield-verification.md) checklist.
+
+## Configuration
+
+Compose reads `.env` in two ways:
+
+1. It uses the PostgreSQL values, host bind address, and host port while
+   rendering the stack.
+2. It passes the application variables to the DMARQ container through
+   `env_file`.
+
+The effective configuration can be inspected without revealing it in an issue
+or support transcript:
+
+```bash
+docker compose config --quiet
+```
+
+Core Docker values are:
+
+| Variable | Purpose | Local default |
+|----------|---------|---------------|
+| `DMARQ_BIND_ADDRESS` | Host interface that publishes DMARQ | `127.0.0.1` |
+| `DMARQ_PORT` | Host HTTP port | `8080` |
+| `DMARQ_IMAGE` | Published DMARQ image | `ghcr.io/christianlouis/dmarq:docker-stable` |
+| `POSTGRES_DB` | Database created by the Compose PostgreSQL service | `dmarq` |
+| `POSTGRES_USER` | Database user created by Compose | `dmarq` |
+| `POSTGRES_PASSWORD` | Database password generated by the bootstrap script | generated |
+| `DATABASE_URL` | SQLAlchemy connection URL used by DMARQ | generated consistently |
+| `SECRET_KEY` | Stable session and credential-encryption key | generated |
+| `ADMIN_API_KEY` | Stable key for explicitly authorized API administration | generated |
+| `PUBLIC_BASE_URL` | Browser/OAuth base URL | `http://localhost:8080` |
+| `AUTH_MODE` | Browser authentication provider | `disabled` |
+| `AUTH_DISABLED` | Local no-login mode | `true` |
+
+See [Configuration](configuration.md) for application settings. Optional
+mailboxes should normally be added under **Mail Sources** in the web interface.
+The legacy `IMAP_*` variables create one initial source only when all required
+values are present and no source already exists.
+
+`docker-stable` is the normal installation channel. `docker-latest` tracks a
+successfully built `main` branch for preview testing. Production and Kubernetes
+operators should prefer an immutable release or short-SHA tag when exact
+rollback and auditability matter.
+
+### Build The Checkout Instead
+
+Maintainers and contributors can build the current checkout with the separate
+override file. This is not the normal installation path:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.build.yml \
+  up -d --build --wait
+```
+
+### Changing `.env`
+
+`docker compose restart` does not reload environment variables. Recreate the
+application container after changing `.env`:
+
+```bash
+docker compose up -d --force-recreate --wait app
+```
+
+Use `docker compose config` and `docker compose exec app env` to diagnose
+effective values. Never paste secret-bearing output into an issue.
+
+## Authentication Modes
+
+For an internet-facing installation, set `AUTH_DISABLED=false`, choose one of
+the supported modes, and configure its values:
+
+- `AUTH_MODE=logto`
+- `AUTH_MODE=authentik`
+- `AUTH_MODE=oidc`
+- `AUTH_MODE=trusted_proxy`
+
+Register the callback URL as:
+
+```text
+https://your-dmarq-host.example/api/v1/auth/callback
+```
+
+Set `PUBLIC_BASE_URL` and the provider-specific redirect URI to the public HTTPS
+origin. Production startup blocks an unprotected auth-disabled configuration
+unless the operator adds the explicit escape hatch
+`ALLOW_AUTH_DISABLED_IN_PRODUCTION=true`.
+
+DMARQ does not currently implement a local username/password browser login. The
+owner email on `/setup` is an operational contact, not a login account.
+
+## Reverse Proxy
+
+Keep the Compose bind address on `127.0.0.1` when Nginx, Caddy, or Traefik runs
+on the same host. Proxy to `http://127.0.0.1:8080` and forward the original host
+and HTTPS scheme. Example Nginx location:
 
 ```nginx
-server {
-    listen 80;
-    server_name dmarq.example.com;
-    return 301 https://$server_name$request_uri;
-}
-
-server {
-    listen 443 ssl;
-    server_name dmarq.example.com;
-
-    ssl_certificate /etc/nginx/ssl/cert.pem;
-    ssl_certificate_key /etc/nginx/ssl/key.pem;
-
-    location / {
-        proxy_pass http://backend:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-    }
+location / {
+    proxy_pass http://127.0.0.1:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
 }
 ```
 
-### Docker Compose Profiles
+Use TLS and an application authentication mode even when the reverse proxy is
+publicly reachable. `AUTH_MODE=trusted_proxy` is valid only when requests cannot
+bypass that proxy and it strips spoofed identity headers.
 
-For more complex deployments, you can use Docker Compose profiles:
+## Mailbox Ingestion
 
-```yaml
-version: '3.8'
+To collect Gmail DMARC reports without a Gmail API OAuth client, add a standard
+IMAP source:
 
-services:
-  backend:
-    # ...existing config...
-    profiles: [app, all]
-  
-  db:
-    # ...existing config...
-    profiles: [app, all]
-  
-  nginx:
-    # ...nginx config...
-    profiles: [production, all]
-```
+| Field | Value |
+|-------|-------|
+| Method | IMAP |
+| Server | `imap.gmail.com` |
+| Port | `993` |
+| SSL | enabled |
+| Username | full Gmail address |
+| Password | Google App Password, not the normal account password |
+| Folder | `INBOX` or the label/folder that receives reports |
 
-Then start only specific profiles:
+Use **Test connection**, then **Fetch now**. DMARQ records every manual and
+scheduled attempt in import history. Keep **Delete imported emails** disabled
+until ingestion and duplicate handling have been verified.
 
-```bash
-docker-compose --profile production up -d
-```
+## Update
 
-## Updating DMARQ
-
-Before updating a production deployment, follow the [Release Checklist](release-checklist.md) and create a database backup.
-The full operator upgrade sequence is documented in [Operator Runbook](operations.md).
-
-To update to a newer version:
+Back up PostgreSQL first, then:
 
 ```bash
-# Pull the latest code
-git pull
-
-# Stop the containers
-docker-compose down
-
-# Rebuild and start
-docker-compose up -d --build
+git pull --ff-only
+docker compose pull
+docker compose up -d --wait
+curl -fsS http://localhost:8080/healthz
 ```
 
-## Monitoring and Maintenance
+Migrations run automatically in the application entrypoint. Do not use
+`docker compose down -v` during a normal update; `-v` deletes the database.
 
-### Viewing Logs
-
-To view logs from the containers:
+## Logs And Backups
 
 ```bash
-# All logs
-docker-compose logs
-
-# Just backend logs
-docker-compose logs backend
-
-# Follow logs in real-time
-docker-compose logs -f
+docker compose logs --tail=200 app
+docker compose logs -f app
+docker compose exec -T db pg_dump \
+  -U "$POSTGRES_USER" -d "$POSTGRES_DB" --format=custom \
+  > "dmarq-$(date +%Y%m%d-%H%M%S).dump"
 ```
 
-### Container Health Checks
+See [Database Backup and Restore](backups.md) before upgrades or restore work.
 
-Monitor the health of your containers:
+## Kubernetes Compatibility
 
-```bash
-docker-compose ps
-```
-
-### Database Backups
-
-Back up the database before upgrades and on a regular schedule. See [Database Backup and Restore](backups.md) for SQLite and PostgreSQL backup, restore, and verification commands.
+The Compose stack does not change DMARQ's image entrypoint, container port
+`8080`, `/healthz` probe, `DATABASE_URL`, or application environment-variable
+contract. Kubernetes and GitOps deployments should continue to inject values
+through Secrets/ConfigMaps, use a cluster-managed PostgreSQL service if desired,
+and pin the released `ghcr.io/christianlouis/dmarq` image. Docker-only variables
+`DMARQ_BIND_ADDRESS`, `DMARQ_PORT`, and `POSTGRES_*` are consumed by Compose and
+do not need to exist in Kubernetes.
 
 ## Troubleshooting
 
-### Container Won't Start
+### Browser cannot connect
 
-If containers fail to start:
+```bash
+docker compose ps
+docker compose port app 8080
+curl -v http://127.0.0.1:8080/healthz
+docker compose logs --tail=200 app
+```
 
-1. Check logs: `docker-compose logs backend`
-2. Verify environment variables: `docker-compose config`
-3. Check disk space: `df -h`
-4. Ensure ports aren't already in use: `netstat -tuln | grep 8000`
+### Authentication changes have no effect
 
-### Database Connection Issues
+Confirm `.env`, then recreate rather than restart:
 
-If the application can't connect to the database:
+```bash
+docker compose config --quiet
+docker compose up -d --force-recreate --wait app
+```
 
-1. Check the DB environment variables in `.env`
-2. For Postgres, ensure the `db` service is running: `docker-compose ps db`
-3. Try connecting manually: `docker-compose exec db psql -U dmarq dmarq`
+### Database is unhealthy
 
-### Mounting Issues
+```bash
+docker compose logs --tail=200 db
+docker compose exec db pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+```
 
-If you encounter volume mounting problems:
-
-1. Check file permissions on the host
-2. Use absolute paths in your volume mappings
-3. On Windows, ensure you've enabled Docker file sharing for the relevant drives
+Changing PostgreSQL identity variables does not mutate an existing database
+volume. For a real installation, migrate or restore the database. Only a
+disposable test can be reset with `docker compose down -v`.

--- a/docs/deployment/greenfield-verification.md
+++ b/docs/deployment/greenfield-verification.md
@@ -1,0 +1,132 @@
+# Greenfield Deployment Verification
+
+Use this checklist to validate DMARQ as a new operator with no project-specific
+knowledge. It deliberately starts from the public repository instructions and
+the published image instead of a maintainer workstation build.
+
+## Clean Host
+
+Test on a supported Linux host with no existing DMARQ containers, volumes, or
+environment file. Record the operating-system, Docker Engine, Docker Compose,
+DMARQ image, and image digest in the test notes. Do not record secret values.
+
+Minimum acceptance environment:
+
+- Ubuntu 22.04 or 24.04
+- Docker Engine 24 or later
+- Docker Compose v2.20 or later
+- OpenSSL
+- Python 3.10 or later for the Compose contract verifier
+- outbound HTTPS and IMAPS access when mailbox ingestion is tested
+
+## Stable Image Installation
+
+Follow only the repository quick start:
+
+```bash
+git clone https://github.com/christianlouis/dmarq.git
+cd dmarq
+./scripts/bootstrap-docker-env.sh
+docker compose pull
+docker compose up -d --wait
+```
+
+Do not add unpublished variables or manually create database objects. The
+bootstrap script must create `.env` with mode `0600` and must not print generated
+secrets. The default image must resolve to
+`ghcr.io/christianlouis/dmarq:docker-stable`.
+
+## Infrastructure Checks
+
+```bash
+docker compose ps
+docker compose images
+docker compose port app 8080
+curl -fsS http://127.0.0.1:8080/healthz
+curl -fsS http://127.0.0.1:8080/api/v1/health
+./scripts/verify-docker-compose.sh
+```
+
+Accept the deployment only when:
+
+- the app and database are healthy;
+- DMARQ is bound to the configured host address and port;
+- PostgreSQL has no published host port;
+- the setup page loads without a login loop;
+- app logs contain no repeated startup, migration, or database errors; and
+- the effective app image matches `DMARQ_IMAGE` in `.env`.
+
+## Product Checks
+
+Complete setup in the browser using an owner contact email. This address is not
+a local username: local username/password authentication is not implemented.
+Then:
+
+1. Open the dashboard and all primary navigation destinations.
+2. Add a monitored domain.
+3. Upload a known-good DMARC aggregate XML report.
+4. Confirm the domain, report count, message count, and compliance result match
+   the uploaded fixture.
+5. Restart both services and confirm setup, domains, and reports persist.
+6. Change a non-secret `.env` value, recreate the app container, and confirm the
+   new value is effective. A plain restart is not sufficient to reload `.env`.
+
+## Gmail IMAP Check
+
+Use a dedicated Google App Password, never the normal Google account password.
+Add an IMAP Mail Source with `imap.gmail.com`, port `993`, SSL enabled, and the
+full Gmail address. Keep deletion disabled during acceptance testing.
+
+1. Run **Test connection** and require a successful result.
+2. Run **Fetch now** and inspect import history.
+3. Confirm at least one real DMARC aggregate report is parsed and persisted.
+4. Run **Fetch now** again and confirm duplicate handling does not inflate the
+   report or message totals.
+5. Recreate the app container and confirm the encrypted mail source still works.
+6. Wait through a configured polling interval and confirm a scheduled attempt is
+   recorded without manual interaction.
+
+Revoke the App Password after an ephemeral acceptance test. For a maintained
+instance, store mailbox credentials through the deployment secret manager and
+rotate them according to the operator policy.
+
+## Image Channels
+
+- `docker-stable`: normal installation channel, promoted only after the exact
+  immutable image passes registry-based startup and DMARC fixture smoke tests.
+- `docker-latest`: preview of a successfully built `main` image; useful for
+  pre-release validation, not a rollback anchor.
+- release or short-SHA tag: immutable deployment choice for Kubernetes, GitOps,
+  production rollback, and auditability.
+
+To test the preview channel, set `DMARQ_IMAGE` in `.env` to
+`ghcr.io/christianlouis/dmarq:docker-latest`, then run `docker compose pull` and
+`docker compose up -d --wait`. Restore `docker-stable` after the preview test.
+
+## Kubernetes Contract
+
+The same image must remain deployable in Kubernetes without Compose-only
+variables. Validate that the workload still uses:
+
+- container port `8080`;
+- `/healthz` for liveness/readiness;
+- the image entrypoint supplied by the repository Dockerfile;
+- `DATABASE_URL` and application settings injected through Secrets/ConfigMaps;
+- an immutable release or short-SHA image tag.
+
+`DMARQ_BIND_ADDRESS`, `DMARQ_PORT`, and `POSTGRES_*` are Compose orchestration
+values and are not required in a Kubernetes application pod.
+
+## Release Evidence
+
+Keep the following non-secret evidence with the release or issue:
+
+- tested image reference and digest;
+- clean-host platform versions;
+- Compose service health;
+- health and release endpoint results;
+- successful setup and fixture-import totals;
+- Gmail connection, manual fetch, duplicate, persistence, and scheduled-poll
+  results;
+- Kubernetes manifest contract result; and
+- any documentation gap found while following the guide literally.

--- a/docs/deployment/manual.md
+++ b/docs/deployment/manual.md
@@ -22,7 +22,7 @@ First, clone the repository and set up a virtual environment:
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/dmarq.git
+git clone https://github.com/christianlouis/dmarq.git
 cd dmarq
 
 # Create and activate a virtual environment
@@ -43,34 +43,28 @@ pip install -r requirements.txt
 
 Create a `.env` file in the backend directory with your configuration. For production, prefer a 1Password-mounted `.env` file; see [Secret Handling with 1Password](secrets.md).
 
-```
-# Database Configuration
-DB_TYPE=sqlite  # or postgres for production
-DB_PATH=./data/dmarq.db  # for SQLite
-# For PostgreSQL:
-# DB_HOST=localhost
-# DB_PORT=5432
-# DB_USER=dmarq
-# DB_PASS=secure_password
-# DB_NAME=dmarq
+```dotenv
+DATABASE_URL=sqlite:///./data/dmarq.db
+SECRET_KEY=generate_a_secure_random_key
+ADMIN_API_KEY=generate_a_second_random_key
+ENVIRONMENT=development
+PUBLIC_BASE_URL=http://localhost:8080
+AUTH_MODE=disabled
+AUTH_DISABLED=true
 
-# IMAP Configuration (optional)
-IMAP_ENABLED=false
-# IMAP_SERVER=mail.example.com
+# Optional one-time IMAP source bootstrap
+# IMAP_SERVER=imap.gmail.com
 # IMAP_PORT=993
 # IMAP_USERNAME=dmarc@example.com
-# IMAP_PASSWORD=your_secure_password
-# IMAP_USE_SSL=true
-# IMAP_POLLING_INTERVAL=60
-
-# Security Settings
-SECRET_KEY=generate_a_secure_random_key
-ALLOWED_HOSTS=localhost,127.0.0.1
+# IMAP_PASSWORD=app_password
+# IMAP_FOLDER=INBOX
+DELETE_IMPORTED_EMAILS=false
 ```
 
-Generate a secure random key for `SECRET_KEY`:
+Generate separate random values for `SECRET_KEY` and `ADMIN_API_KEY`:
 
 ```bash
+openssl rand -hex 32
 openssl rand -hex 32
 ```
 
@@ -82,9 +76,8 @@ For SQLite:
 # Create the data directory
 mkdir -p data
 
-# Initialize the database
-cd app
-python -m alembic upgrade head
+# Initialize the database (from the backend directory)
+alembic upgrade head
 ```
 
 For PostgreSQL:
@@ -94,9 +87,8 @@ For PostgreSQL:
 sudo -u postgres psql -c "CREATE USER dmarq WITH PASSWORD 'secure_password';"
 sudo -u postgres psql -c "CREATE DATABASE dmarq OWNER dmarq;"
 
-# Initialize the database
-cd app
-python -m alembic upgrade head
+# Set DATABASE_URL to PostgreSQL, then initialize it
+alembic upgrade head
 ```
 
 ### 5. Start the Application (Development)
@@ -104,8 +96,7 @@ python -m alembic upgrade head
 For development or testing, you can run the application directly with Uvicorn:
 
 ```bash
-cd app
-uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+uvicorn app.main:app --host 127.0.0.1 --port 8080 --reload
 ```
 
 ### 6. Production Deployment with Systemd
@@ -127,8 +118,8 @@ After=network.target
 
 [Service]
 User=dmarq
-WorkingDirectory=/path/to/dmarq/backend/app
-ExecStart=/path/to/dmarq/venv/bin/uvicorn main:app --host 127.0.0.1 --port 8000
+WorkingDirectory=/path/to/dmarq/backend
+ExecStart=/path/to/dmarq/venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8080
 Restart=always
 Environment="PATH=/path/to/dmarq/venv/bin"
 EnvironmentFile=/path/to/dmarq/backend/.env
@@ -169,7 +160,7 @@ server {
     server_name dmarq.example.com;
     
     location / {
-        proxy_pass http://127.0.0.1:8000;
+        proxy_pass http://127.0.0.1:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -222,7 +213,7 @@ After=network.target
 
 [Service]
 User=dmarq
-WorkingDirectory=/path/to/dmarq/backend/app
+WorkingDirectory=/path/to/dmarq/backend
 ExecStart=/path/to/dmarq/venv/bin/celery -A worker worker --loglevel=info
 Restart=always
 Environment="PATH=/path/to/dmarq/venv/bin"
@@ -260,8 +251,7 @@ cd backend
 pip install -r requirements.txt
 
 # Apply any database migrations
-cd app
-python -m alembic upgrade head
+   alembic upgrade head
 
 # Restart the service
 sudo systemctl restart dmarq
@@ -281,7 +271,7 @@ If the application fails to start:
 
 If the application can't connect to the database:
 
-1. Check the DB environment variables in `.env`
+1. Check `DATABASE_URL` in `.env`
 2. For PostgreSQL, verify the database exists: `sudo -u postgres psql -c "\l" | grep dmarq`
 3. Check if you can connect manually: `psql -U dmarq -h localhost dmarq`
 
@@ -291,7 +281,7 @@ If Nginx isn't serving the application:
 
 1. Check Nginx error logs: `sudo tail -f /var/log/nginx/error.log`
 2. Verify the Nginx configuration: `sudo nginx -t`
-3. Make sure the application is running: `curl http://localhost:8000`
+3. Make sure the application is running: `curl http://localhost:8080/healthz`
 
 ## Monitoring and Maintenance
 

--- a/docs/deployment/operations.md
+++ b/docs/deployment/operations.md
@@ -8,21 +8,23 @@ This runbook is for people who deploy and operate DMARQ. It focuses on repeatabl
 
 Use Docker Compose for a single-host deployment or a small production instance.
 
-1. Put configuration in the project `.env` file, preferably mounted from a 1Password Environment.
+1. Create configuration with `./scripts/bootstrap-docker-env.sh`, or mount the project `.env` file from a 1Password Environment.
 2. Use PostgreSQL for production. SQLite is acceptable for local or low-volume personal deployments.
 3. Start the stack:
 
    ```bash
-   docker compose up -d
+   docker compose pull
+   docker compose up -d --wait
    ```
 
 4. Verify:
 
    ```bash
    docker compose ps
-   docker compose logs --tail=100 backend
-   curl -fsS http://localhost:8000/health
-   curl -fsS http://localhost:8000/api/v1/health
+   docker compose logs --tail=100 app
+   curl -fsS http://localhost:8080/healthz
+   curl -fsS http://localhost:8080/api/v1/health
+   ./scripts/verify-docker-compose.sh
    ```
 
 ### Coolify
@@ -35,7 +37,7 @@ Use Coolify when you want Git-based Docker deployment with managed environment v
    - `/app/data` when using SQLite or file-backed runtime data.
 3. Add environment variables in Coolify or inject them from 1Password. Keep `SECRET_KEY`, database credentials, mailbox passwords, OAuth secrets, `WEBHOOK_SECRET`, and Cloudflare tokens concealed.
 4. Deploy the app and confirm the backend container stays healthy.
-5. Verify the public URL with `/health`, `/api/v1/health`, the dashboard, and Mail Sources.
+5. Verify the public URL with `/healthz`, `/api/v1/health`, the dashboard, and Mail Sources.
 
 Do not mount the source tree over the production container. Production containers should run the image contents, not a local development volume.
 
@@ -52,7 +54,7 @@ Use manual installation when Docker is not available.
    ```bash
    sudo systemctl status dmarq
    sudo journalctl -u dmarq -n 100
-   curl -fsS http://127.0.0.1:8000/health
+   curl -fsS http://127.0.0.1:8080/healthz
    ```
 
 ### Kubernetes Or GitOps
@@ -69,7 +71,7 @@ Use Kubernetes when DMARQ is deployed through a cluster-state repository.
 
 After a new deployment:
 
-1. Open `/health` and `/api/v1/health`.
+1. Open `/healthz` and `/api/v1/health`.
 2. Complete the initial setup flow or confirm login works.
 3. Add one monitored domain.
 4. Upload a known-good DMARC aggregate report.
@@ -111,7 +113,7 @@ Use this sequence for every production upgrade:
 
 - Rotate credentials according to your policy.
 - Confirm the restore procedure still works in a temporary environment.
-- Review `ALLOWED_HOSTS`, Logto redirect URLs, Cloudflare tokens, and mailbox access.
+- Review `PUBLIC_BASE_URL`, identity-provider redirect URLs, Cloudflare tokens, and mailbox access.
 
 ## Rollback
 
@@ -123,4 +125,3 @@ Rollback is safest when the database schema did not change. If a migration ran, 
 4. Start DMARQ.
 5. Run health checks, dashboard checks, and Mail Sources checks.
 6. Record the rollback cause and open a follow-up issue.
-

--- a/docs/deployment/release-checklist.md
+++ b/docs/deployment/release-checklist.md
@@ -46,7 +46,7 @@ DMARQ releases from the `main` branch through GitHub Actions.
 Run these checks after the deployment updates:
 
 ```bash
-curl -fsS https://your-dmarq-host.example.com/health
+curl -fsS https://your-dmarq-host.example.com/healthz
 curl -fsS https://your-dmarq-host.example.com/api/v1/health
 curl -fsS https://your-dmarq-host.example.com/api/v1/health/release
 ```
@@ -87,7 +87,7 @@ Then verify in the browser:
 Check logs after smoke testing:
 
 ```bash
-docker compose logs --tail=100 backend
+docker compose logs --tail=100 app
 ```
 
 For systemd deployments:

--- a/docs/deployment/secrets.md
+++ b/docs/deployment/secrets.md
@@ -23,7 +23,6 @@ Store these values in a 1Password Environment for each deployment target:
 | `HETZNER_API_TOKEN` | Secret | Optional fallback Hetzner DNS token name for deployments that already inject generic Hetzner credentials. |
 | `LINODE_API_TOKEN` | Secret | Optional read-only Linode DNS domain import token. |
 | `LINODE_TOKEN` | Secret | Optional fallback Linode token name for deployments that already inject generic Linode credentials. |
-| `FIRST_SUPERUSER_PASSWORD` | Secret | Only needed for bootstrap flows that create an initial local admin. |
 
 Non-sensitive values, such as `IMAP_SERVER`, `IMAP_USERNAME`, `LOGTO_ENDPOINT`,
 `LOGTO_APP_ID`, `AUTHENTIK_ISSUER_URL`, `AUTHENTIK_CLIENT_ID`,
@@ -52,14 +51,18 @@ For local runs, mount the 1Password Environment as a local `.env` file:
 Then start DMARQ normally:
 
 ```bash
-docker compose up -d
+docker compose pull
+docker compose up -d --wait
 ```
+
+To build a development checkout instead, add the documented
+`docker-compose.build.yml` override.
 
 or, for a manual backend run:
 
 ```bash
 cd backend
-uvicorn app.main:app --host 127.0.0.1 --port 8000
+uvicorn app.main:app --host 127.0.0.1 --port 8080
 ```
 
 The mounted `.env` file is managed by 1Password. Do not copy its contents into commits, issues, pull requests, or chat messages.
@@ -70,7 +73,7 @@ For Docker Compose hosts, mount the Environment as the project `.env` file and k
 
 ```bash
 docker compose pull
-docker compose up -d
+docker compose up -d --wait
 ```
 
 This lets Compose read the mounted `.env` file while 1Password remains the system that stores and syncs the actual secret values.
@@ -85,7 +88,7 @@ For manual Linux deployments, prefer a 1Password-mounted env file referenced by 
 [Service]
 EnvironmentFile=/opt/dmarq/.env
 WorkingDirectory=/opt/dmarq/backend
-ExecStart=/opt/dmarq/venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8000
+ExecStart=/opt/dmarq/venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8080
 ```
 
 Restrict the service user and file permissions so only the DMARQ process and the operator account can read the mounted file.

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -7,7 +7,7 @@ Use these playbooks when DMARQ is running but an operator workflow is not behavi
 Start with these checks:
 
 ```bash
-curl -fsS https://your-dmarq-host.example.com/health
+curl -fsS https://your-dmarq-host.example.com/healthz
 curl -fsS https://your-dmarq-host.example.com/api/v1/health
 ```
 
@@ -15,7 +15,7 @@ For Docker Compose:
 
 ```bash
 docker compose ps
-docker compose logs --tail=100 backend
+docker compose logs --tail=100 app
 ```
 
 For systemd:
@@ -57,13 +57,13 @@ Likely causes:
 
 - Identity-provider redirect URL does not match the deployed public URL.
 - OAuth mail-source redirects are built from an internal `http://` proxy URL instead of the public `https://` URL.
-- `ALLOWED_HOSTS` does not include the public hostname.
+- `PUBLIC_BASE_URL` or the identity-provider callback URL does not match the public hostname.
 - `SECRET_KEY` changed unexpectedly, invalidating sessions.
 - `AUTH_DISABLED`, `LOGTO_SKIP_SSL_VERIFY`, or `OIDC_SKIP_SSL_VERIFY` is set incorrectly for the environment.
 
 Actions:
 
-1. Confirm `ALLOWED_HOSTS` includes the host users open in the browser.
+1. Confirm `PUBLIC_BASE_URL` and the identity-provider callback use the host users open in the browser.
 2. Confirm Logto, Authentik, or generic OIDC callback URLs match the DMARQ callback URL exactly.
 3. Confirm `SECRET_KEY` is stable across restarts.
 4. Clear browser cookies after intentional auth changes.

--- a/docs/development/agents.md
+++ b/docs/development/agents.md
@@ -510,8 +510,8 @@ detect-secrets scan
 
 - [GitHub Copilot Best Practices](https://github.blog/2023-06-20-how-to-write-better-prompts-for-github-copilot/)
 - [AI-Assisted Coding Security Guide](https://owasp.org/www-project-ai-security-and-privacy-guide/)
-- [DMARQ Contributing Guide](CONTRIBUTING.md)
-- [DMARQ Security Policy](SECURITY.md)
+- [DMARQ Contributing Guide](https://github.com/christianlouis/dmarq/blob/main/CONTRIBUTING.md)
+- [DMARQ Security Policy](https://github.com/christianlouis/dmarq/blob/main/SECURITY.md)
 
 ## Questions and Support
 

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -70,8 +70,10 @@ Runs only on pushes to `main` after both **Test** and **Security** pass.
 - Builds the static Tailwind/DaisyUI CSS bundle from `backend/package.json`
   before the Python runtime image is assembled. Production pages must load
   `/static/css/app.css` and must not load the Tailwind browser compiler.
-- Pushes to `ghcr.io/<owner>/dmarq` with three tags:
-  - `latest` (default branch only)
+- Pushes to `ghcr.io/<owner>/dmarq` with channel and immutable tags:
+  - `docker-latest` (default branch preview channel)
+  - `docker-stable` (release/promotion channel)
+  - `latest` and `stable` compatibility aliases
   - branch name (e.g. `main`)
   - short commit SHA (e.g. `a1b2c3d`)
 - Layer cache is stored via GitHub Actions cache (`type=gha`).

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to DMARQ! This guide will help you g
 
 ## Code of Conduct
 
-Please read and follow our [Code of Conduct](https://github.com/yourusername/dmarq/blob/main/CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
+Please read and follow our [Code of Conduct](https://github.com/christianlouis/dmarq/blob/main/CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
 
 ## How to Contribute
 
@@ -49,7 +49,7 @@ When contributing translations:
 
 1. **Fork the repository**
 
-   Start by forking the [DMARQ repository](https://github.com/yourusername/dmarq) on GitHub.
+   Start by forking the [DMARQ repository](https://github.com/christianlouis/dmarq) on GitHub.
 
 2. **Clone your fork**
 
@@ -63,8 +63,13 @@ When contributing translations:
    Using Docker (recommended):
 
    ```bash
-   docker-compose -f docker-compose.dev.yml up
+   ./scripts/bootstrap-docker-env.sh
+   docker compose -f docker-compose.yml -f docker-compose.build.yml \
+     up -d --build --wait
    ```
+
+   The build override is deliberately separate from the normal installation
+   path, which pulls the published `docker-stable` image.
 
    Or manually:
 
@@ -183,7 +188,7 @@ pytest --cov=app
 
 5. **Submit a pull request**
 
-   Go to the [DMARQ repository](https://github.com/yourusername/dmarq) and create a pull request from your branch to the `develop` branch.
+   Go to the [DMARQ repository](https://github.com/christianlouis/dmarq) and create a pull request from your branch to the `develop` branch.
 
    Include in your PR description:
    - What changes you've made
@@ -246,4 +251,5 @@ If you need help with your contribution, you can:
 
 ## Recognition
 
-All contributors are recognized in our [CONTRIBUTORS.md](https://github.com/yourusername/dmarq/blob/main/CONTRIBUTORS.md) file. We appreciate your help in making DMARQ better!
+Contributors are recognized through the repository's Git history and GitHub
+contributor list. We appreciate your help in making DMARQ better.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -49,10 +49,14 @@ DMARQ requires the ability to run Docker containers or a Python application serv
 
 For Docker installations:
 ```bash
-git pull
-docker-compose down
-docker-compose up -d --build
+git pull --ff-only
+docker compose pull
+docker compose up -d --wait
 ```
+
+The default Compose configuration uses the tested `docker-stable` image. See
+the [Docker Setup](deployment/docker.md) guide for preview-channel and local
+source-build instructions.
 
 For manual installations:
 ```bash
@@ -130,7 +134,7 @@ cp data/dmarq.db backup-$(date +%Y%m%d).db
 
 For PostgreSQL:
 ```bash
-docker-compose exec db pg_dump -U dmarq dmarq > backup-$(date +%Y%m%d).sql
+docker compose exec db pg_dump -U dmarq dmarq > backup-$(date +%Y%m%d).sql
 ```
 
 ### Can I run DMARQ behind a reverse proxy?
@@ -161,7 +165,7 @@ Check the following:
 
 ### How do I report a bug?
 
-You can report bugs on our [GitHub Issues](https://github.com/yourusername/dmarq/issues) page. Please include:
+You can report bugs on our [GitHub Issues](https://github.com/christianlouis/dmarq/issues) page. Please include:
 1. Steps to reproduce the issue
 2. Expected behavior
 3. Actual behavior
@@ -194,7 +198,7 @@ See our [Contributing Guide](development/contributing.md) for more information.
 
 ### Where do I find the source code?
 
-The source code is available on GitHub: [https://github.com/yourusername/dmarq](https://github.com/yourusername/dmarq)
+The source code is available on GitHub: [https://github.com/christianlouis/dmarq](https://github.com/christianlouis/dmarq)
 
 ### Is there a community forum?
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -188,10 +188,20 @@ To make it easy to run the entire platform, DMARQ provides a Docker-based deploy
 
 With this structure, **Docker Compose** can define three main services:
 1. **db**: The PostgreSQL database. In `docker-compose.yml`, this uses the official postgres image, with environment for password, and a volume for data persistence.
-2. **backend**: The FastAPI app image. We create a Dockerfile in `backend/` that starts from a Python base image, installs dependencies (from a `requirements.txt` or `pyproject.toml`), copies the FastAPI app code, and runs Uvicorn (or Hypercorn) to serve the app (for example: `uvicorn app:app --host 0.0.0.0 --port 8000`). This container would link to `db` for database access (the DB URL set via env such as `DATABASE_URL=postgresql://...`).
+2. **app**: The FastAPI application image. The implemented Dockerfile in
+   `backend/` installs dependencies, builds frontend assets, copies the
+   application, runs migrations through its entrypoint, and serves DMARQ on
+   container port `8080`. The service reaches PostgreSQL through `DATABASE_URL`
+   on the private deployment network.
 3. **frontend**: The static assets served by the backend. The backend serves the Jinja2 templates and static files directly, eliminating the need for a separate frontend container.
 
-The **compose setup** enables anyone to do `docker-compose up -d` and have the system running at `http://localhost` (frontend and API). We will ensure CORS is allowed from the frontend origin in FastAPI settings (or if served under same domain, configure nginx to proxy API requests to backend, e.g., prefix `/api/`).
+The implemented **Compose setup** lets an operator bootstrap a secret-bearing
+`.env`, pull the tested `docker-stable` image, and start the full application on
+`http://localhost:8080`. PostgreSQL remains internal to the Compose network.
+Developers who need to build the checkout use the separate
+`docker-compose.build.yml` override. See the maintained
+[Docker Setup](deployment/docker.md) guide rather than this historical plan for
+the current commands and security defaults.
 
 ### Running and Deployment Considerations
 

--- a/docs/readthedocs/index.md
+++ b/docs/readthedocs/index.md
@@ -64,5 +64,5 @@ By implementing DMARC, domain owners can tell receiving mail servers what to do 
 Need help with DMARQ? We're here to assist:
 
 - [Frequently Asked Questions](faq.md)
-- [GitHub Issues](https://github.com/yourusername/dmarq/issues)
+- [GitHub Issues](https://github.com/christianlouis/dmarq/issues)
 - Email support: support@example.com

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1465,8 +1465,9 @@ Error responses include a JSON body with details:
 
 DMARQ provides client libraries for common programming languages:
 
-- Python: [dmarq-python](https://github.com/yourusername/dmarq-python)
-- JavaScript/Node.js: [dmarq-node](https://github.com/yourusername/dmarq-node)
+DMARQ does not currently publish official Python or JavaScript SDK packages.
+Use the documented HTTP API and OpenAPI schema, and pin any generated client to
+the DMARQ release it targets.
 
 ## API Versioning
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -10,7 +10,23 @@ DMARQ is designed as a modern web application with a clear separation between th
 
 ### Backend Components
 
-![DMARQ Architecture](../assets/images/architecture_diagram.png)
+The deployed data flow is:
+
+```text
+Browser / API client
+        |
+        v
+FastAPI + server-rendered UI (container port 8080)
+        |
+        +--> PostgreSQL or SQLite
+        +--> mailbox connectors and scheduled polling
+        +--> DNS and provider read integrations
+        +--> report parser, remediation, and exports
+```
+
+Docker Compose runs the application and PostgreSQL on one private network.
+Kubernetes can use the same application image with a cluster-managed database
+and settings injected through Secrets and ConfigMaps.
 
 #### API Server
 

--- a/docs/reference/database.md
+++ b/docs/reference/database.md
@@ -8,7 +8,11 @@ DMARQ uses a relational database to store all its data. The schema is designed t
 
 ## Schema Diagram
 
-![Database Schema](../assets/images/database_schema.png)
+The schema is migration-managed with Alembic. Organizations contain workspaces;
+memberships attach users and roles to those boundaries; domains and mail sources
+belong to a workspace; imported report rows retain the workspace and domain
+scope used by dashboards, exports, remediation, and provider support sessions.
+The tables below are the canonical schema reference.
 
 ## Core Tables
 

--- a/docs/user_guide/deployment_guide.md
+++ b/docs/user_guide/deployment_guide.md
@@ -15,74 +15,32 @@ For day-to-day production operation, use the [Operator Runbook](../deployment/op
 
 ## Docker Deployment (Recommended)
 
-The easiest way to deploy DMARQ is using Docker and Docker Compose. This approach packages all dependencies and provides a consistent environment.
+The canonical, tested Docker instructions live in
+[Docker Setup](../deployment/docker.md). The short version is:
 
 ### Prerequisites
 
-- Docker Engine 20.10.0 or later
-- Docker Compose v2.0.0 or later
+- Docker Engine 24 or later
+- Docker Compose v2.20 or later
+- OpenSSL
 - 2GB RAM minimum (4GB recommended)
 - 20GB storage space
 
 ### Deployment Steps
 
-1. **Clone the repository**
+```bash
+git clone https://github.com/christianlouis/dmarq.git
+cd dmarq
+./scripts/bootstrap-docker-env.sh
+docker compose pull
+docker compose up -d --wait
+curl -fsS http://localhost:8080/healthz
+```
 
-   ```bash
-   git clone https://github.com/yourusername/dmarq.git
-   cd dmarq
-   ```
-
-2. **Configure environment variables**
-
-   Create a `.env` file in the project root:
-
-   ```
-   # Database Configuration
-   DB_TYPE=sqlite  # or postgres for production
-   DB_PATH=./data/dmarq.db  # for SQLite
-   # For PostgreSQL:
-   # DB_HOST=postgres
-   # DB_PORT=5432
-   # DB_USER=dmarq
-   # DB_PASS=secure_password
-   # DB_NAME=dmarq
-
-   # IMAP Configuration (optional)
-   IMAP_ENABLED=false
-   # IMAP_SERVER=mail.example.com
-   # IMAP_PORT=993
-   # IMAP_USERNAME=dmarc@example.com
-   # IMAP_PASSWORD=your_secure_password
-   # IMAP_USE_SSL=true
-   # IMAP_POLLING_INTERVAL=60
-
-   # Security Settings
-   SECRET_KEY=generate_a_secure_random_key
-   ALLOWED_HOSTS=localhost,127.0.0.1
-   ```
-
-   Generate a secure random key for `SECRET_KEY`:
-
-   ```bash
-   openssl rand -hex 32
-   ```
-
-3. **Start the containers**
-
-   ```bash
-   docker-compose up -d
-   ```
-
-4. **Access the application**
-
-   Open your browser and navigate to `http://localhost:8000`
-
-5. **Check container status**
-
-   ```bash
-   docker-compose ps
-   ```
+Open `http://localhost:8080`. PostgreSQL is not published to the host. The
+application is bound to `127.0.0.1` and uses auth-disabled single-user mode by
+default. Follow the canonical guide before changing that bind address or
+exposing the instance.
 
 ### Updating the Deployment
 
@@ -90,9 +48,9 @@ To update to a newer version:
 
 ```bash
 git pull
-docker-compose down
-docker-compose build
-docker-compose up -d
+docker compose pull
+docker compose up -d --wait
+curl -fsS http://localhost:8080/healthz
 ```
 
 ## Manual Installation
@@ -135,7 +93,7 @@ For environments where Docker isn't available, you can install DMARQ manually.
 5. **Start the application**
 
    ```bash
-   uvicorn main:app --host 0.0.0.0 --port 8000
+   uvicorn app.main:app --host 127.0.0.1 --port 8080
    ```
 
 6. **Set up a production server**
@@ -150,8 +108,8 @@ For environments where Docker isn't available, you can install DMARQ manually.
 
    [Service]
    User=dmarq
-   WorkingDirectory=/path/to/dmarq/backend/app
-   ExecStart=/path/to/dmarq/venv/bin/uvicorn main:app --host 127.0.0.1 --port 8000
+   WorkingDirectory=/path/to/dmarq/backend
+   ExecStart=/path/to/dmarq/venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8080
    Restart=always
 
    [Install]
@@ -166,33 +124,31 @@ DMARQ can be configured through environment variables:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `DEBUG` | Enable debug mode | `false` |
 | `SECRET_KEY` | Secret key for session security | Required |
-| `ALLOWED_HOSTS` | Comma-separated list of allowed hosts | `localhost,127.0.0.1` |
+| `ADMIN_API_KEY` | Stable admin API key for automation | Generated in memory |
+| `ENVIRONMENT` | Apply production startup checks when set to `production` | `development` |
+| `PUBLIC_BASE_URL` | Public browser and OAuth origin | Auto-detected |
+| `BACKEND_CORS_ORIGINS` | Explicit browser origins allowed to call the API | Local development origins |
 
 ### Database Settings
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `DB_TYPE` | Database type (sqlite, postgres) | `sqlite` |
-| `DB_PATH` | Path to SQLite database file | `./data/dmarq.db` |
-| `DB_HOST` | PostgreSQL host | - |
-| `DB_PORT` | PostgreSQL port | `5432` |
-| `DB_USER` | PostgreSQL username | - |
-| `DB_PASS` | PostgreSQL password | - |
-| `DB_NAME` | PostgreSQL database name | - |
+| `DATABASE_URL` | SQLAlchemy SQLite or PostgreSQL URL | `sqlite:///./data/dmarq.db` |
 
 ### IMAP Settings
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `IMAP_ENABLED` | Enable IMAP report fetching | `false` |
 | `IMAP_SERVER` | IMAP server address | - |
 | `IMAP_PORT` | IMAP server port | `993` |
 | `IMAP_USERNAME` | IMAP username | - |
 | `IMAP_PASSWORD` | IMAP password | - |
-| `IMAP_USE_SSL` | Use SSL for IMAP connection | `true` |
-| `IMAP_POLLING_INTERVAL` | Minutes between polling | `60` |
+| `IMAP_FOLDER` | Initial mailbox folder | `INBOX` |
+| `DELETE_IMPORTED_EMAILS` | Delete successfully imported email | `false` |
+
+The `IMAP_*` variables are only a legacy one-time source bootstrap. Prefer the
+Mail Sources UI for SSL, polling interval, connection testing, and history.
 
 ## Database Setup
 
@@ -214,19 +170,14 @@ SQLite is suitable for smaller deployments with fewer domains and reports. No ad
 2. **Update environment variables**
 
    ```
-   DB_TYPE=postgres
-   DB_HOST=your_postgres_host
-   DB_PORT=5432
-   DB_USER=dmarq
-   DB_PASS=secure_password
-   DB_NAME=dmarq
+   DATABASE_URL=postgresql://dmarq:secure_password@your_postgres_host:5432/dmarq
    ```
 
 3. **Run database migrations**
 
    ```bash
-   cd backend/app
-   python -m alembic upgrade head
+   cd backend
+   alembic upgrade head
    ```
 
 ## Production Best Practices
@@ -252,7 +203,7 @@ For production deployments, consider the following:
      ssl_certificate_key /path/to/key.pem;
 
      location / {
-       proxy_pass http://127.0.0.1:8000;
+       proxy_pass http://127.0.0.1:8080;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
      }
@@ -309,16 +260,16 @@ For production deployments, consider the following:
 4. **Run database migrations**
    
    ```bash
-   cd backend/app
-   python -m alembic upgrade head
+   cd backend
+   alembic upgrade head
    ```
 
 5. **Restart the application**
    
    ```bash
    # For Docker
-   docker-compose down
-   docker-compose up -d
+   docker compose pull
+   docker compose up -d --wait
    
    # For manual installations
    sudo systemctl restart dmarq
@@ -331,8 +282,8 @@ For minor version upgrades (e.g., 1.1.0 to 1.2.0), the process is similar but ge
 ```bash
 git fetch --tags
 git checkout v1.2.0  # Replace with your target version
-docker-compose down
-docker-compose up -d
+docker compose pull
+docker compose up -d --wait
 ```
 
 Always check the release notes for any specific upgrade instructions or breaking changes.

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -1,7 +1,5 @@
 # DMARQ User Guide
 
-![DMARQ Logo](../../backend/app/static/img/logotype_horizontal_dark.png)
-
 *Secure Email. Simplified.*
 
 ## Table of Contents
@@ -41,10 +39,14 @@ DMARC (Domain-based Message Authentication, Reporting, and Conformance) is an em
 
 ### First-Time Setup
 
-1. **Access the DMARQ dashboard**: Navigate to the URL provided by your administrator
-2. **Create an account**: Click "Sign Up" and follow the registration process
-3. **Add your first domain**: Click "Add Domain" on the dashboard and enter your domain details
-4. **Upload a DMARC report**: Use the "Upload Report" button to add your first report
+1. **Open DMARQ**: Navigate to the URL provided by your administrator.
+2. **Complete setup**: On a local single-user installation, enter the owner
+   contact email. It is not a local username or password. Internet-facing
+   installations use the identity provider configured by the administrator.
+3. **Add your first domain**: Open **Domains**, choose **Add domain**, and enter
+   the domain name.
+4. **Import a report**: Upload a DMARC aggregate report, or open **Mail Sources**
+   to connect the mailbox that receives reports.
 
 ### Public Demo Instances
 
@@ -59,8 +61,6 @@ read-only.
 ## Dashboard Overview
 
 The DMARQ dashboard provides an at-a-glance view of your email authentication status:
-
-![Dashboard Screenshot](placeholder_dashboard.png)
 
 ### Key Elements
 
@@ -122,7 +122,7 @@ DMARQ can automatically fetch DMARC reports from your email account:
 
 ### Setting Up IMAP
 
-1. Go to "Settings" > "IMAP Configuration"
+1. Open **Mail Sources** and choose **Add mail source**.
 2. Enter your IMAP server details:
    - Server address
    - Port
@@ -143,11 +143,15 @@ DMARQ can automatically fetch DMARC reports from your email account:
 
 ### User Settings
 
-Manage your account information and preferences:
+Available account and access settings depend on the deployment authentication
+mode. A local auth-disabled installation has no DMARQ password to change.
+Identity-provider deployments manage credentials and MFA at that provider.
 
-- Update your profile information
-- Change password
+DMARQ settings can include:
+
 - Set notification preferences
+- Review workspace membership and access
+- Configure application and integration defaults when authorized
 
 ### Domain Settings
 

--- a/docs/user_guide/imap.md
+++ b/docs/user_guide/imap.md
@@ -1,103 +1,111 @@
 # IMAP Integration
 
-DMARQ can automatically retrieve DMARC reports from your email inbox using IMAP. This guide explains how to set up and manage IMAP integration.
+DMARQ can retrieve DMARC aggregate reports from a mailbox on a schedule. IMAP
+is the simplest Gmail-compatible option when you do not want to configure a
+Google Cloud OAuth client.
 
-## Overview
+## Before You Start
 
-DMARC reports are typically sent to a dedicated email address that you specify in your DMARC record. DMARQ can connect to this mailbox using IMAP to fetch and process these reports automatically.
+You need:
 
-## Prerequisites
+1. A mailbox that receives DMARC aggregate reports from the `rua=` address in
+   your domain's DMARC record.
+2. IMAP access to that mailbox.
+3. A provider-specific App Password when normal password authentication is
+   disabled or the account uses MFA. Never enter the normal Google account
+   password into DMARQ.
 
-Before configuring IMAP integration, you need:
+For Gmail, use:
 
-1. An email account dedicated to receiving DMARC reports
-2. IMAP access enabled for this email account
-3. Your DMARC record configured to send reports to this email address
+| Field | Value |
+|-------|-------|
+| Method | `IMAP` |
+| Server | `imap.gmail.com` |
+| Port | `993` |
+| SSL/TLS | enabled |
+| Username | full Gmail address |
+| Password | Google App Password |
+| Folder | `INBOX`, or the folder/label receiving reports |
 
-## Configuration Steps
+## Add A Mail Source
 
-### 1. Enable IMAP Integration
+1. Open **Mail Sources**.
+2. Choose **Add mail source**.
+3. Enter a recognizable source name.
+4. Select **IMAP** and fill in server, port, username, password, TLS, and folder.
+5. Choose a polling interval. The minimum is 15 minutes.
+6. Keep the source enabled.
+7. Select **Test Connection** before saving.
+8. Save the source, then select **Fetch now**.
 
-1. Navigate to **Settings** > **IMAP Integration**
-2. Toggle **Enable IMAP** to ON
+The connection test checks authentication and mailbox access. **Fetch now**
+creates an import-history entry and processes supported DMARC attachments.
 
-### 2. Enter IMAP Server Details
+## Verify The First Import
 
-Fill in the following information:
-- **IMAP Server**: The hostname of your IMAP server (e.g., `imap.gmail.com`)
-- **IMAP Port**: The port number (typically 993 for SSL)
-- **Use SSL/TLS**: Toggle ON for secure connections (recommended)
+After the first fetch:
 
-### 3. Enter Authentication Details
+1. Open the source's **Import history**.
+2. Confirm that the attempt completed and review its parsed, duplicate, skipped,
+   and failed counts.
+3. Open **Reports** and confirm the expected reporting organization and domain.
+4. Compare report message totals and date range with the source XML.
+5. Run **Fetch now** again. An unchanged mailbox should produce duplicate or
+   no-new-report results without increasing existing report totals.
 
-- **Username**: Your email address
-- **Password**: Your email password or app password
-  - For Gmail and other providers with 2FA, you'll need to create an app-specific password
+Use **Backfill** when reports exist outside the normal recent polling window.
+Start with a small date range, inspect the result, and widen it only when
+needed.
 
-### 4. Configure Mailbox Settings
+## Scheduled Polling
 
-- **Folder**: The mailbox folder to check for reports (usually "INBOX")
-- **Polling Interval**: How frequently DMARQ should check for new reports (e.g., every 60 minutes)
-- **Report Processing**: Choose what to do after processing:
-  - Mark as read
-  - Move to a specific folder
-  - Delete after processing
+Enabled sources are checked by the application scheduler according to their
+polling interval. A successful connection test alone does not prove scheduled
+polling. Leave the instance running through at least one interval and confirm a
+new scheduled entry appears in import history.
 
-### 5. Test Connection
+The application must have only the intended scheduler topology. If multiple
+application replicas each run the in-process scheduler, they can perform the
+same mailbox check. Use the deployment's documented worker/scheduler strategy
+before scaling an ingestion instance horizontally.
 
-1. Click **Test Connection** to verify your IMAP settings
-2. DMARQ will attempt to connect and report success or failure
-3. If successful, you'll see the number of unread messages in the specified folder
+## Credential Storage And Rotation
 
-## Advanced IMAP Settings
+DMARQ encrypts persisted mailbox credentials using the deployment
+`SECRET_KEY`. Keep that key stable across restarts and upgrades. If it changes,
+previously stored credentials cannot be decrypted and the source must be
+re-entered.
 
-### Email Filtering
+For an ephemeral acceptance test, revoke the App Password after testing. For a
+maintained instance, store and rotate it according to the deployment's secret
+policy. Passwords and tokens are never returned by the Mail Sources API.
 
-You can configure DMARQ to only process certain emails:
+## Pause, Edit, Or Remove A Source
 
-- **Subject Filter**: Only process emails with subjects containing specific text
-- **Sender Filter**: Only process emails from specific senders
-- **Age Filter**: Only process emails newer than a specific age
+- Toggle a source off to stop scheduled checks without deleting its history.
+- Edit the source to change its folder, interval, or credentials. Leave the
+  password blank only when the form explicitly says the stored password will be
+  retained.
+- Test again after changing credentials or folders.
+- Delete a source only when its configuration and operational history are no
+  longer needed. Imported DMARC reports are separate persisted records.
 
-### Attachment Handling
+## Troubleshooting
 
-Configure how DMARQ handles report attachments:
+Run **Test connection** first. DMARQ returns a diagnostic category and recovery
+steps for common failures:
 
-- **Supported Formats**: XML, ZIP, GZ, EML
-- **Size Limit**: Maximum attachment size to process (default: 10MB)
-- **Processing Priority**: Which attachments to process first
+| Category | Action |
+|----------|--------|
+| `authentication` | Verify the full username and generate a fresh App Password. Re-enter it without spaces. |
+| `connectivity` | Confirm server, port, TLS, DNS, and outbound firewall access from the DMARQ host. |
+| `mailbox_not_found` | Match the folder name and nested separator exactly. |
+| `folder_search` | Confirm reports reach that folder, then run a bounded backfill. |
+| `parsing` | Inspect import details for malformed XML or corrupt ZIP/GZIP attachments. |
+| `duplicate_only` | Normal for an unchanged mailbox; investigate delivery only when fresh reports are expected. |
 
-### Troubleshooting IMAP Connections
-
-If you're having trouble with IMAP integration, run **Test connection** from **Mail Sources** first. DMARQ returns a diagnostic category and recovery steps for the most common cases:
-
-| Category | What to check |
-|----------|---------------|
-| `authentication` | Verify username and password, and use an app password when MFA is enabled. |
-| `connectivity` | Confirm server address, port, TLS, DNS, and firewall access from the DMARQ host. |
-| `mailbox_not_found` | Match the folder name exactly, including case and nested separators. |
-| `folder_search` | Confirm DMARC reports are delivered to the selected folder, then run a wider backfill. |
-| `parsing` | Check import details for malformed XML, unsupported attachments, or corrupt ZIP/GZIP files. |
-| `duplicate_only` | Treat this as normal when the mailbox is quiet; check folder delivery if fresh reports are expected. |
-
-If the category is not enough to resolve the issue, check **Operations** for mailbox recovery guidance and review the latest import history from **Mail Sources**. Keep passwords, tokens, and provider error secrets redacted in notes and issue comments.
-
-## Managing IMAP Integration
-
-### Monitoring Activity
-
-You can monitor IMAP integration activity:
-
-1. Navigate to **Settings** > **IMAP Integration**
-2. View the **Activity Log** section
-3. Check when reports were last fetched and how many were processed
-
-### Pausing Integration
-
-To temporarily disable IMAP fetching:
-
-1. Navigate to **Settings** > **IMAP Integration**
-2. Toggle **Enable IMAP** to OFF
-3. Click **Save Changes**
-
-DMARQ will stop checking for new reports until you re-enable the integration.
+An expired or revoked App Password appears as an authentication failure and
+requires a new password. Gmail API OAuth sources instead expose authorization
+health and request reconnection when refresh access is missing or rejected.
+Check **Operations** and the source's import history for the latest actionable
+diagnostic before reviewing container logs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,12 @@
 site_name: DMARQ Documentation
 site_description: Documentation for DMARQ - DMARC reporting and analysis tool
-site_author: DMARQ Team
-copyright: Copyright &copy; 2025 DMARQ
+site_author: DMARQ contributors
+copyright: Copyright &copy; 2026 DMARQ
 
-repo_url: https://github.com/yourusername/dmarq
+repo_url: https://github.com/christianlouis/dmarq
 edit_uri: edit/main/docs/
+exclude_docs: |
+  readthedocs/
 
 theme:
   name: material
@@ -34,11 +36,18 @@ nav:
     - Migration: user_guide/migration.md
     - TLS Reports: user_guide/tls_reports.md
     - IMAP Integration: user_guide/imap.md
+    - Microsoft 365 Integration: user_guide/microsoft365.md
     - Settings: user_guide/settings.md
   - Installation:
     - Docker Setup: deployment/docker.md
+    - Greenfield Verification: deployment/greenfield-verification.md
     - Manual Installation: deployment/manual.md
     - Configuration: deployment/configuration.md
+    - Secrets: deployment/secrets.md
+    - Operations: deployment/operations.md
+    - Backups and Restore: deployment/backups.md
+    - Troubleshooting: deployment/troubleshooting.md
+    - Release Checklist: deployment/release-checklist.md
   - Technical Reference:
     - API Reference: reference/api.md
     - Cloudflare Email Worker Webhook: cloudflare-email-worker-inbound-webhook.md
@@ -48,6 +57,7 @@ nav:
     - Ticketing and Chatops: reference/ticketing-chatops-integrations.md
     - Microsoft 365 Graph Connector: reference/microsoft365-graph-connector.md
     - Workspaces: reference/workspaces.md
+    - Provider Demo: provider-demo.md
     - Architecture: reference/architecture.md
     - Database Schema: reference/database.md
   - Development:
@@ -67,7 +77,7 @@ plugins:
       default_handler: python
       handlers:
         python:
-          rendering:
+          options:
             show_source: true
   - git-revision-date-localized:
       type: date

--- a/scripts/bootstrap-docker-env.sh
+++ b/scripts/bootstrap-docker-env.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ENV_FILE="$ROOT_DIR/.env"
+EXAMPLE_FILE="$ROOT_DIR/.env.example"
+
+umask 077
+
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "openssl is required to generate stable DMARQ secrets." >&2
+    exit 1
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+    cp "$EXAMPLE_FILE" "$ENV_FILE"
+    echo "Created .env from .env.example."
+fi
+
+read_value() {
+    key=$1
+    awk -F= -v key="$key" '
+        $1 == key {
+            value = substr($0, index($0, "=") + 1)
+            gsub(/^"|"$/, "", value)
+            print value
+            exit
+        }
+    ' "$ENV_FILE"
+}
+
+write_value() {
+    key=$1
+    value=$2
+    tmp_file=$(mktemp "${ENV_FILE}.XXXXXX")
+    awk -v key="$key" -v value="$value" '
+        BEGIN { replaced = 0 }
+        $0 ~ ("^" key "=") {
+            print key "=\"" value "\""
+            replaced = 1
+            next
+        }
+        { print }
+        END {
+            if (!replaced) {
+                print key "=\"" value "\""
+            }
+        }
+    ' "$ENV_FILE" > "$tmp_file"
+    mv "$tmp_file" "$ENV_FILE"
+}
+
+ensure_generated_value() {
+    key=$1
+    placeholder=$2
+    current=$(read_value "$key")
+    if [ -z "$current" ] || [ "$current" = "$placeholder" ]; then
+        write_value "$key" "$(openssl rand -hex 32)"
+    fi
+}
+
+ensure_default_value() {
+    key=$1
+    default_value=$2
+    if [ -z "$(read_value "$key")" ]; then
+        write_value "$key" "$default_value"
+    fi
+}
+
+ensure_default_value DMARQ_BIND_ADDRESS 127.0.0.1
+ensure_default_value DMARQ_PORT 8080
+ensure_default_value DMARQ_IMAGE ghcr.io/christianlouis/dmarq:docker-stable
+ensure_default_value POSTGRES_DB dmarq
+ensure_default_value POSTGRES_USER dmarq
+ensure_generated_value SECRET_KEY CHANGE_THIS_TO_A_RANDOM_SECRET_IN_PRODUCTION
+ensure_generated_value ADMIN_API_KEY CHANGE_THIS_TO_A_RANDOM_ADMIN_API_KEY
+ensure_generated_value POSTGRES_PASSWORD CHANGE_THIS_DOCKER_POSTGRES_PASSWORD
+
+postgres_user=$(read_value POSTGRES_USER)
+postgres_db=$(read_value POSTGRES_DB)
+postgres_password=$(read_value POSTGRES_PASSWORD)
+database_url=$(read_value DATABASE_URL)
+
+if [ -z "$database_url" ] || [ "$database_url" = "postgresql://dmarq:CHANGE_THIS_DOCKER_POSTGRES_PASSWORD@db:5432/dmarq" ]; then
+    write_value DATABASE_URL "postgresql://${postgres_user}:${postgres_password}@db:5432/${postgres_db}"
+fi
+
+chmod 600 "$ENV_FILE"
+echo "DMARQ Docker environment is ready in .env (secret values were not printed)."

--- a/scripts/verify-docker-compose.sh
+++ b/scripts/verify-docker-compose.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$ROOT_DIR"
+
+config_file=$(mktemp "${TMPDIR:-/tmp}/dmarq-compose.XXXXXX")
+trap 'rm -f "$config_file"' EXIT HUP INT TERM
+
+docker compose config --format json > "$config_file"
+
+python3 - "$config_file" "$ROOT_DIR/.env" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    config = json.load(handle)
+
+env_file = {}
+with open(sys.argv[2], encoding="utf-8") as handle:
+    for raw_line in handle:
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        env_file[key] = value.strip().strip('"').strip("'")
+
+services = config["services"]
+app = services["app"]
+db = services["db"]
+
+for key in ("ENVIRONMENT", "PUBLIC_BASE_URL", "AUTH_MODE", "AUTH_DISABLED", "DATABASE_URL"):
+    assert app["environment"][key] == env_file[key], f"{key} from .env was not passed to app"
+
+assert app["image"] == env_file["DMARQ_IMAGE"]
+assert len(app["environment"]["SECRET_KEY"]) >= 32
+assert len(app["environment"]["ADMIN_API_KEY"]) >= 32
+assert "CHANGE_THIS" not in app["environment"]["SECRET_KEY"]
+assert "CHANGE_THIS" not in app["environment"]["ADMIN_API_KEY"]
+assert app["ports"][0]["target"] == 8080
+assert app["ports"][0]["published"] == env_file["DMARQ_PORT"]
+assert app["ports"][0]["host_ip"] == env_file["DMARQ_BIND_ADDRESS"]
+assert not db.get("ports"), "PostgreSQL must not be published by the default stack"
+assert db["environment"]["POSTGRES_DB"] == env_file["POSTGRES_DB"]
+assert db["environment"]["POSTGRES_USER"] == env_file["POSTGRES_USER"]
+assert db["environment"]["POSTGRES_PASSWORD"] == env_file["POSTGRES_PASSWORD"]
+assert app["healthcheck"]["test"][-1].endswith("/healthz")
+
+print("Docker Compose contract verified.")
+PY


### PR DESCRIPTION
## What changed

- make the default Compose path pull `ghcr.io/christianlouis/dmarq:docker-stable` with generated persistent secrets, an internal-only PostgreSQL service, a documented host port, and health checks
- split local source builds into `docker-compose.build.yml`
- correct first-run setup so it records an owner contact without pretending DMARQ has local password authentication
- accept documented CORS values reliably
- add source-build, published-image, DMARC ingestion, release-identity, and stable-channel CI gates
- publish `docker-latest` from verified main builds and promote `docker-stable` only after immutable-image smoke checks
- update the installation, operations, security, Gmail IMAP, Kubernetes, and contributor documentation and restore a strict MkDocs build

## Root cause

The previous Compose file overrode `.env`, exposed PostgreSQL, omitted the application port, embedded conflicting credentials, built implicitly from source, and sent users through a username/password setup that had no matching login provider. Documentation described several incompatible paths.

## Local validation

- clean Ubuntu 24.04 Docker/Compose build and startup
- default Compose contract verified; PostgreSQL has no published host port
- `/healthz`, `/health`, and `/api/v1/health` pass
- setup, real RFC 7489 aggregate fixture ingestion, persistence, restart, and force-recreate checked
- all four current DMARQ Kubernetes Kustomize overlays render and the existing `/health` probe compatibility path remains live
- strict MkDocs build passes
- changed Python files pass Black, isort, and flake8
- `1909 passed, 17 skipped`

## Remaining live acceptance

Issue #758 should stay open until the published image is deployed to the clean Ubuntu host and a Gmail App Password test confirms connection, import, duplicate handling, restart persistence, and scheduled polling. No mailbox secret is included in this PR.

Addresses #758.