### PR TITLE
fix: make Docker installs and mailbox imports reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.release_ref || 'branch' }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,8 @@ jobs:
           curl -fsS http://127.0.0.1:8080/healthz
           curl -fsS http://127.0.0.1:8080/api/v1/health
           ./scripts/verify-docker-compose.sh
-          test -z "$(docker compose -f docker-compose.yml -f docker-compose.build.yml port db 5432)"
-          docker image inspect dmarq-app:local \
-            --format '{{ json .Config.ExposedPorts }}' | grep -q '8080/tcp'
+          docker image inspect \
+            --format '{{ json .Config.ExposedPorts }}' dmarq-app:local | grep -q '8080/tcp'
 
       - name: Show logs on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main, develop]

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -13,7 +13,16 @@ import math
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    status,
+)
 from jose import JWTError, jwt
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -33,6 +42,7 @@ from app.services.demo_data import (
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
+from app.services.mail_source_backfill_worker import run_mail_source_backfill_job_by_id
 from app.services.mailbox_recovery import (
     connection_diagnostic,
     connection_test_response,
@@ -1247,6 +1257,7 @@ async def create_mail_source_backfill(
     source_id: int,
     payload: MailSourceBackfillCreate,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
@@ -1327,6 +1338,7 @@ async def create_mail_source_backfill(
     )
     db.commit()
     db.refresh(row)
+    background_tasks.add_task(run_mail_source_backfill_job_by_id, row.id)
     return _backfill_to_response(row)
 
 
@@ -1429,6 +1441,7 @@ async def retry_mail_source_backfill(
     source_id: int,
     job_id: int,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
@@ -1493,6 +1506,7 @@ async def retry_mail_source_backfill(
     )
     db.commit()
     db.refresh(row)
+    background_tasks.add_task(run_mail_source_backfill_job_by_id, row.id)
     return _backfill_to_response(row)
 
 
@@ -1548,6 +1562,9 @@ async def update_mail_source(
     source = _get_source_or_404(source_id, db, workspace)
 
     update_data = payload.model_dump(exclude_unset=True)
+    for secret_field in ("password", "gmail_client_secret", "m365_client_secret"):
+        if update_data.get(secret_field) == "":
+            update_data.pop(secret_field)
     if "method" in update_data and update_data["method"]:
         update_data["method"] = update_data["method"].upper()
     for field, value in update_data.items():

--- a/backend/app/services/import_history.py
+++ b/backend/app/services/import_history.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from app.core.redaction import redact_sensitive_text
 from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
+from app.utils.stats_summarizer import StatsSummarizer
 
 MAX_STORED_ERRORS = 10
 MAX_ERROR_LENGTH = 500
@@ -58,6 +59,27 @@ def _json_details(values: Optional[Iterable[Any]]) -> str:
     return json.dumps(details)
 
 
+def _invalidate_imported_report_caches(source: MailSource, results: Dict[str, Any]) -> None:
+    """Discard cached dashboard/domain summaries after persisted report imports."""
+    imported = int(results.get("reports_found", 0) or 0) + int(
+        results.get("forensic_reports_found", 0) or 0
+    )
+    if imported <= 0:
+        return
+
+    workspace_id = getattr(source, "workspace_id", None)
+    summarizer = StatsSummarizer()
+    summarizer.invalidate_cache(workspace_id=workspace_id)
+
+    imported_domains = {
+        str(detail.get("domain") or "").strip().lower()
+        for detail in results.get("details", [])
+        if isinstance(detail, dict) and detail.get("status") == "imported"
+    }
+    for domain in imported_domains - {""}:
+        summarizer.invalidate_cache(domain, workspace_id=workspace_id)
+
+
 def record_import_attempt(
     db: Session,
     source: MailSource,
@@ -87,4 +109,5 @@ def record_import_attempt(
         finished_at=datetime.utcnow(),
     )
     db.add(attempt)
+    _invalidate_imported_report_caches(source, results)
     return attempt

--- a/backend/app/services/mail_source_backfill_worker.py
+++ b/backend/app/services/mail_source_backfill_worker.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Iterable, List, Optional
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
+from app.core.database import SessionLocal
 from app.core.redaction import redact_sensitive_text
 from app.models.mail_source import MailSource
 from app.models.mail_source_backfill import MailSourceBackfillJob
@@ -656,6 +657,27 @@ def run_mail_source_backfill_job(db: Session, job: MailSourceBackfillJob) -> boo
     if source.method == "M365_GRAPH":
         return run_m365_backfill_job(db, job)
     return False
+
+
+def run_mail_source_backfill_job_by_id(job_id: int) -> bool:
+    """Run one queued backfill in a standalone session for API background tasks."""
+    db = SessionLocal()
+    try:
+        job = (
+            db.query(MailSourceBackfillJob)
+            .filter(MailSourceBackfillJob.id == job_id)
+            .with_for_update(skip_locked=True)
+            .first()
+        )
+        if job is None:
+            return False
+        return run_mail_source_backfill_job(db, job)
+    except Exception:  # pylint: disable=broad-exception-caught
+        db.rollback()
+        logger.exception("Background backfill job id=%s could not start", job_id)
+        return False
+    finally:
+        db.close()
 
 
 def run_due_imap_backfill_jobs(db: Session, limit: int = 1) -> int:

--- a/backend/app/static/js/mail-sources-page.js
+++ b/backend/app/static/js/mail-sources-page.js
@@ -12,6 +12,7 @@ function mailSourcesApp() {
         backfillJobs: {},
         backfillLoading: {},
         backfillAction: {},
+        backfillPollTimers: {},
         backfillSource: null,
         backfillDays: 30,
         historySource: null,
@@ -208,9 +209,26 @@ function mailSourcesApp() {
                     this.feedback = this.apiErrorFeedback(result, 'Import error', 'Import failed');
                     return;
                 }
+                const imported = Number(result.reports_found || 0) + Number(result.forensic_reports_found || 0);
+                const duplicates = Number(result.duplicate_reports || 0) + Number(result.duplicate_forensic_reports || 0);
+                const errors = Number(result.error_count || 0);
+                let outcome;
+                if (imported === 0 && duplicates > 0) {
+                    outcome = `No new reports; ${duplicates} already imported report${duplicates === 1 ? '' : 's'} confirmed.`;
+                } else {
+                    outcome = `${imported} new report${imported === 1 ? '' : 's'} imported`;
+                    if (duplicates > 0) {
+                        outcome += `; ${duplicates} already imported report${duplicates === 1 ? '' : 's'} confirmed`;
+                    }
+                    outcome += '.';
+                }
+                if (errors > 0) {
+                    outcome += ` ${errors} other attachment${errors === 1 ? '' : 's'} could not be parsed; review Import History.`;
+                }
                 this.feedback = {
-                    message: `Import finished for ${source.name} (${safeDays} day${safeDays === 1 ? '' : 's'}): ${result.reports_found} report${result.reports_found === 1 ? '' : 's'}, ${result.duplicate_reports || 0} duplicate${result.duplicate_reports === 1 ? '' : 's'}.`,
-                    type: result.success ? 'success' : 'error',
+                    message: `Import finished for ${source.name} (${safeDays} day${safeDays === 1 ? '' : 's'}): ${outcome}`,
+                    type: result.success ? (errors > 0 ? 'warning' : 'success') : 'error',
+                    ...this.diagnosticFromResult(result),
                 };
                 await this.loadSources();
                 if (this.historySource && this.historySource.id === source.id) {
@@ -267,6 +285,12 @@ function mailSourcesApp() {
                     throw new Error(this.apiErrorMessage(data, 'Failed to load backfill jobs'));
                 }
                 this.backfillJobs = { ...this.backfillJobs, [source.id]: data };
+                const latest = data[0];
+                if (!latest || this.backfillIsTerminal(latest.status)) {
+                    this.stopBackfillPolling(source.id);
+                } else {
+                    this.startBackfillPolling(source);
+                }
             } catch (e) {
                 if (!silent) {
                     this.feedback = { message: `Backfill status error: ${e.message}`, type: 'error' };
@@ -305,6 +329,7 @@ function mailSourcesApp() {
                 };
                 const existing = this.backfillJobs[source.id] || [];
                 this.backfillJobs = { ...this.backfillJobs, [source.id]: [data, ...existing].slice(0, 5) };
+                this.startBackfillPolling(source);
                 await this.loadBackfills(source, true);
             } catch (e) {
                 this.feedback = { ...this.emptyFeedback(), message: `Backfill error: ${e.message}`, type: 'error' };
@@ -326,6 +351,7 @@ function mailSourcesApp() {
                     throw new Error(this.apiErrorMessage(data, 'Failed to cancel backfill'));
                 }
                 this.replaceBackfill(source, data);
+                this.stopBackfillPolling(source.id);
                 this.feedback = { message: `Backfill cancelled for ${source.name}.`, type: 'success' };
             } catch (e) {
                 this.feedback = { message: `Cancel error: ${e.message}`, type: 'error' };
@@ -347,6 +373,7 @@ function mailSourcesApp() {
                     throw new Error(this.apiErrorMessage(data, 'Failed to retry backfill'));
                 }
                 this.replaceBackfill(source, data);
+                this.startBackfillPolling(source);
                 this.feedback = { message: `Backfill retried for ${source.name}.`, type: 'success' };
             } catch (e) {
                 this.feedback = { message: `Retry error: ${e.message}`, type: 'error' };
@@ -362,6 +389,30 @@ function mailSourcesApp() {
                 nextRows.unshift(updated);
             }
             this.backfillJobs = { ...this.backfillJobs, [source.id]: nextRows.slice(0, 5) };
+        },
+
+        backfillIsTerminal(status) {
+            return ['completed', 'failed', 'cancelled'].includes(status);
+        },
+
+        startBackfillPolling(source) {
+            if (!source || this.backfillPollTimers[source.id]) return;
+            const poll = async () => {
+                await this.loadBackfills(source, true);
+                const latest = this.latestBackfill(source);
+                if (!latest || this.backfillIsTerminal(latest.status)) {
+                    this.stopBackfillPolling(source.id);
+                    return;
+                }
+                this.backfillPollTimers[source.id] = window.setTimeout(poll, 2000);
+            };
+            this.backfillPollTimers[source.id] = window.setTimeout(poll, 500);
+        },
+
+        stopBackfillPolling(sourceId) {
+            const timer = this.backfillPollTimers[sourceId];
+            if (timer) window.clearTimeout(timer);
+            delete this.backfillPollTimers[sourceId];
         },
 
         async loadImportHistory(source) {
@@ -391,6 +442,50 @@ function mailSourcesApp() {
 
         formatDate(value) {
             return value ? new Date(value).toLocaleString() : '—';
+        },
+
+        lastCheckedLabel(source) {
+            return source && source.last_checked ? this.formatDate(source.last_checked) : 'Never';
+        },
+
+        isFetching(source) {
+            return Boolean(source && this.fetching[source.id]);
+        },
+
+        isTestingSource(source) {
+            return Boolean(source && this.testing[source.id]);
+        },
+
+        hasBackfillAction(source) {
+            return Boolean(source && this.backfillAction[source.id]);
+        },
+
+        importHistoryTitle(source) {
+            return source ? `${source.name} • ${this.sourceTargetLabel(source)}` : '';
+        },
+
+        importErrorLabel(entry) {
+            const count = Number(entry && entry.error_count ? entry.error_count : 0);
+            return `${count} error${count === 1 ? '' : 's'}`;
+        },
+
+        detailKey(detail) {
+            if (!detail) return 'detail';
+            return [detail.status, detail.message_id, detail.filename, detail.report_id]
+                .filter(Boolean)
+                .join('-');
+        },
+
+        detailMailboxFolder(detail) {
+            return `${detail.mailbox || 'mailbox'} / ${detail.folder || 'folder'}`;
+        },
+
+        detailSuffix(value) {
+            return value ? ` • ${value}` : '';
+        },
+
+        detailReasonSuffix(value) {
+            return this.detailSuffix((value || '').replaceAll('_', ' '));
         },
 
         sourceAccountLabel(source) {
@@ -479,6 +574,10 @@ function mailSourcesApp() {
             return labels[status] || status || 'Unknown';
         },
 
+        backfillRetryLabel(job) {
+            return job && job.next_retry_at ? `Retry ${this.formatDate(job.next_retry_at)}` : '';
+        },
+
         backfillBadgeClass(status) {
             if (status === 'completed') return 'badge-success';
             if (status === 'running') return 'badge-info';
@@ -503,7 +602,10 @@ function mailSourcesApp() {
         },
 
         backfillWindowLabel(job) {
-            if (job && job.requested_window_days) return `${job.requested_window_days} days`;
+            if (job && job.requested_window_days) {
+                const days = Number(job.requested_window_days);
+                return `${days} day${days === 1 ? '' : 's'}`;
+            }
             if (!job || !job.requested_start || !job.requested_end) return 'Default search window';
             const start = new Date(job.requested_start).toLocaleDateString();
             const end = new Date(job.requested_end).toLocaleDateString();
@@ -747,7 +849,7 @@ function mailSourcesApp() {
             this.feedback = { message: '', type: '' };
             try {
                 const payload = { ...this.form };
-                // Don't send empty password on edit
+                // A blank edit field means the encrypted stored secret remains unchanged.
                 if (this.editingId && !payload.password) {
                     delete payload.password;
                 }
@@ -854,6 +956,11 @@ function mailSourcesApp() {
             this.isTesting = true;
             this.testResult = this.emptyTestResult();
             try {
+                const useStoredCredentials = Boolean(
+                    this.editingId
+                    && !this.form.password
+                    && ['IMAP', 'POP3'].includes(this.form.method)
+                );
                 const payload = {
                     server: this.form.server,
                     port: this.form.port,
@@ -862,17 +969,23 @@ function mailSourcesApp() {
                     ssl: this.form.use_ssl,
                     method: this.form.method,
                 };
-                const resp = await fetch('/api/v1/mail-sources/test-connection', {
+                const url = useStoredCredentials
+                    ? `/api/v1/mail-sources/${this.editingId}/test`
+                    : '/api/v1/mail-sources/test-connection';
+                const options = {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(payload),
-                });
+                };
+                if (!useStoredCredentials) {
+                    options.headers = { 'Content-Type': 'application/json' };
+                    options.body = JSON.stringify(payload);
+                }
+                const resp = await fetch(url, options);
                 const result = await resp.json();
                 const diagnostic = this.diagnosticFromResult(result);
                 this.testResult = {
                     success: result.success,
                     message: result.success
-                        ? `✓ Connected. ${result.message_count || 0} messages, ${result.dmarc_count || 0} potential DMARC reports.`
+                        ? `✓ Connected${useStoredCredentials ? ' with the saved password' : ''}. ${result.message_count || 0} messages, ${result.dmarc_count || 0} potential DMARC reports.`
                         : `✗ ${result.message}`,
                     ...diagnostic,
                 };

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -57,6 +57,19 @@
             {% endcall %}
         {% endcall %}
     </template>
+    <template x-if="feedback.message && feedback.type === 'warning'">
+        {% call alert(variant="warning") %}
+            {% call alert_description() %}
+                <span x-text="feedback.message"></span>
+                <div class="mt-2 text-xs font-medium" x-show="feedback.diagnostic_summary" x-text="feedback.diagnostic_summary"></div>
+                <ul class="mt-2 list-disc pl-5 text-xs space-y-1" x-show="feedback.recovery_steps && feedback.recovery_steps.length">
+                    <template x-for="step in feedback.recovery_steps" :key="step">
+                        <li x-text="step"></li>
+                    </template>
+                </ul>
+            {% endcall %}
+        {% endcall %}
+    </template>
 
     <!-- Sources list -->
     {% call card() %}
@@ -102,7 +115,7 @@
                                                 x-text="source.connection_message"></p>
                                         </div>
                                     </td>
-                                    <td x-text="source.last_checked ? new Date(source.last_checked).toLocaleString() : 'Never'"></td>
+                                    <td x-text="lastCheckedLabel(source)"></td>
                                     <td class="min-w-72">
                                         <template x-if="backfillLoading[source.id]">
                                             <p class="text-xs text-muted-foreground">Loading backfill status…</p>
@@ -134,7 +147,7 @@
                                                     <span><strong class="text-foreground" x-text="latestBackfill(source).duplicate_reports"></strong> duplicates</span>
                                                 </div>
                                                 <p class="text-[11px] text-warning" x-show="latestBackfill(source).next_retry_at"
-                                                    x-text="`Retry ${formatDate(latestBackfill(source).next_retry_at)}`"></p>
+                                                    x-text="backfillRetryLabel(latestBackfill(source))"></p>
                                                 <p class="text-[11px] text-error" x-show="latestBackfill(source).errors && latestBackfill(source).errors.length"
                                                     x-text="latestBackfill(source).errors[0]"></p>
                                                 <div class="flex flex-wrap gap-1">
@@ -185,7 +198,7 @@
                                                 </svg>
                                             </button>
                                             <button class="btn btn-ghost btn-xs" :data-source-id="source.id" data-mail-source-test title="Test connection"
-                                                :disabled="testing[source.id]">
+                                                :disabled="isTestingSource(source)">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
                                                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                                     stroke-linejoin="round">
@@ -194,7 +207,7 @@
                                                 </svg>
                                             </button>
                                             <button class="btn btn-ghost btn-xs" :data-source-id="source.id" data-mail-source-fetch title="Run import now"
-                                                :disabled="Boolean(fetching[source.id])">
+                                                :disabled="isFetching(source)">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
                                                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                                     stroke-linejoin="round">
@@ -203,7 +216,7 @@
                                                 </svg>
                                             </button>
                                             <button class="btn btn-ghost btn-xs" :data-source-id="source.id" data-mail-source-backfill title="Backfill date range"
-                                                :disabled="Boolean(fetching[source.id])">
+                                                :disabled="isFetching(source)">
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
                                                     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                                     stroke-linejoin="round">
@@ -251,7 +264,7 @@
                     <div>
                         {% call card_title() %}Import History{% endcall %}
                         {% call card_description() %}
-                            <span x-text="historySource ? `${historySource.name} • ${sourceTargetLabel(historySource)}` : ''"></span>
+                            <span x-text="importHistoryTitle(historySource)"></span>
                         {% endcall %}
                     </div>
                     <button class="btn btn-ghost btn-sm" data-mail-source-history-close>Close</button>
@@ -295,7 +308,7 @@
                                         <td>
                                             <template x-if="entry.errors && entry.errors.length">
                                                 <details class="max-w-xs">
-                                                    <summary class="cursor-pointer" x-text="`${entry.error_count} error${entry.error_count === 1 ? '' : 's'}`"></summary>
+                                                    <summary class="cursor-pointer" x-text="importErrorLabel(entry)"></summary>
                                                     <ul class="list-disc pl-4 mt-2 text-xs space-y-1">
                                                         <template x-for="error in entry.errors" :key="error">
                                                             <li x-text="error"></li>
@@ -312,19 +325,19 @@
                                                 <details class="max-w-sm">
                                                     <summary class="cursor-pointer" x-text="formatDetailsSummary(entry.details)"></summary>
                                                     <div class="mt-2 space-y-2 text-xs">
-                                                        <template x-for="detail in entry.details" :key="`${detail.status}-${detail.message_id || ''}-${detail.filename || ''}-${detail.report_id || ''}`">
+                                                        <template x-for="detail in entry.details" :key="detailKey(detail)">
                                                             <div class="rounded border border-base-300 p-2">
                                                                 <div class="flex flex-wrap items-center gap-2">
                                                                     <span class="badge badge-sm" :class="detailBadgeClass(detail.status)" x-text="detail.status"></span>
                                                                     <span class="font-mono" x-show="detail.report_id" x-text="detail.report_id"></span>
                                                                 </div>
                                                                 <div class="mt-1 text-muted-foreground">
-                                                                    <span x-show="detail.mailbox || detail.folder" x-text="`${detail.mailbox || 'mailbox'} / ${detail.folder || 'folder'}`"></span>
+                                                                    <span x-show="detail.mailbox || detail.folder" x-text="detailMailboxFolder(detail)"></span>
                                                                     <span x-show="(detail.mailbox || detail.folder) && (detail.filename || detail.domain || detail.reason || detail.error)"> • </span>
                                                                     <span x-show="detail.filename" x-text="detail.filename"></span>
-                                                                    <span x-show="detail.domain" x-text="` • ${detail.domain}`"></span>
-                                                                    <span x-show="detail.reason" x-text="` • ${(detail.reason || '').replaceAll('_', ' ')}`"></span>
-                                                                    <span x-show="detail.error" x-text="` • ${detail.error}`"></span>
+                                                                    <span x-show="detail.domain" x-text="detailSuffix(detail.domain)"></span>
+                                                                    <span x-show="detail.reason" x-text="detailReasonSuffix(detail.reason)"></span>
+                                                                    <span x-show="detail.error" x-text="detailSuffix(detail.error)"></span>
                                                                 </div>
                                                             </div>
                                                         </template>
@@ -396,6 +409,7 @@
                         <div>
                             <label class="label"><span class="label-text font-medium">Username <span class="text-error">*</span></span></label>
                             <input type="text" x-model="form.username" placeholder="dmarc@example.com"
+                                autocomplete="username"
                                 class="input input-bordered w-full" />
                         </div>
                     </template>
@@ -404,11 +418,14 @@
                     <template x-if="form.method === 'IMAP' || form.method === 'POP3'">
                         <div>
                             <label class="label">
-                                <span class="label-text font-medium">Password <span class="text-error">*</span></span>
-                                <span class="label-text-alt text-muted-foreground" x-show="editingId">Leave blank to keep existing</span>
+                                <span class="label-text font-medium">Password <span class="text-error" x-show="!editingId">*</span></span>
+                                <span class="label-text-alt text-muted-foreground" x-show="editingId" data-stored-secret-preserved>Leave blank to keep the saved password</span>
                             </label>
                             <div class="relative">
                                 <input :type="showPassword ? 'text' : 'password'" x-model="form.password"
+                                    :required="!editingId"
+                                    :placeholder="editingId ? 'Saved password remains unchanged' : 'App password or mailbox password'"
+                                    autocomplete="new-password"
                                     class="input input-bordered w-full pr-10" />
                                 <button type="button" class="absolute right-2 top-3 text-muted-foreground hover:text-foreground"
                                     data-mail-source-password-toggle>
@@ -717,7 +734,7 @@
             <div class="flex justify-end gap-2">
                 <button class="btn btn-ghost btn-sm" data-mail-source-backfill-close>Cancel</button>
                 <button class="btn btn-primary btn-sm" data-mail-source-backfill-run
-                    :disabled="!validBackfillDays() || Boolean(backfillAction[backfillSource && backfillSource.id])">
+                    :disabled="!validBackfillDays() || hasBackfillAction(backfillSource)">
                     Queue Backfill
                 </button>
             </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1943,6 +1943,9 @@ def test_mail_sources_list_actions_are_bound_from_external_script():
     assert "data-mail-source-backfill-modal" in template
     assert "data-backfill-days" in template
     assert "bindPageControls" in script
+    assert "feedback.type === 'warning'" in template
+    assert "already imported report" in script
+    assert "review Import History" in script
     assert "sourceById" in script
     assert "data-mail-source-toggle" in script
     assert "event.key !== 'Escape'" in script

--- a/backend/app/tests/test_mail_source_backfill_worker.py
+++ b/backend/app/tests/test_mail_source_backfill_worker.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
 
 from app.models.mail_source import MailSource
 from app.models.mail_source_backfill import MailSourceBackfillJob
@@ -14,6 +15,7 @@ from app.services.mail_source_backfill_worker import (
     run_imap_backfill_job,
     run_m365_backfill_job,
     run_mail_source_backfill_job,
+    run_mail_source_backfill_job_by_id,
 )
 from app.services.workspaces import get_or_create_default_workspace
 
@@ -633,6 +635,26 @@ def test_run_mail_source_backfill_dispatches_or_skips(db_session, monkeypatch):
     assert run_mail_source_backfill_job(db_session, imap_job) is True
     assert run_mail_source_backfill_job(db_session, gmail_job) is True
     assert run_mail_source_backfill_job(db_session, m365_job) is True
+
+
+def test_run_mail_source_backfill_job_by_id_uses_standalone_session(db_session, monkeypatch):
+    workspace, source = _source(db_session)
+    job = _job(db_session, workspace, source)
+    standalone = MagicMock(wraps=db_session)
+    dispatched = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.SessionLocal",
+        lambda: standalone,
+    )
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.run_mail_source_backfill_job",
+        dispatched,
+    )
+
+    assert run_mail_source_backfill_job_by_id(job.id) is True
+    dispatched.assert_called_once()
+    assert dispatched.call_args.args[1].id == job.id
+    standalone.close.assert_called_once()
 
 
 def test_run_imap_backfill_skips_unsupported_status_or_future_retry(db_session):

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -529,6 +529,54 @@ class TestMailSourceImportModel:
         assert "**redacted**" in attempt.errors
         assert "**redacted**" in attempt.details
 
+    def test_record_import_attempt_invalidates_imported_report_caches(self, db_session: Session):
+        source = MailSource(name="Cache Refresh", method="IMAP", workspace_id=23)
+        db_session.add(source)
+        db_session.commit()
+
+        with patch("app.services.import_history.StatsSummarizer") as summarizer_class:
+            record_import_attempt(
+                db_session,
+                source,
+                {
+                    "success": True,
+                    "reports_found": 2,
+                    "details": [
+                        {"status": "imported", "domain": "Example.COM"},
+                        {"status": "imported", "domain": "second.example"},
+                        {"status": "duplicate", "domain": "ignored.example"},
+                    ],
+                },
+                started_at=datetime.utcnow(),
+                trigger="manual",
+            )
+
+        invalidate = summarizer_class.return_value.invalidate_cache
+        invalidate.assert_any_call(workspace_id=23)
+        invalidate.assert_any_call("example.com", workspace_id=23)
+        invalidate.assert_any_call("second.example", workspace_id=23)
+        assert invalidate.call_count == 3
+
+    def test_record_import_attempt_keeps_caches_for_duplicate_only_run(self, db_session: Session):
+        source = MailSource(name="Duplicate Cache", method="IMAP")
+        db_session.add(source)
+        db_session.commit()
+
+        with patch("app.services.import_history.StatsSummarizer") as summarizer_class:
+            record_import_attempt(
+                db_session,
+                source,
+                {
+                    "success": True,
+                    "reports_found": 0,
+                    "duplicate_reports": 2,
+                },
+                started_at=datetime.utcnow(),
+                trigger="manual",
+            )
+
+        summarizer_class.assert_not_called()
+
 
 class TestMailSourceBackfillModel:
     """Unit tests for persisted mail source backfill progress rows."""
@@ -594,7 +642,18 @@ def test_mail_sources_template_exposes_backfill_progress_controls():
     assert "/backfills?limit=5" in script
     assert "/backfills/${job.id}/cancel" in script
     assert "/backfills/${job.id}/retry" in script
+    assert "startBackfillPolling" in script
+    assert "backfillIsTerminal" in script
     assert "Queue Backfill" in template
+    assert "data-stored-secret-preserved" in template
+    assert ':required="!editingId"' in template
+    assert "Saved password remains unchanged" in template
+    assert "useStoredCredentials" in script
+    assert "with the saved password" in script
+    assert "isTestingSource(source)" in template
+    assert "Boolean(" not in template
+    assert "new Date(" not in template
+    assert "`" not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
     assert "canCancelBackfill" in template
     assert "canRetryBackfill" in template
@@ -705,6 +764,17 @@ class TestMailSourcesAPI:
 
 class TestMailSourcesAPIAuthed:
     """HTTP-level tests using the authed_client fixture (auth dependency bypassed)."""
+
+    @pytest.fixture(autouse=True)
+    def _defer_background_backfills(self, monkeypatch):
+        """Keep API lifecycle assertions deterministic while recording dispatches."""
+        deferred = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            mail_sources_endpoint,
+            "run_mail_source_backfill_job_by_id",
+            deferred,
+        )
+        return deferred
 
     # ------------------------------------------------------------------
     # List
@@ -989,6 +1059,7 @@ class TestMailSourcesAPIAuthed:
         self,
         authed_client: TestClient,
         db_session: Session,
+        _defer_background_backfills,
     ):
         workspace = get_or_create_default_workspace(db_session)
         _add_domain(db_session, workspace, verified=False)
@@ -1034,6 +1105,7 @@ class TestMailSourcesAPIAuthed:
         assert get_response.status_code == 200
         assert get_response.json()["id"] == job["id"]
         assert get_response.json()["can_cancel"] is True
+        _defer_background_backfills.assert_called_once_with(job["id"])
 
         row = db_session.get(MailSourceBackfillJob, job["id"])
         row.cursor = json.dumps(
@@ -1284,6 +1356,50 @@ class TestMailSourcesAPIAuthed:
         )
         assert update_resp.status_code == 200
         assert update_resp.json()["method"] == "POP3"
+
+    def test_update_blank_password_preserves_stored_secret_for_connection_test(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        create_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            json={
+                "name": "Stored Gmail IMAP",
+                "method": "IMAP",
+                "server": "imap.gmail.com",
+                "port": 993,
+                "username": "reports@example.com",
+                "password": "stored-app-password",
+            },
+        )
+        source_id = create_resp.json()["id"]
+
+        update_resp = authed_client.put(
+            f"/api/v1/mail-sources/{source_id}",
+            json={"name": "Stored Gmail IMAP Updated", "password": ""},
+        )
+
+        source = db_session.get(MailSource, source_id)
+        db_session.refresh(source)
+        assert update_resp.status_code == 200
+        assert source.password == "stored-app-password"
+
+        mock_client = MagicMock()
+        mock_client.test_connection.return_value = (
+            True,
+            "Connection successful",
+            {"message_count": 1, "unread_count": 0, "dmarc_count": 1},
+        )
+        with patch(
+            "app.api.api_v1.endpoints.mail_sources.IMAPClient",
+            return_value=mock_client,
+        ) as client_class:
+            test_resp = authed_client.post(f"/api/v1/mail-sources/{source_id}/test")
+
+        assert test_resp.status_code == 200
+        assert test_resp.json()["success"] is True
+        assert client_class.call_args.kwargs["password"] == "stored-app-password"
 
     def test_update_enable_allows_unverified_report_domains(
         self,

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -101,6 +101,26 @@ def test_ci_cancels_superseded_runs_for_the_same_ref():
     assert "cancel-in-progress: true" in workflow
 
 
+def test_greenfield_smoke_uses_rendered_config_for_database_isolation():
+    """An intentionally unpublished DB port must not fail the smoke command itself."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    smoke = workflow.split("docker-compose-smoke:", maxsplit=1)[1].split("security:", maxsplit=1)[0]
+    assert "./scripts/verify-docker-compose.sh" in smoke
+    assert "port db 5432" not in smoke
+    assert "--format '{{ json .Config.ExposedPorts }}' dmarq-app:local" in smoke
+
+
+def test_compose_verifier_supports_plugin_and_standalone_compose():
+    """Greenfield verification must work with both documented Compose variants."""
+    script = (REPO_ROOT / "scripts" / "verify-docker-compose.sh").read_text(encoding="utf-8")
+
+    assert "docker compose version" in script
+    assert "command -v docker-compose" in script
+    assert "set -- docker-compose" in script
+    assert '"$@" config --format json' in script
+
+
 def test_release_workflow_promotes_multi_user_demo_with_nonprod():
     """Every release must keep the separate provider demo on the current image."""
     workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -93,6 +93,14 @@ def test_release_workflow_skips_gitops_for_stale_main_runs():
     ) in workflow
 
 
+def test_ci_cancels_superseded_runs_for_the_same_ref():
+    """A newer main or PR run must own moving image tags and deployment gates."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "group: ci-${{ github.workflow }}-${{ github.ref }}" in workflow
+    assert "cancel-in-progress: true" in workflow
+
+
 def test_release_workflow_promotes_multi_user_demo_with_nonprod():
     """Every release must keep the separate provider demo on the current image."""
     workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -94,10 +94,13 @@ def test_release_workflow_skips_gitops_for_stale_main_runs():
 
 
 def test_ci_cancels_superseded_runs_for_the_same_ref():
-    """A newer main or PR run must own moving image tags and deployment gates."""
+    """Superseded branch runs cancel without aborting tag release dispatches."""
     workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
-    assert "group: ci-${{ github.workflow }}-${{ github.ref }}" in workflow
+    assert (
+        "group: ci-${{ github.workflow }}-${{ github.ref }}-"
+        "${{ github.event.inputs.release_ref || 'branch' }}"
+    ) in workflow
     assert "cancel-in-progress: true" in workflow
 
 

--- a/docs/readthedocs/requirements.txt
+++ b/docs/readthedocs/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs==1.4.3
-mkdocs-material==9.1.15
-mkdocstrings==0.21.2
-mkdocstrings-python==1.1.2
-pymdown-extensions==10.21.3
-mkdocs-git-revision-date-localized-plugin==1.2.0
+mkdocs==1.6.1
+mkdocs-material==9.7.6
+mkdocstrings==1.0.6
+mkdocstrings-python==2.0.5
+pymdown-extensions==11.0.1
+mkdocs-git-revision-date-localized-plugin==1.5.3

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -350,8 +350,8 @@ settings are preserved unless `overwrite_existing` is set to `true`.
 ### Mail Source Backfills
 
 Mailbox backfills are admin endpoints for resumable historical imports. Creating
-a backfill queues a progress row; connector workers can then process the window
-without blocking the UI.
+a backfill queues a progress row and starts it as an API background task; the
+scheduled connector worker remains a fallback without blocking the UI.
 
 | Endpoint | Purpose |
 | --- | --- |
@@ -361,7 +361,8 @@ without blocking the UI.
 | `POST /mail-sources/{source_id}/backfills/{job_id}/cancel` | Cancel a queued, running, or backoff job |
 | `POST /mail-sources/{source_id}/backfills/{job_id}/retry` | Re-queue a failed, cancelled, or backoff job |
 
-The Mail Sources UI shows the latest backfill status, processed message counts,
+The Mail Sources UI automatically follows active jobs and shows the latest
+backfill status, processed message counts,
 reports found, duplicates, retry timing, progress percentage, and operator
 controls. Backfill responses also include computed fields for
 `requested_window_days`, `elapsed_seconds`, `status_summary`, `can_cancel`, and

--- a/docs/user_guide/imap.md
+++ b/docs/user_guide/imap.md
@@ -55,7 +55,8 @@ After the first fetch:
 
 Use **Backfill** when reports exist outside the normal recent polling window.
 Start with a small date range, inspect the result, and widen it only when
-needed.
+needed. A queued backfill starts immediately in the background, and the Mail
+Sources page refreshes its progress until it completes or needs attention.
 
 ## Scheduled Polling
 
@@ -84,8 +85,12 @@ policy. Passwords and tokens are never returned by the Mail Sources API.
 
 - Toggle a source off to stop scheduled checks without deleting its history.
 - Edit the source to change its folder, interval, or credentials. Leave the
-  password blank only when the form explicitly says the stored password will be
-  retained.
+  password blank to retain the encrypted stored password. DMARQ omits the blank
+  field in the browser and also ignores an explicitly empty password at the API
+  boundary.
+- In an existing source, **Test Connection** uses the saved password while the
+  field remains blank. Enter a new password only when you want to test and then
+  save a credential replacement.
 - Test again after changing credentials or folders.
 - Delete a source only when its configuration and operational history are no
   longer needed. Imported DMARC reports are separate persisted records.

--- a/scripts/verify-docker-compose.sh
+++ b/scripts/verify-docker-compose.sh
@@ -8,7 +8,16 @@ cd "$ROOT_DIR"
 config_file=$(mktemp "${TMPDIR:-/tmp}/dmarq-compose.XXXXXX")
 trap 'rm -f "$config_file"' EXIT HUP INT TERM
 
-docker compose config --format json > "$config_file"
+if docker compose version >/dev/null 2>&1; then
+    set -- docker compose
+elif command -v docker-compose >/dev/null 2>&1; then
+    set -- docker-compose
+else
+    echo "Docker Compose is required (docker compose or docker-compose)." >&2
+    exit 1
+fi
+
+"$@" config --format json > "$config_file"
 
 python3 - "$config_file" "$ROOT_DIR/.env" <<'PY'
 import json


### PR DESCRIPTION
## What changed

- preserve stored IMAP, Gmail, and Microsoft 365 secrets when an edit submits a blank secret field
- let the edit dialog test the stored mailbox credentials without asking users to re-enter the password
- start queued and retried mailbox backfills immediately and refresh their progress in the UI
- invalidate report summary caches after successful imports
- harden the Mail Sources page for Alpine CSP and clarify import outcomes
- support both `docker compose` and standalone `docker-compose` in greenfield verification
- fix Docker image inspection and superseded CI run handling
- refresh the MkDocs dependency set so the documented documentation build resolves again

## Why

A greenfield user could configure Gmail successfully but later edits required re-entering the App Password, queued backfills appeared idle, and the documented Compose verifier depended on one Compose installation shape. These behaviors made the standalone setup in #758 unreliable even though the underlying mailbox credentials were still valid.

## Validation

- 1,916 tests passed, 17 skipped
- coverage: 96.85%
- 295 focused mail-source, backfill, template-security, and rollout tests passed
- strict MkDocs build passed
- Docker Compose contract passed with standalone Compose
- production Docker image built and health check passed
- browser smoke: blank-password edit, stored-credential connection test, save, post-save connection test, and completed backfill progress

Closes #758