### PR TITLE
Make DMARC workflows action-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parsed quoted Gmail folder names correctly.
 - Restored report-detail and forensics interactions under strict CSP and kept
   each DKIM remediation card tied to its matching selector.
+- Stopped remediation queues from advertising provider previews when the
+  connector exists but its credentials are not configured; manual DNS guidance
+  remains available until a provider connection is ready.
+- Labeled the dashboard health score as traffic-weighted so a high-volume
+  healthy domain cannot visually hide the separate count of domains needing
+  attention.
 
 ### Added
+- Added state-aware self-hosted onboarding that recognizes existing domains,
+  mailbox health, imported evidence, DNS-provider credentials, and notification
+  setup, then routes operators to the first required incomplete step instead of
+  reopening a blank setup form.
+- Added one dashboard next-action surface with report-backed domain scope,
+  explicit scheduled-import state, and progressively disclosed analytics so
+  remediation or mailbox recovery leads before secondary metrics.
+- Added report investigation summaries and provider/network source clusters,
+  with failing traffic first, compact IP evidence, paginated raw records, and
+  destructive report deletion moved into an overflow menu.
+- Clarified domain-remediation priority so active DMARC and sender-alignment
+  blockers lead while optional BIMI, MTA-STS, and TLS posture work is identified
+  as secondary when no higher-impact issue is active.
 - Added honest, incremental IMAP backfill diagnostics with checked, recognized,
   new, existing, ignored, and warning counts plus persisted polling progress.
 - Replaced the wide Mail Sources account table with responsive account rows,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -785,6 +785,15 @@ def _provider_credentials_configured(db: Session, provider_id: Optional[str]) ->
     return False
 
 
+def _configured_dns_write_provider_ids(db: Session) -> List[str]:
+    """Return write-capable provider IDs that also have configured credentials."""
+    return [
+        provider_id
+        for provider_id in _ready_dns_write_provider_ids()
+        if _provider_credentials_configured(db, provider_id)
+    ]
+
+
 def _dns_provider_repair_context(
     db: Session,
     *,
@@ -6250,7 +6259,7 @@ async def _build_domain_remediation_queue_for_workspace(
         refresh=refresh,
     )
     guidance = await _build_domain_dns_guidance(db, store, domain_name, refresh=refresh)
-    available_providers = _ready_dns_write_provider_ids()
+    available_providers = _configured_dns_write_provider_ids(db)
     recommended_provider = _recommended_dns_write_provider(
         guidance.get("dns_provider"),
         available_providers,

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -44,6 +44,13 @@ function dashboardApp() {
         hasEnabledMailSources: false,
         triggerPollStatus: '',
         triggerPollMessage: '',
+        hiddenEmptyDomainsCount: 0,
+        intakeState: {
+            schedulerActive: false,
+            attentionSources: 0,
+            reauthSources: 0,
+            lastCheck: '',
+        },
         demoDeployment: null,
         selectedDemoScenarioId: 'single-user-multiple-domains',
         selectedDemoZoomLevel: 'workspace',
@@ -152,6 +159,76 @@ function dashboardApp() {
 
         get hasTopHealthActions() {
             return this.topHealthActions.length > 0;
+        },
+
+        get secondaryHealthActions() {
+            return this.topHealthActions.slice(1);
+        },
+
+        get hasSecondaryHealthActions() {
+            return this.secondaryHealthActions.length > 0;
+        },
+
+        get dashboardNextAction() {
+            if (this.intakeState.reauthSources > 0) {
+                return {
+                    eyebrow: 'Report intake blocked',
+                    title: 'Reconnect the report mailbox',
+                    detail: 'A connected mailbox needs authorization before scheduled imports can continue.',
+                    label: 'Review mail source',
+                    href: '/mail-sources',
+                    severity: 'high',
+                };
+            }
+            if (this.intakeState.attentionSources > 0) {
+                return {
+                    eyebrow: 'Report intake needs attention',
+                    title: 'Resolve the mailbox connection warning',
+                    detail: 'DMARQ cannot rely on fresh evidence until the affected source succeeds again.',
+                    label: 'Review mail source',
+                    href: '/mail-sources',
+                    severity: 'high',
+                };
+            }
+            const action = this.topHealthActions[0];
+            if (action) {
+                return {
+                    eyebrow: `${action.severity || 'medium'} priority`,
+                    title: action.title || 'Review the highest-priority domain issue',
+                    detail: action.next_step || action.detail || 'Review current evidence before changing DNS or sender configuration.',
+                    label: 'Open remediation',
+                    href: this.domainActionHref(action),
+                    severity: action.severity || 'medium',
+                };
+            }
+            return {
+                eyebrow: 'Monitoring',
+                title: 'No immediate remediation action',
+                detail: 'Keep report intake running and review new sender or DNS changes when they appear.',
+                label: 'Review reports',
+                href: '/reports',
+                severity: 'info',
+            };
+        },
+
+        get dashboardScopeLabel() {
+            const hidden = Number(this.hiddenEmptyDomainsCount || 0);
+            if (!hidden) return 'Report-backed domains only';
+            return `Report-backed domains only · ${hidden} empty domain${hidden === 1 ? '' : 's'} hidden`;
+        },
+
+        get configuredDomainCount() {
+            return this.domains.length + Number(this.hiddenEmptyDomainsCount || 0);
+        },
+
+        get hasConfiguredDomainData() {
+            return this.configuredDomainCount > 0;
+        },
+
+        get intakeSchedulerLabel() {
+            if (this.triggerPollRunning) return 'Import running';
+            if (this.intakeState.schedulerActive) return 'Scheduled checks active';
+            return this.hasEnabledMailSources ? 'Scheduled checks stopped' : 'No source configured';
         },
 
         get selectedDnsPolicyLabel() {
@@ -399,6 +476,12 @@ function dashboardApp() {
                 }
                 const data = await response.json();
                 this.hasEnabledMailSources = (data.enabled_sources || 0) > 0;
+                this.intakeState = {
+                    schedulerActive: Boolean(data.is_running),
+                    attentionSources: Number(data.attention_sources || 0),
+                    reauthSources: Number(data.reauth_required_sources || 0),
+                    lastCheck: data.latest_source_check || data.last_check || '',
+                };
                 
                 const statusIcon = document.getElementById('imap-status-icon');
                 const statusText = document.getElementById('imap-status-text');
@@ -414,7 +497,7 @@ function dashboardApp() {
                 } else if (data.is_running && (data.enabled_sources || 0) > 0) {
                     statusIcon.classList.remove('bg-red-500');
                     statusIcon.classList.add('bg-green-500');
-                    statusText.textContent = 'Running';
+                    statusText.textContent = 'Scheduled checks active';
                 } else {
                     statusIcon.classList.remove('bg-green-500');
                     statusIcon.classList.add('bg-red-500');
@@ -489,12 +572,13 @@ function dashboardApp() {
             this.dashboardError = '';
             this.dashboardRefreshError = '';
             try {
-                const response = await fetch('/api/v1/domains/summary');
+                const response = await fetch('/api/v1/domains/summary?include_empty=false');
                 if (!response.ok) {
                     throw new Error('Dashboard data could not be loaded. Check the API service and try again.');
                 }
                 const data = await response.json();
                 this.domainSummaryLoadedAt = new Date().toISOString();
+                this.hiddenEmptyDomainsCount = Number(data.empty_domains_hidden || 0);
 
                 if (data && data.domains && data.domains.length > 0) {
                     this.domains = data.domains || [];
@@ -536,6 +620,7 @@ function dashboardApp() {
                 }
                 this.dashboardError = message;
                 this.domains = [];
+                this.hiddenEmptyDomainsCount = 0;
                 this.healthSummary = null;
                 this.healthHistory = null;
                 this.selectedDnsDomain = '';
@@ -1796,6 +1881,14 @@ function dashboardApp() {
             if (value === 'high') return 'text-[#b8431d]';
             if (value === 'medium') return 'text-[#8a6418]';
             return 'text-[#247982]';
+        },
+
+        severityDotClass(severity) {
+            const value = String(severity || '').toLowerCase();
+            if (value === 'critical') return 'bg-[#9f2525]';
+            if (value === 'high') return 'bg-[#b8431d]';
+            if (value === 'medium') return 'bg-[#c28a18]';
+            return 'bg-[#2f9da5]';
         },
 
         demoOrganizations() {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -717,6 +717,15 @@ function domainDetailsApp(domainId = '') {
             return item.repair_progression?.next_safe_action || this.primaryRemediationNextStep;
         },
 
+        get primaryRemediationScopeNote() {
+            const itemId = String(this.primaryRemediationItem?.id || '').toLowerCase();
+            const optionalPosture = ['bimi', 'mta_sts', 'mta-sts', 'tls_rpt', 'tls-rpt'];
+            if (optionalPosture.some(token => itemId.includes(token))) {
+                return 'No higher-priority DMARC authentication blocker is active. This is an optional posture improvement.';
+            }
+            return 'DMARQ prioritizes active DMARC failures, sender alignment, and enforcement blockers before optional posture work.';
+        },
+
         get primaryRemediationReadinessContext() {
             const reasons = this.primaryRemediationItem?.repair_progression?.readiness_reasons || [];
             return reasons[0] || 'Review current evidence before opening, dispatching, or closing this remediation.';

--- a/backend/app/static/js/onboarding-page.js
+++ b/backend/app/static/js/onboarding-page.js
@@ -10,6 +10,19 @@ function workspaceOnboarding(options = {}) {
         tasks: [],
         lastPreviewSignature: '',
         initialized: false,
+        setupStateLoading: true,
+        setupStateError: '',
+        setupStateLoaded: false,
+        configuring: false,
+        initialDraftSignature: '',
+        setupState: {
+            domains: 0,
+            reports: 0,
+            sources: 0,
+            healthySources: 0,
+            dnsProviderConnected: false,
+            notificationsConfigured: false,
+        },
         form: {
             organizationName: '',
             workspaceName: '',
@@ -27,6 +40,96 @@ function workspaceOnboarding(options = {}) {
         },
         get singleUserMode() {
             return !this.multiWorkspaceUiEnabled;
+        },
+        get hasExistingSetup() {
+            return this.setupState.domains > 0 || this.setupState.sources > 0 || this.setupState.reports > 0;
+        },
+        get showSetupStatus() {
+            return this.singleUserMode && this.setupStateLoaded && this.hasExistingSetup && !this.configuring;
+        },
+        get showSetupForm() {
+            return this.multiWorkspaceUiEnabled || !this.setupStateLoaded || !this.hasExistingSetup || this.configuring;
+        },
+        get setupStatusItems() {
+            const state = this.setupState;
+            return [
+                {
+                    id: 'domain',
+                    label: 'Monitored domains',
+                    complete: state.domains > 0,
+                    detail: state.domains > 0
+                        ? `${state.domains} domain${state.domains === 1 ? '' : 's'} configured`
+                        : 'Add the first domain you want to monitor.',
+                    href: '/domains',
+                    action: state.domains > 0 ? 'Review domains' : 'Add a domain',
+                },
+                {
+                    id: 'source',
+                    label: 'Report mailbox',
+                    complete: state.healthySources > 0,
+                    detail: state.sources === 0
+                        ? 'No Gmail or IMAP source is connected.'
+                        : state.healthySources > 0
+                            ? `${state.healthySources} enabled source${state.healthySources === 1 ? '' : 's'} ready`
+                            : `${state.sources} source${state.sources === 1 ? '' : 's'} need attention`,
+                    href: '/mail-sources',
+                    action: state.sources === 0 ? 'Connect mailbox' : 'Review mail sources',
+                },
+                {
+                    id: 'reports',
+                    label: 'DMARC evidence',
+                    complete: state.reports > 0,
+                    detail: state.reports > 0
+                        ? `${state.reports} aggregate report${state.reports === 1 ? '' : 's'} imported`
+                        : 'Import reports before acting on sender or policy guidance.',
+                    href: state.sources > 0 ? '/mail-sources' : '/upload',
+                    action: state.sources > 0 ? 'Import reports' : 'Choose import method',
+                },
+                {
+                    id: 'dns',
+                    label: 'DNS provider',
+                    complete: state.dnsProviderConnected,
+                    detail: state.dnsProviderConnected
+                        ? 'A provider connection is available for read or repair workflows.'
+                        : 'Optional: connect a provider for verified previews and approved changes.',
+                    href: '/settings#provider-integrations',
+                    action: state.dnsProviderConnected ? 'Review provider' : 'Connect provider',
+                    optional: true,
+                },
+                {
+                    id: 'notifications',
+                    label: 'Notifications',
+                    complete: state.notificationsConfigured,
+                    detail: state.notificationsConfigured
+                        ? 'Operator notifications are configured.'
+                        : 'Optional: add a notification target after report intake works.',
+                    href: '/settings#notification-settings',
+                    action: state.notificationsConfigured ? 'Review notifications' : 'Configure notifications',
+                    optional: true,
+                },
+            ];
+        },
+        get firstRequiredSetupAction() {
+            return this.setupStatusItems.find(item => !item.complete && !item.optional) || null;
+        },
+        get setupPrimaryHref() {
+            return this.firstRequiredSetupAction?.href || '/';
+        },
+        get setupPrimaryLabel() {
+            return this.firstRequiredSetupAction?.action || 'Open dashboard';
+        },
+        get setupHeadline() {
+            if (this.firstRequiredSetupAction) return 'Continue setup';
+            return 'Core monitoring is ready';
+        },
+        get setupSummary() {
+            if (this.firstRequiredSetupAction) {
+                return `${this.firstRequiredSetupAction.label} is the next required step.`;
+            }
+            return 'Domains, report intake, and DMARC evidence are available. Optional integrations can be configured when needed.';
+        },
+        get hasUnsavedDraft() {
+            return Boolean(this.initialDraftSignature && this.initialDraftSignature !== this.currentPreviewSignature);
         },
         get showWorkspaceSwitchSuccess() {
             return this.multiWorkspaceUiEnabled && Boolean(this.result?.workspace);
@@ -87,10 +190,18 @@ function workspaceOnboarding(options = {}) {
                 }
                 this.$watch(`form.${field}`, () => this.persistDraft());
             });
+            this.initialDraftSignature = this.currentPreviewSignature;
             this.bindControls();
+            this.loadSetupState();
         },
         bindControls() {
             const root = this.$root;
+            root?.addEventListener('submit', (event) => {
+                if (!(event.target instanceof Element)) return;
+                if (!event.target.matches('[data-onboarding-form]')) return;
+                event.preventDefault();
+                this.previewPlan();
+            });
             root?.addEventListener('click', (event) => {
                 if (!(event.target instanceof Element)) return;
                 const previewButton = event.target.closest('[data-onboarding-preview]');
@@ -104,9 +215,60 @@ function workspaceOnboarding(options = {}) {
                     return;
                 }
                 const pathButton = event.target.closest('[data-onboarding-mail-path]');
-                if (!pathButton) return;
-                this.form.mailSourcePath = pathButton.getAttribute('data-onboarding-mail-path') || 'imap';
+                if (pathButton) {
+                    this.form.mailSourcePath = pathButton.getAttribute('data-onboarding-mail-path') || 'imap';
+                    return;
+                }
+                const reconfigureButton = event.target.closest('[data-onboarding-reconfigure]');
+                if (reconfigureButton && root.contains(reconfigureButton)) {
+                    this.configuring = true;
+                }
             });
+        },
+        async loadSetupState() {
+            if (!this.singleUserMode) {
+                this.setupStateLoading = false;
+                this.setupStateLoaded = true;
+                return;
+            }
+            this.setupStateLoading = true;
+            this.setupStateError = '';
+            try {
+                const [domainResponse, sourceResponse, providerResponse, notificationResponse] = await Promise.all([
+                    fetch('/api/v1/domains/summary?include_empty=true'),
+                    fetch('/api/v1/mail-sources'),
+                    fetch('/api/v1/domains/dns/providers'),
+                    fetch('/api/v1/settings/notifications.apprise_enabled'),
+                ]);
+                if (!domainResponse.ok || !sourceResponse.ok) {
+                    throw new Error('Core setup status could not be loaded.');
+                }
+                const domains = await domainResponse.json();
+                const sources = await sourceResponse.json();
+                const providers = providerResponse.ok ? await providerResponse.json() : {};
+                const notifications = notificationResponse.ok ? await notificationResponse.json() : {};
+                const providerList = Array.isArray(providers.providers) ? providers.providers : [];
+                const sourceList = Array.isArray(sources) ? sources : [];
+                this.setupState = {
+                    domains: Number(domains.total_domains || 0),
+                    reports: Number(domains.reports_processed || 0),
+                    sources: sourceList.length,
+                    healthySources: sourceList.filter(source => (
+                        source.enabled && !source.connection_attention && source.connection_status !== 'reauth_required'
+                    )).length,
+                    dnsProviderConnected: providerList.some(provider => (
+                        provider.credentials_configured || provider.connection_status === 'connected'
+                    )),
+                    notificationsConfigured: ['true', '1', 'yes', 'on'].includes(
+                        String(notifications.value || '').trim().toLowerCase()
+                    ),
+                };
+            } catch (error) {
+                this.setupStateError = error.message || 'Setup status could not be loaded.';
+            } finally {
+                this.setupStateLoading = false;
+                this.setupStateLoaded = true;
+            }
         },
         draftFields() {
             return [
@@ -217,6 +379,8 @@ function workspaceOnboarding(options = {}) {
                         ? 'Mail health setup was applied.'
                         : 'Workspace onboarding was applied.';
                     this.persistAppliedWorkspace(data.result);
+                    this.initialDraftSignature = this.currentPreviewSignature;
+                    await this.loadSetupState();
                 }
                 this.persistDraft();
             } catch (err) {

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -7,6 +7,7 @@ function reportDetailApp(reportId = '') {
         reputationRefreshing: false,
         reputationRefreshError: '',
         recordRiskFilter: 'all',
+        recordPageSize: 25,
 
         async init() {
             this.reportId = this.$el?.dataset?.reportId || this.reportId;
@@ -35,6 +36,18 @@ function reportDetailApp(reportId = '') {
                 const refreshReputationButton = event.target.closest('[data-report-refresh-reputation]');
                 if (refreshReputationButton && root.contains(refreshReputationButton)) {
                     this.fetchReport({ refreshReputation: true });
+                    return;
+                }
+
+                const riskFilterButton = event.target.closest('[data-report-risk-filter]');
+                if (riskFilterButton && root.contains(riskFilterButton)) {
+                    this.setRecordRiskFilter(riskFilterButton.dataset.reportRiskFilter || 'all');
+                    return;
+                }
+
+                const showMoreButton = event.target.closest('[data-report-show-more-records]');
+                if (showMoreButton && root.contains(showMoreButton)) {
+                    this.recordPageSize += 25;
                     return;
                 }
 
@@ -76,6 +89,10 @@ function reportDetailApp(reportId = '') {
                 }
                 if (response.ok) {
                     this.report = this.normalizeReport(await response.json());
+                    if (!refreshReputation) {
+                        this.recordRiskFilter = this.recordRiskCounts.authReview > 0 ? 'auth_review' : 'all';
+                        this.recordPageSize = 25;
+                    }
                     if (!refreshReputation) {
                         this.reputationRefreshError = '';
                     }
@@ -171,6 +188,134 @@ function reportDetailApp(reportId = '') {
         get filteredRecords() {
             const records = this.report?.records || [];
             return records.filter((record) => this.recordRiskMatches(record, this.recordRiskFilter));
+        },
+
+        get visibleFilteredRecords() {
+            return this.filteredRecords.slice(0, this.recordPageSize);
+        },
+
+        get hiddenFilteredRecordCount() {
+            return Math.max(this.filteredRecords.length - this.visibleFilteredRecords.length, 0);
+        },
+
+        get senderClusters() {
+            const clusters = new Map();
+            (this.report?.records || []).forEach((record) => {
+                const details = record.source_details || {};
+                const sender = this.recordSender(record);
+                const provider = sender.provider || sender.name || details.organization || 'Unknown sender';
+                const network = details.network || details.asn || details.bgp_prefix || 'Unknown network';
+                const key = `${provider}|${network}`;
+                const cluster = clusters.get(key) || {
+                    key,
+                    provider,
+                    network,
+                    messages: 0,
+                    records: 0,
+                    failures: 0,
+                    mixed: 0,
+                    unknown: 0,
+                    ips: [],
+                    nextAction: '',
+                };
+                const count = Number(record.count || 0);
+                const dkim = String(record.dkim_result || '').toLowerCase();
+                const spf = String(record.spf_result || '').toLowerCase();
+                const disposition = String(record.disposition || '').toLowerCase();
+                const authFailure = (dkim === 'fail' && spf === 'fail') || ['reject', 'quarantine'].includes(disposition);
+                const mixed = (dkim === 'pass' && spf === 'fail') || (dkim === 'fail' && spf === 'pass');
+                const unknown = this.recordSenderStatus(record) === 'unknown' || provider === 'Unknown sender';
+                cluster.messages += count;
+                cluster.records += 1;
+                if (authFailure) cluster.failures += count;
+                if (mixed) cluster.mixed += count;
+                if (unknown) cluster.unknown += count;
+                if (record.source_ip && !cluster.ips.includes(record.source_ip)) cluster.ips.push(record.source_ip);
+                if (!cluster.nextAction) {
+                    cluster.nextAction = (record.next_steps || [])[0] ||
+                        this.recordSenderRemediationHint(record) ||
+                        (record.failure_reasons || [])[0] || '';
+                }
+                clusters.set(key, cluster);
+            });
+            return Array.from(clusters.values())
+                .sort((left, right) => (
+                    right.failures - left.failures ||
+                    right.unknown - left.unknown ||
+                    right.messages - left.messages
+                ))
+                .slice(0, 8);
+        },
+
+        get investigationCounts() {
+            return (this.report?.records || []).reduce((counts, record) => {
+                const count = Number(record.count || 0);
+                const dkim = String(record.dkim_result || '').toLowerCase();
+                const spf = String(record.spf_result || '').toLowerCase();
+                const disposition = String(record.disposition || '').toLowerCase();
+                if ((dkim === 'fail' && spf === 'fail') || ['reject', 'quarantine'].includes(disposition)) {
+                    counts.failed += count;
+                } else if ((dkim === 'pass' && spf === 'fail') || (dkim === 'fail' && spf === 'pass')) {
+                    counts.mixed += count;
+                } else if (!dkim || !spf || (dkim !== 'pass' && spf !== 'pass')) {
+                    counts.unknown += count;
+                }
+                return counts;
+            }, { failed: 0, mixed: 0, unknown: 0 });
+        },
+
+        get investigationTitle() {
+            const counts = this.investigationCounts;
+            if (counts.failed > 0) {
+                return `${this.countLabel(counts.failed, 'message')} ${counts.failed === 1 ? 'needs' : 'need'} authentication review`;
+            }
+            if (counts.mixed > 0) {
+                return `${this.countLabel(counts.mixed, 'message')} ${counts.mixed === 1 ? 'has' : 'have'} mixed SPF and DKIM results`;
+            }
+            if (counts.unknown > 0) {
+                return `${this.countLabel(counts.unknown, 'message')} ${counts.unknown === 1 ? 'needs' : 'need'} classification`;
+            }
+            return 'No authentication failure requires action';
+        },
+
+        countLabel(count, singular) {
+            const normalized = Number(count || 0);
+            return `${normalized} ${singular}${normalized === 1 ? '' : 's'}`;
+        },
+
+        get investigationDetail() {
+            const first = this.senderClusters.find(cluster => cluster.failures || cluster.mixed || cluster.unknown);
+            if (!first) return 'Keep monitoring this domain for new or changed sending sources.';
+            const signal = first.failures ? 'failing authentication' : first.mixed ? 'mixed authentication' : 'unclassified traffic';
+            return `${first.provider} on ${first.network} is the largest ${signal} cluster in this report.`;
+        },
+
+        get investigationPrimaryLabel() {
+            return this.investigationCounts.failed > 0 ? 'Review failing records' : 'Review source evidence';
+        },
+
+        get investigationPrimaryFilter() {
+            return this.investigationCounts.failed > 0 ? 'auth_review' : 'all';
+        },
+
+        setRecordRiskFilter(filter) {
+            this.recordRiskFilter = filter;
+            this.recordPageSize = 25;
+            window.location.hash = 'report-records';
+        },
+
+        clusterStatusLabel(cluster) {
+            if (cluster.failures > 0) return `${cluster.failures} failing`;
+            if (cluster.mixed > 0) return `${cluster.mixed} mixed`;
+            if (cluster.unknown > 0) return `${cluster.unknown} unknown`;
+            return 'No auth issue';
+        },
+
+        clusterStatusClass(cluster) {
+            if (cluster.failures > 0) return 'bg-red-100 text-red-800';
+            if (cluster.mixed > 0) return 'bg-yellow-100 text-yellow-800';
+            if (cluster.unknown > 0) return 'bg-gray-100 text-gray-700';
+            return 'bg-green-100 text-green-800';
         },
 
         get recordRiskCounts() {

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -121,10 +121,14 @@
                             </div>
                             <h2 class="mt-2 text-lg font-semibold text-[#07071f]" x-text="primaryRemediationItem.title"></h2>
                             <p class="mt-1 text-sm text-[#5f5c78]" x-text="primaryRemediationItem.detail"></p>
+                            <p class="mt-2 text-xs font-medium text-[#5f5c78]" x-text="primaryRemediationScopeNote"></p>
                             <p class="mt-3 text-sm text-[#120d36]">
                                 <span class="font-semibold">Next step: </span>
                                 <span x-text="primaryRemediationNextSafeAction"></span>
                             </p>
+                            <a :href="primaryRemediationCtaHref"
+                               class="btn mt-4 w-full border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f] lg:hidden"
+                               x-text="primaryRemediationCtaLabel"></a>
                             <details class="mt-3 rounded-md border border-[#e6e3e1] bg-white">
                                 <summary class="cursor-pointer px-3 py-2 text-sm font-semibold text-[#272a5f]">Technical workflow details</summary>
                                 <div class="grid gap-3 border-t border-[#e6e3e1] p-3 md:grid-cols-2 xl:grid-cols-3">
@@ -196,7 +200,7 @@
                         </div>
                         <div class="flex w-full flex-col gap-2 sm:w-auto">
                             <a :href="primaryRemediationCtaHref"
-                               class="btn btn-sm border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f]"
+                               class="btn btn-sm hidden border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f] lg:inline-flex"
                                x-text="primaryRemediationCtaLabel"></a>
                             <button type="button"
                                     x-show="primaryRemediationItem.evidence_refresh"

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -40,50 +40,32 @@
         <p class="mt-1" x-text="dashboardRefreshError"></p>
     </div>
 
-    <div class="rounded-lg bg-white p-4 shadow-sm" x-show="hasReportData" x-cloak data-tour="date-filter">
-        <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-            <div class="grid gap-1">
-                <label class="text-sm font-semibold text-[#120d36]" for="dashboard-date-interval">
-                    Date range
-                </label>
-                <div class="flex flex-wrap items-center gap-2">
-                    <select id="dashboard-date-interval"
-                            class="rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm font-semibold text-[#120d36]"
-                            x-model="dateInterval"
-                            data-dashboard-date-interval>
-                        <template x-for="option in dateIntervalOptions" :key="option.value">
-                            <option :value="option.value"
-                                    :selected="option.value === dateInterval"
-                                    x-text="option.label"></option>
-                        </template>
-                    </select>
-                    <template x-if="dateInterval === 'custom'">
-                        <div class="flex flex-wrap items-center gap-2">
-                            <input type="date"
-                                   class="rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm text-[#120d36]"
-                                   aria-label="Custom start date"
-                                   x-model="customStartDate">
-                            <input type="date"
-                                   class="rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm text-[#120d36]"
-                                   aria-label="Custom end date"
-                                   x-model="customEndDate">
-                            <button type="button"
-                                    class="rounded-md bg-[#272a5f] px-3 py-2 text-sm font-semibold text-white hover:bg-[#171346]"
-                                    data-dashboard-custom-apply>
-                                Apply
-                            </button>
-                        </div>
-                    </template>
+    <section class="rounded-lg border border-[#d8edf0] bg-[#f3fbfc] p-5 shadow-sm"
+             x-show="hasReportData" x-cloak aria-labelledby="dashboard-next-action-heading">
+        <div class="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+            <div class="flex min-w-0 items-start gap-4">
+                <span class="mt-1 h-3 w-3 flex-none rounded-full"
+                      :class="severityDotClass(dashboardNextAction.severity)"></span>
+                <div class="min-w-0">
+                    <p class="text-xs font-semibold uppercase tracking-wide text-[#247982]" x-text="dashboardNextAction.eyebrow"></p>
+                    <h2 id="dashboard-next-action-heading" class="mt-1 text-2xl font-semibold text-[#07071f]" x-text="dashboardNextAction.title"></h2>
+                    <p class="mt-2 max-w-3xl text-sm leading-6 text-[#5f5c78]" x-text="dashboardNextAction.detail"></p>
+                    <div class="mt-3 flex flex-wrap gap-2 text-xs font-semibold text-[#5f5c78]">
+                        <span class="rounded-full bg-white px-3 py-1" x-text="dashboardScopeLabel"></span>
+                        <span class="rounded-full bg-white px-3 py-1" x-text="intakeSchedulerLabel"></span>
+                    </div>
                 </div>
             </div>
-            <p class="text-sm text-[#5f5c78]" x-text="dateRangeLabel"></p>
+            <a :href="dashboardNextAction.href"
+               class="btn btn-primary w-full flex-none lg:w-auto"
+               x-text="dashboardNextAction.label"></a>
         </div>
-    </div>
+    </section>
 
     <section class="rounded-lg bg-white p-6 shadow-sm" x-show="healthSummary && hasReportData" x-cloak data-tour="health-score">
         <div class="grid gap-6 xl:grid-cols-[18rem_minmax(0,1fr)]">
             <div class="rounded-lg bg-[#f4f3f2] p-5">
-                <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]">System Health</p>
+                <p class="text-xs font-semibold uppercase tracking-wide text-[#2f9da5]">Traffic-weighted health</p>
                 <div class="mt-4 flex items-end gap-4">
                     <div class="text-6xl font-bold leading-none text-[#120d36]" x-text="healthScore"></div>
                     <div class="pb-1">
@@ -94,6 +76,7 @@
                     </div>
                 </div>
                 <p class="mt-4 text-sm text-[#5f5c78]">
+                    <span>Weighted by message volume. </span>
                     <span x-text="healthAttentionDomains"></span>
                     <span> of </span>
                     <span x-text="healthDomainCount"></span>
@@ -145,18 +128,18 @@
                 <div>
                     <div class="flex items-start justify-between gap-3">
                         <div>
-                            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">Action Plan</h2>
-                            <p class="mt-1 text-sm text-[#5f5c78]">Prioritized fixes linked to domain remediation queues.</p>
+                            <h2 class="text-2xl font-semibold tracking-normal text-[#07071f]">More actions</h2>
+                            <p class="mt-1 text-sm text-[#5f5c78]">Additional fixes after the primary next action above.</p>
                         </div>
                         <a href="/domains" class="text-sm font-semibold text-[#2f9da5] hover:text-[#272a5f]">Open domains</a>
                     </div>
                     <div class="mt-4 grid gap-3">
-                        <template x-if="!hasTopHealthActions">
+                        <template x-if="!hasSecondaryHealthActions">
                             <div class="rounded-md border border-[#e6e3e1] p-4 text-sm text-[#5f5c78]">
-                                No immediate remediation actions. Keep monitoring reports and DNS drift.
+                                No additional remediation actions. Keep monitoring reports and DNS drift.
                             </div>
                         </template>
-                        <template x-for="action in topHealthActions" :key="action.domain + action.type">
+                        <template x-for="action in secondaryHealthActions" :key="action.domain + action.type">
                             <a class="rounded-md border border-[#e6e3e1] p-4 transition hover:border-[#2f9da5] hover:shadow-sm"
                                :href="domainActionHref(action)">
                                 <div class="flex items-start justify-between gap-3">
@@ -219,6 +202,49 @@
             </div>
         </div>
     </section>
+
+    <details class="rounded-lg border border-[#dfdfdf] bg-white shadow-sm"
+             x-show="hasReportData" x-cloak data-tour="date-filter">
+        <summary class="flex cursor-pointer list-none flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <p class="font-semibold text-[#120d36]">Analytics window</p>
+                <p class="mt-1 text-sm text-[#5f5c78]">Change the evidence period used by trends and report-volume analytics.</p>
+            </div>
+            <span class="w-fit rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#5f5c78]" x-text="dateRangeLabel"></span>
+        </summary>
+        <div class="border-t border-[#dfdfdf] p-4">
+            <div class="flex flex-wrap items-center gap-2">
+                <label class="sr-only" for="dashboard-date-interval">Date range</label>
+                <select id="dashboard-date-interval"
+                        class="rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm font-semibold text-[#120d36]"
+                        x-model="dateInterval"
+                        data-dashboard-date-interval>
+                    <template x-for="option in dateIntervalOptions" :key="option.value">
+                        <option :value="option.value"
+                                :selected="option.value === dateInterval"
+                                x-text="option.label"></option>
+                    </template>
+                </select>
+                <template x-if="dateInterval === 'custom'">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <input type="date"
+                               class="rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm text-[#120d36]"
+                               aria-label="Custom start date"
+                               x-model="customStartDate">
+                        <input type="date"
+                               class="rounded-md border border-[#dfdfdf] bg-white px-3 py-2 text-sm text-[#120d36]"
+                               aria-label="Custom end date"
+                               x-model="customEndDate">
+                        <button type="button"
+                                class="rounded-md bg-[#272a5f] px-3 py-2 text-sm font-semibold text-white hover:bg-[#171346]"
+                                data-dashboard-custom-apply>
+                            Apply
+                        </button>
+                    </div>
+                </template>
+            </div>
+        </div>
+    </details>
 
     <details class="rounded-lg border border-[#dfdfdf] bg-white shadow-sm"
              x-show="healthSummary && hasReportData" x-cloak>
@@ -605,7 +631,17 @@
     </section>
     </details>
 
-    <div class="grid grid-cols-1 gap-6 xl:grid-cols-12" x-show="hasReportData" x-cloak>
+    <details class="rounded-lg border border-[#dfdfdf] bg-white shadow-sm"
+             x-show="hasReportData" x-cloak>
+        <summary class="flex cursor-pointer list-none flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <p class="font-semibold text-[#120d36]">Analytics and evidence</p>
+                <p class="mt-1 text-sm text-[#5f5c78]">Trends, enforcement, sending sources, changes, and the full domain table.</p>
+            </div>
+            <span class="w-fit rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#5f5c78]" x-text="dateRangeLabel"></span>
+        </summary>
+        <div class="space-y-6 border-t border-[#dfdfdf] p-4 sm:p-6">
+    <div class="grid grid-cols-1 gap-6 xl:grid-cols-12">
         <section class="rounded-lg bg-white p-6 shadow-sm xl:col-span-6" data-tour="compliance-chart">
             <div class="mb-3 grid gap-2 sm:flex sm:items-start sm:justify-between sm:gap-4">
                 <h2 class="min-w-0 text-2xl font-semibold tracking-normal text-[#07071f]">
@@ -783,6 +819,8 @@
             {% endcall %}
         {% endcall %}
     </div>
+        </div>
+    </details>
     
     <!-- No Data Message -->
     <div x-show="!dashboardLoading && !dashboardError && !hasReportData" x-cloak>
@@ -792,9 +830,9 @@
                     <p class="text-sm font-semibold uppercase tracking-wide text-[#2f9da5]">Welcome to DMARQ</p>
                     <h3 class="mt-2 text-2xl font-semibold text-[#120d36]">Start by connecting your report mailbox</h3>
                     <p class="mt-2 max-w-2xl text-sm text-[#5f5c78]">DMARQ needs aggregate reports before it can identify senders, measure authentication, or recommend DNS changes.</p>
-                    <p class="mt-2 text-sm font-semibold text-[#247982]" x-show="hasDomainData">
-                        <span x-text="domains.length"></span>
-                        monitored domain<span x-show="domains.length !== 1">s</span> already added. Report intake is the next step.
+                    <p class="mt-2 text-sm font-semibold text-[#247982]" x-show="hasConfiguredDomainData">
+                        <span x-text="configuredDomainCount"></span>
+                        monitored domain<span x-show="configuredDomainCount !== 1">s</span> already added. Report intake is the next step.
                     </p>
                     <div class="mt-5 flex flex-wrap gap-2">
                         {% call button_link(href="/mail-sources", variant="primary") %}

--- a/backend/app/templates/onboarding.html
+++ b/backend/app/templates/onboarding.html
@@ -23,7 +23,11 @@
                 {% endif %}
             </p>
         </div>
-        <div class="flex flex-wrap gap-2">
+        <div class="flex flex-wrap gap-2" x-show="showSetupForm">
+            <span x-show="hasUnsavedDraft"
+                  class="inline-flex items-center rounded-full bg-[#fff4df] px-3 py-1 text-xs font-semibold text-[#8a5b00]">
+                Unsaved setup changes
+            </span>
             <button type="button" class="btn btn-primary" :disabled="saving" data-onboarding-preview>
                 <span x-show="previewing" class="loading loading-spinner loading-xs"></span>
                 Preview tasks
@@ -54,8 +58,58 @@
         </div>
     </div>
 
-    <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]">
-        <section class="space-y-6">
+    <div x-show="setupStateLoading && singleUserMode"
+         role="status"
+         class="rounded-lg border border-[#e6e3e1] bg-white p-5 shadow-sm">
+        <div class="flex items-center gap-3">
+            <span class="loading loading-spinner loading-sm text-[#2f9da6]"></span>
+            <span class="text-sm font-medium text-[#5f5c78]">Checking the current setup...</span>
+        </div>
+    </div>
+
+    <div x-show="setupStateError && singleUserMode"
+         role="alert"
+         class="rounded-lg border border-[#ffcfbd] bg-[#fff2ec] p-4 text-sm text-[#8a2d0d]">
+        <p class="font-semibold">Setup status is unavailable</p>
+        <p class="mt-1" x-text="setupStateError"></p>
+    </div>
+
+    <section x-show="showSetupStatus"
+             class="rounded-lg bg-white p-6 shadow-sm"
+             aria-labelledby="current-setup-heading">
+        <div class="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+                <p class="text-sm font-semibold uppercase tracking-wide text-[#2f9da6]">Current setup</p>
+                <h2 id="current-setup-heading" class="mt-1 text-2xl font-semibold text-[#07071f]" x-text="setupHeadline"></h2>
+                <p class="mt-2 max-w-2xl text-sm leading-6 text-[#5f5c78]" x-text="setupSummary"></p>
+            </div>
+            <div class="flex flex-wrap gap-2">
+                <a :href="setupPrimaryHref" class="btn btn-primary" x-text="setupPrimaryLabel"></a>
+                <button type="button" class="btn btn-outline" data-onboarding-reconfigure>
+                    Reconfigure setup
+                </button>
+            </div>
+        </div>
+        <div class="mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            <template x-for="item in setupStatusItems" :key="item.id">
+                <a :href="item.href"
+                   class="flex items-start gap-3 rounded-md border border-[#e6e3e1] p-4 transition hover:border-[#2f9da6] hover:bg-[#f7fbfb]">
+                    <span class="mt-0.5 grid h-6 w-6 flex-none place-items-center rounded-full text-xs font-bold"
+                          :class="item.complete ? 'bg-[#e7f6f2] text-[#176d58]' : item.optional ? 'bg-[#f1f0ef] text-[#6c687b]' : 'bg-[#fff0e8] text-[#9c3f18]'"
+                          x-text="item.complete ? 'OK' : item.optional ? 'Opt' : '!'">
+                    </span>
+                    <span class="min-w-0">
+                        <span class="block font-semibold text-[#120d36]" x-text="item.label"></span>
+                        <span class="mt-1 block text-sm leading-5 text-[#5f5c78]" x-text="item.detail"></span>
+                        <span class="mt-2 block text-sm font-semibold text-[#247982]" x-text="item.action"></span>
+                    </span>
+                </a>
+            </template>
+        </div>
+    </section>
+
+    <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]" x-show="showSetupForm">
+        <form class="space-y-6" data-onboarding-form>
             <div class="grid gap-6 xl:grid-cols-2">
                 {% if multi_workspace_ui_enabled %}
                 <div class="rounded-lg bg-white p-6 shadow-sm">
@@ -158,7 +212,8 @@
                     <label class="form-control mt-4">
                         <span class="label-text font-medium">DMARC report mailbox</span>
                         <input x-model.trim="form.reportMailbox" type="email"
-                               class="input input-bordered" placeholder="dmarc@example.com">
+                               class="input input-bordered" placeholder="dmarc@example.com"
+                               autocomplete="email">
                     </label>
                 </div>
             </div>
@@ -196,7 +251,8 @@
                     <label class="form-control">
                         <span class="label-text font-medium">Username</span>
                         <input x-model.trim="form.imapUsername" type="text"
-                               class="input input-bordered" placeholder="dmarc@example.com">
+                               class="input input-bordered" placeholder="dmarc@example.com"
+                               autocomplete="username">
                     </label>
                     <label class="form-control">
                         <span class="label-text font-medium">Password</span>
@@ -214,7 +270,7 @@
                     A report source can be connected later from Mail Sources.
                 </div>
             </div>
-        </section>
+        </form>
 
         <aside class="space-y-6">
             <div class="rounded-lg bg-white p-6 shadow-sm">
@@ -271,10 +327,6 @@
                             <p class="mt-1 text-sm text-[#07071f]/60">
                                 DMARQ will show the exact domain, DNS, and report-source tasks first. Apply stays locked until the preview matches the current form.
                             </p>
-                            <button type="button" class="btn btn-primary btn-sm mt-4" :disabled="saving" data-onboarding-preview>
-                                <span x-show="previewing" class="loading loading-spinner loading-xs"></span>
-                                Preview setup tasks
-                            </button>
                         </div>
                     </template>
                     <template x-for="task in tasks" :key="task.id">

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -61,22 +61,49 @@
                         <a href="/reports" class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]">
                             All Reports
                         </a>
-                        <button type="button"
-                                class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]"
-                                data-report-refresh-reputation
-                                :disabled="reputationRefreshing">
-                            <span x-show="reputationRefreshing" class="loading loading-spinner loading-xs"></span>
-                            <span x-text="reputationRefreshing ? 'Refreshing reputation...' : 'Recalculate reputation'"></span>
-                        </button>
-                        <button class="btn btn-error btn-sm"
-                                data-report-delete
-                                :data-report-domain="report.domain"
-                                :data-report-id="report.report_id">
-                            Delete Report
-                        </button>
+                        <details class="dropdown dropdown-end">
+                            <summary class="btn btn-outline btn-sm border-[#dfdfdf] text-[#272a5f] hover:border-[#2f9da5] hover:bg-[#f4f3f2]">
+                                More actions
+                            </summary>
+                            <div class="menu dropdown-content z-20 mt-2 w-64 rounded-lg border border-[#e6e3e1] bg-white p-2 shadow-lg">
+                                <button type="button"
+                                        class="rounded-md px-3 py-2 text-left text-sm font-semibold text-[#272a5f] hover:bg-[#f4f3f2]"
+                                        data-report-refresh-reputation
+                                        :disabled="reputationRefreshing">
+                                    <span x-text="reputationRefreshing ? 'Refreshing reputation...' : 'Recalculate reputation'"></span>
+                                </button>
+                                <button type="button"
+                                        class="rounded-md px-3 py-2 text-left text-sm font-semibold text-[#a33717] hover:bg-[#fff2ec]"
+                                        data-report-delete
+                                        :data-report-domain="report.domain"
+                                        :data-report-id="report.report_id">
+                                    Delete report
+                                </button>
+                            </div>
+                        </details>
                     </div>
                 </div>
             </div>
+
+            <section class="rounded-lg border border-[#d8edf0] bg-[#f3fbfc] p-5 shadow-sm"
+                     aria-labelledby="report-investigation-heading">
+                <div class="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+                    <div>
+                        <p class="text-xs font-semibold uppercase tracking-wide text-[#247982]">Investigation summary</p>
+                        <h2 id="report-investigation-heading" class="mt-1 text-2xl font-semibold text-[#07071f]" x-text="investigationTitle"></h2>
+                        <p class="mt-2 max-w-3xl text-sm leading-6 text-[#5f5c78]" x-text="investigationDetail"></p>
+                        <div class="mt-3 flex flex-wrap gap-2 text-xs font-semibold">
+                            <span class="rounded-full bg-white px-3 py-1 text-[#8a2d0d]"><span x-text="investigationCounts.failed"></span> failing</span>
+                            <span class="rounded-full bg-white px-3 py-1 text-[#8a5b00]"><span x-text="investigationCounts.mixed"></span> mixed</span>
+                            <span class="rounded-full bg-white px-3 py-1 text-[#5f5c78]"><span x-text="investigationCounts.unknown"></span> unknown</span>
+                        </div>
+                    </div>
+                    <button type="button"
+                            class="btn btn-primary w-full flex-none lg:w-auto"
+                            :data-report-risk-filter="investigationPrimaryFilter"
+                            x-text="investigationPrimaryLabel"></button>
+                </div>
+            </section>
 
             <!-- Summary Cards -->
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -187,6 +214,42 @@
                 {% endcall %}
             {% endcall %}
 
+            {% call card() %}
+                {% call card_header() %}
+                    {% call card_title() %}Sending source clusters{% endcall %}
+                    {% call card_description() %}Providers and networks grouped before individual IP evidence{% endcall %}
+                {% endcall %}
+                {% call card_content() %}
+                    <div class="grid gap-3 lg:grid-cols-2">
+                        <template x-for="cluster in senderClusters" :key="cluster.key">
+                            <article class="rounded-md border border-[#e6e3e1] p-4">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div class="min-w-0">
+                                        <h3 class="truncate font-semibold text-[#120d36]" x-text="cluster.provider"></h3>
+                                        <p class="mt-1 truncate text-sm text-[#5f5c78]" x-text="cluster.network"></p>
+                                    </div>
+                                    <span class="flex-none rounded-full px-2 py-1 text-xs font-semibold"
+                                          :class="clusterStatusClass(cluster)"
+                                          x-text="clusterStatusLabel(cluster)"></span>
+                                </div>
+                                <div class="mt-3 flex flex-wrap gap-2 text-xs text-[#5f5c78]">
+                                    <span class="rounded bg-[#f4f3f2] px-2 py-1" x-text="countLabel(cluster.messages, 'message')"></span>
+                                    <span class="rounded bg-[#f4f3f2] px-2 py-1" x-text="countLabel(cluster.ips.length, 'IP')"></span>
+                                    <span class="rounded bg-[#f4f3f2] px-2 py-1" x-text="countLabel(cluster.records, 'record')"></span>
+                                </div>
+                                <p class="mt-3 text-sm font-semibold text-[#272a5f]"
+                                   x-show="cluster.nextAction"
+                                   x-text="cluster.nextAction"></p>
+                                <details class="mt-3 text-xs text-[#5f5c78]">
+                                    <summary class="cursor-pointer font-semibold text-[#247982]">Show IP evidence</summary>
+                                    <p class="mt-2 break-words font-mono" x-text="cluster.ips.join(', ') || 'No source IP recorded'"></p>
+                                </details>
+                            </article>
+                        </template>
+                    </div>
+                {% endcall %}
+            {% endcall %}
+
             <!-- Report Metadata -->
             {% call card() %}
                 {% call card_header() %}
@@ -289,6 +352,15 @@
                             </select>
                         </label>
                     </div>
+                    <details id="report-records" class="rounded-md border border-[#e6e3e1]">
+                        <summary class="flex cursor-pointer list-none items-center justify-between gap-3 p-4">
+                            <span>
+                                <span class="block font-semibold text-[#120d36]">Raw record evidence</span>
+                                <span class="mt-1 block text-sm text-[#5f5c78]">Expand individual IP, authentication, reputation, and policy results.</span>
+                            </span>
+                            <span class="rounded bg-[#f4f3f2] px-2 py-1 text-xs font-semibold text-[#5f5c78]" x-text="recordRiskLabel()"></span>
+                        </summary>
+                        <div class="overflow-x-auto border-t border-[#e6e3e1] p-3">
                     {% call table() %}
                         {% call thead() %}
                             {% call tr() %}
@@ -318,7 +390,7 @@
                                     </td>
                                 </tr>
                             </template>
-                            <template x-for="(record, index) in filteredRecords" :key="index">
+                            <template x-for="(record, index) in visibleFilteredRecords" :key="record.source_ip + '-' + index">
                                 {% call tr() %}
                                     {% call td() %}
                                         <span class="font-mono text-sm" x-text="record.source_ip"></span>
@@ -482,6 +554,14 @@
                             </template>
                         {% endcall %}
                     {% endcall %}
+                            <div class="mt-3 flex items-center justify-between gap-3" x-show="hiddenFilteredRecordCount > 0">
+                                <p class="text-sm text-[#5f5c78]">
+                                    <span x-text="hiddenFilteredRecordCount"></span> more matching records
+                                </p>
+                                <button type="button" class="btn btn-outline btn-sm" data-report-show-more-records>Show 25 more</button>
+                            </div>
+                        </div>
+                    </details>
                 {% endcall %}
             {% endcall %}
         </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -248,6 +248,30 @@ def _report_detail_script() -> str:
     return _read_project_file("static", "js", "report-detail-page.js")
 
 
+def _run_report_detail_expression(payload: dict[str, object], expression: str) -> object:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required to execute report-detail-page.js behavior tests")
+
+    script_path = Path(__file__).resolve().parents[1] / "static" / "js" / "report-detail-page.js"
+    runner = textwrap.dedent("""
+        const fs = require('fs');
+        const script = fs.readFileSync(process.argv[1], 'utf8');
+        const reportDetailFactory = new Function(`${script}\nreturn reportDetailApp;`)();
+        const app = reportDetailFactory('report-id');
+        app.report = { records: JSON.parse(process.argv[2]) };
+        const result = new Function('app', `return ${process.argv[3]};`)(app);
+        process.stdout.write(JSON.stringify(result));
+        """)
+    result = subprocess.run(
+        [node, "-e", runner, str(script_path), json.dumps(payload["records"]), expression],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
 def test_settings_cloudflare_oauth_uses_popup_with_full_window_fallback():
     template = _settings_template()
     script = _settings_script()
@@ -1371,6 +1395,16 @@ def test_dashboard_uses_external_page_script_for_csp_migration():
     assert "data-dashboard-custom-apply" in script
     assert "data-dashboard-dns-health-domain" in script
     assert "data-dashboard-trigger-poll" in script
+    assert "dashboardNextAction" in script
+    assert "severityDotClass(severity)" in script
+    assert "Report-backed domains only" in script
+    assert "Scheduled checks active" in script
+    assert "/api/v1/domains/summary?include_empty=false" in script
+    assert "Analytics window" in template
+    assert "Analytics and evidence" in template
+    assert "Traffic-weighted health" in template
+    assert "Weighted by message volume." in template
+    assert 'id="dashboard-next-action-heading"' in template
     assert "data-dashboard-demo-tour-close" in script
     assert "ownerDocument.addEventListener('keydown'" in script
     assert "removeEventListener('keydown'" in script
@@ -1832,6 +1866,7 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "record.reputation.feed_summary" in template
     assert "recordRiskFilter" in template
     assert "filteredRecords" in template
+    assert "visibleFilteredRecords" in template
     assert "recordRiskCounts" in template
     assert "recordRiskMatches(record, this.recordRiskFilter)" in script
     assert "recordRiskLabel()" in template
@@ -1846,6 +1881,15 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "seenLabel(record.reputation.last_seen)" in template
     assert "Use Recalculate reputation" in template
     assert "reputationFeedClass" in script
+    assert "Investigation summary" in template
+    assert "Sending source clusters" in template
+    assert "Raw record evidence" in template
+    assert "senderClusters" in script
+    assert "investigationCounts" in script
+    assert "data-report-risk-filter" in template
+    assert "data-report-risk-filter" in script
+    assert "data-report-show-more-records" in template
+    assert "data-report-show-more-records" in script
     assert "reputationLabel" in script
     assert "reputationEvidencePreview" in script
     assert "senderStatusClass" in script
@@ -2475,6 +2519,7 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "primaryRemediationItem" in script
     assert "primaryRemediationNextStep" in script
     assert "primaryRemediationNextSafeAction" in script
+    assert "primaryRemediationScopeNote" in script
     assert "primaryRemediationReadinessContext" in script
     assert "primaryRemediationBlockedText" in script
     assert "primaryRemediationDispatchText" in script
@@ -2504,6 +2549,7 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "repairReadinessLabel(primaryRemediationItem.repair_progression)" in template
     assert "repairReadinessScore(primaryRemediationItem.repair_progression)" in template
     assert "Next safe action" in template
+    assert "primaryRemediationScopeNote" in template
     assert "Freshness required" in template
     assert "primaryRemediationFreshnessText" in template
     assert "primaryRemediationClosureGateText" in template
@@ -2593,6 +2639,54 @@ def test_report_detail_exposes_record_review_guidance_without_html_injection():
     assert "record.next_steps" in template
     assert "Needs review" in template
     assert "x-html" not in template
+
+
+def test_report_detail_distinguishes_dmarc_failure_from_mixed_authentication():
+    payload = {
+        "records": [
+            {
+                "count": 1,
+                "dkim_result": "fail",
+                "spf_result": "fail",
+                "disposition": "reject",
+                "source_ip": "192.0.2.10",
+                "source_details": {
+                    "network": "Example Network",
+                    "sender": {"provider": "Example Sender", "status": "known"},
+                },
+            },
+            {
+                "count": 2,
+                "dkim_result": "fail",
+                "spf_result": "pass",
+                "disposition": "none",
+                "source_ip": "192.0.2.11",
+                "source_details": {
+                    "network": "Example Network",
+                    "sender": {"provider": "Example Sender", "status": "known"},
+                },
+            },
+        ]
+    }
+
+    result = _run_report_detail_expression(
+        payload,
+        "({ counts: app.investigationCounts, title: app.investigationTitle, clusters: app.senderClusters })",
+    )
+
+    assert result["counts"] == {"failed": 1, "mixed": 2, "unknown": 0}
+    assert result["title"] == "1 message needs authentication review"
+    assert result["clusters"][0]["failures"] == 1
+    assert result["clusters"][0]["mixed"] == 2
+
+
+def test_report_detail_count_labels_handle_singular_and_plural():
+    result = _run_report_detail_expression(
+        {"records": []},
+        "[app.countLabel(1, 'IP'), app.countLabel(2, 'IP'), app.countLabel(1, 'record')]",
+    )
+
+    assert result == ["1 IP", "2 IPs", "1 record"]
 
 
 def test_members_template_uses_membership_api_without_html_injection():
@@ -2834,6 +2928,16 @@ def test_onboarding_template_uses_single_user_setup_story_by_default():
     assert "showWorkspaceSwitchSuccess" in template
     assert "taskPreviewLabel" in template
     assert "showNoTasks" in template
+    assert "Current setup" in template
+    assert "setupStatusItems" in script
+    assert "loadSetupState()" in script
+    assert "/api/v1/domains/summary?include_empty=true" in script
+    assert "/api/v1/mail-sources" in script
+    assert "data-onboarding-reconfigure" in template
+    assert "data-onboarding-reconfigure" in script
+    assert "data-onboarding-form" in template
+    assert "data-onboarding-form" in script
+    assert "Unsaved setup changes" in template
     assert 'x-init="init()"' not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
     assert "Account boundary" not in rendered

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -128,7 +128,9 @@ def _stub_approval_ready_remediation(monkeypatch):
 
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
-    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: ["cloudflare"])
+    monkeypatch.setattr(
+        domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: ["cloudflare"]
+    )
     monkeypatch.setattr(
         domains_endpoint,
         "_recommended_dns_write_provider",
@@ -157,6 +159,21 @@ def seeded_client(authed_client: TestClient, db_session):
     db_session.commit()
     ReportStore.get_instance().add_report(REPORT_DICT_POLICY)
     return authed_client
+
+
+def test_configured_dns_write_providers_require_credentials(db_session, monkeypatch):
+    monkeypatch.setattr(
+        domains_endpoint,
+        "_ready_dns_write_provider_ids",
+        lambda: ["cloudflare", "route53"],
+    )
+    monkeypatch.setattr(
+        domains_endpoint,
+        "_provider_credentials_configured",
+        lambda _db, provider_id: provider_id == "route53",
+    )
+
+    assert domains_endpoint._configured_dns_write_provider_ids(db_session) == ["route53"]
 
 
 @pytest.fixture(autouse=True)
@@ -816,7 +833,9 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
 
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
-    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: ["cloudflare"])
+    monkeypatch.setattr(
+        domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: ["cloudflare"]
+    )
     monkeypatch.setattr(
         domains_endpoint,
         "_recommended_dns_write_provider",
@@ -1479,7 +1498,9 @@ def test_domain_remediation_notification_lifecycle_audit_records_sanitized_marke
 
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
-    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: ["cloudflare"])
+    monkeypatch.setattr(
+        domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: ["cloudflare"]
+    )
     monkeypatch.setattr(
         domains_endpoint,
         "_recommended_dns_write_provider",
@@ -1630,7 +1651,9 @@ def test_domain_remediation_notification_lifecycle_audit_rejects_mismatched_even
 
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
-    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: ["cloudflare"])
+    monkeypatch.setattr(
+        domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: ["cloudflare"]
+    )
     monkeypatch.setattr(
         domains_endpoint,
         "_recommended_dns_write_provider",
@@ -1705,7 +1728,7 @@ def test_domain_remediation_notification_lifecycle_audit_rejects_unknown_item(
 
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
-    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: [])
+    monkeypatch.setattr(domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: [])
 
     response = seeded_client.post(
         f"/api/v1/domains/{DOMAIN}/remediation/notifications/audit",
@@ -1760,7 +1783,9 @@ def test_domain_remediation_notification_lifecycle_audit_rejects_mismatched_dedu
 
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
-    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: ["cloudflare"])
+    monkeypatch.setattr(
+        domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: ["cloudflare"]
+    )
     monkeypatch.setattr(
         domains_endpoint,
         "_recommended_dns_write_provider",
@@ -1827,7 +1852,7 @@ def test_domain_remediation_queue_hydrates_report_store_with_workspace_filter(
     monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
-    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: [])
+    monkeypatch.setattr(domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: [])
 
     response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
 
@@ -1873,7 +1898,7 @@ def test_domain_remediation_queue_falls_back_for_legacy_report_domains(
     monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
-    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: [])
+    monkeypatch.setattr(domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: [])
 
     response = authed_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
 
@@ -1922,7 +1947,7 @@ def test_domain_remediation_queue_accepts_numeric_domain_id(
     monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
-    monkeypatch.setattr(domains_endpoint, "_ready_dns_write_provider_ids", lambda: [])
+    monkeypatch.setattr(domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: [])
 
     response = seeded_client.get(f"/api/v1/domains/{domain.id}/remediation")
 


### PR DESCRIPTION
## Summary
- lead the dashboard with one evidence-backed next action and hide secondary analytics behind progressive disclosure
- turn onboarding into a state-aware setup status for existing self-hosted installs
- group report evidence by sender/provider/network while retaining paginated raw records
- clarify domain remediation priority and keep provider previews blocked until credentials are configured
- improve desktop/mobile CTA placement without removing advanced workflows

Closes #765
Closes #766
Closes #767
Closes #768

## Local validation
- full backend suite: 1,946 passed
- focused dashboard/setup/domain suite: 210 passed
- dashboard/health follow-up: 109 passed
- JavaScript syntax and diff checks passed
- fresh Docker image built from `backend/Dockerfile` and started with the persisted Gmail-backed SQLite volume
- desktop and 390px browser smokes for dashboard, onboarding, report detail, and domain detail; no console errors/warnings or horizontal overflow
- live local data smoke: 81 reports, 3 configured domains, 1 empty domain, provider preview count remains 0 without credentials

## Stack
This PR is intentionally stacked on #770 so GitHub reviews only this completed UX wave. Rebase it onto `main` after #770 merges.