### PR TITLE
feat: secure unattended mailbox ingestion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,17 @@ jobs:
           curl -fsS http://127.0.0.1:8080/healthz
           curl -fsS http://127.0.0.1:8080/api/v1/health
           ./scripts/verify-docker-compose.sh
+          python3 scripts/verify-greenfield-product.py
           docker image inspect \
             --format '{{ json .Config.ExposedPorts }}' dmarq-app:local | grep -q '8080/tcp'
+
+      - name: Recreate the app and verify persistent product state
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.build.yml \
+            up -d --force-recreate --wait app
+          python3 scripts/verify-greenfield-product.py --verify-existing
 
       - name: Show logs on failure
         if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Distinguished active failing DKIM selectors from active passing, recent,
+  historical, and manually configured evidence. Only current selector failures
+  now enter the primary DNS remediation flow; rotation history remains visible
+  with first/last seen dates and report/message counts under progressive
+  disclosure.
+- Expanded standalone Docker greenfield verification beyond health checks to
+  cover first-run setup, deterministic DMARC fixture ingestion, exact totals,
+  duplicate rejection, application-container recreation, and persisted state.
 - Kept provider support-session user selection CSP-safe and resolved the
   selected user by ID before stale email fallback state, so multi-user account
   impersonation opens the customer view for the operator's actual selection.
@@ -29,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attention.
 
 ### Added
+- Added unattended Microsoft 365 shared-mailbox ingestion through Entra
+  application permissions, including tenant-specific client credentials,
+  explicit mailbox targeting, folder discovery, connection tests, manual and
+  scheduled imports, backfills, encrypted secrets, and Exchange Online RBAC
+  safety guidance without requiring a redirect URI or interactive user.
 - Added state-aware self-hosted onboarding that recognizes existing domains,
   mailbox health, imported evidence, DNS-provider credentials, and notification
   setup, then routes operators to the first required incomplete step instead of

--- a/backend/alembic/versions/f4a5b6c7d8e9_add_m365_application_auth_mode.py
+++ b/backend/alembic/versions/f4a5b6c7d8e9_add_m365_application_auth_mode.py
@@ -1,0 +1,31 @@
+"""Add Microsoft 365 application authentication mode.
+
+Revision ID: f4a5b6c7d8e9
+Revises: e3f4a5b6c7d8
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f4a5b6c7d8e9"
+down_revision: Union[str, Sequence[str], None] = "e3f4a5b6c7d8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "mail_sources",
+        sa.Column(
+            "m365_auth_mode",
+            sa.String(),
+            nullable=False,
+            server_default="delegated",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mail_sources", "m365_auth_mode")

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -538,6 +538,27 @@ class DNSLintFindingResponse(BaseModel):
     target_record: Optional[DNSGuidanceRecordResponse] = None
     evidence: List[str] = Field(default_factory=list)
     remediation_steps: List[str] = Field(default_factory=list)
+    primary_eligible: bool = True
+
+
+class DKIMSelectorEvidenceResponse(BaseModel):
+    """Report-derived DKIM selector activity shown separately from remediation."""
+
+    selector: str
+    classification: str
+    classification_reason: str
+    first_seen: Optional[int] = None
+    first_seen_at: Optional[str] = None
+    last_seen: Optional[int] = None
+    last_seen_at: Optional[str] = None
+    report_count: int = 0
+    message_count: int = 0
+    current_failure_count: int = 0
+    current_pass_count: int = 0
+    manual_configured: bool = False
+    active_window_days: int = 7
+    recent_window_days: int = 30
+    dns_status: str = "not_checked"
 
 
 class DNSChangePlanItemResponse(BaseModel):
@@ -1120,6 +1141,7 @@ class DNSGuidanceResponse(BaseModel):
     target_records: List[DNSGuidanceRecordResponse]
     dns_provider: Optional[Dict[str, Any]] = None
     change_plans: List[DNSChangePlanItemResponse] = Field(default_factory=list)
+    selector_evidence: List[DKIMSelectorEvidenceResponse] = Field(default_factory=list)
 
 
 class DNSBulkGuidanceItem(BaseModel):
@@ -3041,17 +3063,11 @@ def _get_selectors_from_reports(store: "ReportStore", domain: str) -> List[str]:
     real-world selectors to verify against live DNS, in addition to any
     manually configured selectors.
     """
-    selectors: List[str] = []
-    for report in store.get_domain_reports(domain):
-        for record in report.get("records", []):
-            dkim_entries = record.get("dkim") or []
-            for dkim_entry in dkim_entries:
-                if not isinstance(dkim_entry, dict):
-                    continue
-                sel = dkim_entry.get("selector", "").strip()
-                if sel and sel not in selectors:
-                    selectors.append(sel)
-    return selectors
+    return [
+        str(item["selector"])
+        for item in store.get_domain_selector_evidence(domain)
+        if item.get("selector")
+    ]
 
 
 def _normalize_domain_selectors(selectors: Optional[List[str]]) -> List[str]:
@@ -3614,7 +3630,15 @@ async def _build_domain_dns_health(  # pylint: disable=too-many-locals
 ) -> DNSHealthResponse:
     """Build the shared DNS/posture health payload for a monitored domain."""
     manual_selectors = _get_domain_selectors_from_db(db, domain_id)
-    report_selectors = _get_selectors_from_reports(store, domain_id)
+    selector_evidence = store.get_domain_selector_evidence(
+        domain_id,
+        manual_selectors=manual_selectors,
+    )
+    report_selectors = [
+        str(item["selector"])
+        for item in selector_evidence
+        if int(item.get("report_count") or 0) > 0
+    ]
     combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
 
     provider = get_default_provider(db)
@@ -3642,6 +3666,29 @@ async def _build_domain_dns_health(  # pylint: disable=too-many-locals
     bimi_dmarc_ready, bimi_dmarc_issues, bimi_dmarc_evidence = _bimi_dmarc_readiness(
         result.dmarc_record
     )
+    active_failing_selectors = [
+        item for item in selector_evidence if item.get("classification") == "active_failing"
+    ]
+    active_passing_selectors = [
+        item for item in selector_evidence if item.get("classification") == "active_passing"
+    ]
+    report_evidence_exists = any(int(item.get("report_count") or 0) for item in selector_evidence)
+    dated_report_evidence = any(
+        int(item.get("report_count") or 0) and item.get("last_seen") is not None
+        for item in selector_evidence
+    )
+    dkim_healthy = result.dkim
+    dkim_success_message = "At least one DKIM selector resolved."
+    dkim_failure_message = "No DKIM record was found for configured or active failing selectors."
+    if report_evidence_exists and dated_report_evidence and not active_failing_selectors:
+        dkim_healthy = True
+        if active_passing_selectors:
+            dkim_success_message = "Current report evidence shows active DKIM passing traffic."
+        else:
+            dkim_success_message = (
+                "No current DKIM selector failure is present; older selectors remain evidence only."
+            )
+
     checks = [
         _dns_check(
             "dmarc",
@@ -3662,9 +3709,9 @@ async def _build_domain_dns_health(  # pylint: disable=too-many-locals
         _dns_check(
             "dkim",
             "DKIM",
-            result.dkim,
-            "At least one DKIM selector resolved.",
-            "No DKIM record was found for configured or observed selectors.",
+            dkim_healthy,
+            dkim_success_message,
+            dkim_failure_message,
             [
                 _record_evidence(
                     "Selectors checked",
@@ -3732,7 +3779,15 @@ async def _build_domain_dns_guidance(
 ) -> Dict[str, Any]:
     """Build typed DNS lint findings and target records for a monitored domain."""
     manual_selectors = _get_domain_selectors_from_db(db, domain_id)
-    report_selectors = _get_selectors_from_reports(store, domain_id)
+    selector_evidence = store.get_domain_selector_evidence(
+        domain_id,
+        manual_selectors=manual_selectors,
+    )
+    report_selectors = [
+        str(item["selector"])
+        for item in selector_evidence
+        if int(item.get("report_count") or 0) > 0
+    ]
     combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
 
     provider = get_default_provider(db)
@@ -3772,6 +3827,7 @@ async def _build_domain_dns_guidance(
         dane_result,
         monitored_selectors=combined_selectors,
         observed_selectors=report_selectors,
+        selector_evidence=selector_evidence,
         mail_service_records=mail_service_records,
         setup_defaults=_mail_auth_setup_defaults(db, stored_domain),
         locale=locale or get_settings().default_locale,

--- a/backend/app/api/api_v1/endpoints/health.py
+++ b/backend/app/api/api_v1/endpoints/health.py
@@ -10,6 +10,12 @@ from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
 from app.models.report import DMARCReport
 from app.services.mailbox_recovery import import_row_diagnostic, not_configured_guidance
+from app.services.microsoft_graph_client import (
+    M365_AUTH_MODE_APPLICATION,
+    m365_application_configuration_error,
+    m365_source_can_authenticate,
+    normalize_m365_auth_mode,
+)
 from app.services.release_info import build_release_info
 from app.services.runtime_status import get_scheduler_status
 
@@ -100,25 +106,53 @@ def _source_health(source: MailSource, latest_import=None):
             "action_label": "Reconnect Gmail",
             "diagnostic_category": "auth_expired",
         }
-    if method == "M365_GRAPH" and not source.m365_access_token:
+    if method == "M365_GRAPH" and not m365_source_can_authenticate(source):
+        application_mode = (
+            normalize_m365_auth_mode(getattr(source, "m365_auth_mode", "delegated"))
+            == M365_AUTH_MODE_APPLICATION
+        )
         return {
             "source_id": source.id,
             "label": _source_label(source),
             "method": method,
-            "status": "not_authorized",
+            "status": "missing_config" if application_mode else "not_authorized",
             "attention": True,
-            "message": "Microsoft 365 is not authorised yet.",
-            "action_label": "Connect Microsoft 365",
-            "diagnostic_category": "auth_required",
+            "message": m365_application_configuration_error(source)
+            or "Microsoft 365 is not authorised yet.",
+            "action_label": (
+                "Review application settings" if application_mode else "Connect Microsoft 365"
+            ),
+            "diagnostic_category": "missing_config" if application_mode else "auth_required",
+        }
+    if (
+        method == "M365_GRAPH"
+        and normalize_m365_auth_mode(getattr(source, "m365_auth_mode", "delegated"))
+        == M365_AUTH_MODE_APPLICATION
+        and not source.m365_access_token
+    ):
+        return {
+            "source_id": source.id,
+            "label": _source_label(source),
+            "method": method,
+            "status": "ready_to_test",
+            "attention": False,
+            "message": "Application credentials are saved; test mailbox access.",
+            "action_label": "Test connection",
+            "diagnostic_category": "ok",
         }
 
     diagnostic = import_row_diagnostic(latest_import)
     category = (diagnostic or {}).get("category")
-    if latest_import and latest_import.status == "failed" and category in {
-        "auth_expired",
-        "authentication",
-        "permissions",
-    }:
+    if (
+        latest_import
+        and latest_import.status == "failed"
+        and category
+        in {
+            "auth_expired",
+            "authentication",
+            "permissions",
+        }
+    ):
         return {
             "source_id": source.id,
             "label": _source_label(source),
@@ -165,9 +199,7 @@ async def operations_health(  # noqa: C901
         enabled_source_rows = (
             db.query(MailSource).filter(MailSource.enabled == True).all()  # noqa: E712
         )
-        enabled_sources = (
-            len(enabled_source_rows)
-        )
+        enabled_sources = len(enabled_source_rows)
         total_sources = db.query(func.count(MailSource.id)).scalar()
         report_count = db.query(func.count(DMARCReport.id)).scalar()
         latest_report = db.query(func.max(DMARCReport.processed_at)).scalar()
@@ -249,23 +281,27 @@ async def operations_health(  # noqa: C901
             "sources": mail_source_health,
         },
         "imports": {
-            "latest": {
-                "status": latest_import.status,
-                "trigger": latest_import.trigger,
-                "reports_found": latest_import.reports_found,
-                "finished_at": _iso(latest_import.finished_at),
-                "diagnostic": latest_import_diagnostic,
-            }
-            if latest_import
-            else None,
-            "latest_successful": {
-                "status": latest_successful_import.status,
-                "trigger": latest_successful_import.trigger,
-                "reports_found": latest_successful_import.reports_found,
-                "finished_at": _iso(latest_successful_import.finished_at),
-            }
-            if latest_successful_import
-            else None,
+            "latest": (
+                {
+                    "status": latest_import.status,
+                    "trigger": latest_import.trigger,
+                    "reports_found": latest_import.reports_found,
+                    "finished_at": _iso(latest_import.finished_at),
+                    "diagnostic": latest_import_diagnostic,
+                }
+                if latest_import
+                else None
+            ),
+            "latest_successful": (
+                {
+                    "status": latest_successful_import.status,
+                    "trigger": latest_successful_import.trigger,
+                    "reports_found": latest_successful_import.reports_found,
+                    "finished_at": _iso(latest_successful_import.finished_at),
+                }
+                if latest_successful_import
+                else None
+            ),
         },
         "reports": {
             "count": int(report_count or 0),

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -51,7 +51,13 @@ from app.services.mailbox_recovery import (
     import_row_diagnostic,
     redact_recovery_text,
 )
-from app.services.microsoft_graph_client import MicrosoftGraphClient
+from app.services.microsoft_graph_client import (
+    M365_AUTH_MODE_APPLICATION,
+    MicrosoftGraphClient,
+    m365_application_configuration_error,
+    m365_source_can_authenticate,
+    normalize_m365_auth_mode,
+)
 from app.services.workspace_access import (
     PERMISSION_MAIL_SOURCES_READ,
     PERMISSION_MAIL_SOURCES_WRITE,
@@ -95,6 +101,7 @@ class MailSourceBase(BaseModel):
     gmail_client_id: Optional[str] = None
     gmail_client_secret: Optional[str] = None
     # Microsoft 365 Graph OAuth2 fields (only relevant when method == M365_GRAPH)
+    m365_auth_mode: str = "delegated"
     m365_tenant_id: Optional[str] = "common"
     m365_client_id: Optional[str] = None
     m365_client_secret: Optional[str] = None
@@ -121,6 +128,7 @@ class MailSourceUpdate(BaseModel):
     enabled: Optional[bool] = None
     gmail_client_id: Optional[str] = None
     gmail_client_secret: Optional[str] = None
+    m365_auth_mode: Optional[str] = None
     m365_tenant_id: Optional[str] = None
     m365_client_id: Optional[str] = None
     m365_client_secret: Optional[str] = None
@@ -149,6 +157,7 @@ class MailSourceResponse(MailSourceBase):
     # Microsoft 365: show the authorised account and token state, but not tokens
     m365_email: Optional[str] = None
     m365_connected: bool = False
+    m365_configured: bool = False
 
     class Config:
         from_attributes = True
@@ -469,6 +478,28 @@ def _safe_attr(source: MailSource, name: str, default: Any = None) -> Any:
     return value
 
 
+def _m365_auth_mode(source: MailSource) -> str:
+    return normalize_m365_auth_mode(_safe_attr(source, "m365_auth_mode", "delegated"))
+
+
+def _validate_m365_source_configuration(source: MailSource) -> None:
+    if (source.method or "").upper() != "M365_GRAPH":
+        return
+    try:
+        source.m365_auth_mode = _m365_auth_mode(source)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    error = m365_application_configuration_error(source)
+    if error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=error,
+        )
+
+
 def _latest_import_for_source(db: Session, source_id: int) -> Optional[MailSourceImport]:
     """Return the latest persisted import attempt for one source, if available."""
     return (
@@ -557,6 +588,37 @@ def _connection_state_for_source(
         }
 
     if method == "M365_GRAPH":
+        auth_mode = _m365_auth_mode(source)
+        if auth_mode == M365_AUTH_MODE_APPLICATION:
+            config_error = m365_application_configuration_error(source)
+            if config_error:
+                return {
+                    "connection_status": "missing_config",
+                    "connection_attention": True,
+                    "connection_message": config_error,
+                    "connection_action_label": "Review application settings",
+                    "connection_diagnostic_category": "missing_config",
+                }
+            if not _safe_attr(source, "m365_access_token"):
+                return {
+                    "connection_status": "ready_to_test",
+                    "connection_attention": False,
+                    "connection_message": (
+                        "Microsoft 365 application credentials are saved. Test mailbox "
+                        "access before relying on imports."
+                    ),
+                    "connection_action_label": "Test connection",
+                    "connection_diagnostic_category": "ok",
+                }
+            return {
+                "connection_status": "connected",
+                "connection_attention": False,
+                "connection_message": (
+                    "Microsoft 365 application access is configured for the target mailbox."
+                ),
+                "connection_action_label": None,
+                "connection_diagnostic_category": "ok",
+            }
         if not _safe_attr(source, "m365_access_token"):
             return {
                 "connection_status": "not_authorized",
@@ -609,12 +671,14 @@ def _source_to_response(
         gmail_connected=bool(source.gmail_access_token),
         **connection_state,
         m365_tenant_id=_safe_attr(source, "m365_tenant_id", "common") or "common",
+        m365_auth_mode=_m365_auth_mode(source),
         m365_client_id=_safe_attr(source, "m365_client_id"),
         m365_client_secret=("**redacted**" if _safe_attr(source, "m365_client_secret") else None),
         m365_mailbox=_safe_attr(source, "m365_mailbox"),
         m365_folder_id=_safe_attr(source, "m365_folder_id"),
         m365_email=_safe_attr(source, "m365_email"),
         m365_connected=bool(_safe_attr(source, "m365_access_token")),
+        m365_configured=m365_source_can_authenticate(source),
     )
 
 
@@ -1046,10 +1110,13 @@ def _fetch_gmail_source(source: MailSource, db: Session) -> Dict[str, Any]:
 
 def _fetch_m365_source(source: MailSource, db: Session, days: int = 7) -> Dict[str, Any]:
     """Run one Microsoft 365 Graph import and persist source/import metadata."""
-    if not source.m365_access_token:
+    if not m365_source_can_authenticate(source):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Microsoft 365 account not yet authorised. Complete OAuth2 flow first.",
+            detail=(
+                m365_application_configuration_error(source)
+                or "Microsoft 365 account not yet authorised. Complete OAuth2 flow first."
+            ),
         )
 
     already = MicrosoftGraphClient.load_ingested_ids(source.m365_ingested_ids)
@@ -1059,6 +1126,7 @@ def _fetch_m365_source(source: MailSource, db: Session, days: int = 7) -> Dict[s
         client_secret=source.m365_client_secret or "",
         access_token=source.m365_access_token,
         refresh_token=source.m365_refresh_token or "",
+        auth_mode=_m365_auth_mode(source),
         mailbox=source.m365_mailbox,
         folder=source.folder or "INBOX",
         folder_id=_safe_attr(source, "m365_folder_id"),
@@ -1172,12 +1240,14 @@ async def create_mail_source(
         enabled=payload.enabled,
         gmail_client_id=payload.gmail_client_id,
         gmail_client_secret=payload.gmail_client_secret,
+        m365_auth_mode=payload.m365_auth_mode,
         m365_tenant_id=payload.m365_tenant_id or "common",
         m365_client_id=payload.m365_client_id,
         m365_client_secret=payload.m365_client_secret,
         m365_mailbox=payload.m365_mailbox,
         m365_folder_id=payload.m365_folder_id,
     )
+    _validate_m365_source_configuration(source)
     db.add(source)
     db.commit()
     db.refresh(source)
@@ -1589,13 +1659,37 @@ async def update_mail_source(
     source = _get_source_or_404(source_id, db, workspace)
 
     update_data = payload.model_dump(exclude_unset=True)
+    old_m365_auth_mode = _m365_auth_mode(source)
+    old_m365_tenant_id = source.m365_tenant_id
+    old_m365_client_id = source.m365_client_id
+    m365_secret_replaced = bool(update_data.get("m365_client_secret"))
     for secret_field in ("password", "gmail_client_secret", "m365_client_secret"):
         if update_data.get(secret_field) == "":
             update_data.pop(secret_field)
     if "method" in update_data and update_data["method"]:
         update_data["method"] = update_data["method"].upper()
+    if "m365_auth_mode" in update_data and update_data["m365_auth_mode"]:
+        try:
+            update_data["m365_auth_mode"] = normalize_m365_auth_mode(update_data["m365_auth_mode"])
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(exc),
+            ) from exc
     for field, value in update_data.items():
         setattr(source, field, value)
+
+    _validate_m365_source_configuration(source)
+    token_settings_changed = (
+        old_m365_auth_mode != _m365_auth_mode(source)
+        or old_m365_tenant_id != source.m365_tenant_id
+        or old_m365_client_id != source.m365_client_id
+        or m365_secret_replaced
+    )
+    if token_settings_changed:
+        source.m365_access_token = None
+        source.m365_refresh_token = None
+        source.m365_email = None
 
     source.updated_at = datetime.utcnow()
     db.commit()
@@ -1723,11 +1817,14 @@ async def test_stored_mail_source(  # noqa: C901
             )
 
     if source.method == "M365_GRAPH":
-        if not source.m365_access_token:
+        if not m365_source_can_authenticate(source):
             return _connection_test_response(
                 False,
-                "Microsoft 365 source is not yet authorised. "
-                "Use the Connect Microsoft 365 button to complete OAuth2 authorisation.",
+                m365_application_configuration_error(source)
+                or (
+                    "Microsoft 365 source is not yet authorised. "
+                    "Use the Connect Microsoft 365 button to complete OAuth2 authorisation."
+                ),
             )
         try:
             graph_client = MicrosoftGraphClient(
@@ -1736,6 +1833,7 @@ async def test_stored_mail_source(  # noqa: C901
                 client_secret=source.m365_client_secret or "",
                 access_token=source.m365_access_token,
                 refresh_token=source.m365_refresh_token or "",
+                auth_mode=_m365_auth_mode(source),
                 mailbox=source.m365_mailbox,
                 folder=source.folder or "INBOX",
                 folder_id=_safe_attr(source, "m365_folder_id"),
@@ -1750,7 +1848,8 @@ async def test_stored_mail_source(  # noqa: C901
             db.commit()
             return _connection_test_response(
                 True,
-                f"Microsoft 365 credentials are valid (account: {source.m365_email or 'unknown'}).",
+                "Microsoft 365 credentials are valid "
+                f"(mailbox: {source.m365_mailbox or source.m365_email or 'unknown'}).",
                 stats=stats,
             )
         except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -1843,6 +1942,14 @@ async def m365_authorize_url(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="This endpoint is only available for M365_GRAPH sources.",
         )
+    if _m365_auth_mode(source) == M365_AUTH_MODE_APPLICATION:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Application-permission sources do not use interactive OAuth. "
+                "Test the saved application credentials instead."
+            ),
+        )
     if not source.m365_client_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1878,10 +1985,13 @@ async def m365_list_folders(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="This endpoint is only available for M365_GRAPH sources.",
         )
-    if not source.m365_access_token:
+    if not m365_source_can_authenticate(source):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Microsoft 365 account not yet authorised. Complete OAuth2 flow first.",
+            detail=(
+                m365_application_configuration_error(source)
+                or "Microsoft 365 account not yet authorised. Complete OAuth2 flow first."
+            ),
         )
 
     graph_client = MicrosoftGraphClient(
@@ -1890,6 +2000,7 @@ async def m365_list_folders(
         client_secret=source.m365_client_secret or "",
         access_token=source.m365_access_token,
         refresh_token=source.m365_refresh_token or "",
+        auth_mode=_m365_auth_mode(source),
         mailbox=source.m365_mailbox,
         folder=source.folder or "INBOX",
         folder_id=_safe_attr(source, "m365_folder_id"),
@@ -1962,6 +2073,14 @@ async def m365_oauth_callback(
         return HTMLResponse(
             content="<html><body><p>Mail source not found.</p></body></html>",
             status_code=404,
+        )
+    if _m365_auth_mode(source) == M365_AUTH_MODE_APPLICATION:
+        return HTMLResponse(
+            content=(
+                "<html><body><p>This source uses Microsoft 365 application "
+                "permissions and does not accept an interactive OAuth callback.</p></body></html>"
+            ),
+            status_code=400,
         )
 
     base_url = _public_base_url(request, db)
@@ -2040,6 +2159,11 @@ async def m365_oauth_callback_post(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="This endpoint is only available for M365_GRAPH sources.",
+        )
+    if _m365_auth_mode(source) == M365_AUTH_MODE_APPLICATION:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=("Application-permission sources do not accept an interactive OAuth callback."),
         )
 
     try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,7 +44,13 @@ from app.services.mail_connector import initial_import_stats
 from app.services.mail_service_imports import mail_service_context_from_domain
 from app.services.mail_source_backfill_worker import run_due_mail_source_backfill_jobs
 from app.services.mailbox_recovery import import_result_diagnostic, import_row_diagnostic
-from app.services.microsoft_graph_client import MicrosoftGraphClient
+from app.services.microsoft_graph_client import (
+    M365_AUTH_MODE_APPLICATION,
+    MicrosoftGraphClient,
+    m365_application_configuration_error,
+    m365_source_can_authenticate,
+    normalize_m365_auth_mode,
+)
 from app.services.provider_access import require_provider_operator_access
 from app.services.release_info import build_release_info
 from app.services.report_persistence import hydrate_report_store_from_db
@@ -218,9 +224,9 @@ def _poll_single_m365_source(source: MailSource) -> None:
     """Fetch DMARC reports for a single M365_GRAPH mail source."""
     global last_check_time  # pylint: disable=global-statement
 
-    if not source.m365_access_token:
+    if not m365_source_can_authenticate(source):
         logger.info(
-            "Microsoft 365 polling (source id=%d): skipped – OAuth2 not yet authorised",
+            "Microsoft 365 polling (source id=%d): skipped - source cannot authenticate",
             source.id,
         )
         return
@@ -236,6 +242,7 @@ def _poll_single_m365_source(source: MailSource) -> None:
             client_secret=poll_source.m365_client_secret or "",
             access_token=poll_source.m365_access_token,
             refresh_token=poll_source.m365_refresh_token or "",
+            auth_mode=normalize_m365_auth_mode(getattr(poll_source, "m365_auth_mode", "delegated")),
             mailbox=poll_source.m365_mailbox,
             folder=poll_source.folder or "INBOX",
             folder_id=getattr(poll_source, "m365_folder_id", None),
@@ -1009,6 +1016,7 @@ def _trigger_poll_m365_source(source: MailSource, db, days: int = 7) -> dict:
         client_secret=source.m365_client_secret or "",
         access_token=source.m365_access_token,
         refresh_token=source.m365_refresh_token or "",
+        auth_mode=normalize_m365_auth_mode(getattr(source, "m365_auth_mode", "delegated")),
         mailbox=source.m365_mailbox,
         folder=source.folder or "INBOX",
         folder_id=getattr(source, "m365_folder_id", None),
@@ -1063,16 +1071,20 @@ def _poll_source_for_trigger(source: MailSource, db, days: int = 7) -> dict:  # 
                 "error": "Failed to poll. Check server logs for details.",
             }
     if source.method == "M365_GRAPH":
-        if not source.m365_access_token:
+        if not m365_source_can_authenticate(source):
+            error = (
+                m365_application_configuration_error(source)
+                or "Microsoft 365 account not yet authorised. Complete OAuth2 flow first."
+            )
             results = {
                 **initial_import_stats(),
                 "success": False,
-                "errors": ["Microsoft 365 account not yet authorised. Complete OAuth2 flow first."],
+                "errors": [error],
             }
             return {
                 **_trigger_poll_result(source, "M365_GRAPH", results),
                 "skipped": True,
-                "reason": "Microsoft 365 account not yet authorised",
+                "reason": error,
             }
         try:
             return _trigger_poll_m365_source(source, db, days=days)
@@ -1237,13 +1249,33 @@ def _mail_source_connection_state(
                 "action_label": "Reconnect Gmail",
                 "diagnostic_category": "auth_expired",
             }
-    if method == "M365_GRAPH" and not source.m365_access_token:
+    if method == "M365_GRAPH" and not m365_source_can_authenticate(source):
+        application_mode = (
+            normalize_m365_auth_mode(getattr(source, "m365_auth_mode", "delegated"))
+            == M365_AUTH_MODE_APPLICATION
+        )
         return {
-            "status": "not_authorized",
+            "status": "missing_config" if application_mode else "not_authorized",
             "attention": True,
-            "message": "Microsoft 365 is not authorised yet.",
-            "action_label": "Connect Microsoft 365",
-            "diagnostic_category": "auth_required",
+            "message": m365_application_configuration_error(source)
+            or "Microsoft 365 is not authorised yet.",
+            "action_label": (
+                "Review application settings" if application_mode else "Connect Microsoft 365"
+            ),
+            "diagnostic_category": "missing_config" if application_mode else "auth_required",
+        }
+    if (
+        method == "M365_GRAPH"
+        and normalize_m365_auth_mode(getattr(source, "m365_auth_mode", "delegated"))
+        == M365_AUTH_MODE_APPLICATION
+        and not source.m365_access_token
+    ):
+        return {
+            "status": "ready_to_test",
+            "attention": False,
+            "message": "Application credentials are saved; test mailbox access.",
+            "action_label": "Test connection",
+            "diagnostic_category": "ok",
         }
 
     diagnostic = import_row_diagnostic(latest_import)

--- a/backend/app/models/mail_source.py
+++ b/backend/app/models/mail_source.py
@@ -51,6 +51,14 @@ class MailSource(Base):
     gmail_ingested_ids = Column(Text, nullable=True, default="[]")
 
     # Microsoft 365 / Graph OAuth2 credentials (used by M365_GRAPH method)
+    # ``delegated`` uses the interactive authorization-code flow; ``application``
+    # uses client credentials and always targets an explicit mailbox.
+    m365_auth_mode = Column(
+        String,
+        nullable=False,
+        default="delegated",
+        server_default="delegated",
+    )
     m365_tenant_id = Column(String, nullable=True, default="common")
     m365_client_id = Column(String, nullable=True)
     _m365_client_secret = Column("m365_client_secret", Text, nullable=True)

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -52,6 +52,7 @@ class DNSLintFinding:
     target_record: Optional[DNSGuidanceRecord] = None
     evidence: List[str] = field(default_factory=list)
     remediation_steps: List[str] = field(default_factory=list)
+    primary_eligible: bool = True
 
 
 @dataclass
@@ -87,6 +88,7 @@ class DNSGuidanceResult:
     target_records: List[DNSGuidanceRecord]
     dns_provider: Optional[DNSProviderDetection] = None
     change_plans: List[DNSChangePlan] = field(default_factory=list)
+    selector_evidence: List[Dict[str, object]] = field(default_factory=list)
 
 
 def _today_id() -> str:
@@ -127,9 +129,7 @@ def _target_records(
     setup_defaults: Optional[MailAuthSetupDefaults] = None,
 ) -> List[DNSGuidanceRecord]:
     defaults = setup_defaults or MailAuthSetupDefaults()
-    dmarc_value = result.dmarc_record or (
-        _dmarc_record_value(domain, defaults)
-    )
+    dmarc_value = result.dmarc_record or (_dmarc_record_value(domain, defaults))
     spf_value = result.spf_record or "v=spf1 -all"
     dkim_selector = (result.dkim_selectors or result.selectors_checked or ["selector1"])[0]
     tls_report_mailbox = _mailbox(defaults.tls_report_mailbox, "tlsrpt", domain)
@@ -243,6 +243,7 @@ def _finding(
     target_record: Optional[DNSGuidanceRecord] = None,
     evidence: Optional[List[str]] = None,
     remediation_steps: Optional[List[str]] = None,
+    primary_eligible: bool = True,
 ) -> DNSLintFinding:
     return DNSLintFinding(
         code=code,
@@ -255,6 +256,7 @@ def _finding(
         target_record=target_record,
         evidence=list(evidence or []),
         remediation_steps=list(remediation_steps or _default_remediation_steps(code)),
+        primary_eligible=primary_eligible,
     )
 
 
@@ -824,6 +826,7 @@ def _dkim_record_findings(
     *,
     has_report_evidence: bool,
     observed_selector_set: set[str],
+    primary_eligible: bool = True,
 ) -> List[DNSLintFinding]:
     findings: List[DNSLintFinding] = []
     if _dkim_record_is_too_short(record):
@@ -844,6 +847,7 @@ def _dkim_record_findings(
                 record_name,
                 target_record=target,
                 evidence=[record],
+                primary_eligible=primary_eligible,
             )
         )
     if has_report_evidence and selector not in observed_selector_set:
@@ -864,6 +868,7 @@ def _dkim_record_findings(
                 record_name,
                 target_record=target,
                 evidence=[record],
+                primary_eligible=primary_eligible,
             )
         )
     return findings
@@ -880,6 +885,8 @@ async def _dkim_cname_finding(
     selector: str,
     record_name: str,
     target: DNSGuidanceRecord,
+    *,
+    primary_eligible: bool = True,
 ) -> Optional[DNSLintFinding]:
     cname_target = await _dkim_cname_target(provider, record_name)
     if not cname_target:
@@ -909,11 +916,16 @@ async def _dkim_cname_finding(
         record_name,
         target_record=target,
         evidence=[f"{record_name} -> {cname_target}"],
+        primary_eligible=primary_eligible,
     )
 
 
 def _dkim_missing_finding(
-    selector: str, record_name: str, target: DNSGuidanceRecord
+    selector: str,
+    record_name: str,
+    target: DNSGuidanceRecord,
+    *,
+    primary_eligible: bool = True,
 ) -> DNSLintFinding:
     return _finding(
         "dkim_selector_missing",
@@ -924,7 +936,62 @@ def _dkim_missing_finding(
         "TXT",
         record_name,
         target_record=target,
+        primary_eligible=primary_eligible,
     )
+
+
+async def _inspect_dkim_selector(
+    provider: BaseDNSProvider,
+    domain: str,
+    result: DomainDNSResult,
+    selector: str,
+    target: DNSGuidanceRecord,
+    *,
+    has_report_evidence: bool,
+    observed_selector_set: set[str],
+    selector_activity: Optional[Dict[str, object]],
+    primary_eligible: bool,
+) -> List[DNSLintFinding]:
+    record_name = f"{selector}._domainkey.{domain}"
+    selector_target = DNSGuidanceRecord(
+        code=target.code,
+        record_type=target.record_type,
+        name=record_name,
+        value=target.value,
+        purpose=target.purpose,
+        priority=target.priority,
+    )
+    record = await _dkim_selector_record(provider, selector, domain)
+    if record:
+        if selector_activity is not None:
+            selector_activity["dns_status"] = "resolved"
+        if not primary_eligible:
+            return []
+        return _dkim_record_findings(
+            selector,
+            record_name,
+            record,
+            selector_target,
+            has_report_evidence=has_report_evidence,
+            observed_selector_set=observed_selector_set,
+        )
+
+    cname_finding = await _dkim_cname_finding(
+        provider,
+        selector,
+        record_name,
+        selector_target,
+    )
+    if cname_finding:
+        if selector_activity is not None:
+            selector_activity["dns_status"] = "broken_cname"
+        return [cname_finding] if primary_eligible else []
+
+    if selector_activity is not None:
+        selector_activity["dns_status"] = "missing"
+    if selector in set(result.dkim_selectors or []) or not primary_eligible:
+        return []
+    return [_dkim_missing_finding(selector, record_name, selector_target)]
 
 
 async def _dkim_selector_findings(
@@ -934,47 +1001,32 @@ async def _dkim_selector_findings(
     target: DNSGuidanceRecord,
     monitored_selectors: List[str],
     observed_selectors: List[str],
+    selector_evidence: Optional[List[Dict[str, object]]] = None,
 ) -> List[DNSLintFinding]:
     findings: List[DNSLintFinding] = []
-    resolved_selectors = set(result.dkim_selectors or [])
     observed_selector_set = set(observed_selectors or [])
     has_report_evidence = bool(observed_selector_set)
+    evidence_by_selector = {
+        str(item.get("selector") or ""): item for item in selector_evidence or []
+    }
 
     for selector in monitored_selectors:
-        record_name = f"{selector}._domainkey.{domain}"
-        selector_target = DNSGuidanceRecord(
-            code=target.code,
-            record_type=target.record_type,
-            name=record_name,
-            value=target.value,
-            purpose=target.purpose,
-            priority=target.priority,
-        )
-        record = await _dkim_selector_record(provider, selector, domain)
-        if record:
-            findings.extend(
-                _dkim_record_findings(
-                    selector,
-                    record_name,
-                    record,
-                    selector_target,
-                    has_report_evidence=has_report_evidence,
-                    observed_selector_set=observed_selector_set,
-                )
+        selector_activity = evidence_by_selector.get(selector)
+        classification = str((selector_activity or {}).get("classification") or "")
+        primary_eligible = not selector_evidence or classification == "active_failing"
+        findings.extend(
+            await _inspect_dkim_selector(
+                provider,
+                domain,
+                result,
+                selector,
+                target,
+                has_report_evidence=has_report_evidence,
+                observed_selector_set=observed_selector_set,
+                selector_activity=selector_activity,
+                primary_eligible=primary_eligible,
             )
-            continue
-
-        cname_finding = await _dkim_cname_finding(
-            provider, selector, record_name, selector_target
         )
-        if cname_finding:
-            findings.append(cname_finding)
-            continue
-
-        if selector not in resolved_selectors:
-            findings.append(
-                _dkim_missing_finding(selector, record_name, selector_target)
-            )
     return findings
 
 
@@ -986,12 +1038,13 @@ async def _dkim_findings(
     *,
     monitored_selectors: Optional[List[str]] = None,
     observed_selectors: Optional[List[str]] = None,
+    selector_evidence: Optional[List[Dict[str, object]]] = None,
 ) -> List[DNSLintFinding]:
     target = _target_by_code(targets, "target_dkim")
     selectors_for_detail = list(
         dict.fromkeys(monitored_selectors or result.selectors_checked or [])
     )
-    if result.dkim and selectors_for_detail:
+    if selectors_for_detail and (result.dkim or selector_evidence is not None):
         return await _dkim_selector_findings(
             provider,
             domain,
@@ -999,6 +1052,7 @@ async def _dkim_findings(
             target,
             selectors_for_detail,
             list(dict.fromkeys(observed_selectors or [])),
+            selector_evidence,
         )
     if result.dkim:
         return []
@@ -1433,6 +1487,8 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
     """Create read-only operator change plans from DNS lint findings."""
     plans: List[DNSChangePlan] = []
     for finding in findings:
+        if not finding.primary_eligible:
+            continue
         operation = _operation_for_finding(finding)
         proposed_value = _proposed_value(finding)
         if operation == "defer":
@@ -1468,6 +1524,7 @@ async def build_dns_guidance(
     *,
     monitored_selectors: Optional[List[str]] = None,
     observed_selectors: Optional[List[str]] = None,
+    selector_evidence: Optional[List[Dict[str, object]]] = None,
     mail_service_records: Optional[List[Dict[str, str]]] = None,
     setup_defaults: Optional[MailAuthSetupDefaults] = None,
     locale: Optional[str] = None,
@@ -1476,8 +1533,20 @@ async def build_dns_guidance(
     normalized_domain = domain.strip().strip(".").lower()
     dane_result = dane or DANEResult(errors=["No DANE/TLSA context was evaluated."])
     targets = _target_records(normalized_domain, result, setup_defaults=setup_defaults)
+    if selector_evidence is not None:
+        active_selector = next(
+            (
+                str(item.get("selector") or "")
+                for item in selector_evidence
+                if item.get("classification") == "active_failing" and item.get("selector")
+            ),
+            "<provider-selector>",
+        )
+        target_dkim = _target_by_code(targets, "target_dkim")
+        target_dkim.name = f"{active_selector}._domainkey.{normalized_domain}"
     targets.append(_dane_target_record(normalized_domain, dane_result))
     findings: List[DNSLintFinding] = []
+    normalized_selector_evidence = [dict(item) for item in selector_evidence or []]
     findings.extend(_dmarc_findings(normalized_domain, result, targets))
     findings.extend(await _spf_findings(normalized_domain, provider, result, targets))
     findings.extend(
@@ -1488,6 +1557,7 @@ async def build_dns_guidance(
             targets,
             monitored_selectors=monitored_selectors,
             observed_selectors=observed_selectors,
+            selector_evidence=normalized_selector_evidence,
         )
     )
     findings.extend(_mta_sts_findings(mta_sts, targets))
@@ -1503,4 +1573,5 @@ async def build_dns_guidance(
         target_records=targets,
         dns_provider=result.dns_provider,
         change_plans=build_dns_change_plans(findings),
+        selector_evidence=normalized_selector_evidence,
     )

--- a/backend/app/services/mail_source_backfill_worker.py
+++ b/backend/app/services/mail_source_backfill_worker.py
@@ -18,7 +18,12 @@ from app.models.mail_source_backfill import MailSourceBackfillJob
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
-from app.services.microsoft_graph_client import MicrosoftGraphClient
+from app.services.microsoft_graph_client import (
+    MicrosoftGraphClient,
+    m365_application_configuration_error,
+    m365_source_can_authenticate,
+    normalize_m365_auth_mode,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -440,8 +445,11 @@ def _fetch_m365_backfill_results(
     days: int,
     page_cursor: Optional[str] = None,
 ) -> tuple[Dict[str, Any], Any]:
-    if not source.m365_access_token:
-        raise ValueError("Microsoft 365 account not yet authorised. Complete OAuth2 flow first.")
+    if not m365_source_can_authenticate(source):
+        raise ValueError(
+            m365_application_configuration_error(source)
+            or "Microsoft 365 account not yet authorised. Complete OAuth2 flow first."
+        )
 
     already = MicrosoftGraphClient.load_ingested_ids(source.m365_ingested_ids)
     client = MicrosoftGraphClient(
@@ -450,6 +458,7 @@ def _fetch_m365_backfill_results(
         client_secret=source.m365_client_secret or "",
         access_token=source.m365_access_token,
         refresh_token=source.m365_refresh_token or "",
+        auth_mode=normalize_m365_auth_mode(getattr(source, "m365_auth_mode", "delegated")),
         mailbox=source.m365_mailbox,
         folder=source.folder or "INBOX",
         folder_id=getattr(source, "m365_folder_id", None),

--- a/backend/app/services/microsoft_graph_client.py
+++ b/backend/app/services/microsoft_graph_client.py
@@ -35,6 +35,10 @@ M365_SCOPES = [
     "https://graph.microsoft.com/Mail.Read",
     "https://graph.microsoft.com/Mail.Read.Shared",
 ]
+M365_APPLICATION_SCOPE = "https://graph.microsoft.com/.default"
+M365_AUTH_MODE_DELEGATED = "delegated"
+M365_AUTH_MODE_APPLICATION = "application"
+M365_AUTH_MODES = {M365_AUTH_MODE_DELEGATED, M365_AUTH_MODE_APPLICATION}
 
 _PAGE_SIZE = 100
 _MAX_FOLDER_DEPTH = 5
@@ -60,13 +64,50 @@ class MicrosoftGraphError(RuntimeError):
     """Raised when Microsoft Graph or the token endpoint returns a failure."""
 
 
+def normalize_m365_auth_mode(value: Any) -> str:
+    """Return a supported Microsoft 365 auth mode or fail closed."""
+    if value is not None and value.__class__.__module__.startswith("unittest.mock"):
+        value = None
+    mode = str(value or M365_AUTH_MODE_DELEGATED).strip().lower()
+    if mode not in M365_AUTH_MODES:
+        raise ValueError("m365_auth_mode must be either 'delegated' or 'application'.")
+    return mode
+
+
+def m365_application_configuration_error(source: Any) -> Optional[str]:
+    """Return the first missing/unsafe app-only setting for a mail source."""
+    if normalize_m365_auth_mode(getattr(source, "m365_auth_mode", None)) != (
+        M365_AUTH_MODE_APPLICATION
+    ):
+        return None
+    tenant_id = str(getattr(source, "m365_tenant_id", None) or "").strip()
+    if not tenant_id or tenant_id.lower() in {"common", "organizations", "consumers"}:
+        return "Application authentication requires a tenant-specific ID or domain."
+    if not str(getattr(source, "m365_client_id", None) or "").strip():
+        return "Application authentication requires an application (client) ID."
+    if not str(getattr(source, "m365_client_secret", None) or "").strip():
+        return "Application authentication requires a client secret."
+    mailbox = str(getattr(source, "m365_mailbox", None) or "").strip()
+    if not mailbox or mailbox.lower() == "me":
+        return "Application authentication requires an explicit target mailbox."
+    return None
+
+
+def m365_source_can_authenticate(source: Any) -> bool:
+    """Return whether a source can obtain or refresh a usable Graph token."""
+    mode = normalize_m365_auth_mode(getattr(source, "m365_auth_mode", None))
+    if mode == M365_AUTH_MODE_APPLICATION:
+        return m365_application_configuration_error(source) is None
+    return bool(getattr(source, "m365_access_token", None))
+
+
 class MicrosoftGraphClient(MailSourceConnector):
     """
     Retrieve DMARC aggregate reports from Microsoft 365 through Microsoft Graph.
 
-    The client uses delegated OAuth tokens and read-only Graph scopes. Messages
-    are never modified or deleted; already-ingested Graph message IDs are stored
-    by the caller to avoid reprocessing the same email.
+    The client supports delegated OAuth and application client credentials.
+    Messages are never modified or deleted; already-ingested Graph message IDs
+    are stored by the caller to avoid reprocessing the same email.
     """
 
     def __init__(
@@ -83,12 +124,14 @@ class MicrosoftGraphClient(MailSourceConnector):
         db: Any = None,
         workspace_id: Optional[int] = None,
         sleep: Optional[Callable[[float], None]] = None,
+        auth_mode: str = M365_AUTH_MODE_DELEGATED,
     ):
         self.tenant_id = tenant_id or "common"
         self.client_id = client_id
         self.client_secret = client_secret
         self.access_token = access_token
         self.refresh_token = refresh_token
+        self.auth_mode = normalize_m365_auth_mode(auth_mode)
         self.mailbox = (mailbox or "").strip()
         self.folder = folder or "inbox"
         self.folder_id = (folder_id or "").strip()
@@ -176,7 +219,7 @@ class MicrosoftGraphClient(MailSourceConnector):
         return dump_ingested_ids(ids)
 
     def test_connection(self) -> Dict[str, Any]:
-        """Verify that the saved delegated token can read the target mailbox."""
+        """Verify that the configured identity can read the target mailbox."""
         data = self._request(
             "GET",
             self._messages_path(),
@@ -328,7 +371,11 @@ class MicrosoftGraphClient(MailSourceConnector):
         append_import_detail(stats, context=self.import_context(), **detail)
 
     def _target_mailbox_label(self) -> str:
-        return self.mailbox or "authorized account"
+        if self.mailbox:
+            return self.mailbox
+        if self.auth_mode == M365_AUTH_MODE_APPLICATION:
+            return "missing target mailbox"
+        return "authorized account"
 
     def _target_folder_label(self) -> str:
         if self.folder:
@@ -338,6 +385,10 @@ class MicrosoftGraphClient(MailSourceConnector):
         return "All messages"
 
     def _mailbox_path(self) -> str:
+        if self.auth_mode == M365_AUTH_MODE_APPLICATION and not self.mailbox:
+            raise MicrosoftGraphError(
+                "Application authentication requires an explicit target mailbox."
+            )
         if not self.mailbox or self.mailbox.lower() == "me":
             return "/me"
         return f"/users/{quote(self.mailbox, safe='')}"
@@ -354,7 +405,18 @@ class MicrosoftGraphClient(MailSourceConnector):
         return f"{mailbox_path}/mailFolders/{quote(folder, safe='')}/messages"
 
     def _headers(self) -> Dict[str, str]:
+        self._ensure_access_token()
         return {"Authorization": f"Bearer {self.access_token}"}
+
+    def _ensure_access_token(self) -> None:
+        if self.access_token:
+            return
+        if self.auth_mode == M365_AUTH_MODE_APPLICATION:
+            self._acquire_application_access_token()
+            return
+        raise MicrosoftGraphError(
+            "Delegated Microsoft 365 authorization is missing an access token."
+        )
 
     def _request(
         self,
@@ -368,8 +430,13 @@ class MicrosoftGraphClient(MailSourceConnector):
 
         for attempt in range(_MAX_GRAPH_RETRIES + 1):
             resp = httpx.request(method, url, headers=self._headers(), params=params, timeout=30)
-            if resp.status_code == 401 and self.refresh_token:
-                self._refresh_access_token()
+            if resp.status_code == 401:
+                if self.auth_mode == M365_AUTH_MODE_APPLICATION:
+                    self._acquire_application_access_token()
+                elif self.refresh_token:
+                    self._refresh_access_token()
+                else:
+                    break
                 resp = httpx.request(
                     method, url, headers=self._headers(), params=params, timeout=30
                 )
@@ -422,6 +489,31 @@ class MicrosoftGraphClient(MailSourceConnector):
             self.refresh_token = token_data["refresh_token"]
             refreshed["refresh_token"] = token_data["refresh_token"]
         self._refreshed_tokens = refreshed
+
+    def _acquire_application_access_token(self) -> None:
+        if not self.client_id or not self.client_secret:
+            raise MicrosoftGraphError(
+                "Application authentication requires a client ID and client secret."
+            )
+        data = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "grant_type": "client_credentials",
+            "scope": M365_APPLICATION_SCOPE,
+        }
+        resp = httpx.post(self._token_url(self.tenant_id), data=data, timeout=30)
+        if resp.status_code != 200:
+            raise MicrosoftGraphError(
+                f"Microsoft application token request failed ({resp.status_code}): "
+                f"{self._format_error(resp)}"
+            )
+        access_token = str(resp.json().get("access_token") or "")
+        if not access_token:
+            raise MicrosoftGraphError(
+                "Microsoft application token request did not return an access token."
+            )
+        self.access_token = access_token
+        self._refreshed_tokens = {"access_token": access_token}
 
     @staticmethod
     def _format_error(resp: httpx.Response) -> str:

--- a/backend/app/services/report_store.py
+++ b/backend/app/services/report_store.py
@@ -2,6 +2,10 @@ import threading
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+ACTIVE_SELECTOR_WINDOW_DAYS = 7
+RECENT_SELECTOR_WINDOW_DAYS = 30
+SECONDS_PER_DAY = 86_400
+
 
 def _auth_status_from_counts(pass_count: int, fail_count: int, unknown_count: int = 0) -> str:
     """Return a compact status label for aggregated authentication results."""
@@ -119,16 +123,18 @@ def _now_timestamp() -> int:
     return int(datetime.now(timezone.utc).timestamp())
 
 
-def _observed_report_window(report: Dict[str, Any]) -> tuple[Optional[int], Optional[int]]:
+def _observed_report_window(
+    report: Dict[str, Any], *, now: Optional[int] = None
+) -> tuple[Optional[int], Optional[int]]:
     """Return a source-observation window, clamped so UI recency never points ahead."""
     begin, end = _report_time_window(report)
     observed_start = begin if begin is not None else end
     observed_end = end if end is not None else begin
-    now = _now_timestamp()
-    if observed_start is not None and observed_start > now:
-        observed_start = now
-    if observed_end is not None and observed_end > now:
-        observed_end = now
+    current_time = int(now if now is not None else _now_timestamp())
+    if observed_start is not None and observed_start > current_time:
+        observed_start = current_time
+    if observed_end is not None and observed_end > current_time:
+        observed_end = current_time
     if observed_start is not None and observed_end is not None and observed_start > observed_end:
         observed_start = observed_end
     return observed_start, observed_end
@@ -138,6 +144,120 @@ def _date_bucket(timestamp: Optional[int]) -> Optional[str]:
     if timestamp is None:
         return None
     return datetime.fromtimestamp(timestamp, tz=timezone.utc).date().isoformat()
+
+
+def _timestamp_iso(timestamp: Optional[int]) -> Optional[str]:
+    if timestamp is None:
+        return None
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat()
+
+
+def _dkim_domain_matches(entry_domain: Any, monitored_domain: str) -> bool:
+    """Keep aligned or potentially relaxed-aligned DKIM evidence for this domain."""
+    value = str(entry_domain or "").strip().strip(".").lower()
+    normalized_domain = monitored_domain.strip().strip(".").lower()
+    if not value:
+        return True
+    return value == normalized_domain or value.endswith(f".{normalized_domain}")
+
+
+def _selector_classification(entry: Dict[str, Any], now: int) -> tuple[str, str]:
+    last_seen = entry.get("last_seen")
+    active_cutoff = now - ACTIVE_SELECTOR_WINDOW_DAYS * SECONDS_PER_DAY
+    recent_cutoff = now - RECENT_SELECTOR_WINDOW_DAYS * SECONDS_PER_DAY
+    current_failures = int(entry.get("current_failure_count") or 0)
+    current_passes = int(entry.get("current_pass_count") or 0)
+
+    if last_seen is not None and int(last_seen) >= active_cutoff and current_failures > 0:
+        return (
+            "active_failing",
+            f"Observed with {current_failures} failing messages in the last "
+            f"{ACTIVE_SELECTOR_WINDOW_DAYS} days.",
+        )
+    if last_seen is not None and int(last_seen) >= active_cutoff and current_passes > 0:
+        return (
+            "active_passing",
+            f"Observed passing DKIM in the last {ACTIVE_SELECTOR_WINDOW_DAYS} days; "
+            "no current selector failure needs DNS remediation.",
+        )
+    if last_seen is not None and int(last_seen) >= recent_cutoff:
+        return (
+            "recently_observed",
+            f"Observed within the last {RECENT_SELECTOR_WINDOW_DAYS} days, but not in "
+            f"the active {ACTIVE_SELECTOR_WINDOW_DAYS}-day failure window.",
+        )
+    report_count = int(entry.get("report_count") or len(entry.get("_report_ids") or []))
+    if report_count > 0:
+        return (
+            "historical",
+            "Only historical report evidence remains; confirm the sender is still used "
+            "before considering a DNS change.",
+        )
+    return (
+        "manually_configured",
+        "Configured by an operator without matching report evidence; keep it visible for "
+        "review, but do not treat it as an active failure.",
+    )
+
+
+def _new_selector_evidence(selector: str) -> Dict[str, Any]:
+    return {
+        "selector": selector,
+        "first_seen": None,
+        "last_seen": None,
+        "message_count": 0,
+        "current_failure_count": 0,
+        "current_pass_count": 0,
+        "_report_ids": set(),
+        "_record_keys": set(),
+    }
+
+
+def _selector_results_from_record(record: Dict[str, Any], domain: str) -> Dict[str, set[str]]:
+    results: Dict[str, set[str]] = {}
+    for auth in record.get("dkim") or []:
+        if not isinstance(auth, dict) or not _dkim_domain_matches(auth.get("domain"), domain):
+            continue
+        selector = str(auth.get("selector") or "").strip()
+        if selector:
+            results.setdefault(selector, set()).add(
+                str(auth.get("result") or "unknown").strip().lower()
+            )
+    return results
+
+
+def _update_selector_evidence(
+    row: Dict[str, Any],
+    *,
+    count: int,
+    report_id: str,
+    record_key: tuple[Any, int],
+    observed_start: Optional[int],
+    observed_end: Optional[int],
+    active_cutoff: int,
+    results: set[str],
+) -> None:
+    if record_key not in row["_record_keys"]:
+        row["_record_keys"].add(record_key)
+        row["message_count"] += count
+    if report_id:
+        row["_report_ids"].add(report_id)
+    if observed_start is not None:
+        row["first_seen"] = (
+            observed_start
+            if row["first_seen"] is None
+            else min(int(row["first_seen"]), observed_start)
+        )
+    if observed_end is not None:
+        row["last_seen"] = (
+            observed_end if row["last_seen"] is None else max(int(row["last_seen"]), observed_end)
+        )
+    if observed_end is None or observed_end < active_cutoff:
+        return
+    if "fail" in results:
+        row["current_failure_count"] += count
+    elif "pass" in results:
+        row["current_pass_count"] += count
 
 
 def _update_source_window(
@@ -428,6 +548,80 @@ class ReportStore:
         if limit is not None:
             return sorted_reports[:limit]
         return sorted_reports
+
+    def get_domain_selector_evidence(
+        self,
+        domain: str,
+        *,
+        manual_selectors: Optional[List[str]] = None,
+        now: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Derive selector activity and failure evidence from aggregate reports."""
+        current_time = int(now if now is not None else _now_timestamp())
+        active_cutoff = current_time - ACTIVE_SELECTOR_WINDOW_DAYS * SECONDS_PER_DAY
+        evidence: Dict[str, Dict[str, Any]] = {}
+
+        for report in self.get_domain_reports(domain):
+            observed_start, observed_end = _observed_report_window(report, now=current_time)
+            report_id = str(report.get("report_id") or "").strip()
+            for record_index, record in enumerate(report.get("records") or []):
+                count = max(0, int(record.get("count") or 0))
+                for selector, results in _selector_results_from_record(record, domain).items():
+                    row = evidence.setdefault(selector, _new_selector_evidence(selector))
+                    _update_selector_evidence(
+                        row,
+                        count=count,
+                        report_id=report_id,
+                        record_key=(report_id or id(report), record_index),
+                        observed_start=observed_start,
+                        observed_end=observed_end,
+                        active_cutoff=active_cutoff,
+                        results=results,
+                    )
+
+        manual = list(dict.fromkeys(str(value).strip() for value in manual_selectors or []))
+        for selector in manual:
+            if not selector:
+                continue
+            evidence.setdefault(selector, _new_selector_evidence(selector))
+
+        manual_set = set(manual)
+        priority = {
+            "active_failing": 0,
+            "active_passing": 1,
+            "recently_observed": 2,
+            "historical": 3,
+            "manually_configured": 4,
+        }
+        rows: List[Dict[str, Any]] = []
+        for selector, raw in evidence.items():
+            classification, reason = _selector_classification(raw, current_time)
+            rows.append(
+                {
+                    "selector": selector,
+                    "classification": classification,
+                    "classification_reason": reason,
+                    "first_seen": raw["first_seen"],
+                    "first_seen_at": _timestamp_iso(raw["first_seen"]),
+                    "last_seen": raw["last_seen"],
+                    "last_seen_at": _timestamp_iso(raw["last_seen"]),
+                    "report_count": len(raw["_report_ids"]),
+                    "message_count": int(raw["message_count"]),
+                    "current_failure_count": int(raw["current_failure_count"]),
+                    "current_pass_count": int(raw["current_pass_count"]),
+                    "manual_configured": selector in manual_set,
+                    "active_window_days": ACTIVE_SELECTOR_WINDOW_DAYS,
+                    "recent_window_days": RECENT_SELECTOR_WINDOW_DAYS,
+                }
+            )
+        rows.sort(
+            key=lambda row: (
+                priority.get(str(row["classification"]), 99),
+                -int(row.get("last_seen") or 0),
+                str(row["selector"]),
+            )
+        )
+        return rows
 
     def get_domain_sources(self, domain: str, days: int = 30) -> List[Dict[str, Any]]:
         """

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -35,6 +35,7 @@ function domainDetailsApp(domainId = '') {
             target_records: [],
             dns_provider: null,
             change_plans: [],
+            selector_evidence: [],
             recommended_provider: null,
             available_write_providers: [],
             safety_notes: []
@@ -1086,6 +1087,38 @@ function domainDetailsApp(domainId = '') {
             if (this.dnsGuidance.status === 'attention') return 'bg-yellow-100 text-yellow-800';
             if (this.dnsGuidance.status === 'critical') return 'bg-red-100 text-red-700';
             return 'bg-base-200 text-base-content/70';
+        },
+
+        selectorEvidenceLabel(classification) {
+            const labels = {
+                active_failing: 'Active failing',
+                active_passing: 'Active passing',
+                recently_observed: 'Recently observed',
+                historical: 'Historical evidence',
+                manually_configured: 'Manually configured',
+            };
+            return labels[classification] || 'Evidence';
+        },
+
+        selectorEvidenceClass(classification) {
+            if (classification === 'active_failing') return 'bg-red-100 text-red-700';
+            if (classification === 'active_passing') return 'bg-green-100 text-green-700';
+            if (classification === 'recently_observed') return 'bg-amber-100 text-amber-800';
+            return 'bg-base-200 text-base-content/70';
+        },
+
+        selectorDnsStatusLabel(status) {
+            const labels = {
+                resolved: 'DNS resolves',
+                missing: 'DNS not found',
+                broken_cname: 'CNAME target broken',
+                not_checked: 'Not checked',
+            };
+            return labels[status] || 'Not checked';
+        },
+
+        selectorEvidenceLastSeen(item) {
+            return item?.last_seen ? this.sourceSeenLabel(item.last_seen) : 'No dated evidence';
         },
 
         targetRecordByCode(code) {

--- a/backend/app/static/js/mail-sources-page.js
+++ b/backend/app/static/js/mail-sources-page.js
@@ -23,6 +23,7 @@ function mailSourcesApp() {
         gmailConnected: false,
         gmailEmail: '',
         m365Connected: false,
+        m365Configured: false,
         m365Email: '',
         m365Folders: [],
         m365FoldersLoading: false,
@@ -41,6 +42,7 @@ function mailSourcesApp() {
             enabled: true,
             gmail_client_id: '',
             gmail_client_secret: '',
+            m365_auth_mode: 'delegated',
             m365_tenant_id: 'common',
             m365_client_id: '',
             m365_client_secret: '',
@@ -126,6 +128,9 @@ function mailSourcesApp() {
                 } else if (button.matches('[data-mail-source-connect-m365]')) {
                     event.preventDefault();
                     this.connectM365();
+                } else if (button.matches('[data-mail-source-test-m365]')) {
+                    event.preventDefault();
+                    this.testM365();
                 } else if (button.matches('[data-mail-source-delete-cancel]')) {
                     event.preventDefault();
                     this.deleteTarget = null;
@@ -515,7 +520,11 @@ function mailSourcesApp() {
                 return source.gmail_connected ? 'Connected' : 'Not authorised';
             }
             if (source.method === 'M365_GRAPH') {
-                return source.m365_connected ? 'Connected' : 'Not authorised';
+                if (source.m365_connected) return 'Connected';
+                if (source.m365_auth_mode === 'application' && source.m365_configured) {
+                    return 'Ready to test';
+                }
+                return source.m365_auth_mode === 'application' ? 'Needs configuration' : 'Not authorised';
             }
             return source.username || '—';
         },
@@ -684,6 +693,7 @@ function mailSourcesApp() {
             this.gmailConnected = false;
             this.gmailEmail = '';
             this.m365Connected = false;
+            this.m365Configured = false;
             this.m365Email = '';
             this.m365Folders = [];
             this.m365FoldersError = '';
@@ -700,6 +710,7 @@ function mailSourcesApp() {
                 enabled: true,
                 gmail_client_id: '',
                 gmail_client_secret: '',
+                m365_auth_mode: 'delegated',
                 m365_tenant_id: 'common',
                 m365_client_id: '',
                 m365_client_secret: '',
@@ -715,6 +726,7 @@ function mailSourcesApp() {
             this.gmailConnected = source.gmail_connected || false;
             this.gmailEmail = source.gmail_email || '';
             this.m365Connected = source.m365_connected || false;
+            this.m365Configured = source.m365_configured || false;
             this.m365Email = source.m365_email || '';
             this.m365Folders = [];
             this.m365FoldersError = '';
@@ -731,6 +743,7 @@ function mailSourcesApp() {
                 enabled: source.enabled !== false,
                 gmail_client_id: source.gmail_client_id || '',
                 gmail_client_secret: '',  // never pre-fill client secret
+                m365_auth_mode: source.m365_auth_mode || 'delegated',
                 m365_tenant_id: source.m365_tenant_id || 'common',
                 m365_client_id: source.m365_client_id || '',
                 m365_client_secret: '',  // never pre-fill client secret
@@ -815,6 +828,7 @@ function mailSourcesApp() {
                         const updated = this.sources.find(s => s.id === this.editingId);
                         if (updated) {
                             this.m365Connected = updated.m365_connected || false;
+                            this.m365Configured = updated.m365_configured || false;
                             this.m365Email = updated.m365_email || '';
                             this.form.m365_folder_id = updated.m365_folder_id || this.form.m365_folder_id || '';
                             if (this.m365Connected) {
@@ -828,6 +842,38 @@ function mailSourcesApp() {
                 }, 1000);
             } catch (e) {
                 this.feedback = { message: `Error: ${e.message}`, type: 'error' };
+            }
+        },
+
+        async testM365() {
+            if (!this.editingId) return;
+            this.isTesting = true;
+            this.testResult = this.emptyTestResult();
+            try {
+                const resp = await fetch(`/api/v1/mail-sources/${this.editingId}/test`, {
+                    method: 'POST',
+                });
+                const result = await resp.json();
+                const diagnostic = this.diagnosticFromResult(result);
+                this.testResult = {
+                    success: Boolean(result.success),
+                    message: result.success
+                        ? `Connected. ${result.message}`
+                        : result.message || 'Microsoft 365 connection test failed.',
+                    ...diagnostic,
+                };
+                if (result.success) {
+                    await this.loadSources();
+                    const updated = this.sources.find(source => source.id === this.editingId);
+                    if (updated) {
+                        this.m365Connected = updated.m365_connected || false;
+                        this.m365Configured = updated.m365_configured || false;
+                    }
+                }
+            } catch (e) {
+                this.testResult = { success: false, message: `Test error: ${e.message}` };
+            } finally {
+                this.isTesting = false;
             }
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1977,18 +1977,42 @@
                                 </div>
                             </template>
                         </div>
-                        <!-- Auto-discovered selectors from DMARC reports -->
-                        <template x-if="reportSelectors.length > 0">
-                            <div class="mb-3">
-                                <p class="text-xs text-muted-foreground font-semibold uppercase tracking-wide mb-1">From DMARC reports (auto-detected)</p>
-                                <template x-for="sel in reportSelectors" :key="sel">
-                                    <div class="flex items-center py-1 px-2 rounded bg-muted/50 border border-dashed mb-1">
-                                        <span class="font-mono text-sm text-muted-foreground" x-text="sel"></span>
-                                        <span class="ml-2 text-xs text-muted-foreground italic">auto</span>
+                        <details class="mb-3 rounded-md border border-base-300 bg-base-100"
+                                 x-show="(dnsGuidance.selector_evidence || []).length > 0">
+                            <summary class="cursor-pointer px-3 py-2 text-sm font-semibold text-[#272a5f]">
+                                Selector evidence
+                                <span class="font-normal text-base-content/60"
+                                      x-text="'(' + (dnsGuidance.selector_evidence || []).length + ')' "></span>
+                            </summary>
+                            <div class="space-y-2 border-t border-base-300 p-3">
+                                <p class="text-xs text-base-content/60">
+                                    Only selectors failing in the active report window can become a primary remediation. Passing, recent, and historical selectors remain evidence.
+                                </p>
+                                <template x-for="item in (dnsGuidance.selector_evidence || [])"
+                                          :key="'selector-evidence-' + item.selector">
+                                    <div class="rounded border border-base-300 bg-white p-3">
+                                        <div class="flex flex-wrap items-center gap-2">
+                                            <code class="text-sm font-semibold" x-text="item.selector"></code>
+                                            <span class="rounded px-2 py-1 text-xs font-semibold"
+                                                  :class="selectorEvidenceClass(item.classification)"
+                                                  x-text="selectorEvidenceLabel(item.classification)"></span>
+                                            <span class="text-xs text-base-content/60"
+                                                  x-text="selectorDnsStatusLabel(item.dns_status)"></span>
+                                            <span x-show="item.manual_configured"
+                                                  class="rounded bg-base-200 px-2 py-1 text-xs text-base-content/70">manual</span>
+                                        </div>
+                                        <p class="mt-2 text-xs text-base-content/70" x-text="item.classification_reason"></p>
+                                        <div class="mt-2 grid gap-2 text-xs text-base-content/70 sm:grid-cols-2 lg:grid-cols-5">
+                                            <span><strong>Last seen:</strong> <span x-text="selectorEvidenceLastSeen(item)"></span></span>
+                                            <span><strong>Reports:</strong> <span x-text="item.report_count"></span></span>
+                                            <span><strong>Messages:</strong> <span x-text="formatLargeNumber(item.message_count)"></span></span>
+                                            <span><strong>Current failures:</strong> <span x-text="formatLargeNumber(item.current_failure_count)"></span></span>
+                                            <span><strong>Current passes:</strong> <span x-text="formatLargeNumber(item.current_pass_count)"></span></span>
+                                        </div>
                                     </div>
                                 </template>
                             </div>
-                        </template>
+                        </details>
                         <!-- Add selector form -->
                         <div class="flex items-center gap-2">
                             <input

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -327,7 +327,7 @@
                             <option value="IMAP">IMAP</option>
                             <option value="POP3">POP3 (coming soon)</option>
                             <option value="GMAIL_API">Gmail API (OAuth2)</option>
-                            <option value="M365_GRAPH">Microsoft 365 (Graph OAuth2)</option>
+                            <option value="M365_GRAPH">Microsoft 365 (Graph)</option>
                         </select>
                     </div>
 
@@ -476,35 +476,74 @@
                     <!-- Microsoft 365 Graph fields -->
                     <template x-if="form.method === 'M365_GRAPH'">
                         <div class="space-y-4">
+                            <fieldset>
+                                <legend class="label-text font-medium mb-2">Authentication</legend>
+                                <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                    <label class="flex cursor-pointer items-start gap-3 rounded-md border border-border p-3"
+                                        :class="form.m365_auth_mode === 'delegated' ? 'border-primary bg-primary/5' : ''">
+                                        <input type="radio" class="radio radio-sm mt-0.5" value="delegated"
+                                            x-model="form.m365_auth_mode" />
+                                        <span>
+                                            <span class="block text-sm font-semibold">User sign-in</span>
+                                            <span class="block text-xs text-muted-foreground">Interactive OAuth with a redirect URL.</span>
+                                        </span>
+                                    </label>
+                                    <label class="flex cursor-pointer items-start gap-3 rounded-md border border-border p-3"
+                                        :class="form.m365_auth_mode === 'application' ? 'border-primary bg-primary/5' : ''">
+                                        <input type="radio" class="radio radio-sm mt-0.5" value="application"
+                                            x-model="form.m365_auth_mode" />
+                                        <span>
+                                            <span class="block text-sm font-semibold">Application access</span>
+                                            <span class="block text-xs text-muted-foreground">Unattended access for a shared mailbox.</span>
+                                        </span>
+                                    </label>
+                                </div>
+                            </fieldset>
+
                             <div class="alert alert-info text-sm p-3">
+                                <div x-show="form.m365_auth_mode === 'delegated'">
+                                    <p class="font-semibold">User sign-in setup</p>
+                                    <p class="mt-1">Create an Entra app with delegated Mail.Read permissions and a Web redirect URI. Save this source, then sign in with a user that can read the mailbox.</p>
+                                </div>
+                                <div x-show="form.m365_auth_mode === 'application'">
+                                    <p class="font-semibold">Unattended application setup</p>
+                                    <p class="mt-1">Create a tenant-specific Entra app with the <strong>Mail.Read application permission</strong> and admin consent. No redirect URI or user sign-in is used.</p>
+                                </div>
+                            </div>
+
+                            <div class="alert alert-warning text-sm p-3"
+                                x-show="form.m365_auth_mode === 'application'">
                                 <div>
-                                    <p class="font-semibold">Microsoft 365 Setup</p>
-                                    <p class="mt-1">Enter an app registration Client ID and client secret from Microsoft Entra admin center. Add this app's callback URL as a Web redirect URI, then save and click <strong>Connect Microsoft 365</strong>.</p>
+                                    <p class="font-semibold">Limit mailbox access in Exchange Online</p>
+                                    <p class="mt-1">Mail.Read application permission can otherwise read every mailbox in the tenant. Restrict this app to the report mailbox with Exchange Online RBAC for Applications. Legacy Application Access Policies may be used only where already required.</p>
                                 </div>
                             </div>
 
                             <div>
-                                <label class="label"><span class="label-text font-medium">Tenant ID</span></label>
+                                <label class="label"><span class="label-text font-medium">Tenant ID <span class="text-error" x-show="form.m365_auth_mode === 'application'">*</span></span></label>
                                 <input type="text" x-model="form.m365_tenant_id"
-                                    placeholder="common, organizations, or tenant GUID"
+                                    :placeholder="form.m365_auth_mode === 'application' ? 'Tenant GUID or verified tenant domain' : 'common, organizations, or tenant GUID'"
+                                    :required="form.m365_auth_mode === 'application'"
                                     class="input input-bordered w-full" />
+                                <p class="text-xs text-muted-foreground mt-1" x-show="form.m365_auth_mode === 'application'">Application access requires a concrete tenant; common and organizations are not accepted.</p>
                             </div>
 
                             <div>
                                 <label class="label"><span class="label-text font-medium">Microsoft Client ID <span class="text-error">*</span></span></label>
                                 <input type="text" x-model="form.m365_client_id"
                                     placeholder="Application (client) ID"
-                                    class="input input-bordered w-full" />
+                                    class="input input-bordered w-full" required />
                             </div>
 
                             <div>
-                                <label class="label">
+                                <label class="label flex-col items-start gap-1 sm:flex-row sm:items-center">
                                     <span class="label-text font-medium">Microsoft Client Secret <span class="text-error">*</span></span>
-                                    <span class="label-text-alt text-muted-foreground" x-show="editingId">Leave blank to keep existing</span>
+                                    <span class="label-text-alt text-muted-foreground sm:ml-auto" x-show="editingId">Leave blank to keep existing</span>
                                 </label>
                                 <div class="relative">
                                     <input :type="showPassword ? 'text' : 'password'"
                                         x-model="form.m365_client_secret"
+                                        :required="!editingId"
                                         class="input input-bordered w-full pr-10" />
                                     <button type="button"
                                         class="absolute right-2 top-3 text-muted-foreground hover:text-foreground"
@@ -527,10 +566,12 @@
                             </div>
 
                             <div>
-                                <label class="label"><span class="label-text font-medium">Mailbox</span></label>
+                                <label class="label"><span class="label-text font-medium">Mailbox <span class="text-error" x-show="form.m365_auth_mode === 'application'">*</span></span></label>
                                 <input type="text" x-model="form.m365_mailbox"
-                                    placeholder="Leave blank for the authorised account"
+                                    :placeholder="form.m365_auth_mode === 'application' ? 'dmarc-reports@example.com' : 'Leave blank for the signed-in account'"
+                                    :required="form.m365_auth_mode === 'application'"
                                     class="input input-bordered w-full" />
+                                <p class="text-xs text-muted-foreground mt-1" x-show="form.m365_auth_mode === 'application'">Every Graph request is scoped to this explicit mailbox; /me is never used.</p>
                             </div>
 
                             <div>
@@ -546,7 +587,7 @@
                                     </select>
                                     <button type="button" class="btn btn-outline"
                                         data-mail-source-m365-load-folders
-                                        :disabled="!editingId || !m365Connected || m365FoldersLoading">
+                                        :disabled="!editingId || !(m365Connected || m365Configured) || m365FoldersLoading">
                                         <span x-text="m365FoldersLoading ? 'Loading…' : 'Load folders'"></span>
                                     </button>
                                 </div>
@@ -559,13 +600,21 @@
 
                             <template x-if="editingId && m365Connected">
                                 <div class="alert alert-success text-sm p-3">
-                                    <span>Connected as <strong x-text="m365Email || 'Microsoft 365 account'"></strong></span>
+                                    <span>Mailbox access verified for <strong x-text="form.m365_mailbox || m365Email || 'Microsoft 365 account'"></strong></span>
                                 </div>
                             </template>
-                            <template x-if="editingId && !m365Connected">
+                            <template x-if="editingId && !m365Connected && form.m365_auth_mode === 'delegated'">
                                 <div class="alert alert-warning text-sm p-3">
                                     <span>Not yet authorised. Save this source first, then click <strong>Connect Microsoft 365</strong>.</span>
                                 </div>
+                            </template>
+                            <template x-if="editingId && !m365Connected && form.m365_auth_mode === 'application' && m365Configured">
+                                <div class="alert alert-info text-sm p-3">
+                                    <span>Application credentials are saved. Use <strong>Test application access</strong> to verify the Exchange mailbox scope.</span>
+                                </div>
+                            </template>
+                            <template x-if="!editingId && form.m365_auth_mode === 'application'">
+                                <p class="text-xs text-muted-foreground">Save the source first, then edit it to test mailbox access and load folders.</p>
                             </template>
                         </div>
                     </template>
@@ -628,11 +677,18 @@
                                     Connect Gmail
                                 </button>
                             </template>
-                            <template x-if="form.method === 'M365_GRAPH' && editingId">
+                            <template x-if="form.method === 'M365_GRAPH' && editingId && form.m365_auth_mode === 'delegated'">
                                 <button type="button" class="btn btn-outline btn-sm"
                                     data-mail-source-connect-m365
                                     :disabled="isTesting || isSaving">
                                     Connect Microsoft 365
+                                </button>
+                            </template>
+                            <template x-if="form.method === 'M365_GRAPH' && editingId && form.m365_auth_mode === 'application'">
+                                <button type="button" class="btn btn-outline btn-sm"
+                                    data-mail-source-test-m365
+                                    :disabled="isTesting || isSaving">
+                                    <span x-text="isTesting ? 'Testing…' : 'Test application access'"></span>
                                 </button>
                             </template>
                         </div>

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -8,9 +8,9 @@ from sqlalchemy.exc import IntegrityError
 from starlette.requests import Request
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
-from app.main import app, dashboard, index
+from app.main import app, dashboard
 from app.main import health as root_health
-from app.main import members_page, provider_demo_page, settings
+from app.main import index, members_page, provider_demo_page, settings
 from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.report import DMARCReport, ReportRecord
@@ -510,6 +510,37 @@ def test_operations_health_surfaces_gmail_reauth_attention(
     assert data["scheduler"]["reauth_required_sources"] == 1
     assert data["scheduler"]["sources"][0]["status"] == "reauth_required"
     assert data["mailbox_recovery"][0]["category"] == "auth_expired"
+
+
+def test_operations_health_accepts_configured_m365_application_source_without_token(
+    authed_client: TestClient,
+    db_session,
+):
+    """Client-credential sources can obtain tokens during each polling cycle."""
+    workspace = get_or_create_default_workspace(db_session)
+    source = MailSource(
+        workspace_id=workspace.id,
+        name="Shared report mailbox",
+        method="M365_GRAPH",
+        enabled=True,
+        m365_auth_mode="application",
+        m365_tenant_id="tenant-id",
+        m365_client_id="client-id",
+        m365_client_secret="client-secret",
+        m365_mailbox="dmarc-reports@example.com",
+        m365_access_token=None,
+    )
+    db_session.add(source)
+    db_session.commit()
+
+    response = authed_client.get("/api/v1/health/operations")
+
+    assert response.status_code == 200
+    source_health = response.json()["scheduler"]["sources"][0]
+    assert source_health["status"] == "ready_to_test"
+    assert source_health["attention"] is False
+    assert source_health["action_label"] == "Test connection"
+    assert source_health["diagnostic_category"] == "ok"
 
 
 def test_setup_status_includes_mailbox_recovery_hint(authed_client: TestClient):

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2161,6 +2161,7 @@ def test_mail_sources_form_actions_are_bound_from_external_script():
     assert "data-mail-source-test-adhoc" in template
     assert "data-mail-source-connect-gmail" in template
     assert "data-mail-source-connect-m365" in template
+    assert "data-mail-source-test-m365" in template
     assert "data-mail-source-delete-modal" in template
     assert "data-mail-source-delete-cancel" in template
     assert "data-mail-source-delete-confirm" in template
@@ -2173,6 +2174,7 @@ def test_mail_sources_form_actions_are_bound_from_external_script():
     assert "data-mail-source-test-adhoc" in script
     assert "data-mail-source-connect-gmail" in script
     assert "data-mail-source-connect-m365" in script
+    assert "data-mail-source-test-m365" in script
     assert "data-mail-source-delete-cancel" in script
     assert "data-mail-source-delete-confirm" in script
     assert "data-mail-source-form-modal" in script

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -469,6 +469,25 @@ def test_dns_endpoint_marks_connected_provider_repair_ready(
 
 
 def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: TestClient):
+    now = datetime.now(timezone.utc)
+    ReportStore.get_instance().add_report(
+        {
+            **MINIMAL_REPORT,
+            "report_id": "current-dkim-failure",
+            "begin_timestamp": int((now - timedelta(days=1)).timestamp()),
+            "end_timestamp": int(now.timestamp()),
+            "records": [
+                {
+                    "source_ip": "203.0.113.20",
+                    "count": 6,
+                    "disposition": "none",
+                    "dkim_result": "fail",
+                    "spf_result": "fail",
+                    "dkim": [{"domain": DOMAIN, "result": "fail", "selector": "google"}],
+                }
+            ],
+        }
+    )
     result = DomainDNSResult(
         dmarc=True,
         dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@example.com",
@@ -524,6 +543,9 @@ def test_dns_lint_endpoint_returns_typed_findings_and_targets(authed_client: Tes
     assert change_plan["provider_write_available"] is False
     assert change_plan["provider_value_required"] is True
     assert change_plan["manual_steps"]
+    selector = next(item for item in data["selector_evidence"] if item["selector"] == "google")
+    assert selector["classification"] == "active_failing"
+    assert selector["current_failure_count"] == 6
 
 
 def test_dns_lint_endpoint_uses_configured_mail_auth_defaults(
@@ -2470,7 +2492,9 @@ def test_dashboard_remediation_item_exposes_summary_notification_profile():
     assert notification["state"] == "summary_only"
     assert notification["event"] == "dmarq.remediation.summary"
     assert notification["channel"] == "daily_summary"
-    assert notification["reason"] == "Include this lower-risk remediation item in summary reporting."
+    assert (
+        notification["reason"] == "Include this lower-risk remediation item in summary reporting."
+    )
     assert notification["payload_preview"]["schema_version"] == (
         "dmarq.dashboard.remediation.notification_preview.v1"
     )

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -444,17 +444,13 @@ async def test_build_dns_guidance_lints_dkim_selector_health():
     assert "dkim_selector_cname_broken" in findings
     assert "dkim_selector_missing" in findings
     assert findings["dkim_selector_missing"].record_name == "old._domainkey.example.com"
-    assert (
-        findings["dkim_selector_missing"].target_record.name
-        == "old._domainkey.example.com"
-    )
+    assert findings["dkim_selector_missing"].target_record.name == "old._domainkey.example.com"
     assert (
         findings["dkim_selector_cname_broken"].target_record.name
         == "mailchimp._domainkey.example.com"
     )
     assert (
-        findings["dkim_selector_key_too_short"].target_record.name
-        == "short._domainkey.example.com"
+        findings["dkim_selector_key_too_short"].target_record.name == "short._domainkey.example.com"
     )
     assert findings["dkim_selector_cname_broken"].record_type == "CNAME"
     assert findings["dkim_selector_key_too_short"].remediation_steps
@@ -662,3 +658,69 @@ async def test_build_dns_guidance_adds_postmark_dns_change_plans():
     assert missing.operation == "create"
     assert missing.record_type == "CNAME"
     assert missing.proposed_value == "pm.mtasv.net"
+
+
+@pytest.mark.asyncio
+async def test_selector_history_cannot_become_primary_dns_remediation():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=False,
+        selectors_checked=["active", "passing", "retired", "manual"],
+    )
+    selector_evidence = [
+        {
+            "selector": "active",
+            "classification": "active_failing",
+            "current_failure_count": 12,
+        },
+        {
+            "selector": "passing",
+            "classification": "active_passing",
+            "current_pass_count": 8,
+        },
+        {
+            "selector": "retired",
+            "classification": "historical",
+            "current_failure_count": 0,
+        },
+        {
+            "selector": "manual",
+            "classification": "manually_configured",
+            "manual_configured": True,
+        },
+    ]
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        monitored_selectors=["active", "passing", "retired", "manual"],
+        observed_selectors=["active", "passing", "retired"],
+        selector_evidence=selector_evidence,
+    )
+
+    dkim_findings = [finding for finding in guidance.findings if finding.code.startswith("dkim_")]
+    dkim_plans = [plan for plan in guidance.change_plans if plan.finding_code.startswith("dkim_")]
+
+    assert [finding.record_name for finding in dkim_findings] == ["active._domainkey.example.com"]
+    assert [plan.name for plan in dkim_plans] == ["active._domainkey.example.com"]
+    assert dkim_plans[0].provider_value_required is True
+    assert dkim_plans[0].requires_approval is True
+    assert (
+        next(record for record in guidance.target_records if record.code == "target_dkim").name
+        == "active._domainkey.example.com"
+    )
+    evidence = {item["selector"]: item for item in guidance.selector_evidence}
+    assert evidence["active"]["dns_status"] == "missing"
+    assert evidence["retired"]["dns_status"] == "missing"

--- a/backend/app/tests/test_mail_source_backfill_worker.py
+++ b/backend/app/tests/test_mail_source_backfill_worker.py
@@ -430,6 +430,55 @@ def test_run_m365_backfill_without_token_moves_to_backoff(db_session):
     assert attempt.status == "failed"
 
 
+def test_run_m365_application_backfill_runs_without_stored_token(db_session, monkeypatch):
+    workspace, source = _source(db_session, method="M365_GRAPH")
+    source.m365_auth_mode = "application"
+    source.m365_tenant_id = "tenant-id"
+    source.m365_access_token = None
+    source.m365_refresh_token = None
+    db_session.commit()
+    row = _job(db_session, workspace, source)
+    captured = {}
+
+    class FakeMicrosoftGraphClient:
+        load_ingested_ids = staticmethod(lambda _value: [])
+        dump_ingested_ids = staticmethod(lambda values: ",".join(values))
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def fetch_reports(self, days, **_kwargs):
+            return {
+                "success": True,
+                "processed": 0,
+                "reports_found": 0,
+                "duplicate_reports": 0,
+                "new_domains": [],
+                "new_ingested_ids": [],
+                "errors": [],
+                "details": [],
+            }
+
+        def get_refreshed_tokens(self):
+            return {"access_token": "application-access-token"}
+
+    monkeypatch.setattr(
+        "app.services.mail_source_backfill_worker.MicrosoftGraphClient",
+        FakeMicrosoftGraphClient,
+    )
+
+    assert run_m365_backfill_job(db_session, row) is True
+
+    db_session.refresh(row)
+    db_session.refresh(source)
+    assert row.status == "completed"
+    assert captured["auth_mode"] == "application"
+    assert captured["access_token"] is None
+    assert captured["mailbox"] == "shared@example.com"
+    assert source.m365_access_token == "application-access-token"
+    assert source.m365_refresh_token is None
+
+
 def test_run_m365_backfill_provider_failure_moves_to_backoff(db_session, monkeypatch):
     workspace, source = _source(db_session, method="M365_GRAPH")
     row = _job(db_session, workspace, source, max_attempts=3)

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -663,6 +663,22 @@ def test_mail_sources_template_exposes_backfill_progress_controls():
     assert "new Date(" not in template
     assert "`" not in template
     assert not re.search(r"<script\b(?![^>]*\bsrc=)[^>]*>", template, re.IGNORECASE)
+
+
+def test_mail_sources_template_exposes_m365_application_access_safely():
+    template = (Path(__file__).resolve().parents[1] / "templates" / "mail_sources.html").read_text()
+    script = (
+        Path(__file__).resolve().parents[1] / "static" / "js" / "mail-sources-page.js"
+    ).read_text()
+
+    assert 'value="application"' in template
+    assert "Mail.Read application permission" in template
+    assert "Exchange Online RBAC for Applications" in template
+    assert "No redirect URI or user sign-in is used" in template
+    assert "data-mail-source-test-m365" in template
+    assert "data-mail-source-test-m365" in script
+    assert "m365_auth_mode: 'delegated'" in script
+    assert "m365Configured" in script
     assert "canCancelBackfill" in template
     assert "canRetryBackfill" in template
     assert "latestBackfill(source)" in template
@@ -2000,6 +2016,177 @@ class TestMicrosoft365GraphMailSource:
         assert data["m365_connected"] is False
         assert data["m365_email"] is None
 
+    @pytest.mark.parametrize(
+        ("overrides", "expected_detail"),
+        [
+            ({"m365_tenant_id": "common"}, "tenant-specific"),
+            ({"m365_client_id": ""}, "client) ID"),
+            ({"m365_client_secret": ""}, "client secret"),
+            ({"m365_mailbox": ""}, "target mailbox"),
+            ({"m365_mailbox": "me"}, "target mailbox"),
+        ],
+    )
+    def test_application_mode_rejects_incomplete_or_unsafe_configuration(
+        self,
+        authed_client: TestClient,
+        overrides: dict,
+        expected_detail: str,
+    ):
+        payload = {
+            "name": "Application M365",
+            "method": "M365_GRAPH",
+            "m365_auth_mode": "application",
+            "m365_tenant_id": "tenant-id",
+            "m365_client_id": "client-id",
+            "m365_client_secret": "client-secret",
+            "m365_mailbox": "dmarc-reports@example.com",
+        }
+        payload.update(overrides)
+
+        resp = authed_client.post("/api/v1/mail-sources", json=payload)
+
+        assert resp.status_code == 422
+        assert expected_detail in resp.json()["detail"]
+
+    def test_application_mode_is_saved_redacted_and_ready_to_test(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        resp = authed_client.post(
+            "/api/v1/mail-sources",
+            json={
+                "name": "Shared report mailbox",
+                "method": "M365_GRAPH",
+                "m365_auth_mode": "application",
+                "m365_tenant_id": "tenant-id",
+                "m365_client_id": "client-id",
+                "m365_client_secret": "client-secret",
+                "m365_mailbox": "dmarc-reports@example.com",
+            },
+        )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["m365_auth_mode"] == "application"
+        assert data["m365_client_secret"] == "**redacted**"
+        assert data["m365_configured"] is True
+        assert data["m365_connected"] is False
+        assert data["connection_status"] == "ready_to_test"
+        assert data["connection_action_label"] == "Test connection"
+        source = db_session.get(MailSource, data["id"])
+        assert source.m365_client_secret == "client-secret"
+        assert source._m365_client_secret != "client-secret"  # pylint: disable=protected-access
+
+    def test_application_mode_test_acquires_and_persists_access_token(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        create_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            json={
+                "name": "Application test",
+                "method": "M365_GRAPH",
+                "m365_auth_mode": "application",
+                "m365_tenant_id": "tenant-id",
+                "m365_client_id": "client-id",
+                "m365_client_secret": "client-secret",
+                "m365_mailbox": "dmarc-reports@example.com",
+            },
+        )
+        source_id = create_resp.json()["id"]
+        mock_client = MagicMock()
+        mock_client.test_connection.return_value = {
+            "success": True,
+            "message_count": 1,
+            "target_mailbox": "dmarc-reports@example.com",
+        }
+        mock_client.get_refreshed_tokens.return_value = {"access_token": "application-access-token"}
+
+        with patch(
+            "app.api.api_v1.endpoints.mail_sources.MicrosoftGraphClient",
+            return_value=mock_client,
+        ) as client_cls:
+            resp = authed_client.post(f"/api/v1/mail-sources/{source_id}/test")
+
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert "dmarc-reports@example.com" in resp.json()["message"]
+        _, kwargs = client_cls.call_args
+        assert kwargs["auth_mode"] == "application"
+        assert kwargs["access_token"] is None
+        assert kwargs["mailbox"] == "dmarc-reports@example.com"
+        source = db_session.get(MailSource, source_id)
+        db_session.refresh(source)
+        assert source.m365_access_token == "application-access-token"
+        assert source.m365_refresh_token is None
+
+    def test_application_mode_rejects_interactive_oauth_endpoints(
+        self,
+        authed_client: TestClient,
+    ):
+        create_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            json={
+                "name": "No redirect flow",
+                "method": "M365_GRAPH",
+                "m365_auth_mode": "application",
+                "m365_tenant_id": "tenant-id",
+                "m365_client_id": "client-id",
+                "m365_client_secret": "client-secret",
+                "m365_mailbox": "dmarc-reports@example.com",
+            },
+        )
+        source_id = create_resp.json()["id"]
+
+        authorize = authed_client.get(f"/api/v1/mail-sources/{source_id}/m365/authorize-url")
+        callback = authed_client.post(
+            f"/api/v1/mail-sources/{source_id}/m365/callback",
+            json={"code": "code", "redirect_uri": "https://example.com/callback"},
+        )
+
+        assert authorize.status_code == 400
+        assert "do not use interactive OAuth" in authorize.json()["detail"]
+        assert callback.status_code == 400
+        assert "do not accept" in callback.json()["detail"]
+
+    def test_unchanged_delegated_settings_preserve_existing_tokens(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        create_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            json={
+                "name": "Delegated settings",
+                "method": "M365_GRAPH",
+                "m365_auth_mode": "delegated",
+                "m365_tenant_id": "organizations",
+                "m365_client_id": "client-id",
+                "m365_client_secret": "client-secret",
+            },
+        )
+        source = db_session.get(MailSource, create_resp.json()["id"])
+        source.m365_access_token = "access-token"
+        source.m365_refresh_token = "refresh-token"
+        db_session.commit()
+
+        update = authed_client.put(
+            f"/api/v1/mail-sources/{source.id}",
+            json={
+                "name": "Renamed delegated settings",
+                "m365_auth_mode": "delegated",
+                "m365_tenant_id": "organizations",
+                "m365_client_id": "client-id",
+            },
+        )
+
+        assert update.status_code == 200
+        db_session.refresh(source)
+        assert source.m365_access_token == "access-token"
+        assert source.m365_refresh_token == "refresh-token"
+
     def test_m365_source_test_no_token(self, authed_client: TestClient):
         create_resp = authed_client.post(
             "/api/v1/mail-sources",
@@ -2333,6 +2520,41 @@ class TestMicrosoft365GraphMailSource:
         db_session.refresh(source)
         assert source.m365_access_token == "new-access"
         assert source.m365_refresh_token == "new-refresh"
+
+    def test_m365_application_lists_folders_without_preexisting_token(
+        self,
+        authed_client: TestClient,
+    ):
+        create_resp = authed_client.post(
+            "/api/v1/mail-sources",
+            json={
+                "name": "Application folder list",
+                "method": "M365_GRAPH",
+                "m365_auth_mode": "application",
+                "m365_tenant_id": "tenant-id",
+                "m365_client_id": "client-id",
+                "m365_client_secret": "client-secret",
+                "m365_mailbox": "dmarc-reports@example.com",
+            },
+        )
+        source_id = create_resp.json()["id"]
+        mock_client = MagicMock()
+        mock_client.list_mail_folders.return_value = [
+            {"id": "folder-id", "display_name": "DMARC", "path": "Inbox / DMARC"}
+        ]
+        mock_client.get_refreshed_tokens.return_value = {"access_token": "application-access-token"}
+
+        with patch(
+            "app.api.api_v1.endpoints.mail_sources.MicrosoftGraphClient",
+            return_value=mock_client,
+        ) as client_cls:
+            resp = authed_client.get(f"/api/v1/mail-sources/{source_id}/m365/folders")
+
+        assert resp.status_code == 200
+        assert resp.json()["target_mailbox"] == "dmarc-reports@example.com"
+        _, kwargs = client_cls.call_args
+        assert kwargs["auth_mode"] == "application"
+        assert kwargs["access_token"] is None
 
     def test_m365_list_folders_requires_method_and_token(self, authed_client: TestClient):
         imap_resp = authed_client.post(

--- a/backend/app/tests/test_main_polling.py
+++ b/backend/app/tests/test_main_polling.py
@@ -178,6 +178,53 @@ def test_poll_single_m365_source_skips_without_token():
     mock_session.assert_not_called()
 
 
+def test_poll_single_m365_application_source_runs_without_stored_token():
+    from app.main import _poll_single_m365_source
+
+    source = SimpleNamespace(
+        id=4,
+        m365_auth_mode="application",
+        m365_access_token=None,
+        m365_tenant_id="tenant-id",
+        m365_client_id="client-id",
+        m365_client_secret="client-secret",
+        m365_refresh_token=None,
+        m365_mailbox="dmarc-reports@example.com",
+        m365_ingested_ids="[]",
+        folder="INBOX",
+    )
+    db_source = SimpleNamespace(**source.__dict__)
+    db = MagicMock()
+    db.query.return_value.get.return_value = db_source
+
+    with (
+        patch("app.main.SessionLocal", return_value=db),
+        patch("app.main.MicrosoftGraphClient") as client_cls,
+        patch("app.main.MicrosoftGraphClient.load_ingested_ids", return_value=[]),
+        patch("app.main.record_import_attempt"),
+    ):
+        client_cls.return_value.fetch_reports.return_value = {
+            "success": True,
+            "processed": 0,
+            "reports_found": 0,
+            "new_domains": [],
+            "new_ingested_ids": [],
+        }
+        client_cls.return_value.get_refreshed_tokens.return_value = {
+            "access_token": "new-application-token"
+        }
+
+        _poll_single_m365_source(source)
+
+    _, kwargs = client_cls.call_args
+    assert kwargs["auth_mode"] == "application"
+    assert kwargs["access_token"] is None
+    assert kwargs["mailbox"] == "dmarc-reports@example.com"
+    assert db_source.m365_access_token == "new-application-token"
+    db.commit.assert_called_once()
+    db.close.assert_called_once()
+
+
 def test_run_due_mail_source_backfills_logs_processed_count():
     from app.main import _run_due_mail_source_backfills
 

--- a/backend/app/tests/test_microsoft_graph_client.py
+++ b/backend/app/tests/test_microsoft_graph_client.py
@@ -3,13 +3,21 @@
 import base64
 import zipfile
 from io import BytesIO
+from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 
 from app.models.report import DMARCReport
 from app.services.mail_connector import initial_import_stats
-from app.services.microsoft_graph_client import M365_SCOPES, MicrosoftGraphClient
+from app.services.microsoft_graph_client import (
+    M365_APPLICATION_SCOPE,
+    M365_SCOPES,
+    MicrosoftGraphClient,
+    MicrosoftGraphError,
+    m365_application_configuration_error,
+    m365_source_can_authenticate,
+)
 from app.tests.test_data import SAMPLE_XML
 
 
@@ -35,6 +43,115 @@ def _make_client(db=None, already_ingested=None) -> MicrosoftGraphClient:
 
 
 class TestMicrosoftGraphOAuthHelpers:
+    def test_application_configuration_requires_tenant_credentials_and_mailbox(self):
+        source = SimpleNamespace(
+            m365_auth_mode="application",
+            m365_tenant_id="common",
+            m365_client_id="",
+            m365_client_secret="",
+            m365_mailbox="",
+        )
+
+        assert "tenant-specific" in m365_application_configuration_error(source)
+        assert m365_source_can_authenticate(source) is False
+
+        source.m365_tenant_id = "tenant.example"
+        source.m365_client_id = "client-id"
+        source.m365_client_secret = "client-secret"
+        source.m365_mailbox = "dmarc-reports@example.com"
+
+        assert m365_application_configuration_error(source) is None
+        assert m365_source_can_authenticate(source) is True
+
+    def test_application_client_credentials_read_explicit_mailbox(self, monkeypatch):
+        seen = {}
+
+        def fake_post(url, data=None, timeout=None):
+            seen["token_url"] = url
+            seen["token_data"] = data
+            return httpx.Response(200, json={"access_token": "application-token"})
+
+        def fake_request(method, url, headers=None, params=None, timeout=None):
+            seen["graph_url"] = url
+            seen["authorization"] = headers["Authorization"]
+            return httpx.Response(200, json={"value": []})
+
+        monkeypatch.setattr("app.services.microsoft_graph_client.httpx.post", fake_post)
+        monkeypatch.setattr("app.services.microsoft_graph_client.httpx.request", fake_request)
+        client = MicrosoftGraphClient(
+            tenant_id="tenant-id",
+            client_id="client-id",
+            client_secret="client-secret",
+            access_token="",
+            refresh_token="",
+            auth_mode="application",
+            mailbox="dmarc-reports@example.com",
+            folder="INBOX",
+        )
+
+        result = client.test_connection()
+
+        assert result["success"] is True
+        assert seen["token_url"].endswith("/tenant-id/oauth2/v2.0/token")
+        assert seen["token_data"] == {
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "grant_type": "client_credentials",
+            "scope": M365_APPLICATION_SCOPE,
+        }
+        assert seen["graph_url"].endswith(
+            "/users/dmarc-reports%40example.com/mailFolders/inbox/messages"
+        )
+        assert seen["authorization"] == "Bearer application-token"
+        assert client.get_refreshed_tokens() == {"access_token": "application-token"}
+
+    def test_application_client_never_falls_back_to_me(self):
+        client = MicrosoftGraphClient(
+            tenant_id="tenant-id",
+            client_id="client-id",
+            client_secret="client-secret",
+            access_token="",
+            refresh_token="",
+            auth_mode="application",
+            mailbox="",
+        )
+
+        try:
+            client.test_connection()
+        except MicrosoftGraphError as exc:
+            assert "explicit target mailbox" in str(exc)
+        else:
+            raise AssertionError("application access must require a target mailbox")
+
+    def test_application_client_reacquires_token_after_401(self, monkeypatch):
+        token_values = iter(["token-1", "token-2"])
+        seen_authorization = []
+
+        def fake_post(url, data=None, timeout=None):
+            return httpx.Response(200, json={"access_token": next(token_values)})
+
+        def fake_request(method, url, headers=None, params=None, timeout=None):
+            seen_authorization.append(headers["Authorization"])
+            if len(seen_authorization) == 1:
+                return httpx.Response(401, json={"error": {"code": "InvalidToken"}})
+            return httpx.Response(200, json={"value": []})
+
+        monkeypatch.setattr("app.services.microsoft_graph_client.httpx.post", fake_post)
+        monkeypatch.setattr("app.services.microsoft_graph_client.httpx.request", fake_request)
+        client = MicrosoftGraphClient(
+            tenant_id="tenant-id",
+            client_id="client-id",
+            client_secret="client-secret",
+            access_token="",
+            refresh_token="",
+            auth_mode="application",
+            mailbox="dmarc-reports@example.com",
+        )
+
+        assert client.test_connection()["success"] is True
+        assert seen_authorization == ["Bearer token-1", "Bearer token-2"]
+        assert client.get_refreshed_tokens() == {"access_token": "token-2"}
+
     def test_connector_contract_uses_read_only_scopes_and_safe_context(self):
         client = MicrosoftGraphClient(
             tenant_id="organizations",

--- a/backend/app/tests/test_report_store.py
+++ b/backend/app/tests/test_report_store.py
@@ -388,3 +388,58 @@ class TestReportStore:
 
         summary = store.get_domain_summary("test.com")
         assert summary["compliance_rate"] == 80.0
+
+    def test_selector_evidence_separates_active_rotation_from_history(self):
+        store = ReportStore.get_instance()
+        now = 1_800_000_000
+
+        def add_selector_report(report_id, age_days, selector, result, count, signing_domain):
+            report = _sample_report("test.com")
+            report.update(
+                {
+                    "report_id": report_id,
+                    "begin_timestamp": now - age_days * 86_400 - 3600,
+                    "end_timestamp": now - age_days * 86_400,
+                    "records": [
+                        {
+                            "source_ip": "203.0.113.8",
+                            "count": count,
+                            "disposition": "none",
+                            "dkim_result": result,
+                            "spf_result": "fail",
+                            "header_from": "test.com",
+                            "dkim": [
+                                {
+                                    "domain": signing_domain,
+                                    "selector": selector,
+                                    "result": result,
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+            store.add_report(report)
+
+        add_selector_report("current-fail", 1, "rotated-2026", "fail", 9, "test.com")
+        add_selector_report("current-pass", 2, "current-pass", "pass", 7, "test.com")
+        add_selector_report("recent", 14, "recent-provider", "pass", 4, "test.com")
+        add_selector_report("historical", 70, "retired-2024", "fail", 3, "test.com")
+        add_selector_report("unaligned", 1, "provider-internal", "fail", 20, "vendor.test")
+
+        rows = store.get_domain_selector_evidence(
+            "test.com",
+            manual_selectors=["manual-only"],
+            now=now,
+        )
+        by_selector = {row["selector"]: row for row in rows}
+
+        assert by_selector["rotated-2026"]["classification"] == "active_failing"
+        assert by_selector["rotated-2026"]["current_failure_count"] == 9
+        assert by_selector["rotated-2026"]["report_count"] == 1
+        assert by_selector["current-pass"]["classification"] == "active_passing"
+        assert by_selector["recent-provider"]["classification"] == "recently_observed"
+        assert by_selector["retired-2024"]["classification"] == "historical"
+        assert by_selector["manual-only"]["classification"] == "manually_configured"
+        assert by_selector["manual-only"]["manual_configured"] is True
+        assert "provider-internal" not in by_selector

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -1051,9 +1051,15 @@ test('dashboard becomes useful before false empty states appear', async ({ page 
 
   await expect(page.getByText('Fix DKIM alignment for owned infrastructure')).toBeVisible();
   await expect(page.getByText('cklnet.com').first()).toBeVisible();
-  await expect(page.getByText('92.6%')).toBeVisible();
-
+  await expect(page.getByText('Traffic-weighted health')).toBeVisible();
   expect(Date.now() - started).toBeLessThan(2_000);
+
+  const analytics = page.locator('details', {
+    has: page.locator('summary', { hasText: 'Analytics and evidence' }),
+  });
+  await analytics.locator(':scope > summary').click();
+  await expect(analytics.getByText('92.6%')).toBeVisible();
+
   await expect(page.getByText('Dashboard could not be loaded')).not.toBeVisible();
   await expect(page.getByText('No reports match this filter')).not.toBeVisible();
   await expect(page.getByText('Publish DMARC')).not.toBeVisible();
@@ -1084,9 +1090,11 @@ test('settings page exposes clear next actions and labeled navigation', async ({
   await page.goto('/settings');
 
   await expect(page.getByRole('heading', { name: 'Finish the next safe setup step' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Review DMARC defaults' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Connect report mailbox' })).toBeVisible();
-  await expect(page.getByRole('navigation', { name: 'Settings sections' })).toContainText('DNS providers');
+  await expect(page.getByRole('link', { name: 'Add or review domains' })).toBeVisible();
+  const settingsNavigation = page.getByLabel('Settings navigation');
+  await expect(settingsNavigation).toContainText('DMARC defaults');
+  await expect(settingsNavigation).toContainText('Domains and DNS');
   await expect(page.getByRole('link', { name: 'Dashboard' }).first()).toBeVisible();
   await expect(page.getByRole('link', { name: 'Settings' }).first()).toBeVisible();
   await expect(page.locator('summary', { hasText: 'Advanced webhook delivery' })).toBeVisible();
@@ -1152,6 +1160,7 @@ test('onboarding page keeps setup controls wired without inline handlers', async
   await page.goto('/onboarding');
 
   await expect(page.getByRole('heading', { name: 'Mail health setup' })).toBeVisible();
+  await page.getByRole('button', { name: 'Reconfigure setup' }).click();
   await page.getByRole('button', { name: 'DNS only' }).click();
   await expect(page.getByText('without storing mailbox credentials')).toBeVisible();
 
@@ -1173,8 +1182,9 @@ test('domain detail shows cached DNS evidence and sender reputation context', as
   await expect(page.getByText('Reputation clean').first()).toBeVisible();
   await expect(page.getByText('Reputation not checked').first()).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Review owned infrastructure DKIM' }).first()).toBeVisible();
-  await page.getByRole('link', { name: 'Review remediation queue' }).click();
-  const acknowledgeButton = page.getByRole('button', { name: 'Acknowledge' }).first();
+  const advancedPosture = page.locator('#posture-dashboard');
+  await advancedPosture.locator(':scope > summary').click();
+  const acknowledgeButton = advancedPosture.getByRole('button', { name: 'Acknowledge' }).first();
   await acknowledgeButton.scrollIntoViewIfNeeded();
   page.once('dialog', async (dialog) => {
     await dialog.accept('');
@@ -1194,17 +1204,25 @@ test('reports list and aggregate detail keep source evidence actionable', async 
 
   await page.getByRole('link', { name: 'View Details' }).first().click();
   await expect(page.getByRole('heading', { name: 'Report: browser-smoke-cklnet' })).toBeVisible();
-  await expect(page.getByText('50.31.205.203')).toBeVisible();
-  await expect(page.getByText('mta203-ab1.mtasv.net')).toBeVisible();
-  await expect(page.getByText('AS23352').first()).toBeVisible();
-  await expect(page.getByText('SERVERCENTRAL - DEFT.COM, US').first()).toBeVisible();
-  await expect(page.getByRole('columnheader', { name: 'Reputation' })).toBeVisible();
-  await expect(page.getByText('Reputation clean').first()).toBeVisible();
-  await expect(page.getByText('risk 0/100').first()).toBeVisible();
-  await expect(page.getByText('No blacklist listings found.').first()).toBeVisible();
-  await expect(page.getByText('Reputation not checked').first()).toBeVisible();
-  await expect(page.getByText('Reputation feeds are disabled.').first()).toBeVisible();
-  await expect(page.getByText('DKIM did not pass for this source.')).toBeVisible();
+  const postmarkCluster = page.getByRole('article').filter({
+    has: page.getByRole('heading', { name: 'ActiveCampaign Postmark' }),
+  });
+  await postmarkCluster.locator('summary', { hasText: 'Show IP evidence' }).click();
+  await expect(postmarkCluster.getByText('50.31.205.203')).toBeVisible();
+
+  await page.locator('select[x-model="recordRiskFilter"]').selectOption('all');
+  const rawEvidence = page.locator('#report-records');
+  await rawEvidence.locator(':scope > summary').click();
+  await expect(rawEvidence.getByText('mta203-ab1.mtasv.net')).toBeVisible();
+  await expect(rawEvidence.getByText('AS23352').first()).toBeVisible();
+  await expect(rawEvidence.getByText('SERVERCENTRAL - DEFT.COM, US').first()).toBeVisible();
+  await expect(rawEvidence.getByRole('columnheader', { name: 'Reputation' })).toBeVisible();
+  await expect(rawEvidence.getByText('Reputation clean').first()).toBeVisible();
+  await expect(rawEvidence.getByText('risk 0/100').first()).toBeVisible();
+  await expect(rawEvidence.getByText('No blacklist listings found.').first()).toBeVisible();
+  await expect(rawEvidence.getByText('Reputation not checked').first()).toBeVisible();
+  await expect(rawEvidence.getByText('Reputation feeds are disabled.').first()).toBeVisible();
+  await expect(rawEvidence.getByText('DKIM did not pass for this source.')).toBeVisible();
   await expect(page.getByText('Failed to load report')).not.toBeVisible();
 });
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -57,6 +57,9 @@ identity, and the absence of a published PostgreSQL port.
 
 For a release-grade acceptance test on a new host, follow the
 [Greenfield Deployment Verification](greenfield-verification.md) checklist.
+Maintainers can run `python3 scripts/verify-greenfield-product.py` on a fresh,
+disposable stack to exercise setup, a known DMARC import, exact totals, and
+duplicate handling rather than stopping at container health.
 
 ## Configuration
 

--- a/docs/deployment/greenfield-verification.md
+++ b/docs/deployment/greenfield-verification.md
@@ -71,6 +71,20 @@ Then:
 6. Change a non-secret `.env` value, recreate the app container, and confirm the
    new value is effective. A plain restart is not sufficient to reload `.env`.
 
+The deterministic setup/import/persistence subset can be run against a fresh
+instance with:
+
+```bash
+python3 scripts/verify-greenfield-product.py
+docker compose up -d --force-recreate --wait app
+python3 scripts/verify-greenfield-product.py --verify-existing
+```
+
+The verifier completes first-run setup, imports the repository DMARC fixture,
+checks exact report/message/compliance totals, rejects a duplicate upload, and
+then confirms the same state after the application container is recreated. Run
+it only against a disposable, unconfigured acceptance instance.
+
 ## Gmail IMAP Check
 
 Use a dedicated Google App Password, never the normal Google account password.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -209,6 +209,7 @@ Delivered:
 - Shared mailbox and folder selection support for DMARC report collection. Delivered with shared mailbox targeting, Microsoft Graph folder listing, folder-id based imports, UI selection, and mailbox/folder context in import history.
 - Import-history parity with existing sources (auditable attachment outcomes, duplicates, parse failures). Delivered for Microsoft 365 imports.
 - Backfill support with safe throttling and progressive search windows. Delivered with days-based Graph `receivedDateTime` filters, duplicate-safe reruns, and retry/backoff for throttled or temporarily unavailable Graph requests.
+- Unattended shared-mailbox ingestion through Entra application permissions. Delivered as an explicit client-credentials mode with tenant/mailbox validation, `/users/{mailbox}` targeting, manual and scheduled imports, folder discovery, resumable backfill, encrypted credentials, and Exchange Online RBAC safety guidance.
 - Secret handling mirrors existing guidance (no raw secrets in logs; 1Password-friendly). Delivered with a shared connector protocol, sanitized import-result helpers, duplicate ID serialization helpers, and connector development guidance for future sources.
 
 Exit criteria:

--- a/docs/reference/database.md
+++ b/docs/reference/database.md
@@ -413,6 +413,7 @@ forensic, and SMTP TLS reports.
 | port | INTEGER | IMAP/POP server port |
 | username | VARCHAR | Mailbox username |
 | password | TEXT | Encrypted mailbox password |
+| m365_auth_mode | VARCHAR | Microsoft 365 authentication mode: `delegated` or `application` |
 | enabled | BOOLEAN | Whether scheduled imports should poll this source |
 | last_checked | TIMESTAMP | Last polling attempt time |
 | created_at | TIMESTAMP | When the source was created |

--- a/docs/reference/microsoft365-graph-connector.md
+++ b/docs/reference/microsoft365-graph-connector.md
@@ -17,9 +17,12 @@ The connector must remain read-only:
 - It must pass supported `.xml`, `.zip`, `.gz`, and `.gzip` attachments through
   the same aggregate DMARC parser used by upload, IMAP, and Gmail imports.
 
-## OAuth Permissions
+## Authentication and Permissions
 
-DMARQ uses delegated Microsoft Graph permissions:
+DMARQ supports delegated and application authentication as explicit, separate
+source modes.
+
+Delegated mode uses:
 
 | Permission | Purpose |
 |------------|---------|
@@ -28,19 +31,32 @@ DMARQ uses delegated Microsoft Graph permissions:
 | `Mail.Read` | List messages and read report attachments from the authorized account. |
 | `Mail.Read.Shared` | Read report messages and attachments in shared or delegated mailboxes. |
 
-Application-wide Graph permissions are outside this contract. If a deployment
-needs application permissions later, it should be designed as a separate
-connector mode with a separate risk review.
+Application mode uses the tenant-specific client-credentials token endpoint,
+the `https://graph.microsoft.com/.default` scope, and the Microsoft Graph
+`Mail.Read` **application permission**. It must not use a redirect URI, user
+sign-in, `/me`, or refresh tokens. A concrete tenant and explicit target mailbox
+are mandatory.
+
+Because Entra `Mail.Read` application permission is tenant-wide by default, the
+operator must limit the service principal to the report mailbox with Exchange
+Online RBAC for Applications and verify the effective scope. DMARQ's mailbox
+field is a request target, not an authorization boundary. New deployments
+should not use legacy Application Access Policies when Exchange RBAC for
+Applications is available.
 
 ## Mailbox and Folder Selection
 
-The connector supports two mailbox targets:
+Delegated mode supports two mailbox targets:
 
 - Blank mailbox or `me`: read the authorized account through `/me`.
 - User principal name: read a delegated or shared mailbox through `/users/{upn}`.
 
 The authorized account must already have Exchange Online read access to any
 shared mailbox or folder. DMARQ does not grant mailbox permissions.
+
+Application mode supports only an explicit user principal name and always uses
+`/users/{upn}`. Blank, `me`, `common`, `organizations`, and `consumers` values
+must fail validation before polling begins.
 
 Folder selection should prefer Microsoft Graph folder ids returned by **Load
 folders**. Folder ids are stable across localized or renamed folders. Manually
@@ -114,6 +130,13 @@ The connector must never store or return:
 - raw message bodies,
 - raw attachment content,
 - full provider errors containing secrets.
+
+Short-lived application access tokens may be persisted in the same encrypted
+column as delegated access tokens for diagnostics and request reuse. Their
+presence is not required for readiness because application mode can acquire a
+new token during test, folder listing, manual import, scheduled polling, and
+backfill. Client secrets and all token values remain encrypted at rest and
+redacted from responses.
 
 Operators should keep Microsoft 365 secrets in 1Password or the deployment
 secret manager and inject them into the authorized deployment process. DMARQ

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -70,9 +70,11 @@ The report intake card shows whether the background scheduler is running, when a
 mail source last checked for reports, and which sources are enabled. Gmail and
 Microsoft 365 sources also expose authorization attention states. If an OAuth
 connection is missing, expired, revoked, or missing the refresh token required
-for scheduled imports, the dashboard shows **Needs attention** and links to Mail
-Sources so the operator can reconnect the mailbox before relying on automated
-imports.
+for delegated scheduled imports, the dashboard shows **Needs attention** and
+links to Mail Sources. Microsoft 365 application sources instead show a
+configuration problem when tenant, application credentials, or the explicit
+target mailbox are missing; a stored access token is not required because DMARQ
+can obtain one through client credentials while polling.
 
 Manual **Trigger Poll Now** results include the number of sources, processed
 messages, discovered reports, and any recovery summary from the failing source.

--- a/docs/user_guide/microsoft365.md
+++ b/docs/user_guide/microsoft365.md
@@ -1,53 +1,153 @@
 # Microsoft 365 Mail Sources
 
-DMARQ can import DMARC aggregate report attachments from Exchange Online through Microsoft Graph. Use this source type when IMAP is disabled or unavailable in a Microsoft 365 tenant.
+DMARQ imports DMARC aggregate report attachments from Exchange Online through
+Microsoft Graph. Microsoft 365 sources support two authentication modes:
 
-## App Registration
+- **User sign-in (delegated)**: an operator signs in interactively. This is a
+  good fit when an existing licensed user already has access to the report
+  mailbox.
+- **Application access (client credentials)**: DMARQ authenticates unattended
+  as an Entra application. This is the recommended mode for a dedicated shared
+  report mailbox because it needs no redirect URI, interactive user, or refresh
+  token.
 
-Create an app registration in Microsoft Entra admin center:
+Both modes are read-only. DMARQ lists folders and messages and downloads report
+attachments; it never moves, deletes, labels, forwards, or marks messages read.
+
+## Prerequisites
+
+You need an organizational Microsoft Entra tenant with Exchange Online and a
+target mailbox containing DMARC aggregate reports. A consumer Microsoft 365
+Personal/Family or Outlook.com mailbox is not an Exchange Online mailbox in an
+organizational tenant and is not suitable for application access.
+
+For a minimal test tenant, one Exchange Online Plan 1 user is sufficient. The
+target can initially be that user's mailbox. A shared mailbox can then be added
+without a separate license under Microsoft's normal shared-mailbox limits.
+
+## Application Access (Recommended for Shared Mailboxes)
+
+### 1. Register the Entra Application
+
+Create an app registration in the Microsoft Entra admin center. Record:
+
+- Directory (tenant) ID or a verified tenant domain
+- Application (client) ID
+- A new client secret value
+
+Under **API permissions**, add Microsoft Graph **Application permission**
+`Mail.Read` and grant tenant-wide admin consent. Do not add a redirect URI;
+client-credential authentication does not use one.
+
+`Mail.Read` application permission can read every mailbox in the tenant unless
+Exchange Online limits it. Do not rely on the mailbox field in DMARQ as the
+authorization boundary.
+
+### 2. Limit the Application in Exchange Online
+
+Use **Exchange Online RBAC for Applications** to grant the service principal a
+mail-read role scoped to only the report mailbox. Microsoft recommends RBAC for
+Applications for new configurations. Legacy Application Access Policies are
+documented by Microsoft but are not the preferred design for a new deployment.
+
+Important: Exchange RBAC grants and broad Entra application grants are
+additive. Verify the effective permissions and do not leave an unscoped Entra
+`Mail.Read` grant that defeats the intended Exchange scope.
+
+Follow Microsoft's current procedures:
+
+- [Role Based Access Control for Applications in Exchange Online](https://learn.microsoft.com/en-us/exchange/permissions-exo/application-rbac)
+- [Microsoft identity platform client credentials flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow)
+
+### 3. Configure DMARQ
+
+1. Open **Mail Sources** and add **Microsoft 365 (Graph)**.
+2. Select **Application access**.
+3. Enter the tenant ID, client ID, client secret, and the explicit target
+   mailbox user principal name, for example `dmarc-reports@example.com`.
+4. Save the source, edit it, and select **Test application access**.
+5. Load folders and choose the dedicated report folder when applicable.
+6. Run **Import now**, then run a bounded historical backfill.
+
+Application mode rejects `common`, `organizations`, `consumers`, a blank
+mailbox, and `me`. Every Graph mailbox request uses `/users/{mailbox}/...`.
+DMARQ obtains short-lived tokens from the tenant-specific token endpoint with
+the `https://graph.microsoft.com/.default` scope and obtains a new token when
+needed. No refresh token is expected.
+
+## User Sign-in (Delegated)
+
+### 1. Register the Entra Application
+
+Create an Entra app registration with:
 
 - Platform: Web
-- Redirect URI: `https://<your-dmarq-host>/api/v1/mail-sources/<source-id>/m365/callback`
-- Delegated API permissions:
-  - `User.Read`
-  - `Mail.Read`
-  - `offline_access`
-- Client secret: create a secret for the web app and store it in your deployment secret manager.
+- Redirect URI:
+  `https://<your-dmarq-host>/api/v1/mail-sources/<source-id>/m365/callback`
+- Delegated permissions: `User.Read`, `Mail.Read`, and `offline_access`
+- A client secret stored in your deployment secret manager
 
-`Mail.Read` is the least-privilege delegated Graph permission DMARQ needs to list messages and read file attachments. `offline_access` is requested so Microsoft returns a refresh token for scheduled polling.
+DMARQ also requests `Mail.Read.Shared` so the signed-in user can read a shared
+mailbox to which Exchange Online has already granted that user access.
 
-## DMARQ Setup
+### 2. Configure DMARQ
 
-1. Open **Mail Sources**.
-2. Add a source with method **Microsoft 365 (Graph OAuth2)**.
-3. Enter the tenant ID (`organizations`, `common`, or a tenant GUID), client ID, and client secret.
-4. Leave **Mailbox** empty to read the authorised account, or enter a user principal name for a shared/delegated mailbox that the authorised user can read.
-5. Save the source.
-6. Use **Connect Microsoft 365** and approve the read-only mailbox access request.
-7. If DMARC reports are delivered to a dedicated folder, click **Load folders** and choose the folder. If folder loading is unavailable, enter a well-known folder name such as `INBOX`.
-8. Run **Test connection** and **Run import now**.
+1. Add **Microsoft 365 (Graph)** and select **User sign-in**.
+2. Enter `common`, `organizations`, or a concrete tenant ID, plus client ID and
+   client secret.
+3. Leave **Mailbox** blank for the signed-in user's mailbox, or enter a shared
+   mailbox that the user can read.
+4. Save, select **Connect Microsoft 365**, and complete the sign-in.
+5. Load folders, test the connection, import current reports, and run a backfill.
 
-## Shared Mailboxes and Folders
+Delegated mode persists encrypted access and refresh tokens so scheduled polls
+can continue without another sign-in. If consent is revoked or the refresh
+token expires, DMARQ surfaces a reconnect action in Mail Sources and operations
+health.
 
-DMARQ uses delegated Microsoft Graph access. That means the authorised Microsoft 365 user must be able to read the mailbox and folder you configure:
+## Folder and Import Behavior
 
-- For the authorised user's own mailbox, leave **Mailbox** blank.
-- For a shared mailbox, enter the shared mailbox user principal name, for example `dmarc-reports@example.com`.
-- The authorised user must have mailbox or folder-level read access in Exchange Online before DMARQ can list folders or messages.
-- Folder selection stores the Microsoft Graph folder id when you choose a folder from **Load folders**. This is safer for localized or renamed folders than typing a display name.
-- If you type a folder manually, use a well-known Graph folder name such as `INBOX` unless your tenant has confirmed a custom folder identifier.
+Folder selection should prefer the Graph folder IDs returned by **Load
+folders**. Folder IDs remain stable when display names are localized or
+renamed. A manually entered well-known name such as `INBOX` is also accepted.
 
-## Import Behavior
+DMARQ filters messages by the selected search window, detects likely DMARC
+report mail, and passes `.xml`, `.zip`, `.gz`, and `.gzip` file attachments
+through the same parser and persistence path used by upload, IMAP, and Gmail.
+Imported Graph message IDs prevent repeated processing. Import history records
+processed messages, new reports, duplicates, parse failures, and safe
+mailbox/folder context.
 
-DMARQ reads messages in the configured search window, filters for messages that look like DMARC reports, downloads Graph `fileAttachment` items, and sends `.xml`, `.zip`, `.gz`, and `.gzip` attachments through the same parser and persistence path used by upload, IMAP, and Gmail imports.
+Manual imports and scheduled imports use bounded date windows. Historical
+backfills are resumable, duplicate-safe jobs with progress, retry, cancel, and
+provider-throttling handling.
 
-Imported Graph message IDs are stored on the mail source so scheduled polling does not reprocess the same message. Import history records processed messages, imported reports, duplicates, parse failures, attachment-level details, and the mailbox/folder target used for the attempt.
+## Acceptance Test
 
-Manual imports use the **days** value from the Mail Sources UI or trigger-poll endpoint. DMARQ passes that selected window to Microsoft Graph as a `receivedDateTime` filter, so large mailboxes can be searched without scanning unrelated older mail. Backfills are queued as resumable jobs from the **Backfill** action and show progress, reports found, duplicates, retry timing, cancel, and retry controls in the Mail Sources table. The background worker processes due Microsoft 365 backfill jobs alongside IMAP and Gmail jobs.
+A Microsoft 365 application source is ready for production only after all of
+the following succeed:
+
+1. **Test application access** reads the configured mailbox.
+2. **Load folders** returns folders for that mailbox.
+3. **Import now** finds a known DMARC report attachment.
+4. A backfill imports older reports without creating duplicate reports.
+5. Scheduled polling acquires a new application token without user interaction.
+6. Exchange Online confirms that the service principal cannot read an unrelated
+   mailbox.
+
+Use a non-production tenant or narrowly scoped test mailbox while validating
+permissions. Never paste the client secret into issue comments or commit it to
+the repository.
 
 ## Troubleshooting
 
-- **Not authorised**: reconnect the source from Mail Sources.
-- **Permission error**: confirm the app registration has delegated `Mail.Read` and the authorised account can read the target mailbox.
-- **Throttling**: wait and retry, or increase the polling interval.
-- **Mailbox/folder not found**: leave Mailbox blank for `/me`, use a valid user principal name for delegated/shared mailboxes, confirm the authorised user has access, and reload folders after changing the target mailbox.
+- **Tenant-specific ID required**: replace `common` or `organizations` with the
+  directory tenant ID or verified tenant domain.
+- **Application token request failed**: confirm the client ID, active secret,
+  tenant, `Mail.Read` application permission, and admin consent.
+- **Access denied**: verify both Entra consent and the effective Exchange Online
+  RBAC assignment for the exact target mailbox.
+- **Mailbox not found**: use the mailbox's Exchange Online user principal name,
+  not a display name or consumer Microsoft account.
+- **Delegated authorization expired**: reconnect the source interactively.
+- **Throttling**: wait for the bounded retry or increase the polling interval.

--- a/scripts/verify-greenfield-product.py
+++ b/scripts/verify-greenfield-product.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Exercise the documented standalone product flow against a running DMARQ."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import secrets
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+DEFAULT_FIXTURE = Path("backend/app/tests/fixtures/dmarc_aggregate/rfc7489-google.xml")
+
+
+def _request(
+    base_url: str,
+    path: str,
+    *,
+    method: str = "GET",
+    payload: Optional[dict[str, Any]] = None,
+    body: Optional[bytes] = None,
+    content_type: Optional[str] = None,
+    expected_status: int = 200,
+) -> Any:
+    headers = {"Accept": "application/json"}
+    data = body
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    elif content_type:
+        headers["Content-Type"] = content_type
+
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    try:
+        response = urllib.request.urlopen(request, timeout=30)  # noqa: S310
+        status = response.status
+        raw = response.read()
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        raw = exc.read()
+    if status != expected_status:
+        detail = raw.decode("utf-8", errors="replace")[:1000]
+        raise AssertionError(
+            f"{method} {path} returned {status}, expected {expected_status}: {detail}"
+        )
+    if not raw:
+        return None
+    return json.loads(raw)
+
+
+def _upload_fixture(base_url: str, fixture: Path, *, expected_status: int = 200) -> Any:
+    boundary = f"----dmarq-greenfield-{secrets.token_hex(12)}"
+    filename = fixture.name
+    body = b"".join(
+        [
+            f"--{boundary}\r\n".encode(),
+            (f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n').encode(),
+            b"Content-Type: application/xml\r\n\r\n",
+            fixture.read_bytes(),
+            f"\r\n--{boundary}--\r\n".encode(),
+        ]
+    )
+    return _request(
+        base_url,
+        "/api/v1/reports/upload",
+        method="POST",
+        body=body,
+        content_type=f"multipart/form-data; boundary={boundary}",
+        expected_status=expected_status,
+    )
+
+
+def _assert_persisted_product_state(base_url: str) -> None:
+    status = _request(base_url, "/api/v1/setup/status")
+    assert status["is_setup_complete"] is True
+    assert status["total_domains"] == 1
+
+    domains = _request(base_url, "/api/v1/reports/domains")
+    assert domains == ["example.com"]
+
+    stats = _request(base_url, "/api/v1/domains/example.com/stats")
+    assert stats["reportCount"] == 1
+    assert stats["totalEmails"] == 2
+    assert stats["failedEmails"] == 0
+    assert stats["complianceRate"] == 100.0
+
+    reports = _request(base_url, "/api/v1/domains/example.com/reports")
+    assert len(reports["reports"]) == 1
+    assert reports["reports"][0]["id"] == "123456789"
+
+    release = _request(base_url, "/api/v1/health/release")
+    assert release["version"]
+    assert release["environment"]
+
+
+def _initialize(base_url: str, fixture: Path, owner_email: str) -> None:
+    status = _request(base_url, "/api/v1/setup/status")
+    assert status["is_setup_complete"] is False, "Expected a clean, unconfigured instance"
+
+    _request(
+        base_url,
+        "/api/v1/setup/admin",
+        method="POST",
+        payload={"email": owner_email},
+        expected_status=201,
+    )
+    _request(
+        base_url,
+        "/api/v1/setup/system",
+        method="POST",
+        payload={
+            "app_name": "DMARQ Greenfield Acceptance",
+            "base_url": base_url.rstrip("/"),
+            "cloudflare_enabled": False,
+        },
+    )
+
+    uploaded = _upload_fixture(base_url, fixture)
+    assert uploaded["success"] is True
+    assert uploaded["domain"] == "example.com"
+    assert uploaded["processed_records"] == 2
+
+    duplicate = _upload_fixture(base_url, fixture, expected_status=409)
+    assert "already been uploaded" in duplicate["detail"]
+    _assert_persisted_product_state(base_url)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://127.0.0.1:8080")
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE)
+    parser.add_argument("--owner-email", default="greenfield-test@dmarq.org")
+    parser.add_argument("--verify-existing", action="store_true")
+    args = parser.parse_args()
+
+    if not args.verify_existing and not args.fixture.is_file():
+        parser.error(f"Fixture not found: {args.fixture}")
+
+    try:
+        if args.verify_existing:
+            _assert_persisted_product_state(args.base_url)
+            print("Greenfield product persistence verified.")
+        else:
+            _initialize(args.base_url, args.fixture, args.owner_email)
+            print("Greenfield setup, fixture import, totals, and duplicate handling verified.")
+    except (AssertionError, OSError, ValueError, KeyError) as exc:
+        print(f"Greenfield product verification failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- distinguish active DKIM selector failures from passing, recent, historical, and manually configured evidence; keep history visible while only active failures enter remediation\n- add unattended Microsoft 365 shared-mailbox ingestion with Entra application permissions, encrypted client secrets, explicit mailbox targeting, folder discovery, tests, and Exchange RBAC guidance\n- strengthen standalone Docker acceptance with first-run setup, fixture ingestion, duplicate handling, exact totals, app recreation, and persistence verification\n- align browser smoke tests with the current progressive-disclosure UX\n\n## Safety\n- Microsoft 365 application mode requires a tenant-specific authority and explicit mailbox; no interactive redirect or delegated token is used\n- blank client-secret edits preserve the encrypted stored value\n- DKIM selector history does not trigger DNS remediation\n- no DNS or mailbox live-write action is introduced\n\n## Local validation\n- 1,979 Python tests passed; coverage 96.86%\n- 308 focused tests passed after final UI polish\n- 11 Playwright browser flows passed; 3 provider-environment flows skipped as expected\n- formatting, linting, import sorting, compilation, Alembic single-head, and diff checks passed\n- PostgreSQL migration upgrade/default behavior verified\n- fresh Compose setup, deterministic report import, duplicate rejection, M365 configuration preservation, app recreation, and persistent state verified\n- candidate image rebuilt and desktop/mobile M365 UI checked\n\nFixes #773\nFixes #776