### PR TITLE
fix: publish ARM64 Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,9 @@ jobs:
           echo "build_ref=${BUILD_REF}" >> "$GITHUB_OUTPUT"
           echo "build_date=${BUILD_DATE}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU for multi-platform builds
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -340,6 +343,7 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -355,15 +359,23 @@ jobs:
         id: verify-image
         run: |
           IMAGE="${{ steps.release_ref.outputs.image }}"
+          verify_platforms() {
+            docker buildx imagetools inspect --raw "$IMAGE" 2>/dev/null |
+              jq -e '
+                [.manifests[]? | select(.platform.os == "linux") | .platform.architecture] as $architectures
+                | ($architectures | index("amd64")) != null
+                  and ($architectures | index("arm64")) != null
+              ' >/dev/null
+          }
           for attempt in 1 2 3 4 5; do
-            if docker buildx imagetools inspect "$IMAGE" >/dev/null; then
+            if verify_platforms; then
               echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
               echo "short_sha=${{ steps.release_ref.outputs.short_sha }}" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             sleep $((attempt * 5))
           done
-          echo "::error::Verified image tag did not become available in GHCR: $IMAGE"
+          echo "::error::Verified AMD64 and ARM64 image manifests did not become available in GHCR: $IMAGE"
           exit 1
 
   registry-image-smoke:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Published `docker-stable`, `docker-latest`, immutable release, and short-SHA
+  images for both Linux AMD64 and ARM64, and made the release gate reject an
+  incomplete architecture manifest before promotion.
 - Distinguished active failing DKIM selectors from active passing, recent,
   historical, and manually configured evidence. Only current selector failures
   now enter the primary DNS remediation flow; rotation history remains visible

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -9,6 +9,7 @@ on an internal network, and publishes DMARQ only on
 
 - Docker Engine 24 or later
 - Docker Compose v2.20 or later (`docker compose version`)
+- Linux AMD64 or ARM64 host
 - OpenSSL
 - Python 3.10 or later for `scripts/verify-docker-compose.sh`
 - 2 GB RAM minimum, 4 GB recommended
@@ -102,7 +103,8 @@ values are present and no source already exists.
 `docker-stable` is the normal installation channel. `docker-latest` tracks a
 successfully built `main` branch for preview testing. Production and Kubernetes
 operators should prefer an immutable release or short-SHA tag when exact
-rollback and auditability matter.
+rollback and auditability matter. Published release, short-SHA, `docker-stable`,
+and `docker-latest` tags include Linux AMD64 and ARM64 manifests.
 
 ### Build The Checkout Instead
 

--- a/docs/deployment/greenfield-verification.md
+++ b/docs/deployment/greenfield-verification.md
@@ -136,7 +136,8 @@ values and are not required in a Kubernetes application pod.
 Keep the following non-secret evidence with the release or issue:
 
 - tested image reference and digest;
-- clean-host platform versions;
+- clean-host platform versions and architecture;
+- published Linux AMD64 and ARM64 manifest entries;
 - Compose service health;
 - health and release endpoint results;
 - successful setup and fixture-import totals;


### PR DESCRIPTION
## Summary

- publish Linux AMD64 and ARM64 variants for release, short-SHA, `docker-stable`, and `docker-latest` tags
- configure QEMU before the Buildx cross-platform build
- reject release promotion unless both architecture entries exist in the OCI index
- document the supported standalone host architectures and required release evidence

## Why

Independent post-release acceptance found that v1.172.0 passed all AMD64 GitHub smoke tests but could not be pulled on a Linux ARM64 Docker host.

## Local validation

- workflow YAML parsed successfully
- Compose configuration contract passed in an isolated bootstrapped environment
- manifest gate correctly rejected the AMD64-only v1.172.0 index
- Dockerfile had already completed a native ARM64 candidate build
- diff and secret checks passed

Fixes #778
