### PR TITLE
Simplify DMARC evidence views and harden public demo UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Reduced dashboard and domain-detail information density without removing
   workflows: health and remediation now lead with one concise status and next
-  action, the primary analytics view follows it immediately and remains open by
-  default, and queue metrics, evidence, DNS, sender intelligence, reports,
+  action, analytics and evidence stay folded until requested, and queue metrics,
+  evidence, DNS, sender intelligence, reports,
   migration, and audit context remain directly available through progressive
   disclosure and the existing domain-section navigation.
+- Kept public-demo exploration honest and consistent by disabling write controls
+  in the browser, matching dashboard intake status to seeded mail sources, and
+  returning read-only ownership context instead of a broken demo-domain 404.
+- Aligned Dashboard and Reports rolling presets to inclusive UTC calendar days,
+  compacted all-time domain rows, and added usable report cards plus complete
+  loading, error, and empty states on small screens.
 - Removed the provider-console organization-summary N+1 query pattern by
   batching workspaces, billing, subscriptions, entitlements, and active seat
   usage, with a query-count regression test across multiple tenants.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -49,7 +49,7 @@ from app.services.cloudflare_oauth import (
     persist_cloudflare_oauth_tokens,
 )
 from app.services.dane import check_dane_cached
-from app.services.demo_data import DEMO_DAYS, build_demo_health_score_history
+from app.services.demo_data import DEMO_DAYS, DEMO_DOMAINS, build_demo_health_score_history
 from app.services.dns_cache import (
     get_cached_domain_dns_result,
     get_latest_cached_domain_dns_evidence,
@@ -5582,6 +5582,21 @@ async def get_domain_ownership(
     domain_name = normalize_domain_name(domain_id)
     domain = workspace_domain_query(db, workspace).filter(Domain.name == domain_name).first()
     if domain is None:
+        if uses_legacy_demo_fixtures(get_settings()) and domain_name in DEMO_DOMAINS:
+            return DomainOwnershipResponse(
+                domain=domain_name,
+                verified=False,
+                proof_record_name=_ownership_record_name(domain_name),
+                proof_record_value="Not available in the read-only demo",
+                proof_reason=(
+                    "The public demo uses seeded report evidence and cannot verify DNS ownership. "
+                    "A self-hosted installation returns a unique TXT proof before DNS writes."
+                ),
+                next_steps=[
+                    "Install DMARQ with DEMO_MODE=false to create an ownership proof.",
+                    "Publish the generated TXT record, then check ownership after DNS propagation.",
+                ],
+            )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Domain not found",

--- a/backend/app/api/api_v1/endpoints/stats.py
+++ b/backend/app/api/api_v1/endpoints/stats.py
@@ -87,10 +87,13 @@ def _custom_date_range(start_date: Optional[str], end_date: Optional[str]) -> Di
 
 def _rolling_date_range(now: datetime, interval: str, days: int) -> Dict[str, Any]:
     interval_name = interval if interval in DATE_INTERVALS else f"last_{days}_days"
+    # Rolling day presets are calendar-day windows in UTC. Starting at midnight
+    # keeps Dashboard and Reports on the same set of included dates.
+    start_day = now.date() - timedelta(days=days - 1)
     return _date_range_response(
         interval=interval_name,
         label=DATE_INTERVALS.get(interval_name, f"Last {days} days"),
-        start_at=now - timedelta(days=days),
+        start_at=datetime.combine(start_day, time.min, tzinfo=timezone.utc),
         end_at=now,
     )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,7 +26,7 @@ import app.models.workspace  # noqa: F401 – ensure workspace table is register
 import app.models.workspace_access  # noqa: F401 – ensure RBAC/audit tables are registered
 from app.api.api_v1.api import api_router
 from app.core.auth_providers import auth_provider_registry
-from app.core.config import get_settings
+from app.core.config import get_settings, uses_legacy_demo_fixtures
 from app.core.database import Base, SessionLocal, engine, get_db
 from app.core.security import add_api_key, generate_api_key, require_admin_auth
 from app.core.startup_checks import run_startup_checks
@@ -37,6 +37,7 @@ from app.models.domain import Domain
 from app.models.mail_source import MailSource  # noqa: F401 – ensure table is registered
 from app.models.mail_source_import import MailSourceImport
 from app.services.dns_prewarm import prewarm_dns_cache
+from app.services.demo_data import build_demo_mail_sources
 from app.services.gmail_client import GmailClient
 from app.services.imap_client import IMAPClient
 from app.services.import_history import record_import_attempt
@@ -1335,6 +1336,61 @@ def _mail_source_status_summary() -> dict:
         enabled_sources = (
             db.query(MailSource).filter(MailSource.enabled == True).all()  # noqa: E712
         )
+        if not enabled_sources and total_sources == 0 and uses_legacy_demo_fixtures(settings):
+            demo_sources = [row for row in build_demo_mail_sources() if row.get("enabled")]
+            latest_checked = max(
+                (row.get("last_checked") for row in demo_sources if row.get("last_checked")),
+                default=None,
+            )
+            source_statuses = []
+            by_method: dict[str, int] = {}
+            source_labels = []
+            for row in demo_sources:
+                method = str(row.get("method") or "IMAP").upper()
+                by_method[method] = by_method.get(method, 0) + 1
+                account = (
+                    row.get("gmail_email")
+                    or row.get("m365_email")
+                    or row.get("username")
+                    or row.get("server")
+                    or row.get("name")
+                )
+                method_label = {
+                    "GMAIL_API": "Gmail API",
+                    "M365_GRAPH": "Microsoft 365",
+                    "IMAP": "IMAP",
+                }.get(method, method)
+                label = f"{method_label}: {account}"
+                source_labels.append(label)
+                source_statuses.append(
+                    {
+                        "source_id": row.get("id"),
+                        "name": row.get("name"),
+                        "method": method,
+                        "label": label,
+                        "enabled": True,
+                        "last_checked": (
+                            row["last_checked"].isoformat() if row.get("last_checked") else None
+                        ),
+                        "connection_status": (
+                            "connected" if method in {"GMAIL_API", "M365_GRAPH"} else "configured"
+                        ),
+                        "connection_attention": False,
+                        "connection_message": None,
+                        "connection_action_label": None,
+                        "connection_diagnostic_category": "ok",
+                    }
+                )
+            return {
+                "enabled_sources": len(demo_sources),
+                "total_sources": len(demo_sources),
+                "sources_by_method": by_method,
+                "source_labels": source_labels,
+                "sources": source_statuses,
+                "attention_sources": 0,
+                "reauth_required_sources": 0,
+                "latest_source_check": latest_checked.isoformat() if latest_checked else None,
+            }
         latest_imports = _latest_imports_by_source(
             db, [int(source.id) for source in enabled_sources]
         )

--- a/backend/app/static/js/base-layout.js
+++ b/backend/app/static/js/base-layout.js
@@ -208,6 +208,81 @@ if (typeof document !== 'undefined') {
     };
 })();
 
+(function enforcePublicDemoReadOnlyUi() {
+    const readonlyMessage = 'Read-only demo: changes are disabled.';
+    const mutationSelectors = [
+        '[data-demo-mutation]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-add]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-toggle]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-fetch]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-backfill]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-edit]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-test]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-delete]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-delete-confirm]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-backfill-cancel]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-backfill-retry]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-backfill-run]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-connect-gmail]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-connect-m365]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-test-m365]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-test-adhoc]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-m365-load-folders]',
+        '[data-demo-readonly-scope="mail-sources"] [data-mail-source-form] button[type="submit"]',
+        '[data-demo-readonly-scope="settings"] form input',
+        '[data-demo-readonly-scope="settings"] form select',
+        '[data-demo-readonly-scope="settings"] form textarea',
+        '[data-demo-readonly-scope="settings"] form button[type="submit"]',
+        '[data-demo-readonly-scope="settings"] [data-settings-cloudflare-connect]',
+        '[data-demo-readonly-scope="settings"] [data-settings-discover-dns-zones]',
+        '[data-demo-readonly-scope="settings"] [data-settings-import-dns-zones]',
+        '[data-demo-readonly-scope="settings"] [data-settings-discover-mail-domains]',
+        '[data-demo-readonly-scope="settings"] [data-settings-import-mail-domains]',
+        '[data-demo-readonly-scope="settings"] [data-settings-action]',
+        '[data-demo-readonly-scope="settings"] [data-settings-create-webhook]',
+        '[data-demo-readonly-scope="settings"] [data-settings-save-automation]',
+        '[data-demo-readonly-scope="settings"] [data-settings-save-category]',
+        '[data-demo-readonly-scope="settings"] [data-settings-webhook-action]',
+    ];
+
+    const disableMutationControls = () => {
+        if (document.documentElement.dataset.demoMode !== 'true') return;
+        document.querySelectorAll(mutationSelectors.join(',')).forEach((control) => {
+            if (!(control instanceof HTMLElement)) {
+                return;
+            }
+            const remainsDisabled = 'disabled' in control
+                ? control.disabled === true
+                : control.getAttribute('aria-disabled') === 'true';
+            if (control.dataset.demoReadonlyDisabled === 'true' && remainsDisabled) return;
+            control.dataset.demoReadonlyDisabled = 'true';
+            control.setAttribute('aria-disabled', 'true');
+            control.setAttribute('title', readonlyMessage);
+            if ('disabled' in control) {
+                control.disabled = true;
+            }
+        });
+    };
+
+    const start = () => {
+        if (document.documentElement.dataset.demoMode !== 'true') return;
+        disableMutationControls();
+        const observer = new MutationObserver(disableMutationControls);
+        observer.observe(document.body, {
+            attributes: true,
+            attributeFilter: ['disabled', 'aria-disabled'],
+            childList: true,
+            subtree: true,
+        });
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start, {once: true});
+    } else {
+        start();
+    }
+})();
+
 (function bindSupportSessionExit() {
     document.addEventListener('click', async (event) => {
         const target = event.target;

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -2452,8 +2452,6 @@ function dashboardApp() {
                 row.appendChild(this.createGradeCell(domain.health));
                 row.appendChild(this.createRemediationCell(domain.remediation, domain.remediation_workload));
                 row.appendChild(this.createPassRateCell(domain.pass_rate || 0));
-                row.appendChild(this.createTextCell(this.formatLargeNumber(domain.failed_count || 0)));
-                row.appendChild(this.createTextCell(this.formatLargeNumber(domain.report_count || 0)));
                 row.appendChild(this.createDetailsCell(domain));
 
                 tableBody.appendChild(row);
@@ -2509,84 +2507,12 @@ function dashboardApp() {
                 : this.remediationStatusLabel(status);
             wrapper.appendChild(badge);
 
-            const latest = document.createElement('span');
-            latest.className = 'text-xs text-muted-foreground whitespace-nowrap';
-            if (workload?.primary?.state) {
-                const track = this.remediationTrackLabel(workload.primary.remediation_track);
-                const readiness = this.repairReadinessLabel(workload.primary.repair_progression);
-                latest.textContent = `${this.remediationLoopStateLabel(workload.primary.state)} · ${track} · ${readiness}`;
-            } else if (remediation?.latest_at) {
-                latest.textContent = this.remediationActivityText(remediation);
-            } else {
-                latest.textContent = 'No operator action';
-            }
-            wrapper.appendChild(latest);
-
-            const activityText = this.remediationActivityText(remediation);
-            if (activityText && activityText !== latest.textContent) {
-                const activity = document.createElement('span');
-                activity.className = 'max-w-56 truncate text-xs text-muted-foreground';
-                activity.textContent = activityText;
-                wrapper.appendChild(activity);
-            }
-
-            if (workload?.primary?.title) {
-                const action = document.createElement('span');
-                action.className = 'max-w-48 truncate text-xs text-muted-foreground';
-                action.textContent = workload.primary.title;
-                wrapper.appendChild(action);
-            }
-
-            if (workload?.primary) {
-                const nextAction = document.createElement('span');
-                nextAction.className = 'max-w-56 truncate text-xs font-semibold text-[#1f7c83]';
-                nextAction.textContent = this.dashboardRemediationNextActionText(workload.primary);
-                wrapper.appendChild(nextAction);
-            }
-
-            if (workload?.primary?.evidence_refresh?.required) {
-                const evidence = document.createElement('span');
-                evidence.className = 'max-w-56 truncate text-xs font-semibold text-[#247982]';
-                evidence.textContent = workload.primary.evidence_refresh.safe_to_run === false
-                    ? 'Evidence: provider value required'
-                    : `Evidence: ${this.evidenceRefreshLabel(workload.primary.evidence_refresh)}`;
-                wrapper.appendChild(evidence);
-            }
-
-            this.appendCountBadge(wrapper, [
-                [Number(workload?.provider_preview_available || 0), 'provider preview'],
-                [Number(workload?.provider_apply_after_approval || 0), 'apply-ready'],
-                [Number(workload?.provider_apply_blocked || 0), 'apply blocked'],
-                [Number(workload?.provider_apply_history || 0), 'apply history'],
-                [Number(workload?.provider_apply_verified || 0), 'verified'],
-            ], 'max-w-56 truncate text-xs font-semibold text-[#24507a]');
-
-            this.appendCountBadge(wrapper, [
-                [Number(workload?.notification_profile_ready || 0), 'notify-ready'],
-                [Number(workload?.notification_approval_required || 0), 'approval'],
-                [Number(workload?.notification_action_required || 0), 'action'],
-                [Number(workload?.notification_investigation_required || 0), 'investigate'],
-                [Number(workload?.notification_profiles || 0), 'profiles'],
-                [Number(workload?.notification_summary_only || 0), 'summary-only'],
-            ], 'max-w-56 truncate text-xs font-semibold text-[#7a5a24]');
-
-            this.appendCountBadge(wrapper, [
-                [Number(remediation?.dispatch_enqueued || 0), 'dispatched'],
-                [Number(remediation?.needs_operator_follow_up || 0), 'follow-up'],
-                [this.dashboardRemediationFollowUpAgeDays(remediation) >= 1 ? 1 : 0, 'aging follow-up'],
-            ], 'max-w-56 truncate text-xs font-semibold text-[#5f5c78]');
-
-            const followUpAge = this.dashboardRemediationFollowUpAgeText(remediation);
-            if (followUpAge) {
-                const age = document.createElement('span');
-                age.className = `max-w-56 truncate text-xs font-semibold ${
-                    this.dashboardRemediationFollowUpAgeDays(remediation) >= 7
-                        ? 'text-[#8a2d0d]'
-                        : 'text-[#8a6418]'
-                }`;
-                age.textContent = followUpAge;
-                wrapper.appendChild(age);
-            }
+            const summary = document.createElement('span');
+            summary.className = 'max-w-52 truncate text-xs text-muted-foreground';
+            summary.title = workload?.primary?.title || '';
+            summary.textContent = workload?.primary?.title
+                || (remediation?.latest_at ? this.remediationActivityText(remediation) : 'No operator action');
+            wrapper.appendChild(summary);
 
             cell.appendChild(wrapper);
             return cell;

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -386,7 +386,7 @@ function domainsApp() {
 
         formatCount(value, noun) {
             const count = Number(value || 0);
-            return `${count} ${noun}${count === 1 ? '' : 's'}`;
+            return `${new Intl.NumberFormat().format(count)} ${noun}${count === 1 ? '' : 's'}`;
         },
 
         showEmptyDomainHint() {

--- a/backend/app/static/js/reports-page.js
+++ b/backend/app/static/js/reports-page.js
@@ -123,8 +123,12 @@ function reportsApp() {
 
                 if (this.filters.dateRange !== 'all') {
                     const days = parseInt(this.filters.dateRange, 10);
-                    const cutoff = new Date();
-                    cutoff.setDate(cutoff.getDate() - days);
+                    const now = new Date();
+                    const cutoff = new Date(Date.UTC(
+                        now.getUTCFullYear(),
+                        now.getUTCMonth(),
+                        now.getUTCDate() - (days - 1)
+                    ));
 
                     const reportDate = new Date(report.end_date);
                     if (reportDate < cutoff) {

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -36,7 +36,7 @@
                             <span x-show="refreshing" class="loading loading-spinner loading-xs"></span>
                             <span x-text="refreshing ? 'Refreshing...' : 'Reload'"></span>
                         </button>
-                        <button type="button" class="btn btn-outline btn-sm" data-domain-create-open>
+                        <button type="button" class="btn btn-outline btn-sm" data-domain-create-open data-demo-mutation>
                             <span class="mr-1">+</span> Add Domain
                         </button>
                     </div>
@@ -161,6 +161,7 @@
                                         <button type="button"
                                                 class="btn btn-outline btn-sm"
                                                 data-domain-edit
+                                                data-demo-mutation
                                                 :data-domain-index="index">
                                             Edit
                                         </button>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -62,7 +62,7 @@
         </div>
     </section>
 
-    <details open
+    <details
              class="rounded-lg border border-[#dfdfdf] bg-white shadow-sm"
              x-show="hasReportData" x-cloak data-dashboard-analytics>
         <summary class="flex cursor-pointer list-none flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between">
@@ -222,7 +222,7 @@
                     </button>
                 </div>
                 {% call card_description() %}
-                    Overview of domains and their DMARC compliance status
+                    All-time imported evidence. Open a domain for the complete remediation plan.
                 {% endcall %}
             {% endcall %}
             {% call card_content() %}
@@ -230,12 +230,10 @@
                     {% call thead() %}
                         {% call tr() %}
                             {% call th() %}Domain{% endcall %}
-                            {% call th() %}Emails{% endcall %}
+                            {% call th() %}All-time volume{% endcall %}
                             {% call th() %}Grade{% endcall %}
                             {% call th() %}Remediation{% endcall %}
                             {% call th() %}Pass Rate{% endcall %}
-                            {% call th() %}Failed{% endcall %}
-                            {% call th() %}Reports{% endcall %}
                             {% call th("text-right") %}Actions{% endcall %}
                         {% endcall %}
                     {% endcall %}

--- a/backend/app/templates/layouts/base.html
+++ b/backend/app/templates/layouts/base.html
@@ -247,11 +247,11 @@
     {% if not provider_console_shell %}
     <nav class="fixed inset-x-0 bottom-0 z-40 grid h-16 grid-cols-5 border-t border-white/10 bg-[#272a5f] text-white shadow-lg md:hidden"
          aria-label="Primary navigation">
-        <a href="/" class="grid place-items-center text-[11px] font-semibold {{ 'bg-white/10 text-white' if current_path == '/' else 'text-white/65' }}">Dashboard</a>
-        <a href="/domains" class="grid place-items-center text-[11px] font-semibold {{ 'bg-white/10 text-white' if current_path.startswith('/domains') else 'text-white/65' }}">Domains</a>
-        <a href="/reports" class="grid place-items-center text-[11px] font-semibold {{ 'bg-white/10 text-white' if current_path.startswith('/reports') else 'text-white/65' }}">Reports</a>
-        <a href="/mail-sources" class="grid place-items-center text-center text-[11px] font-semibold {{ 'bg-white/10 text-white' if current_path.startswith('/mail-sources') else 'text-white/65' }}">Mail Sources</a>
-        <a href="/settings" class="grid place-items-center text-[11px] font-semibold {{ 'bg-white/10 text-white' if current_path.startswith('/settings') else 'text-white/65' }}">Settings</a>
+        <a href="/" class="grid min-w-0 place-items-center overflow-hidden px-1 text-center text-[10px] font-semibold leading-tight {{ 'bg-white/10 text-white' if current_path == '/' else 'text-white/65' }}">Dashboard</a>
+        <a href="/domains" class="grid min-w-0 place-items-center overflow-hidden px-1 text-center text-[10px] font-semibold leading-tight {{ 'bg-white/10 text-white' if current_path.startswith('/domains') else 'text-white/65' }}">Domains</a>
+        <a href="/reports" class="grid min-w-0 place-items-center overflow-hidden px-1 text-center text-[10px] font-semibold leading-tight {{ 'bg-white/10 text-white' if current_path.startswith('/reports') else 'text-white/65' }}">Reports</a>
+        <a href="/mail-sources" aria-label="Mail Sources" class="grid min-w-0 place-items-center overflow-hidden px-1 text-center text-[10px] font-semibold leading-tight {{ 'bg-white/10 text-white' if current_path.startswith('/mail-sources') else 'text-white/65' }}"><span>Mail<br>Sources</span></a>
+        <a href="/settings" class="grid min-w-0 place-items-center overflow-hidden px-1 text-center text-[10px] font-semibold leading-tight {{ 'bg-white/10 text-white' if current_path.startswith('/settings') else 'text-white/65' }}">Settings</a>
     </nav>
     {% endif %}
 

--- a/backend/app/templates/mail_sources.html
+++ b/backend/app/templates/mail_sources.html
@@ -9,7 +9,7 @@
 {% block page_title %}Mail Sources{% endblock %}
 
 {% block content %}
-<div class="grid gap-4 py-4 pb-24 md:gap-8 md:pb-4" x-data="mailSourcesApp" data-mail-sources-page>
+<div class="grid gap-4 py-4 pb-24 md:gap-8 md:pb-4" x-data="mailSourcesApp" data-mail-sources-page data-demo-readonly-scope="mail-sources">
 
     <!-- Page header -->
     <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">

--- a/backend/app/templates/reports.html
+++ b/backend/app/templates/reports.html
@@ -81,6 +81,7 @@
                 <template x-if="showWarning">
                     <div class="alert alert-warning mb-4" x-text="warning"></div>
                 </template>
+                <div class="hidden md:block">
                 {% call table() %}
                     {% call thead() %}
                         {% call tr() %}
@@ -173,6 +174,7 @@
                                         </a>
                                         <button class="btn btn-error btn-sm"
                                                 data-report-delete
+                                                data-demo-mutation
                                                 :data-report-domain="report.domain"
                                                 :data-report-id="report.report_id">
                                             Delete
@@ -183,6 +185,54 @@
                         </template>
                     {% endcall %}
                 {% endcall %}
+                </div>
+                <div class="md:hidden">
+                    <div x-show="showLoading" class="py-8 text-center text-sm text-[#5f5c78]" role="status">
+                        <span class="loading loading-spinner loading-sm"></span>
+                        <p class="mt-3 font-semibold text-[#120d36]">Checking report index...</p>
+                    </div>
+                    <div x-show="showError" class="py-8 text-center">
+                        <p class="text-sm text-red-700" x-text="error"></p>
+                        <div class="mt-4 grid gap-2">
+                            <button type="button" class="btn btn-primary btn-sm" data-report-retry-load>Retry loading reports</button>
+                            <a href="/mail-sources" class="btn btn-outline btn-sm">Check Mail Sources</a>
+                        </div>
+                    </div>
+                    <div x-show="showEmpty" class="py-8 text-center">
+                        <p class="font-semibold text-[#120d36]" x-text="emptyStateTitle"></p>
+                        <p class="mt-2 text-sm text-[#5f5c78]" x-text="emptyStateText"></p>
+                        <div class="mt-4 grid gap-2">
+                            <button type="button" class="btn btn-primary btn-sm" data-report-refresh>Trigger report refresh</button>
+                            <a href="/mail-sources" class="btn btn-outline btn-sm">Connect report mailbox</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="grid gap-3 md:hidden" x-show="!showLoading && !showError && !showEmpty">
+                    <template x-for="report in visibleReports" :key="'mobile-' + report.report_id">
+                        <article class="rounded-lg border border-[#dfdfdf] bg-white p-4 shadow-sm">
+                            <div class="flex items-start justify-between gap-3">
+                                <div class="min-w-0">
+                                    <p class="truncate font-semibold text-[#120d36]" x-text="report.domain"></p>
+                                    <p class="mt-1 text-xs text-[#5f5c78]" x-text="report.end_date_label"></p>
+                                </div>
+                                <span class="inline-flex flex-none items-center rounded px-2 py-1 text-xs font-semibold"
+                                      :class="report.pass_rate_class"
+                                      x-text="report.pass_rate_label"></span>
+                            </div>
+                            <dl class="mt-4 grid grid-cols-2 gap-3 text-sm">
+                                <div>
+                                    <dt class="text-xs text-[#5f5c78]">Messages</dt>
+                                    <dd class="mt-1 font-semibold text-[#120d36]" x-text="report.total_count"></dd>
+                                </div>
+                                <div>
+                                    <dt class="text-xs text-[#5f5c78]">Reporter</dt>
+                                    <dd class="mt-1 truncate font-semibold text-[#120d36]" x-text="report.org_name"></dd>
+                                </div>
+                            </dl>
+                            <a :href="report.detail_url" class="btn btn-primary btn-sm mt-4 w-full">View details</a>
+                        </article>
+                    </template>
+                </div>
             {% endcall %}
         {% endcall %}
     </div>

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -29,6 +29,7 @@
 {% block content %}
 <div
     data-settings-page
+    data-demo-readonly-scope="settings"
     x-data="settingsApp"
     class="space-y-6 py-4"
 >

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -374,10 +374,9 @@ def test_dashboard_and_domain_overview_use_progressive_disclosure_for_dense_work
     assert "Domain health breakdown" in dashboard
     assert "Queue controls and operational metrics" in dashboard
     assert "Evidence and workflow details" in dashboard
-    assert re.search(
-        r"<details\b(?=[^>]*\bopen\b)(?=[^>]*\bdata-dashboard-analytics\b)[^>]*>",
-        dashboard,
-    )
+    analytics_start = dashboard.index("data-dashboard-analytics")
+    analytics_tag = dashboard[dashboard.rfind("<details", 0, analytics_start) : analytics_start]
+    assert " open" not in analytics_tag
     assert (
         dashboard.index('id="dashboard-next-action-heading"')
         < dashboard.index("data-dashboard-analytics")
@@ -598,8 +597,8 @@ def test_dashboard_remediation_cards_show_owner_and_completion_context():
     assert "Show all matching cards" in template
     assert "Show compact cards" in template
     assert "Fresh evidence path" in template
-    assert "evidenceRefreshLabel(workload.primary.evidence_refresh)" in script
-    assert "Evidence: provider value required" in script
+    assert "evidenceRefreshLabel(item.evidence_refresh)" in template
+    assert "evidenceRefreshLabel(refresh)" in script
     assert "remediationRefreshRunning" in script
     assert "dashboardRefreshError" in script
     assert "Showing the previously loaded dashboard data." in script
@@ -1227,7 +1226,7 @@ def test_dashboard_remediation_stale_evidence_links_to_evidence_anchor():
     )
 
 
-def test_domain_list_remediation_cell_shows_provider_workload_summary():
+def test_domain_list_remediation_cell_keeps_provider_workload_summary_compact():
     result = _run_dashboard_expression("""(() => {
             global.document = {
                 createElement: (tagName) => {
@@ -1288,23 +1287,10 @@ def test_domain_list_remediation_cell_shows_provider_workload_summary():
         })()""")
 
     assert "3 open" in result
-    assert "2 provider preview" in result
-    assert "1 apply-ready" in result
-    assert "1 apply blocked" in result
-    assert "2 apply history" in result
-    assert "1 verified" in result
-    assert "3 notify-ready" in result
-    assert "1 approval" in result
-    assert "1 action" in result
-    assert "1 investigate" in result
-    assert "4 profiles" in result
-    assert "1 summary-only" in result
-    assert "1 dispatched" in result
-    assert "1 follow-up" in result
-    assert "1 aging follow-up" in result
-    assert "Dispatch enqueued" in result
-    assert "Open the remediation queue" in result
-    assert "Follow-up waiting since" in result
+    assert "Review provider repair" in result
+    assert "provider preview" not in result
+    assert "notify-ready" not in result
+    assert "aging follow-up" not in result
 
 
 def test_domain_details_remediation_queue_shows_verification_context():
@@ -3356,3 +3342,52 @@ def test_dashboard_poll_summary_uses_fallback_message_without_sources():
         _run_dashboard_poll_summary({"sources_polled": 0, "message": "No mailbox configured."})
         == "No mailbox configured."
     )
+
+
+def test_dashboard_keeps_evidence_folded_and_domain_rows_compact():
+    template = _dashboard_template()
+    script = _dashboard_script()
+    analytics_start = template.index("data-dashboard-analytics")
+    analytics_tag = template[template.rfind("<details", 0, analytics_start) : analytics_start]
+
+    assert " open" not in analytics_tag
+    assert "Analytics and evidence" in template
+    assert "All-time imported evidence" in template
+    assert "All-time volume" in template
+    assert "Failed{% endcall %}" not in template
+    assert "Reports{% endcall %}" not in template
+    assert "createTextCell(this.formatLargeNumber(domain.failed_count" not in script
+    assert "createTextCell(this.formatLargeNumber(domain.report_count" not in script
+    assert "workload?.primary?.title" in script
+
+
+def test_public_demo_marks_mutations_and_disables_them_in_shared_shell():
+    domains = _domains_template()
+    reports = _reports_template()
+    mail_sources = _mail_sources_template()
+    settings = _read_project_file("templates", "settings.html")
+    base_script = _read_project_file("static", "js", "base-layout.js")
+
+    assert domains.count("data-demo-mutation") >= 2
+    assert "data-demo-mutation" in reports
+    assert 'data-demo-readonly-scope="mail-sources"' in mail_sources
+    assert 'data-demo-readonly-scope="settings"' in settings
+    assert "enforcePublicDemoReadOnlyUi" in base_script
+    assert "MutationObserver" in base_script
+    assert "attributeFilter: ['disabled', 'aria-disabled']" in base_script
+    assert "data-demo-readonly-scope" in base_script
+    assert "data-demo-readonly-disabled" not in base_script
+    assert "demoReadonlyDisabled" in base_script
+
+
+def test_reports_and_mobile_navigation_have_compact_small_screen_views():
+    reports = _reports_template()
+    base = _read_project_file("templates", "layouts", "base.html")
+
+    assert '<div class="hidden md:block">' in reports
+    assert 'class="grid gap-3 md:hidden"' in reports
+    assert "View details" in reports
+    assert "'mobile-' + report.report_id" in reports
+    assert "`mobile-${report.report_id}`" not in reports
+    assert "Mail<br>Sources" in base
+    assert base.count("min-w-0 place-items-center overflow-hidden") == 5

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -306,6 +306,24 @@ def test_domain_ownership_endpoint_returns_dns_proof(
     assert db_session.query(Domain).filter(Domain.name == DOMAIN).one().verification_token
 
 
+def test_demo_domain_ownership_endpoint_returns_read_only_context(
+    authed_client: TestClient,
+    monkeypatch,
+):
+    """Seeded demo domains explain ownership instead of returning a broken 404."""
+    monkeypatch.setattr(domains_endpoint, "uses_legacy_demo_fixtures", lambda _settings: True)
+
+    response = authed_client.get("/api/v1/domains/dmarq.com/ownership")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["domain"] == "dmarq.com"
+    assert data["verified"] is False
+    assert data["proof_record_type"] == "TXT"
+    assert data["proof_record_value"] == "Not available in the read-only demo"
+    assert "cannot verify DNS ownership" in data["proof_reason"]
+
+
 def test_domain_ownership_verify_marks_matching_txt_verified(
     seeded_client: TestClient,
     db_session,

--- a/backend/app/tests/test_mail_sources.py
+++ b/backend/app/tests/test_mail_sources.py
@@ -4564,6 +4564,60 @@ class TestTriggerPollEndpoint:
         assert data["sources"][0]["connection_status"] == "reauth_required"
         assert data["sources"][0]["connection_action_label"] == "Reconnect Gmail"
 
+    def test_poll_status_uses_seeded_sources_in_public_demo(self):
+        """Dashboard intake status matches the mail-source list in fixture-backed demos."""
+        from app.core.security import require_admin_auth
+        from app.main import app as main_app
+
+        async def mock_auth():
+            return {"auth_type": "session"}
+
+        main_app.dependency_overrides[require_admin_auth] = mock_auth
+        mock_db = MagicMock()
+        mock_db.query.return_value.count.return_value = 0
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+        demo_sources = [
+            {
+                "id": 9001,
+                "name": "Aggregate reports",
+                "method": "IMAP",
+                "server": "imap.demo.example",
+                "username": "reports@example.test",
+                "enabled": True,
+                "last_checked": datetime(2026, 7, 16, 7, 30, tzinfo=timezone.utc),
+            },
+            {
+                "id": 9002,
+                "name": "Google reports",
+                "method": "GMAIL_API",
+                "gmail_email": "dmarc@example.test",
+                "enabled": True,
+                "last_checked": datetime(2026, 7, 16, 8, 0, tzinfo=timezone.utc),
+            },
+        ]
+
+        try:
+            with TestClient(main_app) as tc:
+                with (
+                    patch("app.main.SessionLocal", return_value=mock_db),
+                    patch("app.main.uses_legacy_demo_fixtures", return_value=True),
+                    patch("app.main.build_demo_mail_sources", return_value=demo_sources),
+                ):
+                    resp = tc.get("/api/v1/poll-status")
+        finally:
+            main_app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled_sources"] == 2
+        assert data["total_sources"] == 2
+        assert data["sources_by_method"] == {"IMAP": 1, "GMAIL_API": 1}
+        assert data["source_labels"] == [
+            "IMAP: reports@example.test",
+            "Gmail API: dmarc@example.test",
+        ]
+        assert data["latest_source_check"] == "2026-07-16T08:00:00+00:00"
+
     def test_trigger_poll_with_no_enabled_sources(self):
         """With no enabled sources, the endpoint returns an empty-success response."""
         from app.core.security import require_admin_auth

--- a/backend/app/tests/test_stats_date_filters.py
+++ b/backend/app/tests/test_stats_date_filters.py
@@ -1,7 +1,21 @@
+from datetime import datetime, timezone
+
 import pytest
 from fastapi import HTTPException
 
-from app.api.api_v1.endpoints.stats import resolve_dashboard_date_range
+from app.api.api_v1.endpoints.stats import _rolling_date_range, resolve_dashboard_date_range
+
+
+def test_rolling_date_range_uses_inclusive_utc_calendar_days():
+    date_range = _rolling_date_range(
+        datetime(2026, 7, 16, 14, 30, tzinfo=timezone.utc),
+        "last_30_days",
+        30,
+    )
+
+    assert date_range["start_date"] == "2026-06-17"
+    assert date_range["end_date"] == "2026-07-16"
+    assert date_range["period_days"] == 30
 
 
 def test_resolve_dashboard_date_range_accepts_custom_dates():

--- a/docs/user_guide/dashboard.md
+++ b/docs/user_guide/dashboard.md
@@ -6,6 +6,11 @@ The DMARQ dashboard provides an at-a-glance view of your email authentication st
 
 When you log in to DMARQ, you'll be presented with the main dashboard that displays key metrics about your DMARC compliance and email authentication status. The dashboard is designed to give you immediate insight into the report-and-DNS loop DMARQ focuses on: who sent mail, whether it aligned, which DNS records are healthy, and what should be fixed next.
 
+The first visible surface is the next recommended action. Charts, detailed
+evidence, and the compact all-time domain comparison stay under **Analytics and
+evidence** until you open it. This keeps the initial decision clear without
+removing any investigative data.
+
 ## Dashboard Components
 
 ### DMARC Compliance Rate
@@ -80,6 +85,10 @@ Manual **Trigger Poll Now** results include the number of sources, processed
 messages, discovered reports, and any recovery summary from the failing source.
 For example, a Gmail token problem is reported as a reconnect action instead of
 only saying that polling failed.
+
+In the public demo, this status is calculated from the same seeded mail sources
+shown on the Mail Sources page. Those sources are examples only; their write
+controls are disabled while filters, details, and history remain available.
 
 ### Remediation Loop
 
@@ -162,26 +171,13 @@ forensic report summaries, SMTP TLS report summaries, DNS posture, and exports.
 It intentionally includes healthy senders, partially aligned senders, and a few
 misconfigurations so each dashboard panel has realistic content.
 
-The public demo is meant to start in the same place a normal self-service user
-would: one account with multiple domains. From there, the demo path on the
-dashboard walks through the larger deployment models:
-
-1. Start with `dmarq.org` and `dmarq.com` as a single-user, multi-domain account.
-2. Zoom out to an account view with users, roles, workspaces, plan limits, and billing ownership.
-3. Switch to an ISP/provider view with bundled customer workspaces and monthly billing export examples.
-4. Impersonate a demo customer user to see scoped workspace access.
-5. Compare the same DMARC workflows in a self-hosted deployment where billing remains local.
-
-All demo users, customer IDs, provider IDs, invoices, and domains outside
-`dmarq.org`/`dmarq.com` are generated examples. Support impersonation in the
-demo is explicit UI state; production impersonation should be audited and
-permission-gated.
-
-The account detail panel keeps the active organization, workspace, and viewed
-user visible while you move through the demo path. Workspaces can be selected
-directly; `dmarq.org` and `dmarq.com` link to report-backed domain detail pages,
-while ISP and self-hosted sample domains are marked as demo-only tenant context
-until the demo includes full report stores for those generated tenants.
+The public demo tells the same single-user, multi-domain story as a normal
+self-hosted installation. It starts with `dmarq.org` and `dmarq.com`, realistic
+aggregate evidence, seeded intake sources, and read-only remediation context.
+Write controls are disabled at both the interface and API layers, but users can
+still filter reports, open domain evidence, inspect DNS guidance, and navigate
+the complete product. Multi-tenant provider workflows live in the separate
+provider demo and are not mixed into this dashboard.
 
 ## Customizing the Dashboard
 

--- a/docs/user_guide/reports.md
+++ b/docs/user_guide/reports.md
@@ -47,6 +47,12 @@ Use **Refresh** to reload the aggregate report list from the backend. If the
 backend cannot answer temporarily, DMARQ keeps the last loaded reports visible
 and shows a warning instead of replacing the table with an empty state.
 
+On small screens, reports are shown as compact cards with the domain, report
+date, pass rate, message count, reporter, and one clear detail action. Loading,
+error, and empty states retain the same recovery actions as the desktop list.
+Preset date ranges use inclusive UTC calendar days, so **Last 30 days** covers
+today and the preceding 29 UTC dates consistently across Reports and Dashboard.
+
 ### Aggregate Report Details
 
 To view details of a specific aggregate report:


### PR DESCRIPTION
## What changed

- keep dashboard analytics and evidence folded by default and compact the domain compliance table around the next remediation action
- align rolling date windows to inclusive UTC calendar days across dashboard and reports
- add responsive report cards and a compact mobile navigation path
- make public-demo mutation controls reliably read-only, including controls rendered or re-enabled dynamically
- keep seeded demo mail sources consistent with dashboard intake status
- return useful read-only ownership guidance for seeded demo domains instead of a 404
- update the dashboard/report documentation and changelog

## Why

The fresh-install and public-demo experience exposed too much evidence at once, mixed time-window semantics, and presented controls that looked writable even though the backend rejected mutations. On smaller screens, the report table and navigation were also difficult to use.

## Validation

- 410 focused backend/template tests passed
- JavaScript syntax checks passed for all changed page scripts
- production Docker image built and started successfully
- browser smoke against the persisted Gmail-backed instance on `127.0.0.1:8081`
- browser smoke against a separate `DEMO_MODE=true` instance, including dynamically rendered settings and mail-source controls
- no browser console errors or horizontal overflow in the mobile report view

Closes #783
Closes #784
Closes #785
Closes #786
Closes #787
Closes #788
Closes #789
