### PR TITLE
fix: fall back for sender ASN enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Restored sender ASN, network, and country enrichment when a selected private
+  DNS resolver is unavailable by falling back to independent public DNS and
+  Cloudflare DoH for Team Cymru lookups. Failed enrichments now retry after a
+  short cache interval instead of remaining unknown for a full day.
 - Reduced dashboard and domain-detail information density without removing
   workflows: health and remediation now lead with one concise status and next
   action, analytics and evidence stay folded until requested, and queue metrics,

--- a/backend/app/services/source_network.py
+++ b/backend/app/services/source_network.py
@@ -6,7 +6,7 @@ import asyncio
 import ipaddress
 import json
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 from urllib.error import HTTPError, URLError
@@ -18,9 +18,12 @@ from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
 from app.models.dns_cache import DNSCache
+from app.services.dns_fallbacks import dns_fallback_candidates
+from app.services.dns_resolver import BaseDNSProvider
 
 _CACHE_PROVIDER = "source-network-intelligence-v1"
-_SELECTORS_KEY = "source-network-v3"
+_SELECTORS_KEY = "source-network-v4"
+_ERROR_CACHE_TTL_SECONDS = 300
 _ASN_NAME_CACHE: Dict[str, str] = {}
 _IPINFO_LITE_URL = "https://api.ipinfo.io/lite"
 _IPGEOLOCATION_URL = "https://api.ipgeolocation.io/v3/ipgeo"
@@ -106,6 +109,7 @@ class SourceNetworkIntelligence:  # pylint: disable=too-many-instance-attributes
     source: str = "unknown"
     checked_at: str = ""
     error: Optional[str] = None
+    dns_retry_pending: bool = False
 
 
 def _utcnow_naive() -> datetime:
@@ -157,6 +161,13 @@ def _as_name_from_cymru_txt(txt_records: Iterable[str]) -> Optional[str]:
     return None
 
 
+def _network_lookup_candidates(provider: Any) -> List[Any]:
+    """Return independent DNS candidates for production resolver providers."""
+    if isinstance(provider, BaseDNSProvider):
+        return list(dns_fallback_candidates(provider))
+    return [provider]
+
+
 async def _lookup_as_name(provider: Any, asn: str) -> Optional[str]:
     normalized = _normalize_asn(asn)
     if not normalized:
@@ -166,18 +177,21 @@ async def _lookup_as_name(provider: Any, asn: str) -> Optional[str]:
     query = _asn_name_query(normalized)
     if not query:
         return None
-    try:
-        as_name = _as_name_from_cymru_txt(await provider.lookup_txt(query))
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.debug(
-            "ASN name lookup failed for %s: %s",
-            normalized,
-            type(exc).__name__,
-        )
-        return None
-    if as_name:
-        _ASN_NAME_CACHE[normalized] = as_name
-    return as_name
+    for candidate in _network_lookup_candidates(provider):
+        try:
+            as_name = _as_name_from_cymru_txt(await candidate.lookup_txt(query))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.debug(
+                "ASN name lookup failed for %s via %s: %s",
+                normalized,
+                candidate.__class__.__name__,
+                type(exc).__name__,
+            )
+            continue
+        if as_name:
+            _ASN_NAME_CACHE[normalized] = as_name
+            return as_name
+    return None
 
 
 def _normalize_global_source_ip(value: Any) -> Optional[str]:
@@ -282,6 +296,45 @@ def _from_cymru_txt(ip: str, txt_records: Iterable[str]) -> SourceNetworkIntelli
         source="team-cymru",
         checked_at=checked_at,
         error="No ASN record returned.",
+    )
+
+
+async def _lookup_cymru_network(
+    provider: Any,
+    ip: str,
+    checked_at: str,
+) -> SourceNetworkIntelligence:
+    query = _query_name(ip)
+    lookup_errors: List[Exception] = []
+    completed_lookup = False
+    for candidate in _network_lookup_candidates(provider):
+        try:
+            records = await candidate.lookup_txt(query)
+            completed_lookup = True
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            lookup_errors.append(exc)
+            logger.debug(
+                "ASN origin lookup failed for %s via %s: %s",
+                ip,
+                candidate.__class__.__name__,
+                type(exc).__name__,
+            )
+            continue
+        result = _from_cymru_txt(ip, records)
+        if result.error:
+            continue
+        if result.asn and not result.as_name:
+            result.as_name = await _lookup_as_name(candidate, result.asn)
+        return result
+
+    error = "No ASN record returned."
+    if lookup_errors and not completed_lookup:
+        error = f"ASN lookup failed: {type(lookup_errors[-1]).__name__}."
+    return SourceNetworkIntelligence(
+        ip=ip,
+        source="team-cymru",
+        checked_at=checked_at,
+        error=error,
     )
 
 
@@ -497,18 +550,7 @@ async def lookup_source_network(
     if api_merged and api_merged.asn and api_merged.country_code:
         return api_merged
 
-    try:
-        records = await provider.lookup_txt(_query_name(ip))
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        return SourceNetworkIntelligence(
-            ip=ip,
-            source="team-cymru",
-            checked_at=checked_at,
-            error=f"ASN lookup failed: {type(exc).__name__}.",
-        )
-    result = _from_cymru_txt(ip, records)
-    if result.asn and not result.as_name:
-        result.as_name = await _lookup_as_name(provider, result.asn)
+    result = await _lookup_cymru_network(provider, ip, checked_at)
     merged = _merge_network_results(
         ip,
         ipinfo_result,
@@ -516,7 +558,30 @@ async def lookup_source_network(
         cloudflare_radar_result,
         result,
     )
+    if merged and result.error:
+        merged.error = result.error
+        merged.dns_retry_pending = True
     return merged or result
+
+
+async def _retry_cached_dns_enrichment(
+    provider: Any,
+    cached_result: SourceNetworkIntelligence,
+) -> SourceNetworkIntelligence:
+    """Retry only Cymru DNS while retaining successful API enrichment."""
+    checked_at = _utcnow_iso()
+    dns_result = await _lookup_cymru_network(provider, cached_result.ip, checked_at)
+    cached_data = replace(
+        cached_result,
+        checked_at=checked_at,
+        error=None,
+        dns_retry_pending=False,
+    )
+    merged = _merge_network_results(cached_result.ip, cached_data, dns_result)
+    if merged and dns_result.error:
+        merged.error = dns_result.error
+        merged.dns_retry_pending = True
+    return merged or dns_result
 
 
 async def lookup_source_network_cached(
@@ -538,10 +603,19 @@ async def lookup_source_network_cached(
         )
         .first()
     )
-    if row and not refresh and _is_fresh(row, ttl_seconds, now):
-        return _from_json(row.result_json), True, row.checked_at
+    cached_result: Optional[SourceNetworkIntelligence] = None
+    if row and not refresh:
+        cached_result = _from_json(row.result_json)
+        cache_ttl = (
+            min(ttl_seconds, _ERROR_CACHE_TTL_SECONDS) if cached_result.error else ttl_seconds
+        )
+        if _is_fresh(row, cache_ttl, now):
+            return cached_result, True, row.checked_at
 
-    result = await lookup_source_network(provider, ip)
+    if cached_result and cached_result.dns_retry_pending:
+        result = await _retry_cached_dns_enrichment(provider, cached_result)
+    else:
+        result = await lookup_source_network(provider, ip)
     payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
     if row is None:
         row = DNSCache(

--- a/backend/app/tests/test_source_network.py
+++ b/backend/app/tests/test_source_network.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -74,6 +75,65 @@ async def test_lookup_source_network_accepts_team_cymru_dns_without_as_name():
     assert result.bgp_prefix == "50.31.205.0/24"
     assert result.country == "United States"
     assert result.region == "North America"
+    assert result.error is None
+
+
+async def test_lookup_source_network_falls_back_from_failed_primary_resolver(monkeypatch):
+    _ASN_NAME_CACHE.pop("AS23352", None)
+    origin_query = "200.209.245.104.origin.asn.cymru.com"
+    primary = FakeProvider({origin_query: LookupError("Akamai ETP resolver is not configured")})
+    fallback = FakeProvider(
+        {
+            origin_query: ['"23352 | 104.245.208.0/21 | US | arin | 2014-12-16"'],
+            "AS23352.asn.cymru.com": [
+                '"23352 | US | arin | 2002-03-05 | SERVERCENTRAL - DEFT.COM, US"'
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        "app.services.source_network._network_lookup_candidates",
+        lambda provider: [primary, fallback] if provider is primary else [provider],
+    )
+
+    result = await lookup_source_network(primary, "104.245.209.200")
+
+    assert primary.queries == [origin_query]
+    assert fallback.queries == [origin_query, "AS23352.asn.cymru.com"]
+    assert result.asn == "AS23352"
+    assert result.as_name == "SERVERCENTRAL - DEFT.COM, US"
+    assert result.bgp_prefix == "104.245.208.0/21"
+    assert result.country_code == "US"
+    assert result.country == "United States"
+    assert result.region == "North America"
+    assert result.error is None
+
+
+async def test_lookup_source_network_falls_back_for_as_name_lookup(monkeypatch):
+    _ASN_NAME_CACHE.pop("AS23352", None)
+    origin_query = "200.209.245.104.origin.asn.cymru.com"
+    as_name_query = "AS23352.asn.cymru.com"
+    primary = FakeProvider(
+        {
+            origin_query: ['"23352 | 104.245.208.0/21 | US | arin | 2014-12-16"'],
+            as_name_query: LookupError("primary resolver blocked the AS query"),
+        }
+    )
+    fallback = FakeProvider(
+        {as_name_query: ['"23352 | US | arin | 2002-03-05 | SERVERCENTRAL - DEFT.COM, US"']}
+    )
+
+    monkeypatch.setattr(
+        "app.services.source_network._network_lookup_candidates",
+        lambda provider: [primary, fallback] if provider is primary else [provider],
+    )
+
+    result = await lookup_source_network(primary, "104.245.209.200")
+
+    assert primary.queries == [origin_query, as_name_query]
+    assert fallback.queries == [as_name_query]
+    assert result.asn == "AS23352"
+    assert result.as_name == "SERVERCENTRAL - DEFT.COM, US"
     assert result.error is None
 
 
@@ -202,6 +262,42 @@ async def test_lookup_source_network_prefers_ipinfo_lite(monkeypatch):
     assert result.country == "United States"
     assert result.region == "North America"
     assert result.error is None
+
+
+async def test_lookup_source_network_preserves_dns_error_with_partial_api_data(monkeypatch):
+    async def partial_ipinfo(_ip):
+        return SourceNetworkIntelligence(
+            ip="104.245.209.200",
+            asn="AS23352",
+            source="ipinfo-lite",
+        )
+
+    async def no_api_data(_ip):
+        return None
+
+    monkeypatch.setattr(
+        "app.services.source_network._lookup_ipinfo_network",
+        partial_ipinfo,
+    )
+    monkeypatch.setattr(
+        "app.services.source_network._lookup_ipgeolocation_network",
+        no_api_data,
+    )
+    monkeypatch.setattr(
+        "app.services.source_network._lookup_cloudflare_radar_network",
+        no_api_data,
+    )
+    provider = FakeProvider(
+        {"200.209.245.104.origin.asn.cymru.com": LookupError("all DNS candidates unavailable")}
+    )
+
+    result = await lookup_source_network(provider, "104.245.209.200")
+
+    assert result.asn == "AS23352"
+    assert result.country_code is None
+    assert result.source == "ipinfo-lite"
+    assert result.error == "ASN lookup failed: LookupError."
+    assert result.dns_retry_pending is True
 
 
 async def test_lookup_source_network_uses_ipgeolocation_when_configured(monkeypatch):
@@ -351,6 +447,108 @@ async def test_lookup_source_network_cached_reuses_fresh_result(db_session):
     assert first.asn == "AS64500"
     assert second.asn == "AS64500"
     assert provider.queries == ["8.8.8.8.origin.asn.cymru.com"]
+
+
+async def test_lookup_source_network_cached_retries_errors_after_short_ttl(db_session, monkeypatch):
+    origin_query = "8.8.8.8.origin.asn.cymru.com"
+    provider = FakeProvider({origin_query: LookupError("resolver unavailable")})
+    first_now = datetime(2026, 7, 16, 20, 0, 0)
+    lookup_times = iter([first_now, first_now + timedelta(seconds=301)])
+    monkeypatch.setattr(
+        "app.services.source_network._utcnow_naive",
+        lambda: next(lookup_times),
+    )
+
+    first, first_cached, _ = await lookup_source_network_cached(
+        db_session,
+        provider,
+        "8.8.8.8",
+    )
+    provider.records = {
+        origin_query: ['"15169 | 8.8.8.0/24 | US | arin | 1992-12-01 | GOOGLE, US"']
+    }
+    second, second_cached, _ = await lookup_source_network_cached(
+        db_session,
+        provider,
+        "8.8.8.8",
+    )
+
+    assert first.error == "ASN lookup failed: LookupError."
+    assert first_cached is False
+    assert second.asn == "AS15169"
+    assert second.error is None
+    assert second_cached is False
+    assert provider.queries == [origin_query, origin_query]
+
+
+async def test_lookup_source_network_cached_retries_only_dns_for_partial_api_data(
+    db_session,
+    monkeypatch,
+):
+    _ASN_NAME_CACHE.pop("AS23352", None)
+    origin_query = "200.209.245.104.origin.asn.cymru.com"
+    provider = FakeProvider({origin_query: LookupError("resolver unavailable")})
+    api_calls = []
+
+    async def partial_ipinfo(ip):
+        api_calls.append(ip)
+        return SourceNetworkIntelligence(
+            ip=ip,
+            asn="AS23352",
+            source="ipinfo-lite",
+        )
+
+    async def no_api_data(_ip):
+        return None
+
+    first_now = datetime(2026, 7, 16, 20, 0, 0)
+    lookup_times = iter([first_now, first_now + timedelta(seconds=301)])
+    monkeypatch.setattr(
+        "app.services.source_network._utcnow_naive",
+        lambda: next(lookup_times),
+    )
+    monkeypatch.setattr(
+        "app.services.source_network._lookup_ipinfo_network",
+        partial_ipinfo,
+    )
+    monkeypatch.setattr(
+        "app.services.source_network._lookup_ipgeolocation_network",
+        no_api_data,
+    )
+    monkeypatch.setattr(
+        "app.services.source_network._lookup_cloudflare_radar_network",
+        no_api_data,
+    )
+
+    first, first_cached, _ = await lookup_source_network_cached(
+        db_session,
+        provider,
+        "104.245.209.200",
+    )
+    provider.records = {
+        origin_query: ['"23352 | 104.245.208.0/21 | US | arin | 2014-12-16"'],
+        "AS23352.asn.cymru.com": [
+            '"23352 | US | arin | 2002-03-05 | SERVERCENTRAL - DEFT.COM, US"'
+        ],
+    }
+    second, second_cached, _ = await lookup_source_network_cached(
+        db_session,
+        provider,
+        "104.245.209.200",
+    )
+
+    assert first_cached is False
+    assert first.asn == "AS23352"
+    assert first.error == "ASN lookup failed: LookupError."
+    assert first.dns_retry_pending is True
+    assert second_cached is False
+    assert second.asn == "AS23352"
+    assert second.as_name == "SERVERCENTRAL - DEFT.COM, US"
+    assert second.country_code == "US"
+    assert second.error is None
+    assert second.dns_retry_pending is False
+    assert api_calls == ["104.245.209.200"]
+    assert provider.queries == [origin_query, origin_query, "AS23352.asn.cymru.com"]
 
 
 async def test_lookup_sources_network_cached_filters_invalid_and_non_global_ips(db_session):


### PR DESCRIPTION
## Summary
- fall back from unavailable private DNS resolvers to public recursive DNS and Cloudflare DoH for Team Cymru origin and AS-name lookups
- version the source-network cache and retry failed enrichments after five minutes while retaining the normal successful-result TTL
- cover primary-origin failure, AS-name failure, and error-cache recovery

## Validation
- `148 passed`: source-network, domain-detail, and report-detail API tests
- Black and Flake8
- real lookup with an unconfigured Akamai provider: `104.245.209.200` -> `AS23352`, `104.245.208.0/21`, `US`, `SERVERCENTRAL`
- `git diff --check`

Closes #791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sender network enrichment reliability by falling back to alternate DNS resolvers when the selected resolver is unavailable.
  * Restored ASN, network, and country details when fallback lookups succeed.
  * Failed enrichment results now retry after a short interval instead of remaining unavailable for an extended period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->