### PR TITLE
Agentic installation with Helm and Terraform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@
 # Docker Compose host binding. The secure default is reachable only from this
 # host. Set DMARQ_BIND_ADDRESS=0.0.0.0 only when a firewall or reverse proxy
 # protects the instance.
+DMARQ_ENV_FILE=".env"
 DMARQ_BIND_ADDRESS="127.0.0.1"
 DMARQ_PORT=8080
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Bootstrap a new standalone environment
-        run: ./scripts/bootstrap-docker-env.sh
+      - name: Validate and render a new standalone environment
+        run: |
+          python3 scripts/dmarqctl.py \
+            --config docs/deployment/examples/agent-install.compose.json \
+            --json preflight
+          python3 scripts/dmarqctl.py \
+            --config docs/deployment/examples/agent-install.compose.json \
+            --json bootstrap --no-start
 
       - name: Build and start the documented stack
         run: >-
@@ -158,7 +164,13 @@ jobs:
           curl -fsS http://127.0.0.1:8080/healthz
           curl -fsS http://127.0.0.1:8080/api/v1/health
           ./scripts/verify-docker-compose.sh
-          python3 scripts/verify-greenfield-product.py
+          python3 scripts/dmarqctl.py \
+            --config docs/deployment/examples/agent-install.compose.json \
+            --json bootstrap --setup-existing
+          python3 scripts/verify-greenfield-product.py --configured
+          python3 scripts/dmarqctl.py \
+            --config docs/deployment/examples/agent-install.compose.json \
+            --json status
           docker image inspect \
             --format '{{ json .Config.ExposedPorts }}' dmarq-app:local | grep -q '8080/tcp'
 
@@ -168,7 +180,13 @@ jobs:
             -f docker-compose.yml \
             -f docker-compose.build.yml \
             up -d --force-recreate --wait app
+          python3 scripts/dmarqctl.py \
+            --config docs/deployment/examples/agent-install.compose.json \
+            --json bootstrap --setup-existing
           python3 scripts/verify-greenfield-product.py --verify-existing
+          python3 scripts/dmarqctl.py \
+            --config docs/deployment/examples/agent-install.compose.json \
+            --json status
 
       - name: Show logs on failure
         if: failure()
@@ -177,6 +195,90 @@ jobs:
       - name: Remove the disposable stack
         if: always()
         run: docker compose -f docker-compose.yml -f docker-compose.build.yml down -v --remove-orphans
+
+  agentic-kubernetes:
+    name: Agentic Helm And Terraform
+    runs-on: ubuntu-latest
+    needs: lint
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.19.0
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.12.2
+          terraform_wrapper: false
+
+      - name: Validate Helm and Terraform packaging
+        run: |
+          helm lint deploy/helm/dmarq -f deploy/helm/dmarq/ci/test-values.yaml
+          helm template dmarq deploy/helm/dmarq \
+            --namespace dmarq \
+            -f deploy/helm/dmarq/ci/test-values.yaml \
+            > /tmp/dmarq.yaml
+          terraform fmt -recursive -check deploy/terraform
+          terraform -chdir=deploy/terraform/modules/kubernetes-dmarq init -backend=false
+          terraform -chdir=deploy/terraform/modules/kubernetes-dmarq validate
+          terraform -chdir=deploy/terraform/examples/kubernetes init -backend=false
+          terraform -chdir=deploy/terraform/examples/kubernetes validate
+
+      - name: Create disposable Kubernetes cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: dmarq-ci
+
+      - name: Create test-only secret boundary
+        run: |
+          kubectl create namespace dmarq
+          kubectl --namespace dmarq create secret generic dmarq \
+            --from-literal=DATABASE_URL='postgresql://dmarq:test-database-password@dmarq-postgresql:5432/dmarq' \
+            --from-literal=SECRET_KEY='ci-only-not-a-secret-ci-only-not-a-secret' \
+            --from-literal=ADMIN_API_KEY='ci-only-not-an-api-key-ci-only-not-an-api-key' \
+            --from-literal=POSTGRES_DB='dmarq' \
+            --from-literal=POSTGRES_USER='dmarq' \
+            --from-literal=POSTGRES_PASSWORD='test-database-password'
+
+      - name: Apply, verify, upgrade, and check drift
+        working-directory: deploy/terraform/tests/kind
+        run: |
+          terraform init -backend=false
+          terraform apply -auto-approve
+          kubectl --namespace dmarq rollout status deployment/dmarq --timeout=10m
+          kubectl --namespace dmarq port-forward service/dmarq 18080:80 >/tmp/dmarq-port-forward.log 2>&1 &
+          PORT_FORWARD_PID=$!
+          trap 'kill "$PORT_FORWARD_PID" 2>/dev/null || true' EXIT
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:18080/healthz; then
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              cat /tmp/dmarq-port-forward.log
+              exit 1
+            fi
+            sleep 2
+          done
+          curl --fail --silent http://127.0.0.1:18080/api/v1/setup/status \
+            | grep -q '"is_setup_complete":true'
+          terraform apply -auto-approve -var='project_name=DMARQ CI Upgrade'
+          terraform plan -detailed-exitcode -var='project_name=DMARQ CI Upgrade'
+
+      - name: Destroy disposable release
+        if: always()
+        working-directory: deploy/terraform/tests/kind
+        run: |
+          if [ -d .terraform ]; then
+            terraform destroy -auto-approve -var='project_name=DMARQ CI Upgrade'
+          fi
+          kubectl --namespace dmarq get all || true
 
   security:
     name: Security Scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Kept the bundled PostgreSQL workload least-privileged but bootable by granting
+  only the five capabilities required by the official Alpine image to prepare
+  its data directory and drop from root to the `postgres` user.
 - Restored sender ASN, network, and country enrichment when a selected private
   DNS resolver is unavailable by falling back to independent public DNS and
   Cloudflare DoH for Team Cymru lookups. Failed enrichments now retry after a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added the versioned DMARQ agent-installation contract and `dmarqctl` control
+  surface for machine-readable host preflight, idempotent Compose environment
+  bootstrap, browserless first-run setup, secret-safe output, and bounded
+  release/intake readiness status.
+- Added a supported Kubernetes Helm chart with existing-Secret references,
+  bundled or external PostgreSQL, persistence, ingress, health probes, safe
+  production defaults, and an idempotent browserless setup Job.
+- Added a provisioner-free Terraform module for declarative Kubernetes install,
+  upgrade, drift detection, and destroy, plus a disposable-cluster CI acceptance
+  path that exercises the complete lifecycle.
+
 ### Fixed
 - Restored sender ASN, network, and country enrichment when a selected private
   DNS resolver is unavailable by falling back to independent public DNS and

--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ exposing it publicly. See the [Docker setup guide](docs/deployment/docker.md) fo
 verification, the `docker-stable` and `docker-latest` channels, Gmail IMAP
 ingestion, updates, and production configuration.
 
+Automation agents can use the versioned, non-interactive install contract:
+
+```bash
+python3 scripts/dmarqctl.py \
+  --config docs/deployment/examples/agent-install.compose.json \
+  --json preflight
+python3 scripts/dmarqctl.py --config install.json --json bootstrap
+python3 scripts/dmarqctl.py --config install.json --json status
+```
+
+See [Agentic Installation](docs/deployment/agentic-installation.md) for schema,
+secret-reference, idempotency, and exit-code details. Kubernetes operators can
+use the supported Helm chart or Terraform module described in
+[Kubernetes, Helm, and Terraform](docs/deployment/kubernetes-terraform.md).
+
 ### Development Setup
 
 For development without Docker:

--- a/backend/app/tests/test_dmarqctl.py
+++ b/backend/app/tests/test_dmarqctl.py
@@ -1,0 +1,331 @@
+import json
+import shutil
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import dmarqctl  # noqa: E402
+
+EXAMPLE_CONFIG = ROOT_DIR / "docs/deployment/examples/agent-install.compose.json"
+KUBERNETES_CONFIG = ROOT_DIR / "docs/deployment/examples/agent-install.kubernetes.json"
+SCHEMA = ROOT_DIR / "docs/deployment/schemas/install-v1.schema.json"
+
+
+def _config():
+    return json.loads(EXAMPLE_CONFIG.read_text(encoding="utf-8"))
+
+
+def _kubernetes_config():
+    return json.loads(KUBERNETES_CONFIG.read_text(encoding="utf-8"))
+
+
+def _environment_values(path):
+    values = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            key, value = stripped.split("=", 1)
+            values[key] = value.strip().strip('"').strip("'")
+    return values
+
+
+def test_install_contract_schema_and_example_are_versioned():
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    config = _config()
+
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["properties"]["schemaVersion"]["const"] == "1"
+    assert config["schemaVersion"] == "1"
+    assert dmarqctl.validate_config(config) == []
+    assert dmarqctl.validate_config(_kubernetes_config()) == []
+
+
+def test_validate_config_rejects_unknown_and_incomplete_inputs():
+    errors = dmarqctl.validate_config(
+        {
+            "schemaVersion": "2",
+            "deployment": {"mode": "shell", "publicBaseUrl": "localhost"},
+            "product": {"profile": "unknown", "ownerEmail": "invalid"},
+            "unexpected": True,
+        }
+    )
+
+    assert {error["code"] for error in errors} >= {
+        "unknown_field",
+        "unsupported_version",
+        "invalid_choice",
+        "invalid_url",
+        "invalid_email",
+    }
+
+
+def test_bootstrap_is_idempotent_and_does_not_return_secrets(tmp_path):
+    shutil.copy(ROOT_DIR / ".env.example", tmp_path / ".env.example")
+    config = _config()
+
+    first = dmarqctl.bootstrap(config, tmp_path, start=False)
+    env_path = tmp_path / ".env"
+    first_contents = env_path.read_text(encoding="utf-8")
+    second = dmarqctl.bootstrap(config, tmp_path, start=False)
+    second_contents = env_path.read_text(encoding="utf-8")
+    values = _environment_values(env_path)
+
+    assert first["status"] == "configured"
+    assert first["environmentUnchanged"] is False
+    assert second["environmentUnchanged"] is True
+    assert first_contents == second_contents
+    assert env_path.stat().st_mode & 0o777 == 0o600
+    assert len(values["SECRET_KEY"]) == 64
+    assert len(values["ADMIN_API_KEY"]) == 64
+    assert len(values["POSTGRES_PASSWORD"]) == 64
+    serialized = json.dumps(first) + json.dumps(second)
+    assert values["SECRET_KEY"] not in serialized
+    assert values["ADMIN_API_KEY"] not in serialized
+    assert values["POSTGRES_PASSWORD"] not in serialized
+
+
+def test_bootstrap_reads_secret_reference_without_echoing_it(tmp_path, monkeypatch):
+    shutil.copy(ROOT_DIR / ".env.example", tmp_path / ".env.example")
+    config = _config()
+    config["secrets"]["secretKey"] = {"env": "DMARQ_TEST_SECRET"}
+    monkeypatch.setenv("DMARQ_TEST_SECRET", "a" * 64)
+
+    result = dmarqctl.bootstrap(config, tmp_path, start=False)
+    values = _environment_values(tmp_path / ".env")
+
+    assert values["SECRET_KEY"] == "a" * 64
+    assert "a" * 64 not in json.dumps(result)
+
+
+def test_bootstrap_supports_custom_env_file_and_url_encodes_database_secret(
+    tmp_path,
+    monkeypatch,
+):
+    shutil.copy(ROOT_DIR / ".env.example", tmp_path / ".env.example")
+    config = _config()
+    config["deployment"]["envFile"] = "config/dmarq.env"
+    config["secrets"]["databasePassword"] = {"env": "DMARQ_TEST_DATABASE_PASSWORD"}
+    monkeypatch.setenv("DMARQ_TEST_DATABASE_PASSWORD", "space and@colon:")
+
+    result = dmarqctl.bootstrap(config, tmp_path, start=False)
+    env_path = tmp_path / "config/dmarq.env"
+    values = _environment_values(env_path)
+
+    assert result["environmentFile"] == str(env_path)
+    assert values["DMARQ_ENV_FILE"] == "config/dmarq.env"
+    assert values["POSTGRES_PASSWORD"] == "space and@colon:"
+    assert "space%20and%40colon%3A" in values["DATABASE_URL"]
+
+
+def test_bootstrap_rejects_env_file_outside_project(tmp_path):
+    shutil.copy(ROOT_DIR / ".env.example", tmp_path / ".env.example")
+    config = _config()
+    config["deployment"]["envFile"] = "../outside.env"
+
+    try:
+        dmarqctl.bootstrap(config, tmp_path, start=False)
+    except dmarqctl.ControlError as exc:
+        assert exc.code == "environment_path_outside_project"
+        assert exc.exit_code == dmarqctl.EXIT_INVALID_CONFIG
+    else:
+        raise AssertionError("Expected environment path traversal to be rejected")
+
+
+def test_bootstrap_rejects_multiline_environment_secret(tmp_path, monkeypatch):
+    shutil.copy(ROOT_DIR / ".env.example", tmp_path / ".env.example")
+    config = _config()
+    config["secrets"]["secretKey"] = {"env": "DMARQ_TEST_SECRET"}
+    monkeypatch.setenv("DMARQ_TEST_SECRET", "line-one\nline-two")
+
+    try:
+        dmarqctl.bootstrap(config, tmp_path, start=False)
+    except dmarqctl.ControlError as exc:
+        assert exc.code == "environment_value_not_env_safe"
+        assert exc.exit_code == dmarqctl.EXIT_INVALID_CONFIG
+    else:
+        raise AssertionError("Expected multiline environment secret to be rejected")
+
+
+def test_bootstrap_preserves_dollar_sign_in_referenced_secret(tmp_path, monkeypatch):
+    shutil.copy(ROOT_DIR / ".env.example", tmp_path / ".env.example")
+    config = _config()
+    config["secrets"]["secretKey"] = {"env": "DMARQ_TEST_SECRET"}
+    monkeypatch.setenv("DMARQ_TEST_SECRET", "literal$dollar$value")
+
+    dmarqctl.bootstrap(config, tmp_path, start=False)
+    first = (tmp_path / ".env").read_text(encoding="utf-8")
+    result = dmarqctl.bootstrap(config, tmp_path, start=False)
+
+    assert result["environmentUnchanged"] is True
+    assert (tmp_path / ".env").read_text(encoding="utf-8") == first
+    assert _environment_values(tmp_path / ".env")["SECRET_KEY"] == "literal$dollar$value"
+
+
+def test_preflight_returns_structured_checks(tmp_path, monkeypatch):
+    monkeypatch.setattr(dmarqctl, "_compose_available", lambda: True)
+    monkeypatch.setattr(dmarqctl, "_port_available", lambda _address, _port: True)
+    monkeypatch.setattr(dmarqctl.platform, "machine", lambda: "arm64")
+
+    result = dmarqctl.preflight(_config(), tmp_path)
+
+    assert result["status"] == "ready"
+    assert [check["code"] for check in result["checks"]] == [
+        "architecture_supported",
+        "docker_compose_available",
+        "listen_port_available",
+        "project_directory_writable",
+    ]
+    assert all(check["status"] == "pass" for check in result["checks"])
+
+
+def test_kubernetes_preflight_checks_tools_context_chart_and_secret(monkeypatch):
+    def command_result(command, **_kwargs):
+        if command[:3] == ["kubectl", "config", "current-context"]:
+            return SimpleNamespace(returncode=0, stdout="kind-dmarq\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(dmarqctl, "_command_result", command_result)
+    monkeypatch.setattr(dmarqctl.platform, "machine", lambda: "arm64")
+
+    result = dmarqctl.preflight(_kubernetes_config(), ROOT_DIR)
+
+    assert result["status"] == "ready"
+    assert [check["code"] for check in result["checks"]] == [
+        "architecture_supported",
+        "helm_available",
+        "kubernetes_context_available",
+        "helm_chart_available",
+        "kubernetes_secret_available",
+        "project_directory_writable",
+    ]
+    assert "kind-dmarq" in result["checks"][2]["message"]
+
+
+def test_kubernetes_bootstrap_uses_non_secret_temporary_values(monkeypatch):
+    captured = {}
+
+    def command_result(command, **_kwargs):
+        values_path = Path(command[command.index("--values") + 1])
+        captured["command"] = command
+        captured["valuesPath"] = values_path
+        captured["values"] = json.loads(values_path.read_text(encoding="utf-8"))
+        return SimpleNamespace(returncode=0, stdout="deployed\n", stderr="")
+
+    monkeypatch.setattr(dmarqctl, "_command_result", command_result)
+
+    result = dmarqctl.bootstrap(_kubernetes_config(), ROOT_DIR, start=True)
+
+    assert result["status"] == "ready"
+    assert result["deploymentMode"] == "kubernetes"
+    assert captured["command"][:3] == ["helm", "upgrade", "--install"]
+    assert captured["values"]["existingSecret"] == "dmarq"
+    assert captured["values"]["bootstrap"]["ownerEmail"] == "owner@example.com"
+    assert "secretKey" not in json.dumps(captured["values"])
+    assert not captured["valuesPath"].exists()
+
+
+def test_compose_command_falls_back_to_standalone_binary(monkeypatch):
+    monkeypatch.setattr(
+        dmarqctl.shutil,
+        "which",
+        lambda command: f"/usr/bin/{command}" if command in {"docker", "docker-compose"} else None,
+    )
+
+    def fake_run(command, **_kwargs):
+        return SimpleNamespace(returncode=0 if command[0] == "docker-compose" else 1)
+
+    monkeypatch.setattr(dmarqctl.subprocess, "run", fake_run)
+
+    assert dmarqctl._compose_command() == ["docker-compose"]
+
+
+def test_bootstrap_can_start_and_complete_setup_without_browser(tmp_path, monkeypatch):
+    shutil.copy(ROOT_DIR / ".env.example", tmp_path / ".env.example")
+    calls = []
+    monkeypatch.setattr(dmarqctl, "_compose_available", lambda: True)
+    monkeypatch.setattr(
+        dmarqctl,
+        "_start_compose",
+        lambda root, env_path: calls.append((root, env_path)),
+    )
+    monkeypatch.setattr(dmarqctl, "_complete_setup", lambda _config: True)
+
+    result = dmarqctl.bootstrap(_config(), tmp_path, start=True)
+
+    assert result["status"] == "ready"
+    assert result["started"] is True
+    assert result["setupCompletedNow"] is True
+    assert calls[0] == (tmp_path, tmp_path / ".env")
+
+
+def test_bootstrap_can_configure_an_already_running_instance(tmp_path, monkeypatch):
+    shutil.copy(ROOT_DIR / ".env.example", tmp_path / ".env.example")
+    monkeypatch.setattr(dmarqctl, "_complete_setup", lambda _config: True)
+
+    result = dmarqctl.bootstrap(
+        _config(),
+        tmp_path,
+        start=False,
+        setup_existing=True,
+    )
+
+    assert result["status"] == "ready"
+    assert result["started"] is False
+    assert result["configuredExistingInstance"] is True
+    assert result["setupCompletedNow"] is True
+
+
+def test_status_returns_machine_readable_release_and_intake_state(monkeypatch):
+    responses = {
+        "/healthz": {"status": "healthy"},
+        "/api/v1/setup/status": {
+            "is_setup_complete": True,
+            "total_domains": 2,
+            "total_mail_sources": 1,
+            "enabled_mail_sources": 1,
+        },
+        "/api/v1/health/release": {
+            "version": "1.2.3",
+            "image": "ghcr.io/christianlouis/dmarq:sha-test",
+            "git_ref": "abc123",
+        },
+    }
+    monkeypatch.setattr(
+        dmarqctl,
+        "_request_json",
+        lambda _base_url, path, **_kwargs: responses[path],
+    )
+
+    result = dmarqctl.status(_config())
+
+    assert result == {
+        "command": "status",
+        "status": "ready",
+        "publicBaseUrl": "http://127.0.0.1:8080",
+        "health": "healthy",
+        "setupComplete": True,
+        "domains": 2,
+        "mailSources": 1,
+        "enabledMailSources": 1,
+        "release": {
+            "version": "1.2.3",
+            "image": "ghcr.io/christianlouis/dmarq:sha-test",
+            "gitRef": "abc123",
+        },
+        "errors": [],
+    }
+
+
+def test_main_uses_stable_exit_code_for_invalid_config(tmp_path, capsys):
+    config_path = tmp_path / "invalid.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    exit_code = dmarqctl.main(["--config", str(config_path), "--json", "preflight"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == dmarqctl.EXIT_INVALID_CONFIG
+    assert output["status"] == "invalid"
+    assert output["command"] == "preflight"

--- a/deploy/helm/dmarq/Chart.yaml
+++ b/deploy/helm/dmarq/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: dmarq
+description: Self-hosted DMARC report analysis and remediation
+type: application
+version: 0.1.0
+appVersion: "1.172.4"
+home: https://dmarq.org
+sources:
+  - https://github.com/christianlouis/dmarq
+maintainers:
+  - name: DMARQ maintainers
+    url: https://github.com/christianlouis/dmarq

--- a/deploy/helm/dmarq/ci/test-values.yaml
+++ b/deploy/helm/dmarq/ci/test-values.yaml
@@ -1,0 +1,13 @@
+existingSecret: dmarq-test
+image:
+  tag: docker-stable
+config:
+  publicBaseUrl: http://dmarq.dmarq-test.svc.cluster.local
+bootstrap:
+  enabled: true
+  ownerEmail: owner@example.com
+persistence:
+  enabled: false
+postgresql:
+  persistence:
+    enabled: false

--- a/deploy/helm/dmarq/templates/NOTES.txt
+++ b/deploy/helm/dmarq/templates/NOTES.txt
@@ -1,0 +1,11 @@
+DMARQ has been installed as {{ include "dmarq.fullname" . }}.
+
+Check readiness:
+  kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ include "dmarq.fullname" . }}
+  kubectl -n {{ .Release.Namespace }} port-forward service/{{ include "dmarq.fullname" . }} 8080:{{ .Values.service.port }}
+  curl --fail http://127.0.0.1:8080/healthz
+
+The Secret {{ .Values.existingSecret }} is referenced, not managed by this chart.
+{{- if not .Values.bootstrap.enabled }}
+First-run setup was not automated. Complete it in the browser or enable bootstrap with an owner email.
+{{- end }}

--- a/deploy/helm/dmarq/templates/_helpers.tpl
+++ b/deploy/helm/dmarq/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{- define "dmarq.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "dmarq.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else if contains (include "dmarq.name" .) .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name (include "dmarq.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "dmarq.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "dmarq.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "dmarq.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dmarq.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: app
+{{- end }}
+
+{{- define "dmarq.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "dmarq.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "dmarq.requirements" -}}
+{{- if not .Values.existingSecret }}
+{{- fail "existingSecret is required and must contain DATABASE_URL, SECRET_KEY, and ADMIN_API_KEY" }}
+{{- end }}
+{{- if and (eq .Values.config.environment "production") (eq .Values.config.authMode "disabled") (not .Values.config.allowAuthDisabledInProduction) }}
+{{- fail "production installs must configure authentication or explicitly allow auth-disabled mode" }}
+{{- end }}
+{{- if and .Values.bootstrap.enabled (not .Values.bootstrap.ownerEmail) }}
+{{- fail "bootstrap.ownerEmail is required when bootstrap.enabled=true" }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/dmarq/templates/bootstrap-job.yaml
+++ b/deploy/helm/dmarq/templates/bootstrap-job.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.bootstrap.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "dmarq.fullname" . }}-bootstrap
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bootstrap
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.bootstrap.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "dmarq.labels" . | nindent 8 }}
+        app.kubernetes.io/component: bootstrap
+    spec:
+      restartPolicy: OnFailure
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bootstrap
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - python
+            - -c
+          args:
+            - |
+              import json
+              import os
+              import time
+              from urllib.error import URLError
+              from urllib.request import Request, urlopen
+
+              base_url = os.environ["DMARQ_INTERNAL_URL"].rstrip("/")
+
+              def request(path, method="GET", payload=None):
+                  body = json.dumps(payload).encode() if payload is not None else None
+                  headers = {"Accept": "application/json"}
+                  if body is not None:
+                      headers["Content-Type"] = "application/json"
+                  with urlopen(
+                      Request(base_url + path, data=body, headers=headers, method=method),
+                      timeout=15,
+                  ) as response:
+                      return json.loads(response.read() or b"{}")
+
+              for attempt in range(60):
+                  try:
+                      request("/healthz")
+                      break
+                  except (OSError, URLError):
+                      if attempt == 59:
+                          raise
+                      time.sleep(5)
+
+              status = request("/api/v1/setup/status")
+              if not status.get("is_setup_complete"):
+                  request(
+                      "/api/v1/setup/admin",
+                      "POST",
+                      {"email": os.environ["DMARQ_OWNER_EMAIL"]},
+                  )
+                  request(
+                      "/api/v1/setup/system",
+                      "POST",
+                      {
+                          "app_name": os.environ["DMARQ_APP_NAME"],
+                          "base_url": os.environ["DMARQ_PUBLIC_BASE_URL"],
+                          "cloudflare_enabled": False,
+                      },
+                  )
+
+              final_status = request("/api/v1/setup/status")
+              if not final_status.get("is_setup_complete"):
+                  raise RuntimeError("DMARQ setup did not complete")
+              print(json.dumps({"status": "ready", "setupComplete": True}))
+          env:
+            - name: DMARQ_INTERNAL_URL
+              value: http://{{ include "dmarq.fullname" . }}:{{ .Values.service.port }}
+            - name: DMARQ_PUBLIC_BASE_URL
+              value: {{ .Values.config.publicBaseUrl | quote }}
+            - name: DMARQ_OWNER_EMAIL
+              value: {{ .Values.bootstrap.ownerEmail | quote }}
+            - name: DMARQ_APP_NAME
+              value: {{ .Values.config.projectName | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+{{- end }}

--- a/deploy/helm/dmarq/templates/configmap.yaml
+++ b/deploy/helm/dmarq/templates/configmap.yaml
@@ -1,0 +1,20 @@
+{{- include "dmarq.requirements" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dmarq.fullname" . }}
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+data:
+  PROJECT_NAME: {{ .Values.config.projectName | quote }}
+  ENVIRONMENT: {{ .Values.config.environment | quote }}
+  PUBLIC_BASE_URL: {{ .Values.config.publicBaseUrl | quote }}
+  LANGUAGE: {{ .Values.config.language | quote }}
+  AUTH_MODE: {{ .Values.config.authMode | quote }}
+  AUTH_DISABLED: {{ eq .Values.config.authMode "disabled" | quote }}
+  ALLOW_AUTH_DISABLED_IN_PRODUCTION: {{ .Values.config.allowAuthDisabledInProduction | quote }}
+  MULTI_WORKSPACE_UI_ENABLED: {{ ne .Values.config.profile "single-user" | quote }}
+  PROVIDER_BOOTSTRAP_DEFAULT_PLANS: {{ eq .Values.config.profile "provider" | quote }}
+  {{- range $name, $value := .Values.config.extraEnv }}
+  {{ $name }}: {{ $value | quote }}
+  {{- end }}

--- a/deploy/helm/dmarq/templates/deployment.yaml
+++ b/deploy/helm/dmarq/templates/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dmarq.fullname" . }}
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "dmarq.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "dmarq.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "dmarq.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: dmarq
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "dmarq.fullname" . }}
+            {{- if .Values.includeExistingSecretEnvFrom }}
+            - secretRef:
+                name: {{ .Values.existingSecret | quote }}
+            {{- end }}
+            {{- range .Values.extraSecretEnvFrom }}
+            - secretRef:
+                name: {{ . | quote }}
+            {{- end }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret | quote }}
+                  key: {{ .Values.secretKeys.databaseUrl | quote }}
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret | quote }}
+                  key: {{ .Values.secretKeys.secretKey | quote }}
+            - name: ADMIN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret | quote }}
+                  key: {{ .Values.secretKeys.adminApiKey | quote }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "dmarq.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/dmarq/templates/ingress.yaml
+++ b/deploy/helm/dmarq/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "dmarq.fullname" . }}
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "dmarq.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/dmarq/templates/networkpolicy.yaml
+++ b/deploy/helm/dmarq/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "dmarq.fullname" . }}
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "dmarq.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+        {{- with .Values.networkPolicy.ingressFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 8080
+{{- end }}

--- a/deploy/helm/dmarq/templates/postgresql.yaml
+++ b/deploy/helm/dmarq/templates/postgresql.yaml
@@ -1,0 +1,120 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dmarq.fullname" . }}-postgresql
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: {{ include "dmarq.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: database
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "dmarq.fullname" . }}-postgresql
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  serviceName: {{ include "dmarq.fullname" . }}-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "dmarq.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: database
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "dmarq.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: database
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret | quote }}
+                  key: {{ .Values.postgresql.secretKeys.database | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret | quote }}
+                  key: {{ .Values.postgresql.secretKeys.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret | quote }}
+                  key: {{ .Values.postgresql.secretKeys.password | quote }}
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 12
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.postgresql.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "dmarq.fullname" . }}-postgresql
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+{{- if .Values.postgresql.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "dmarq.fullname" . }}-postgresql
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+  {{- with .Values.postgresql.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.postgresql.persistence.accessModes | nindent 4 }}
+  {{- if .Values.postgresql.persistence.storageClass }}
+  storageClassName: {{ .Values.postgresql.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.postgresql.persistence.size }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/dmarq/templates/postgresql.yaml
+++ b/deploy/helm/dmarq/templates/postgresql.yaml
@@ -48,10 +48,7 @@ spec:
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.postgresql.securityContext | nindent 12 }}
           env:
             - name: POSTGRES_DB
               valueFrom:

--- a/deploy/helm/dmarq/templates/pvc.yaml
+++ b/deploy/helm/dmarq/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "dmarq.fullname" . }}-data
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/dmarq/templates/service.yaml
+++ b/deploy/helm/dmarq/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dmarq.fullname" . }}
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "dmarq.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/dmarq/templates/serviceaccount.yaml
+++ b/deploy/helm/dmarq/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dmarq.serviceAccountName" . }}
+  labels:
+    {{- include "dmarq.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/deploy/helm/dmarq/values.schema.json
+++ b/deploy/helm/dmarq/values.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["image", "existingSecret", "config", "service", "persistence", "postgresql"],
+  "properties": {
+    "replicaCount": {"type": "integer", "minimum": 1, "maximum": 1},
+    "existingSecret": {"type": "string"},
+    "includeExistingSecretEnvFrom": {"type": "boolean"},
+    "image": {
+      "type": "object",
+      "required": ["repository", "tag", "pullPolicy"],
+      "properties": {
+        "repository": {"type": "string", "minLength": 1},
+        "tag": {"type": "string", "minLength": 1},
+        "pullPolicy": {"enum": ["Always", "IfNotPresent", "Never"]}
+      }
+    },
+    "config": {
+      "type": "object",
+      "required": ["projectName", "environment", "publicBaseUrl", "language", "profile", "authMode"],
+      "properties": {
+        "projectName": {"type": "string", "minLength": 1},
+        "environment": {"type": "string", "minLength": 1},
+        "publicBaseUrl": {"type": "string", "pattern": "^https?://"},
+        "language": {"type": "string", "minLength": 2},
+        "profile": {"enum": ["single-user", "multi-workspace", "provider"]},
+        "authMode": {"enum": ["disabled", "logto", "oidc", "authentik", "trusted_proxy"]},
+        "allowAuthDisabledInProduction": {"type": "boolean"},
+        "extraEnv": {"type": "object", "additionalProperties": {"type": ["string", "number", "boolean"]}}
+      }
+    },
+    "bootstrap": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "ownerEmail": {"type": "string"},
+        "backoffLimit": {"type": "integer", "minimum": 0, "maximum": 20}
+      }
+    },
+    "service": {
+      "type": "object",
+      "required": ["type", "port"],
+      "properties": {
+        "type": {"enum": ["ClusterIP", "NodePort", "LoadBalancer"]},
+        "port": {"type": "integer", "minimum": 1, "maximum": 65535}
+      }
+    },
+    "persistence": {"type": "object"},
+    "postgresql": {"type": "object"}
+  }
+}

--- a/deploy/helm/dmarq/values.yaml
+++ b/deploy/helm/dmarq/values.yaml
@@ -1,0 +1,118 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/christianlouis/dmarq
+  tag: docker-stable
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+
+existingSecret: ""
+includeExistingSecretEnvFrom: true
+secretKeys:
+  databaseUrl: DATABASE_URL
+  secretKey: SECRET_KEY
+  adminApiKey: ADMIN_API_KEY
+
+config:
+  projectName: DMARQ
+  environment: development
+  publicBaseUrl: http://dmarq.local
+  language: en
+  profile: single-user
+  authMode: disabled
+  allowAuthDisabledInProduction: false
+  extraEnv: {}
+
+extraSecretEnvFrom: []
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: dmarq.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+persistence:
+  enabled: true
+  accessModes:
+    - ReadWriteOnce
+  size: 5Gi
+  storageClass: ""
+  annotations: {}
+
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: 14-alpine
+    pullPolicy: IfNotPresent
+  secretKeys:
+    database: POSTGRES_DB
+    username: POSTGRES_USER
+    password: POSTGRES_PASSWORD
+  persistence:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    size: 8Gi
+    storageClass: ""
+    annotations: {}
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+
+bootstrap:
+  enabled: false
+  ownerEmail: ""
+  backoffLimit: 4
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+networkPolicy:
+  enabled: false
+  ingressFrom: []
+
+terminationGracePeriodSeconds: 30

--- a/deploy/helm/dmarq/values.yaml
+++ b/deploy/helm/dmarq/values.yaml
@@ -76,6 +76,18 @@ postgresql:
     repository: postgres
     tag: 14-alpine
     pullPolicy: IfNotPresent
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop:
+        - ALL
+      add:
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - SETGID
+        - SETUID
   secretKeys:
     database: POSTGRES_DB
     username: POSTGRES_USER

--- a/deploy/terraform/examples/kubernetes/.terraform.lock.hcl
+++ b/deploy/terraform/examples/kubernetes/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "3.2.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:3WcDkgmMy9vTO6hSMzqI7o4nNeSa5AXDENxk6WphT6w=",
     "h1:adNoKZ2Uj0TOmrDmrTZEYdmhmB4ZwVumT1LOmYuRvbA=",
     "zh:2f1d55bf4e6a9c2629dfd3b162a05632f2e251bf6083d8613f38af3d51cea553",
     "zh:33b378f15d39c2050a9272f6d5e8437f162972c93244af6df6de54ba2b0a416c",

--- a/deploy/terraform/examples/kubernetes/.terraform.lock.hcl
+++ b/deploy/terraform/examples/kubernetes/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "3.2.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:adNoKZ2Uj0TOmrDmrTZEYdmhmB4ZwVumT1LOmYuRvbA=",
+    "zh:2f1d55bf4e6a9c2629dfd3b162a05632f2e251bf6083d8613f38af3d51cea553",
+    "zh:33b378f15d39c2050a9272f6d5e8437f162972c93244af6df6de54ba2b0a416c",
+    "zh:501d7e7b3d42f5b40a6e5e979d5a6a4d67eba0fb37d786e2c3d7186e742dd557",
+    "zh:52e430da694bad4a06d049aa574d4a7a2b4e11c47d7bab637131068cc1160593",
+    "zh:77fb8ecaa27f4218177917bb3865551b058b92193408fa20366c45a529f0ac94",
+    "zh:b114d6ea5ab4486dc26b83cd595f0af820b3d66d0d1cf81975dfe7baa84419e2",
+    "zh:b6729f6f32fab90945e3cb4ba0268b73262dad0d14c1d71514ac767bac644595",
+    "zh:b9ff1756e698e1d3bdb0c2605ee31794f15d8275e2f8817a2bf66f3272ed9362",
+    "zh:be4791496afea715783f0efb65d21c99d3dc84ddb94ba4868f3afee2d50e71ef",
+    "zh:c8f66bd76991d7521a805cce3000a5226b1b18baf1d6b63a03d38e09208a564b",
+    "zh:e2bdd80b8956307f7307f90ffab0e91169bb83babeb540c712239dbc5c09916f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fcda8394edc50d2a2132534edf8655cb25dc76f55937e859b9ffb5f787430f37",
+  ]
+}

--- a/deploy/terraform/examples/kubernetes/main.tf
+++ b/deploy/terraform/examples/kubernetes/main.tf
@@ -1,0 +1,12 @@
+module "dmarq" {
+  source = "../../modules/kubernetes-dmarq"
+
+  existing_secret_name = var.existing_secret_name
+  public_base_url      = var.public_base_url
+  owner_email          = var.owner_email
+  image_tag            = var.image_tag
+
+  ingress_enabled    = var.ingress_enabled
+  ingress_class_name = var.ingress_class_name
+  ingress_host       = var.ingress_host
+}

--- a/deploy/terraform/examples/kubernetes/outputs.tf
+++ b/deploy/terraform/examples/kubernetes/outputs.tf
@@ -1,0 +1,7 @@
+output "release" {
+  value = {
+    name      = module.dmarq.release_name
+    namespace = module.dmarq.namespace
+    status    = module.dmarq.status
+  }
+}

--- a/deploy/terraform/examples/kubernetes/variables.tf
+++ b/deploy/terraform/examples/kubernetes/variables.tf
@@ -1,3 +1,16 @@
+variable "kubeconfig_path" {
+  description = "Path to the kubeconfig used by the Helm provider."
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "kubeconfig_context" {
+  description = "Optional kubeconfig context. Null uses the file's current context."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
 variable "existing_secret_name" {
   type    = string
   default = "dmarq"

--- a/deploy/terraform/examples/kubernetes/variables.tf
+++ b/deploy/terraform/examples/kubernetes/variables.tf
@@ -1,0 +1,34 @@
+variable "existing_secret_name" {
+  type    = string
+  default = "dmarq"
+}
+
+variable "public_base_url" {
+  type    = string
+  default = "https://dmarq.example.com"
+}
+
+variable "owner_email" {
+  type    = string
+  default = "owner@example.com"
+}
+
+variable "image_tag" {
+  type    = string
+  default = "docker-stable"
+}
+
+variable "ingress_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "ingress_class_name" {
+  type    = string
+  default = ""
+}
+
+variable "ingress_host" {
+  type    = string
+  default = "dmarq.example.com"
+}

--- a/deploy/terraform/examples/kubernetes/versions.tf
+++ b/deploy/terraform/examples/kubernetes/versions.tf
@@ -9,4 +9,9 @@ terraform {
   }
 }
 
-provider "helm" {}
+provider "helm" {
+  kubernetes = {
+    config_path    = pathexpand(var.kubeconfig_path)
+    config_context = var.kubeconfig_context
+  }
+}

--- a/deploy/terraform/examples/kubernetes/versions.tf
+++ b/deploy/terraform/examples/kubernetes/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "helm" {}

--- a/deploy/terraform/modules/kubernetes-dmarq/README.md
+++ b/deploy/terraform/modules/kubernetes-dmarq/README.md
@@ -5,6 +5,10 @@ receive raw credentials. The referenced Kubernetes Secret must already exist,
 normally through External Secrets, Sealed Secrets, SOPS, or an operator-managed
 secret store.
 
+Configure the `hashicorp/helm` provider in the calling root module with an
+explicit kubeconfig path or equivalent in-cluster credentials. The runnable
+example exposes `kubeconfig_path` and `kubeconfig_context` for this purpose.
+
 ```hcl
 module "dmarq" {
   source = "../../modules/kubernetes-dmarq"

--- a/deploy/terraform/modules/kubernetes-dmarq/README.md
+++ b/deploy/terraform/modules/kubernetes-dmarq/README.md
@@ -1,0 +1,29 @@
+# DMARQ Kubernetes Terraform Module
+
+This module installs the checked-in DMARQ Helm chart. It does not create or
+receive raw credentials. The referenced Kubernetes Secret must already exist,
+normally through External Secrets, Sealed Secrets, SOPS, or an operator-managed
+secret store.
+
+```hcl
+module "dmarq" {
+  source = "../../modules/kubernetes-dmarq"
+
+  existing_secret_name = "dmarq"
+  public_base_url       = "https://dmarq.example.com"
+  owner_email           = "owner@example.com"
+  image_tag             = "1.172.4"
+
+  ingress_enabled    = true
+  ingress_class_name = "nginx"
+  ingress_host       = "dmarq.example.com"
+}
+```
+
+The module deliberately contains no `local-exec` or `remote-exec`
+provisioners. Helm performs declarative apply, upgrade, rollback, and destroy.
+The chart's idempotent post-install job completes first-run product setup.
+
+For an external database, set `postgresql_enabled = false` and point the
+Secret's `DATABASE_URL` key at that database. Pin `image_tag` to an immutable
+release or short SHA in production.

--- a/deploy/terraform/modules/kubernetes-dmarq/main.tf
+++ b/deploy/terraform/modules/kubernetes-dmarq/main.tf
@@ -1,0 +1,67 @@
+locals {
+  chart_path = var.chart_path != null ? var.chart_path : abspath("${path.module}/../../../helm/dmarq")
+
+  values = {
+    image = {
+      repository = var.image_repository
+      tag        = var.image_tag
+    }
+    existingSecret = var.existing_secret_name
+    config = {
+      projectName                   = var.project_name
+      environment                   = var.environment
+      publicBaseUrl                 = var.public_base_url
+      language                      = var.language
+      profile                       = var.profile
+      authMode                      = var.auth_mode
+      allowAuthDisabledInProduction = var.allow_auth_disabled_in_production
+      extraEnv                      = var.extra_env
+    }
+    extraSecretEnvFrom = var.extra_secret_env_from
+    bootstrap = {
+      enabled    = true
+      ownerEmail = var.owner_email
+    }
+    persistence = {
+      enabled      = var.app_persistence_enabled
+      size         = var.app_storage_size
+      storageClass = var.storage_class
+    }
+    postgresql = {
+      enabled = var.postgresql_enabled
+      persistence = {
+        enabled      = var.postgresql_enabled && var.database_persistence_enabled
+        size         = var.database_storage_size
+        storageClass = var.storage_class
+      }
+    }
+    ingress = {
+      enabled     = var.ingress_enabled
+      className   = var.ingress_class_name
+      annotations = var.ingress_annotations
+      hosts = [{
+        host = var.ingress_host
+        paths = [{
+          path     = "/"
+          pathType = "Prefix"
+        }]
+      }]
+      tls = var.ingress_tls
+    }
+  }
+}
+
+resource "helm_release" "dmarq" {
+  name             = var.release_name
+  namespace        = var.namespace
+  create_namespace = var.create_namespace
+  chart            = local.chart_path
+
+  values = [yamlencode(local.values)]
+
+  atomic          = var.atomic
+  cleanup_on_fail = true
+  wait            = true
+  wait_for_jobs   = true
+  timeout         = var.timeout_seconds
+}

--- a/deploy/terraform/modules/kubernetes-dmarq/outputs.tf
+++ b/deploy/terraform/modules/kubernetes-dmarq/outputs.tf
@@ -1,0 +1,19 @@
+output "release_name" {
+  description = "Installed Helm release name."
+  value       = helm_release.dmarq.name
+}
+
+output "namespace" {
+  description = "Kubernetes namespace containing DMARQ."
+  value       = helm_release.dmarq.namespace
+}
+
+output "chart_version" {
+  description = "Installed DMARQ chart version."
+  value       = helm_release.dmarq.metadata.chart
+}
+
+output "status" {
+  description = "Helm release status."
+  value       = helm_release.dmarq.status
+}

--- a/deploy/terraform/modules/kubernetes-dmarq/variables.tf
+++ b/deploy/terraform/modules/kubernetes-dmarq/variables.tf
@@ -1,0 +1,208 @@
+variable "release_name" {
+  description = "Helm release name."
+  type        = string
+  default     = "dmarq"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for DMARQ."
+  type        = string
+  default     = "dmarq"
+}
+
+variable "create_namespace" {
+  description = "Allow Helm to create the namespace."
+  type        = bool
+  default     = true
+}
+
+variable "chart_path" {
+  description = "Optional path or published chart reference. Defaults to the chart in this repository."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "existing_secret_name" {
+  description = "Existing Kubernetes Secret containing DMARQ and database credentials."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.existing_secret_name)) > 0
+    error_message = "existing_secret_name must reference a pre-created Secret."
+  }
+}
+
+variable "public_base_url" {
+  description = "Externally visible absolute URL for DMARQ."
+  type        = string
+
+  validation {
+    condition     = can(regex("^https?://", var.public_base_url))
+    error_message = "public_base_url must be an absolute HTTP or HTTPS URL."
+  }
+}
+
+variable "owner_email" {
+  description = "Owner email used by the idempotent first-run bootstrap job."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[^@[:space:]]+@[^@[:space:]]+$", var.owner_email))
+    error_message = "owner_email must be a valid email address."
+  }
+}
+
+variable "profile" {
+  description = "DMARQ product profile."
+  type        = string
+  default     = "single-user"
+
+  validation {
+    condition     = contains(["single-user", "multi-workspace", "provider"], var.profile)
+    error_message = "profile must be single-user, multi-workspace, or provider."
+  }
+}
+
+variable "image_repository" {
+  description = "DMARQ image repository."
+  type        = string
+  default     = "ghcr.io/christianlouis/dmarq"
+}
+
+variable "image_tag" {
+  description = "DMARQ image tag. Pin a release or short SHA for production."
+  type        = string
+  default     = "docker-stable"
+}
+
+variable "project_name" {
+  description = "Product name shown in the interface."
+  type        = string
+  default     = "DMARQ"
+}
+
+variable "language" {
+  description = "Default product language."
+  type        = string
+  default     = "en"
+}
+
+variable "environment" {
+  description = "Application environment."
+  type        = string
+  default     = "production"
+}
+
+variable "auth_mode" {
+  description = "Authentication mode configured through non-secret application settings."
+  type        = string
+  default     = "oidc"
+
+  validation {
+    condition = contains(
+      ["disabled", "logto", "oidc", "authentik", "trusted_proxy"],
+      var.auth_mode
+    )
+    error_message = "auth_mode is not supported."
+  }
+}
+
+variable "allow_auth_disabled_in_production" {
+  description = "Explicitly permit an auth-disabled production instance. Keep false for exposed installs."
+  type        = bool
+  default     = false
+}
+
+variable "extra_env" {
+  description = "Additional non-secret application environment values."
+  type        = map(string)
+  default     = {}
+}
+
+variable "extra_secret_env_from" {
+  description = "Additional existing Secrets exposed as application environment variables."
+  type        = list(string)
+  default     = []
+}
+
+variable "postgresql_enabled" {
+  description = "Deploy the bundled single-node PostgreSQL workload. Disable for an external database."
+  type        = bool
+  default     = true
+}
+
+variable "app_storage_size" {
+  description = "Persistent storage request for DMARQ application data."
+  type        = string
+  default     = "5Gi"
+}
+
+variable "app_persistence_enabled" {
+  description = "Persist DMARQ application data. Disable only for disposable tests."
+  type        = bool
+  default     = true
+}
+
+variable "database_storage_size" {
+  description = "Persistent storage request for bundled PostgreSQL."
+  type        = string
+  default     = "8Gi"
+}
+
+variable "database_persistence_enabled" {
+  description = "Persist bundled PostgreSQL data. Disable only for disposable tests."
+  type        = bool
+  default     = true
+}
+
+variable "storage_class" {
+  description = "Optional storage class for application and bundled database claims."
+  type        = string
+  default     = ""
+}
+
+variable "ingress_enabled" {
+  description = "Create a Kubernetes Ingress."
+  type        = bool
+  default     = false
+}
+
+variable "ingress_class_name" {
+  description = "IngressClass name when ingress is enabled."
+  type        = string
+  default     = ""
+}
+
+variable "ingress_host" {
+  description = "Ingress host when ingress is enabled."
+  type        = string
+  default     = "dmarq.local"
+}
+
+variable "ingress_annotations" {
+  description = "Ingress annotations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "ingress_tls" {
+  description = "Ingress TLS blocks passed to the chart."
+  type = list(object({
+    secretName = string
+    hosts      = list(string)
+  }))
+  default = []
+}
+
+variable "atomic" {
+  description = "Roll back a failed Helm installation or upgrade automatically."
+  type        = bool
+  default     = true
+}
+
+variable "timeout_seconds" {
+  description = "Maximum Helm operation duration."
+  type        = number
+  default     = 900
+}

--- a/deploy/terraform/modules/kubernetes-dmarq/versions.tf
+++ b/deploy/terraform/modules/kubernetes-dmarq/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/deploy/terraform/tests/kind/.terraform.lock.hcl
+++ b/deploy/terraform/tests/kind/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "3.2.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:3WcDkgmMy9vTO6hSMzqI7o4nNeSa5AXDENxk6WphT6w=",
     "h1:adNoKZ2Uj0TOmrDmrTZEYdmhmB4ZwVumT1LOmYuRvbA=",
     "zh:2f1d55bf4e6a9c2629dfd3b162a05632f2e251bf6083d8613f38af3d51cea553",
     "zh:33b378f15d39c2050a9272f6d5e8437f162972c93244af6df6de54ba2b0a416c",

--- a/deploy/terraform/tests/kind/.terraform.lock.hcl
+++ b/deploy/terraform/tests/kind/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "3.2.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:adNoKZ2Uj0TOmrDmrTZEYdmhmB4ZwVumT1LOmYuRvbA=",
+    "zh:2f1d55bf4e6a9c2629dfd3b162a05632f2e251bf6083d8613f38af3d51cea553",
+    "zh:33b378f15d39c2050a9272f6d5e8437f162972c93244af6df6de54ba2b0a416c",
+    "zh:501d7e7b3d42f5b40a6e5e979d5a6a4d67eba0fb37d786e2c3d7186e742dd557",
+    "zh:52e430da694bad4a06d049aa574d4a7a2b4e11c47d7bab637131068cc1160593",
+    "zh:77fb8ecaa27f4218177917bb3865551b058b92193408fa20366c45a529f0ac94",
+    "zh:b114d6ea5ab4486dc26b83cd595f0af820b3d66d0d1cf81975dfe7baa84419e2",
+    "zh:b6729f6f32fab90945e3cb4ba0268b73262dad0d14c1d71514ac767bac644595",
+    "zh:b9ff1756e698e1d3bdb0c2605ee31794f15d8275e2f8817a2bf66f3272ed9362",
+    "zh:be4791496afea715783f0efb65d21c99d3dc84ddb94ba4868f3afee2d50e71ef",
+    "zh:c8f66bd76991d7521a805cce3000a5226b1b18baf1d6b63a03d38e09208a564b",
+    "zh:e2bdd80b8956307f7307f90ffab0e91169bb83babeb540c712239dbc5c09916f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fcda8394edc50d2a2132534edf8655cb25dc76f55937e859b9ffb5f787430f37",
+  ]
+}

--- a/deploy/terraform/tests/kind/main.tf
+++ b/deploy/terraform/tests/kind/main.tf
@@ -1,0 +1,28 @@
+variable "project_name" {
+  type    = string
+  default = "DMARQ"
+}
+
+variable "image_tag" {
+  type    = string
+  default = "docker-stable"
+}
+
+module "dmarq" {
+  source = "../../modules/kubernetes-dmarq"
+
+  existing_secret_name = "dmarq"
+  public_base_url      = "http://dmarq.dmarq.svc.cluster.local"
+  owner_email          = "owner@example.com"
+  project_name         = var.project_name
+  image_tag            = var.image_tag
+  environment          = "development"
+  auth_mode            = "disabled"
+
+  app_persistence_enabled      = false
+  database_persistence_enabled = false
+}
+
+output "release_status" {
+  value = module.dmarq.status
+}

--- a/deploy/terraform/tests/kind/versions.tf
+++ b/deploy/terraform/tests/kind/versions.tf
@@ -9,4 +9,8 @@ terraform {
   }
 }
 
-provider "helm" {}
+provider "helm" {
+  kubernetes = {
+    config_path = pathexpand("~/.kube/config")
+  }
+}

--- a/deploy/terraform/tests/kind/versions.tf
+++ b/deploy/terraform/tests/kind/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "helm" {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     security_opt:
       - no-new-privileges:true
     env_file:
-      - .env
+      - ${DMARQ_ENV_FILE:-.env}
     environment:
       DATABASE_URL: ${DATABASE_URL:?Run ./scripts/bootstrap-docker-env.sh first}
       SECRET_KEY: ${SECRET_KEY:?Run ./scripts/bootstrap-docker-env.sh first}

--- a/docs/deployment/agentic-installation.md
+++ b/docs/deployment/agentic-installation.md
@@ -1,0 +1,122 @@
+# Agentic and Non-Interactive Installation
+
+DMARQ includes a versioned installation contract and a standard-library control
+tool for automation that must work before application dependencies are
+installed. It supports Docker Compose and the checked-in Kubernetes Helm chart;
+the Terraform module consumes the same chart.
+
+## Contract
+
+Start from the checked-in Compose example:
+
+```text
+docs/deployment/examples/agent-install.compose.json
+```
+
+The corresponding JSON Schema is:
+
+```text
+docs/deployment/schemas/install-v1.schema.json
+```
+
+Kubernetes automation starts from:
+
+```text
+docs/deployment/examples/agent-install.kubernetes.json
+```
+
+The contract separates non-secret installation intent from credentials. Secret
+sources are either generated once or read from a named environment variable:
+
+```json
+{
+  "secretKey": {"env": "DMARQ_SECRET_KEY"},
+  "adminApiKey": {"generate": true}
+}
+```
+
+DMARQ never prints the resolved value. For production, inject those environment
+variables from the operator's secret manager. A generated or injected value is
+preserved on repeat bootstrap runs so automation does not rotate encryption or
+database credentials accidentally.
+
+## Preflight
+
+Run all host and configuration checks with deterministic JSON output:
+
+```bash
+python3 scripts/dmarqctl.py \
+  --config docs/deployment/examples/agent-install.compose.json \
+  --json preflight
+```
+
+For Compose, the result includes stable check codes for host architecture,
+Docker Compose, the listen address, and writable storage. Kubernetes preflight
+checks Helm, the active cluster context, the local chart, and the referenced
+existing Secret.
+
+## Bootstrap
+
+Edit a copy of the example with the owner email, URL, bind address, and desired
+profile, then run:
+
+```bash
+python3 scripts/dmarqctl.py --config install.json --json bootstrap
+```
+
+For Compose this command:
+
+1. creates the configured environment file with mode `0600`;
+2. generates missing local secrets without printing them;
+3. preserves existing secret values on repeat runs;
+4. pulls and starts the configured published image; and
+5. completes the owner and system setup through the local API when setup is not
+   already complete.
+
+Use `bootstrap --no-start` to validate and render the environment without
+starting containers. This is useful for plan, review, and secret-injection
+stages. Use `bootstrap --setup-existing` after an external orchestrator has
+started the stack to complete only the idempotent first-run API setup.
+
+For Kubernetes, `bootstrap` performs an atomic, waiting Helm install or upgrade
+with a temporary non-secret values file and the chart's idempotent setup Job.
+The existing Kubernetes Secret is never read or returned by `dmarqctl`. See
+[Kubernetes, Helm, and Terraform](kubernetes-terraform.md) for the complete
+secret, storage, ingress, upgrade, drift, and destroy contract.
+
+## Status
+
+After startup, request one bounded readiness result:
+
+```bash
+python3 scripts/dmarqctl.py --config install.json --json status
+```
+
+The response contains health, setup completion, domain and mail-source counts,
+and release identity. It contains no credential values.
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Operation completed and the requested state is ready |
+| `2` | Invalid or unsupported installation configuration |
+| `3` | Host preflight requirement is not satisfied |
+| `4` | DMARQ is unreachable or not ready |
+| `5` | Bootstrap or API operation failed |
+
+Automation should branch on the exit code and the structured `status`,
+`checks`, or `error.code` fields. Human-readable output remains available by
+omitting `--json`.
+
+## Security Boundary
+
+- Keep installation JSON free of raw secret values.
+- Pass secret values through the named process environment only for the
+  bootstrap process.
+- Do not upload the generated environment file to support tickets or source
+  control.
+- Keep `AUTH_MODE=disabled` bound to localhost. Internet-facing installations
+  must use a supported identity provider or trusted authentication proxy.
+- Terraform installations reference existing Kubernetes Secrets or an External
+  Secrets resource so normal plans do not contain credentials.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -32,6 +32,11 @@ application, API, and database secrets, and never prints those values. Open
 [http://localhost:8080](http://localhost:8080) after both containers are
 healthy.
 
+For unattended setup, use the versioned
+[Agentic Installation](agentic-installation.md) contract. `dmarqctl` performs
+machine-readable preflight, renders the same Compose environment safely, starts
+the published image, and completes first-run setup without a browser.
+
 The default is a local single-user installation:
 
 - DMARQ is bound to `127.0.0.1`, not every network interface.
@@ -237,6 +242,9 @@ through Secrets/ConfigMaps, use a cluster-managed PostgreSQL service if desired,
 and pin the released `ghcr.io/christianlouis/dmarq` image. Docker-only variables
 `DMARQ_BIND_ADDRESS`, `DMARQ_PORT`, and `POSTGRES_*` are consumed by Compose and
 do not need to exist in Kubernetes.
+
+Use the supported [Kubernetes, Helm, and Terraform](kubernetes-terraform.md)
+package for new cluster deployments instead of translating Compose manually.
 
 ## Troubleshooting
 

--- a/docs/deployment/examples/agent-install.compose.json
+++ b/docs/deployment/examples/agent-install.compose.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "1",
+  "deployment": {
+    "mode": "compose",
+    "image": "ghcr.io/christianlouis/dmarq:docker-stable",
+    "bindAddress": "127.0.0.1",
+    "port": 8080,
+    "publicBaseUrl": "http://127.0.0.1:8080",
+    "envFile": ".env"
+  },
+  "product": {
+    "profile": "single-user",
+    "ownerEmail": "owner@example.com",
+    "appName": "DMARQ",
+    "language": "en",
+    "authentication": {
+      "mode": "disabled"
+    }
+  },
+  "database": {
+    "mode": "bundled",
+    "name": "dmarq",
+    "user": "dmarq"
+  },
+  "secrets": {
+    "secretKey": {
+      "generate": true
+    },
+    "adminApiKey": {
+      "generate": true
+    },
+    "databasePassword": {
+      "generate": true
+    }
+  }
+}

--- a/docs/deployment/examples/agent-install.kubernetes.json
+++ b/docs/deployment/examples/agent-install.kubernetes.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "1",
+  "deployment": {
+    "mode": "kubernetes",
+    "image": "ghcr.io/christianlouis/dmarq:docker-stable",
+    "publicBaseUrl": "https://dmarq.example.com",
+    "namespace": "dmarq",
+    "releaseName": "dmarq",
+    "existingSecret": "dmarq",
+    "chartPath": "deploy/helm/dmarq"
+  },
+  "product": {
+    "profile": "single-user",
+    "ownerEmail": "owner@example.com",
+    "appName": "DMARQ",
+    "language": "en",
+    "authentication": {
+      "mode": "oidc"
+    }
+  },
+  "database": {
+    "mode": "bundled",
+    "name": "dmarq",
+    "user": "dmarq"
+  }
+}

--- a/docs/deployment/examples/dmarq-kubernetes-secret.example.yaml
+++ b/docs/deployment/examples/dmarq-kubernetes-secret.example.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dmarq
+type: Opaque
+stringData:
+  DATABASE_URL: postgresql://dmarq:replace-with-one-random-database-password@dmarq-postgresql:5432/dmarq
+  SECRET_KEY: replace-with-at-least-32-random-characters
+  ADMIN_API_KEY: replace-with-a-separate-random-value
+  POSTGRES_DB: dmarq
+  POSTGRES_USER: dmarq
+  POSTGRES_PASSWORD: replace-with-one-random-database-password

--- a/docs/deployment/greenfield-verification.md
+++ b/docs/deployment/greenfield-verification.md
@@ -58,6 +58,29 @@ Accept the deployment only when:
 
 ## Product Checks
 
+For the agentic acceptance path, use the contract before starting the stack:
+
+```bash
+python3 scripts/dmarqctl.py \
+  --config docs/deployment/examples/agent-install.compose.json \
+  --json preflight
+python3 scripts/dmarqctl.py \
+  --config docs/deployment/examples/agent-install.compose.json \
+  --json bootstrap --no-start
+docker compose pull
+docker compose up -d --wait
+python3 scripts/dmarqctl.py \
+  --config docs/deployment/examples/agent-install.compose.json \
+  --json bootstrap --setup-existing
+python3 scripts/verify-greenfield-product.py --configured
+python3 scripts/dmarqctl.py \
+  --config docs/deployment/examples/agent-install.compose.json \
+  --json status
+```
+
+This path must finish setup, import the fixture, and report ready without a
+browser or an unpublished setting.
+
 Complete setup in the browser using an owner contact email. This address is not
 a local username: local username/password authentication is not implemented.
 Then:
@@ -130,6 +153,22 @@ variables. Validate that the workload still uses:
 
 `DMARQ_BIND_ADDRESS`, `DMARQ_PORT`, and `POSTGRES_*` are Compose orchestration
 values and are not required in a Kubernetes application pod.
+
+Validate the supported packaging before a cluster apply:
+
+```bash
+helm lint deploy/helm/dmarq -f deploy/helm/dmarq/ci/test-values.yaml
+helm template dmarq deploy/helm/dmarq \
+  --namespace dmarq \
+  -f deploy/helm/dmarq/ci/test-values.yaml >/tmp/dmarq.yaml
+terraform fmt -recursive -check deploy/terraform
+terraform -chdir=deploy/terraform/modules/kubernetes-dmarq init -backend=false
+terraform -chdir=deploy/terraform/modules/kubernetes-dmarq validate
+```
+
+The CI acceptance then applies the Terraform module to a disposable Kubernetes
+cluster, waits for the browserless setup Job, verifies HTTP health and setup,
+performs an upgrade, requires a drift-free plan, and destroys the release.
 
 ## Release Evidence
 

--- a/docs/deployment/kubernetes-terraform.md
+++ b/docs/deployment/kubernetes-terraform.md
@@ -89,7 +89,19 @@ secret is returned in the machine-readable result.
 The module is at `deploy/terraform/modules/kubernetes-dmarq`; a runnable example
 is at `deploy/terraform/examples/kubernetes`.
 
+The root module must configure the Helm provider with an explicit kubeconfig.
+The checked-in example defaults to `~/.kube/config` and accepts
+`kubeconfig_path` and `kubeconfig_context` overrides for CI agents and
+multi-cluster operators.
+
 ```hcl
+provider "helm" {
+  kubernetes = {
+    config_path    = pathexpand(var.kubeconfig_path)
+    config_context = var.kubeconfig_context
+  }
+}
+
 module "dmarq" {
   source = "../../modules/kubernetes-dmarq"
 

--- a/docs/deployment/kubernetes-terraform.md
+++ b/docs/deployment/kubernetes-terraform.md
@@ -1,0 +1,132 @@
+# Kubernetes, Helm, and Terraform
+
+DMARQ ships one supported Helm chart and a Terraform module that consumes that
+chart. Both use the same application image as Docker Compose and keep
+credentials outside chart values and Terraform configuration.
+
+## Prerequisites
+
+- Kubernetes 1.28 or newer
+- Helm 3.14 or newer
+- an ingress controller and TLS issuer when the instance is exposed publicly
+- a default StorageClass, or explicit storage classes in the values
+- an existing Kubernetes Secret with the required application and database keys
+
+Pin a release or short-SHA image for production. `docker-stable` is appropriate
+for an initial test, but it is intentionally a moving installation channel.
+
+## Secret Boundary
+
+Create the Secret before installing DMARQ. The checked-in
+`docs/deployment/examples/dmarq-kubernetes-secret.example.yaml` documents the
+required keys without containing usable credentials:
+
+- `DATABASE_URL`
+- `SECRET_KEY`
+- `ADMIN_API_KEY`
+- `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` when bundled
+  PostgreSQL is enabled
+
+Prefer External Secrets, Sealed Secrets, SOPS, or the cluster's existing secret
+delivery mechanism. The Helm chart and Terraform module reference the Secret by
+name and never copy its values into Terraform state. The referenced Secret is
+also loaded as application environment so it can carry OIDC or DNS-provider
+credentials; do not mix unrelated credentials into it.
+
+The bundled database service is named `<release>-postgresql`. For the default
+release name, the database URL host is `dmarq-postgresql`. With an external
+database, disable bundled PostgreSQL and provide its URL in the same Secret.
+
+## Helm Install
+
+Review `deploy/helm/dmarq/values.yaml`, then install with non-secret values:
+
+```bash
+helm upgrade --install dmarq deploy/helm/dmarq \
+  --namespace dmarq \
+  --create-namespace \
+  --atomic \
+  --wait \
+  --set existingSecret=dmarq \
+  --set image.tag=1.172.4 \
+  --set config.environment=production \
+  --set config.publicBaseUrl=https://dmarq.example.com \
+  --set config.authMode=oidc \
+  --set bootstrap.enabled=true \
+  --set bootstrap.ownerEmail=owner@example.com
+```
+
+Production rendering fails when authentication is disabled unless the operator
+explicitly accepts that unsafe mode. OIDC, Logto, Authentik, and trusted-proxy
+credentials belong in an additional existing Secret listed under
+`extraSecretEnvFrom`.
+
+The optional bootstrap Job waits for DMARQ, creates the owner, completes system
+setup, verifies the final state, and exits. Repeated Helm upgrades are
+idempotent because the setup API reports completion before accepting new setup
+writes.
+
+## Agent-Controlled Install
+
+Start from the Kubernetes contract example and update its URL, owner, image,
+namespace, authentication mode, and existing Secret name:
+
+```bash
+python3 scripts/dmarqctl.py \
+  --config docs/deployment/examples/agent-install.kubernetes.json \
+  --json preflight
+python3 scripts/dmarqctl.py --config install.json --json bootstrap
+python3 scripts/dmarqctl.py --config install.json --json status
+```
+
+Preflight verifies the architecture, Helm, active Kubernetes context, chart,
+and Secret. Bootstrap performs an atomic Helm install or upgrade and removes
+its temporary non-secret values file. No Kubernetes credential or application
+secret is returned in the machine-readable result.
+
+## Terraform
+
+The module is at `deploy/terraform/modules/kubernetes-dmarq`; a runnable example
+is at `deploy/terraform/examples/kubernetes`.
+
+```hcl
+module "dmarq" {
+  source = "../../modules/kubernetes-dmarq"
+
+  existing_secret_name = "dmarq"
+  public_base_url       = "https://dmarq.example.com"
+  owner_email           = "owner@example.com"
+  image_tag             = "1.172.4"
+
+  ingress_enabled    = true
+  ingress_class_name = "nginx"
+  ingress_host       = "dmarq.example.com"
+}
+```
+
+Apply and verify:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+kubectl --namespace dmarq rollout status deployment/dmarq
+```
+
+The module has no `local-exec` or `remote-exec` provisioners. A normal plan
+contains only non-secret deployment intent. Upgrades change `image_tag` and run
+through Helm's atomic upgrade path. `terraform plan -detailed-exitcode` is the
+drift gate; `terraform destroy` removes the release but deliberately does not
+delete the externally managed Secret.
+
+## Runtime Verification
+
+```bash
+kubectl --namespace dmarq port-forward service/dmarq 8080:80
+curl --fail http://127.0.0.1:8080/healthz
+curl --fail http://127.0.0.1:8080/api/v1/setup/status
+curl --fail http://127.0.0.1:8080/api/v1/health/release
+```
+
+After readiness, connect a report mailbox and ingest a real or fixture DMARC
+aggregate report. A healthy pod alone does not prove the product workflow.

--- a/docs/deployment/schemas/install-v1.schema.json
+++ b/docs/deployment/schemas/install-v1.schema.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dmarq.org/schemas/install-v1.schema.json",
+  "title": "DMARQ agent installation contract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "deployment", "product"],
+  "properties": {
+    "schemaVersion": {
+      "const": "1"
+    },
+    "deployment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "publicBaseUrl"],
+      "properties": {
+        "mode": {
+          "enum": ["compose", "kubernetes"]
+        },
+        "image": {
+          "type": "string",
+          "minLength": 1,
+          "default": "ghcr.io/christianlouis/dmarq:docker-stable"
+        },
+        "bindAddress": {
+          "type": "string",
+          "default": "127.0.0.1"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 8080
+        },
+        "publicBaseUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "envFile": {
+          "type": "string",
+          "minLength": 1,
+          "default": ".env"
+        },
+        "namespace": {
+          "type": "string",
+          "minLength": 1,
+          "default": "dmarq"
+        },
+        "releaseName": {
+          "type": "string",
+          "minLength": 1,
+          "default": "dmarq"
+        },
+        "existingSecret": {
+          "type": "string",
+          "minLength": 1
+        },
+        "chartPath": {
+          "type": "string",
+          "minLength": 1,
+          "default": "deploy/helm/dmarq"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"mode": {"const": "kubernetes"}},
+            "required": ["mode"]
+          },
+          "then": {
+            "required": ["existingSecret"]
+          }
+        }
+      ]
+    },
+    "product": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile", "ownerEmail"],
+      "properties": {
+        "profile": {
+          "enum": ["single-user", "multi-workspace", "provider"]
+        },
+        "ownerEmail": {
+          "type": "string",
+          "format": "email"
+        },
+        "appName": {
+          "type": "string",
+          "minLength": 1,
+          "default": "DMARQ"
+        },
+        "language": {
+          "type": "string",
+          "minLength": 2,
+          "default": "en"
+        },
+        "authentication": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mode": {
+              "enum": ["disabled", "logto", "oidc", "authentik", "trusted_proxy"],
+              "default": "disabled"
+            }
+          }
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "enum": ["bundled", "external"],
+          "default": "bundled"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "default": "dmarq"
+        },
+        "user": {
+          "type": "string",
+          "minLength": 1,
+          "default": "dmarq"
+        },
+        "urlEnv": {
+          "$ref": "#/$defs/environmentVariable"
+        }
+      }
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "secretKey": {
+          "$ref": "#/$defs/secretSource"
+        },
+        "adminApiKey": {
+          "$ref": "#/$defs/secretSource"
+        },
+        "databasePassword": {
+          "$ref": "#/$defs/secretSource"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "environmentVariable": {
+      "type": "string",
+      "pattern": "^[A-Z_][A-Z0-9_]*$"
+    },
+    "secretSource": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["generate"],
+          "properties": {
+            "generate": {
+              "const": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["env"],
+          "properties": {
+            "env": {
+              "$ref": "#/$defs/environmentVariable"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,17 @@ The product direction is intentionally practical:
 
 To get started with DMARQ, please see the [Getting Started](user_guide/getting_started.md) guide.
 
-For installation instructions, check the [Docker Setup](deployment/docker.md) or [Manual Installation](deployment/manual.md) guides. Operators should use the [Operator Runbook](deployment/operations.md) for deployment modes, verification, upgrades, and rollback, and the [Troubleshooting Playbooks](deployment/troubleshooting.md) for ingestion, authentication, DNS, database, and notification failures. For production secrets, use [Secret Handling with 1Password](deployment/secrets.md). For database operations, use [Database Backup and Restore](deployment/backups.md). For upgrades, use the [Release Checklist](deployment/release-checklist.md).
+For installation instructions, check the [Docker Setup](deployment/docker.md),
+[Agentic Installation](deployment/agentic-installation.md),
+[Kubernetes, Helm, and Terraform](deployment/kubernetes-terraform.md), or
+[Manual Installation](deployment/manual.md) guides. Operators should use the
+[Operator Runbook](deployment/operations.md) for deployment modes,
+verification, upgrades, and rollback, and the
+[Troubleshooting Playbooks](deployment/troubleshooting.md) for ingestion,
+authentication, DNS, database, and notification failures. For production
+secrets, use [Secret Handling with 1Password](deployment/secrets.md). For
+database operations, use [Database Backup and Restore](deployment/backups.md).
+For upgrades, use the [Release Checklist](deployment/release-checklist.md).
 
 For Microsoft 365 setup, see [Microsoft 365 Mail Sources](user_guide/microsoft365.md).
 For connector implementation boundaries, see the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,8 @@ nav:
     - Settings: user_guide/settings.md
   - Installation:
     - Docker Setup: deployment/docker.md
+    - Agentic Installation: deployment/agentic-installation.md
+    - Kubernetes, Helm, and Terraform: deployment/kubernetes-terraform.md
     - Greenfield Verification: deployment/greenfield-verification.md
     - Manual Installation: deployment/manual.md
     - Configuration: deployment/configuration.md

--- a/scripts/dmarqctl.py
+++ b/scripts/dmarqctl.py
@@ -1,0 +1,813 @@
+#!/usr/bin/env python3
+"""Non-interactive DMARQ installation and readiness control surface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import secrets
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlparse
+from urllib.request import Request, urlopen
+
+EXIT_OK = 0
+EXIT_INVALID_CONFIG = 2
+EXIT_PREFLIGHT_FAILED = 3
+EXIT_NOT_READY = 4
+EXIT_OPERATION_FAILED = 5
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = ROOT_DIR / "docs/deployment/examples/agent-install.compose.json"
+DEFAULT_IMAGE = "ghcr.io/christianlouis/dmarq:docker-stable"
+PLACEHOLDERS = {
+    "SECRET_KEY": "CHANGE_THIS_TO_A_RANDOM_SECRET_IN_PRODUCTION",
+    "ADMIN_API_KEY": "CHANGE_THIS_TO_A_RANDOM_ADMIN_API_KEY",
+    "POSTGRES_PASSWORD": "CHANGE_THIS_DOCKER_POSTGRES_PASSWORD",
+}
+SUPPORTED_ARCHITECTURES = {"x86_64", "amd64", "aarch64", "arm64"}
+
+
+class ControlError(RuntimeError):
+    """Structured operator error with a stable code and process exit status."""
+
+    def __init__(self, code: str, message: str, exit_code: int) -> None:
+        super().__init__(message)
+        self.code = code
+        self.exit_code = exit_code
+
+
+def _emit(payload: Dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+        return
+    status = str(payload.get("status", "unknown")).upper()
+    print(f"DMARQ {payload.get('command', 'operation')}: {status}")
+    for check in payload.get("checks", []):
+        print(f"- {check['status']}: {check['code']} - {check['message']}")
+    if payload.get("message"):
+        print(payload["message"])
+
+
+def _load_config(path: str) -> Dict[str, Any]:
+    try:
+        if path == "-":
+            payload = json.load(sys.stdin)
+        else:
+            with Path(path).open(encoding="utf-8") as handle:
+                payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ControlError(
+            "config_read_failed",
+            f"Installation configuration could not be read: {type(exc).__name__}.",
+            EXIT_INVALID_CONFIG,
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ControlError(
+            "config_not_object",
+            "Installation configuration must be a JSON object.",
+            EXIT_INVALID_CONFIG,
+        )
+    return payload
+
+
+def _validation_error(path: str, code: str, message: str) -> Dict[str, str]:
+    return {"path": path, "code": code, "message": message}
+
+
+def validate_config(config: Dict[str, Any]) -> list[Dict[str, str]]:  # noqa: C901
+    """Validate the v1 contract without requiring third-party Python packages."""
+    errors: list[Dict[str, str]] = []
+    allowed_root = {"schemaVersion", "deployment", "product", "database", "secrets"}
+    for key in sorted(set(config) - allowed_root):
+        errors.append(_validation_error(key, "unknown_field", "Unknown top-level field."))
+    if config.get("schemaVersion") != "1":
+        errors.append(
+            _validation_error("schemaVersion", "unsupported_version", "Expected schemaVersion 1.")
+        )
+
+    deployment = config.get("deployment")
+    if not isinstance(deployment, dict):
+        errors.append(_validation_error("deployment", "required_object", "Object is required."))
+        deployment = {}
+    mode = deployment.get("mode")
+    if mode not in {"compose", "kubernetes"}:
+        errors.append(
+            _validation_error(
+                "deployment.mode", "invalid_choice", "Expected compose or kubernetes."
+            )
+        )
+    if mode == "kubernetes" and not deployment.get("existingSecret"):
+        errors.append(
+            _validation_error(
+                "deployment.existingSecret",
+                "required_for_kubernetes",
+                "Kubernetes mode requires an existing Secret name.",
+            )
+        )
+    public_base_url = deployment.get("publicBaseUrl")
+    parsed_url = urlparse(str(public_base_url or ""))
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        errors.append(
+            _validation_error(
+                "deployment.publicBaseUrl",
+                "invalid_url",
+                "An absolute HTTP or HTTPS URL is required.",
+            )
+        )
+    port = deployment.get("port", 8080)
+    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+        errors.append(
+            _validation_error("deployment.port", "invalid_port", "Expected an integer 1-65535.")
+        )
+
+    product = config.get("product")
+    if not isinstance(product, dict):
+        errors.append(_validation_error("product", "required_object", "Object is required."))
+        product = {}
+    if product.get("profile") not in {"single-user", "multi-workspace", "provider"}:
+        errors.append(
+            _validation_error(
+                "product.profile", "invalid_choice", "Unknown product installation profile."
+            )
+        )
+    owner_email = product.get("ownerEmail")
+    if not isinstance(owner_email, str) or "@" not in owner_email or owner_email.startswith("@"):
+        errors.append(
+            _validation_error(
+                "product.ownerEmail", "invalid_email", "A valid owner email is required."
+            )
+        )
+    authentication = product.get("authentication", {})
+    if not isinstance(authentication, dict) or authentication.get("mode", "disabled") not in {
+        "disabled",
+        "logto",
+        "oidc",
+        "authentik",
+        "trusted_proxy",
+    }:
+        errors.append(
+            _validation_error(
+                "product.authentication.mode", "invalid_choice", "Unknown authentication mode."
+            )
+        )
+
+    database = config.get("database", {})
+    if not isinstance(database, dict):
+        errors.append(_validation_error("database", "invalid_object", "Expected an object."))
+        database = {}
+    database_mode = database.get("mode", "bundled")
+    if database_mode not in {"bundled", "external"}:
+        errors.append(
+            _validation_error("database.mode", "invalid_choice", "Expected bundled or external.")
+        )
+    if database_mode == "external" and not database.get("urlEnv"):
+        errors.append(
+            _validation_error(
+                "database.urlEnv",
+                "required_for_external_database",
+                "External database mode requires the environment variable name containing its URL.",
+            )
+        )
+
+    secrets_config = config.get("secrets", {})
+    if not isinstance(secrets_config, dict):
+        errors.append(_validation_error("secrets", "invalid_object", "Expected an object."))
+        secrets_config = {}
+    for name in ("secretKey", "adminApiKey", "databasePassword"):
+        source = secrets_config.get(name, {"generate": True})
+        if not isinstance(source, dict) or not (
+            source == {"generate": True}
+            or (
+                set(source) == {"env"}
+                and isinstance(source.get("env"), str)
+                and re.fullmatch(r"[A-Z_][A-Z0-9_]*", source["env"])
+            )
+        ):
+            errors.append(
+                _validation_error(
+                    f"secrets.{name}",
+                    "invalid_secret_source",
+                    'Use either {"generate":true} or {"env":"VARIABLE_NAME"}.',
+                )
+            )
+    return errors
+
+
+def _check(code: str, status: str, message: str) -> Dict[str, str]:
+    return {"code": code, "status": status, "message": message}
+
+
+def _compose_command() -> Optional[list[str]]:
+    candidates: list[list[str]] = []
+    if shutil.which("docker"):
+        candidates.append(["docker", "compose"])
+    if shutil.which("docker-compose"):
+        candidates.append(["docker-compose"])
+    for candidate in candidates:
+        try:
+            completed = subprocess.run(
+                [*candidate, "version"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if completed.returncode == 0:
+            return candidate
+    return None
+
+
+def _compose_available() -> bool:
+    return _compose_command() is not None
+
+
+def _command_result(command: list[str], *, timeout: int = 15) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(command, 1, "", type(exc).__name__)
+
+
+def _port_available(address: str, port: int) -> bool:
+    family = socket.AF_INET6 if ":" in address else socket.AF_INET
+    try:
+        with socket.socket(family, socket.SOCK_STREAM) as candidate:
+            candidate.bind((address, port))
+    except OSError:
+        return False
+    return True
+
+
+def preflight(config: Dict[str, Any], root: Path) -> Dict[str, Any]:
+    errors = validate_config(config)
+    if errors:
+        return {"command": "preflight", "status": "invalid", "errors": errors, "checks": []}
+
+    deployment = config["deployment"]
+    checks: list[Dict[str, str]] = []
+    architecture = platform.machine().lower()
+    checks.append(
+        _check(
+            "architecture_supported",
+            "pass" if architecture in SUPPORTED_ARCHITECTURES else "fail",
+            f"Host architecture is {architecture or 'unknown'}.",
+        )
+    )
+    if deployment["mode"] == "compose":
+        compose_available = _compose_available()
+        checks.append(
+            _check(
+                "docker_compose_available",
+                "pass" if compose_available else "fail",
+                (
+                    "Docker Compose is available."
+                    if compose_available
+                    else "Docker Compose is required."
+                ),
+            )
+        )
+        address = str(deployment.get("bindAddress", "127.0.0.1"))
+        port = int(deployment.get("port", 8080))
+        port_available = _port_available(address, port)
+        checks.append(
+            _check(
+                "listen_port_available",
+                "pass" if port_available else "fail",
+                (
+                    f"Listen address {address}:{port} is available."
+                    if port_available
+                    else f"Listen address {address}:{port} is already in use or unavailable."
+                ),
+            )
+        )
+    else:
+        helm = _command_result(["helm", "version", "--short"])
+        checks.append(
+            _check(
+                "helm_available",
+                "pass" if helm.returncode == 0 else "fail",
+                "Helm is available." if helm.returncode == 0 else "Helm is required.",
+            )
+        )
+        context = _command_result(["kubectl", "config", "current-context"])
+        context_name = context.stdout.strip()
+        checks.append(
+            _check(
+                "kubernetes_context_available",
+                "pass" if context.returncode == 0 and context_name else "fail",
+                (
+                    f"Kubernetes context is {context_name}."
+                    if context.returncode == 0 and context_name
+                    else "An active Kubernetes context is required."
+                ),
+            )
+        )
+        chart_path = (root / deployment.get("chartPath", "deploy/helm/dmarq")).resolve()
+        chart_available = (chart_path / "Chart.yaml").is_file()
+        checks.append(
+            _check(
+                "helm_chart_available",
+                "pass" if chart_available else "fail",
+                (
+                    f"DMARQ Helm chart is available at {chart_path}."
+                    if chart_available
+                    else f"DMARQ Helm chart is missing at {chart_path}."
+                ),
+            )
+        )
+        namespace = str(deployment.get("namespace", "dmarq"))
+        secret_name = str(deployment["existingSecret"])
+        secret = _command_result(
+            ["kubectl", "--namespace", namespace, "get", "secret", secret_name, "-o", "name"]
+        )
+        checks.append(
+            _check(
+                "kubernetes_secret_available",
+                "pass" if secret.returncode == 0 else "fail",
+                (
+                    f"Kubernetes Secret {namespace}/{secret_name} is available."
+                    if secret.returncode == 0
+                    else f"Kubernetes Secret {namespace}/{secret_name} must exist before install."
+                ),
+            )
+        )
+    checks.append(
+        _check(
+            "project_directory_writable",
+            "pass" if root.is_dir() and os.access(root, os.W_OK) else "fail",
+            (
+                f"Project directory {root} is writable."
+                if root.is_dir() and os.access(root, os.W_OK)
+                else f"Project directory {root} is missing or not writable."
+            ),
+        )
+    )
+    status = "ready" if all(item["status"] != "fail" for item in checks) else "blocked"
+    return {"command": "preflight", "status": status, "checks": checks, "errors": []}
+
+
+def _read_env_file(path: Path) -> tuple[list[str], Dict[str, str]]:
+    if not path.exists():
+        return [], {}
+    lines = path.read_text(encoding="utf-8").splitlines()
+    values: Dict[str, str] = {}
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        values[key] = value.strip().strip('"').strip("'")
+    return lines, values
+
+
+def _render_env(lines: Iterable[str], values: Dict[str, str]) -> str:
+    remaining = dict(values)
+    rendered: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            key = stripped.split("=", 1)[0]
+            if key in remaining:
+                rendered.append(f"{key}={_quote_env_value(remaining.pop(key), key)}")
+                continue
+        rendered.append(line)
+    if remaining:
+        if rendered and rendered[-1]:
+            rendered.append("")
+        rendered.append("# Managed by scripts/dmarqctl.py")
+        for key in sorted(remaining):
+            rendered.append(f"{key}={_quote_env_value(remaining[key], key)}")
+    return "\n".join(rendered).rstrip() + "\n"
+
+
+def _quote_env_value(value: str, key: str) -> str:
+    if any(character in value for character in ("\x00", "\n", "\r", "'")):
+        raise ControlError(
+            "environment_value_not_env_safe",
+            f"Environment value for {key} contains characters that cannot be preserved safely.",
+            EXIT_INVALID_CONFIG,
+        )
+    return f"'{value}'"
+
+
+def _resolve_secret(
+    config: Dict[str, Any],
+    config_key: str,
+    env_key: str,
+    existing: Dict[str, str],
+) -> str:
+    current = existing.get(env_key, "")
+    if current and current != PLACEHOLDERS[env_key]:
+        return current
+    source = config.get("secrets", {}).get(config_key, {"generate": True})
+    source_env = source.get("env") if isinstance(source, dict) else None
+    if source_env:
+        value = os.environ.get(source_env, "")
+        if not value:
+            raise ControlError(
+                "secret_environment_missing",
+                f"Required secret environment variable {source_env} is not set.",
+                EXIT_INVALID_CONFIG,
+            )
+        return value
+    return secrets.token_hex(32)
+
+
+def _write_environment(config: Dict[str, Any], root: Path) -> tuple[Path, bool]:
+    deployment = config["deployment"]
+    env_path = (root / str(deployment.get("envFile", ".env"))).resolve()
+    if not env_path.is_relative_to(root):
+        raise ControlError(
+            "environment_path_outside_project",
+            "The Compose environment file must stay inside the DMARQ project directory.",
+            EXIT_INVALID_CONFIG,
+        )
+    example_path = root / ".env.example"
+    if not env_path.exists() and not example_path.exists():
+        raise ControlError(
+            "environment_template_missing",
+            f"Environment template was not found at {example_path}.",
+            EXIT_OPERATION_FAILED,
+        )
+    source_path = env_path if env_path.exists() else example_path
+    lines, existing = _read_env_file(source_path)
+    product = config["product"]
+    database = config.get("database", {})
+    profile = product["profile"]
+    auth_mode = product.get("authentication", {}).get("mode", "disabled")
+    values = {
+        "DMARQ_ENV_FILE": str(env_path.relative_to(root)),
+        "DMARQ_BIND_ADDRESS": str(deployment.get("bindAddress", "127.0.0.1")),
+        "DMARQ_PORT": str(deployment.get("port", 8080)),
+        "DMARQ_IMAGE": str(deployment.get("image", DEFAULT_IMAGE)),
+        "PUBLIC_BASE_URL": str(deployment["publicBaseUrl"]).rstrip("/"),
+        "PROJECT_NAME": str(product.get("appName", "DMARQ")),
+        "LANGUAGE": str(product.get("language", "en")),
+        "AUTH_MODE": str(auth_mode),
+        "AUTH_DISABLED": "true" if auth_mode == "disabled" else "false",
+        "MULTI_WORKSPACE_UI_ENABLED": "true" if profile != "single-user" else "false",
+        "PROVIDER_BOOTSTRAP_DEFAULT_PLANS": "true" if profile == "provider" else "false",
+        "SECRET_KEY": _resolve_secret(config, "secretKey", "SECRET_KEY", existing),
+        "ADMIN_API_KEY": _resolve_secret(config, "adminApiKey", "ADMIN_API_KEY", existing),
+    }
+    database_mode = database.get("mode", "bundled")
+    if database_mode == "external":
+        url_env = database["urlEnv"]
+        database_url = os.environ.get(url_env, "")
+        if not database_url:
+            raise ControlError(
+                "database_url_environment_missing",
+                f"Required database URL environment variable {url_env} is not set.",
+                EXIT_INVALID_CONFIG,
+            )
+        values["DATABASE_URL"] = database_url
+    else:
+        database_name = str(database.get("name", "dmarq"))
+        database_user = str(database.get("user", "dmarq"))
+        database_password = _resolve_secret(
+            config, "databasePassword", "POSTGRES_PASSWORD", existing
+        )
+        values.update(
+            {
+                "POSTGRES_DB": database_name,
+                "POSTGRES_USER": database_user,
+                "POSTGRES_PASSWORD": database_password,
+                "DATABASE_URL": (
+                    "postgresql://"
+                    f"{quote(database_user, safe='')}:{quote(database_password, safe='')}"
+                    f"@db:5432/{quote(database_name, safe='')}"
+                ),
+            }
+        )
+
+    rendered = _render_env(lines, values)
+    unchanged = env_path.exists() and env_path.read_text(encoding="utf-8") == rendered
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    env_path.write_text(rendered, encoding="utf-8")
+    env_path.chmod(0o600)
+    return env_path, unchanged
+
+
+def _request_json(
+    base_url: str,
+    path: str,
+    *,
+    method: str = "GET",
+    payload: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    request = Request(
+        f"{base_url.rstrip('/')}{path}",
+        data=body,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urlopen(request, timeout=30) as response:  # noqa: S310 - operator URL.
+            raw = response.read()
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        raise ControlError(
+            "http_request_failed",
+            f"{method} {path} returned HTTP {exc.code}: {detail}",
+            EXIT_OPERATION_FAILED,
+        ) from exc
+    except (URLError, TimeoutError, OSError) as exc:
+        raise ControlError(
+            "instance_unreachable",
+            f"DMARQ instance could not be reached for {path}: {type(exc).__name__}.",
+            EXIT_NOT_READY,
+        ) from exc
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ControlError(
+            "invalid_json_response",
+            f"DMARQ returned an invalid JSON response for {path}.",
+            EXIT_OPERATION_FAILED,
+        ) from exc
+    return parsed if isinstance(parsed, dict) else {"value": parsed}
+
+
+def _start_compose(root: Path, env_path: Path) -> None:
+    env_arg = str(env_path.relative_to(root)) if env_path.is_relative_to(root) else str(env_path)
+    compose_command = _compose_command()
+    if not compose_command:
+        raise ControlError(
+            "docker_compose_unavailable",
+            "Docker Compose is required to start DMARQ.",
+            EXIT_PREFLIGHT_FAILED,
+        )
+    commands = (
+        [*compose_command, "--env-file", env_arg, "pull"],
+        [*compose_command, "--env-file", env_arg, "up", "-d", "--wait"],
+    )
+    for command in commands:
+        completed = subprocess.run(command, cwd=root, check=False, capture_output=True, text=True)
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout).strip().splitlines()[-1:]
+            raise ControlError(
+                "compose_failed",
+                f"Docker Compose failed: {detail[0] if detail else 'unknown error'}",
+                EXIT_OPERATION_FAILED,
+            )
+
+
+def _install_kubernetes(config: Dict[str, Any], root: Path) -> None:
+    deployment = config["deployment"]
+    product = config["product"]
+    image = str(deployment.get("image", DEFAULT_IMAGE))
+    if ":" not in image:
+        raise ControlError(
+            "image_tag_required",
+            "Kubernetes image must include an explicit tag.",
+            EXIT_INVALID_CONFIG,
+        )
+    image_repository, image_tag = image.rsplit(":", 1)
+    chart_path = (root / deployment.get("chartPath", "deploy/helm/dmarq")).resolve()
+    if not (chart_path / "Chart.yaml").is_file():
+        raise ControlError(
+            "helm_chart_missing",
+            f"DMARQ Helm chart was not found at {chart_path}.",
+            EXIT_OPERATION_FAILED,
+        )
+    values = {
+        "image": {"repository": image_repository, "tag": image_tag},
+        "existingSecret": deployment["existingSecret"],
+        "config": {
+            "projectName": product.get("appName", "DMARQ"),
+            "environment": "production",
+            "publicBaseUrl": deployment["publicBaseUrl"],
+            "language": product.get("language", "en"),
+            "profile": product["profile"],
+            "authMode": product.get("authentication", {}).get("mode", "disabled"),
+        },
+        "bootstrap": {"enabled": True, "ownerEmail": product["ownerEmail"]},
+        "postgresql": {"enabled": config.get("database", {}).get("mode", "bundled") == "bundled"},
+    }
+    values_file: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            prefix="dmarq-values-",
+            suffix=".json",
+            dir=root,
+            delete=False,
+        ) as handle:
+            json.dump(values, handle)
+            values_file = Path(handle.name)
+        values_file.chmod(0o600)
+        command = [
+            "helm",
+            "upgrade",
+            "--install",
+            str(deployment.get("releaseName", "dmarq")),
+            str(chart_path),
+            "--namespace",
+            str(deployment.get("namespace", "dmarq")),
+            "--create-namespace",
+            "--atomic",
+            "--wait",
+            "--wait-for-jobs",
+            "--timeout",
+            "15m",
+            "--values",
+            str(values_file),
+        ]
+        completed = _command_result(command, timeout=960)
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout).strip().splitlines()[-1:]
+            raise ControlError(
+                "helm_install_failed",
+                f"Helm install failed: {detail[0] if detail else 'unknown error'}",
+                EXIT_OPERATION_FAILED,
+            )
+    finally:
+        if values_file is not None:
+            values_file.unlink(missing_ok=True)
+
+
+def _complete_setup(config: Dict[str, Any]) -> bool:
+    base_url = str(config["deployment"]["publicBaseUrl"]).rstrip("/")
+    status = _request_json(base_url, "/api/v1/setup/status")
+    if status.get("is_setup_complete"):
+        return False
+    product = config["product"]
+    _request_json(
+        base_url,
+        "/api/v1/setup/admin",
+        method="POST",
+        payload={"email": product["ownerEmail"]},
+    )
+    _request_json(
+        base_url,
+        "/api/v1/setup/system",
+        method="POST",
+        payload={
+            "app_name": product.get("appName", "DMARQ"),
+            "base_url": base_url,
+            "cloudflare_enabled": False,
+        },
+    )
+    return True
+
+
+def bootstrap(
+    config: Dict[str, Any],
+    root: Path,
+    *,
+    start: bool,
+    setup_existing: bool = False,
+) -> Dict[str, Any]:
+    errors = validate_config(config)
+    if errors:
+        return {"command": "bootstrap", "status": "invalid", "errors": errors}
+    if config["deployment"]["mode"] == "kubernetes":
+        if not start or setup_existing:
+            raise ControlError(
+                "kubernetes_bootstrap_mode_invalid",
+                "Kubernetes bootstrap installs and configures the Helm release in one operation.",
+                EXIT_INVALID_CONFIG,
+            )
+        _install_kubernetes(config, root)
+        return {
+            "command": "bootstrap",
+            "status": "ready",
+            "deploymentMode": "kubernetes",
+            "releaseName": config["deployment"].get("releaseName", "dmarq"),
+            "namespace": config["deployment"].get("namespace", "dmarq"),
+            "image": config["deployment"].get("image", DEFAULT_IMAGE),
+            "publicBaseUrl": config["deployment"]["publicBaseUrl"],
+            "started": True,
+            "setupCompletedNow": True,
+            "errors": [],
+        }
+    env_path, unchanged = _write_environment(config, root)
+    setup_completed = False
+    if start:
+        if not _compose_available():
+            raise ControlError(
+                "docker_compose_unavailable",
+                "Docker Compose is required to start DMARQ.",
+                EXIT_PREFLIGHT_FAILED,
+            )
+        _start_compose(root, env_path)
+        setup_completed = _complete_setup(config)
+    elif setup_existing:
+        setup_completed = _complete_setup(config)
+    return {
+        "command": "bootstrap",
+        "status": "ready" if start or setup_existing else "configured",
+        "deploymentMode": "compose",
+        "environmentFile": str(env_path),
+        "environmentUnchanged": unchanged,
+        "image": config["deployment"].get("image", DEFAULT_IMAGE),
+        "publicBaseUrl": config["deployment"]["publicBaseUrl"],
+        "started": start,
+        "configuredExistingInstance": setup_existing,
+        "setupCompletedNow": setup_completed,
+        "errors": [],
+    }
+
+
+def status(config: Dict[str, Any]) -> Dict[str, Any]:
+    errors = validate_config(config)
+    if errors:
+        return {"command": "status", "status": "invalid", "errors": errors}
+    base_url = str(config["deployment"]["publicBaseUrl"]).rstrip("/")
+    health = _request_json(base_url, "/healthz")
+    setup = _request_json(base_url, "/api/v1/setup/status")
+    release = _request_json(base_url, "/api/v1/health/release")
+    ready = health.get("status") in {"ok", "healthy"} and bool(setup.get("is_setup_complete"))
+    return {
+        "command": "status",
+        "status": "ready" if ready else "attention",
+        "publicBaseUrl": base_url,
+        "health": health.get("status"),
+        "setupComplete": bool(setup.get("is_setup_complete")),
+        "domains": int(setup.get("total_domains") or 0),
+        "mailSources": int(setup.get("total_mail_sources") or 0),
+        "enabledMailSources": int(setup.get("enabled_mail_sources") or 0),
+        "release": {
+            "version": release.get("version"),
+            "image": release.get("image"),
+            "gitRef": release.get("git_ref"),
+        },
+        "errors": [],
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="dmarqctl")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG))
+    parser.add_argument("--root", type=Path, default=ROOT_DIR)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("preflight")
+    bootstrap_parser = subparsers.add_parser("bootstrap")
+    bootstrap_mode = bootstrap_parser.add_mutually_exclusive_group()
+    bootstrap_mode.add_argument("--no-start", action="store_true")
+    bootstrap_mode.add_argument("--setup-existing", action="store_true")
+    subparsers.add_parser("status")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        config = _load_config(args.config)
+        if args.command == "preflight":
+            result = preflight(config, args.root.resolve())
+            exit_code = EXIT_OK if result["status"] == "ready" else EXIT_PREFLIGHT_FAILED
+            if result["status"] == "invalid":
+                exit_code = EXIT_INVALID_CONFIG
+        elif args.command == "bootstrap":
+            result = bootstrap(
+                config,
+                args.root.resolve(),
+                start=not args.no_start and not args.setup_existing,
+                setup_existing=args.setup_existing,
+            )
+            exit_code = EXIT_OK if result["status"] != "invalid" else EXIT_INVALID_CONFIG
+        else:
+            result = status(config)
+            exit_code = EXIT_OK if result["status"] == "ready" else EXIT_NOT_READY
+            if result["status"] == "invalid":
+                exit_code = EXIT_INVALID_CONFIG
+    except ControlError as exc:
+        result = {
+            "command": args.command,
+            "status": "error",
+            "error": {"code": exc.code, "message": str(exc)},
+        }
+        exit_code = exc.exit_code
+    _emit(result, as_json=args.as_json)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-greenfield-product.py
+++ b/scripts/verify-greenfield-product.py
@@ -123,6 +123,10 @@ def _initialize(base_url: str, fixture: Path, owner_email: str) -> None:
         },
     )
 
+    _import_fixture(base_url, fixture)
+
+
+def _import_fixture(base_url: str, fixture: Path) -> None:
     uploaded = _upload_fixture(base_url, fixture)
     assert uploaded["success"] is True
     assert uploaded["domain"] == "example.com"
@@ -139,6 +143,7 @@ def main() -> int:
     parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE)
     parser.add_argument("--owner-email", default="greenfield-test@dmarq.org")
     parser.add_argument("--verify-existing", action="store_true")
+    parser.add_argument("--configured", action="store_true")
     args = parser.parse_args()
 
     if not args.verify_existing and not args.fixture.is_file():
@@ -148,6 +153,12 @@ def main() -> int:
         if args.verify_existing:
             _assert_persisted_product_state(args.base_url)
             print("Greenfield product persistence verified.")
+        elif args.configured:
+            status = _request(args.base_url, "/api/v1/setup/status")
+            assert status["is_setup_complete"] is True
+            assert status["total_domains"] == 0
+            _import_fixture(args.base_url, args.fixture)
+            print("Configured greenfield fixture import and totals verified.")
         else:
             _initialize(args.base_url, args.fixture, args.owner_email)
             print("Greenfield setup, fixture import, totals, and duplicate handling verified.")


### PR DESCRIPTION
## What changed

- add a versioned machine-readable install contract for Compose and Kubernetes
- add `dmarqctl` preflight, idempotent bootstrap, browserless setup, and readiness status
- add a supported Helm chart with existing-Secret references, bundled or external PostgreSQL, persistence, ingress, probes, and an idempotent setup Job
- add a provisioner-free Terraform module plus examples and locked acceptance roots
- add a disposable Kind lifecycle gate covering apply, setup, upgrade, drift, and destroy
- update Docker Compose, greenfield verification, README, deployment docs, navigation, and changelog

## Why

DMARQ should be installable deterministically by a fresh operator or automation agent without hidden project knowledge. Kubernetes and Terraform paths must preserve the same image and product setup contract while keeping raw credentials out of chart values, Terraform state, logs, and machine-readable output.

## Local validation

- 2,009 backend tests passed
- 16 focused `dmarqctl` tests passed
- Black and Flake8 passed for the new Python surfaces
- Compose bootstrap/preflight and Compose contract passed on a fresh temporary directory
- both install examples passed JSON Schema Draft 2020-12 validation
- Helm lint, deterministic render, unsafe-production rejection, and Kubernetes client dry-run passed
- Terraform module and example validation passed with Terraform 1.12.2 / Helm provider 3.2.0
- strict MkDocs build passed
- staged diff and workflow YAML checks passed

## Release note

The previously merged sender ASN/country fix is still waiting for the existing main release workflow: GitHub Actions currently returns HTTP 503 and the 1.172.4 image has not been published, so all live deployments remain on 1.172.3. This PR does not bypass that release gate.

Closes #794
Closes #795
Closes #796
Closes #797
Closes #798
Closes #799
Closes #800
Closes #801