### PR TITLE
Degrade unavailable enterprise DNS profiles safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Made a selected but unconfigured Akamai ETP, Infoblox, or custom DNS profile
+  explicitly degrade to Public DNS for read-only lookups. Settings and setup
+  now show the deployment configuration still required, while domain DNS and
+  DANE checks retain fallback evidence instead of failing with HTTP 500.
 - Kept the bundled PostgreSQL workload least-privileged but bootable by granting
   only the five capabilities required by the official Alpine image to prepare
   its data directory and drop from root to the `postgres` user.

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -30,6 +30,7 @@ from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.setting import Setting
 from app.services.account_milestone import build_account_milestone_readiness
+from app.services.dns_resolver import resolver_profile_status
 from app.services.ai_assistance import AI_DEFAULTS
 from app.services.alert_history import (
     list_alert_config_audit,
@@ -596,6 +597,18 @@ class SettingResponse(BaseModel):
     updated_at: Optional[str]
 
 
+class DNSResolverStatusResponse(BaseModel):
+    """Runtime readiness of the selected DNS resolver profile."""
+
+    selected_resolver: str
+    selected_label: str
+    status: str
+    configured: bool
+    active_resolver: str
+    message: str
+    required_configuration: List[str]
+
+
 class NotificationTestResponse(BaseModel):
     """Sanitized response from a test notification send."""
 
@@ -1053,6 +1066,16 @@ async def get_account_milestone_readiness(
 ) -> AccountReadinessResponse:
     """Return the #12 account/auth/provider milestone readiness summary."""
     return build_account_milestone_readiness(db, get_settings())
+
+
+@router.get("/dns/resolver-status", response_model=DNSResolverStatusResponse)
+async def get_dns_resolver_status(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+) -> DNSResolverStatusResponse:
+    """Expose resolver readiness without exposing deployment secret values."""
+    _seed_defaults(db)
+    return DNSResolverStatusResponse(**resolver_profile_status(db))
 
 
 @router.get("/{key:path}", response_model=SettingResponse)

--- a/backend/app/api/api_v1/endpoints/setup.py
+++ b/backend/app/api/api_v1/endpoints/setup.py
@@ -13,6 +13,7 @@ from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
 from app.models.setting import Setting
 from app.services.mailbox_recovery import import_row_diagnostic, not_configured_guidance
+from app.services.dns_resolver import resolver_profile_status
 
 router = APIRouter()
 
@@ -102,6 +103,7 @@ class SetupStatusResponse(BaseModel):
     total_mail_sources: int = 0
     enabled_mail_sources: int = 0
     mailbox_recovery_hint: Optional[Dict[str, Any]] = None
+    dns_resolver: Dict[str, Any]
 
 
 class AdminSetupRequest(BaseModel):
@@ -167,6 +169,7 @@ async def get_setup_status(db: Session = Depends(get_db)):
         total_mail_sources=total_mail_sources,
         enabled_mail_sources=enabled_mail_sources,
         mailbox_recovery_hint=mailbox_recovery_hint,
+        dns_resolver=resolver_profile_status(db),
     )
 
 

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
 from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS
+from app.services.dns_fallbacks import dns_fallback_candidates
 from app.services.dns_resolver import BaseDNSProvider
 
 _CACHE_KEY = "dane-v1"
@@ -431,6 +432,33 @@ async def check_dane(
     return result
 
 
+async def check_dane_with_fallback(
+    domain: str,
+    provider: BaseDNSProvider,
+    *,
+    port: int = 25,
+    derive_suggestions: bool = False,
+) -> DANEResult:
+    """Check DANE through independent public DNS if the selected resolver fails."""
+    last_error: Optional[LookupError] = None
+    for candidate in dns_fallback_candidates(provider):
+        try:
+            return await check_dane(
+                domain,
+                candidate,
+                port=port,
+                derive_suggestions=derive_suggestions,
+            )
+        except LookupError as exc:
+            last_error = exc
+    result = DANEResult(port=port)
+    result.errors.append(
+        "DANE/TLSA DNS lookup failed for all configured resolvers"
+        + (f": {last_error}" if last_error else ".")
+    )
+    return result
+
+
 async def check_dane_cached(
     db: Session,
     provider: BaseDNSProvider,
@@ -460,7 +488,7 @@ async def check_dane_cached(
     if row and not refresh and _is_fresh(row, ttl_seconds, now):
         return _result_from_json(row.result_json), True, row.checked_at
 
-    result = await check_dane(
+    result = await check_dane_with_fallback(
         normalized_domain,
         provider,
         port=port,

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -18,7 +18,7 @@ from app.services.dns_fallbacks import dns_fallback_candidates
 from app.services.dns_provider_detection import detection_from_json
 from app.services.dns_resolver import (
     BaseDNSProvider,
-    CloudflareDNSProvider,
+    ConfiguredRecursiveDNSProvider,
     DomainDNSResult,
     PublicRecursiveDNSProvider,
     SystemDNSProvider,
@@ -314,8 +314,14 @@ async def _resolve_with_fallback(  # noqa: C901
 ) -> DomainDNSResult:
     """Resolve DNS, checking independent resolvers before accepting an empty result."""
     provider = _normalize_dns_provider(provider)
-    if not isinstance(provider, (PublicRecursiveDNSProvider, CloudflareDNSProvider)):
+    if not isinstance(
+        provider,
+        (PublicRecursiveDNSProvider, ConfiguredRecursiveDNSProvider),
+    ):
         return await provider.check_domain(domain, selectors=selectors)
+
+    if isinstance(provider, ConfiguredRecursiveDNSProvider):
+        return await _resolve_configured_with_fallback(provider, domain, selectors=selectors)
 
     first_empty_result: Optional[DomainDNSResult] = None
     resolver_errors: List[str] = []
@@ -347,11 +353,16 @@ async def _resolve_with_fallback(  # noqa: C901
                 continue
 
             if _has_dns_evidence(result):
-                return _fallback_result(
+                resolved = _fallback_result(
                     result,
                     task_name=task_name,
                     primary_name=provider.__class__.__name__,
                 )
+                degradation_message = getattr(provider, "degradation_message", None)
+                if degradation_message:
+                    resolved.lookup_status = "fallback"
+                    resolved.lookup_error = degradation_message
+                return resolved
 
             if first_empty_result is None:
                 first_empty_result = result
@@ -362,6 +373,55 @@ async def _resolve_with_fallback(  # noqa: C901
     if empty_result is not None:
         return empty_result
 
+    raise LookupError(
+        "All DNS resolvers failed: " + ", ".join(resolver_errors or ["no resolver attempted"])
+    )
+
+
+async def _resolve_configured_with_fallback(  # noqa: C901
+    provider: ConfiguredRecursiveDNSProvider,
+    domain: str,
+    *,
+    selectors: List[str],
+) -> DomainDNSResult:
+    """Prefer a configured private resolver before trying public evidence."""
+    first_empty_result: Optional[DomainDNSResult] = None
+    resolver_errors: List[str] = []
+
+    try:
+        primary_result = await provider.check_domain(domain, selectors=selectors)
+        if _has_dns_evidence(primary_result):
+            return primary_result
+        first_empty_result = primary_result
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        resolver_errors.append(f"{provider.__class__.__name__}:{exc.__class__.__name__}")
+        logger.debug(
+            "Configured DNS resolver %s failed with %s",
+            provider.__class__.__name__,
+            exc.__class__.__name__,
+        )
+
+    for candidate in _fallback_candidates(provider)[1:]:
+        _name, result, error = await _run_dns_candidate(candidate, domain, selectors=selectors)
+        if error is not None:
+            resolver_errors.append(f"{_name}:{error.__class__.__name__}")
+            continue
+        if result is None:
+            continue
+        if _has_dns_evidence(result):
+            return _fallback_result(
+                result,
+                task_name=_name,
+                primary_name=provider.__class__.__name__,
+            )
+        if first_empty_result is None:
+            first_empty_result = result
+
+    empty_result = _empty_fallback_result(first_empty_result, resolver_errors)
+    if empty_result is not None:
+        return empty_result
     raise LookupError(
         "All DNS resolvers failed: " + ", ".join(resolver_errors or ["no resolver attempted"])
     )

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -810,6 +810,11 @@ class ConfiguredRecursiveDNSProvider(PublicRecursiveDNSProvider):
         self.dot_hostname = dot_hostname
         self.proxy_chaining_url = proxy_chaining_url
 
+    @property
+    def is_ready(self) -> bool:
+        """Whether this profile has a usable DNS or DoH endpoint."""
+        return bool(self.nameservers or self.doh_hostname)
+
     def _resolver(self) -> Any:
         if not self.nameservers:
             if self.doh_hostname:
@@ -936,6 +941,25 @@ class CustomDNSProvider(ConfiguredRecursiveDNSProvider):
     """Operator-defined recursive resolver profile supplied by deployment secrets."""
 
     provider_label = "Custom DNS"
+
+
+class DegradedResolverDNSProvider(PublicRecursiveDNSProvider):
+    """Public DNS fallback for a selected but unavailable resolver profile.
+
+    The selected profile remains visible through ``selected_resolver`` and
+    ``degradation_message``.  This avoids turning a deployment-secret mistake
+    into missing DNS evidence or an HTTP 500 in read-only workflows.
+    """
+
+    provider_label = "Public DNS fallback"
+
+    def __init__(self, *, selected_resolver: str, selected_label: str) -> None:
+        self.selected_resolver = selected_resolver
+        self.selected_label = selected_label
+        self.degradation_message = (
+            f"{selected_label} is selected but is not configured in this deployment; "
+            "using Public DNS (1.1.1.1 and 8.8.8.8)."
+        )
 
 
 class CloudflareDNSProvider(BaseDNSProvider):
@@ -1471,7 +1495,74 @@ def _setting_value(db: Any, key: str) -> Optional[str]:
         return None
 
 
-def get_default_provider(db: Any = None) -> BaseDNSProvider:
+_RESOLVER_PROFILE_LABELS = {
+    "public": "Public DNS",
+    "cloudflare": "Cloudflare DoH",
+    "quad9": "Quad9 secure DNS",
+    "opendns": "OpenDNS / Cisco Umbrella",
+    "dns4eu_unfiltered": "DNS4EU unfiltered",
+    "dns4eu_protective": "DNS4EU protective",
+    "akamai_etp": "Akamai ETP DNS",
+    "infoblox": "Infoblox DNS",
+    "custom": "Custom DNS",
+}
+
+
+def resolver_profile_status(db: Any = None) -> Dict[str, Any]:
+    """Describe the selected resolver and whether deployment config is ready.
+
+    Enterprise profiles are configured by deployment environment variables or
+    Kubernetes Secrets, never from the browser.  A missing profile therefore
+    degrades to Public DNS and is surfaced explicitly to settings and setup.
+    """
+    from app.core.config import get_settings
+
+    settings = get_settings()
+    selected = (_setting_value(db, "dns.resolver") or "public").strip().lower()
+    if selected not in _RESOLVER_PROFILE_LABELS:
+        selected = "public"
+
+    configured = True
+    required_configuration: List[str] = []
+    if selected == "akamai_etp":
+        configured = bool(settings.AKAMAI_ETP_DNS_SERVERS or settings.AKAMAI_ETP_DOH_HOSTNAME)
+        required_configuration = ["AKAMAI_ETP_DNS_SERVERS or AKAMAI_ETP_DOH_HOSTNAME"]
+    elif selected == "infoblox":
+        configured = bool(settings.INFOBLOX_DNS_SERVERS or settings.INFOBLOX_DOH_HOSTNAME)
+        required_configuration = ["INFOBLOX_DNS_SERVERS or INFOBLOX_DOH_HOSTNAME"]
+    elif selected == "custom":
+        configured = bool(
+            settings.DMARQ_DNS_CUSTOM_SERVERS or settings.DMARQ_DNS_CUSTOM_DOH_HOSTNAME
+        )
+        required_configuration = ["DMARQ_DNS_CUSTOM_SERVERS or DMARQ_DNS_CUSTOM_DOH_HOSTNAME"]
+
+    label = _RESOLVER_PROFILE_LABELS[selected]
+    if configured:
+        return {
+            "selected_resolver": selected,
+            "selected_label": label,
+            "status": "ready",
+            "configured": True,
+            "active_resolver": label,
+            "message": f"{label} is ready for DNS lookups.",
+            "required_configuration": required_configuration,
+        }
+
+    return {
+        "selected_resolver": selected,
+        "selected_label": label,
+        "status": "degraded",
+        "configured": False,
+        "active_resolver": "Public DNS (1.1.1.1 and 8.8.8.8)",
+        "message": (
+            f"{label} is selected but this deployment has no resolver endpoint. "
+            "Read-only DNS checks are using Public DNS until the deployment configuration is added."
+        ),
+        "required_configuration": required_configuration,
+    }
+
+
+def get_default_provider(db: Any = None) -> BaseDNSProvider:  # noqa: C901
     """Return the configured default DNS provider."""
     from app.core.config import get_settings
 
@@ -1489,24 +1580,39 @@ def get_default_provider(db: Any = None) -> BaseDNSProvider:
     if resolver == "dns4eu_protective":
         return DNS4EUProtectiveDNSProvider()
     if resolver == "infoblox":
-        return InfobloxDNSProvider(
+        provider = InfobloxDNSProvider(
             nameservers=_parse_csv_setting(settings.INFOBLOX_DNS_SERVERS),
             doh_hostname=settings.INFOBLOX_DOH_HOSTNAME,
             dot_hostname=settings.INFOBLOX_DOT_HOSTNAME,
         )
+        if not provider.is_ready:
+            return DegradedResolverDNSProvider(
+                selected_resolver=resolver, selected_label=_RESOLVER_PROFILE_LABELS[resolver]
+            )
+        return provider
     if resolver == "custom":
-        return CustomDNSProvider(
+        provider = CustomDNSProvider(
             nameservers=_parse_csv_setting(settings.DMARQ_DNS_CUSTOM_SERVERS),
             doh_hostname=settings.DMARQ_DNS_CUSTOM_DOH_HOSTNAME,
             dot_hostname=settings.DMARQ_DNS_CUSTOM_DOT_HOSTNAME,
         )
+        if not provider.is_ready:
+            return DegradedResolverDNSProvider(
+                selected_resolver=resolver, selected_label=_RESOLVER_PROFILE_LABELS[resolver]
+            )
+        return provider
     if resolver == "akamai_etp":
-        return AkamaiETPDNSProvider(
+        provider = AkamaiETPDNSProvider(
             nameservers=_parse_csv_setting(settings.AKAMAI_ETP_DNS_SERVERS),
             doh_hostname=settings.AKAMAI_ETP_DOH_HOSTNAME,
             dot_hostname=settings.AKAMAI_ETP_DOT_HOSTNAME,
             proxy_chaining_url=settings.AKAMAI_ETP_PROXY_CHAINING_URL,
         )
+        if not provider.is_ready:
+            return DegradedResolverDNSProvider(
+                selected_resolver=resolver, selected_label=_RESOLVER_PROFILE_LABELS[resolver]
+            )
+        return provider
     if resolver == "cloudflare":
         api_token = _decrypt_setting_value(_setting_value(db, "cloudflare.api_token"))
         zone_id = _setting_value(db, "cloudflare.zone_id")

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -50,6 +50,7 @@ function settingsApp() {
         testingAIConnection: false,
         loadingAccountReadiness: false,
         accountReadiness: null,
+        resolverStatus: null,
         aiProviderProfiles: [],
         aiConnectionResult: null,
         aiModels: [],
@@ -207,6 +208,7 @@ function settingsApp() {
                 rows.forEach(r => { map[r.key] = r.value ?? ''; });
                 this.s = map;
                 this.applyCloudflareOAuthQueryState();
+                await this.loadResolverStatus(false);
                 await this.loadAlertHistory(false);
                 await this.loadConfigAudit(false);
                 await this.loadWebhooks(false);
@@ -233,6 +235,19 @@ function settingsApp() {
                 if (showFlash) this.showFlash('Error loading account readiness: ' + err.message, false);
             } finally {
                 this.loadingAccountReadiness = false;
+            }
+        },
+
+        async loadResolverStatus(showFlash = true) {
+            try {
+                const res = await fetch('/api/v1/settings/dns/resolver-status', { headers: this.apiHeaders() });
+                if (!res.ok) {
+                    if (showFlash) this.showFlash('Failed to load DNS resolver status: ' + res.statusText, false);
+                    return;
+                }
+                this.resolverStatus = await res.json();
+            } catch (err) {
+                if (showFlash) this.showFlash('Error loading DNS resolver status: ' + err.message, false);
             }
         },
 
@@ -304,6 +319,9 @@ function settingsApp() {
                     rows.forEach(r => { this.s[r.key] = r.value ?? ''; });
                     if (category === 'notifications') {
                         await this.loadConfigAudit(false);
+                    }
+                    if (category === 'dns') {
+                        await this.loadResolverStatus(false);
                     }
                     this.showFlash('Settings saved successfully.', true);
                 }

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -318,6 +318,15 @@
                     </select>
                     <label class="label"><span class="label-text-alt text-muted-foreground">All profiles bypass the host resolver. Enterprise and custom profiles use resolver values supplied by environment or secret configuration.</span></label>
                 </div>
+                <div x-show="resolverStatus" x-cloak
+                    class="rounded-md border p-3 text-sm"
+                    :class="resolverStatus?.status === 'degraded' ? 'border-amber-300 bg-amber-50 text-amber-950' : 'border-emerald-200 bg-emerald-50 text-emerald-950'">
+                    <p class="font-medium" x-text="resolverStatus?.status === 'degraded' ? 'Using safe DNS fallback' : 'Resolver ready'"></p>
+                    <p class="mt-1" x-text="resolverStatus?.message"></p>
+                    <p class="mt-2 text-xs" x-show="resolverStatus?.status === 'degraded'">
+                        Add <span class="font-mono" x-text="(resolverStatus?.required_configuration || []).join(', ')"></span> to this deployment, then save or refresh this page to use the selected resolver.
+                    </p>
+                </div>
                 {{ save_footer("Resolver changes affect DNS linting, cache refreshes, and remediation evidence.", "Save DNS Settings") }}
             </form>
         {% endcall %}

--- a/backend/app/tests/test_dane.py
+++ b/backend/app/tests/test_dane.py
@@ -7,6 +7,7 @@ from app.services.dane import (
     _derive_tlsa_suggestions,
     check_dane,
     check_dane_cached,
+    check_dane_with_fallback,
     parse_tlsa_record,
 )
 from app.services.dns_resolver import BaseDNSProvider
@@ -78,6 +79,22 @@ async def test_check_dane_requires_mx_hosts():
     assert result.status == "fail"
     assert result.records == []
     assert result.errors == ["No MX hosts were found for DANE/TLSA evaluation."]
+
+
+@pytest.mark.asyncio
+async def test_check_dane_falls_back_after_selected_resolver_failure(monkeypatch):
+    unavailable = FakeDANEDNSProvider()
+    unavailable.lookup_mx = AsyncMock(side_effect=LookupError("resolver not configured"))
+    fallback = FakeDANEDNSProvider(mx_hosts=["mx.example.com"])
+    monkeypatch.setattr(
+        "app.services.dane.dns_fallback_candidates", lambda _provider: [unavailable, fallback]
+    )
+
+    result = await check_dane_with_fallback("example.com", unavailable)
+
+    assert result.mx_hosts == ["mx.example.com"]
+    unavailable.lookup_mx.assert_awaited_once()
+    fallback.lookup_mx.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1405,6 +1405,7 @@ async def test_dns_cache_allows_old_positive_evidence_to_expire(db_session):
 async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_session):
     """A primary resolver with no evidence should not force a false F grade."""
     primary_provider = PublicRecursiveDNSProvider()
+    fallback_provider = CloudflareDNSProvider()
     primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
     fallback_result = DomainDNSResult(
         dmarc=True,
@@ -1418,7 +1419,12 @@ async def test_dns_cache_uses_public_fallback_for_empty_primary_result(db_sessio
     with (
         patch.object(primary_provider, "check_domain", new=primary_check),
         patch(
-            "app.services.dns_cache.CloudflareDNSProvider.check_domain",
+            "app.services.dns_cache._fallback_candidates",
+            return_value=[primary_provider, fallback_provider],
+        ),
+        patch.object(
+            fallback_provider,
+            "check_domain",
             new=AsyncMock(return_value=fallback_result),
         ) as cloudflare_fallback,
     ):
@@ -1488,15 +1494,17 @@ async def test_dns_cache_replaces_system_provider_with_public_resolver(db_sessio
 async def test_dns_cache_propagates_fallback_cancellation(db_session):
     """Request cancellation must not be swallowed by defensive fallback handling."""
     primary_provider = PublicRecursiveDNSProvider()
+    fallback_provider = CloudflareDNSProvider()
     primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
     fallback_check = AsyncMock(side_effect=asyncio.CancelledError())
 
     with (
         patch.object(primary_provider, "check_domain", new=primary_check),
         patch(
-            "app.services.dns_cache.CloudflareDNSProvider.check_domain",
-            new=fallback_check,
+            "app.services.dns_cache._fallback_candidates",
+            return_value=[primary_provider, fallback_provider],
         ),
+        patch.object(fallback_provider, "check_domain", new=fallback_check),
         pytest.raises(asyncio.CancelledError),
     ):
         await resolve_domain_dns_cached(
@@ -1515,6 +1523,7 @@ async def test_dns_cache_fallback_failure_log_omits_user_values(db_session, capl
     """Fallback failure logging should not echo domains or exception messages."""
     domain = "bad.example\nforged-log-line"
     primary_provider = PublicRecursiveDNSProvider()
+    fallback_provider = CloudflareDNSProvider()
     primary_check = AsyncMock(return_value=DomainDNSResult(dmarc=False, spf=False, dkim=False))
     fallback_check = AsyncMock(side_effect=RuntimeError(f"resolver failed for {domain}"))
     caplog.set_level(logging.DEBUG, logger="app.services.dns_cache")
@@ -1522,9 +1531,10 @@ async def test_dns_cache_fallback_failure_log_omits_user_values(db_session, capl
     with (
         patch.object(primary_provider, "check_domain", new=primary_check),
         patch(
-            "app.services.dns_cache.CloudflareDNSProvider.check_domain",
-            new=fallback_check,
+            "app.services.dns_cache._fallback_candidates",
+            return_value=[primary_provider, fallback_provider],
         ),
+        patch.object(fallback_provider, "check_domain", new=fallback_check),
     ):
         result, cached, _checked = await resolve_domain_dns_cached(
             db_session,

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -13,11 +13,13 @@ import pytest
 from app.core.config import get_settings
 from app.core.credential_encryption import encrypt_secret
 from app.models.setting import Setting
+from app.services.dns_cache import _resolve_with_fallback
 from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import (
     AkamaiETPDNSProvider,
     BaseDNSProvider,
     CloudflareDNSProvider,
+    DegradedResolverDNSProvider,
     ConfiguredRecursiveDNSProvider,
     CustomDNSProvider,
     DemoDNSProvider,
@@ -1064,6 +1066,48 @@ def test_get_default_provider_uses_akamai_etp_env_profile(db_session, monkeypatc
     assert provider.doh_hostname == "resolver.example.test"
     assert provider.dot_hostname == "dot-resolver.example.test"
     assert provider.proxy_chaining_url == "https://proxy.example.test:443"
+
+
+@pytest.mark.anyio
+async def test_get_default_provider_degrades_missing_akamai_profile_to_public_dns(
+    db_session, monkeypatch
+):
+    db_session.add(Setting(key="dns.resolver", value="akamai_etp", category="dns"))
+    db_session.commit()
+    monkeypatch.delenv("AKAMAI_ETP_DNS_SERVERS", raising=False)
+    monkeypatch.delenv("AKAMAI_ETP_DOH_HOSTNAME", raising=False)
+    get_settings.cache_clear()
+    lookup_mx = AsyncMock(return_value=["mx.example.test"])
+    monkeypatch.setattr(PublicRecursiveDNSProvider, "lookup_mx", lookup_mx)
+
+    try:
+        provider = get_default_provider(db_session)
+        result = await provider.lookup_mx("example.test")
+    finally:
+        get_settings.cache_clear()
+
+    assert isinstance(provider, DegradedResolverDNSProvider)
+    assert provider.selected_resolver == "akamai_etp"
+    assert "Akamai ETP" in provider.degradation_message
+    assert result == ["mx.example.test"]
+    lookup_mx.assert_awaited_once_with("example.test")
+
+
+@pytest.mark.anyio
+async def test_configured_resolver_keeps_first_priority_before_public_fallback(monkeypatch):
+    provider = AkamaiETPDNSProvider(nameservers=["192.0.2.53"])
+    provider.check_domain = AsyncMock(
+        return_value=DomainDNSResult(dmarc=True, dmarc_record="v=DMARC1; p=none")
+    )
+    monkeypatch.setattr(
+        "app.services.dns_cache.dns_fallback_candidates",
+        lambda _provider: (_ for _ in ()).throw(AssertionError("fallback should not be called")),
+    )
+
+    result = await _resolve_with_fallback(provider, "example.test", selectors=[])
+
+    assert result.dmarc is True
+    provider.check_domain.assert_awaited_once_with("example.test", selectors=[])
 
 
 def test_get_default_provider_uses_infoblox_env_profile(db_session, monkeypatch):

--- a/backend/app/tests/test_settings.py
+++ b/backend/app/tests/test_settings.py
@@ -136,6 +136,26 @@ class TestSettingsAPI:
         assert "forensics.redaction_mode" in keys
         assert "forensics.redact_long_tokens_enabled" in keys
 
+    def test_resolver_status_marks_missing_enterprise_profile_degraded(
+        self, authed_client: TestClient, db_session: Session, monkeypatch
+    ):
+        monkeypatch.delenv("AKAMAI_ETP_DNS_SERVERS", raising=False)
+        monkeypatch.delenv("AKAMAI_ETP_DOH_HOSTNAME", raising=False)
+        db_session.add(Setting(key="dns.resolver", value="akamai_etp", category="dns"))
+        db_session.commit()
+
+        response = authed_client.get("/api/v1/settings/dns/resolver-status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["selected_resolver"] == "akamai_etp"
+        assert data["status"] == "degraded"
+        assert data["configured"] is False
+        assert data["active_resolver"] == "Public DNS (1.1.1.1 and 8.8.8.8)"
+        assert data["required_configuration"] == [
+            "AKAMAI_ETP_DNS_SERVERS or AKAMAI_ETP_DOH_HOSTNAME"
+        ]
+
     def test_account_readiness_endpoint_summarizes_milestone_12(
         self,
         authed_client: TestClient,

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -35,6 +35,7 @@ class TestSetupStatus:
         data = response.json()
         assert data["is_setup_complete"] is False
         assert data["app_name"] == "DMARQ"
+        assert data["dns_resolver"]["status"] == "ready"
 
     def test_status_after_system_setup(self, client: TestClient):
         client.post(

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -213,6 +213,14 @@ matching resolver profile in DMARQ settings and inject the assigned resolver
 values through your secret manager. These values may be account-specific and
 should not be committed.
 
+If an enterprise or custom profile is selected before its deployment values are
+available, DMARQ keeps that selection visible as **degraded** and uses Public
+DNS (`1.1.1.1` and `8.8.8.8`) for read-only checks. The Settings page and
+`GET /api/v1/settings/dns/resolver-status` identify the selected profile, the
+active fallback, and the exact environment variable pair required to restore
+the private resolver. This prevents DNS linting, DANE, and remediation
+evidence from failing solely because a deployment secret is absent.
+
 ### Mail Authentication Defaults
 
 The Settings page includes DMARC defaults used by domain-level DNS guidance and


### PR DESCRIPTION
## What changed
- expose resolver readiness through Settings and setup status without revealing deployment secrets
- keep a selected Akamai ETP, Infoblox, or custom profile visible as degraded when its resolver endpoint is absent
- use Public DNS for read-only checks in that state and preserve fallback evidence
- retain configured enterprise resolver priority; only use public resolvers after an error or empty evidence
- add DANE fallback coverage and operator documentation

## Root cause
A persisted enterprise resolver selection could create a provider with no DNS or DoH endpoint. Some direct DNS workflows then raised LookupError instead of returning actionable evidence.

## Validation
- Black and Flake8 on all touched Python files
- 217 focused resolver, DANE, Settings, setup, and AI/remediation tests passed
- full suite was started; its existing long-running browser/demo section did not complete in this workstation session

Closes #793