### PR TITLE
fix: bound report-detail enrichment and dedupe PTR lookups

### DIFF
--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -655,6 +655,18 @@ class ReportSummaryDetail(BaseModel):
     pass_rate: float
 
 
+class ReportEnrichmentStatus(BaseModel):
+    """Bounded enrichment outcome for report-detail progressive hydration."""
+
+    status: str = "complete"
+    pending: bool = False
+    ptr: str = "complete"
+    network: str = "complete"
+    reputation: str = "complete"
+    unique_source_ips: int = 0
+    record_count: int = 0
+
+
 class ReportDetail(BaseModel):
     """Full detail of a single DMARC report"""
 
@@ -670,6 +682,7 @@ class ReportDetail(BaseModel):
     records: List[ReportRecordDetail]
     summary: ReportSummaryDetail
     reputation_summary: Dict[str, Any] = Field(default_factory=dict)
+    enrichment: ReportEnrichmentStatus = Field(default_factory=ReportEnrichmentStatus)
 
 
 def _record_review_guidance(record: Dict[str, Any]) -> Dict[str, Any]:
@@ -722,6 +735,133 @@ async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Opti
         return await asyncio.wait_for(provider.lookup_ptr(ip), timeout=timeout)
     except Exception:
         return None
+
+
+def _unique_source_ips(ips: List[str]) -> List[str]:
+    """Preserve first-seen order while collapsing duplicate report-row IPs."""
+    return list(dict.fromkeys(ips))
+
+
+async def _ptr_lookups_by_ip(
+    provider: Any,
+    unique_ips: List[str],
+    *,
+    concurrency: int = 20,
+) -> Dict[str, Optional[str]]:
+    """Resolve PTR hostnames once per unique IP with bounded concurrency."""
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+
+    async def _lookup(ip: str) -> tuple[str, Optional[str]]:
+        async with semaphore:
+            return ip, await _safe_ptr_lookup(provider, ip)
+
+    pairs = await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
+    return dict(pairs)
+
+
+async def _report_networks_by_ip(
+    db: Session,
+    provider: Any,
+    unique_ips: List[str],
+    settings: Any,
+) -> tuple[Dict[str, SourceNetworkIntelligence], str]:
+    """Batch network enrichment with a hard detail-path timeout."""
+    if not settings.SOURCE_NETWORK_ENRICHMENT_ENABLED:
+        return {}, "disabled"
+    try:
+        networks = await asyncio.wait_for(
+            lookup_sources_network_cached(
+                db,
+                provider,
+                unique_ips,
+                ttl_seconds=settings.SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS,
+                max_ips=settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS,
+            ),
+            timeout=max(
+                0.5,
+                float(settings.SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS),
+            ),
+        )
+        return networks, "complete"
+    except asyncio.TimeoutError:
+        logger.info("Report source network enrichment timed out for report detail")
+        return {}, "timed_out"
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.info(
+            "Report source network enrichment failed for report detail: %s",
+            type(exc).__name__,
+        )
+        return {}, "failed"
+
+
+async def _report_reputations_by_ip(
+    db: Session,
+    domain_name: str,
+    report: Dict[str, Any],
+    source_rows: List[Dict[str, Any]],
+    sender_by_ip: Dict[str, Dict[str, Any]],
+    *,
+    refresh: bool,
+    settings: Any,
+) -> tuple[Optional[DomainReputation], Dict[str, SourceReputation], str]:
+    """Build reputation evidence with a hard detail-path timeout."""
+    try:
+        reputation_result, _, _ = await asyncio.wait_for(
+            build_source_reputation_cached(
+                db,
+                domain_name,
+                [report],
+                source_rows,
+                senders_by_ip=sender_by_ip,
+                anomalies_by_ip={},
+                days=1,
+                refresh=refresh,
+            ),
+            timeout=max(
+                0.5,
+                float(settings.SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS) * (2 if refresh else 1),
+            ),
+        )
+        return reputation_result, source_reputation_by_ip(reputation_result), "complete"
+    except asyncio.TimeoutError:
+        logger.info("Report source reputation enrichment timed out for report detail")
+        return None, {}, "timed_out"
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.info(
+            "Report source reputation enrichment failed for report detail: %s",
+            type(exc).__name__,
+        )
+        _raise_refresh_reputation_failure(refresh, exc)
+        return None, {}, "failed"
+
+
+def _report_enrichment_status(
+    *,
+    ptr_status: str,
+    network_status: str,
+    reputation_status: str,
+    unique_source_ips: int,
+    record_count: int,
+) -> ReportEnrichmentStatus:
+    pending_states = {"timed_out", "pending"}
+    pending = network_status in pending_states or reputation_status in pending_states
+    if pending:
+        overall = "partial"
+    elif "failed" in {network_status, reputation_status, ptr_status}:
+        overall = "partial"
+    elif network_status == "disabled" and reputation_status == "complete":
+        overall = "complete"
+    else:
+        overall = "complete"
+    return ReportEnrichmentStatus(
+        status=overall,
+        pending=pending,
+        ptr=ptr_status,
+        network=network_status,
+        reputation=reputation_status,
+        unique_source_ips=unique_source_ips,
+        record_count=record_count,
+    )
 
 
 def _raise_refresh_reputation_failure(refresh_reputation: bool, exc: Exception) -> None:
@@ -990,52 +1130,33 @@ async def get_report_by_id(
     provider = get_default_provider(db)
     settings = get_settings()
     ips = [str(row.get("source_ip") or "unknown") for row in source_rows]
-    ptr_semaphore = asyncio.Semaphore(20)
+    unique_ips = _unique_source_ips(ips)
 
-    async def _bounded_ptr_lookup(ip: str) -> Optional[str]:
-        async with ptr_semaphore:
-            return await _safe_ptr_lookup(provider, ip)
+    # Evidence first: PTR and network enrichment run in parallel, each bounded.
+    # PTR is deduped to one lookup per unique IP (not per report row).
+    ptr_task = asyncio.create_task(_ptr_lookups_by_ip(provider, unique_ips))
+    network_task = asyncio.create_task(
+        _report_networks_by_ip(db, provider, unique_ips, settings)
+    )
+    hostnames_by_ip, (networks_by_ip, network_status) = await asyncio.gather(
+        ptr_task, network_task
+    )
+    hostnames = [hostnames_by_ip.get(ip) for ip in ips]
+    ptr_status = "complete"
 
-    hostnames = await asyncio.gather(*[_bounded_ptr_lookup(ip) for ip in ips])
-    networks_by_ip: Dict[str, SourceNetworkIntelligence] = {}
-    if settings.SOURCE_NETWORK_ENRICHMENT_ENABLED:
-        try:
-            networks_by_ip = await lookup_sources_network_cached(
-                db,
-                provider,
-                ips,
-                ttl_seconds=settings.SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS,
-                max_ips=settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS,
-            )
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            logger.info(
-                "Report source network enrichment failed for report detail: %s",
-                type(exc).__name__,
-            )
     sender_by_ip = {
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))
         for ip, row, hostname in zip(ips, source_rows, hostnames, strict=True)
     }
-    reputation_result: Optional[DomainReputation] = None
-    reputations_by_ip: Dict[str, SourceReputation] = {}
-    try:
-        reputation_result, _, _ = await build_source_reputation_cached(
-            db,
-            str(report.get("domain", "")),
-            [report],
-            source_rows,
-            senders_by_ip=sender_by_ip,
-            anomalies_by_ip={},
-            days=1,
-            refresh=refresh_reputation,
-        )
-        reputations_by_ip = source_reputation_by_ip(reputation_result)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.info(
-            "Report source reputation enrichment failed for report detail: %s",
-            type(exc).__name__,
-        )
-        _raise_refresh_reputation_failure(refresh_reputation, exc)
+    reputation_result, reputations_by_ip, reputation_status = await _report_reputations_by_ip(
+        db,
+        str(report.get("domain", "")),
+        report,
+        source_rows,
+        sender_by_ip,
+        refresh=refresh_reputation,
+        settings=settings,
+    )
 
     # Normalize records
     record_details = []
@@ -1072,6 +1193,13 @@ async def get_report_by_id(
         failed_count=raw_summary.get("failed_count", 0),
         pass_rate=raw_summary.get("pass_rate", 0.0),
     )
+    enrichment = _report_enrichment_status(
+        ptr_status=ptr_status,
+        network_status=network_status,
+        reputation_status=reputation_status,
+        unique_source_ips=len(unique_ips),
+        record_count=len(raw_records),
+    )
 
     return ReportDetail(
         report_id=report.get("report_id", ""),
@@ -1086,4 +1214,5 @@ async def get_report_by_id(
         records=record_details,
         summary=summary_detail,
         reputation_summary=_report_reputation_summary(reputation_result),
+        enrichment=enrichment,
     )

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -747,16 +747,43 @@ async def _ptr_lookups_by_ip(
     unique_ips: List[str],
     *,
     concurrency: int = 20,
+    results: Optional[Dict[str, Optional[str]]] = None,
 ) -> Dict[str, Optional[str]]:
     """Resolve PTR hostnames once per unique IP with bounded concurrency."""
     semaphore = asyncio.Semaphore(max(1, concurrency))
+    resolved = results if results is not None else {}
 
-    async def _lookup(ip: str) -> tuple[str, Optional[str]]:
+    async def _lookup(ip: str) -> None:
         async with semaphore:
-            return ip, await _safe_ptr_lookup(provider, ip)
+            resolved[ip] = await _safe_ptr_lookup(provider, ip)
 
-    pairs = await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
-    return dict(pairs)
+    await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
+    return resolved
+
+
+async def _report_ptrs_by_ip(
+    provider: Any,
+    unique_ips: List[str],
+    settings: Any,
+) -> tuple[Dict[str, Optional[str]], str]:
+    """Cap and time-box PTR enrichment while retaining completed lookups."""
+    max_ips = max(0, int(settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS))
+    selected_ips = unique_ips[:max_ips]
+    resolved: Dict[str, Optional[str]] = {}
+    if not selected_ips:
+        return resolved, "complete" if not unique_ips else "pending"
+    try:
+        await asyncio.wait_for(
+            _ptr_lookups_by_ip(provider, selected_ips, results=resolved),
+            timeout=max(
+                0.5,
+                float(settings.SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS),
+            ),
+        )
+    except asyncio.TimeoutError:
+        logger.info("Report PTR enrichment timed out for report detail")
+        return resolved, "pending"
+    return resolved, "complete" if len(selected_ips) == len(unique_ips) else "pending"
 
 
 async def _report_networks_by_ip(
@@ -823,8 +850,9 @@ async def _report_reputations_by_ip(
             ),
         )
         return reputation_result, source_reputation_by_ip(reputation_result), "complete"
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
         logger.info("Report source reputation enrichment timed out for report detail")
+        _raise_refresh_reputation_failure(refresh, exc)
         return None, {}, "timed_out"
     except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.info(
@@ -844,13 +872,14 @@ def _report_enrichment_status(
     record_count: int,
 ) -> ReportEnrichmentStatus:
     pending_states = {"timed_out", "pending"}
-    pending = network_status in pending_states or reputation_status in pending_states
+    pending = any(
+        enrichment_status in pending_states
+        for enrichment_status in (ptr_status, network_status, reputation_status)
+    )
     if pending:
         overall = "partial"
     elif "failed" in {network_status, reputation_status, ptr_status}:
         overall = "partial"
-    elif network_status == "disabled" and reputation_status == "complete":
-        overall = "complete"
     else:
         overall = "complete"
     return ReportEnrichmentStatus(
@@ -1134,15 +1163,14 @@ async def get_report_by_id(
 
     # Evidence first: PTR and network enrichment run in parallel, each bounded.
     # PTR is deduped to one lookup per unique IP (not per report row).
-    ptr_task = asyncio.create_task(_ptr_lookups_by_ip(provider, unique_ips))
+    ptr_task = asyncio.create_task(_report_ptrs_by_ip(provider, unique_ips, settings))
     network_task = asyncio.create_task(
         _report_networks_by_ip(db, provider, unique_ips, settings)
     )
-    hostnames_by_ip, (networks_by_ip, network_status) = await asyncio.gather(
+    (hostnames_by_ip, ptr_status), (networks_by_ip, network_status) = await asyncio.gather(
         ptr_task, network_task
     )
     hostnames = [hostnames_by_ip.get(ip) for ip in ips]
-    ptr_status = "complete"
 
     sender_by_ip = {
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -6,6 +6,7 @@ function reportDetailApp(reportId = '') {
         error: null,
         reputationRefreshing: false,
         reputationRefreshError: '',
+        enrichmentHydrating: false,
         recordRiskFilter: 'all',
         recordPageSize: 25,
 
@@ -96,6 +97,9 @@ function reportDetailApp(reportId = '') {
                     if (!refreshReputation) {
                         this.reputationRefreshError = '';
                     }
+                    if (!refreshReputation && this.report?.enrichment?.pending) {
+                        this.hydrateEnrichment();
+                    }
                 } else if (response.status === 404) {
                     if (!refreshReputation) {
                         this.report = null;
@@ -167,11 +171,48 @@ function reportDetailApp(reportId = '') {
             return {
                 ...normalized,
                 reputation_summary: normalized.reputation_summary || {},
+                enrichment: normalized.enrichment || {
+                    status: 'complete',
+                    pending: false,
+                    ptr: 'complete',
+                    network: 'complete',
+                    reputation: 'complete',
+                    unique_source_ips: 0,
+                    record_count: 0,
+                },
                 records: (normalized.records || []).map((record) => ({
                     ...record,
                     source_details: record.source_details || {},
                 })),
             };
+        },
+
+        async hydrateEnrichment() {
+            if (this.enrichmentHydrating || !this.reportId) {
+                return;
+            }
+            this.enrichmentHydrating = true;
+            try {
+                const response = await fetch(
+                    `/api/v1/reports/${encodeURIComponent(this.reportId)}`
+                );
+                if (!response.ok) {
+                    return;
+                }
+                const next = this.normalizeReport(await response.json());
+                // Keep evidence already on screen; only replace enrichment-bearing fields.
+                this.report = {
+                    ...this.report,
+                    ...next,
+                    records: next.records,
+                    reputation_summary: next.reputation_summary,
+                    enrichment: next.enrichment,
+                };
+            } catch (_err) {
+                // Evidence remains visible; enrichment stays partial until the next load.
+            } finally {
+                this.enrichmentHydrating = false;
+            }
         },
 
         get reportDomainUrl() {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1979,6 +1979,9 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "reputationEvidencePreview" in script
     assert "senderStatusClass" in script
     assert "normalizeReport" in script
+    assert "hydrateEnrichment" in script
+    assert "enrichmentHydrating" in script
+    assert "report?.enrichment?.pending" in script
     assert "reportDomainUrl" in script
     assert "?." not in template
     assert "??" not in template

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -4,8 +4,10 @@ import time
 import zipfile
 from contextlib import contextmanager
 from datetime import date, datetime
+from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
@@ -1205,6 +1207,34 @@ def test_get_report_by_id_surfaces_refresh_reputation_failure(
     assert response.json()["detail"] == "Source reputation could not be refreshed."
 
 
+def test_report_reputation_refresh_timeout_is_a_service_failure(monkeypatch):
+    async def timed_out_reputation(*_args, **_kwargs):
+        await asyncio.sleep(2)
+
+    monkeypatch.setattr(
+        reports_endpoint,
+        "build_source_reputation_cached",
+        timed_out_reputation,
+    )
+    settings = SimpleNamespace(SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS=0)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            reports_endpoint._report_reputations_by_ip(
+                None,
+                "example.com",
+                {},
+                [],
+                {},
+                refresh=True,
+                settings=settings,
+            )
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Source reputation could not be refreshed."
+
+
 def test_safe_ptr_lookup_returns_none_for_invalid_or_failed_lookup():
     class FailingProvider:
         async def lookup_ptr(self, _ip):
@@ -1277,8 +1307,12 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
             None,
         )
 
+    async def fake_networks(*_args, **_kwargs):
+        return {}
+
     monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", counting_ptr)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+    monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", fake_networks)
 
     started = time.monotonic()
     response = authed_client.get("/api/v1/reports/large-ptr-dedupe-report")
@@ -1293,6 +1327,36 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
     assert len(set(ptr_calls)) == 25
     # Unbounded per-row PTR (300 * 10ms) would exceed ~2s; deduped path stays bounded.
     assert elapsed < 2.0
+
+
+def test_report_ptr_enrichment_is_capped_and_preserves_completed_lookups(monkeypatch):
+    calls: list[str] = []
+
+    async def staggered_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
+        calls.append(ip)
+        if ip.endswith(".1"):
+            await asyncio.sleep(0.01)
+            return "resolved.example.net"
+        await asyncio.sleep(2)
+        return "late.example.net"
+
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", staggered_ptr)
+    settings = SimpleNamespace(
+        SOURCE_NETWORK_ENRICHMENT_MAX_IPS=2,
+        SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS=0,
+    )
+
+    resolved, ptr_status = asyncio.run(
+        reports_endpoint._report_ptrs_by_ip(
+            None,
+            ["203.0.113.1", "203.0.113.2", "203.0.113.3"],
+            settings,
+        )
+    )
+
+    assert calls == ["203.0.113.1", "203.0.113.2"]
+    assert resolved == {"203.0.113.1": "resolved.example.net"}
+    assert ptr_status == "pending"
 
 
 def test_get_report_by_id_bounds_slow_network_enrichment(

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -1,5 +1,6 @@
 import asyncio
 import io
+import time
 import zipfile
 from contextlib import contextmanager
 from datetime import date, datetime
@@ -1211,6 +1212,155 @@ def test_safe_ptr_lookup_returns_none_for_invalid_or_failed_lookup():
 
     assert asyncio.run(reports_endpoint._safe_ptr_lookup(FailingProvider(), "not-an-ip")) is None
     assert asyncio.run(reports_endpoint._safe_ptr_lookup(FailingProvider(), "192.0.2.55")) is None
+
+
+def _large_report_fixture(*, report_id: str, record_count: int = 320, unique_ips: int = 40) -> dict:
+    """Build a large aggregate report with repeated source IPs for perf regression."""
+    records = []
+    for index in range(record_count):
+        octet = (index % unique_ips) + 1
+        records.append(
+            {
+                "source_ip": f"203.0.113.{octet}",
+                "count": 1,
+                "disposition": "none",
+                "dkim_result": "pass" if index % 3 else "fail",
+                "spf_result": "pass" if index % 2 else "fail",
+                "header_from": "example.com",
+            }
+        )
+    return {
+        "domain": "example.com",
+        "report_id": report_id,
+        "org_name": "google.com",
+        "email": "noreply@example.com",
+        "begin_timestamp": 1782691200,
+        "end_timestamp": 1782777599,
+        "policy": {"p": "reject", "sp": "reject", "pct": "100"},
+        "records": records,
+        "summary": {
+            "total_count": record_count,
+            "passed_count": record_count // 2,
+            "failed_count": record_count - (record_count // 2),
+            "pass_rate": 50.0,
+        },
+    }
+
+
+def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Report detail must perform at most one PTR lookup per unique source IP."""
+    workspace = get_or_create_default_workspace(db_session)
+    fixture = _large_report_fixture(report_id="large-ptr-dedupe-report", record_count=300, unique_ips=25)
+    _persist_parsed_report(db_session, fixture, workspace_id=workspace.id)
+
+    ptr_calls: list[str] = []
+
+    async def counting_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
+        ptr_calls.append(ip)
+        await asyncio.sleep(0.01)
+        return f"host-{ip.replace('.', '-')}.example.net"
+
+    async def fake_reputation(*_args, **_kwargs):
+        return (
+            DomainReputation(
+                domain="example.com",
+                status="unknown",
+                checked_at="2026-07-01T00:00:00Z",
+                sources=[],
+                summary={"total_sources": 0},
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", counting_ptr)
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+
+    started = time.monotonic()
+    response = authed_client.get("/api/v1/reports/large-ptr-dedupe-report")
+    elapsed = time.monotonic() - started
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["records"]) == 300
+    assert body["enrichment"]["unique_source_ips"] == 25
+    assert body["enrichment"]["record_count"] == 300
+    assert len(ptr_calls) == 25
+    assert len(set(ptr_calls)) == 25
+    # Unbounded per-row PTR (300 * 10ms) would exceed ~2s; deduped path stays bounded.
+    assert elapsed < 2.0
+
+
+def test_get_report_by_id_bounds_slow_network_enrichment(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Slow per-IP network enrichment must not block report evidence indefinitely."""
+    workspace = get_or_create_default_workspace(db_session)
+    fixture = _large_report_fixture(
+        report_id="large-network-timeout-report",
+        record_count=320,
+        unique_ips=40,
+    )
+    _persist_parsed_report(db_session, fixture, workspace_id=workspace.id)
+
+    network_calls: list[str] = []
+
+    async def slow_networks(_db, _provider, source_ips, **_kwargs):
+        unique = list(dict.fromkeys(str(ip) for ip in source_ips))
+        for ip in unique:
+            network_calls.append(ip)
+            await asyncio.sleep(0.25)
+        return {}
+
+    async def fake_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
+        return None
+
+    async def fake_reputation(*_args, **_kwargs):
+        return (
+            DomainReputation(
+                domain="example.com",
+                status="unknown",
+                checked_at="2026-07-01T00:00:00Z",
+                sources=[],
+                summary={"total_sources": 0},
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", slow_networks)
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr)
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+
+    class _Settings:
+        SOURCE_NETWORK_ENRICHMENT_ENABLED = True
+        SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS = 86_400
+        SOURCE_NETWORK_ENRICHMENT_MAX_IPS = 100
+        SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS = 0.6
+        SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS = 4.0
+
+    monkeypatch.setattr(reports_endpoint, "get_settings", lambda: _Settings())
+
+    started = time.monotonic()
+    response = authed_client.get("/api/v1/reports/large-network-timeout-report")
+    elapsed = time.monotonic() - started
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["records"]) == 320
+    assert body["records"][0]["source_ip"].startswith("203.0.113.")
+    assert body["enrichment"]["network"] == "timed_out"
+    assert body["enrichment"]["pending"] is True
+    assert body["enrichment"]["status"] == "partial"
+    # Unbounded sequential enrichment (~40 * 0.25s) would take ~10s; bound stays near timeout.
+    assert elapsed < 3.0
+    assert len(set(network_calls)) <= 40
 
 
 def test_get_report_by_id_not_found(authed_client: TestClient):


### PR DESCRIPTION
## Summary
- Report detail (`GET /api/v1/reports/{id}`) no longer awaits unbounded per-row enrichment: unique source IPs are deduped for PTR, network enrichment runs in parallel with PTR under `SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS`, and reputation is bounded by `SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS`.
- Responses include an `enrichment` status block (`pending`/`partial`/`complete`) so the report-detail page can return evidence immediately and hydrate once when enrichment timed out.
- Added a large-report fixture and performance regression tests asserting ≤1 PTR lookup per unique IP and bounded response time under slow network enrichment.

## Files touched
- `backend/app/api/api_v1/endpoints/reports.py`
- `backend/app/static/js/report-detail-page.js`
- `backend/app/tests/test_reports_api.py`
- `backend/app/tests/test_dashboard_template_security.py`

## How tested
- `pytest backend/app/tests/test_reports_api.py` (incl. new large-fixture perf tests)
- `pytest ...::test_report_detail_uses_external_page_script_for_csp_migration`
- `flake8` on changed Python files
- `uvicorn app.main:app --port 8080` boots successfully

Fixes #818

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report details now display enrichment status, including PTR, network, and reputation results.
  * Enrichment updates load automatically while preserving already displayed report evidence.
* **Bug Fixes**
  * Repeated source IPs are processed more efficiently.
  * Slow enrichment requests now time out gracefully and report partial results instead of delaying the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->