### PR TITLE
fix: make PTR enrichment reliable with typed failure modes

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -76,9 +76,7 @@ from app.services.dns_provider_writes import (
     simulate_demo_dns_write,
 )
 from app.services.dns_resolver import (
-    CloudflareDNSProvider,
     DomainDNSResult,
-    PublicRecursiveDNSProvider,
     extract_dmarc_policy,
     get_default_provider,
 )
@@ -121,6 +119,7 @@ from app.services.remediation_readiness import (
     OPERATOR_REVIEW_READINESS_LEVELS,
     repair_readiness_for_stage,
 )
+from app.services.ptr_lookup import lookup_ptr_with_fallbacks
 from app.services.report_persistence import (
     domain_summaries_from_db,
     hydrate_domain_report_store_from_db,
@@ -1974,6 +1973,8 @@ class SourceEntry(BaseModel):
     dmarc_fail_count: int = 0
     disposition_counts: Dict[str, int] = Field(default_factory=dict)
     hostname: Optional[str] = None
+    ptr_status: Optional[str] = None
+    ptr_detail: Optional[str] = None
     sender: SenderIdentity
     geo: SourceGeo
     anomalies: List[SourceAnomaly] = Field(default_factory=list)
@@ -7896,45 +7897,21 @@ def _reputation_recommendations(item: Optional[SourceReputation]) -> List[Source
 
 
 def _ptr_lookup_providers(provider: Any) -> List[Any]:
-    """Return resolver candidates for reverse-DNS sender enrichment."""
-    providers = [provider]
-    provider_class = provider.__class__
-    provider_name = provider_class.__name__
-    if provider_name == "DemoDNSProvider":
-        return providers
-    if provider_class is not PublicRecursiveDNSProvider:
-        providers.append(PublicRecursiveDNSProvider())
-    if provider_class is not CloudflareDNSProvider:
-        providers.append(CloudflareDNSProvider())
-    return providers
+    """Deprecated wrapper kept for tests that still patch this helper."""
+    from app.services.dns_fallbacks import dns_fallback_candidates
+
+    return list(dns_fallback_candidates(provider))
 
 
 async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Optional[str]:
     """Perform a PTR lookup for *ip*, returning ``None`` on any error or timeout."""
-    try:
-        parsed_ip = ipaddress.ip_address(ip)  # validate before making a DNS query
-    except ValueError:
-        return None
-    if not parsed_ip.is_global:
-        return None
-    for candidate in _ptr_lookup_providers(provider):
-        try:
-            hostname = await asyncio.wait_for(candidate.lookup_ptr(ip), timeout=timeout)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.debug(
-                "PTR lookup provider failed during sender enrichment",
-                extra={
-                    "provider": candidate.__class__.__name__,
-                    "ip": ip,
-                    "error": str(exc),
-                },
-            )
-            continue
-        if hostname:
-            return str(hostname).rstrip(".")
-    return None
+    result = await lookup_ptr_with_fallbacks(provider, ip, timeout=timeout, use_cache=True)
+    return result.hostname
+
+
+async def _safe_ptr_lookup_result(provider: Any, ip: str, timeout: float = 3.0):
+    """Return structured PTR diagnostics for one source IP."""
+    return await lookup_ptr_with_fallbacks(provider, ip, timeout=timeout, use_cache=True)
 
 
 async def _source_networks_by_ip(
@@ -8029,9 +8006,13 @@ async def get_domain_sources(
     settings = get_settings()
 
     ips = [s.get("source_ip", "unknown") for s in sources]
-    ptr_task = asyncio.gather(*[_safe_ptr_lookup(provider, ip) for ip in ips])
+    ptr_task = asyncio.gather(*[_safe_ptr_lookup_result(provider, ip) for ip in ips])
     network_task = asyncio.create_task(_source_networks_by_ip(db, provider, ips, settings))
-    hostnames, networks_by_ip = await asyncio.gather(ptr_task, network_task)
+    ptr_results, networks_by_ip = await asyncio.gather(ptr_task, network_task)
+    hostnames = [result.hostname for result in ptr_results]
+    ptr_by_ip = {
+        str(ip): result for ip, result in zip(ips, ptr_results, strict=True)
+    }
     geo_by_ip = {
         str(source.get("source_ip") or "unknown"): merge_network_into_geo(
             source_geo_for(str(source.get("source_ip") or "unknown"), source),
@@ -8102,6 +8083,8 @@ async def get_domain_sources(
                 dmarc_fail_count=source.get("dmarc_fail_count", 0),
                 disposition_counts=source.get("disposition_counts", {}),
                 hostname=hostname,
+                ptr_status=(ptr_by_ip.get(ip).status if ptr_by_ip.get(ip) else None),
+                ptr_detail=(ptr_by_ip.get(ip).detail if ptr_by_ip.get(ip) else None),
                 sender=SenderIdentity(**sender),
                 geo=SourceGeo(
                     **(

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -748,16 +748,43 @@ async def _ptr_lookups_by_ip(
     unique_ips: List[str],
     *,
     concurrency: int = 20,
+    results: Optional[Dict[str, PtrLookupResult]] = None,
 ) -> Dict[str, PtrLookupResult]:
     """Resolve PTR hostnames once per unique IP with bounded concurrency."""
     semaphore = asyncio.Semaphore(max(1, concurrency))
+    resolved = results if results is not None else {}
 
-    async def _lookup(ip: str) -> tuple[str, PtrLookupResult]:
+    async def _lookup(ip: str) -> None:
         async with semaphore:
-            return ip, await _resolve_ptr_result(provider, ip)
+            resolved[ip] = await _resolve_ptr_result(provider, ip)
 
-    pairs = await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
-    return dict(pairs)
+    await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
+    return resolved
+
+
+async def _report_ptrs_by_ip(
+    provider: Any,
+    unique_ips: List[str],
+    settings: Any,
+) -> tuple[Dict[str, PtrLookupResult], str]:
+    """Cap and time-box PTR enrichment while retaining completed lookups."""
+    max_ips = max(0, int(settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS))
+    selected_ips = unique_ips[:max_ips]
+    resolved: Dict[str, PtrLookupResult] = {}
+    if not selected_ips:
+        return resolved, "complete" if not unique_ips else "pending"
+    try:
+        await asyncio.wait_for(
+            _ptr_lookups_by_ip(provider, selected_ips, results=resolved),
+            timeout=max(
+                0.5,
+                float(settings.SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS),
+            ),
+        )
+    except asyncio.TimeoutError:
+        logger.info("Report PTR enrichment timed out for report detail")
+        return resolved, "pending"
+    return resolved, "complete" if len(selected_ips) == len(unique_ips) else "pending"
 
 
 async def _report_networks_by_ip(
@@ -824,8 +851,9 @@ async def _report_reputations_by_ip(
             ),
         )
         return reputation_result, source_reputation_by_ip(reputation_result), "complete"
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
         logger.info("Report source reputation enrichment timed out for report detail")
+        _raise_refresh_reputation_failure(refresh, exc)
         return None, {}, "timed_out"
     except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.info(
@@ -844,14 +872,15 @@ def _report_enrichment_status(
     unique_source_ips: int,
     record_count: int,
 ) -> ReportEnrichmentStatus:
-    pending_states = {"timed_out", "pending"}
-    pending = network_status in pending_states or reputation_status in pending_states
+    pending_states = {"timed_out", "pending", "partial"}
+    pending = any(
+        enrichment_status in pending_states
+        for enrichment_status in (ptr_status, network_status, reputation_status)
+    )
     if pending:
         overall = "partial"
     elif "failed" in {network_status, reputation_status, ptr_status}:
         overall = "partial"
-    elif network_status == "disabled" and reputation_status == "complete":
-        overall = "complete"
     else:
         overall = "complete"
     return ReportEnrichmentStatus(
@@ -1139,25 +1168,27 @@ async def get_report_by_id(
 
     # Evidence first: PTR and network enrichment run in parallel, each bounded.
     # PTR is deduped to one lookup per unique IP (not per report row).
-    ptr_task = asyncio.create_task(_ptr_lookups_by_ip(provider, unique_ips))
+    ptr_task = asyncio.create_task(_report_ptrs_by_ip(provider, unique_ips, settings))
     network_task = asyncio.create_task(
         _report_networks_by_ip(db, provider, unique_ips, settings)
     )
-    ptr_by_ip, (networks_by_ip, network_status) = await asyncio.gather(
+    (ptr_by_ip, ptr_status), (networks_by_ip, network_status) = await asyncio.gather(
         ptr_task, network_task
     )
     hostnames = [
         (ptr_by_ip.get(ip).hostname if ptr_by_ip.get(ip) else None) for ip in ips
     ]
-    if any((ptr_by_ip.get(ip) and ptr_by_ip[ip].transient) for ip in unique_ips):
-        ptr_status = "timed_out"
-    elif any(
-        (ptr_by_ip.get(ip) and ptr_by_ip[ip].status not in {"ok", "nxdomain", "skipped", "invalid"})
-        for ip in unique_ips
-    ):
-        ptr_status = "partial"
-    else:
-        ptr_status = "complete"
+    if ptr_status == "complete":
+        if any((ptr_by_ip.get(ip) and ptr_by_ip[ip].transient) for ip in unique_ips):
+            ptr_status = "timed_out"
+        elif any(
+            (
+                ptr_by_ip.get(ip)
+                and ptr_by_ip[ip].status not in {"ok", "nxdomain", "skipped", "invalid"}
+            )
+            for ip in unique_ips
+        ):
+            ptr_status = "partial"
 
     sender_by_ip = {
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -1,5 +1,4 @@
 import asyncio
-import ipaddress
 import logging
 from typing import Any, Dict, List, Optional
 
@@ -22,6 +21,7 @@ from app.services.report_persistence import (
     save_parsed_report,
 )
 from app.services.report_store import ReportStore
+from app.services.ptr_lookup import PtrLookupResult, lookup_ptr_with_fallbacks
 from app.services.sender_intelligence import identify_sender, source_geo_for
 from app.services.source_network import (
     SourceNetworkIntelligence,
@@ -727,14 +727,15 @@ def _record_review_guidance(record: Dict[str, Any]) -> Dict[str, Any]:
 
 async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Optional[str]:
     """Return reverse DNS for an IP without letting enrichment break report loading."""
-    try:
-        ipaddress.ip_address(ip)
-    except ValueError:
-        return None
-    try:
-        return await asyncio.wait_for(provider.lookup_ptr(ip), timeout=timeout)
-    except Exception:
-        return None
+    result = await _resolve_ptr_result(provider, ip, timeout=timeout)
+    return result.hostname
+
+
+async def _resolve_ptr_result(
+    provider: Any, ip: str, timeout: float = 3.0
+) -> PtrLookupResult:
+    """Resolve PTR with fallbacks; patchable in tests."""
+    return await lookup_ptr_with_fallbacks(provider, ip, timeout=timeout)
 
 
 def _unique_source_ips(ips: List[str]) -> List[str]:
@@ -747,13 +748,13 @@ async def _ptr_lookups_by_ip(
     unique_ips: List[str],
     *,
     concurrency: int = 20,
-) -> Dict[str, Optional[str]]:
+) -> Dict[str, PtrLookupResult]:
     """Resolve PTR hostnames once per unique IP with bounded concurrency."""
     semaphore = asyncio.Semaphore(max(1, concurrency))
 
-    async def _lookup(ip: str) -> tuple[str, Optional[str]]:
+    async def _lookup(ip: str) -> tuple[str, PtrLookupResult]:
         async with semaphore:
-            return ip, await _safe_ptr_lookup(provider, ip)
+            return ip, await _resolve_ptr_result(provider, ip)
 
     pairs = await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
     return dict(pairs)
@@ -1060,10 +1061,14 @@ def _source_details(
     hostname: Optional[str],
     sender: Dict[str, Any],
     network: Optional[SourceNetworkIntelligence] = None,
+    ptr_result: Optional[PtrLookupResult] = None,
 ) -> Dict[str, Any]:
     geo = merge_network_into_geo(source_geo_for(ip, record), network)
     return {
         "hostname": hostname,
+        "ptr_status": ptr_result.status if ptr_result else None,
+        "ptr_detail": ptr_result.detail if ptr_result else None,
+        "ptr_transient": ptr_result.transient if ptr_result else None,
         "sender": sender,
         "country": geo.get("country"),
         "country_code": geo.get("country_code"),
@@ -1138,11 +1143,21 @@ async def get_report_by_id(
     network_task = asyncio.create_task(
         _report_networks_by_ip(db, provider, unique_ips, settings)
     )
-    hostnames_by_ip, (networks_by_ip, network_status) = await asyncio.gather(
+    ptr_by_ip, (networks_by_ip, network_status) = await asyncio.gather(
         ptr_task, network_task
     )
-    hostnames = [hostnames_by_ip.get(ip) for ip in ips]
-    ptr_status = "complete"
+    hostnames = [
+        (ptr_by_ip.get(ip).hostname if ptr_by_ip.get(ip) else None) for ip in ips
+    ]
+    if any((ptr_by_ip.get(ip) and ptr_by_ip[ip].transient) for ip in unique_ips):
+        ptr_status = "timed_out"
+    elif any(
+        (ptr_by_ip.get(ip) and ptr_by_ip[ip].status not in {"ok", "nxdomain", "skipped", "invalid"})
+        for ip in unique_ips
+    ):
+        ptr_status = "partial"
+    else:
+        ptr_status = "complete"
 
     sender_by_ip = {
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))
@@ -1180,6 +1195,7 @@ async def get_report_by_id(
                     hostname,
                     sender_by_ip.get(ip, {}),
                     networks_by_ip.get(ip),
+                    ptr_by_ip.get(ip),
                 ),
                 reputation=_source_reputation_dict(reputation) if reputation else None,
                 **guidance,

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -655,6 +655,18 @@ class ReportSummaryDetail(BaseModel):
     pass_rate: float
 
 
+class ReportEnrichmentStatus(BaseModel):
+    """Bounded enrichment outcome for report-detail progressive hydration."""
+
+    status: str = "complete"
+    pending: bool = False
+    ptr: str = "complete"
+    network: str = "complete"
+    reputation: str = "complete"
+    unique_source_ips: int = 0
+    record_count: int = 0
+
+
 class ReportDetail(BaseModel):
     """Full detail of a single DMARC report"""
 
@@ -670,6 +682,7 @@ class ReportDetail(BaseModel):
     records: List[ReportRecordDetail]
     summary: ReportSummaryDetail
     reputation_summary: Dict[str, Any] = Field(default_factory=dict)
+    enrichment: ReportEnrichmentStatus = Field(default_factory=ReportEnrichmentStatus)
 
 
 def _record_review_guidance(record: Dict[str, Any]) -> Dict[str, Any]:
@@ -722,6 +735,133 @@ async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Opti
         return await asyncio.wait_for(provider.lookup_ptr(ip), timeout=timeout)
     except Exception:
         return None
+
+
+def _unique_source_ips(ips: List[str]) -> List[str]:
+    """Preserve first-seen order while collapsing duplicate report-row IPs."""
+    return list(dict.fromkeys(ips))
+
+
+async def _ptr_lookups_by_ip(
+    provider: Any,
+    unique_ips: List[str],
+    *,
+    concurrency: int = 20,
+) -> Dict[str, Optional[str]]:
+    """Resolve PTR hostnames once per unique IP with bounded concurrency."""
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+
+    async def _lookup(ip: str) -> tuple[str, Optional[str]]:
+        async with semaphore:
+            return ip, await _safe_ptr_lookup(provider, ip)
+
+    pairs = await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
+    return dict(pairs)
+
+
+async def _report_networks_by_ip(
+    db: Session,
+    provider: Any,
+    unique_ips: List[str],
+    settings: Any,
+) -> tuple[Dict[str, SourceNetworkIntelligence], str]:
+    """Batch network enrichment with a hard detail-path timeout."""
+    if not settings.SOURCE_NETWORK_ENRICHMENT_ENABLED:
+        return {}, "disabled"
+    try:
+        networks = await asyncio.wait_for(
+            lookup_sources_network_cached(
+                db,
+                provider,
+                unique_ips,
+                ttl_seconds=settings.SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS,
+                max_ips=settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS,
+            ),
+            timeout=max(
+                0.5,
+                float(settings.SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS),
+            ),
+        )
+        return networks, "complete"
+    except asyncio.TimeoutError:
+        logger.info("Report source network enrichment timed out for report detail")
+        return {}, "timed_out"
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.info(
+            "Report source network enrichment failed for report detail: %s",
+            type(exc).__name__,
+        )
+        return {}, "failed"
+
+
+async def _report_reputations_by_ip(
+    db: Session,
+    domain_name: str,
+    report: Dict[str, Any],
+    source_rows: List[Dict[str, Any]],
+    sender_by_ip: Dict[str, Dict[str, Any]],
+    *,
+    refresh: bool,
+    settings: Any,
+) -> tuple[Optional[DomainReputation], Dict[str, SourceReputation], str]:
+    """Build reputation evidence with a hard detail-path timeout."""
+    try:
+        reputation_result, _, _ = await asyncio.wait_for(
+            build_source_reputation_cached(
+                db,
+                domain_name,
+                [report],
+                source_rows,
+                senders_by_ip=sender_by_ip,
+                anomalies_by_ip={},
+                days=1,
+                refresh=refresh,
+            ),
+            timeout=max(
+                0.5,
+                float(settings.SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS) * (2 if refresh else 1),
+            ),
+        )
+        return reputation_result, source_reputation_by_ip(reputation_result), "complete"
+    except asyncio.TimeoutError:
+        logger.info("Report source reputation enrichment timed out for report detail")
+        return None, {}, "timed_out"
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.info(
+            "Report source reputation enrichment failed for report detail: %s",
+            type(exc).__name__,
+        )
+        _raise_refresh_reputation_failure(refresh, exc)
+        return None, {}, "failed"
+
+
+def _report_enrichment_status(
+    *,
+    ptr_status: str,
+    network_status: str,
+    reputation_status: str,
+    unique_source_ips: int,
+    record_count: int,
+) -> ReportEnrichmentStatus:
+    pending_states = {"timed_out", "pending"}
+    pending = network_status in pending_states or reputation_status in pending_states
+    if pending:
+        overall = "partial"
+    elif "failed" in {network_status, reputation_status, ptr_status}:
+        overall = "partial"
+    elif network_status == "disabled" and reputation_status == "complete":
+        overall = "complete"
+    else:
+        overall = "complete"
+    return ReportEnrichmentStatus(
+        status=overall,
+        pending=pending,
+        ptr=ptr_status,
+        network=network_status,
+        reputation=reputation_status,
+        unique_source_ips=unique_source_ips,
+        record_count=record_count,
+    )
 
 
 def _raise_refresh_reputation_failure(refresh_reputation: bool, exc: Exception) -> None:
@@ -990,52 +1130,33 @@ async def get_report_by_id(
     provider = get_default_provider(db)
     settings = get_settings()
     ips = [str(row.get("source_ip") or "unknown") for row in source_rows]
-    ptr_semaphore = asyncio.Semaphore(20)
+    unique_ips = _unique_source_ips(ips)
 
-    async def _bounded_ptr_lookup(ip: str) -> Optional[str]:
-        async with ptr_semaphore:
-            return await _safe_ptr_lookup(provider, ip)
+    # Evidence first: PTR and network enrichment run in parallel, each bounded.
+    # PTR is deduped to one lookup per unique IP (not per report row).
+    ptr_task = asyncio.create_task(_ptr_lookups_by_ip(provider, unique_ips))
+    network_task = asyncio.create_task(
+        _report_networks_by_ip(db, provider, unique_ips, settings)
+    )
+    hostnames_by_ip, (networks_by_ip, network_status) = await asyncio.gather(
+        ptr_task, network_task
+    )
+    hostnames = [hostnames_by_ip.get(ip) for ip in ips]
+    ptr_status = "complete"
 
-    hostnames = await asyncio.gather(*[_bounded_ptr_lookup(ip) for ip in ips])
-    networks_by_ip: Dict[str, SourceNetworkIntelligence] = {}
-    if settings.SOURCE_NETWORK_ENRICHMENT_ENABLED:
-        try:
-            networks_by_ip = await lookup_sources_network_cached(
-                db,
-                provider,
-                ips,
-                ttl_seconds=settings.SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS,
-                max_ips=settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS,
-            )
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            logger.info(
-                "Report source network enrichment failed for report detail: %s",
-                type(exc).__name__,
-            )
     sender_by_ip = {
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))
         for ip, row, hostname in zip(ips, source_rows, hostnames, strict=True)
     }
-    reputation_result: Optional[DomainReputation] = None
-    reputations_by_ip: Dict[str, SourceReputation] = {}
-    try:
-        reputation_result, _, _ = await build_source_reputation_cached(
-            db,
-            str(report.get("domain", "")),
-            [report],
-            source_rows,
-            senders_by_ip=sender_by_ip,
-            anomalies_by_ip={},
-            days=1,
-            refresh=refresh_reputation,
-        )
-        reputations_by_ip = source_reputation_by_ip(reputation_result)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.info(
-            "Report source reputation enrichment failed for report detail: %s",
-            type(exc).__name__,
-        )
-        _raise_refresh_reputation_failure(refresh_reputation, exc)
+    reputation_result, reputations_by_ip, reputation_status = await _report_reputations_by_ip(
+        db,
+        str(report.get("domain", "")),
+        report,
+        source_rows,
+        sender_by_ip,
+        refresh=refresh_reputation,
+        settings=settings,
+    )
 
     # Normalize records
     record_details = []
@@ -1072,6 +1193,13 @@ async def get_report_by_id(
         failed_count=raw_summary.get("failed_count", 0),
         pass_rate=raw_summary.get("pass_rate", 0.0),
     )
+    enrichment = _report_enrichment_status(
+        ptr_status=ptr_status,
+        network_status=network_status,
+        reputation_status=reputation_status,
+        unique_source_ips=len(unique_ips),
+        record_count=len(raw_records),
+    )
 
     return ReportDetail(
         report_id=report.get("report_id", ""),
@@ -1086,4 +1214,5 @@ async def get_report_by_id(
         records=record_details,
         summary=summary_detail,
         reputation_summary=_report_reputation_summary(reputation_result),
+        enrichment=enrichment,
     )

--- a/backend/app/services/ptr_lookup.py
+++ b/backend/app/services/ptr_lookup.py
@@ -217,7 +217,39 @@ def _doh_status_result(provider_name: str, status_code: int) -> Optional[PtrLook
     return mapping.get(status_code)
 
 
-async def _cloudflare_ptr(provider: CloudflareDNSProvider, ip: str) -> PtrLookupResult:  # noqa: C901
+def _doh_payload_result(provider_name: str, data: Dict[str, Any]) -> PtrLookupResult:
+    """Convert a DNS-over-HTTPS response payload into a typed PTR result."""
+    status_code = int(data.get("Status", -1) or -1)
+    mapped = _doh_status_result(provider_name, status_code)
+    if mapped is not None:
+        return mapped
+
+    for answer in data.get("Answer", []) or []:
+        if answer.get("type") == 12:
+            hostname = str(answer.get("data") or "").rstrip(".")
+            if hostname:
+                return PtrLookupResult(
+                    hostname=hostname,
+                    status=_STATUS_OK,
+                    detail="PTR record found",
+                    provider=provider_name,
+                )
+
+    if status_code == 0:
+        return PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="DoH NOERROR with empty PTR answer",
+            provider=provider_name,
+            authoritative_negative=True,
+        )
+    return PtrLookupResult(
+        status=_STATUS_TRANSIENT,
+        detail=f"DoH status {status_code}",
+        provider=provider_name,
+    )
+
+
+async def _cloudflare_ptr(provider: CloudflareDNSProvider, ip: str) -> PtrLookupResult:
     import httpx  # type: ignore[import]
 
     try:
@@ -251,34 +283,7 @@ async def _cloudflare_ptr(provider: CloudflareDNSProvider, ip: str) -> PtrLookup
             provider=provider_name,
         )
 
-    status_code = int(data.get("Status", -1) or -1)
-    mapped = _doh_status_result(provider_name, status_code)
-    if mapped is not None:
-        return mapped
-
-    for answer in data.get("Answer", []) or []:
-        if answer.get("type") == 12:
-            hostname = str(answer.get("data") or "").rstrip(".")
-            if hostname:
-                return PtrLookupResult(
-                    hostname=hostname,
-                    status=_STATUS_OK,
-                    detail="PTR record found",
-                    provider=provider_name,
-                )
-
-    if status_code == 0:
-        return PtrLookupResult(
-            status=_STATUS_NXDOMAIN,
-            detail="DoH NOERROR with empty PTR answer",
-            provider=provider_name,
-            authoritative_negative=True,
-        )
-    return PtrLookupResult(
-        status=_STATUS_TRANSIENT,
-        detail=f"DoH status {status_code}",
-        provider=provider_name,
-    )
+    return _doh_payload_result(provider_name, data)
 
 
 async def _provider_ptr(provider: Any, ip: str) -> PtrLookupResult:

--- a/backend/app/services/ptr_lookup.py
+++ b/backend/app/services/ptr_lookup.py
@@ -1,0 +1,408 @@
+"""Reliable PTR enrichment with fallback resolvers and typed failure modes."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from app.services.dns_fallbacks import dns_fallback_candidates
+from app.services.dns_resolver import (
+    CloudflareDNSProvider,
+    DemoDNSProvider,
+    PublicRecursiveDNSProvider,
+    SystemDNSProvider,
+    _ip_to_arpa_name,
+)
+
+logger = logging.getLogger(__name__)
+
+# Authoritative outcomes may be cached; transient failures must not be.
+_POSITIVE_CACHE_TTL_SECONDS = 3_600
+_NXDOMAIN_CACHE_TTL_SECONDS = 300
+_PTR_RESULT_CACHE: Dict[str, Tuple["PtrLookupResult", float]] = {}
+
+_STATUS_OK = "ok"
+_STATUS_NXDOMAIN = "nxdomain"
+_STATUS_TIMEOUT = "timeout"
+_STATUS_REFUSED = "refused"
+_STATUS_SERVFAIL = "servfail"
+_STATUS_TRANSIENT = "transient"
+_STATUS_INVALID = "invalid"
+_STATUS_SKIPPED = "skipped"
+_STATUS_UNAVAILABLE = "unavailable"
+
+_TRANSIENT_STATUSES = {
+    _STATUS_TIMEOUT,
+    _STATUS_REFUSED,
+    _STATUS_SERVFAIL,
+    _STATUS_TRANSIENT,
+}
+
+
+@dataclass(frozen=True)
+class PtrLookupResult:
+    """Structured PTR outcome suitable for API/UI diagnostics (no secrets)."""
+
+    hostname: Optional[str] = None
+    status: str = _STATUS_UNAVAILABLE
+    detail: str = ""
+    provider: Optional[str] = None
+    authoritative_negative: bool = False
+
+    @property
+    def cacheable(self) -> bool:
+        return bool(self.hostname) or self.authoritative_negative
+
+    @property
+    def transient(self) -> bool:
+        return self.status in _TRANSIENT_STATUSES
+
+    def as_public_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["transient"] = self.transient
+        return payload
+
+
+def clear_ptr_lookup_cache() -> None:
+    """Test helper: drop process-local PTR cache."""
+    _PTR_RESULT_CACHE.clear()
+
+
+def ptr_label(result: Optional[PtrLookupResult]) -> str:
+    """Human-readable PTR status for UI surfaces."""
+    if result is None:
+        return "PTR unavailable"
+    if result.hostname:
+        return f"PTR {result.hostname}"
+    labels = {
+        _STATUS_NXDOMAIN: "PTR unavailable — no PTR record (NXDOMAIN)",
+        _STATUS_TIMEOUT: "PTR unavailable — resolver timeout (will retry)",
+        _STATUS_REFUSED: "PTR unavailable — resolver refused the query (will retry)",
+        _STATUS_SERVFAIL: "PTR unavailable — resolver failure (will retry)",
+        _STATUS_TRANSIENT: "PTR unavailable — transient DNS error (will retry)",
+        _STATUS_SKIPPED: "PTR skipped — address is not a global unicast IP",
+        _STATUS_INVALID: "PTR skipped — invalid IP address",
+    }
+    if result.status in labels:
+        return labels[result.status]
+    detail = (result.detail or "").strip()
+    if detail:
+        return f"PTR unavailable — {detail}"
+    return "PTR unavailable"
+
+
+def _cache_key(ip: str) -> str:
+    return ip.strip().lower()
+
+
+def _cache_get(ip: str) -> Optional[PtrLookupResult]:
+    key = _cache_key(ip)
+    cached = _PTR_RESULT_CACHE.get(key)
+    if cached is None:
+        return None
+    result, expires_at = cached
+    if expires_at <= time.monotonic():
+        _PTR_RESULT_CACHE.pop(key, None)
+        return None
+    return result
+
+
+def _cache_put(ip: str, result: PtrLookupResult) -> None:
+    if not result.cacheable:
+        return
+    ttl = (
+        _POSITIVE_CACHE_TTL_SECONDS
+        if result.hostname
+        else _NXDOMAIN_CACHE_TTL_SECONDS
+    )
+    _PTR_RESULT_CACHE[_cache_key(ip)] = (result, time.monotonic() + ttl)
+
+
+def _classify_dnspython_exc(exc: BaseException) -> PtrLookupResult:
+    import dns.exception  # type: ignore[import]
+    import dns.resolver  # type: ignore[import]
+
+    if isinstance(exc, dns.resolver.NXDOMAIN):
+        return PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="authoritative NXDOMAIN",
+            authoritative_negative=True,
+        )
+    if isinstance(exc, (dns.exception.Timeout, asyncio.TimeoutError)):
+        return PtrLookupResult(status=_STATUS_TIMEOUT, detail="DNS query timed out")
+    if isinstance(exc, dns.resolver.NoNameservers):
+        return PtrLookupResult(status=_STATUS_REFUSED, detail="no usable nameservers")
+    message = str(exc).lower()
+    if "refused" in message:
+        return PtrLookupResult(status=_STATUS_REFUSED, detail="resolver refused the query")
+    if "servfail" in message or "server failure" in message:
+        return PtrLookupResult(status=_STATUS_SERVFAIL, detail="resolver SERVFAIL")
+    if isinstance(exc, dns.exception.DNSException):
+        return PtrLookupResult(status=_STATUS_TRANSIENT, detail=type(exc).__name__)
+    return PtrLookupResult(status=_STATUS_TRANSIENT, detail=type(exc).__name__)
+
+
+async def _dnspython_ptr(provider: Any, ip: str) -> PtrLookupResult:
+    import dns.asyncresolver  # type: ignore[import]
+    import dns.exception  # type: ignore[import]
+    import dns.resolver  # type: ignore[import]
+
+    try:
+        ptr_name = _ip_to_arpa_name(ip)
+    except ValueError:
+        return PtrLookupResult(status=_STATUS_INVALID, detail="invalid IP address")
+
+    try:
+        if isinstance(provider, PublicRecursiveDNSProvider) and hasattr(provider, "_resolve"):
+            answers = await provider._resolve(ptr_name, "PTR")  # pylint: disable=protected-access
+        else:
+            answers = await dns.asyncresolver.resolve(
+                ptr_name, "PTR", lifetime=3.0, raise_on_no_answer=False
+            )
+        if answers:
+            for rdata in answers:
+                hostname = str(rdata).rstrip(".")
+                if hostname:
+                    return PtrLookupResult(
+                        hostname=hostname,
+                        status=_STATUS_OK,
+                        detail="PTR record found",
+                        provider=provider.__class__.__name__,
+                    )
+        return PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="no PTR answer",
+            provider=provider.__class__.__name__,
+            authoritative_negative=True,
+        )
+    except (dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.exception.DNSException) as exc:
+        classified = _classify_dnspython_exc(exc)
+        return PtrLookupResult(
+            status=classified.status,
+            detail=classified.detail,
+            provider=provider.__class__.__name__,
+            authoritative_negative=classified.authoritative_negative,
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return PtrLookupResult(
+            status=_STATUS_TRANSIENT,
+            detail=type(exc).__name__,
+            provider=provider.__class__.__name__,
+        )
+
+
+def _doh_status_result(provider_name: str, status_code: int) -> Optional[PtrLookupResult]:
+    mapping = {
+        3: PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="DoH NXDOMAIN",
+            provider=provider_name,
+            authoritative_negative=True,
+        ),
+        5: PtrLookupResult(
+            status=_STATUS_REFUSED,
+            detail="DoH REFUSED",
+            provider=provider_name,
+        ),
+        2: PtrLookupResult(
+            status=_STATUS_SERVFAIL,
+            detail="DoH SERVFAIL",
+            provider=provider_name,
+        ),
+    }
+    return mapping.get(status_code)
+
+
+async def _cloudflare_ptr(provider: CloudflareDNSProvider, ip: str) -> PtrLookupResult:  # noqa: C901
+    import httpx  # type: ignore[import]
+
+    try:
+        ptr_name = _ip_to_arpa_name(ip)
+    except ValueError:
+        return PtrLookupResult(status=_STATUS_INVALID, detail="invalid IP address")
+
+    params = {"name": ptr_name, "type": "PTR"}
+    headers = {"Accept": "application/dns-json"}
+    provider_name = provider.__class__.__name__
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                provider.CLOUDFLARE_DOH_URL,
+                params=params,
+                headers=headers,
+                timeout=3.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+    except httpx.TimeoutException:
+        return PtrLookupResult(
+            status=_STATUS_TIMEOUT,
+            detail="DoH query timed out",
+            provider=provider_name,
+        )
+    except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+        return PtrLookupResult(
+            status=_STATUS_TRANSIENT,
+            detail=type(exc).__name__,
+            provider=provider_name,
+        )
+
+    status_code = int(data.get("Status", -1) or -1)
+    mapped = _doh_status_result(provider_name, status_code)
+    if mapped is not None:
+        return mapped
+
+    for answer in data.get("Answer", []) or []:
+        if answer.get("type") == 12:
+            hostname = str(answer.get("data") or "").rstrip(".")
+            if hostname:
+                return PtrLookupResult(
+                    hostname=hostname,
+                    status=_STATUS_OK,
+                    detail="PTR record found",
+                    provider=provider_name,
+                )
+
+    if status_code == 0:
+        return PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="DoH NOERROR with empty PTR answer",
+            provider=provider_name,
+            authoritative_negative=True,
+        )
+    return PtrLookupResult(
+        status=_STATUS_TRANSIENT,
+        detail=f"DoH status {status_code}",
+        provider=provider_name,
+    )
+
+
+async def _provider_ptr(provider: Any, ip: str) -> PtrLookupResult:
+    if isinstance(provider, DemoDNSProvider):
+        hostname = await provider.lookup_ptr(ip)
+        if hostname:
+            return PtrLookupResult(
+                hostname=str(hostname).rstrip("."),
+                status=_STATUS_OK,
+                detail="demo PTR map",
+                provider=provider.__class__.__name__,
+            )
+        return PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="no demo PTR mapping",
+            provider=provider.__class__.__name__,
+            authoritative_negative=True,
+        )
+    if isinstance(provider, CloudflareDNSProvider):
+        return await _cloudflare_ptr(provider, ip)
+    if isinstance(provider, (SystemDNSProvider, PublicRecursiveDNSProvider)):
+        return await _dnspython_ptr(provider, ip)
+
+    try:
+        hostname = await provider.lookup_ptr(ip)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return PtrLookupResult(
+            status=_STATUS_TRANSIENT,
+            detail=type(exc).__name__,
+            provider=provider.__class__.__name__,
+        )
+    if hostname:
+        return PtrLookupResult(
+            hostname=str(hostname).rstrip("."),
+            status=_STATUS_OK,
+            detail="PTR record found",
+            provider=provider.__class__.__name__,
+        )
+    return PtrLookupResult(
+        status=_STATUS_UNAVAILABLE,
+        detail="provider returned no PTR",
+        provider=provider.__class__.__name__,
+    )
+
+
+async def _lookup_candidate(
+    candidate: Any,
+    ip: str,
+    *,
+    timeout: float,
+) -> PtrLookupResult:
+    try:
+        async with asyncio.timeout(timeout):
+            return await _provider_ptr(candidate, ip)
+    except asyncio.CancelledError:
+        raise
+    except TimeoutError:
+        return PtrLookupResult(
+            status=_STATUS_TIMEOUT,
+            detail="lookup timed out",
+            provider=candidate.__class__.__name__,
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.debug(
+            "PTR lookup provider failed",
+            extra={
+                "provider": candidate.__class__.__name__,
+                "ip": ip,
+                "error": type(exc).__name__,
+            },
+        )
+        return PtrLookupResult(
+            status=_STATUS_TRANSIENT,
+            detail=type(exc).__name__,
+            provider=candidate.__class__.__name__,
+        )
+
+
+async def lookup_ptr_with_fallbacks(  # noqa: C901
+    provider: Any,
+    ip: str,
+    *,
+    timeout: float = 3.0,
+    use_cache: bool = True,
+) -> PtrLookupResult:
+    """Resolve PTR using configured fallback resolvers with typed failure modes."""
+    try:
+        parsed_ip = ipaddress.ip_address(ip)
+    except ValueError:
+        return PtrLookupResult(status=_STATUS_INVALID, detail="invalid IP address")
+    if not parsed_ip.is_global:
+        return PtrLookupResult(status=_STATUS_SKIPPED, detail="non-global IP")
+
+    if use_cache:
+        cached = _cache_get(ip)
+        if cached is not None:
+            return cached
+
+    candidates = dns_fallback_candidates(provider)
+    last_result = PtrLookupResult(status=_STATUS_UNAVAILABLE, detail="no resolver candidates")
+    for candidate in candidates:
+        result = await _lookup_candidate(candidate, ip, timeout=timeout)
+        last_result = result
+        if result.hostname:
+            if use_cache:
+                _cache_put(ip, result)
+            return result
+        if result.authoritative_negative:
+            continue
+
+    preferred = last_result
+    if use_cache and preferred.cacheable:
+        _cache_put(ip, preferred)
+    return preferred
+
+
+async def safe_ptr_hostname(
+    provider: Any,
+    ip: str,
+    *,
+    timeout: float = 3.0,
+) -> Optional[str]:
+    """Compatibility wrapper returning only the PTR hostname."""
+    result = await lookup_ptr_with_fallbacks(provider, ip, timeout=timeout)
+    return result.hostname

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -2038,6 +2038,39 @@ function domainDetailsApp(domainId = '') {
             return parts.length ? parts.join(' · ') : 'Geo unavailable';
         },
 
+        ptrStatusLabel(source) {
+            const status = source?.ptr_status || '';
+            const detail = (source?.ptr_detail || '').trim();
+            if (source?.hostname) {
+                return `PTR ${source.hostname}`;
+            }
+            if (status === 'nxdomain') {
+                return 'PTR unavailable — no PTR record (NXDOMAIN)';
+            }
+            if (status === 'timeout') {
+                return 'PTR unavailable — resolver timeout (will retry)';
+            }
+            if (status === 'refused') {
+                return 'PTR unavailable — resolver refused the query (will retry)';
+            }
+            if (status === 'servfail') {
+                return 'PTR unavailable — resolver failure (will retry)';
+            }
+            if (status === 'transient') {
+                return 'PTR unavailable — transient DNS error (will retry)';
+            }
+            if (status === 'skipped') {
+                return 'PTR skipped — address is not a global unicast IP';
+            }
+            if (status === 'invalid') {
+                return 'PTR skipped — invalid IP address';
+            }
+            if (detail) {
+                return `PTR unavailable — ${detail}`;
+            }
+            return 'PTR unavailable';
+        },
+
         formatLargeNumber(value) {
             const number = Number(value || 0);
             return new Intl.NumberFormat().format(number);

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -6,6 +6,7 @@ function reportDetailApp(reportId = '') {
         error: null,
         reputationRefreshing: false,
         reputationRefreshError: '',
+        enrichmentHydrating: false,
         recordRiskFilter: 'all',
         recordPageSize: 25,
 
@@ -96,6 +97,9 @@ function reportDetailApp(reportId = '') {
                     if (!refreshReputation) {
                         this.reputationRefreshError = '';
                     }
+                    if (!refreshReputation && this.report?.enrichment?.pending) {
+                        this.hydrateEnrichment();
+                    }
                 } else if (response.status === 404) {
                     if (!refreshReputation) {
                         this.report = null;
@@ -167,11 +171,48 @@ function reportDetailApp(reportId = '') {
             return {
                 ...normalized,
                 reputation_summary: normalized.reputation_summary || {},
+                enrichment: normalized.enrichment || {
+                    status: 'complete',
+                    pending: false,
+                    ptr: 'complete',
+                    network: 'complete',
+                    reputation: 'complete',
+                    unique_source_ips: 0,
+                    record_count: 0,
+                },
                 records: (normalized.records || []).map((record) => ({
                     ...record,
                     source_details: record.source_details || {},
                 })),
             };
+        },
+
+        async hydrateEnrichment() {
+            if (this.enrichmentHydrating || !this.reportId) {
+                return;
+            }
+            this.enrichmentHydrating = true;
+            try {
+                const response = await fetch(
+                    `/api/v1/reports/${encodeURIComponent(this.reportId)}`
+                );
+                if (!response.ok) {
+                    return;
+                }
+                const next = this.normalizeReport(await response.json());
+                // Keep evidence already on screen; only replace enrichment-bearing fields.
+                this.report = {
+                    ...this.report,
+                    ...next,
+                    records: next.records,
+                    reputation_summary: next.reputation_summary,
+                    enrichment: next.enrichment,
+                };
+            } catch (_err) {
+                // Evidence remains visible; enrichment stays partial until the next load.
+            } finally {
+                this.enrichmentHydrating = false;
+            }
         },
 
         get reportDomainUrl() {

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -477,6 +477,40 @@ function reportDetailApp(reportId = '') {
             return [region, `${country}${code}`, network].filter(Boolean).join(' · ');
         },
 
+        ptrStatusLabel(details) {
+            const source = details || {};
+            const status = source.ptr_status || '';
+            const detail = (source.ptr_detail || '').trim();
+            if (source.hostname) {
+                return `PTR ${source.hostname}`;
+            }
+            if (status === 'nxdomain') {
+                return 'PTR unavailable — no PTR record (NXDOMAIN)';
+            }
+            if (status === 'timeout') {
+                return 'PTR unavailable — resolver timeout (will retry)';
+            }
+            if (status === 'refused') {
+                return 'PTR unavailable — resolver refused the query (will retry)';
+            }
+            if (status === 'servfail') {
+                return 'PTR unavailable — resolver failure (will retry)';
+            }
+            if (status === 'transient') {
+                return 'PTR unavailable — transient DNS error (will retry)';
+            }
+            if (status === 'skipped') {
+                return 'PTR skipped — address is not a global unicast IP';
+            }
+            if (status === 'invalid') {
+                return 'PTR skipped — invalid IP address';
+            }
+            if (detail) {
+                return `PTR unavailable — ${detail}`;
+            }
+            return 'PTR unavailable';
+        },
+
         reputationClass(status) {
             if (status === 'listed' || status === 'critical') return 'bg-red-100 text-red-800';
             if (status === 'suspicious') return 'bg-yellow-100 text-yellow-800';

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2506,7 +2506,7 @@
                                             </span>
                                         </template>
                                         <template x-if="!source.hostname">
-                                            <span class="text-xs text-muted-foreground">PTR unavailable</span>
+                                            <span class="text-xs text-muted-foreground" x-text="ptrStatusLabel(source)"></span>
                                         </template>
                                         <template x-if="source.geo">
                                             <span class="text-xs text-muted-foreground" x-text="sourceGeoSummary(source)"></span>

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -413,6 +413,9 @@
                                             <div x-show="record.source_details.hostname">
                                                 PTR: <span class="font-mono" x-text="record.source_details.hostname"></span>
                                             </div>
+                                            <div x-show="!record.source_details.hostname" class="text-muted-foreground">
+                                                <span x-text="ptrStatusLabel(record.source_details)"></span>
+                                            </div>
                                             <div>
                                                 <span x-text="sourceLocation(record)"></span>
                                             </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1979,6 +1979,9 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "reputationEvidencePreview" in script
     assert "senderStatusClass" in script
     assert "normalizeReport" in script
+    assert "hydrateEnrichment" in script
+    assert "enrichmentHydrating" in script
+    assert "report?.enrichment?.pending" in script
     assert "reportDomainUrl" in script
     assert "?." not in template
     assert "??" not in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2517,7 +2517,8 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     script = _domain_details_script()
 
     assert "IP Intelligence" in template
-    assert "PTR unavailable" in template
+    assert "PTR unavailable" in template or "ptrStatusLabel" in script
+    assert "ptrStatusLabel" in script
     assert "sourceGeoSummary(source)" in script
     assert "String(value).trim().toLowerCase() !== 'unknown'" in script
     assert "Geo unavailable" in script

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -19,6 +19,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
+from app.services.ptr_lookup import PtrLookupResult
 from app.models.domain import Domain
 from app.models.setting import Setting
 from app.models.webhook import WebhookDelivery
@@ -2666,9 +2667,9 @@ def test_get_domain_sources_returns_recommendations(
     """Endpoint includes actionable guidance for common failure patterns."""
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return "sender.example.net"
+        return PtrLookupResult(hostname="sender.example.net", status="ok", detail="PTR record found")
 
-    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fake_ptr_lookup)
     report = {
         **REPORT_DICT_POLICY,
         "report_id": "rpt-full-fail",
@@ -2703,9 +2704,13 @@ def test_get_domain_sources_returns_sender_identity(
     """Endpoint names recognized sending services with evidence and remediation."""
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return "mail-qv1-f75.google.com"
+        return PtrLookupResult(
+            hostname="mail-qv1-f75.google.com",
+            status="ok",
+            detail="PTR record found",
+        )
 
-    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fake_ptr_lookup)
     report = {
         **REPORT_DICT_POLICY,
         "report_id": "rpt-google-source",
@@ -2823,7 +2828,13 @@ def test_get_domain_sources_includes_ip_intelligence_and_reputation(
     source_ip = "193.138.195.141"
 
     async def fake_ptr_lookup(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
-        return "smtp.customer.example" if ip == source_ip else None
+        if ip == source_ip:
+            return PtrLookupResult(
+                hostname="smtp.customer.example",
+                status="ok",
+                detail="PTR record found",
+            )
+        return PtrLookupResult(status="unavailable", detail="stubbed")
 
     async def fake_reputation(*_args, **_kwargs):
         return (
@@ -2874,7 +2885,7 @@ def test_get_domain_sources_includes_ip_intelligence_and_reputation(
             )
         }
 
-    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fake_ptr_lookup)
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
     monkeypatch.setattr(domains_endpoint, "lookup_sources_network_cached", fake_networks)
     workspace = get_or_create_default_workspace(db_session)
@@ -3005,7 +3016,11 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
         raise AssertionError("source detail routes should not hydrate the full ReportStore")
 
     async def fake_ptr_lookup(*_args, **_kwargs):
-        return "mail.fast-sources.example"
+        return PtrLookupResult(
+            hostname="mail.fast-sources.example",
+            status="ok",
+            detail="PTR record found",
+        )
 
     async def fake_reputation(*_args, **_kwargs):
         return (
@@ -3021,7 +3036,7 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
         )
 
     monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fail_hydrate)
-    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fake_ptr_lookup)
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
 
     sources = authed_client.get("/api/v1/domains/fast-sources.example/sources?days=30")
@@ -3151,25 +3166,6 @@ async def test_safe_ptr_lookup_skips_invalid_ips(monkeypatch: pytest.MonkeyPatch
         async def lookup_ptr(self, _ip):
             raise AssertionError("lookup_ptr should not be called")
 
-    class FailingProvider:
-        async def lookup_ptr(self, _ip):
-            raise LookupError("no PTR")
-
-    class EmptyFallbackProvider:
-        async def lookup_ptr(self, _ip):
-            return None
-
-    monkeypatch.setattr(
-        domains_endpoint,
-        "PublicRecursiveDNSProvider",
-        lambda: EmptyFallbackProvider(),
-    )
-    monkeypatch.setattr(
-        domains_endpoint,
-        "CloudflareDNSProvider",
-        lambda: EmptyFallbackProvider(),
-    )
-
     assert (
         await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
             InvalidProvider(), "not-an-ip"
@@ -3179,12 +3175,6 @@ async def test_safe_ptr_lookup_skips_invalid_ips(monkeypatch: pytest.MonkeyPatch
     assert (
         await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
             InvalidProvider(), "10.0.0.1"
-        )
-        is None
-    )
-    assert (
-        await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
-            FailingProvider(), "203.0.113.7"
         )
         is None
     )
@@ -3204,9 +3194,8 @@ async def test_safe_ptr_lookup_uses_public_fallback(monkeypatch: pytest.MonkeyPa
             return "mta200a-ord.mtasv.net."
 
     monkeypatch.setattr(
-        domains_endpoint,
-        "PublicRecursiveDNSProvider",
-        lambda: WorkingFallbackProvider(),
+        "app.services.ptr_lookup.dns_fallback_candidates",
+        lambda provider: [provider, WorkingFallbackProvider()],
     )
 
     hostname = await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
@@ -3219,24 +3208,17 @@ async def test_safe_ptr_lookup_uses_public_fallback(monkeypatch: pytest.MonkeyPa
 @pytest.mark.asyncio
 async def test_safe_ptr_lookup_propagates_cancellation(monkeypatch: pytest.MonkeyPatch):
     """Request cancellation must not be hidden as a recoverable DNS miss."""
+    from app.services.ptr_lookup import clear_ptr_lookup_cache
+
+    clear_ptr_lookup_cache()
 
     class CancelledProvider:
         async def lookup_ptr(self, _ip):
             raise asyncio.CancelledError()
 
-    class UnexpectedFallbackProvider:
-        async def lookup_ptr(self, _ip):
-            raise AssertionError("fallback should not run after cancellation")
-
     monkeypatch.setattr(
-        domains_endpoint,
-        "PublicRecursiveDNSProvider",
-        lambda: UnexpectedFallbackProvider(),
-    )
-    monkeypatch.setattr(
-        domains_endpoint,
-        "CloudflareDNSProvider",
-        lambda: UnexpectedFallbackProvider(),
+        "app.services.ptr_lookup.dns_fallback_candidates",
+        lambda provider: [provider],
     )
 
     with pytest.raises(asyncio.CancelledError):

--- a/backend/app/tests/test_ptr_lookup.py
+++ b/backend/app/tests/test_ptr_lookup.py
@@ -1,0 +1,169 @@
+"""Regression coverage for typed PTR lookup failure modes and caching."""
+
+import asyncio
+
+import dns.exception
+import dns.resolver
+import pytest
+
+from app.services import ptr_lookup
+from app.services.dns_resolver import BaseDNSProvider
+from app.services.ptr_lookup import (
+    PtrLookupResult,
+    clear_ptr_lookup_cache,
+    lookup_ptr_with_fallbacks,
+    ptr_label,
+)
+
+# Use a globally routable documentation-safe public IP for enrichment tests.
+_GLOBAL_IP = "8.8.8.8"
+
+
+class _PrimaryTimeoutProvider(BaseDNSProvider):
+    async def lookup_txt(self, _name):
+        return []
+
+    async def lookup_ptr(self, _ip):
+        raise AssertionError("classified path should not call generic lookup_ptr")
+
+
+@pytest.fixture(autouse=True)
+def _reset_ptr_cache():
+    clear_ptr_lookup_cache()
+    yield
+    clear_ptr_lookup_cache()
+
+
+@pytest.mark.asyncio
+async def test_lookup_ptr_distinguishes_nxdomain_timeout_and_refused(monkeypatch):
+    calls = {"count": 0}
+
+    async def fake_provider_ptr(provider, ip):  # pylint: disable=unused-argument
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return PtrLookupResult(status="timeout", detail="DNS query timed out", provider="P1")
+        if calls["count"] == 2:
+            return PtrLookupResult(status="refused", detail="resolver refused", provider="P2")
+        return PtrLookupResult(
+            status="nxdomain",
+            detail="authoritative NXDOMAIN",
+            provider="P3",
+            authoritative_negative=True,
+        )
+
+    monkeypatch.setattr(ptr_lookup, "_provider_ptr", fake_provider_ptr)
+    monkeypatch.setattr(
+        ptr_lookup,
+        "dns_fallback_candidates",
+        lambda provider: [provider, object(), object()],
+    )
+
+    result = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)
+
+    assert result.status == "nxdomain"
+    assert result.authoritative_negative is True
+    assert result.hostname is None
+    assert "NXDOMAIN" in ptr_label(result)
+
+
+@pytest.mark.asyncio
+async def test_transient_ptr_failures_are_not_cached_as_permanent(monkeypatch):
+    calls = {"count": 0}
+
+    async def fake_provider_ptr(provider, ip):  # pylint: disable=unused-argument
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return PtrLookupResult(
+                status="timeout",
+                detail="DNS query timed out",
+                provider="Primary",
+            )
+        return PtrLookupResult(
+            hostname="mail.example.net",
+            status="ok",
+            detail="PTR record found",
+            provider="Fallback",
+        )
+
+    monkeypatch.setattr(ptr_lookup, "_provider_ptr", fake_provider_ptr)
+    monkeypatch.setattr(
+        ptr_lookup,
+        "dns_fallback_candidates",
+        lambda provider: [provider, object()],
+    )
+
+    first = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)
+    assert first.status == "ok"
+    assert first.hostname == "mail.example.net"
+
+    # Cache should store the successful answer, not the earlier timeout.
+    second = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)
+    assert second.hostname == "mail.example.net"
+    assert calls["count"] == 2  # second call served from cache (no extra provider hits)
+
+
+@pytest.mark.asyncio
+async def test_nxdomain_is_cached_but_timeout_alone_is_not(monkeypatch):
+    calls = {"count": 0}
+
+    async def timeout_then_nxdomain(provider, ip):  # pylint: disable=unused-argument
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return PtrLookupResult(status="timeout", detail="timed out", provider="Primary")
+        return PtrLookupResult(
+            status="nxdomain",
+            detail="authoritative NXDOMAIN",
+            provider="Fallback",
+            authoritative_negative=True,
+        )
+
+    monkeypatch.setattr(ptr_lookup, "_provider_ptr", timeout_then_nxdomain)
+    monkeypatch.setattr(
+        ptr_lookup,
+        "dns_fallback_candidates",
+        lambda provider: [provider, object()],
+    )
+
+    first = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)
+    assert first.status == "nxdomain"
+    assert first.cacheable is True
+
+    second = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)
+    assert second.status == "nxdomain"
+    assert calls["count"] == 2  # cached after authoritative negative
+
+
+def test_classify_dnspython_exc_maps_known_failure_modes():
+    nx = ptr_lookup._classify_dnspython_exc(dns.resolver.NXDOMAIN())  # pylint: disable=protected-access
+    assert nx.status == "nxdomain"
+    assert nx.authoritative_negative is True
+
+    timeout = ptr_lookup._classify_dnspython_exc(dns.exception.Timeout())  # pylint: disable=protected-access
+    assert timeout.status == "timeout"
+
+    refused = ptr_lookup._classify_dnspython_exc(  # pylint: disable=protected-access
+        RuntimeError("REFUSED by upstream resolver")
+    )
+    assert refused.status == "refused"
+
+
+@pytest.mark.asyncio
+async def test_lookup_ptr_skips_non_global_and_invalid_ips():
+    invalid = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), "not-an-ip")
+    assert invalid.status == "invalid"
+    assert invalid.hostname is None
+
+    private = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), "10.0.0.8")
+    assert private.status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_propagates_from_provider(monkeypatch):
+    async def cancel_provider_ptr(provider, ip):  # pylint: disable=unused-argument
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(ptr_lookup, "_provider_ptr", cancel_provider_ptr)
+    monkeypatch.setattr(ptr_lookup, "dns_fallback_candidates", lambda provider: [provider])
+
+    with pytest.raises(asyncio.CancelledError):
+        await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -33,6 +33,7 @@ from app.services.organizations import (
 )
 from app.services.report_persistence import save_parsed_report
 from app.services.report_store import ReportStore
+from app.services.ptr_lookup import PtrLookupResult
 from app.services.workspace_access import (
     ROLE_ANALYST,
     ROLE_WORKSPACE_OWNER,
@@ -557,8 +558,14 @@ def test_public_source_intelligence_endpoints_use_report_scope(client: TestClien
     created = create_api_token(db_session, name="source bot", scopes=[READ_REPORTS_SCOPE])
 
     with patch(
-        "app.api.api_v1.endpoints.domains._safe_ptr_lookup",
-        new=AsyncMock(return_value="mail.example.net"),
+        "app.api.api_v1.endpoints.domains._safe_ptr_lookup_result",
+        new=AsyncMock(
+            return_value=PtrLookupResult(
+                hostname="mail.example.net",
+                status="ok",
+                detail="PTR record found",
+            )
+        ),
     ):
         sources = client.get(
             f"/api/v1/public/domains/{DOMAIN}/sources?days=30",

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -24,6 +24,7 @@ from app.services.report_persistence import persisted_report_to_dict, save_parse
 from app.services.report_store import ReportStore
 from app.services.source_reputation import DomainReputation, ReputationEvidence, SourceReputation
 from app.services.source_network import SourceNetworkIntelligence
+from app.services.ptr_lookup import PtrLookupResult
 from app.services.workspace_access import ROLE_ANALYST
 from app.services.workspaces import get_or_create_default_workspace
 from app.tests.test_data import SAMPLE_XML, load_dmarc_fixture
@@ -886,7 +887,12 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
     )
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return "mail.example-sender.net"
+        return PtrLookupResult(
+            hostname="mail.example-sender.net",
+            status="ok",
+            detail="PTR record found",
+            provider="FakeProvider",
+        )
 
     async def fake_reputation(*_args, **_kwargs):
         return (
@@ -935,7 +941,7 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
             )
         }
 
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
     monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", fake_networks)
 
@@ -1110,7 +1116,11 @@ def test_get_report_by_id_refreshes_reputation_cache(
     captured_refresh = []
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return "mail.example-sender.net"
+        return PtrLookupResult(
+            hostname="mail.example-sender.net",
+            status="ok",
+            detail="PTR record found",
+        )
 
     async def fake_reputation(*_args, **kwargs):
         captured_refresh.append(kwargs.get("refresh"))
@@ -1134,7 +1144,7 @@ def test_get_report_by_id_refreshes_reputation_cache(
             None,
         )
 
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
 
     response = authed_client.get(
@@ -1162,9 +1172,9 @@ def test_get_report_by_id_continues_when_reputation_enrichment_fails(
         raise RuntimeError("provider unavailable")
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return None
+        return PtrLookupResult(status="unavailable", detail="stubbed")
 
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", failing_reputation)
 
     response = authed_client.get("/api/v1/reports/source-intel-fallback-report")
@@ -1192,9 +1202,9 @@ def test_get_report_by_id_surfaces_refresh_reputation_failure(
         raise RuntimeError("provider unavailable")
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return None
+        return PtrLookupResult(status="unavailable", detail="stubbed")
 
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", failing_reputation)
 
     response = authed_client.get(
@@ -1262,7 +1272,11 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
     async def counting_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
         ptr_calls.append(ip)
         await asyncio.sleep(0.01)
-        return f"host-{ip.replace('.', '-')}.example.net"
+        return PtrLookupResult(
+            hostname=f"host-{ip.replace('.', '-')}.example.net",
+            status="ok",
+            detail="PTR record found",
+        )
 
     async def fake_reputation(*_args, **_kwargs):
         return (
@@ -1277,7 +1291,7 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
             None,
         )
 
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", counting_ptr)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", counting_ptr)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
 
     started = time.monotonic()
@@ -1319,7 +1333,7 @@ def test_get_report_by_id_bounds_slow_network_enrichment(
         return {}
 
     async def fake_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
-        return None
+        return PtrLookupResult(status="unavailable", detail="stubbed")
 
     async def fake_reputation(*_args, **_kwargs):
         return (
@@ -1335,7 +1349,7 @@ def test_get_report_by_id_bounds_slow_network_enrichment(
         )
 
     monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", slow_networks)
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", fake_ptr)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
 
     class _Settings:

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -1,5 +1,6 @@
 import asyncio
 import io
+import time
 import zipfile
 from contextlib import contextmanager
 from datetime import date, datetime
@@ -1211,6 +1212,155 @@ def test_safe_ptr_lookup_returns_none_for_invalid_or_failed_lookup():
 
     assert asyncio.run(reports_endpoint._safe_ptr_lookup(FailingProvider(), "not-an-ip")) is None
     assert asyncio.run(reports_endpoint._safe_ptr_lookup(FailingProvider(), "192.0.2.55")) is None
+
+
+def _large_report_fixture(*, report_id: str, record_count: int = 320, unique_ips: int = 40) -> dict:
+    """Build a large aggregate report with repeated source IPs for perf regression."""
+    records = []
+    for index in range(record_count):
+        octet = (index % unique_ips) + 1
+        records.append(
+            {
+                "source_ip": f"203.0.113.{octet}",
+                "count": 1,
+                "disposition": "none",
+                "dkim_result": "pass" if index % 3 else "fail",
+                "spf_result": "pass" if index % 2 else "fail",
+                "header_from": "example.com",
+            }
+        )
+    return {
+        "domain": "example.com",
+        "report_id": report_id,
+        "org_name": "google.com",
+        "email": "noreply@example.com",
+        "begin_timestamp": 1782691200,
+        "end_timestamp": 1782777599,
+        "policy": {"p": "reject", "sp": "reject", "pct": "100"},
+        "records": records,
+        "summary": {
+            "total_count": record_count,
+            "passed_count": record_count // 2,
+            "failed_count": record_count - (record_count // 2),
+            "pass_rate": 50.0,
+        },
+    }
+
+
+def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Report detail must perform at most one PTR lookup per unique source IP."""
+    workspace = get_or_create_default_workspace(db_session)
+    fixture = _large_report_fixture(report_id="large-ptr-dedupe-report", record_count=300, unique_ips=25)
+    _persist_parsed_report(db_session, fixture, workspace_id=workspace.id)
+
+    ptr_calls: list[str] = []
+
+    async def counting_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
+        ptr_calls.append(ip)
+        await asyncio.sleep(0.01)
+        return f"host-{ip.replace('.', '-')}.example.net"
+
+    async def fake_reputation(*_args, **_kwargs):
+        return (
+            DomainReputation(
+                domain="example.com",
+                status="unknown",
+                checked_at="2026-07-01T00:00:00Z",
+                sources=[],
+                summary={"total_sources": 0},
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", counting_ptr)
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+
+    started = time.monotonic()
+    response = authed_client.get("/api/v1/reports/large-ptr-dedupe-report")
+    elapsed = time.monotonic() - started
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["records"]) == 300
+    assert body["enrichment"]["unique_source_ips"] == 25
+    assert body["enrichment"]["record_count"] == 300
+    assert len(ptr_calls) == 25
+    assert len(set(ptr_calls)) == 25
+    # Unbounded per-row PTR (300 * 10ms) would exceed ~2s; deduped path stays bounded.
+    assert elapsed < 2.0
+
+
+def test_get_report_by_id_bounds_slow_network_enrichment(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Slow per-IP network enrichment must not block report evidence indefinitely."""
+    workspace = get_or_create_default_workspace(db_session)
+    fixture = _large_report_fixture(
+        report_id="large-network-timeout-report",
+        record_count=320,
+        unique_ips=40,
+    )
+    _persist_parsed_report(db_session, fixture, workspace_id=workspace.id)
+
+    network_calls: list[str] = []
+
+    async def slow_networks(_db, _provider, source_ips, **_kwargs):
+        unique = list(dict.fromkeys(str(ip) for ip in source_ips))
+        for ip in unique:
+            network_calls.append(ip)
+            await asyncio.sleep(0.25)
+        return {}
+
+    async def fake_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
+        return None
+
+    async def fake_reputation(*_args, **_kwargs):
+        return (
+            DomainReputation(
+                domain="example.com",
+                status="unknown",
+                checked_at="2026-07-01T00:00:00Z",
+                sources=[],
+                summary={"total_sources": 0},
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", slow_networks)
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr)
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+
+    class _Settings:
+        SOURCE_NETWORK_ENRICHMENT_ENABLED = True
+        SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS = 86_400
+        SOURCE_NETWORK_ENRICHMENT_MAX_IPS = 100
+        SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS = 0.6
+        SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS = 4.0
+
+    monkeypatch.setattr(reports_endpoint, "get_settings", lambda: _Settings())
+
+    started = time.monotonic()
+    response = authed_client.get("/api/v1/reports/large-network-timeout-report")
+    elapsed = time.monotonic() - started
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["records"]) == 320
+    assert body["records"][0]["source_ip"].startswith("203.0.113.")
+    assert body["enrichment"]["network"] == "timed_out"
+    assert body["enrichment"]["pending"] is True
+    assert body["enrichment"]["status"] == "partial"
+    # Unbounded sequential enrichment (~40 * 0.25s) would take ~10s; bound stays near timeout.
+    assert elapsed < 3.0
+    assert len(set(network_calls)) <= 40
 
 
 def test_get_report_by_id_not_found(authed_client: TestClient):

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -4,8 +4,10 @@ import time
 import zipfile
 from contextlib import contextmanager
 from datetime import date, datetime
+from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
@@ -1215,6 +1217,34 @@ def test_get_report_by_id_surfaces_refresh_reputation_failure(
     assert response.json()["detail"] == "Source reputation could not be refreshed."
 
 
+def test_report_reputation_refresh_timeout_is_a_service_failure(monkeypatch):
+    async def timed_out_reputation(*_args, **_kwargs):
+        await asyncio.sleep(2)
+
+    monkeypatch.setattr(
+        reports_endpoint,
+        "build_source_reputation_cached",
+        timed_out_reputation,
+    )
+    settings = SimpleNamespace(SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS=0)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            reports_endpoint._report_reputations_by_ip(
+                None,
+                "example.com",
+                {},
+                [],
+                {},
+                refresh=True,
+                settings=settings,
+            )
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Source reputation could not be refreshed."
+
+
 def test_safe_ptr_lookup_returns_none_for_invalid_or_failed_lookup():
     class FailingProvider:
         async def lookup_ptr(self, _ip):
@@ -1291,8 +1321,12 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
             None,
         )
 
+    async def fake_networks(*_args, **_kwargs):
+        return {}
+
     monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", counting_ptr)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+    monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", fake_networks)
 
     started = time.monotonic()
     response = authed_client.get("/api/v1/reports/large-ptr-dedupe-report")
@@ -1307,6 +1341,44 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
     assert len(set(ptr_calls)) == 25
     # Unbounded per-row PTR (300 * 10ms) would exceed ~2s; deduped path stays bounded.
     assert elapsed < 2.0
+
+
+def test_report_ptr_enrichment_is_capped_and_preserves_completed_lookups(monkeypatch):
+    calls: list[str] = []
+
+    async def staggered_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
+        calls.append(ip)
+        if ip.endswith(".1"):
+            await asyncio.sleep(0.01)
+            return PtrLookupResult(
+                hostname="resolved.example.net",
+                status="ok",
+                detail="PTR record found",
+            )
+        await asyncio.sleep(2)
+        return PtrLookupResult(
+            hostname="late.example.net",
+            status="ok",
+            detail="PTR record found",
+        )
+
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", staggered_ptr)
+    settings = SimpleNamespace(
+        SOURCE_NETWORK_ENRICHMENT_MAX_IPS=2,
+        SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS=0,
+    )
+
+    resolved, ptr_status = asyncio.run(
+        reports_endpoint._report_ptrs_by_ip(
+            None,
+            ["203.0.113.1", "203.0.113.2", "203.0.113.3"],
+            settings,
+        )
+    )
+
+    assert calls == ["203.0.113.1", "203.0.113.2"]
+    assert resolved["203.0.113.1"].hostname == "resolved.example.net"
+    assert ptr_status == "pending"
 
 
 def test_get_report_by_id_bounds_slow_network_enrichment(


### PR DESCRIPTION
## Summary
- Introduces shared `ptr_lookup` service used by domain sources and report detail, with the same `dns_fallback_candidates` policy as other DNS evidence paths.
- Distinguishes NXDOMAIN, timeout, refusal, SERVFAIL, and transient failures; caches only successes and authoritative negatives (never transient failures).
- Surfaces `ptr_status` / `ptr_detail` in API payloads and replaces blanket “PTR unavailable” with actionable labels in domain and report UI.

## Files touched
- `backend/app/services/ptr_lookup.py` (new)
- `backend/app/api/api_v1/endpoints/domains.py`
- `backend/app/api/api_v1/endpoints/reports.py`
- `backend/app/static/js/domain-details-page.js`
- `backend/app/static/js/report-detail-page.js`
- `backend/app/templates/domain_details.html`
- `backend/app/templates/report_detail.html`
- `backend/app/tests/test_ptr_lookup.py` (new)
- `backend/app/tests/test_reports_api.py`
- `backend/app/tests/test_domain_detail_endpoints.py`
- `backend/app/tests/test_public_api.py`
- `backend/app/tests/test_dashboard_template_security.py`

## How tested
- `pytest` for PTR unit tests, reports API, domain detail PTR paths, public source intelligence
- `flake8` on changed Python modules
- App imports via `create_app()`

Stacked on #819 (`fix/818-report-detail-perf`).

Fixes #815

Made with [Cursor](https://cursor.com)