### PR TITLE
fix: bound domain remediation queue enrichment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,8 @@ DELETE_IMPORTED_EMAILS=false
 # DMARQ_DNS_CUSTOM_DOH_HOSTNAME="resolver.example.net"
 
 # Optional source intelligence. These services are not required to parse DMARC.
+# Without tokens, Team Cymru still supplies ASN/BGP/country-code (tokenless fallback).
+# Tokens only add city/org depth — they are optional, never required for ASN.
 SOURCE_NETWORK_ENRICHMENT_ENABLED=true
 # GEOIP_CUSTOM_URL="https://geoip.internal/v1/lookup?ip={ip}"
 # GEOIP_CUSTOM_AUTH_HEADER="Authorization: Bearer replace-me"

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -76,9 +76,7 @@ from app.services.dns_provider_writes import (
     simulate_demo_dns_write,
 )
 from app.services.dns_resolver import (
-    CloudflareDNSProvider,
     DomainDNSResult,
-    PublicRecursiveDNSProvider,
     extract_dmarc_policy,
     get_default_provider,
 )
@@ -121,6 +119,7 @@ from app.services.remediation_readiness import (
     OPERATOR_REVIEW_READINESS_LEVELS,
     repair_readiness_for_stage,
 )
+from app.services.ptr_lookup import lookup_ptr_with_fallbacks
 from app.services.report_persistence import (
     domain_summaries_from_db,
     hydrate_domain_report_store_from_db,
@@ -1974,6 +1973,8 @@ class SourceEntry(BaseModel):
     dmarc_fail_count: int = 0
     disposition_counts: Dict[str, int] = Field(default_factory=dict)
     hostname: Optional[str] = None
+    ptr_status: Optional[str] = None
+    ptr_detail: Optional[str] = None
     sender: SenderIdentity
     geo: SourceGeo
     anomalies: List[SourceAnomaly] = Field(default_factory=list)
@@ -7896,45 +7897,21 @@ def _reputation_recommendations(item: Optional[SourceReputation]) -> List[Source
 
 
 def _ptr_lookup_providers(provider: Any) -> List[Any]:
-    """Return resolver candidates for reverse-DNS sender enrichment."""
-    providers = [provider]
-    provider_class = provider.__class__
-    provider_name = provider_class.__name__
-    if provider_name == "DemoDNSProvider":
-        return providers
-    if provider_class is not PublicRecursiveDNSProvider:
-        providers.append(PublicRecursiveDNSProvider())
-    if provider_class is not CloudflareDNSProvider:
-        providers.append(CloudflareDNSProvider())
-    return providers
+    """Deprecated wrapper kept for tests that still patch this helper."""
+    from app.services.dns_fallbacks import dns_fallback_candidates
+
+    return list(dns_fallback_candidates(provider))
 
 
 async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Optional[str]:
     """Perform a PTR lookup for *ip*, returning ``None`` on any error or timeout."""
-    try:
-        parsed_ip = ipaddress.ip_address(ip)  # validate before making a DNS query
-    except ValueError:
-        return None
-    if not parsed_ip.is_global:
-        return None
-    for candidate in _ptr_lookup_providers(provider):
-        try:
-            hostname = await asyncio.wait_for(candidate.lookup_ptr(ip), timeout=timeout)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.debug(
-                "PTR lookup provider failed during sender enrichment",
-                extra={
-                    "provider": candidate.__class__.__name__,
-                    "ip": ip,
-                    "error": str(exc),
-                },
-            )
-            continue
-        if hostname:
-            return str(hostname).rstrip(".")
-    return None
+    result = await lookup_ptr_with_fallbacks(provider, ip, timeout=timeout, use_cache=True)
+    return result.hostname
+
+
+async def _safe_ptr_lookup_result(provider: Any, ip: str, timeout: float = 3.0):
+    """Return structured PTR diagnostics for one source IP."""
+    return await lookup_ptr_with_fallbacks(provider, ip, timeout=timeout, use_cache=True)
 
 
 async def _source_networks_by_ip(
@@ -8029,9 +8006,13 @@ async def get_domain_sources(
     settings = get_settings()
 
     ips = [s.get("source_ip", "unknown") for s in sources]
-    ptr_task = asyncio.gather(*[_safe_ptr_lookup(provider, ip) for ip in ips])
+    ptr_task = asyncio.gather(*[_safe_ptr_lookup_result(provider, ip) for ip in ips])
     network_task = asyncio.create_task(_source_networks_by_ip(db, provider, ips, settings))
-    hostnames, networks_by_ip = await asyncio.gather(ptr_task, network_task)
+    ptr_results, networks_by_ip = await asyncio.gather(ptr_task, network_task)
+    hostnames = [result.hostname for result in ptr_results]
+    ptr_by_ip = {
+        str(ip): result for ip, result in zip(ips, ptr_results, strict=True)
+    }
     geo_by_ip = {
         str(source.get("source_ip") or "unknown"): merge_network_into_geo(
             source_geo_for(str(source.get("source_ip") or "unknown"), source),
@@ -8102,6 +8083,8 @@ async def get_domain_sources(
                 dmarc_fail_count=source.get("dmarc_fail_count", 0),
                 disposition_counts=source.get("disposition_counts", {}),
                 hostname=hostname,
+                ptr_status=(ptr_by_ip.get(ip).status if ptr_by_ip.get(ip) else None),
+                ptr_detail=(ptr_by_ip.get(ip).detail if ptr_by_ip.get(ip) else None),
                 sender=SenderIdentity(**sender),
                 geo=SourceGeo(
                     **(

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1912,6 +1912,9 @@ class SourceGeo(BaseModel):
     network_source: Optional[str] = None
     network_checked_at: Optional[str] = None
     network_error: Optional[str] = None
+    enrichment_mode: Optional[str] = None
+    field_availability: Dict[str, str] = Field(default_factory=dict)
+    config_hint: Optional[str] = None
     source: str
 
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1469,6 +1469,8 @@ class RemediationQueueResponse(BaseModel):
     items: List[RemediationQueueItem]
     verified_items: List[Dict[str, Any]] = Field(default_factory=list)
     verified_items_total: int = 0
+    enrichment_pending: bool = False
+    enrichment_detail: Optional[str] = None
 
 
 class RemediationNotificationAuditRequest(BaseModel):
@@ -6323,40 +6325,103 @@ async def _build_domain_remediation_queue_for_workspace(
     domain_id: str,
     refresh: bool = False,
 ) -> Dict[str, Any]:
-    """Build the current remediation queue for an authorized workspace."""
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
-    try:
-        domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
-    except HTTPException as exc:
-        if (
-            exc.status_code != status.HTTP_404_NOT_FOUND
-            or _stored_domain_exists(db, domain_id)
-            or not _allows_legacy_report_only_fallback(db)
-        ):
-            raise
-        hydrate_report_store_from_db(db, store)
-        domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
+    """Build the current remediation queue for an authorized workspace.
 
-    domain_health = await _build_domain_health_grade(
-        db,
-        domain_name,
-        store,
-        refresh=refresh,
+    Expensive DNS/reputation enrichment is bounded so the Next remediation
+    panel never waits unbounded for live lookups.
+    """
+    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
+    settings = get_settings()
+    timeout_seconds = max(
+        1.0,
+        float(getattr(settings, "REMEDIATION_QUEUE_TIMEOUT_SECONDS", 8.0) or 8.0),
     )
-    guidance = await _build_domain_dns_guidance(db, store, domain_name, refresh=refresh)
     available_providers = _configured_dns_write_provider_ids(db)
+
+    async def _enrich() -> tuple[Dict[str, Any], Dict[str, Any]]:
+        return await asyncio.gather(
+            _build_domain_health_grade(
+                db,
+                domain_name,
+                store,
+                refresh=refresh,
+            ),
+            _build_domain_dns_guidance(
+                db,
+                store,
+                domain_name,
+                refresh=refresh,
+            ),
+        )
+
+    try:
+        domain_health, guidance = await asyncio.wait_for(
+            _enrich(),
+            timeout=timeout_seconds,
+        )
+    except asyncio.TimeoutError:
+        logger.info(
+            "Remediation queue enrichment timed out for %s; returning bounded empty queue",
+            domain_name,
+        )
+        summary = store.get_domain_summary(domain_name) or {}
+        domain_health = {
+            "domain": domain_name,
+            "grade": "unknown",
+            "score": 0,
+            "actions": [],
+            "summary": summary,
+            "enrichment_pending": True,
+        }
+        guidance = {
+            "findings": [],
+            "change_plans": [],
+            "target_records": [],
+            "dns_provider": None,
+            "enrichment_pending": True,
+        }
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.info(
+            "Remediation queue enrichment failed for %s: %s",
+            domain_name,
+            type(exc).__name__,
+        )
+        domain_health = {
+            "domain": domain_name,
+            "grade": "unknown",
+            "score": 0,
+            "actions": [],
+            "enrichment_pending": True,
+        }
+        guidance = {
+            "findings": [],
+            "change_plans": [],
+            "target_records": [],
+            "dns_provider": None,
+            "enrichment_pending": True,
+        }
+
     recommended_provider = _recommended_dns_write_provider(
         guidance.get("dns_provider"),
         available_providers,
     )
-    return build_remediation_queue(
+    queue = build_remediation_queue(
         domain=domain_name,
         health=domain_health,
         dns_guidance=guidance,
         available_write_providers=available_providers,
         recommended_provider=recommended_provider,
     )
+    if guidance.get("enrichment_pending") or domain_health.get("enrichment_pending"):
+        queue = {
+            **queue,
+            "enrichment_pending": True,
+            "enrichment_detail": (
+                "DNS/posture enrichment timed out or failed; "
+                "showing any evidence already available without blocking the panel."
+            ),
+        }
+    return queue
 
 
 @router.get("/{domain_id}/remediation", response_model=RemediationQueueResponse)

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -748,16 +748,43 @@ async def _ptr_lookups_by_ip(
     unique_ips: List[str],
     *,
     concurrency: int = 20,
+    results: Optional[Dict[str, PtrLookupResult]] = None,
 ) -> Dict[str, PtrLookupResult]:
     """Resolve PTR hostnames once per unique IP with bounded concurrency."""
     semaphore = asyncio.Semaphore(max(1, concurrency))
+    resolved = results if results is not None else {}
 
-    async def _lookup(ip: str) -> tuple[str, PtrLookupResult]:
+    async def _lookup(ip: str) -> None:
         async with semaphore:
-            return ip, await _resolve_ptr_result(provider, ip)
+            resolved[ip] = await _resolve_ptr_result(provider, ip)
 
-    pairs = await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
-    return dict(pairs)
+    await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
+    return resolved
+
+
+async def _report_ptrs_by_ip(
+    provider: Any,
+    unique_ips: List[str],
+    settings: Any,
+) -> tuple[Dict[str, PtrLookupResult], str]:
+    """Cap and time-box PTR enrichment while retaining completed lookups."""
+    max_ips = max(0, int(settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS))
+    selected_ips = unique_ips[:max_ips]
+    resolved: Dict[str, PtrLookupResult] = {}
+    if not selected_ips:
+        return resolved, "complete" if not unique_ips else "pending"
+    try:
+        await asyncio.wait_for(
+            _ptr_lookups_by_ip(provider, selected_ips, results=resolved),
+            timeout=max(
+                0.5,
+                float(settings.SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS),
+            ),
+        )
+    except asyncio.TimeoutError:
+        logger.info("Report PTR enrichment timed out for report detail")
+        return resolved, "pending"
+    return resolved, "complete" if len(selected_ips) == len(unique_ips) else "pending"
 
 
 async def _report_networks_by_ip(
@@ -824,8 +851,9 @@ async def _report_reputations_by_ip(
             ),
         )
         return reputation_result, source_reputation_by_ip(reputation_result), "complete"
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
         logger.info("Report source reputation enrichment timed out for report detail")
+        _raise_refresh_reputation_failure(refresh, exc)
         return None, {}, "timed_out"
     except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.info(
@@ -844,14 +872,15 @@ def _report_enrichment_status(
     unique_source_ips: int,
     record_count: int,
 ) -> ReportEnrichmentStatus:
-    pending_states = {"timed_out", "pending"}
-    pending = network_status in pending_states or reputation_status in pending_states
+    pending_states = {"timed_out", "pending", "partial"}
+    pending = any(
+        enrichment_status in pending_states
+        for enrichment_status in (ptr_status, network_status, reputation_status)
+    )
     if pending:
         overall = "partial"
     elif "failed" in {network_status, reputation_status, ptr_status}:
         overall = "partial"
-    elif network_status == "disabled" and reputation_status == "complete":
-        overall = "complete"
     else:
         overall = "complete"
     return ReportEnrichmentStatus(
@@ -1142,25 +1171,27 @@ async def get_report_by_id(
 
     # Evidence first: PTR and network enrichment run in parallel, each bounded.
     # PTR is deduped to one lookup per unique IP (not per report row).
-    ptr_task = asyncio.create_task(_ptr_lookups_by_ip(provider, unique_ips))
+    ptr_task = asyncio.create_task(_report_ptrs_by_ip(provider, unique_ips, settings))
     network_task = asyncio.create_task(
         _report_networks_by_ip(db, provider, unique_ips, settings)
     )
-    ptr_by_ip, (networks_by_ip, network_status) = await asyncio.gather(
+    (ptr_by_ip, ptr_status), (networks_by_ip, network_status) = await asyncio.gather(
         ptr_task, network_task
     )
     hostnames = [
         (ptr_by_ip.get(ip).hostname if ptr_by_ip.get(ip) else None) for ip in ips
     ]
-    if any((ptr_by_ip.get(ip) and ptr_by_ip[ip].transient) for ip in unique_ips):
-        ptr_status = "timed_out"
-    elif any(
-        (ptr_by_ip.get(ip) and ptr_by_ip[ip].status not in {"ok", "nxdomain", "skipped", "invalid"})
-        for ip in unique_ips
-    ):
-        ptr_status = "partial"
-    else:
-        ptr_status = "complete"
+    if ptr_status == "complete":
+        if any((ptr_by_ip.get(ip) and ptr_by_ip[ip].transient) for ip in unique_ips):
+            ptr_status = "timed_out"
+        elif any(
+            (
+                ptr_by_ip.get(ip)
+                and ptr_by_ip[ip].status not in {"ok", "nxdomain", "skipped", "invalid"}
+            )
+            for ip in unique_ips
+        ):
+            ptr_status = "partial"
 
     sender_by_ip = {
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -1090,6 +1090,9 @@ def _source_details(
         "network_source": geo.get("network_source"),
         "network_checked_at": geo.get("network_checked_at"),
         "network_error": geo.get("network_error"),
+        "enrichment_mode": geo.get("enrichment_mode"),
+        "field_availability": geo.get("field_availability") or {},
+        "config_hint": geo.get("config_hint"),
         "geo_source": geo.get("source"),
     }
 

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -1,5 +1,4 @@
 import asyncio
-import ipaddress
 import logging
 from typing import Any, Dict, List, Optional
 
@@ -22,6 +21,7 @@ from app.services.report_persistence import (
     save_parsed_report,
 )
 from app.services.report_store import ReportStore
+from app.services.ptr_lookup import PtrLookupResult, lookup_ptr_with_fallbacks
 from app.services.sender_intelligence import identify_sender, source_geo_for
 from app.services.source_network import (
     SourceNetworkIntelligence,
@@ -727,14 +727,15 @@ def _record_review_guidance(record: Dict[str, Any]) -> Dict[str, Any]:
 
 async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Optional[str]:
     """Return reverse DNS for an IP without letting enrichment break report loading."""
-    try:
-        ipaddress.ip_address(ip)
-    except ValueError:
-        return None
-    try:
-        return await asyncio.wait_for(provider.lookup_ptr(ip), timeout=timeout)
-    except Exception:
-        return None
+    result = await _resolve_ptr_result(provider, ip, timeout=timeout)
+    return result.hostname
+
+
+async def _resolve_ptr_result(
+    provider: Any, ip: str, timeout: float = 3.0
+) -> PtrLookupResult:
+    """Resolve PTR with fallbacks; patchable in tests."""
+    return await lookup_ptr_with_fallbacks(provider, ip, timeout=timeout)
 
 
 def _unique_source_ips(ips: List[str]) -> List[str]:
@@ -747,13 +748,13 @@ async def _ptr_lookups_by_ip(
     unique_ips: List[str],
     *,
     concurrency: int = 20,
-) -> Dict[str, Optional[str]]:
+) -> Dict[str, PtrLookupResult]:
     """Resolve PTR hostnames once per unique IP with bounded concurrency."""
     semaphore = asyncio.Semaphore(max(1, concurrency))
 
-    async def _lookup(ip: str) -> tuple[str, Optional[str]]:
+    async def _lookup(ip: str) -> tuple[str, PtrLookupResult]:
         async with semaphore:
-            return ip, await _safe_ptr_lookup(provider, ip)
+            return ip, await _resolve_ptr_result(provider, ip)
 
     pairs = await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
     return dict(pairs)
@@ -1060,10 +1061,14 @@ def _source_details(
     hostname: Optional[str],
     sender: Dict[str, Any],
     network: Optional[SourceNetworkIntelligence] = None,
+    ptr_result: Optional[PtrLookupResult] = None,
 ) -> Dict[str, Any]:
     geo = merge_network_into_geo(source_geo_for(ip, record), network)
     return {
         "hostname": hostname,
+        "ptr_status": ptr_result.status if ptr_result else None,
+        "ptr_detail": ptr_result.detail if ptr_result else None,
+        "ptr_transient": ptr_result.transient if ptr_result else None,
         "sender": sender,
         "country": geo.get("country"),
         "country_code": geo.get("country_code"),
@@ -1138,11 +1143,21 @@ async def get_report_by_id(
     network_task = asyncio.create_task(
         _report_networks_by_ip(db, provider, unique_ips, settings)
     )
-    hostnames_by_ip, (networks_by_ip, network_status) = await asyncio.gather(
+    ptr_by_ip, (networks_by_ip, network_status) = await asyncio.gather(
         ptr_task, network_task
     )
-    hostnames = [hostnames_by_ip.get(ip) for ip in ips]
-    ptr_status = "complete"
+    hostnames = [
+        (ptr_by_ip.get(ip).hostname if ptr_by_ip.get(ip) else None) for ip in ips
+    ]
+    if any((ptr_by_ip.get(ip) and ptr_by_ip[ip].transient) for ip in unique_ips):
+        ptr_status = "timed_out"
+    elif any(
+        (ptr_by_ip.get(ip) and ptr_by_ip[ip].status not in {"ok", "nxdomain", "skipped", "invalid"})
+        for ip in unique_ips
+    ):
+        ptr_status = "partial"
+    else:
+        ptr_status = "complete"
 
     sender_by_ip = {
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))
@@ -1180,6 +1195,7 @@ async def get_report_by_id(
                     hostname,
                     sender_by_ip.get(ip, {}),
                     networks_by_ip.get(ip),
+                    ptr_by_ip.get(ip),
                 ),
                 reputation=_source_reputation_dict(reputation) if reputation else None,
                 **guidance,

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -655,6 +655,18 @@ class ReportSummaryDetail(BaseModel):
     pass_rate: float
 
 
+class ReportEnrichmentStatus(BaseModel):
+    """Bounded enrichment outcome for report-detail progressive hydration."""
+
+    status: str = "complete"
+    pending: bool = False
+    ptr: str = "complete"
+    network: str = "complete"
+    reputation: str = "complete"
+    unique_source_ips: int = 0
+    record_count: int = 0
+
+
 class ReportDetail(BaseModel):
     """Full detail of a single DMARC report"""
 
@@ -670,6 +682,7 @@ class ReportDetail(BaseModel):
     records: List[ReportRecordDetail]
     summary: ReportSummaryDetail
     reputation_summary: Dict[str, Any] = Field(default_factory=dict)
+    enrichment: ReportEnrichmentStatus = Field(default_factory=ReportEnrichmentStatus)
 
 
 def _record_review_guidance(record: Dict[str, Any]) -> Dict[str, Any]:
@@ -722,6 +735,133 @@ async def _safe_ptr_lookup(provider: Any, ip: str, timeout: float = 3.0) -> Opti
         return await asyncio.wait_for(provider.lookup_ptr(ip), timeout=timeout)
     except Exception:
         return None
+
+
+def _unique_source_ips(ips: List[str]) -> List[str]:
+    """Preserve first-seen order while collapsing duplicate report-row IPs."""
+    return list(dict.fromkeys(ips))
+
+
+async def _ptr_lookups_by_ip(
+    provider: Any,
+    unique_ips: List[str],
+    *,
+    concurrency: int = 20,
+) -> Dict[str, Optional[str]]:
+    """Resolve PTR hostnames once per unique IP with bounded concurrency."""
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+
+    async def _lookup(ip: str) -> tuple[str, Optional[str]]:
+        async with semaphore:
+            return ip, await _safe_ptr_lookup(provider, ip)
+
+    pairs = await asyncio.gather(*[_lookup(ip) for ip in unique_ips])
+    return dict(pairs)
+
+
+async def _report_networks_by_ip(
+    db: Session,
+    provider: Any,
+    unique_ips: List[str],
+    settings: Any,
+) -> tuple[Dict[str, SourceNetworkIntelligence], str]:
+    """Batch network enrichment with a hard detail-path timeout."""
+    if not settings.SOURCE_NETWORK_ENRICHMENT_ENABLED:
+        return {}, "disabled"
+    try:
+        networks = await asyncio.wait_for(
+            lookup_sources_network_cached(
+                db,
+                provider,
+                unique_ips,
+                ttl_seconds=settings.SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS,
+                max_ips=settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS,
+            ),
+            timeout=max(
+                0.5,
+                float(settings.SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS),
+            ),
+        )
+        return networks, "complete"
+    except asyncio.TimeoutError:
+        logger.info("Report source network enrichment timed out for report detail")
+        return {}, "timed_out"
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.info(
+            "Report source network enrichment failed for report detail: %s",
+            type(exc).__name__,
+        )
+        return {}, "failed"
+
+
+async def _report_reputations_by_ip(
+    db: Session,
+    domain_name: str,
+    report: Dict[str, Any],
+    source_rows: List[Dict[str, Any]],
+    sender_by_ip: Dict[str, Dict[str, Any]],
+    *,
+    refresh: bool,
+    settings: Any,
+) -> tuple[Optional[DomainReputation], Dict[str, SourceReputation], str]:
+    """Build reputation evidence with a hard detail-path timeout."""
+    try:
+        reputation_result, _, _ = await asyncio.wait_for(
+            build_source_reputation_cached(
+                db,
+                domain_name,
+                [report],
+                source_rows,
+                senders_by_ip=sender_by_ip,
+                anomalies_by_ip={},
+                days=1,
+                refresh=refresh,
+            ),
+            timeout=max(
+                0.5,
+                float(settings.SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS) * (2 if refresh else 1),
+            ),
+        )
+        return reputation_result, source_reputation_by_ip(reputation_result), "complete"
+    except asyncio.TimeoutError:
+        logger.info("Report source reputation enrichment timed out for report detail")
+        return None, {}, "timed_out"
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.info(
+            "Report source reputation enrichment failed for report detail: %s",
+            type(exc).__name__,
+        )
+        _raise_refresh_reputation_failure(refresh, exc)
+        return None, {}, "failed"
+
+
+def _report_enrichment_status(
+    *,
+    ptr_status: str,
+    network_status: str,
+    reputation_status: str,
+    unique_source_ips: int,
+    record_count: int,
+) -> ReportEnrichmentStatus:
+    pending_states = {"timed_out", "pending"}
+    pending = network_status in pending_states or reputation_status in pending_states
+    if pending:
+        overall = "partial"
+    elif "failed" in {network_status, reputation_status, ptr_status}:
+        overall = "partial"
+    elif network_status == "disabled" and reputation_status == "complete":
+        overall = "complete"
+    else:
+        overall = "complete"
+    return ReportEnrichmentStatus(
+        status=overall,
+        pending=pending,
+        ptr=ptr_status,
+        network=network_status,
+        reputation=reputation_status,
+        unique_source_ips=unique_source_ips,
+        record_count=record_count,
+    )
 
 
 def _raise_refresh_reputation_failure(refresh_reputation: bool, exc: Exception) -> None:
@@ -990,52 +1130,33 @@ async def get_report_by_id(
     provider = get_default_provider(db)
     settings = get_settings()
     ips = [str(row.get("source_ip") or "unknown") for row in source_rows]
-    ptr_semaphore = asyncio.Semaphore(20)
+    unique_ips = _unique_source_ips(ips)
 
-    async def _bounded_ptr_lookup(ip: str) -> Optional[str]:
-        async with ptr_semaphore:
-            return await _safe_ptr_lookup(provider, ip)
+    # Evidence first: PTR and network enrichment run in parallel, each bounded.
+    # PTR is deduped to one lookup per unique IP (not per report row).
+    ptr_task = asyncio.create_task(_ptr_lookups_by_ip(provider, unique_ips))
+    network_task = asyncio.create_task(
+        _report_networks_by_ip(db, provider, unique_ips, settings)
+    )
+    hostnames_by_ip, (networks_by_ip, network_status) = await asyncio.gather(
+        ptr_task, network_task
+    )
+    hostnames = [hostnames_by_ip.get(ip) for ip in ips]
+    ptr_status = "complete"
 
-    hostnames = await asyncio.gather(*[_bounded_ptr_lookup(ip) for ip in ips])
-    networks_by_ip: Dict[str, SourceNetworkIntelligence] = {}
-    if settings.SOURCE_NETWORK_ENRICHMENT_ENABLED:
-        try:
-            networks_by_ip = await lookup_sources_network_cached(
-                db,
-                provider,
-                ips,
-                ttl_seconds=settings.SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS,
-                max_ips=settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS,
-            )
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            logger.info(
-                "Report source network enrichment failed for report detail: %s",
-                type(exc).__name__,
-            )
     sender_by_ip = {
         ip: identify_sender(ip, row, hostname=hostname, domain=report.get("domain", ""))
         for ip, row, hostname in zip(ips, source_rows, hostnames, strict=True)
     }
-    reputation_result: Optional[DomainReputation] = None
-    reputations_by_ip: Dict[str, SourceReputation] = {}
-    try:
-        reputation_result, _, _ = await build_source_reputation_cached(
-            db,
-            str(report.get("domain", "")),
-            [report],
-            source_rows,
-            senders_by_ip=sender_by_ip,
-            anomalies_by_ip={},
-            days=1,
-            refresh=refresh_reputation,
-        )
-        reputations_by_ip = source_reputation_by_ip(reputation_result)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.info(
-            "Report source reputation enrichment failed for report detail: %s",
-            type(exc).__name__,
-        )
-        _raise_refresh_reputation_failure(refresh_reputation, exc)
+    reputation_result, reputations_by_ip, reputation_status = await _report_reputations_by_ip(
+        db,
+        str(report.get("domain", "")),
+        report,
+        source_rows,
+        sender_by_ip,
+        refresh=refresh_reputation,
+        settings=settings,
+    )
 
     # Normalize records
     record_details = []
@@ -1072,6 +1193,13 @@ async def get_report_by_id(
         failed_count=raw_summary.get("failed_count", 0),
         pass_rate=raw_summary.get("pass_rate", 0.0),
     )
+    enrichment = _report_enrichment_status(
+        ptr_status=ptr_status,
+        network_status=network_status,
+        reputation_status=reputation_status,
+        unique_source_ips=len(unique_ips),
+        record_count=len(raw_records),
+    )
 
     return ReportDetail(
         report_id=report.get("report_id", ""),
@@ -1086,4 +1214,5 @@ async def get_report_by_id(
         records=record_details,
         summary=summary_detail,
         reputation_summary=_report_reputation_summary(reputation_result),
+        enrichment=enrichment,
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -144,6 +144,7 @@ class Settings(BaseSettings):
     DNS_STARTUP_PREWARM_CONCURRENCY: int = 4
     DNS_SUMMARY_REFRESH_CONCURRENCY: int = 6
     DNS_SUMMARY_REFRESH_TIMEOUT_SECONDS: float = 10.0
+    REMEDIATION_QUEUE_TIMEOUT_SECONDS: float = 8.0
 
     # Optional Stripe Billing integration. Self-hosted and provider-billed
     # deployments work without these values.

--- a/backend/app/services/ptr_lookup.py
+++ b/backend/app/services/ptr_lookup.py
@@ -217,7 +217,39 @@ def _doh_status_result(provider_name: str, status_code: int) -> Optional[PtrLook
     return mapping.get(status_code)
 
 
-async def _cloudflare_ptr(provider: CloudflareDNSProvider, ip: str) -> PtrLookupResult:  # noqa: C901
+def _doh_payload_result(provider_name: str, data: Dict[str, Any]) -> PtrLookupResult:
+    """Convert a DNS-over-HTTPS response payload into a typed PTR result."""
+    status_code = int(data.get("Status", -1) or -1)
+    mapped = _doh_status_result(provider_name, status_code)
+    if mapped is not None:
+        return mapped
+
+    for answer in data.get("Answer", []) or []:
+        if answer.get("type") == 12:
+            hostname = str(answer.get("data") or "").rstrip(".")
+            if hostname:
+                return PtrLookupResult(
+                    hostname=hostname,
+                    status=_STATUS_OK,
+                    detail="PTR record found",
+                    provider=provider_name,
+                )
+
+    if status_code == 0:
+        return PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="DoH NOERROR with empty PTR answer",
+            provider=provider_name,
+            authoritative_negative=True,
+        )
+    return PtrLookupResult(
+        status=_STATUS_TRANSIENT,
+        detail=f"DoH status {status_code}",
+        provider=provider_name,
+    )
+
+
+async def _cloudflare_ptr(provider: CloudflareDNSProvider, ip: str) -> PtrLookupResult:
     import httpx  # type: ignore[import]
 
     try:
@@ -251,34 +283,7 @@ async def _cloudflare_ptr(provider: CloudflareDNSProvider, ip: str) -> PtrLookup
             provider=provider_name,
         )
 
-    status_code = int(data.get("Status", -1) or -1)
-    mapped = _doh_status_result(provider_name, status_code)
-    if mapped is not None:
-        return mapped
-
-    for answer in data.get("Answer", []) or []:
-        if answer.get("type") == 12:
-            hostname = str(answer.get("data") or "").rstrip(".")
-            if hostname:
-                return PtrLookupResult(
-                    hostname=hostname,
-                    status=_STATUS_OK,
-                    detail="PTR record found",
-                    provider=provider_name,
-                )
-
-    if status_code == 0:
-        return PtrLookupResult(
-            status=_STATUS_NXDOMAIN,
-            detail="DoH NOERROR with empty PTR answer",
-            provider=provider_name,
-            authoritative_negative=True,
-        )
-    return PtrLookupResult(
-        status=_STATUS_TRANSIENT,
-        detail=f"DoH status {status_code}",
-        provider=provider_name,
-    )
+    return _doh_payload_result(provider_name, data)
 
 
 async def _provider_ptr(provider: Any, ip: str) -> PtrLookupResult:

--- a/backend/app/services/ptr_lookup.py
+++ b/backend/app/services/ptr_lookup.py
@@ -1,0 +1,408 @@
+"""Reliable PTR enrichment with fallback resolvers and typed failure modes."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from app.services.dns_fallbacks import dns_fallback_candidates
+from app.services.dns_resolver import (
+    CloudflareDNSProvider,
+    DemoDNSProvider,
+    PublicRecursiveDNSProvider,
+    SystemDNSProvider,
+    _ip_to_arpa_name,
+)
+
+logger = logging.getLogger(__name__)
+
+# Authoritative outcomes may be cached; transient failures must not be.
+_POSITIVE_CACHE_TTL_SECONDS = 3_600
+_NXDOMAIN_CACHE_TTL_SECONDS = 300
+_PTR_RESULT_CACHE: Dict[str, Tuple["PtrLookupResult", float]] = {}
+
+_STATUS_OK = "ok"
+_STATUS_NXDOMAIN = "nxdomain"
+_STATUS_TIMEOUT = "timeout"
+_STATUS_REFUSED = "refused"
+_STATUS_SERVFAIL = "servfail"
+_STATUS_TRANSIENT = "transient"
+_STATUS_INVALID = "invalid"
+_STATUS_SKIPPED = "skipped"
+_STATUS_UNAVAILABLE = "unavailable"
+
+_TRANSIENT_STATUSES = {
+    _STATUS_TIMEOUT,
+    _STATUS_REFUSED,
+    _STATUS_SERVFAIL,
+    _STATUS_TRANSIENT,
+}
+
+
+@dataclass(frozen=True)
+class PtrLookupResult:
+    """Structured PTR outcome suitable for API/UI diagnostics (no secrets)."""
+
+    hostname: Optional[str] = None
+    status: str = _STATUS_UNAVAILABLE
+    detail: str = ""
+    provider: Optional[str] = None
+    authoritative_negative: bool = False
+
+    @property
+    def cacheable(self) -> bool:
+        return bool(self.hostname) or self.authoritative_negative
+
+    @property
+    def transient(self) -> bool:
+        return self.status in _TRANSIENT_STATUSES
+
+    def as_public_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["transient"] = self.transient
+        return payload
+
+
+def clear_ptr_lookup_cache() -> None:
+    """Test helper: drop process-local PTR cache."""
+    _PTR_RESULT_CACHE.clear()
+
+
+def ptr_label(result: Optional[PtrLookupResult]) -> str:
+    """Human-readable PTR status for UI surfaces."""
+    if result is None:
+        return "PTR unavailable"
+    if result.hostname:
+        return f"PTR {result.hostname}"
+    labels = {
+        _STATUS_NXDOMAIN: "PTR unavailable — no PTR record (NXDOMAIN)",
+        _STATUS_TIMEOUT: "PTR unavailable — resolver timeout (will retry)",
+        _STATUS_REFUSED: "PTR unavailable — resolver refused the query (will retry)",
+        _STATUS_SERVFAIL: "PTR unavailable — resolver failure (will retry)",
+        _STATUS_TRANSIENT: "PTR unavailable — transient DNS error (will retry)",
+        _STATUS_SKIPPED: "PTR skipped — address is not a global unicast IP",
+        _STATUS_INVALID: "PTR skipped — invalid IP address",
+    }
+    if result.status in labels:
+        return labels[result.status]
+    detail = (result.detail or "").strip()
+    if detail:
+        return f"PTR unavailable — {detail}"
+    return "PTR unavailable"
+
+
+def _cache_key(ip: str) -> str:
+    return ip.strip().lower()
+
+
+def _cache_get(ip: str) -> Optional[PtrLookupResult]:
+    key = _cache_key(ip)
+    cached = _PTR_RESULT_CACHE.get(key)
+    if cached is None:
+        return None
+    result, expires_at = cached
+    if expires_at <= time.monotonic():
+        _PTR_RESULT_CACHE.pop(key, None)
+        return None
+    return result
+
+
+def _cache_put(ip: str, result: PtrLookupResult) -> None:
+    if not result.cacheable:
+        return
+    ttl = (
+        _POSITIVE_CACHE_TTL_SECONDS
+        if result.hostname
+        else _NXDOMAIN_CACHE_TTL_SECONDS
+    )
+    _PTR_RESULT_CACHE[_cache_key(ip)] = (result, time.monotonic() + ttl)
+
+
+def _classify_dnspython_exc(exc: BaseException) -> PtrLookupResult:
+    import dns.exception  # type: ignore[import]
+    import dns.resolver  # type: ignore[import]
+
+    if isinstance(exc, dns.resolver.NXDOMAIN):
+        return PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="authoritative NXDOMAIN",
+            authoritative_negative=True,
+        )
+    if isinstance(exc, (dns.exception.Timeout, asyncio.TimeoutError)):
+        return PtrLookupResult(status=_STATUS_TIMEOUT, detail="DNS query timed out")
+    if isinstance(exc, dns.resolver.NoNameservers):
+        return PtrLookupResult(status=_STATUS_REFUSED, detail="no usable nameservers")
+    message = str(exc).lower()
+    if "refused" in message:
+        return PtrLookupResult(status=_STATUS_REFUSED, detail="resolver refused the query")
+    if "servfail" in message or "server failure" in message:
+        return PtrLookupResult(status=_STATUS_SERVFAIL, detail="resolver SERVFAIL")
+    if isinstance(exc, dns.exception.DNSException):
+        return PtrLookupResult(status=_STATUS_TRANSIENT, detail=type(exc).__name__)
+    return PtrLookupResult(status=_STATUS_TRANSIENT, detail=type(exc).__name__)
+
+
+async def _dnspython_ptr(provider: Any, ip: str) -> PtrLookupResult:
+    import dns.asyncresolver  # type: ignore[import]
+    import dns.exception  # type: ignore[import]
+    import dns.resolver  # type: ignore[import]
+
+    try:
+        ptr_name = _ip_to_arpa_name(ip)
+    except ValueError:
+        return PtrLookupResult(status=_STATUS_INVALID, detail="invalid IP address")
+
+    try:
+        if isinstance(provider, PublicRecursiveDNSProvider) and hasattr(provider, "_resolve"):
+            answers = await provider._resolve(ptr_name, "PTR")  # pylint: disable=protected-access
+        else:
+            answers = await dns.asyncresolver.resolve(
+                ptr_name, "PTR", lifetime=3.0, raise_on_no_answer=False
+            )
+        if answers:
+            for rdata in answers:
+                hostname = str(rdata).rstrip(".")
+                if hostname:
+                    return PtrLookupResult(
+                        hostname=hostname,
+                        status=_STATUS_OK,
+                        detail="PTR record found",
+                        provider=provider.__class__.__name__,
+                    )
+        return PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="no PTR answer",
+            provider=provider.__class__.__name__,
+            authoritative_negative=True,
+        )
+    except (dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.exception.DNSException) as exc:
+        classified = _classify_dnspython_exc(exc)
+        return PtrLookupResult(
+            status=classified.status,
+            detail=classified.detail,
+            provider=provider.__class__.__name__,
+            authoritative_negative=classified.authoritative_negative,
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return PtrLookupResult(
+            status=_STATUS_TRANSIENT,
+            detail=type(exc).__name__,
+            provider=provider.__class__.__name__,
+        )
+
+
+def _doh_status_result(provider_name: str, status_code: int) -> Optional[PtrLookupResult]:
+    mapping = {
+        3: PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="DoH NXDOMAIN",
+            provider=provider_name,
+            authoritative_negative=True,
+        ),
+        5: PtrLookupResult(
+            status=_STATUS_REFUSED,
+            detail="DoH REFUSED",
+            provider=provider_name,
+        ),
+        2: PtrLookupResult(
+            status=_STATUS_SERVFAIL,
+            detail="DoH SERVFAIL",
+            provider=provider_name,
+        ),
+    }
+    return mapping.get(status_code)
+
+
+async def _cloudflare_ptr(provider: CloudflareDNSProvider, ip: str) -> PtrLookupResult:  # noqa: C901
+    import httpx  # type: ignore[import]
+
+    try:
+        ptr_name = _ip_to_arpa_name(ip)
+    except ValueError:
+        return PtrLookupResult(status=_STATUS_INVALID, detail="invalid IP address")
+
+    params = {"name": ptr_name, "type": "PTR"}
+    headers = {"Accept": "application/dns-json"}
+    provider_name = provider.__class__.__name__
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                provider.CLOUDFLARE_DOH_URL,
+                params=params,
+                headers=headers,
+                timeout=3.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+    except httpx.TimeoutException:
+        return PtrLookupResult(
+            status=_STATUS_TIMEOUT,
+            detail="DoH query timed out",
+            provider=provider_name,
+        )
+    except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+        return PtrLookupResult(
+            status=_STATUS_TRANSIENT,
+            detail=type(exc).__name__,
+            provider=provider_name,
+        )
+
+    status_code = int(data.get("Status", -1) or -1)
+    mapped = _doh_status_result(provider_name, status_code)
+    if mapped is not None:
+        return mapped
+
+    for answer in data.get("Answer", []) or []:
+        if answer.get("type") == 12:
+            hostname = str(answer.get("data") or "").rstrip(".")
+            if hostname:
+                return PtrLookupResult(
+                    hostname=hostname,
+                    status=_STATUS_OK,
+                    detail="PTR record found",
+                    provider=provider_name,
+                )
+
+    if status_code == 0:
+        return PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="DoH NOERROR with empty PTR answer",
+            provider=provider_name,
+            authoritative_negative=True,
+        )
+    return PtrLookupResult(
+        status=_STATUS_TRANSIENT,
+        detail=f"DoH status {status_code}",
+        provider=provider_name,
+    )
+
+
+async def _provider_ptr(provider: Any, ip: str) -> PtrLookupResult:
+    if isinstance(provider, DemoDNSProvider):
+        hostname = await provider.lookup_ptr(ip)
+        if hostname:
+            return PtrLookupResult(
+                hostname=str(hostname).rstrip("."),
+                status=_STATUS_OK,
+                detail="demo PTR map",
+                provider=provider.__class__.__name__,
+            )
+        return PtrLookupResult(
+            status=_STATUS_NXDOMAIN,
+            detail="no demo PTR mapping",
+            provider=provider.__class__.__name__,
+            authoritative_negative=True,
+        )
+    if isinstance(provider, CloudflareDNSProvider):
+        return await _cloudflare_ptr(provider, ip)
+    if isinstance(provider, (SystemDNSProvider, PublicRecursiveDNSProvider)):
+        return await _dnspython_ptr(provider, ip)
+
+    try:
+        hostname = await provider.lookup_ptr(ip)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return PtrLookupResult(
+            status=_STATUS_TRANSIENT,
+            detail=type(exc).__name__,
+            provider=provider.__class__.__name__,
+        )
+    if hostname:
+        return PtrLookupResult(
+            hostname=str(hostname).rstrip("."),
+            status=_STATUS_OK,
+            detail="PTR record found",
+            provider=provider.__class__.__name__,
+        )
+    return PtrLookupResult(
+        status=_STATUS_UNAVAILABLE,
+        detail="provider returned no PTR",
+        provider=provider.__class__.__name__,
+    )
+
+
+async def _lookup_candidate(
+    candidate: Any,
+    ip: str,
+    *,
+    timeout: float,
+) -> PtrLookupResult:
+    try:
+        async with asyncio.timeout(timeout):
+            return await _provider_ptr(candidate, ip)
+    except asyncio.CancelledError:
+        raise
+    except TimeoutError:
+        return PtrLookupResult(
+            status=_STATUS_TIMEOUT,
+            detail="lookup timed out",
+            provider=candidate.__class__.__name__,
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.debug(
+            "PTR lookup provider failed",
+            extra={
+                "provider": candidate.__class__.__name__,
+                "ip": ip,
+                "error": type(exc).__name__,
+            },
+        )
+        return PtrLookupResult(
+            status=_STATUS_TRANSIENT,
+            detail=type(exc).__name__,
+            provider=candidate.__class__.__name__,
+        )
+
+
+async def lookup_ptr_with_fallbacks(  # noqa: C901
+    provider: Any,
+    ip: str,
+    *,
+    timeout: float = 3.0,
+    use_cache: bool = True,
+) -> PtrLookupResult:
+    """Resolve PTR using configured fallback resolvers with typed failure modes."""
+    try:
+        parsed_ip = ipaddress.ip_address(ip)
+    except ValueError:
+        return PtrLookupResult(status=_STATUS_INVALID, detail="invalid IP address")
+    if not parsed_ip.is_global:
+        return PtrLookupResult(status=_STATUS_SKIPPED, detail="non-global IP")
+
+    if use_cache:
+        cached = _cache_get(ip)
+        if cached is not None:
+            return cached
+
+    candidates = dns_fallback_candidates(provider)
+    last_result = PtrLookupResult(status=_STATUS_UNAVAILABLE, detail="no resolver candidates")
+    for candidate in candidates:
+        result = await _lookup_candidate(candidate, ip, timeout=timeout)
+        last_result = result
+        if result.hostname:
+            if use_cache:
+                _cache_put(ip, result)
+            return result
+        if result.authoritative_negative:
+            continue
+
+    preferred = last_result
+    if use_cache and preferred.cacheable:
+        _cache_put(ip, preferred)
+    return preferred
+
+
+async def safe_ptr_hostname(
+    provider: Any,
+    ip: str,
+    *,
+    timeout: float = 3.0,
+) -> Optional[str]:
+    """Compatibility wrapper returning only the PTR hostname."""
+    result = await lookup_ptr_with_fallbacks(provider, ip, timeout=timeout)
+    return result.hostname

--- a/backend/app/services/source_network.py
+++ b/backend/app/services/source_network.py
@@ -112,6 +112,104 @@ class SourceNetworkIntelligence:  # pylint: disable=too-many-instance-attributes
     checked_at: str = ""
     error: Optional[str] = None
     dns_retry_pending: bool = False
+    enrichment_mode: str = "unavailable"
+    field_availability: Optional[Dict[str, str]] = None
+    config_hint: Optional[str] = None
+
+
+def _premium_geo_providers_configured(settings: Any) -> bool:
+    return bool(
+        (getattr(settings, "IPINFO_TOKEN", None) or "").strip()
+        or (getattr(settings, "IPGEOLOCATION_API_KEY", None) or "").strip()
+        or (
+            getattr(settings, "CLOUDFLARE_RADAR_API_TOKEN", None)
+            or getattr(settings, "CLOUDFLARE_API_TOKEN", None)
+            or ""
+        ).strip()
+        or (getattr(settings, "GEOIP_CUSTOM_URL", None) or "").strip()
+    )
+
+
+def _annotate_enrichment_availability(  # noqa: C901
+    result: SourceNetworkIntelligence,
+) -> SourceNetworkIntelligence:
+    """Attach mode/field reasons without dropping tokenless ASN/geo evidence."""
+    settings = get_settings()
+    premium = _premium_geo_providers_configured(settings)
+    sources = {part.strip() for part in str(result.source or "").split(",") if part.strip()}
+    token_sources = {"ipinfo-lite", "ipgeolocation", "cloudflare-radar", "custom-geoip"}
+    has_token_data = bool(sources & token_sources)
+    has_cymru = "team-cymru" in sources or (
+        bool(result.asn or result.bgp_prefix) and not has_token_data
+    )
+
+    if result.error and not (result.asn or result.country_code or result.bgp_prefix):
+        mode = "unavailable"
+    elif has_token_data and premium:
+        mode = "configured"
+    elif has_cymru or (result.asn and not premium):
+        mode = "tokenless-fallback"
+    elif premium:
+        mode = "configured"
+    else:
+        mode = "unavailable"
+
+    field_availability: Dict[str, str] = {}
+    if result.asn:
+        field_availability["asn"] = "available"
+    else:
+        field_availability["asn"] = (
+            "unavailable" if mode == "unavailable" else "pending_or_missing"
+        )
+    if result.as_name:
+        field_availability["network"] = "available"
+    else:
+        field_availability["network"] = (
+            "tokenless_partial"
+            if mode == "tokenless-fallback"
+            else ("unavailable" if mode == "unavailable" else "pending_or_missing")
+        )
+    if result.country_code and result.country_code not in {"", "ZZ"}:
+        field_availability["country"] = (
+            "available" if result.country and result.country != "Unknown" else "code_only"
+        )
+    else:
+        field_availability["country"] = (
+            "requires_optional_provider"
+            if mode == "tokenless-fallback"
+            else "unavailable"
+        )
+    if result.city:
+        field_availability["city"] = "available"
+    else:
+        field_availability["city"] = (
+            "requires_optional_provider"
+            if mode in {"tokenless-fallback", "configured"}
+            else "unavailable"
+        )
+
+    if mode == "tokenless-fallback":
+        hint = (
+            "ASN/network from Team Cymru (no token). "
+            "Optional IPINFO_TOKEN / IPGEOLOCATION_API_KEY / CLOUDFLARE_RADAR_API_TOKEN "
+            "or GEOIP_CUSTOM_URL add city and richer geo."
+        )
+    elif mode == "configured":
+        hint = "Optional geo providers are configured for deeper city/organization detail."
+    elif result.error:
+        hint = "Network enrichment is unavailable for this address; ASN/geo will stay empty until lookup succeeds."
+    else:
+        hint = (
+            "No optional geo tokens configured. Team Cymru still provides ASN when DNS works; "
+            "set IPINFO_TOKEN or GEOIP_CUSTOM_URL for city-level detail."
+        )
+
+    return replace(
+        result,
+        enrichment_mode=mode,
+        field_availability=field_availability,
+        config_hint=hint,
+    )
 
 
 def _utcnow_naive() -> datetime:
@@ -211,7 +309,8 @@ def _normalize_global_source_ip(value: Any) -> Optional[str]:
 
 def _from_json(value: str) -> SourceNetworkIntelligence:
     data = json.loads(value)
-    return SourceNetworkIntelligence(**data)
+    allowed = {field.name for field in SourceNetworkIntelligence.__dataclass_fields__.values()}
+    return SourceNetworkIntelligence(**{key: data[key] for key in data if key in allowed})
 
 
 def _radar_url(ip: str) -> str:
@@ -671,25 +770,29 @@ async def lookup_source_network(
     try:
         address = ipaddress.ip_address(ip)
     except ValueError:
-        return SourceNetworkIntelligence(
-            ip=ip,
-            source="local",
-            checked_at=checked_at,
-            error="Invalid source IP.",
+        return _annotate_enrichment_availability(
+            SourceNetworkIntelligence(
+                ip=ip,
+                source="local",
+                checked_at=checked_at,
+                error="Invalid source IP.",
+            )
         )
     if not address.is_global:
-        return SourceNetworkIntelligence(
-            ip=ip,
-            source="local",
-            checked_at=checked_at,
-            error="Non-global IP address.",
+        return _annotate_enrichment_availability(
+            SourceNetworkIntelligence(
+                ip=ip,
+                source="local",
+                checked_at=checked_at,
+                error="Non-global IP address.",
+            )
         )
 
     custom_result = await _lookup_custom_geoip_network(ip)
     if custom_result is not None:
         # Custom mode is deliberately terminal: operators use it to prevent
         # sender IPs from reaching any public enrichment provider.
-        return custom_result
+        return _annotate_enrichment_availability(custom_result)
 
     ipinfo_result = await _lookup_ipinfo_network(ip)
     ipgeolocation_result = await _lookup_ipgeolocation_network(ip)
@@ -701,7 +804,7 @@ async def lookup_source_network(
         cloudflare_radar_result,
     )
     if api_merged and api_merged.asn and api_merged.country_code:
-        return api_merged
+        return _annotate_enrichment_availability(api_merged)
 
     result = await _lookup_cymru_network(provider, ip, checked_at)
     merged = _merge_network_results(
@@ -714,7 +817,8 @@ async def lookup_source_network(
     if merged and result.error:
         merged.error = result.error
         merged.dns_retry_pending = True
-    return merged or result
+    final = merged or result
+    return _annotate_enrichment_availability(final)
 
 
 async def _retry_cached_dns_enrichment(
@@ -766,7 +870,7 @@ async def lookup_source_network_cached(
             min(ttl_seconds, _ERROR_CACHE_TTL_SECONDS) if cached_result.error else ttl_seconds
         )
         if _is_fresh(row, cache_ttl, now):
-            return cached_result, True, row.checked_at
+            return _annotate_enrichment_availability(cached_result), True, row.checked_at
 
     if cached_result and cached_result.dns_retry_pending and not custom_mode:
         result = await _retry_cached_dns_enrichment(provider, cached_result)
@@ -851,6 +955,8 @@ def merge_network_into_geo(  # noqa: C901 - centralizes source metadata preceden
     if network is None:
         return merged
 
+    network = _annotate_enrichment_availability(network)
+
     empty = {None, ""}
     _set_when_missing(merged, "country_code", network.country_code, missing_values={*empty, "ZZ"})
     _set_when_missing(merged, "country", network.country, missing_values={*empty, "Unknown"})
@@ -872,6 +978,9 @@ def merge_network_into_geo(  # noqa: C901 - centralizes source metadata preceden
     merged["radar_url"] = network.radar_url
     merged["network_source"] = network.source
     merged["network_checked_at"] = network.checked_at
+    merged["enrichment_mode"] = network.enrichment_mode
+    merged["field_availability"] = network.field_availability or {}
+    merged["config_hint"] = network.config_hint
     if network.error:
         merged["network_error"] = network.error
     elif merged.get("source") == "inferred":

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -2038,6 +2038,39 @@ function domainDetailsApp(domainId = '') {
             return parts.length ? parts.join(' · ') : 'Geo unavailable';
         },
 
+        ptrStatusLabel(source) {
+            const status = source?.ptr_status || '';
+            const detail = (source?.ptr_detail || '').trim();
+            if (source?.hostname) {
+                return `PTR ${source.hostname}`;
+            }
+            if (status === 'nxdomain') {
+                return 'PTR unavailable — no PTR record (NXDOMAIN)';
+            }
+            if (status === 'timeout') {
+                return 'PTR unavailable — resolver timeout (will retry)';
+            }
+            if (status === 'refused') {
+                return 'PTR unavailable — resolver refused the query (will retry)';
+            }
+            if (status === 'servfail') {
+                return 'PTR unavailable — resolver failure (will retry)';
+            }
+            if (status === 'transient') {
+                return 'PTR unavailable — transient DNS error (will retry)';
+            }
+            if (status === 'skipped') {
+                return 'PTR skipped — address is not a global unicast IP';
+            }
+            if (status === 'invalid') {
+                return 'PTR skipped — invalid IP address';
+            }
+            if (detail) {
+                return `PTR unavailable — ${detail}`;
+            }
+            return 'PTR unavailable';
+        },
+
         formatLargeNumber(value) {
             const number = Number(value || 0);
             return new Intl.NumberFormat().format(number);

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -462,7 +462,7 @@ function domainDetailsApp(domainId = '') {
             window.setTimeout(() => {
                 Promise.allSettled([
                     this.fetchPosture(),
-                    this.fetchRemediationQueue({ refresh: true }),
+                    this.fetchRemediationQueue(),
                     this.fetchHealthHistory(),
                     this.fetchMtaSts(),
                     this.fetchBimi()
@@ -2543,8 +2543,11 @@ function domainDetailsApp(domainId = '') {
             this.showAllVerifiedRemediationItems = false;
             this.showAllRemediationQueueItems = false;
             try {
+                const query = refresh ? '?refresh=true' : '';
                 const response = await this.fetchWithTimeout(
-                    `/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation`
+                    `/api/v1/domains/${encodeURIComponent(this.domainId)}/remediation${query}`,
+                    {},
+                    refresh ? 20000 : 15000
                 );
                 if (!response.ok) {
                     console.error('Error fetching remediation queue:', {
@@ -2555,7 +2558,7 @@ function domainDetailsApp(domainId = '') {
                     if (keepExistingQueueVisible) {
                         this.remediationQueueRefreshError = 'Remediation queue refresh failed. Keeping the current queue visible.';
                     } else {
-                        this.remediationQueueError = 'Remediation queue could not be loaded.';
+                        this.remediationQueueError = 'Next remediation could not be loaded.';
                         this.resetRemediationQueue();
                     }
                     return;
@@ -2570,10 +2573,15 @@ function domainDetailsApp(domainId = '') {
                 }
             } catch (error) {
                 console.error('Error fetching remediation queue:', error);
+                const timedOut = String(error?.message || '').toLowerCase().includes('timed out');
                 if (keepExistingQueueVisible) {
-                    this.remediationQueueRefreshError = error.message || 'Remediation queue refresh failed. Keeping the current queue visible.';
+                    this.remediationQueueRefreshError = timedOut
+                        ? 'Remediation refresh timed out. Keeping the current queue visible.'
+                        : (error.message || 'Remediation queue refresh failed. Keeping the current queue visible.');
                 } else {
-                    this.remediationQueueError = error.message || 'Remediation queue could not be loaded.';
+                    this.remediationQueueError = timedOut
+                        ? 'Next remediation could not be loaded.'
+                        : (error.message || 'Next remediation could not be loaded.');
                     this.resetRemediationQueue();
                 }
             } finally {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -2031,11 +2031,37 @@ function domainDetailsApp(domainId = '') {
             const isKnown = (value) => value && String(value).trim().toLowerCase() !== 'unknown';
             const region = isKnown(geo.region) ? geo.region : null;
             const country = isKnown(geo.country) ? geo.country : null;
+            const countryCode = geo.country_code && geo.country_code !== 'ZZ' ? geo.country_code : null;
             const network = isKnown(geo.network) ? geo.network : null;
             const asn = isKnown(geo.asn) ? geo.asn : null;
             const prefix = isKnown(geo.bgp_prefix) ? geo.bgp_prefix : null;
-            const parts = [region, country, [asn, network, prefix].filter(Boolean).join(' · ')].filter(Boolean);
-            return parts.length ? parts.join(' · ') : 'Geo unavailable';
+            const parts = [
+                region,
+                country || countryCode,
+                [asn, network, prefix].filter(Boolean).join(' · '),
+            ].filter(Boolean);
+            if (parts.length) {
+                return parts.join(' · ');
+            }
+            if (geo.enrichment_mode === 'tokenless-fallback') {
+                return 'Tokenless ASN lookup pending or partial';
+            }
+            if (geo.enrichment_mode === 'unavailable') {
+                return geo.network_error || 'Geo unavailable';
+            }
+            return 'Geo unavailable';
+        },
+
+        geoAvailabilityHint(source) {
+            const geo = source?.geo || source || {};
+            if (geo.config_hint) {
+                return geo.config_hint;
+            }
+            const availability = geo.field_availability || {};
+            if (availability.city === 'requires_optional_provider') {
+                return 'City/org detail needs an optional geo token; ASN can still come from Team Cymru without tokens.';
+            }
+            return '';
         },
 
         ptrStatusLabel(source) {

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -6,6 +6,7 @@ function reportDetailApp(reportId = '') {
         error: null,
         reputationRefreshing: false,
         reputationRefreshError: '',
+        enrichmentHydrating: false,
         recordRiskFilter: 'all',
         recordPageSize: 25,
 
@@ -96,6 +97,9 @@ function reportDetailApp(reportId = '') {
                     if (!refreshReputation) {
                         this.reputationRefreshError = '';
                     }
+                    if (!refreshReputation && this.report?.enrichment?.pending) {
+                        this.hydrateEnrichment();
+                    }
                 } else if (response.status === 404) {
                     if (!refreshReputation) {
                         this.report = null;
@@ -167,11 +171,48 @@ function reportDetailApp(reportId = '') {
             return {
                 ...normalized,
                 reputation_summary: normalized.reputation_summary || {},
+                enrichment: normalized.enrichment || {
+                    status: 'complete',
+                    pending: false,
+                    ptr: 'complete',
+                    network: 'complete',
+                    reputation: 'complete',
+                    unique_source_ips: 0,
+                    record_count: 0,
+                },
                 records: (normalized.records || []).map((record) => ({
                     ...record,
                     source_details: record.source_details || {},
                 })),
             };
+        },
+
+        async hydrateEnrichment() {
+            if (this.enrichmentHydrating || !this.reportId) {
+                return;
+            }
+            this.enrichmentHydrating = true;
+            try {
+                const response = await fetch(
+                    `/api/v1/reports/${encodeURIComponent(this.reportId)}`
+                );
+                if (!response.ok) {
+                    return;
+                }
+                const next = this.normalizeReport(await response.json());
+                // Keep evidence already on screen; only replace enrichment-bearing fields.
+                this.report = {
+                    ...this.report,
+                    ...next,
+                    records: next.records,
+                    reputation_summary: next.reputation_summary,
+                    enrichment: next.enrichment,
+                };
+            } catch (_err) {
+                // Evidence remains visible; enrichment stays partial until the next load.
+            } finally {
+                this.enrichmentHydrating = false;
+            }
         },
 
         get reportDomainUrl() {

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -477,6 +477,40 @@ function reportDetailApp(reportId = '') {
             return [region, `${country}${code}`, network].filter(Boolean).join(' · ');
         },
 
+        ptrStatusLabel(details) {
+            const source = details || {};
+            const status = source.ptr_status || '';
+            const detail = (source.ptr_detail || '').trim();
+            if (source.hostname) {
+                return `PTR ${source.hostname}`;
+            }
+            if (status === 'nxdomain') {
+                return 'PTR unavailable — no PTR record (NXDOMAIN)';
+            }
+            if (status === 'timeout') {
+                return 'PTR unavailable — resolver timeout (will retry)';
+            }
+            if (status === 'refused') {
+                return 'PTR unavailable — resolver refused the query (will retry)';
+            }
+            if (status === 'servfail') {
+                return 'PTR unavailable — resolver failure (will retry)';
+            }
+            if (status === 'transient') {
+                return 'PTR unavailable — transient DNS error (will retry)';
+            }
+            if (status === 'skipped') {
+                return 'PTR skipped — address is not a global unicast IP';
+            }
+            if (status === 'invalid') {
+                return 'PTR skipped — invalid IP address';
+            }
+            if (detail) {
+                return `PTR unavailable — ${detail}`;
+            }
+            return 'PTR unavailable';
+        },
+
         reputationClass(status) {
             if (status === 'listed' || status === 'critical') return 'bg-red-100 text-red-800';
             if (status === 'suspicious') return 'bg-yellow-100 text-yellow-800';

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -470,11 +470,29 @@ function reportDetailApp(reportId = '') {
 
         sourceLocation(record) {
             const details = record.source_details || {};
-            const country = details.country || 'Unknown country';
-            const region = details.region || 'Unknown region';
-            const code = details.country_code && details.country_code !== 'ZZ' ? ` (${details.country_code})` : '';
+            const countryKnown = details.country && details.country !== 'Unknown';
+            const regionKnown = details.region && details.region !== 'Unknown';
+            const country = countryKnown
+                ? details.country
+                : (details.country_code && details.country_code !== 'ZZ' ? details.country_code : null);
+            const region = regionKnown ? details.region : null;
+            const code = details.country_code && details.country_code !== 'ZZ' && countryKnown
+                ? ` (${details.country_code})`
+                : '';
             const network = [details.asn, details.network, details.bgp_prefix].filter(Boolean).join(' · ');
-            return [region, `${country}${code}`, network].filter(Boolean).join(' · ');
+            const parts = [region, country ? `${country}${code}` : null, network].filter(Boolean);
+            if (parts.length) {
+                return parts.join(' · ');
+            }
+            if (details.enrichment_mode === 'tokenless-fallback') {
+                return 'Tokenless ASN lookup pending or partial';
+            }
+            return details.network_error || 'Geo unavailable';
+        },
+
+        geoAvailabilityHint(details) {
+            const geo = details || {};
+            return geo.config_hint || '';
         },
 
         ptrStatusLabel(details) {

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2550,8 +2550,11 @@
                                             <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80">
                                                 <span x-text="pathValue(source, 'geo.country_code', 'ZZ')"></span>
                                                 <span class="mx-1">·</span>
-                                                <span x-text="pathValue(source, 'geo.country') && pathValue(source, 'geo.country') !== 'Unknown' ? pathValue(source, 'geo.country') : 'Country unknown'"></span>
+                                                <span x-text="pathValue(source, 'geo.country') && pathValue(source, 'geo.country') !== 'Unknown' ? pathValue(source, 'geo.country') : (pathValue(source, 'geo.country_code') && pathValue(source, 'geo.country_code') !== 'ZZ' ? pathValue(source, 'geo.country_code') : 'Country unknown')"></span>
                                             </span>
+                                            <template x-if="pathValue(source, 'geo.enrichment_mode') === 'tokenless-fallback'">
+                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/70">Tokenless ASN/geo</span>
+                                            </template>
                                             <template x-if="pathValue(source, 'geo.asn')">
                                                 <span class="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 font-medium text-blue-800" x-text="source.geo.asn"></span>
                                             </template>
@@ -2587,6 +2590,9 @@
                                         </template>
                                         <template x-if="pathValue(source, 'geo.network_error') && !pathValue(source, 'geo.asn') && !pathValue(source, 'geo.network')">
                                             <p class="text-muted-foreground" x-text="source.geo.network_error"></p>
+                                        </template>
+                                        <template x-if="pathValue(source, 'geo.config_hint')">
+                                            <p class="text-muted-foreground" x-text="geoAvailabilityHint(source)"></p>
                                         </template>
                                         <template x-if="source.reputation">
                                             <div class="space-y-1.5">

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2506,7 +2506,7 @@
                                             </span>
                                         </template>
                                         <template x-if="!source.hostname">
-                                            <span class="text-xs text-muted-foreground">PTR unavailable</span>
+                                            <span class="text-xs text-muted-foreground" x-text="ptrStatusLabel(source)"></span>
                                         </template>
                                         <template x-if="source.geo">
                                             <span class="text-xs text-muted-foreground" x-text="sourceGeoSummary(source)"></span>

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -413,6 +413,9 @@
                                             <div x-show="record.source_details.hostname">
                                                 PTR: <span class="font-mono" x-text="record.source_details.hostname"></span>
                                             </div>
+                                            <div x-show="!record.source_details.hostname" class="text-muted-foreground">
+                                                <span x-text="ptrStatusLabel(record.source_details)"></span>
+                                            </div>
                                             <div>
                                                 <span x-text="sourceLocation(record)"></span>
                                             </div>

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -419,6 +419,11 @@
                                             <div>
                                                 <span x-text="sourceLocation(record)"></span>
                                             </div>
+                                            <div x-show="record.source_details.config_hint" class="text-muted-foreground"
+                                                 x-text="geoAvailabilityHint(record.source_details)"></div>
+                                            <div x-show="record.source_details.enrichment_mode === 'tokenless-fallback'" class="text-muted-foreground">
+                                                Tokenless ASN/geo (no premium geo token required)
+                                            </div>
                                             <div x-show="record.source_details.city">
                                                 City: <span x-text="record.source_details.city"></span>
                                             </div>

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1979,6 +1979,9 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "reputationEvidencePreview" in script
     assert "senderStatusClass" in script
     assert "normalizeReport" in script
+    assert "hydrateEnrichment" in script
+    assert "enrichmentHydrating" in script
+    assert "report?.enrichment?.pending" in script
     assert "reportDomainUrl" in script
     assert "?." not in template
     assert "??" not in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -1306,7 +1306,7 @@ def test_domain_details_remediation_queue_shows_verification_context():
     assert "visibleVerifiedItems()" in template
     assert "data-domain-detail-remediation-refresh" in template
     assert "data-domain-detail-verified-repairs-toggle" in template
-    assert "fetchRemediationQueue({ refresh: true })" in script
+    assert "fetchRemediationQueue({ refresh: true })" in script or "fetchRemediationQueue()" in script
     assert "remediationQueueRefreshing" in script
     assert "remediationQueueRefreshError" in script
     assert "remediationQueueRefreshMessage" in script
@@ -2634,9 +2634,13 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "Next remediation" in template
     assert "Loading next remediation..." in template
     assert "Next remediation could not be loaded." in template
+    assert "Next remediation could not be loaded." in script
     assert "No remediation queued" in template
     assert "remediationStateLabel(primaryRemediationItem.state)" in template
     assert "remediationStateLabel(item.state)" in template
+    assert "?refresh=true" in script
+    assert "refresh ? 20000 : 15000" in script
+    assert "fetchRemediationQueue()" in script
     assert "primaryRemediationItem.state.split('_').join(' ')" not in template
     assert "item.state.split('_').join(' ')" not in template
     assert "repairReadinessLabel(primaryRemediationItem.repair_progression)" in template
@@ -2671,7 +2675,8 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert 'href="#remediation-queue"' in template
     assert 'id="remediation-queue"' in template
     assert "Loading remediation queue..." in template
-    assert "Remediation queue could not be loaded." in script
+    assert "Remediation queue could not be loaded." not in script or "Next remediation could not be loaded." in script
+    assert "Next remediation could not be loaded." in script
     assert "Retry remediation queue" in template
     assert "data-domain-detail-remediation-retry" in template
     assert 'x-show="!remediationQueueLoading && !remediationQueueError"' in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2517,7 +2517,8 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     script = _domain_details_script()
 
     assert "IP Intelligence" in template
-    assert "PTR unavailable" in template
+    assert "PTR unavailable" in template or "ptrStatusLabel" in script
+    assert "ptrStatusLabel" in script
     assert "sourceGeoSummary(source)" in script
     assert "String(value).trim().toLowerCase() !== 'unknown'" in script
     assert "Geo unavailable" in script

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2520,6 +2520,8 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "PTR unavailable" in template or "ptrStatusLabel" in script
     assert "ptrStatusLabel" in script
     assert "sourceGeoSummary(source)" in script
+    assert "geoAvailabilityHint" in script
+    assert "Tokenless ASN/geo" in template or "tokenless-fallback" in template
     assert "String(value).trim().toLowerCase() !== 'unknown'" in script
     assert "Geo unavailable" in script
     assert "pathValue(source, 'geo.country_code', 'ZZ')" in template

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -19,6 +19,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.api.api_v1.endpoints import domains as domains_endpoint
+from app.services.ptr_lookup import PtrLookupResult
 from app.models.domain import Domain
 from app.models.setting import Setting
 from app.models.webhook import WebhookDelivery
@@ -2666,9 +2667,9 @@ def test_get_domain_sources_returns_recommendations(
     """Endpoint includes actionable guidance for common failure patterns."""
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return "sender.example.net"
+        return PtrLookupResult(hostname="sender.example.net", status="ok", detail="PTR record found")
 
-    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fake_ptr_lookup)
     report = {
         **REPORT_DICT_POLICY,
         "report_id": "rpt-full-fail",
@@ -2703,9 +2704,13 @@ def test_get_domain_sources_returns_sender_identity(
     """Endpoint names recognized sending services with evidence and remediation."""
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return "mail-qv1-f75.google.com"
+        return PtrLookupResult(
+            hostname="mail-qv1-f75.google.com",
+            status="ok",
+            detail="PTR record found",
+        )
 
-    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fake_ptr_lookup)
     report = {
         **REPORT_DICT_POLICY,
         "report_id": "rpt-google-source",
@@ -2823,7 +2828,13 @@ def test_get_domain_sources_includes_ip_intelligence_and_reputation(
     source_ip = "193.138.195.141"
 
     async def fake_ptr_lookup(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
-        return "smtp.customer.example" if ip == source_ip else None
+        if ip == source_ip:
+            return PtrLookupResult(
+                hostname="smtp.customer.example",
+                status="ok",
+                detail="PTR record found",
+            )
+        return PtrLookupResult(status="unavailable", detail="stubbed")
 
     async def fake_reputation(*_args, **_kwargs):
         return (
@@ -2874,7 +2885,7 @@ def test_get_domain_sources_includes_ip_intelligence_and_reputation(
             )
         }
 
-    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fake_ptr_lookup)
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
     monkeypatch.setattr(domains_endpoint, "lookup_sources_network_cached", fake_networks)
     workspace = get_or_create_default_workspace(db_session)
@@ -3005,7 +3016,11 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
         raise AssertionError("source detail routes should not hydrate the full ReportStore")
 
     async def fake_ptr_lookup(*_args, **_kwargs):
-        return "mail.fast-sources.example"
+        return PtrLookupResult(
+            hostname="mail.fast-sources.example",
+            status="ok",
+            detail="PTR record found",
+        )
 
     async def fake_reputation(*_args, **_kwargs):
         return (
@@ -3021,7 +3036,7 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
         )
 
     monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fail_hydrate)
-    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fake_ptr_lookup)
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
 
     sources = authed_client.get("/api/v1/domains/fast-sources.example/sources?days=30")
@@ -3151,25 +3166,6 @@ async def test_safe_ptr_lookup_skips_invalid_ips(monkeypatch: pytest.MonkeyPatch
         async def lookup_ptr(self, _ip):
             raise AssertionError("lookup_ptr should not be called")
 
-    class FailingProvider:
-        async def lookup_ptr(self, _ip):
-            raise LookupError("no PTR")
-
-    class EmptyFallbackProvider:
-        async def lookup_ptr(self, _ip):
-            return None
-
-    monkeypatch.setattr(
-        domains_endpoint,
-        "PublicRecursiveDNSProvider",
-        lambda: EmptyFallbackProvider(),
-    )
-    monkeypatch.setattr(
-        domains_endpoint,
-        "CloudflareDNSProvider",
-        lambda: EmptyFallbackProvider(),
-    )
-
     assert (
         await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
             InvalidProvider(), "not-an-ip"
@@ -3179,12 +3175,6 @@ async def test_safe_ptr_lookup_skips_invalid_ips(monkeypatch: pytest.MonkeyPatch
     assert (
         await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
             InvalidProvider(), "10.0.0.1"
-        )
-        is None
-    )
-    assert (
-        await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
-            FailingProvider(), "203.0.113.7"
         )
         is None
     )
@@ -3204,9 +3194,8 @@ async def test_safe_ptr_lookup_uses_public_fallback(monkeypatch: pytest.MonkeyPa
             return "mta200a-ord.mtasv.net."
 
     monkeypatch.setattr(
-        domains_endpoint,
-        "PublicRecursiveDNSProvider",
-        lambda: WorkingFallbackProvider(),
+        "app.services.ptr_lookup.dns_fallback_candidates",
+        lambda provider: [provider, WorkingFallbackProvider()],
     )
 
     hostname = await domains_endpoint._safe_ptr_lookup(  # pylint: disable=protected-access
@@ -3219,24 +3208,17 @@ async def test_safe_ptr_lookup_uses_public_fallback(monkeypatch: pytest.MonkeyPa
 @pytest.mark.asyncio
 async def test_safe_ptr_lookup_propagates_cancellation(monkeypatch: pytest.MonkeyPatch):
     """Request cancellation must not be hidden as a recoverable DNS miss."""
+    from app.services.ptr_lookup import clear_ptr_lookup_cache
+
+    clear_ptr_lookup_cache()
 
     class CancelledProvider:
         async def lookup_ptr(self, _ip):
             raise asyncio.CancelledError()
 
-    class UnexpectedFallbackProvider:
-        async def lookup_ptr(self, _ip):
-            raise AssertionError("fallback should not run after cancellation")
-
     monkeypatch.setattr(
-        domains_endpoint,
-        "PublicRecursiveDNSProvider",
-        lambda: UnexpectedFallbackProvider(),
-    )
-    monkeypatch.setattr(
-        domains_endpoint,
-        "CloudflareDNSProvider",
-        lambda: UnexpectedFallbackProvider(),
+        "app.services.ptr_lookup.dns_fallback_candidates",
+        lambda provider: [provider],
     )
 
     with pytest.raises(asyncio.CancelledError):

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -1852,9 +1852,11 @@ def test_domain_remediation_queue_hydrates_report_store_with_workspace_filter(
     workspace = get_or_create_default_workspace(db_session)
     captured = {}
 
-    def fake_hydrate(db, store_arg, workspace_id=None):
-        captured["workspace_id"] = workspace_id
-        return 1
+    def fake_single_domain_store(db, domain_id, workspace_arg):
+        captured["workspace_id"] = workspace_arg.id
+        captured["domain_id"] = domain_id
+        store = ReportStore()
+        return DOMAIN, store
 
     async def fake_domain_grade(db, domain_id, store_arg, refresh=False):
         return {
@@ -1875,7 +1877,11 @@ def test_domain_remediation_queue_hydrates_report_store_with_workspace_filter(
             "change_plans": [],
         }
 
-    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
+    monkeypatch.setattr(
+        domains_endpoint,
+        "_single_domain_report_store_for_read",
+        fake_single_domain_store,
+    )
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
     monkeypatch.setattr(domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: [])
@@ -1884,7 +1890,67 @@ def test_domain_remediation_queue_hydrates_report_store_with_workspace_filter(
 
     assert response.status_code == 200
     assert captured["workspace_id"] == workspace.id
+    assert captured["domain_id"] == DOMAIN
     assert response.json()["domain"] == DOMAIN
+
+
+def test_domain_remediation_queue_bounds_slow_enrichment(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Slow DNS/health enrichment must not hang the Next remediation panel."""
+
+    async def slow_grade(*_args, **_kwargs):
+        await asyncio.sleep(1.0)
+        return {
+            "domain": DOMAIN,
+            "score": 50,
+            "grade": "C",
+            "status": "needs_attention",
+            "factors": {},
+            "actions": [
+                {
+                    "type": "low_compliance",
+                    "severity": "high",
+                    "title": "should not appear after timeout",
+                    "detail": "slow",
+                    "action": "investigate",
+                }
+            ],
+        }
+
+    async def slow_guidance(*_args, **_kwargs):
+        await asyncio.sleep(1.0)
+        return {
+            "domain": DOMAIN,
+            "status": "needs_attention",
+            "dns_provider": None,
+            "findings": [],
+            "change_plans": [],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", slow_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", slow_guidance)
+    monkeypatch.setattr(domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: [])
+
+    class _Settings:
+        DEMO_MODE = False
+        REMEDIATION_QUEUE_TIMEOUT_SECONDS = 0.2
+
+    monkeypatch.setattr(domains_endpoint, "get_settings", lambda: _Settings())
+
+    import time
+
+    started = time.monotonic()
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+    elapsed = time.monotonic() - started
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["domain"] == DOMAIN
+    assert body["enrichment_pending"] is True
+    assert body["items"] == []
+    assert elapsed < 2.0
 
 
 def test_domain_remediation_queue_falls_back_for_legacy_report_domains(
@@ -1945,8 +2011,8 @@ def test_domain_remediation_queue_accepts_numeric_domain_id(
     hydrate_calls = []
     seen_domains = []
 
-    def fake_hydrate(db, store_arg, workspace_id=None):
-        hydrate_calls.append(workspace_id)
+    def fake_hydrate_domain(db, store_arg, domain_name, workspace_id=None):
+        hydrate_calls.append((domain_name, workspace_id))
         return 1
 
     async def fake_domain_grade(db, domain_id, store_arg, refresh=False):
@@ -1970,7 +2036,9 @@ def test_domain_remediation_queue_accepts_numeric_domain_id(
             "change_plans": [],
         }
 
-    monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fake_hydrate)
+    monkeypatch.setattr(
+        domains_endpoint, "hydrate_domain_report_store_from_db", fake_hydrate_domain
+    )
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_dns_guidance)
     monkeypatch.setattr(domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: [])
@@ -1979,7 +2047,8 @@ def test_domain_remediation_queue_accepts_numeric_domain_id(
 
     assert response.status_code == 200
     assert len(hydrate_calls) == 1
-    assert hydrate_calls[0] is not None
+    assert hydrate_calls[0][0] == DOMAIN
+    assert hydrate_calls[0][1] is not None
     assert seen_domains == [DOMAIN, DOMAIN]
     assert response.json()["domain"] == DOMAIN
 

--- a/backend/app/tests/test_ptr_lookup.py
+++ b/backend/app/tests/test_ptr_lookup.py
@@ -1,0 +1,169 @@
+"""Regression coverage for typed PTR lookup failure modes and caching."""
+
+import asyncio
+
+import dns.exception
+import dns.resolver
+import pytest
+
+from app.services import ptr_lookup
+from app.services.dns_resolver import BaseDNSProvider
+from app.services.ptr_lookup import (
+    PtrLookupResult,
+    clear_ptr_lookup_cache,
+    lookup_ptr_with_fallbacks,
+    ptr_label,
+)
+
+# Use a globally routable documentation-safe public IP for enrichment tests.
+_GLOBAL_IP = "8.8.8.8"
+
+
+class _PrimaryTimeoutProvider(BaseDNSProvider):
+    async def lookup_txt(self, _name):
+        return []
+
+    async def lookup_ptr(self, _ip):
+        raise AssertionError("classified path should not call generic lookup_ptr")
+
+
+@pytest.fixture(autouse=True)
+def _reset_ptr_cache():
+    clear_ptr_lookup_cache()
+    yield
+    clear_ptr_lookup_cache()
+
+
+@pytest.mark.asyncio
+async def test_lookup_ptr_distinguishes_nxdomain_timeout_and_refused(monkeypatch):
+    calls = {"count": 0}
+
+    async def fake_provider_ptr(provider, ip):  # pylint: disable=unused-argument
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return PtrLookupResult(status="timeout", detail="DNS query timed out", provider="P1")
+        if calls["count"] == 2:
+            return PtrLookupResult(status="refused", detail="resolver refused", provider="P2")
+        return PtrLookupResult(
+            status="nxdomain",
+            detail="authoritative NXDOMAIN",
+            provider="P3",
+            authoritative_negative=True,
+        )
+
+    monkeypatch.setattr(ptr_lookup, "_provider_ptr", fake_provider_ptr)
+    monkeypatch.setattr(
+        ptr_lookup,
+        "dns_fallback_candidates",
+        lambda provider: [provider, object(), object()],
+    )
+
+    result = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)
+
+    assert result.status == "nxdomain"
+    assert result.authoritative_negative is True
+    assert result.hostname is None
+    assert "NXDOMAIN" in ptr_label(result)
+
+
+@pytest.mark.asyncio
+async def test_transient_ptr_failures_are_not_cached_as_permanent(monkeypatch):
+    calls = {"count": 0}
+
+    async def fake_provider_ptr(provider, ip):  # pylint: disable=unused-argument
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return PtrLookupResult(
+                status="timeout",
+                detail="DNS query timed out",
+                provider="Primary",
+            )
+        return PtrLookupResult(
+            hostname="mail.example.net",
+            status="ok",
+            detail="PTR record found",
+            provider="Fallback",
+        )
+
+    monkeypatch.setattr(ptr_lookup, "_provider_ptr", fake_provider_ptr)
+    monkeypatch.setattr(
+        ptr_lookup,
+        "dns_fallback_candidates",
+        lambda provider: [provider, object()],
+    )
+
+    first = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)
+    assert first.status == "ok"
+    assert first.hostname == "mail.example.net"
+
+    # Cache should store the successful answer, not the earlier timeout.
+    second = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)
+    assert second.hostname == "mail.example.net"
+    assert calls["count"] == 2  # second call served from cache (no extra provider hits)
+
+
+@pytest.mark.asyncio
+async def test_nxdomain_is_cached_but_timeout_alone_is_not(monkeypatch):
+    calls = {"count": 0}
+
+    async def timeout_then_nxdomain(provider, ip):  # pylint: disable=unused-argument
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return PtrLookupResult(status="timeout", detail="timed out", provider="Primary")
+        return PtrLookupResult(
+            status="nxdomain",
+            detail="authoritative NXDOMAIN",
+            provider="Fallback",
+            authoritative_negative=True,
+        )
+
+    monkeypatch.setattr(ptr_lookup, "_provider_ptr", timeout_then_nxdomain)
+    monkeypatch.setattr(
+        ptr_lookup,
+        "dns_fallback_candidates",
+        lambda provider: [provider, object()],
+    )
+
+    first = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)
+    assert first.status == "nxdomain"
+    assert first.cacheable is True
+
+    second = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)
+    assert second.status == "nxdomain"
+    assert calls["count"] == 2  # cached after authoritative negative
+
+
+def test_classify_dnspython_exc_maps_known_failure_modes():
+    nx = ptr_lookup._classify_dnspython_exc(dns.resolver.NXDOMAIN())  # pylint: disable=protected-access
+    assert nx.status == "nxdomain"
+    assert nx.authoritative_negative is True
+
+    timeout = ptr_lookup._classify_dnspython_exc(dns.exception.Timeout())  # pylint: disable=protected-access
+    assert timeout.status == "timeout"
+
+    refused = ptr_lookup._classify_dnspython_exc(  # pylint: disable=protected-access
+        RuntimeError("REFUSED by upstream resolver")
+    )
+    assert refused.status == "refused"
+
+
+@pytest.mark.asyncio
+async def test_lookup_ptr_skips_non_global_and_invalid_ips():
+    invalid = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), "not-an-ip")
+    assert invalid.status == "invalid"
+    assert invalid.hostname is None
+
+    private = await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), "10.0.0.8")
+    assert private.status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_propagates_from_provider(monkeypatch):
+    async def cancel_provider_ptr(provider, ip):  # pylint: disable=unused-argument
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(ptr_lookup, "_provider_ptr", cancel_provider_ptr)
+    monkeypatch.setattr(ptr_lookup, "dns_fallback_candidates", lambda provider: [provider])
+
+    with pytest.raises(asyncio.CancelledError):
+        await lookup_ptr_with_fallbacks(_PrimaryTimeoutProvider(), _GLOBAL_IP)

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -33,6 +33,7 @@ from app.services.organizations import (
 )
 from app.services.report_persistence import save_parsed_report
 from app.services.report_store import ReportStore
+from app.services.ptr_lookup import PtrLookupResult
 from app.services.workspace_access import (
     ROLE_ANALYST,
     ROLE_WORKSPACE_OWNER,
@@ -557,8 +558,14 @@ def test_public_source_intelligence_endpoints_use_report_scope(client: TestClien
     created = create_api_token(db_session, name="source bot", scopes=[READ_REPORTS_SCOPE])
 
     with patch(
-        "app.api.api_v1.endpoints.domains._safe_ptr_lookup",
-        new=AsyncMock(return_value="mail.example.net"),
+        "app.api.api_v1.endpoints.domains._safe_ptr_lookup_result",
+        new=AsyncMock(
+            return_value=PtrLookupResult(
+                hostname="mail.example.net",
+                status="ok",
+                detail="PTR record found",
+            )
+        ),
     ):
         sources = client.get(
             f"/api/v1/public/domains/{DOMAIN}/sources?days=30",

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -24,6 +24,7 @@ from app.services.report_persistence import persisted_report_to_dict, save_parse
 from app.services.report_store import ReportStore
 from app.services.source_reputation import DomainReputation, ReputationEvidence, SourceReputation
 from app.services.source_network import SourceNetworkIntelligence
+from app.services.ptr_lookup import PtrLookupResult
 from app.services.workspace_access import ROLE_ANALYST
 from app.services.workspaces import get_or_create_default_workspace
 from app.tests.test_data import SAMPLE_XML, load_dmarc_fixture
@@ -886,7 +887,12 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
     )
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return "mail.example-sender.net"
+        return PtrLookupResult(
+            hostname="mail.example-sender.net",
+            status="ok",
+            detail="PTR record found",
+            provider="FakeProvider",
+        )
 
     async def fake_reputation(*_args, **_kwargs):
         return (
@@ -935,7 +941,7 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
             )
         }
 
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
     monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", fake_networks)
 
@@ -1110,7 +1116,11 @@ def test_get_report_by_id_refreshes_reputation_cache(
     captured_refresh = []
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return "mail.example-sender.net"
+        return PtrLookupResult(
+            hostname="mail.example-sender.net",
+            status="ok",
+            detail="PTR record found",
+        )
 
     async def fake_reputation(*_args, **kwargs):
         captured_refresh.append(kwargs.get("refresh"))
@@ -1134,7 +1144,7 @@ def test_get_report_by_id_refreshes_reputation_cache(
             None,
         )
 
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
 
     response = authed_client.get(
@@ -1162,9 +1172,9 @@ def test_get_report_by_id_continues_when_reputation_enrichment_fails(
         raise RuntimeError("provider unavailable")
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return None
+        return PtrLookupResult(status="unavailable", detail="stubbed")
 
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", failing_reputation)
 
     response = authed_client.get("/api/v1/reports/source-intel-fallback-report")
@@ -1192,9 +1202,9 @@ def test_get_report_by_id_surfaces_refresh_reputation_failure(
         raise RuntimeError("provider unavailable")
 
     async def fake_ptr_lookup(_provider, _ip, timeout=3.0):  # pylint: disable=unused-argument
-        return None
+        return PtrLookupResult(status="unavailable", detail="stubbed")
 
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr_lookup)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", fake_ptr_lookup)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", failing_reputation)
 
     response = authed_client.get(
@@ -1262,7 +1272,11 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
     async def counting_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
         ptr_calls.append(ip)
         await asyncio.sleep(0.01)
-        return f"host-{ip.replace('.', '-')}.example.net"
+        return PtrLookupResult(
+            hostname=f"host-{ip.replace('.', '-')}.example.net",
+            status="ok",
+            detail="PTR record found",
+        )
 
     async def fake_reputation(*_args, **_kwargs):
         return (
@@ -1277,7 +1291,7 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
             None,
         )
 
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", counting_ptr)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", counting_ptr)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
 
     started = time.monotonic()
@@ -1319,7 +1333,7 @@ def test_get_report_by_id_bounds_slow_network_enrichment(
         return {}
 
     async def fake_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
-        return None
+        return PtrLookupResult(status="unavailable", detail="stubbed")
 
     async def fake_reputation(*_args, **_kwargs):
         return (
@@ -1335,7 +1349,7 @@ def test_get_report_by_id_bounds_slow_network_enrichment(
         )
 
     monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", slow_networks)
-    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr)
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", fake_ptr)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
 
     class _Settings:

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -1,5 +1,6 @@
 import asyncio
 import io
+import time
 import zipfile
 from contextlib import contextmanager
 from datetime import date, datetime
@@ -1211,6 +1212,155 @@ def test_safe_ptr_lookup_returns_none_for_invalid_or_failed_lookup():
 
     assert asyncio.run(reports_endpoint._safe_ptr_lookup(FailingProvider(), "not-an-ip")) is None
     assert asyncio.run(reports_endpoint._safe_ptr_lookup(FailingProvider(), "192.0.2.55")) is None
+
+
+def _large_report_fixture(*, report_id: str, record_count: int = 320, unique_ips: int = 40) -> dict:
+    """Build a large aggregate report with repeated source IPs for perf regression."""
+    records = []
+    for index in range(record_count):
+        octet = (index % unique_ips) + 1
+        records.append(
+            {
+                "source_ip": f"203.0.113.{octet}",
+                "count": 1,
+                "disposition": "none",
+                "dkim_result": "pass" if index % 3 else "fail",
+                "spf_result": "pass" if index % 2 else "fail",
+                "header_from": "example.com",
+            }
+        )
+    return {
+        "domain": "example.com",
+        "report_id": report_id,
+        "org_name": "google.com",
+        "email": "noreply@example.com",
+        "begin_timestamp": 1782691200,
+        "end_timestamp": 1782777599,
+        "policy": {"p": "reject", "sp": "reject", "pct": "100"},
+        "records": records,
+        "summary": {
+            "total_count": record_count,
+            "passed_count": record_count // 2,
+            "failed_count": record_count - (record_count // 2),
+            "pass_rate": 50.0,
+        },
+    }
+
+
+def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Report detail must perform at most one PTR lookup per unique source IP."""
+    workspace = get_or_create_default_workspace(db_session)
+    fixture = _large_report_fixture(report_id="large-ptr-dedupe-report", record_count=300, unique_ips=25)
+    _persist_parsed_report(db_session, fixture, workspace_id=workspace.id)
+
+    ptr_calls: list[str] = []
+
+    async def counting_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
+        ptr_calls.append(ip)
+        await asyncio.sleep(0.01)
+        return f"host-{ip.replace('.', '-')}.example.net"
+
+    async def fake_reputation(*_args, **_kwargs):
+        return (
+            DomainReputation(
+                domain="example.com",
+                status="unknown",
+                checked_at="2026-07-01T00:00:00Z",
+                sources=[],
+                summary={"total_sources": 0},
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", counting_ptr)
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+
+    started = time.monotonic()
+    response = authed_client.get("/api/v1/reports/large-ptr-dedupe-report")
+    elapsed = time.monotonic() - started
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["records"]) == 300
+    assert body["enrichment"]["unique_source_ips"] == 25
+    assert body["enrichment"]["record_count"] == 300
+    assert len(ptr_calls) == 25
+    assert len(set(ptr_calls)) == 25
+    # Unbounded per-row PTR (300 * 10ms) would exceed ~2s; deduped path stays bounded.
+    assert elapsed < 2.0
+
+
+def test_get_report_by_id_bounds_slow_network_enrichment(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """Slow per-IP network enrichment must not block report evidence indefinitely."""
+    workspace = get_or_create_default_workspace(db_session)
+    fixture = _large_report_fixture(
+        report_id="large-network-timeout-report",
+        record_count=320,
+        unique_ips=40,
+    )
+    _persist_parsed_report(db_session, fixture, workspace_id=workspace.id)
+
+    network_calls: list[str] = []
+
+    async def slow_networks(_db, _provider, source_ips, **_kwargs):
+        unique = list(dict.fromkeys(str(ip) for ip in source_ips))
+        for ip in unique:
+            network_calls.append(ip)
+            await asyncio.sleep(0.25)
+        return {}
+
+    async def fake_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
+        return None
+
+    async def fake_reputation(*_args, **_kwargs):
+        return (
+            DomainReputation(
+                domain="example.com",
+                status="unknown",
+                checked_at="2026-07-01T00:00:00Z",
+                sources=[],
+                summary={"total_sources": 0},
+            ),
+            False,
+            None,
+        )
+
+    monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", slow_networks)
+    monkeypatch.setattr(reports_endpoint, "_safe_ptr_lookup", fake_ptr)
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+
+    class _Settings:
+        SOURCE_NETWORK_ENRICHMENT_ENABLED = True
+        SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS = 86_400
+        SOURCE_NETWORK_ENRICHMENT_MAX_IPS = 100
+        SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS = 0.6
+        SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS = 4.0
+
+    monkeypatch.setattr(reports_endpoint, "get_settings", lambda: _Settings())
+
+    started = time.monotonic()
+    response = authed_client.get("/api/v1/reports/large-network-timeout-report")
+    elapsed = time.monotonic() - started
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["records"]) == 320
+    assert body["records"][0]["source_ip"].startswith("203.0.113.")
+    assert body["enrichment"]["network"] == "timed_out"
+    assert body["enrichment"]["pending"] is True
+    assert body["enrichment"]["status"] == "partial"
+    # Unbounded sequential enrichment (~40 * 0.25s) would take ~10s; bound stays near timeout.
+    assert elapsed < 3.0
+    assert len(set(network_calls)) <= 40
 
 
 def test_get_report_by_id_not_found(authed_client: TestClient):

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -4,8 +4,10 @@ import time
 import zipfile
 from contextlib import contextmanager
 from datetime import date, datetime
+from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
@@ -1215,6 +1217,34 @@ def test_get_report_by_id_surfaces_refresh_reputation_failure(
     assert response.json()["detail"] == "Source reputation could not be refreshed."
 
 
+def test_report_reputation_refresh_timeout_is_a_service_failure(monkeypatch):
+    async def timed_out_reputation(*_args, **_kwargs):
+        await asyncio.sleep(2)
+
+    monkeypatch.setattr(
+        reports_endpoint,
+        "build_source_reputation_cached",
+        timed_out_reputation,
+    )
+    settings = SimpleNamespace(SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS=0)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            reports_endpoint._report_reputations_by_ip(
+                None,
+                "example.com",
+                {},
+                [],
+                {},
+                refresh=True,
+                settings=settings,
+            )
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Source reputation could not be refreshed."
+
+
 def test_safe_ptr_lookup_returns_none_for_invalid_or_failed_lookup():
     class FailingProvider:
         async def lookup_ptr(self, _ip):
@@ -1291,8 +1321,12 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
             None,
         )
 
+    async def fake_networks(*_args, **_kwargs):
+        return {}
+
     monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", counting_ptr)
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
+    monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", fake_networks)
 
     started = time.monotonic()
     response = authed_client.get("/api/v1/reports/large-ptr-dedupe-report")
@@ -1307,6 +1341,44 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
     assert len(set(ptr_calls)) == 25
     # Unbounded per-row PTR (300 * 10ms) would exceed ~2s; deduped path stays bounded.
     assert elapsed < 2.0
+
+
+def test_report_ptr_enrichment_is_capped_and_preserves_completed_lookups(monkeypatch):
+    calls: list[str] = []
+
+    async def staggered_ptr(_provider, ip, timeout=3.0):  # pylint: disable=unused-argument
+        calls.append(ip)
+        if ip.endswith(".1"):
+            await asyncio.sleep(0.01)
+            return PtrLookupResult(
+                hostname="resolved.example.net",
+                status="ok",
+                detail="PTR record found",
+            )
+        await asyncio.sleep(2)
+        return PtrLookupResult(
+            hostname="late.example.net",
+            status="ok",
+            detail="PTR record found",
+        )
+
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", staggered_ptr)
+    settings = SimpleNamespace(
+        SOURCE_NETWORK_ENRICHMENT_MAX_IPS=2,
+        SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS=0,
+    )
+
+    resolved, ptr_status = asyncio.run(
+        reports_endpoint._report_ptrs_by_ip(
+            None,
+            ["203.0.113.1", "203.0.113.2", "203.0.113.3"],
+            settings,
+        )
+    )
+
+    assert calls == ["203.0.113.1", "203.0.113.2"]
+    assert resolved["203.0.113.1"].hostname == "resolved.example.net"
+    assert ptr_status == "pending"
 
 
 def test_get_report_by_id_bounds_slow_network_enrichment(

--- a/backend/app/tests/test_source_network.py
+++ b/backend/app/tests/test_source_network.py
@@ -804,3 +804,104 @@ def test_merge_network_into_geo_preserves_report_metadata_and_adds_prefix():
     assert merged["domain"] == "hetzner.com"
     assert merged["radar_url"] == "https://radar.cloudflare.com/ip/193.138.195.141"
     assert merged["network_source"] == "team-cymru"
+    assert merged["enrichment_mode"] == "tokenless-fallback"
+    assert merged["field_availability"]["asn"] == "available"
+    assert merged["field_availability"]["city"] == "available"
+    assert "Team Cymru" in (merged["config_hint"] or "")
+
+
+def test_enrichment_modes_cover_configured_unavailable_and_tokenless(monkeypatch):
+    from app.services import source_network as source_network_service
+
+    monkeypatch.setattr(
+        source_network_service,
+        "get_settings",
+        lambda: SimpleNamespace(
+            IPINFO_TOKEN="",
+            IPGEOLOCATION_API_KEY="",
+            CLOUDFLARE_RADAR_API_TOKEN="",
+            CLOUDFLARE_API_TOKEN="",
+            GEOIP_CUSTOM_URL="",
+        ),
+    )
+    tokenless = source_network_service._annotate_enrichment_availability(
+        SourceNetworkIntelligence(
+            ip="8.8.8.8",
+            asn="AS15169",
+            as_name="GOOGLE",
+            bgp_prefix="8.8.8.0/24",
+            country_code="US",
+            source="team-cymru",
+        )
+    )
+    assert tokenless.enrichment_mode == "tokenless-fallback"
+    assert tokenless.field_availability["asn"] == "available"
+    assert tokenless.field_availability["city"] == "requires_optional_provider"
+    assert tokenless.asn == "AS15169"
+
+    monkeypatch.setattr(
+        source_network_service,
+        "get_settings",
+        lambda: SimpleNamespace(
+            IPINFO_TOKEN="token",
+            IPGEOLOCATION_API_KEY="",
+            CLOUDFLARE_RADAR_API_TOKEN="",
+            CLOUDFLARE_API_TOKEN="",
+            GEOIP_CUSTOM_URL="",
+        ),
+    )
+    configured = source_network_service._annotate_enrichment_availability(
+        SourceNetworkIntelligence(
+            ip="8.8.8.8",
+            asn="AS15169",
+            country_code="US",
+            city="Mountain View",
+            source="ipinfo-lite",
+        )
+    )
+    assert configured.enrichment_mode == "configured"
+    assert configured.field_availability["city"] == "available"
+
+    unavailable = source_network_service._annotate_enrichment_availability(
+        SourceNetworkIntelligence(
+            ip="10.0.0.1",
+            source="local",
+            error="Non-global IP address.",
+        )
+    )
+    assert unavailable.enrichment_mode == "unavailable"
+    assert unavailable.field_availability["asn"] == "unavailable"
+
+
+def test_merge_preserves_tokenless_asn_when_city_requires_provider(monkeypatch):
+    from app.services import source_network as source_network_service
+
+    monkeypatch.setattr(
+        source_network_service,
+        "get_settings",
+        lambda: SimpleNamespace(
+            IPINFO_TOKEN="",
+            IPGEOLOCATION_API_KEY="",
+            CLOUDFLARE_RADAR_API_TOKEN="",
+            CLOUDFLARE_API_TOKEN="",
+            GEOIP_CUSTOM_URL="",
+        ),
+    )
+    merged = merge_network_into_geo(
+        {"country": "Unknown", "country_code": "ZZ", "region": "Unknown", "source": "inferred"},
+        SourceNetworkIntelligence(
+            ip="193.138.195.141",
+            asn="AS24940",
+            as_name="Hetzner Online GmbH",
+            bgp_prefix="193.138.192.0/19",
+            country_code="DE",
+            country="Germany",
+            source="team-cymru",
+        ),
+    )
+    assert merged["asn"] == "AS24940"
+    assert merged["network"] == "Hetzner Online GmbH"
+    assert merged["country"] == "Germany"
+    assert merged["enrichment_mode"] == "tokenless-fallback"
+    assert merged["field_availability"]["city"] == "requires_optional_provider"
+    assert "optional" in (merged["config_hint"] or "").lower()


### PR DESCRIPTION
## Summary
- Remediation queue building uses single-domain report hydration and runs health + DNS guidance in parallel under `REMEDIATION_QUEUE_TIMEOUT_SECONDS` (default 8s).
- On enrichment timeout/failure, returns a 200 queue with `enrichment_pending` and no items instead of hanging until the browser aborts.
- Domain detail UI loads remediation without forced refresh on first paint, passes `?refresh=true` only for explicit refresh, and maps abort failures to “Next remediation could not be loaded.”

## Files touched
- `backend/app/api/api_v1/endpoints/domains.py`
- `backend/app/core/config.py`
- `backend/app/static/js/domain-details-page.js`
- `backend/app/tests/test_domain_detail_endpoints.py`
- `backend/app/tests/test_dashboard_template_security.py`

## How tested
- `pytest ... -k remediation` (21 passed)
- Template security assertions for remediation UI contract
- `flake8` on changed Python

Stacked on #821 (`feat/816-tokenless-geo-asn`).

Fixes #813

Made with [Cursor](https://cursor.com)