### PR TITLE
test: add opt-in synthetic report load scenario

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ ENVIRONMENT="development"
 DEMO_MODE=false
 PUBLIC_BASE_URL="http://localhost:8080"
 LANGUAGE="en"
+# Optional, idempotent acceptance scenario. Leave unset for normal installs.
+# SYNTHETIC_LOAD_TEST_SCENARIO="simon-811"
 # IANA timezone for UI/API presentation of mailbox and other timestamps.
 # Storage remains UTC. Invalid values fall back to UTC.
 # OS/container TZ=... does not control DMARQ display — use APP_TIMEZONE.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -48,6 +48,9 @@ class Settings(BaseSettings):
     # provider console. This is intentionally separate from tenant roles.
     PROVIDER_OPERATOR_EMAILS: str = ""
     PROVIDER_BOOTSTRAP_DEFAULT_PLANS: bool = False
+    # Opt-in, versioned acceptance data. The startup hook only accepts known
+    # scenario identifiers, keeping normal installs and DEMO_MODE separate.
+    SYNTHETIC_LOAD_TEST_SCENARIO: Optional[str] = None
 
     # Database
     # Default to a sub-directory so the SQLite file lives in a location that

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -533,6 +533,25 @@ def _initialize_provider_data() -> None:
             provider_db.close()
 
 
+def _initialize_synthetic_load_data() -> None:
+    """Seed an explicit, non-demo acceptance scenario when requested."""
+    if settings.SYNTHETIC_LOAD_TEST_SCENARIO != "simon-811":
+        return
+
+    from app.services.synthetic_load_seed import seed_simon_811_scenario
+
+    scenario_db = SessionLocal()
+    try:
+        seeded = seed_simon_811_scenario(scenario_db)
+        logger.warning("Synthetic acceptance scenario ready: %s", seeded)
+    except Exception:
+        scenario_db.rollback()
+        logger.exception("Failed to seed synthetic acceptance scenario")
+        raise
+    finally:
+        scenario_db.close()
+
+
 def _start_background_tasks() -> None:
     """Start the mailbox scheduler and DNS prewarm tasks for this deployment mode."""
     global background_task, dns_prewarm_task  # pylint: disable=global-statement
@@ -606,6 +625,7 @@ def create_app() -> FastAPI:
         Base.metadata.create_all(bind=engine)
 
         _initialize_provider_data()
+        _initialize_synthetic_load_data()
 
         # Warn loudly when authentication is completely disabled
         if settings.AUTH_DISABLED:

--- a/backend/app/services/synthetic_load_seed.py
+++ b/backend/app/services/synthetic_load_seed.py
@@ -7,9 +7,10 @@ from sqlalchemy.orm import Session
 
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
+from app.services.workspaces import get_or_create_default_workspace
 
 
-SCENARIO_DOMAIN = "simon-load.example"
+SCENARIO_DOMAIN = "simonstest.fret.de"
 SCENARIO_PREFIX = "synthetic-811-"
 SCENARIO_DAYS = 30
 DAILY_RECORDS = 12
@@ -22,12 +23,16 @@ def _source_ip(index: int) -> str:
 
 
 def _ensure_domain(db: Session) -> Domain:
+    workspace = get_or_create_default_workspace(db, commit=False)
     domain = db.query(Domain).filter(Domain.name == SCENARIO_DOMAIN).first()
     if domain is None:
-        domain = Domain(name=SCENARIO_DOMAIN)
+        domain = Domain(name=SCENARIO_DOMAIN, workspace_id=workspace.id)
         db.add(domain)
         db.flush()
 
+    # Acceptance data must be visible through the same workspace-scoped queries
+    # used by a freshly installed single-user deployment.
+    domain.workspace_id = workspace.id
     domain.description = "Synthetic acceptance scenario for report-detail load testing."
     domain.active = True
     domain.verified = False

--- a/backend/app/services/synthetic_load_seed.py
+++ b/backend/app/services/synthetic_load_seed.py
@@ -1,0 +1,123 @@
+"""Opt-in, idempotent acceptance data for report-detail load testing."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from sqlalchemy.orm import Session
+
+from app.models.domain import Domain
+from app.models.report import DMARCReport, ReportRecord
+
+
+SCENARIO_DOMAIN = "simon-load.example"
+SCENARIO_PREFIX = "synthetic-811-"
+SCENARIO_DAYS = 30
+DAILY_RECORDS = 12
+LARGE_REPORT_RECORDS = 360
+
+
+def _source_ip(index: int) -> str:
+    """Return documentation-only addresses without customer infrastructure."""
+    return f"198.51.100.{(index % 240) + 1}"
+
+
+def _ensure_domain(db: Session) -> Domain:
+    domain = db.query(Domain).filter(Domain.name == SCENARIO_DOMAIN).first()
+    if domain is None:
+        domain = Domain(name=SCENARIO_DOMAIN)
+        db.add(domain)
+        db.flush()
+
+    domain.description = "Synthetic acceptance scenario for report-detail load testing."
+    domain.active = True
+    domain.verified = False
+    domain.dmarc_policy = "quarantine"
+    domain.dmarc_report_mailbox = "reports@simon-load.example"
+    domain.spf_record = "v=spf1 -all"
+    domain.dkim_selectors = "synthetic"
+    return domain
+
+
+def _record(report: DMARCReport, index: int, *, large: bool) -> ReportRecord:
+    failure = index % 7 == 0
+    partial_failure = not failure and index % 11 == 0
+    count = 1 + ((index * 17) % (120 if large else 30))
+    dkim = "fail" if failure else "pass"
+    spf = "fail" if failure or partial_failure else "pass"
+    disposition = "quarantine" if failure else "none"
+    return ReportRecord(
+        report_id=report.id,
+        source_ip=_source_ip(index),
+        count=count,
+        disposition=disposition,
+        dkim=dkim,
+        spf=spf,
+        header_from=SCENARIO_DOMAIN,
+        envelope_from="relay.simon-load.example" if failure else SCENARIO_DOMAIN,
+        dkim_auth_details=(
+            '[{"domain":"simon-load.example","selector":"synthetic","result":"'
+            + dkim
+            + '"}]'
+        ),
+        spf_auth_details=(
+            '[{"domain":"simon-load.example","scope":"mfrom","result":"' + spf + '"}]'
+        ),
+    )
+
+
+def seed_simon_811_scenario(db: Session) -> Dict[str, int]:
+    """Create the documented #811-scale report set without external I/O."""
+    domain = _ensure_domain(db)
+    now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    report_count = 0
+    record_count = 0
+
+    for day_offset in range(SCENARIO_DAYS):
+        report_key = f"{SCENARIO_PREFIX}{day_offset:02d}"
+        begin = now - timedelta(days=(SCENARIO_DAYS - day_offset))
+        report = (
+            db.query(DMARCReport)
+            .filter(
+                DMARCReport.domain_id == domain.id, DMARCReport.report_id == report_key
+            )
+            .first()
+        )
+        if report is None:
+            report = DMARCReport(
+                domain_id=domain.id,
+                report_id=report_key,
+                org_name="Synthetic Receiver",
+            )
+            db.add(report)
+
+        report.org_name = "Synthetic Receiver"
+        report.begin_date = int(begin.timestamp())
+        report.end_date = int((begin + timedelta(days=1)).timestamp())
+        report.source_email = "noreply@receiver.example"
+        report.policy = "quarantine"
+        report.subdomain_policy = "quarantine"
+        report.adkim = "r"
+        report.aspf = "r"
+        report.percentage = 100
+        report.processed_at = begin.replace(tzinfo=None)
+
+        db.flush()
+        db.query(ReportRecord).filter(ReportRecord.report_id == report.id).delete(
+            synchronize_session=False
+        )
+        is_large_report = day_offset == SCENARIO_DAYS - 1
+        records_for_report = LARGE_REPORT_RECORDS if is_large_report else DAILY_RECORDS
+        db.add_all(
+            _record(report, day_offset * DAILY_RECORDS + index, large=is_large_report)
+            for index in range(records_for_report)
+        )
+        report_count += 1
+        record_count += records_for_report
+
+    db.commit()
+    return {
+        "domain": SCENARIO_DOMAIN,
+        "reports": report_count,
+        "records": record_count,
+        "large_report_records": LARGE_REPORT_RECORDS,
+    }

--- a/backend/app/tests/test_synthetic_load_seed.py
+++ b/backend/app/tests/test_synthetic_load_seed.py
@@ -8,6 +8,7 @@ from app.services.synthetic_load_seed import (
     SCENARIO_DOMAIN,
     seed_simon_811_scenario,
 )
+from app.services.workspaces import get_default_workspace
 
 
 def test_simon_811_seed_is_idempotent_and_has_large_report(db_session):
@@ -15,6 +16,7 @@ def test_simon_811_seed_is_idempotent_and_has_large_report(db_session):
     second = seed_simon_811_scenario(db_session)
 
     domain = db_session.query(Domain).filter(Domain.name == SCENARIO_DOMAIN).one()
+    workspace = get_default_workspace(db_session)
     reports = (
         db_session.query(DMARCReport).filter(DMARCReport.domain_id == domain.id).all()
     )
@@ -23,6 +25,8 @@ def test_simon_811_seed_is_idempotent_and_has_large_report(db_session):
     assert first["reports"] == SCENARIO_DAYS
     assert second["reports"] == SCENARIO_DAYS
     assert len(reports) == SCENARIO_DAYS
+    assert workspace is not None
+    assert domain.workspace_id == workspace.id
     assert len(largest_report.records) == LARGE_REPORT_RECORDS
     assert (
         db_session.query(ReportRecord)

--- a/backend/app/tests/test_synthetic_load_seed.py
+++ b/backend/app/tests/test_synthetic_load_seed.py
@@ -1,0 +1,32 @@
+"""Tests for the explicit #811-scale synthetic acceptance scenario."""
+
+from app.models.domain import Domain
+from app.models.report import DMARCReport, ReportRecord
+from app.services.synthetic_load_seed import (
+    LARGE_REPORT_RECORDS,
+    SCENARIO_DAYS,
+    SCENARIO_DOMAIN,
+    seed_simon_811_scenario,
+)
+
+
+def test_simon_811_seed_is_idempotent_and_has_large_report(db_session):
+    first = seed_simon_811_scenario(db_session)
+    second = seed_simon_811_scenario(db_session)
+
+    domain = db_session.query(Domain).filter(Domain.name == SCENARIO_DOMAIN).one()
+    reports = (
+        db_session.query(DMARCReport).filter(DMARCReport.domain_id == domain.id).all()
+    )
+    largest_report = max(reports, key=lambda item: len(item.records))
+
+    assert first["reports"] == SCENARIO_DAYS
+    assert second["reports"] == SCENARIO_DAYS
+    assert len(reports) == SCENARIO_DAYS
+    assert len(largest_report.records) == LARGE_REPORT_RECORDS
+    assert (
+        db_session.query(ReportRecord)
+        .filter(ReportRecord.report_id == largest_report.id)
+        .count()
+        == LARGE_REPORT_RECORDS
+    )

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -264,6 +264,7 @@ and import history are stored per source.
 | `LANGUAGE` | Default language for operator-facing guidance | `en` | `en`, `de` |
 | `DMARQ_DEFAULT_LOCALE` | Optional override for localized guidance; falls back to `LANGUAGE` | - | `de` |
 | `APP_TIMEZONE` | IANA timezone for UI/API presentation of timestamps (for example Mail Sources last check). Storage remains UTC. Invalid values fall back to `UTC`. Container `TZ` alone does not change DMARQ display. | `UTC` | `Europe/Berlin` |
+| `SYNTHETIC_LOAD_TEST_SCENARIO` | Explicit idempotent acceptance data seed. Do not set on customer data. | - | `simon-811` |
 | `DEMO_MODE` | Force generated demo reports and demo DNS records for public demo instances. Do not enable on production customer data. | `false` | `true` |
 
 ### Sender Reputation Feeds


### PR DESCRIPTION
Closes #828.

Adds an explicitly opt-in `SYNTHETIC_LOAD_TEST_SCENARIO=simon-811` startup seed for Preprod acceptance. It creates one clearly synthetic `.example` domain, 30 deterministic aggregate reports, and a 360-record report while staying separate from DEMO_MODE and real mail sources.

Validation:
- `ruff check` for changed Python modules
- focused seed idempotence test
- full suite: 2038 passed

The GitOps setting remains disabled until this PR is accepted.