### PR TITLE
Fix sender network evidence and simplify sender signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Kept completed sender ASN, prefix, country, and ownership lookups visible
+  when a larger source batch reaches its response budget. Slow DNS lookups no
+  longer discard already-resolved network evidence for every other sender.
+- Replaced unexplained sender-volume micro-bars with an explicit observed-mail
+  and DMARC-failure summary plus an optional 14-day daily evidence view.
+  Sender network and reputation evidence now lead with compact trust signals
+  and retain provider, feed, and lookup detail behind one disclosure.
 - Made a selected but unconfigured Akamai ETP, Infoblox, or custom DNS profile
   explicitly degrade to Public DNS for read-only lookups. Settings and setup
   now show the deployment configuration still required, while domain DNS and

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -8015,21 +8015,16 @@ async def _source_networks_by_ip(
     if not settings.SOURCE_NETWORK_ENRICHMENT_ENABLED:
         return {}
     try:
-        return await asyncio.wait_for(
-            lookup_sources_network_cached(
-                db,
-                provider,
-                ips,
-                ttl_seconds=settings.SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS,
-                max_ips=settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS,
-            ),
-            timeout=max(
-                0.5,
-                float(settings.SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS),
+        return await lookup_sources_network_cached(
+            db,
+            provider,
+            ips,
+            ttl_seconds=settings.SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS,
+            max_ips=settings.SOURCE_NETWORK_ENRICHMENT_MAX_IPS,
+            timeout_seconds=max(
+                0.5, float(settings.SOURCE_NETWORK_ENRICHMENT_DETAIL_TIMEOUT_SECONDS)
             ),
         )
-    except asyncio.TimeoutError:
-        logger.info("Source network enrichment timed out for domain sources")
     except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.info(
             "Source network enrichment failed for domain sources: %s",

--- a/backend/app/services/source_network.py
+++ b/backend/app/services/source_network.py
@@ -7,6 +7,7 @@ import hashlib
 import ipaddress
 import json
 import logging
+import time
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -922,12 +923,15 @@ async def lookup_sources_network_cached(  # noqa: C901 - batch cache and network
     max_ips: int = 100,
     refresh: bool = False,
     concurrency: int = 8,
+    timeout_seconds: Optional[float] = None,
 ) -> Dict[str, SourceNetworkIntelligence]:
     """Lookup network context for a bounded set of observed source IPs.
 
     Cache reads and writes stay on the request session, while uncached remote
     lookups run with bounded concurrency.  A report with many unique senders
-    must not serially wait for one DNS/API timeout per sender.
+    must not serially wait for one DNS/API timeout per sender. When a time
+    budget is supplied, completed lookups are returned and cached instead of
+    discarding the whole batch because one remote resolver is slow.
     """
     results: Dict[str, SourceNetworkIntelligence] = {}
     seen: set[str] = set()
@@ -982,9 +986,38 @@ async def lookup_sources_network_cached(  # noqa: C901 - batch cache and network
                 result = await lookup_source_network(provider, ip)
             return ip, _row, result
 
-    looked_up = await asyncio.gather(
-        *(_lookup_pending(ip, row, cached) for ip, row, cached in pending)
+    tasks = {
+        asyncio.create_task(_lookup_pending(ip, row, cached))
+        for ip, row, cached in pending
+    }
+    looked_up: List[Tuple[str, Optional[DNSCache], SourceNetworkIntelligence]] = []
+    deadline = (
+        time.monotonic() + max(0.0, float(timeout_seconds))
+        if timeout_seconds is not None
+        else None
     )
+
+    while tasks:
+        remaining = None if deadline is None else deadline - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            break
+        done, tasks = await asyncio.wait(
+            tasks,
+            timeout=remaining,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if not done:
+            break
+        for task in done:
+            try:
+                looked_up.append(task.result())
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                logger.info("Source network lookup failed: %s", type(exc).__name__)
+
+    if tasks:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
     for ip, row, result in looked_up:
         payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
         if row is None:

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -2053,6 +2053,16 @@ function domainDetailsApp(domainId = '') {
             return 'Geo unavailable';
         },
 
+        sourceNetworkSummary(source) {
+            const geo = source?.geo || {};
+            const country = geo.country && geo.country !== 'Unknown'
+                ? geo.country
+                : (geo.country_code && geo.country_code !== 'ZZ' ? geo.country_code : null);
+            const asn = geo.asn || null;
+            if (country || asn) return [country, asn].filter(Boolean).join(' · ');
+            return geo.network_error ? 'Network lookup pending' : 'Network context unavailable';
+        },
+
         geoAvailabilityHint(source) {
             const geo = source?.geo || source || {};
             if (geo.config_hint) {
@@ -2084,27 +2094,20 @@ function domainDetailsApp(domainId = '') {
             return date.toLocaleDateString();
         },
 
-        sourceVolumeBars(source) {
-            const history = (source.volume_history || []).slice(-14);
-            const max = Math.max(...history.map(point => Number(point.count || 0)), 1);
-            const logMax = Math.log10(max + 1);
-            const slotWidth = 140 / Math.max(history.length, 1);
-            const barWidth = Math.max(4, slotWidth - 2);
-            return history.map((point, index) => {
-                const count = Number(point.count || 0);
-                const failed = Number(point.failed || 0);
-                const scaled = logMax > 0 ? Math.log10(count + 1) / logMax : 0;
-                const height = count > 0 ? Math.max(12, Math.round(scaled * 100)) : 4;
-                return {
-                    ...point,
-                    failed,
-                    x: Math.round((index * slotWidth + 1) * 10) / 10,
-                    y: 100 - height,
-                    width: Math.round(barWidth * 10) / 10,
-                    height,
-                    label: `${point.date}: ${this.formatLargeNumber(count)} emails${failed ? ', ' + this.formatLargeNumber(failed) + ' failed' : ''}`,
-                };
-            });
+        sourceVolumeHistory(source) {
+            return (source.volume_history || []).slice(-14).map((point) => ({
+                ...point,
+                count: Number(point.count || 0),
+                failed: Number(point.failed || 0),
+            }));
+        },
+
+        sourceVolumeSummary(source) {
+            const history = this.sourceVolumeHistory(source);
+            const count = history.reduce((total, point) => total + point.count, 0);
+            const failed = history.reduce((total, point) => total + point.failed, 0);
+            const volume = `${this.formatLargeNumber(count)} observed`;
+            return failed ? `${volume} · ${this.formatLargeNumber(failed)} DMARC failed` : volume;
         },
 
         sourceDateWindow() {

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2473,8 +2473,8 @@
                         {% call tr() %}
                             {% call th('w-[14%] align-top') %}Source IP / Hostname{% endcall %}
                             {% call th('w-[13%] align-top') %}Sender{% endcall %}
-                            {% call th('w-[17%] align-top') %}IP Intelligence{% endcall %}
-                            {% call th('w-[10%] align-top') %}Total Emails{% endcall %}
+                            {% call th('w-[17%] align-top') %}Trust signals{% endcall %}
+                            {% call th('w-[10%] align-top') %}Observed mail{% endcall %}
                             {% call th('w-[7%] align-top') %}SPF{% endcall %}
                             {% call th('w-[7%] align-top') %}DKIM{% endcall %}
                             {% call th('w-[7%] align-top') %}DMARC{% endcall %}
@@ -2555,105 +2555,52 @@
                                     </div>
                                 {% endcall %}
                                 {% call td('align-top') %}
-                                    <div class="min-w-0 break-words space-y-2 text-xs">
+                                    <div class="min-w-0 space-y-2 text-xs">
                                         <div class="flex flex-wrap gap-1.5">
-                                            <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80">
-                                                <span x-text="pathValue(source, 'geo.country_code', 'ZZ')"></span>
-                                                <span class="mx-1">·</span>
-                                                <span x-text="pathValue(source, 'geo.country') && pathValue(source, 'geo.country') !== 'Unknown' ? pathValue(source, 'geo.country') : (pathValue(source, 'geo.country_code') && pathValue(source, 'geo.country_code') !== 'ZZ' ? pathValue(source, 'geo.country_code') : 'Country unknown')"></span>
-                                            </span>
-                                            <template x-if="pathValue(source, 'geo.enrichment_mode') === 'tokenless-fallback'">
-                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/70">Tokenless ASN; geo may be partial</span>
+                                            <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80" x-text="sourceNetworkSummary(source)"></span>
+                                            <template x-if="source.reputation">
+                                                <span class="inline-flex items-center rounded-full px-2 py-0.5 font-semibold" :class="reputationStatusClass(source.reputation.status)" x-text="reputationRiskLabel(source.reputation)"></span>
                                             </template>
-                                            <template x-if="pathValue(source, 'geo.asn')">
-                                                <span class="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 font-medium text-blue-800" x-text="source.geo.asn"></span>
-                                            </template>
-                                            <template x-if="pathValue(source, 'geo.network')">
-                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80" x-text="source.geo.network"></span>
-                                            </template>
-                                            <template x-if="pathValue(source, 'geo.bgp_prefix')">
-                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-mono font-medium text-base-content/80" x-text="source.geo.bgp_prefix"></span>
-                                            </template>
-                                            <template x-if="pathValue(source, 'geo.city')">
-                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80" x-text="source.geo.city"></span>
-                                            </template>
-                                            <template x-if="pathValue(source, 'geo.registry')">
-                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium uppercase text-base-content/70" x-text="source.geo.registry"></span>
+                                            <template x-if="!source.reputation">
+                                                <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/70">Reputation pending</span>
                                             </template>
                                         </div>
-                                        <template x-if="pathValue(source, 'geo.allocated') || pathValue(source, 'geo.organization') || pathValue(source, 'geo.domain') || pathValue(source, 'geo.network_source')">
-                                            <p class="text-muted-foreground">
-                                                <span x-show="pathValue(source, 'geo.allocated')">Allocated <span x-text="pathValue(source, 'geo.allocated')"></span></span>
-                                                <span x-show="pathValue(source, 'geo.allocated') && (pathValue(source, 'geo.organization') || pathValue(source, 'geo.domain') || pathValue(source, 'geo.network_source'))"> · </span>
-                                                <span x-show="pathValue(source, 'geo.organization')" x-text="pathValue(source, 'geo.organization')"></span>
-                                                <span x-show="pathValue(source, 'geo.organization') && pathValue(source, 'geo.domain')"> · </span>
-                                                <span x-show="pathValue(source, 'geo.domain')" x-text="pathValue(source, 'geo.domain')"></span>
-                                                <span x-show="(pathValue(source, 'geo.organization') || pathValue(source, 'geo.domain')) && pathValue(source, 'geo.network_source')"> · </span>
-                                                <span x-show="pathValue(source, 'geo.network_source')">Network data: <span x-text="pathValue(source, 'geo.network_source')"></span></span>
-                                            </p>
-                                        </template>
-                                        <template x-if="pathValue(source, 'geo.radar_url')">
-                                            <a class="text-xs font-medium text-primary hover:underline"
-                                               :href="source.geo.radar_url"
-                                               target="_blank"
-                                               rel="noopener noreferrer">Open in Cloudflare Radar</a>
-                                        </template>
-                                        <template x-if="pathValue(source, 'geo.network_error') && !pathValue(source, 'geo.asn') && !pathValue(source, 'geo.network')">
-                                            <p class="text-muted-foreground" x-text="source.geo.network_error"></p>
-                                        </template>
-                                        <template x-if="pathValue(source, 'geo.config_hint')">
-                                            <p class="text-muted-foreground" x-text="geoAvailabilityHint(source)"></p>
-                                        </template>
                                         <template x-if="source.reputation">
-                                            <div class="space-y-1.5">
-                                                <div class="flex flex-wrap items-center gap-1.5">
-                                                    <span
-                                                        class="inline-flex items-center rounded-full px-2 py-0.5 font-semibold"
-                                                        :class="reputationStatusClass(source.reputation.status)"
-                                                        x-text="reputationLabel(source.reputation)"
-                                                    ></span>
-                                                    <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-medium text-base-content/80" x-text="reputationRiskLabel(source.reputation)"></span>
-                                                    <span
-                                                        class="inline-flex items-center rounded-full px-2 py-0.5 font-medium"
-                                                        :class="reputationFeedClass(source.reputation.feed_status)"
-                                                        x-text="source.reputation.feed_summary || 'Local reputation evidence only'"
-                                                    ></span>
-                                                </div>
-                                                <p class="text-muted-foreground" x-text="source.reputation.status_detail || source.reputation.summary"></p>
-                                                <p class="text-muted-foreground">
-                                                    <span x-text="reputationCheckedLabel(source.reputation)"></span>
-                                                    <span> · </span>
-                                                    <span x-text="reputationAgeLabel(source.reputation)"></span>
-                                                </p>
-                                                <template x-if="pathValue(source, 'reputation.listings.length', 0)">
-                                                    <p class="font-medium text-[#ff6f3c]">
-                                                        <span>Listed on </span>
-                                                        <span x-text="source.reputation.listings.slice(0, 2).join(', ')"></span>
-                                                        <span x-show="source.reputation.listings.length > 2" x-text="' +' + (source.reputation.listings.length - 2)"></span>
+                                            <p class="text-muted-foreground" x-text="reputationLabel(source.reputation) + ' · ' + reputationAgeLabel(source.reputation)"></p>
+                                        </template>
+                                        <details class="rounded border border-base-300 bg-base-100 px-2 py-1.5 text-muted-foreground">
+                                            <summary class="cursor-pointer font-medium text-base-content">Network &amp; reputation evidence</summary>
+                                            <div class="mt-2 space-y-2 break-words">
+                                                <p x-text="sourceGeoSummary(source)"></p>
+                                                <template x-if="pathValue(source, 'geo.allocated') || pathValue(source, 'geo.organization') || pathValue(source, 'geo.domain') || pathValue(source, 'geo.network_source')">
+                                                    <p>
+                                                        <span x-show="pathValue(source, 'geo.allocated')">Allocated <span x-text="pathValue(source, 'geo.allocated')"></span></span>
+                                                        <span x-show="pathValue(source, 'geo.network_source')"> · Network data: <span x-text="pathValue(source, 'geo.network_source')"></span></span>
                                                     </p>
                                                 </template>
-                                                <div class="flex flex-wrap gap-1" x-show="reputationEvidencePreview(source.reputation).length">
-                                                    <template x-for="item in reputationEvidencePreview(source.reputation)" :key="item.label + item.value">
-                                                        <span class="inline-flex max-w-full items-center rounded bg-base-200 px-2 py-0.5 text-[11px] text-base-content/75">
-                                                            <span class="font-medium" x-text="item.label"></span>
-                                                            <span class="px-1">·</span>
-                                                            <span class="truncate" x-text="item.value"></span>
-                                                        </span>
-                                                    </template>
-                                                </div>
+                                                <template x-if="pathValue(source, 'geo.network_error') && !pathValue(source, 'geo.asn') && !pathValue(source, 'geo.network')"><p x-text="source.geo.network_error"></p></template>
+                                                <template x-if="pathValue(source, 'geo.config_hint')"><p x-text="geoAvailabilityHint(source)"></p></template>
+                                                <template x-if="source.reputation">
+                                                    <div class="space-y-1">
+                                                        <p x-text="source.reputation.status_detail || source.reputation.summary"></p>
+                                                        <p x-text="reputationCheckedLabel(source.reputation)"></p>
+                                                        <span class="inline-flex items-center rounded-full px-2 py-0.5 font-medium" :class="reputationFeedClass(source.reputation.feed_status)" x-text="source.reputation.feed_summary || 'Local reputation evidence only'"></span>
+                                                        <template x-if="pathValue(source, 'reputation.listings.length', 0)"><p class="font-medium text-[#ff6f3c]">Listed on <span x-text="source.reputation.listings.join(', ')"></span></p></template>
+                                                        <div class="flex flex-wrap gap-1" x-show="reputationEvidencePreview(source.reputation).length">
+                                                            <template x-for="item in reputationEvidencePreview(source.reputation)" :key="item.label + item.value"><span class="inline-flex max-w-full items-center rounded bg-base-200 px-2 py-0.5 text-[11px]"><span class="font-medium" x-text="item.label"></span><span class="px-1">·</span><span class="truncate" x-text="item.value"></span></span></template>
+                                                        </div>
+                                                    </div>
+                                                </template>
+                                                <template x-if="!source.reputation"><p>Reputation has not been calculated yet. Use Refresh reputation to recalculate cached IP evidence.</p></template>
+                                                <template x-if="pathValue(source, 'geo.radar_url')"><a class="font-medium text-primary hover:underline" :href="source.geo.radar_url" target="_blank" rel="noopener noreferrer">Open in Cloudflare Radar</a></template>
                                             </div>
-                                        </template>
-                                        <template x-if="!source.reputation">
-                                            <p class="text-muted-foreground">Reputation has not been calculated for this source yet. Use Refresh reputation to recalculate cached IP evidence.</p>
-                                        </template>
-                                        <template x-if="!pathValue(source, 'geo.asn') && !pathValue(source, 'geo.network') && !source.reputation">
-                                            <p class="text-muted-foreground">No ASN or reputation evidence available yet.</p>
-                                        </template>
+                                        </details>
                                     </div>
                                 {% endcall %}
                                 {% call td('align-top') %}
                                     <div class="min-w-0 space-y-2">
-                                        <div class="font-semibold" x-text="formatLargeNumber(source.count)"></div>
+                                        <div class="font-semibold" x-text="formatLargeNumber(source.count) + ' observed'"></div>
+                                        <div class="text-xs" :class="source.dmarc_fail_count ? 'text-error' : 'text-success'" x-text="source.dmarc_fail_count ? formatLargeNumber(source.dmarc_fail_count) + ' DMARC failed' : 'No DMARC failures'"></div>
                                         <div class="space-y-0.5 text-xs text-muted-foreground">
                                             <div>
                                                 <span>Last sent </span>
@@ -2669,22 +2616,12 @@
                                                 <span x-show="source.report_count" x-text="source.report_count + ' report' + (source.report_count === 1 ? '' : 's')"></span>
                                             </div>
                                         </div>
-                                        <div class="flex h-8 gap-0.5" x-show="pathValue(source, 'volume_history.length', 0)" role="img" aria-label="Recent sending volume">
-                                            <template x-for="point in sourceVolumeBars(source)" :key="point.date">
-                                                <svg class="h-8 flex-1 overflow-visible" :viewBox="'0 0 ' + point.width + ' 100'" preserveAspectRatio="none" aria-hidden="true">
-                                                    <rect
-                                                         x="0"
-                                                         :y="point.y"
-                                                         :width="point.width"
-                                                         :height="point.height"
-                                                         rx="1.5"
-                                                         class="fill-current"
-                                                         :class="point.failed > 0 ? 'text-error' : 'text-success'">
-                                                        <title x-text="point.label"></title>
-                                                    </rect>
-                                                </svg>
-                                            </template>
-                                        </div>
+                                        <details x-show="pathValue(source, 'volume_history.length', 0)" class="rounded border border-base-300 bg-base-100 px-2 py-1.5 text-xs">
+                                            <summary class="cursor-pointer font-medium text-base-content"><span>Recent volume</span><span class="ml-1 text-muted-foreground" x-text="sourceVolumeSummary(source)"></span></summary>
+                                            <div class="mt-2 divide-y divide-base-200">
+                                                <template x-for="point in sourceVolumeHistory(source)" :key="point.date"><div class="flex items-center justify-between gap-2 py-1"><span class="text-muted-foreground" x-text="point.date"></span><span><span x-text="formatLargeNumber(point.count) + ' emails'"></span><span x-show="point.failed" class="ml-1 text-error" x-text="formatLargeNumber(point.failed) + ' failed'"></span></span></div></template>
+                                            </div>
+                                        </details>
                                     </div>
                                 {% endcall %}
                                 {% call td('align-top') %}

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -453,7 +453,7 @@ def test_domain_details_nested_values_are_csp_safe_without_hiding_features():
     assert ".filter(Boolean)" not in template
     assert "pathValue(remediationQueue, 'loop.next_action'" in template
     assert "pathValue(migrationImport, 'preview.sample_rows', [])" in template
-    assert "pathValue(source, 'geo.country_code', 'ZZ')" in template
+    assert "sourceNetworkSummary(source)" in template
 
 
 def test_dashboard_exposes_workspace_health_history():
@@ -2514,15 +2514,14 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     template = _domain_details_template()
     script = _domain_details_script()
 
-    assert "IP Intelligence" in template
+    assert "Trust signals" in template
     assert "PTR unavailable" in template
     assert "sourceGeoSummary(source)" in script
     assert "geoAvailabilityHint" in script
-    assert "Tokenless ASN; geo may be partial" in template
+    assert "sourceNetworkSummary(source)" in template
     assert "String(value).trim().toLowerCase() !== 'unknown'" in script
     assert "Geo unavailable" in script
-    assert "pathValue(source, 'geo.country_code', 'ZZ')" in template
-    assert "pathValue(source, 'geo.country')" in template
+    assert "sourceNetworkSummary(source)" in template
     assert "source.geo?.region" in script
     assert "source.geo?.asn" in script
     assert "source.geo?.network" in script
@@ -2548,7 +2547,8 @@ def test_domain_details_exposes_source_ip_intelligence_without_html_injection():
     assert "if (!options.preserveOnFailure || !hasExistingSources) {" in script
     assert "if (options.preserveOnFailure && hasExistingSources) {" in script
     assert "sourceSeenLabel" in script
-    assert "sourceVolumeBars" in script
+    assert "sourceVolumeHistory" in script
+    assert "sourceVolumeSummary" in script
     assert "source.reputation.status" in template
     assert "source.reputation.feed_status" in template
     assert "source.reputation.feed_summary" in template
@@ -2575,12 +2575,11 @@ def test_domain_details_keeps_sending_source_authentication_columns_visible_on_d
     assert "Use Refresh reputation" in template
     assert 'colspan="9"' in template
     assert "x-effect=\"$el.style.height = point.height + '%'" not in template
-    assert 'aria-label="Recent sending volume"' in template
-    assert ":viewBox=\"'0 0 ' + point.width + ' 100'\"" in template
-    assert '<template x-for="point in sourceVolumeBars(source)"' in template
-    assert "point.y" in template
-    assert "point.width" in template
-    assert '<svg class="h-8 w-full overflow-visible"' not in template
+    assert "Network &amp; reputation evidence" in template
+    assert "Recent volume" in template
+    assert '<template x-for="point in sourceVolumeHistory(source)"' in template
+    assert "DMARC failed" in template
+    assert "sourceVolumeBars" not in template
     assert "x-html" not in template
     assert not _has_inline_style(template)
 
@@ -2711,7 +2710,7 @@ def test_domain_details_distinguishes_loading_error_and_empty_states():
     assert "sourceActivityLabel(source)" in template
     assert "sourceActivityClass(source)" in template
     assert "reputationAgeLabel(source.reputation)" in template
-    assert "Math.log10(count + 1)" in script
+    assert "sourceVolumeSummary(source)" in template
     assert (
         "(!sourceIntelligence.loading && !sourceIntelligence.error ? sourceIntelligence.regions.slice(0, 4) : [])"
         in template

--- a/backend/app/tests/test_source_network.py
+++ b/backend/app/tests/test_source_network.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from urllib.error import URLError
@@ -768,6 +769,37 @@ async def test_lookup_sources_network_cached_filters_invalid_and_non_global_ips(
     assert list(results) == ["8.8.8.8"]
     assert results["8.8.8.8"].asn == "AS15169"
     assert provider.queries == ["8.8.8.8.origin.asn.cymru.com"]
+
+
+async def test_lookup_sources_network_cached_returns_completed_results_on_timeout(
+    db_session, monkeypatch
+):
+    """A slow sender must not hide other resolved sender network evidence."""
+
+    async def fake_lookup(_provider, ip):
+        if ip == "1.1.1.1":
+            await asyncio.sleep(0.2)
+        return SourceNetworkIntelligence(
+            ip=ip,
+            asn="AS15169",
+            as_name="Example network",
+            country_code="US",
+            country="United States",
+            source="team-cymru",
+        )
+
+    monkeypatch.setattr("app.services.source_network.lookup_source_network", fake_lookup)
+
+    results = await lookup_sources_network_cached(
+        db_session,
+        FakeProvider(),
+        ["8.8.8.8", "1.1.1.1"],
+        concurrency=2,
+        timeout_seconds=0.03,
+    )
+
+    assert list(results) == ["8.8.8.8"]
+    assert results["8.8.8.8"].country == "United States"
 
 
 def test_merge_network_into_geo_preserves_report_metadata_and_adds_prefix():


### PR DESCRIPTION
## What changed
- Return and persist completed network lookups when a large sender batch reaches its time budget instead of dropping all resolved results.
- Replace unexplained volume micro-bars with explicit observed-mail and DMARC-failure summaries plus a 14-day evidence disclosure.
- Collapse verbose network and reputation raw evidence behind a single disclosure while keeping primary trust signals visible.

## Why
Production sender rows could show `Geo unavailable` / missing ASN even when Team Cymru resolved the public address. A slow member of a large lookup batch caused the endpoint to discard every completed result.

## Validation
- Docker image build
- `pytest app/tests/test_source_network.py app/tests/test_domain_detail_endpoints.py app/tests/test_dashboard_template_security.py -q`
- 207 passed, 27 skipped
- Local demo runtime/API smoke check with sender volume, DMARC fail counts, network and reputation evidence

Closes #830
Relates to #816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer sending-source trust signals, including network, country, ASN, ownership, reputation, and evidence details.
  * Replaced the recent-volume chart with an accessible summary of observed mail and DMARC failures, plus an optional 14-day daily view.

* **Bug Fixes**
  * Preserved completed sender intelligence results when larger batches exceed the available response time.
  * Improved ordering and consolidation of source evidence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->