### PR TITLE
fix: drain historical sender evidence backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Made sender-evidence backfill drain the complete historical report backlog.
+  Each background cycle now selects only rows still missing a snapshot, so
+  recent enriched senders cannot starve older reports behind the batch limit.
 - Kept completed sender ASN, prefix, country, and ownership lookups visible
   when a larger source batch reaches its response budget. Slow DNS lookups no
   longer discard already-resolved network evidence for every other sender.

--- a/backend/app/services/source_evidence_prewarm.py
+++ b/backend/app/services/source_evidence_prewarm.py
@@ -45,7 +45,12 @@ def network_from_source_evidence(evidence: object):
     return SourceNetworkIntelligence(**{key: payload[key] for key in payload if key in allowed})
 
 
-def _recent_source_ips(limit: int) -> List[str]:
+def _pending_source_ips(limit: int) -> List[str]:
+    """Return the next sender IPs that still need an evidence snapshot.
+
+    Filtering before applying the batch limit is important for upgrades: already
+    enriched, recent senders must not permanently starve older report rows.
+    """
     db = SessionLocal()
     try:
         rows = (
@@ -55,7 +60,11 @@ def _recent_source_ips(limit: int) -> List[str]:
                 func.sum(ReportRecord.count).label("message_count"),
             )
             .join(DMARCReport, DMARCReport.id == ReportRecord.report_id)
-            .filter(ReportRecord.source_ip.isnot(None), ReportRecord.source_ip != "unknown")
+            .filter(
+                ReportRecord.source_evidence.is_(None),
+                ReportRecord.source_ip.isnot(None),
+                ReportRecord.source_ip != "unknown",
+            )
             .group_by(ReportRecord.source_ip)
             .order_by(
                 func.max(DMARCReport.end_date).desc(),
@@ -78,7 +87,7 @@ async def prewarm_source_evidence() -> int:
     limit = max(0, int(settings.SOURCE_EVIDENCE_PREWARM_LIMIT or 0))
     if limit == 0:
         return 0
-    source_ips = _recent_source_ips(limit)
+    source_ips = _pending_source_ips(limit)
     if not source_ips:
         return 0
 

--- a/backend/app/tests/test_source_evidence_prewarm.py
+++ b/backend/app/tests/test_source_evidence_prewarm.py
@@ -10,6 +10,115 @@ from app.services.ptr_lookup import PtrLookupResult
 from app.services.source_network import SourceNetworkIntelligence
 
 
+def test_pending_source_ips_does_not_starve_older_unenriched_rows(db_session, monkeypatch):
+    domain = Domain(name="example.com", active=True)
+    db_session.add(domain)
+    db_session.flush()
+    older_report = DMARCReport(
+        domain_id=domain.id,
+        report_id="older-report",
+        org_name="receiver.example",
+        begin_date=1782000000,
+        end_date=1782086400,
+    )
+    newer_report = DMARCReport(
+        domain_id=domain.id,
+        report_id="newer-report",
+        org_name="receiver.example",
+        begin_date=1783000000,
+        end_date=1783086400,
+    )
+    db_session.add_all([older_report, newer_report])
+    db_session.flush()
+    db_session.add_all(
+        [
+            ReportRecord(
+                report_id=older_report.id,
+                source_ip="93.184.216.34",
+                count=1,
+                disposition="none",
+            ),
+            ReportRecord(
+                report_id=newer_report.id,
+                source_ip="1.1.1.1",
+                count=1,
+                disposition="none",
+                source_evidence='{"captured_at":"2026-07-23T00:00:00Z"}',
+            ),
+        ]
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(source_evidence_prewarm, "SessionLocal", lambda: db_session)
+
+    assert source_evidence_prewarm._pending_source_ips(limit=1) == ["93.184.216.34"]
+
+
+@pytest.mark.asyncio
+async def test_prewarm_drains_historical_rows_across_bounded_cycles(db_session, monkeypatch):
+    domain = Domain(name="historical.example", active=True)
+    db_session.add(domain)
+    db_session.flush()
+    for index, source_ip in enumerate(("192.0.2.10", "192.0.2.20", "192.0.2.30")):
+        report = DMARCReport(
+            domain_id=domain.id,
+            report_id=f"historical-{index}",
+            org_name="receiver.example",
+            begin_date=1781000000 + index,
+            end_date=1781086400 + index,
+        )
+        db_session.add(report)
+        db_session.flush()
+        db_session.add(
+            ReportRecord(
+                report_id=report.id,
+                source_ip=source_ip,
+                count=1,
+                disposition="none",
+            )
+        )
+    db_session.commit()
+
+    async def _network_results(_db, _provider, source_ips, **_kwargs):
+        return {
+            ip: SourceNetworkIntelligence(
+                ip=ip,
+                asn="AS64500",
+                country_code="DE",
+                country="Germany",
+            )
+            for ip in source_ips
+        }
+
+    monkeypatch.setattr(source_evidence_prewarm, "SessionLocal", lambda: db_session)
+    monkeypatch.setattr(source_evidence_prewarm, "get_default_provider", lambda _db: object())
+    monkeypatch.setattr(
+        source_evidence_prewarm,
+        "lookup_ptr_with_fallbacks",
+        AsyncMock(return_value=PtrLookupResult(status="nxdomain", provider="test")),
+    )
+    monkeypatch.setattr(source_evidence_prewarm, "lookup_sources_network_cached", _network_results)
+    monkeypatch.setattr(source_evidence_prewarm, "providers_from_settings", lambda _settings: [])
+    monkeypatch.setattr(
+        source_evidence_prewarm,
+        "lookup_sources_reputation_cached",
+        AsyncMock(return_value={}),
+    )
+    settings = source_evidence_prewarm.get_settings()
+    monkeypatch.setattr(settings, "SOURCE_EVIDENCE_PREWARM_ENABLED", True)
+    monkeypatch.setattr(settings, "SOURCE_EVIDENCE_PREWARM_LIMIT", 1)
+
+    assert [await source_evidence_prewarm.prewarm_source_evidence() for _ in range(4)] == [
+        1,
+        1,
+        1,
+        0,
+    ]
+    assert (
+        db_session.query(ReportRecord).filter(ReportRecord.source_evidence.is_(None)).count() == 0
+    )
+
+
 @pytest.mark.asyncio
 async def test_prewarm_persists_point_in_time_sender_evidence(db_session, monkeypatch):
     domain = Domain(name="example.com", active=True)

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -304,8 +304,8 @@ answer "is this IP listed or risky according to a configured provider?"
 | `SOURCE_NETWORK_ENRICHMENT_ENABLED` | Enable cached sender-IP network enrichment for ASN, BGP prefix, location, and operator metadata. | `true` | `false` |
 | `SOURCE_NETWORK_ENRICHMENT_CACHE_SECONDS` | Persistent cache TTL for per-IP network metadata. | `86400` | `604800` |
 | `SOURCE_NETWORK_ENRICHMENT_MAX_IPS` | Maximum unique source IPs enriched per domain/report request. | `100` | `250` |
-| `SOURCE_EVIDENCE_PREWARM_ENABLED` | Capture PTR, network, country, and configured reputation-feed evidence for recent sender IPs in the background. | `true` | `false` |
-| `SOURCE_EVIDENCE_PREWARM_LIMIT` | Maximum recent unique sender IPs processed per background cycle. | `250` | `500` |
+| `SOURCE_EVIDENCE_PREWARM_ENABLED` | Capture PTR, network, country, and configured reputation-feed evidence for new and historical report rows in the background. Existing snapshots are not overwritten. | `true` | `false` |
+| `SOURCE_EVIDENCE_PREWARM_LIMIT` | Maximum unique sender IPs still missing snapshots processed per background cycle. Repeated cycles drain the historical backlog. | `250` | `500` |
 | `SOURCE_EVIDENCE_PREWARM_CONCURRENCY` | Maximum concurrent PTR/network lookups in one background cycle. | `8` | `12` |
 | `SOURCE_EVIDENCE_PREWARM_TIMEOUT_SECONDS` | Total network-enrichment budget for one background cycle. | `20` | `30` |
 | `SOURCE_EVIDENCE_PREWARM_INTERVAL_SECONDS` | Delay between background cycles. Values below 30 seconds are clamped. | `300` | `600` |


### PR DESCRIPTION
## Summary

- select only report sender IPs that still lack point-in-time evidence
- drain historical report rows across bounded background cycles
- document that upgrades backfill old reports without overwriting existing snapshots
- add regressions for starvation and multi-cycle backlog completion

## Live reproduction

Production on v1.175.2 currently has 2,846 eligible report rows:
- 2,843 with snapshots
- 3 historical rows still pending

The existing worker repeatedly selected 125 already-enriched recent IPs and persisted zero rows, proving older rows could be starved by the batch limit.

## Validation

- 2069 tests passed
- Black, isort, and diff checks pass
- multi-cycle regression with limit 1 drains 3 historical rows in 3 cycles and returns no work on cycle 4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sender-evidence backfill so older report records missing evidence are processed reliably without being blocked by already-enriched records.
  * Background cycles now continue draining historical records until all eligible missing snapshots are completed.

* **Documentation**
  * Clarified prewarming behavior and configuration limits for new and historical report records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->