### PR TITLE
fix(i18n): keep German dashboard responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Kept localized dashboards responsive by preventing translation and Alpine
+  rendering from repeatedly rewriting the same text nodes. Language choices in
+  the asynchronously rendered account menu now apply and persist after reload.
 - Preserved ASN, country, network, and reputation snapshots when reverse DNS
   returns a transient error. PTR remains retryable in the background without
   blocking the rest of the historical sender evidence.

--- a/backend/app/static/js/localization.js
+++ b/backend/app/static/js/localization.js
@@ -54,6 +54,16 @@
         window.location.replace(nextUrl.toString());
     };
 
+    const syncLanguageSelectors = (rootNode = document) => {
+        if (rootNode instanceof Element && rootNode.matches('[data-language-selector]')) {
+            rootNode.value = locale;
+        }
+        if (typeof rootNode.querySelectorAll !== 'function') return;
+        rootNode.querySelectorAll('[data-language-selector]').forEach((selector) => {
+            selector.value = locale;
+        });
+    };
+
     window.dmarqLocale = locale;
     window.dmarqT = translate;
     window.dmarqFormatNumber = (value, options = {}) =>
@@ -66,17 +76,24 @@
 
     document.addEventListener('DOMContentLoaded', () => {
         translateTree(document.body);
-        document.querySelectorAll('[data-language-selector]').forEach((selector) => {
-            selector.value = locale;
-            selector.addEventListener('change', (event) => chooseLocale(event.target.value));
+        syncLanguageSelectors();
+        document.addEventListener('change', (event) => {
+            if (!(event.target instanceof Element)) return;
+            const selector = event.target.closest('[data-language-selector]');
+            if (selector) chooseLocale(selector.value);
         });
 
         const observer = new MutationObserver((mutations) => {
             mutations.forEach((mutation) => {
-                if (mutation.type === 'characterData') translateTextNode(mutation.target);
-                mutation.addedNodes.forEach(translateTree);
+                mutation.addedNodes.forEach((node) => {
+                    translateTree(node);
+                    syncLanguageSelectors(node);
+                });
             });
         });
-        observer.observe(document.body, {childList: true, subtree: true, characterData: true});
+        // Alpine owns existing text nodes. Observing characterData here causes a
+        // feedback loop when Alpine restores source text after it is translated.
+        // Added nodes still cover asynchronously rendered menus and status copy.
+        observer.observe(document.body, {childList: true, subtree: true});
     });
 })();

--- a/backend/tests/browser/localization.spec.js
+++ b/backend/tests/browser/localization.spec.js
@@ -73,14 +73,33 @@ test('German dashboard remains responsive while Alpine renders translated data',
       empty_domains_hidden: 0,
     }),
   }));
+  await page.route('**/api/v1/stats/dashboard?*', route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({
+      total_domains: 1,
+      total_emails: 10,
+      compliant_emails: 9,
+      compliance_rate: 90,
+      reports_processed: 1,
+      top_sources: [],
+      compliance_trend: [],
+      change_summary: [],
+    }),
+  }));
+  const domainResponse = page.waitForResponse(
+    response => response.url().includes('/api/v1/domains/summary?') && response.ok(),
+  );
   const statsResponse = page.waitForResponse(
     response => response.url().includes('/api/v1/stats/dashboard?') && response.ok(),
   );
 
   await page.goto('/?lang=de');
+  await domainResponse;
   await statsResponse;
 
   await expect(page.locator('html')).toHaveAttribute('lang', 'de');
   await expect(page.getByRole('link', { name: 'Übersicht' }).first()).toBeVisible();
-  await expect(page.getByText('DMARC-Konformitätsrate').first()).toBeAttached();
+  await page.locator('[data-dashboard-analytics]').evaluate(element => { element.open = true; });
+  await expect(page.locator('#total-emails')).toHaveText('10');
+  await expect(page.getByText('DMARC-Konformitätsrate').first()).toBeVisible();
 });

--- a/backend/tests/browser/localization.spec.js
+++ b/backend/tests/browser/localization.spec.js
@@ -33,3 +33,54 @@ test('language selector persists an explicit English choice', async ({ page }) =
   await expect(page.getByRole('link', { name: 'Dashboard' }).first()).toBeVisible();
   await expect(page.locator('#settings-language-selector')).toHaveValue('en');
 });
+
+test('language selector in the asynchronously rendered account menu persists the choice', async ({ page }) => {
+  await page.goto('/?lang=en');
+
+  const accountMenu = page.getByLabel('Open account menu');
+  await expect(accountMenu).toBeVisible();
+  await accountMenu.click();
+
+  const languageSelector = page.locator('#account-language-selector');
+  await expect(languageSelector).toBeVisible();
+  await expect(languageSelector).toHaveValue('en');
+  await languageSelector.selectOption('de');
+  await page.waitForLoadState('domcontentloaded');
+
+  await expect(page.locator('html')).toHaveAttribute('lang', 'de');
+  await expect(page.getByRole('link', { name: 'Übersicht' }).first()).toBeVisible();
+
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('lang', 'de');
+  await accountMenu.click();
+  await expect(page.locator('#account-language-selector')).toHaveValue('de');
+});
+
+test('German dashboard remains responsive while Alpine renders translated data', async ({ page }) => {
+  await page.route('**/api/v1/domains/summary?*', route => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({
+      domains: [{
+        domain_name: 'example.com',
+        total_reports: 1,
+        total_emails: 10,
+        passed_emails: 9,
+        failed_emails: 1,
+        compliance_rate: 90,
+      }],
+      total_reports: 1,
+      total_emails: 10,
+      empty_domains_hidden: 0,
+    }),
+  }));
+  const statsResponse = page.waitForResponse(
+    response => response.url().includes('/api/v1/stats/dashboard?') && response.ok(),
+  );
+
+  await page.goto('/?lang=de');
+  await statsResponse;
+
+  await expect(page.locator('html')).toHaveAttribute('lang', 'de');
+  await expect(page.getByRole('link', { name: 'Übersicht' }).first()).toBeVisible();
+  await expect(page.getByText('DMARC-Konformitätsrate').first()).toBeAttached();
+});


### PR DESCRIPTION
## Description
Fixes two regressions in the first English/German localization release: the German dashboard could enter a browser-side translation/rendering feedback loop, and the profile-menu language selector was rendered too late to receive its change handler.

## Related Issue
Follow-up regression for #827.

## Type of Change
- [x] Bug fix (non-breaking change)
- [x] Performance improvement

## Changes Made
- Observe newly added localized DOM content without rewriting Alpine-owned text nodes repeatedly.
- Delegate language-selector changes so asynchronously rendered profile controls work.
- Add browser regressions for profile-menu persistence and German dashboard rendering.
- Document the fixes in the changelog.

## Testing Performed

### Test Environment
- Python Version: 3.13 (project container)
- Database: deterministic SQLite browser-smoke fixture
- OS: Linux container on macOS/Colima

### Test Steps
1. Built the complete backend image locally.
2. Ran localization and dashboard template tests in the image.
3. Ran all localization browser tests against a fresh smoke instance.
4. Replaced only localization.js on the live demo in-browser and tested German dashboard and profile-menu switching.

### Test Results
```text
96 passed, 27 skipped
4 Playwright localization tests passed
Live German dashboard stats loaded in 1.3s; no console errors
Profile-menu selection persisted German after reload
```

## Security Considerations
- [x] N/A - No security implications
- [x] No sensitive data is exposed

## Performance Impact
- [x] Performance improved

The German dashboard no longer reaches the 30-second browser timeout caused by competing DOM mutations.

## Documentation
- [x] Updated changelog
- [x] Added inline comment for the MutationObserver boundary

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Tests prove both regressions are fixed
- [x] Existing targeted tests pass locally
- [x] No migrations or configuration changes required

## AI Assistance
- [x] AI tools were used
- [x] Generated changes were reviewed and tested

## Deployment Notes
No database migration or configuration change. Normal image rollout is sufficient.