### PR TITLE
test: cover API token scope parsing

### DIFF
--- a/backend/app/services/api_tokens.py
+++ b/backend/app/services/api_tokens.py
@@ -75,7 +75,7 @@ def scopes_to_string(
     return ",".join(normalize_scopes(scopes, allowed_scopes=allowed_scopes))
 
 
-def parse_scopes(value: str) -> Set[str]:
+def parse_scopes(value: Optional[str]) -> Set[str]:
     """Parse stored scope text into a set."""
     return {scope.strip().lower() for scope in (value or "").split(",") if scope.strip()}
 

--- a/backend/app/tests/test_api_tokens.py
+++ b/backend/app/tests/test_api_tokens.py
@@ -1,0 +1,24 @@
+"""Focused tests for scoped API token helpers (#810)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.api_tokens import parse_scopes
+
+
+@pytest.mark.parametrize(
+    ("stored_scopes", "expected"),
+    [
+        ("reports:read,posture:read", {"reports:read", "posture:read"}),
+        (
+            " Reports:Read, reports:read, , POSTURE:READ, ",
+            {"reports:read", "posture:read"},
+        ),
+        ("", set()),
+        (None, set()),
+    ],
+)
+def test_parse_scopes_normalizes_stored_values(stored_scopes, expected) -> None:
+    """Stored scope text remains safe to use after legacy or manual edits."""
+    assert parse_scopes(stored_scopes) == expected


### PR DESCRIPTION
## Summary
- add focused coverage for persisted API-token scope parsing
- align the parser type contract with its supported `None` input

## Change type
- [x] Tests and static type contract only
- [ ] Product behavior change

## Validation
- `.venv/bin/python -m pytest backend/app/tests/test_api_tokens.py -q` (4 passed)

## Checklist
- [x] Covers comma splitting, whitespace/case normalization, duplicate and empty values
- [x] Covers empty and `None` persisted scope text
- [x] No secrets or runtime configuration changed

Closes #810