### PR TITLE
Fix sender time windows and delivery classification

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3362,6 +3362,8 @@ def _single_domain_report_store_for_read(
     db: Session,
     domain_id: str,
     workspace: Workspace,
+    *,
+    report_window_days: Optional[int] = None,
 ) -> tuple[str, ReportStore]:
     """Return a ReportStore containing only the requested domain's persisted reports."""
     store = ReportStore()
@@ -3375,6 +3377,7 @@ def _single_domain_report_store_for_read(
             store,
             domain_name,
             workspace_id=workspace.id,
+            days=report_window_days,
         )
         return domain_name, store
 
@@ -4080,8 +4083,11 @@ async def _build_domain_health_grade(
     summary = store.get_domain_summary(domain_id)
     live_policy = extract_dmarc_policy(dns.dmarc_record)
     reported_policy = _normalize_reported_policy(summary.get("policy", {}))
-    sources = store.get_domain_sources(domain_id)
-    reports = store.get_domain_reports(domain_id)
+    # Health and remediation should describe the current operating posture, not
+    # every sender ever observed. Keeping this bounded also prevents a large
+    # historic sender estate from blocking the domain detail request.
+    sources = store.get_domain_sources(domain_id, days=30)
+    reports = store.get_domain_reports(domain_id, days=30)
     intelligence = build_source_intelligence(
         domain_id,
         reports,
@@ -6379,7 +6385,12 @@ async def _build_domain_remediation_queue_for_workspace(
     Expensive DNS/reputation enrichment is bounded so the Next remediation
     panel never waits unbounded for live lookups.
     """
-    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
+    domain_name, store = _single_domain_report_store_for_read(
+        db,
+        domain_id,
+        workspace,
+        report_window_days=30,
+    )
     settings = get_settings()
     timeout_seconds = max(
         1.0,
@@ -6387,68 +6398,78 @@ async def _build_domain_remediation_queue_for_workspace(
     )
     available_providers = _configured_dns_write_provider_ids(db)
 
-    async def _enrich() -> tuple[Dict[str, Any], Dict[str, Any]]:
-        return await asyncio.gather(
+    summary = store.get_domain_summary(domain_name) or {}
+    domain_health: Dict[str, Any] = {
+        "domain": domain_name,
+        "grade": "unknown",
+        "score": 0,
+        "actions": [],
+        "summary": summary,
+        "enrichment_pending": True,
+    }
+    guidance: Dict[str, Any] = {
+        "findings": [],
+        "change_plans": [],
+        "target_records": [],
+        "dns_provider": None,
+        "enrichment_pending": True,
+    }
+    enrichment_tasks = {
+        "health": asyncio.create_task(
             _build_domain_health_grade(
                 db,
                 domain_name,
                 store,
                 refresh=refresh,
-            ),
+            )
+        ),
+        "guidance": asyncio.create_task(
             _build_domain_dns_guidance(
                 db,
                 store,
                 domain_name,
                 refresh=refresh,
-            ),
-        )
+            )
+        ),
+    }
+    completed, pending = await asyncio.wait(
+        set(enrichment_tasks.values()),
+        timeout=timeout_seconds,
+    )
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
 
-    try:
-        domain_health, guidance = await asyncio.wait_for(
-            _enrich(),
-            timeout=timeout_seconds,
-        )
-    except asyncio.TimeoutError:
+    enrichment_failures = []
+    for name, task in enrichment_tasks.items():
+        if task not in completed:
+            enrichment_failures.append(f"{name} timed out")
+            continue
+        try:
+            result = task.result()
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.info(
+                "Remediation %s enrichment failed for %s: %s",
+                name,
+                sanitize_for_log(domain_name),
+                type(exc).__name__,
+            )
+            enrichment_failures.append(f"{name} failed")
+            continue
+        if name == "health":
+            domain_health = result
+        else:
+            guidance = result
+
+    if enrichment_failures:
         logger.info(
-            "Remediation queue enrichment timed out for %s; returning bounded empty queue",
+            "Remediation queue returned partial evidence for %s: %s",
             sanitize_for_log(domain_name),
+            ", ".join(enrichment_failures),
         )
-        summary = store.get_domain_summary(domain_name) or {}
-        domain_health = {
-            "domain": domain_name,
-            "grade": "unknown",
-            "score": 0,
-            "actions": [],
-            "summary": summary,
-            "enrichment_pending": True,
-        }
-        guidance = {
-            "findings": [],
-            "change_plans": [],
-            "target_records": [],
-            "dns_provider": None,
-            "enrichment_pending": True,
-        }
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.info(
-            "Remediation queue enrichment failed for %s: %s",
-            sanitize_for_log(domain_name),
-            type(exc).__name__,
-        )
-        domain_health = {
-            "domain": domain_name,
-            "grade": "unknown",
-            "score": 0,
-            "actions": [],
-            "enrichment_pending": True,
-        }
-        guidance = {
-            "findings": [],
-            "change_plans": [],
-            "target_records": [],
-            "dns_provider": None,
-            "enrichment_pending": True,
-        }
+        domain_health = {**domain_health, "enrichment_pending": True}
+        guidance = {**guidance, "enrichment_pending": True}
 
     recommended_provider = _recommended_dns_write_provider(
         guidance.get("dns_provider"),

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1992,6 +1992,9 @@ class SourceEntry(BaseModel):
     dmarc_pass_count: int = 0
     dmarc_fail_count: int = 0
     disposition_counts: Dict[str, int] = Field(default_factory=dict)
+    delivery_status: str = "unknown"
+    delivery_label: str = "Delivery status unknown"
+    delivery_detail: str = "No DMARC delivery outcome is available for this source."
     hostname: Optional[str] = None
     ptr_status: Optional[str] = None
     ptr_detail: Optional[str] = None
@@ -7799,6 +7802,45 @@ def _source_recommendations(
     return recommendations
 
 
+def _source_delivery_status(source: Dict[str, Any]) -> Dict[str, str]:
+    """Describe the observed DMARC outcome without claiming sender ownership."""
+    passed = int(source.get("dmarc_pass_count") or 0)
+    failed = int(source.get("dmarc_fail_count") or 0)
+    dispositions = source.get("disposition_counts") or {}
+    blocked = int(dispositions.get("reject") or 0) + int(dispositions.get("quarantine") or 0)
+    delivered_failures = int(dispositions.get("none") or 0)
+
+    if passed and not failed:
+        return {
+            "status": "aligned",
+            "label": "Aligned delivery",
+            "detail": "All observed messages passed DMARC in the selected window.",
+        }
+    if failed and blocked >= failed and not delivered_failures:
+        return {
+            "status": "policy_blocked",
+            "label": "Blocked by policy",
+            "detail": "Observed DMARC failures were quarantined or rejected by policy.",
+        }
+    if failed and delivered_failures and not passed:
+        return {
+            "status": "unauthenticated_delivered",
+            "label": "Unauthenticated delivery",
+            "detail": "Observed DMARC failures were delivered with disposition none.",
+        }
+    if passed or failed:
+        return {
+            "status": "mixed",
+            "label": "Mixed delivery",
+            "detail": "The selected window contains both aligned and failing DMARC outcomes.",
+        }
+    return {
+        "status": "unknown",
+        "label": "Delivery status unknown",
+        "detail": "No DMARC delivery outcome is available for this source.",
+    }
+
+
 def _anomaly_recommendations(anomalies: List[Dict[str, Any]]) -> List[SourceRecommendation]:
     """Expose source intelligence anomalies as source-level next steps."""
     recommendations = []
@@ -8165,7 +8207,7 @@ async def _source_reputations_by_ip(
 @router.get("/{domain_id}/sources", response_model=DomainSourcesResponse)
 async def get_domain_sources(
     domain_id: str = Path(..., title="The domain ID or name"),
-    days: int = Query(30, title="Number of days to look back"),
+    days: Optional[int] = Query(None, ge=1, le=3650, title="Number of days to look back"),
     refresh: bool = Query(False, title="Refresh cached source reputation evidence"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
@@ -8177,8 +8219,9 @@ async def get_domain_sources(
     workspace = _authorized_domain_read_workspace(_auth, db)
     domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
+    source_days = days if days is not None else 30
     sources = store.get_domain_sources(domain_name, days=days)
-    reports = store.get_domain_reports(domain_name)
+    reports = store.get_domain_reports(domain_name, days=days)
     provider = get_default_provider(db)
     settings = get_settings()
 
@@ -8214,7 +8257,7 @@ async def get_domain_sources(
         domain_name,
         reports,
         sources,
-        period_days=days,
+        period_days=source_days,
         geo_by_ip=geo_by_ip,
     )
     anomalies_by_ip = intelligence.get("anomalies_by_ip", {})
@@ -8234,7 +8277,7 @@ async def get_domain_sources(
         sources,
         sender_by_ip,
         anomalies_by_ip,
-        days,
+        source_days,
         refresh,
         settings,
     )
@@ -8248,6 +8291,7 @@ async def get_domain_sources(
             spf_fix_hint = None
         source_anomalies = anomalies_by_ip.get(ip, [])
         reputation = reputations_by_ip.get(ip)
+        delivery = _source_delivery_status(source)
         recommendations = _source_recommendations(ip, source, hostname, spf_fix_hint, sender)
         recommendations.extend(_anomaly_recommendations(source_anomalies))
         recommendations.extend(_reputation_recommendations(reputation))
@@ -8272,6 +8316,9 @@ async def get_domain_sources(
                 dmarc_pass_count=source.get("dmarc_pass_count", 0),
                 dmarc_fail_count=source.get("dmarc_fail_count", 0),
                 disposition_counts=source.get("disposition_counts", {}),
+                delivery_status=delivery["status"],
+                delivery_label=delivery["label"],
+                delivery_detail=delivery["detail"],
                 hostname=hostname,
                 ptr_status=(ptr_by_ip.get(ip).status if ptr_by_ip.get(ip) else None),
                 ptr_detail=(ptr_by_ip.get(ip).detail if ptr_by_ip.get(ip) else None),
@@ -8304,7 +8351,7 @@ async def get_domain_sources(
 @router.get("/{domain_id}/source-reputation", response_model=DomainSourceReputationResponse)
 async def get_domain_source_reputation(
     domain_id: str = Path(..., title="The domain ID or name"),
-    days: int = Query(30, ge=1, le=365, title="Number of days to analyze"),
+    days: int = Query(30, ge=1, le=3650, title="Number of days to analyze"),
     refresh: bool = Query(False, title="Refresh cached reputation evidence"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
@@ -8313,7 +8360,7 @@ async def get_domain_source_reputation(
     workspace = _authorized_domain_read_workspace(_auth, db)
     domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
-    reports = store.get_domain_reports(domain_name)
+    reports = store.get_domain_reports(domain_name, days=days)
     sources = store.get_domain_sources(domain_name, days=days)
     intelligence = build_source_intelligence(
         domain_name,
@@ -8354,7 +8401,7 @@ async def get_domain_source_reputation(
 @router.get("/{domain_id}/source-intelligence", response_model=SourceIntelligenceResponse)
 async def get_domain_source_intelligence(
     domain_id: str = Path(..., title="The domain ID or name"),
-    days: int = Query(30, ge=1, le=365, title="Number of days to analyze"),
+    days: int = Query(30, ge=1, le=3650, title="Number of days to analyze"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -8382,7 +8429,7 @@ async def get_domain_source_intelligence(
     }
     intelligence = build_source_intelligence(
         domain_name,
-        store.get_domain_reports(domain_name),
+        store.get_domain_reports(domain_name, days=days),
         sources,
         period_days=days,
         geo_by_ip=geo_by_ip,

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -90,6 +90,13 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
         "value_type": "integer",
         "category": "general",
     },
+    {
+        "key": "general.source_date_window_days",
+        "value": "30",
+        "description": "Default observation window for sending sources: 7, 30, or 90 days",
+        "value_type": "integer",
+        "category": "general",
+    },
     # ── DMARC ────────────────────────────────────────────────────────────────
     {
         "key": "dmarc.default_policy",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,7 @@ from app.middleware.security import SecurityHeadersMiddleware
 from app.models.domain import Domain
 from app.models.mail_source import MailSource  # noqa: F401 – ensure table is registered
 from app.models.mail_source_import import MailSourceImport
+from app.models.setting import Setting
 from app.services.demo_data import build_demo_mail_sources
 from app.services.dns_prewarm import prewarm_dns_cache
 from app.services.gmail_client import GmailClient
@@ -814,6 +815,10 @@ async def domain_details(request: Request, domain_id: str):
     try:
         hydrate_report_store_from_db(db, store)
         stored_domain = db.query(Domain).filter(Domain.name == domain_id).first()
+        source_window_setting = db.get(Setting, "general.source_date_window_days")
+        source_window_days = str(source_window_setting.value or "30") if source_window_setting else "30"
+        if source_window_days not in {"7", "30", "90"}:
+            source_window_days = "30"
     finally:
         db.close()
     known_domains = store.get_domains()
@@ -831,6 +836,7 @@ async def domain_details(request: Request, domain_id: str):
         "domain_details.html",
         {
             "domain_id": domain_id,
+            "source_window_days": source_window_days,
             "domain": {
                 "name": domain_id,
                 "description": stored_domain.description if stored_domain else "",

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import case, distinct, func, or_
@@ -351,8 +351,14 @@ def hydrate_domain_report_store_from_db(
     domain_name: str,
     *,
     workspace_id: Optional[int] = None,
+    days: Optional[int] = None,
 ) -> int:
-    """Load persisted reports for one domain into a fresh ReportStore."""
+    """Load persisted reports for one domain into a fresh ReportStore.
+
+    ``days`` is used by interactive views that only need current evidence. It
+    prevents a large historic report archive from being hydrated just to show a
+    single domain decision.
+    """
     store = store or ReportStore()
     store.clear()
     query = (
@@ -366,6 +372,9 @@ def hydrate_domain_report_store_from_db(
     )
     if workspace_id is not None:
         query = query.filter(Domain.workspace_id == workspace_id)
+    if days is not None:
+        cutoff = datetime.utcnow() - timedelta(days=max(1, int(days)))
+        query = query.filter(DMARCReport.end_date >= cutoff)
     reports = query.order_by(DMARCReport.end_date.desc()).all()
     for report in reports:
         store.add_report(persisted_report_to_dict(report))

--- a/backend/app/services/report_store.py
+++ b/backend/app/services/report_store.py
@@ -318,6 +318,18 @@ def _source_public_entry(ip: str, data: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _aggregate_sources(reports: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Build source aggregates for a specific report collection."""
+    sources: Dict[str, Dict[str, Any]] = {}
+    for report in reports:
+        for record in report.get("records", []):
+            source_ip = record.get("source_ip", "unknown")
+            if source_ip not in sources:
+                sources[source_ip] = _new_source_stats()
+            _update_source_from_record(sources[source_ip], record, report)
+    return sources
+
+
 def _update_source_from_record(
     source: Dict[str, Any],
     record: Dict[str, Any],
@@ -431,8 +443,6 @@ class ReportStore:
             "failed_count": 0,
             "reports_processed": len(reports),
         }
-        sources: Dict[str, Dict[str, Any]] = {}
-
         for report in reports:
             report_summary = report.get("summary", {})
             summary["total_count"] += report_summary.get("total_count", 0)
@@ -442,11 +452,7 @@ class ReportStore:
             if "policy" in report:
                 summary["policy"] = report["policy"]
 
-            for record in report.get("records", []):
-                source_ip = record.get("source_ip", "unknown")
-                if source_ip not in sources:
-                    sources[source_ip] = _new_source_stats()
-                _update_source_from_record(sources[source_ip], record, report)
+        sources = _aggregate_sources(reports)
 
         total = summary["total_count"]
         summary["compliance_rate"] = (
@@ -525,18 +531,35 @@ class ReportStore:
                     return report
         return None
 
-    def get_domain_reports(self, domain: str, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    def get_domain_reports(
+        self,
+        domain: str,
+        limit: Optional[int] = None,
+        *,
+        days: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
         """
         Get all reports for a domain
 
         Args:
             domain: Domain name
             limit: Optional limit on number of reports to return
+            days: Optional observation window. Reports without an observed date
+                are excluded when a window is requested.
 
         Returns:
             List of reports or empty list if domain not found
         """
         reports = self.domain_reports.get(domain, [])
+
+        if days is not None:
+            cutoff = _now_timestamp() - max(1, int(days)) * SECONDS_PER_DAY
+            reports = [
+                report
+                for report in reports
+                if (observed_end := _observed_report_window(report)[1]) is not None
+                and observed_end >= cutoff
+            ]
 
         # Sort reports by date (most recent first)
         sorted_reports = sorted(reports, key=lambda r: r.get("end_date", 0), reverse=True)
@@ -629,13 +652,14 @@ class ReportStore:
         )
         return rows
 
-    def get_domain_sources(self, domain: str, days: int = 30) -> List[Dict[str, Any]]:
+    def get_domain_sources(self, domain: str, days: Optional[int] = None) -> List[Dict[str, Any]]:
         """
         Get sending sources for a domain
 
         Args:
             domain: Domain name
-            days: Number of days to look back
+            days: Number of days to look back. ``None`` returns the historical
+                aggregate for API callers that did not select a time window.
 
         Returns:
             List of source entries or empty list if domain not found
@@ -643,11 +667,25 @@ class ReportStore:
         if domain not in self.domain_sources:
             return []
 
-        # For Milestone 1, we don't filter by date
-        # In a future milestone, we'll add date-based filtering
-        sources = []
-        for ip, data in self.domain_sources[domain].items():
-            sources.append(_source_public_entry(ip, data))
+        if days is None:
+            sources = [
+                _source_public_entry(ip, data)
+                for ip, data in self.domain_sources[domain].items()
+            ]
+            return sorted(sources, key=lambda source: source["count"], reverse=True)
+
+        cutoff = _now_timestamp() - max(1, int(days)) * SECONDS_PER_DAY
+        reports = [
+            report
+            for report in self.domain_reports.get(domain, [])
+            if (observed_end := _observed_report_window(report)[1]) is not None
+            and observed_end >= cutoff
+        ]
+        aggregated_sources = _aggregate_sources(reports)
+        sources = [
+            _source_public_entry(ip, data)
+            for ip, data in aggregated_sources.items()
+        ]
 
         # Sort sources by count (highest first)
         return sorted(sources, key=lambda s: s["count"], reverse=True)

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -263,6 +263,7 @@ function domainDetailsApp(domainId = '') {
             dateRange: '30',
             sourceFilter: '',
             sourceRiskFilter: 'all',
+            sourceDeliveryFilter: 'all',
             exportStartDate: '',
             exportEndDate: ''
         },
@@ -598,9 +599,22 @@ function domainDetailsApp(domainId = '') {
                     if (!source?.reputation) counts.unchecked += 1;
                     if (source?.dmarc === 'fail' || source?.dmarc === 'mixed') counts.authReview += 1;
                     if (this.sourceActivityBucket(source) === 'recent') counts.recent += 1;
+                    if (source?.delivery_status === 'aligned') counts.aligned += 1;
+                    if (source?.delivery_status === 'policy_blocked') counts.blocked += 1;
+                    if (source?.delivery_status === 'unauthenticated_delivered') counts.unauthenticated += 1;
                     return counts;
                 },
-                { total: 0, risky: 0, listed: 0, unchecked: 0, authReview: 0, recent: 0 }
+                {
+                    total: 0,
+                    risky: 0,
+                    listed: 0,
+                    unchecked: 0,
+                    authReview: 0,
+                    recent: 0,
+                    aligned: 0,
+                    blocked: 0,
+                    unauthenticated: 0
+                }
             );
         },
 
@@ -609,6 +623,7 @@ function domainDetailsApp(domainId = '') {
 
             return this.sources.filter(source => {
                 if (!this.sourceRiskMatches(source, this.filters.sourceRiskFilter)) return false;
+                if (!this.sourceDeliveryMatches(source, this.filters.sourceDeliveryFilter)) return false;
                 if (!this.filters.sourceFilter) return true;
                 const needle = this.filters.sourceFilter.toLowerCase();
                 return [
@@ -631,6 +646,8 @@ function domainDetailsApp(domainId = '') {
                     source.last_seen ? this.sourceSeenLabel(source.last_seen) : '',
                     source.reputation?.status,
                     source.reputation?.summary,
+                    source.delivery_label,
+                    source.delivery_detail,
                     ...(source.reputation?.listings || []),
                 ].some(value => String(value || '').toLowerCase().includes(needle));
             });
@@ -646,6 +663,18 @@ function domainDetailsApp(domainId = '') {
             if (filter === 'stale') return this.sourceActivityBucket(source) === 'stale';
             if (filter === 'clean') return source.reputation?.status === 'clean';
             return true;
+        },
+
+        sourceDeliveryMatches(source, filter) {
+            return filter === 'all' || source?.delivery_status === filter;
+        },
+
+        sourceDeliveryClass(source) {
+            if (source?.delivery_status === 'aligned') return 'bg-green-100 text-green-800';
+            if (source?.delivery_status === 'policy_blocked') return 'bg-blue-100 text-blue-800';
+            if (source?.delivery_status === 'unauthenticated_delivered') return 'bg-red-100 text-red-800';
+            if (source?.delivery_status === 'mixed') return 'bg-amber-100 text-amber-800';
+            return 'bg-base-200 text-base-content/70';
         },
 
         sourceReputationNeedsReview(source) {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -340,6 +340,9 @@ function domainDetailsApp(domainId = '') {
                     event.preventDefault();
                     this.remediationQueueFilter = button.dataset.domainDetailRemediationFilter || 'all';
                     this.showAllRemediationQueueItems = false;
+                } else if (button.matches('[data-domain-detail-source-filter]')) {
+                    event.preventDefault();
+                    this.setSourceSummaryFilter(button.dataset.domainDetailSourceFilter || 'all');
                 } else if (
                     button.matches('[data-domain-detail-remediation-retry]') ||
                     button.matches('[data-domain-detail-remediation-refresh]')
@@ -667,6 +670,34 @@ function domainDetailsApp(domainId = '') {
             if (filter === 'stale') return this.sourceActivityBucket(source) === 'stale';
             if (filter === 'clean') return source.reputation?.status === 'clean';
             return true;
+        },
+
+        setSourceSummaryFilter(filter) {
+            if (filter === 'all') {
+                this.filters.sourceRiskFilter = 'all';
+                this.filters.sourceDeliveryFilter = 'all';
+                return;
+            }
+            if (filter.startsWith('delivery:')) {
+                const delivery = filter.slice('delivery:'.length);
+                this.filters.sourceDeliveryFilter = (
+                    this.filters.sourceDeliveryFilter === delivery ? 'all' : delivery
+                );
+                return;
+            }
+            this.filters.sourceRiskFilter = (
+                this.filters.sourceRiskFilter === filter ? 'all' : filter
+            );
+        },
+
+        sourceSummaryFilterActive(filter) {
+            if (filter === 'all') {
+                return this.filters.sourceRiskFilter === 'all' && this.filters.sourceDeliveryFilter === 'all';
+            }
+            if (filter.startsWith('delivery:')) {
+                return this.filters.sourceDeliveryFilter === filter.slice('delivery:'.length);
+            }
+            return this.filters.sourceRiskFilter === filter;
         },
 
         sourceDeliveryMatches(source, filter) {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -274,6 +274,10 @@ function domainDetailsApp(domainId = '') {
 
         init() {
             this.domainId = this.$el?.dataset?.domainId || this.domainId;
+            const configuredSourceWindow = this.$el?.dataset?.sourceWindowDays;
+            if (['7', '30', '90'].includes(configuredSourceWindow)) {
+                this.filters.dateRange = configuredSourceWindow;
+            }
             this.bindPageControls();
             const storedVolumeScale = this.loadStoredVolumeScale();
             if (storedVolumeScale === 'linear' || storedVolumeScale === 'logarithmic') {

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2450,33 +2450,51 @@
                    class="mb-4 rounded-md border border-[#ffcfbd] bg-[#fff2ec] px-3 py-2 text-sm text-[#8a2d0d]"
                    x-text="sourceReputationRefreshError"></p>
                 <div class="mb-4 flex flex-wrap gap-2 text-xs" x-show="!sourcesLoading && !sourcesError">
-                    <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-semibold text-base-content/80">
+                    <button type="button" data-domain-detail-source-filter="all"
+                        class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-semibold text-base-content/80 hover:ring-2 hover:ring-[#2f9da5]/40 focus:outline-none focus:ring-2 focus:ring-[#2f9da5]"
+                        :aria-pressed="sourceSummaryFilterActive('all')">
                         <span x-text="sourceRiskCounts.total"></span><span class="ml-1">sources</span>
-                    </span>
-                    <span class="inline-flex items-center rounded-full bg-[#fff2ec] px-2 py-0.5 font-semibold text-[#8a2d0d]">
+                    </button>
+                    <button type="button" data-domain-detail-source-filter="risky"
+                        class="inline-flex items-center rounded-full bg-[#fff2ec] px-2 py-0.5 font-semibold text-[#8a2d0d] hover:ring-2 hover:ring-[#8a2d0d]/30 focus:outline-none focus:ring-2 focus:ring-[#8a2d0d]"
+                        :aria-pressed="sourceSummaryFilterActive('risky')">
                         <span x-text="sourceRiskCounts.risky"></span><span class="ml-1">reputation review</span>
-                    </span>
-                    <span class="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 font-semibold text-red-800">
+                    </button>
+                    <button type="button" data-domain-detail-source-filter="listed"
+                        class="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 font-semibold text-red-800 hover:ring-2 hover:ring-red-500/30 focus:outline-none focus:ring-2 focus:ring-red-600"
+                        :aria-pressed="sourceSummaryFilterActive('listed')">
                         <span x-text="sourceRiskCounts.listed"></span><span class="ml-1">listed</span>
-                    </span>
-                    <span class="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 font-semibold text-amber-800">
+                    </button>
+                    <button type="button" data-domain-detail-source-filter="auth_review"
+                        class="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 font-semibold text-amber-800 hover:ring-2 hover:ring-amber-500/30 focus:outline-none focus:ring-2 focus:ring-amber-600"
+                        :aria-pressed="sourceSummaryFilterActive('auth_review')">
                         <span x-text="sourceRiskCounts.authReview"></span><span class="ml-1">auth review</span>
-                    </span>
-                    <span class="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 font-semibold text-green-800">
+                    </button>
+                    <button type="button" data-domain-detail-source-filter="recent"
+                        class="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 font-semibold text-green-800 hover:ring-2 hover:ring-green-500/30 focus:outline-none focus:ring-2 focus:ring-green-600"
+                        :aria-pressed="sourceSummaryFilterActive('recent')">
                         <span x-text="sourceRiskCounts.recent"></span><span class="ml-1">recent</span>
-                    </span>
-                    <span class="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 font-semibold text-green-800">
+                    </button>
+                    <button type="button" data-domain-detail-source-filter="delivery:aligned"
+                        class="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 font-semibold text-green-800 hover:ring-2 hover:ring-green-500/30 focus:outline-none focus:ring-2 focus:ring-green-600"
+                        :aria-pressed="sourceSummaryFilterActive('delivery:aligned')">
                         <span x-text="sourceRiskCounts.aligned"></span><span class="ml-1">aligned delivery</span>
-                    </span>
-                    <span class="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 font-semibold text-blue-800">
+                    </button>
+                    <button type="button" data-domain-detail-source-filter="delivery:policy_blocked"
+                        class="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 font-semibold text-blue-800 hover:ring-2 hover:ring-blue-500/30 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                        :aria-pressed="sourceSummaryFilterActive('delivery:policy_blocked')">
                         <span x-text="sourceRiskCounts.blocked"></span><span class="ml-1">blocked by policy</span>
-                    </span>
-                    <span class="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 font-semibold text-red-800">
+                    </button>
+                    <button type="button" data-domain-detail-source-filter="delivery:unauthenticated_delivered"
+                        class="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 font-semibold text-red-800 hover:ring-2 hover:ring-red-500/30 focus:outline-none focus:ring-2 focus:ring-red-600"
+                        :aria-pressed="sourceSummaryFilterActive('delivery:unauthenticated_delivered')">
                         <span x-text="sourceRiskCounts.unauthenticated"></span><span class="ml-1">unauthenticated delivery</span>
-                    </span>
-                    <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-semibold text-base-content/70">
+                    </button>
+                    <button type="button" data-domain-detail-source-filter="unchecked"
+                        class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-semibold text-base-content/70 hover:ring-2 hover:ring-[#2f9da5]/40 focus:outline-none focus:ring-2 focus:ring-[#2f9da5]"
+                        :aria-pressed="sourceSummaryFilterActive('unchecked')">
                         <span x-text="sourceRiskCounts.unchecked"></span><span class="ml-1">unchecked reputation</span>
-                    </span>
+                    </button>
                 </div>
                 <div class="sending-sources-list space-y-3" data-sending-sources-list>
                         <template x-if="sources.length === 0">

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -6,7 +6,7 @@
 {% block title %}DMARQ - {{ domain.name }} Details{% endblock %}
 
 {% block content %}
-<div class="space-y-6" x-data="domainDetailsApp" data-domain-detail-page data-domain-id="{{ domain_id }}">
+<div class="space-y-6" x-data="domainDetailsApp" data-domain-detail-page data-domain-id="{{ domain_id }}" data-source-window-days="{{ source_window_days }}">
     <nav class="text-sm text-[#5f5c78]">
         <ol class="flex items-center space-x-2">
             <li><a href="/" class="font-semibold hover:text-[#2f9da5]">Dashboard</a></li>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2427,6 +2427,13 @@
                             <option value="stale">Stale senders</option>
                             <option value="clean">Clean reputation</option>
                         </select>
+                        <select x-model="filters.sourceDeliveryFilter" class="select select-sm select-bordered">
+                            <option value="all">All delivery outcomes</option>
+                            <option value="aligned">Aligned delivery</option>
+                            <option value="policy_blocked">Blocked by policy</option>
+                            <option value="unauthenticated_delivered">Unauthenticated delivery</option>
+                            <option value="mixed">Mixed delivery</option>
+                        </select>
                         <button type="button"
                                 class="btn btn-sm btn-default"
                                 data-domain-detail-refresh-reputation
@@ -2457,6 +2464,15 @@
                     </span>
                     <span class="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 font-semibold text-green-800">
                         <span x-text="sourceRiskCounts.recent"></span><span class="ml-1">recent</span>
+                    </span>
+                    <span class="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 font-semibold text-green-800">
+                        <span x-text="sourceRiskCounts.aligned"></span><span class="ml-1">aligned delivery</span>
+                    </span>
+                    <span class="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 font-semibold text-blue-800">
+                        <span x-text="sourceRiskCounts.blocked"></span><span class="ml-1">blocked by policy</span>
+                    </span>
+                    <span class="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 font-semibold text-red-800">
+                        <span x-text="sourceRiskCounts.unauthenticated"></span><span class="ml-1">unauthenticated delivery</span>
                     </span>
                     <span class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-semibold text-base-content/70">
                         <span x-text="sourceRiskCounts.unchecked"></span><span class="ml-1">unchecked reputation</span>
@@ -2505,6 +2521,10 @@
                                         <span class="mt-1 inline-flex w-fit rounded-full px-2 py-0.5 text-xs font-semibold"
                                               :class="sourceActivityClass(source)"
                                               x-text="sourceActivityLabel(source)"></span>
+                                        <span class="inline-flex w-fit rounded-full px-2 py-0.5 text-xs font-semibold"
+                                              :class="sourceDeliveryClass(source)"
+                                              :title="source.delivery_detail"
+                                              x-text="source.delivery_label"></span>
                                     </div>
                                     <div class="space-y-1">
                                         <div class="flex flex-wrap items-center gap-2">

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -235,6 +235,15 @@
                             class="input input-bordered w-full" min="5" />
                         <label class="label"><span class="label-text-alt text-muted-foreground">How long login sessions remain valid</span></label>
                     </div>
+                    <div class="form-control w-full">
+                        <label class="label"><span class="label-text font-medium">Default Sending Sources Window</span></label>
+                        <select x-model="s['general.source_date_window_days']" class="select select-bordered w-full">
+                            <option value="7">Last 7 days</option>
+                            <option value="30">Last 30 days</option>
+                            <option value="90">Last 90 days</option>
+                        </select>
+                        <label class="label"><span class="label-text-alt text-muted-foreground">Applied when opening a domain. You can still choose any window, including all time, on that page.</span></label>
+                    </div>
                 </div>
                 {{ save_footer("Save this section after changing product name, public URL, or session behavior.", "Save General Settings") }}
             </form>

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -289,6 +289,8 @@ def test_get_source_reputation_returns_listed_source(authed_client: TestClient, 
     report = {
         **MINIMAL_REPORT,
         "report_id": "listed-source-reputation",
+        "begin_timestamp": int((datetime.now(timezone.utc) - timedelta(days=1)).timestamp()),
+        "end_timestamp": int(datetime.now(timezone.utc).timestamp()),
         "records": [
             {
                 "source_ip": "198.51.100.199",

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -1869,9 +1869,10 @@ def test_domain_remediation_queue_hydrates_report_store_with_workspace_filter(
     workspace = get_or_create_default_workspace(db_session)
     captured = {}
 
-    def fake_single_domain_store(db, domain_id, workspace_arg):
+    def fake_single_domain_store(db, domain_id, workspace_arg, report_window_days=None):
         captured["workspace_id"] = workspace_arg.id
         captured["domain_id"] = domain_id
+        captured["report_window_days"] = report_window_days
         store = ReportStore()
         return DOMAIN, store
 
@@ -1908,6 +1909,7 @@ def test_domain_remediation_queue_hydrates_report_store_with_workspace_filter(
     assert response.status_code == 200
     assert captured["workspace_id"] == workspace.id
     assert captured["domain_id"] == DOMAIN
+    assert captured["report_window_days"] == 30
     assert response.json()["domain"] == DOMAIN
 
 
@@ -1970,6 +1972,57 @@ def test_domain_remediation_queue_bounds_slow_enrichment(
     assert elapsed < 2.0
 
 
+def test_domain_remediation_queue_keeps_completed_evidence_when_one_task_times_out(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """A slow health calculation must not discard already-complete DNS guidance."""
+
+    async def slow_grade(*_args, **_kwargs):
+        await asyncio.sleep(2.0)
+        return {"domain": DOMAIN, "score": 50, "grade": "C", "status": "needs_attention"}
+
+    async def quick_guidance(*_args, **_kwargs):
+        return {
+            "domain": DOMAIN,
+            "status": "critical",
+            "dns_provider": None,
+            "findings": [],
+            "change_plans": [
+                {
+                    "plan_id": "dmarc-missing",
+                    "finding_code": "dmarc_missing",
+                    "severity": "error",
+                    "operation": "create",
+                    "record_type": "TXT",
+                    "name": "_dmarc.example.com",
+                    "proposed_value": "v=DMARC1; p=none",
+                    "current_values": [],
+                    "rationale": "Publish a monitoring DMARC record.",
+                    "expected_health_impact": "High",
+                    "manual_steps": ["Create the TXT record."],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", slow_grade)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", quick_guidance)
+    monkeypatch.setattr(domains_endpoint, "_configured_dns_write_provider_ids", lambda _db: [])
+
+    class _Settings:
+        DEMO_MODE = False
+        REMEDIATION_QUEUE_TIMEOUT_SECONDS = 1
+
+    monkeypatch.setattr(domains_endpoint, "get_settings", lambda: _Settings())
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enrichment_pending"] is True
+    assert any(item["id"] == "dns:dmarc-missing" for item in body["items"])
+
+
 def test_domain_remediation_queue_falls_back_for_legacy_report_domains(
     authed_client: TestClient,
     monkeypatch,
@@ -2028,8 +2081,8 @@ def test_domain_remediation_queue_accepts_numeric_domain_id(
     hydrate_calls = []
     seen_domains = []
 
-    def fake_hydrate_domain(db, store_arg, domain_name, workspace_id=None):
-        hydrate_calls.append((domain_name, workspace_id))
+    def fake_hydrate_domain(db, store_arg, domain_name, workspace_id=None, days=None):
+        hydrate_calls.append((domain_name, workspace_id, days))
         return 1
 
     async def fake_domain_grade(db, domain_id, store_arg, refresh=False):
@@ -2066,6 +2119,7 @@ def test_domain_remediation_queue_accepts_numeric_domain_id(
     assert len(hydrate_calls) == 1
     assert hydrate_calls[0][0] == DOMAIN
     assert hydrate_calls[0][1] is not None
+    assert hydrate_calls[0][2] == 30
     assert seen_domains == [DOMAIN, DOMAIN]
     assert response.json()["domain"] == DOMAIN
 

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2745,6 +2745,38 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
             "failed": 6,
         }
     ]
+    assert source["delivery_status"] == "mixed"
+    assert source["delivery_label"] == "Mixed delivery"
+
+
+@pytest.mark.parametrize(
+    ("source", "status"),
+    [
+        ({"dmarc_pass_count": 12, "dmarc_fail_count": 0}, "aligned"),
+        (
+            {
+                "dmarc_pass_count": 0,
+                "dmarc_fail_count": 12,
+                "disposition_counts": {"reject": 12},
+            },
+            "policy_blocked",
+        ),
+        (
+            {
+                "dmarc_pass_count": 0,
+                "dmarc_fail_count": 12,
+                "disposition_counts": {"none": 12},
+            },
+            "unauthenticated_delivered",
+        ),
+    ],
+)
+def test_source_delivery_status_distinguishes_policy_outcomes(source, status):
+    delivery = domains_endpoint._source_delivery_status(  # pylint: disable=protected-access
+        source
+    )
+
+    assert delivery["status"] == status
 
 
 def test_get_domain_sources_returns_recommendations(
@@ -2876,7 +2908,7 @@ def test_get_domain_source_intelligence_returns_regions_and_anomalies(
 ):
     """Source intelligence summarizes regions and notable sending-source changes."""
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/source-intelligence?days=30")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/source-intelligence?days=3650")
 
     assert response.status_code == 200
     data = response.json()
@@ -2904,7 +2936,7 @@ def test_get_domain_source_intelligence_unknown_domain_returns_404(
 def test_get_domain_sources_includes_geo_and_anomaly_hints(seeded_client: TestClient):
     """Source rows carry coarse geo data and anomaly recommendations."""
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=30")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650")
 
     assert response.status_code == 200
     source = next(item for item in response.json()["sources"] if item["anomalies"])
@@ -3001,7 +3033,7 @@ def test_get_domain_sources_includes_ip_intelligence_and_reputation(
     report_persistence.save_parsed_report(db_session, report, workspace_id=workspace.id)
     db_session.commit()
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=30")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650")
 
     assert response.status_code == 200
     source = next(item for item in response.json()["sources"] if item["ip"] == source_ip)
@@ -3076,7 +3108,7 @@ def test_get_domain_sources_prefers_ingestion_evidence_over_live_lookup(
     monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", reject_snapshot_ptr)
     monkeypatch.setattr(domains_endpoint, "lookup_sources_network_cached", reject_snapshot_network)
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=30")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650")
 
     assert response.status_code == 200
     source = next(item for item in response.json()["sources"] if item["ip"] == source_ip)
@@ -3100,7 +3132,7 @@ def test_get_domain_sources_continues_when_enrichment_times_out(
     monkeypatch.setattr(domains_endpoint, "lookup_sources_network_cached", timeout_networks)
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", timeout_reputation)
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=30")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650")
 
     assert response.status_code == 200
     sources = response.json()["sources"]
@@ -3132,7 +3164,7 @@ def test_get_domain_sources_refreshes_reputation_cache(
 
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=30&refresh=true")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650&refresh=true")
 
     assert response.status_code == 200
     assert captured_refresh == [True]
@@ -3194,11 +3226,11 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
     monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fake_ptr_lookup)
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
 
-    sources = authed_client.get("/api/v1/domains/fast-sources.example/sources?days=30")
+    sources = authed_client.get("/api/v1/domains/fast-sources.example/sources?days=3650")
     intelligence = authed_client.get(
-        "/api/v1/domains/fast-sources.example/source-intelligence?days=30"
+        "/api/v1/domains/fast-sources.example/source-intelligence?days=3650"
     )
-    reputation = authed_client.get("/api/v1/domains/fast-sources.example/source-reputation?days=30")
+    reputation = authed_client.get("/api/v1/domains/fast-sources.example/source-reputation?days=3650")
 
     assert sources.status_code == 200
     assert sources.json()["sources"][0]["ip"] == "203.0.113.42"

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -1,5 +1,5 @@
 import copy
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -85,7 +85,15 @@ def _seed_report_store():
 
 
 def _persist_report(db_session):
-    save_parsed_report(db_session, MINIMAL_REPORT)
+    now = datetime.now(timezone.utc)
+    save_parsed_report(
+        db_session,
+        {
+            **MINIMAL_REPORT,
+            "begin_timestamp": int((now - timedelta(days=1)).timestamp()),
+            "end_timestamp": int(now.timestamp()),
+        },
+    )
     db_session.commit()
 
 

--- a/backend/app/tests/test_report_store.py
+++ b/backend/app/tests/test_report_store.py
@@ -191,6 +191,54 @@ class TestReportStore:
         ]
         assert "_volume_by_date" not in source
 
+    def test_get_domain_sources_honors_the_requested_observation_window(self, monkeypatch):
+        store = ReportStore.get_instance()
+        now = 1709251200  # 2024-03-01T00:00:00Z
+        older = _sample_report("test.com")
+        older.update(
+            {
+                "report_id": "outside-window",
+                "begin_timestamp": 1701388800,
+                "end_timestamp": 1701475199,
+                "records": [
+                    {
+                        "source_ip": "203.0.113.10",
+                        "count": 99,
+                        "disposition": "reject",
+                        "dkim_result": "fail",
+                        "spf_result": "fail",
+                    }
+                ],
+            }
+        )
+        recent = _sample_report("test.com")
+        recent.update(
+            {
+                "report_id": "inside-window",
+                "begin_timestamp": 1709164800,
+                "end_timestamp": 1709251199,
+                "records": [
+                    {
+                        "source_ip": "203.0.113.20",
+                        "count": 7,
+                        "disposition": "none",
+                        "dkim_result": "pass",
+                        "spf_result": "pass",
+                    }
+                ],
+            }
+        )
+        store.add_report(older)
+        store.add_report(recent)
+        monkeypatch.setattr(report_store_module, "_now_timestamp", lambda: now)
+
+        sources = store.get_domain_sources("test.com", days=30)
+        reports = store.get_domain_reports("test.com", days=30)
+
+        assert [source["source_ip"] for source in sources] == ["203.0.113.20"]
+        assert sources[0]["count"] == 7
+        assert [report["report_id"] for report in reports] == ["inside-window"]
+
     def test_get_domain_sources_clamps_future_report_end_to_current_time(self, monkeypatch):
         store = ReportStore.get_instance()
         now = 1706788800

--- a/backend/app/tests/test_sending_sources_layout.py
+++ b/backend/app/tests/test_sending_sources_layout.py
@@ -61,6 +61,15 @@ def test_sending_sources_keeps_auth_and_recommendations_data() -> None:
     assert "sending-source-intel" in section
 
 
+def test_sending_sources_accepts_a_configured_default_window() -> None:
+    body = _domain_details()
+    script = (APP_ROOT / "static" / "js" / "domain-details-page.js").read_text(encoding="utf-8")
+
+    assert 'data-source-window-days="{{ source_window_days }}"' in body
+    assert "configuredSourceWindow" in script
+    assert "['7', '30', '90'].includes(configuredSourceWindow)" in script
+
+
 def test_auth_status_cells_include_labels_beside_badges() -> None:
     section = _sending_sources_section()
     for label in ("SPF", "DKIM", "DMARC", "Disposition"):

--- a/backend/app/tests/test_sending_sources_layout.py
+++ b/backend/app/tests/test_sending_sources_layout.py
@@ -70,6 +70,26 @@ def test_sending_sources_accepts_a_configured_default_window() -> None:
     assert "['7', '30', '90'].includes(configuredSourceWindow)" in script
 
 
+def test_sending_source_summary_chips_are_interactive_filters() -> None:
+    section = _sending_sources_section()
+    script = (APP_ROOT / "static" / "js" / "domain-details-page.js").read_text(encoding="utf-8")
+
+    for value in (
+        "all",
+        "risky",
+        "listed",
+        "auth_review",
+        "recent",
+        "unchecked",
+        "delivery:aligned",
+        "delivery:policy_blocked",
+        "delivery:unauthenticated_delivered",
+    ):
+        assert f'data-domain-detail-source-filter="{value}"' in section
+    assert "setSourceSummaryFilter" in script
+    assert "sourceSummaryFilterActive" in script
+
+
 def test_auth_status_cells_include_labels_beside_badges() -> None:
     section = _sending_sources_section()
     for label in ("SPF", "DKIM", "DMARC", "Disposition"):

--- a/backend/app/tests/test_settings.py
+++ b/backend/app/tests/test_settings.py
@@ -309,6 +309,13 @@ class TestSettingsAPI:
         assert res.json()["key"] == "general.app_name"
         assert res.json()["value"] == "DMARQ"
 
+    def test_settings_seed_the_default_source_date_window(self, authed_client: TestClient):
+        rows = authed_client.get("/api/v1/settings").json()
+        source_window = next(row for row in rows if row["key"] == "general.source_date_window_days")
+
+        assert source_window["value"] == "30"
+        assert source_window["category"] == "general"
+
     def test_get_missing_setting_returns_404(self, authed_client: TestClient):
         """GET /api/v1/settings/{key} returns 404 for unknown keys."""
         authed_client.get("/api/v1/settings")  # seed


### PR DESCRIPTION
## Summary\n- honor the selected observation window for Sending Sources instead of returning all historical IPs\n- keep source intelligence and reputation analysis on that same report window\n- separate aligned delivery, policy-blocked failures, unauthenticated delivery, and mixed outcomes with clear filters and badges\n- support the explicit all-time source view without rejecting its 3650-day request\n\n## Validation\n- ============================= test session starts ==============================
platform darwin -- Python 3.14.5, pytest-9.1.1, pluggy-1.6.0
rootdir: /private/tmp/dmarq-source-quality.nbzsGH/repo
configfile: pyproject.toml (WARNING: ignoring pytest config in setup.cfg!)
plugins: cov-7.1.0, asyncio-1.4.0, anyio-4.14.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 148 items

backend/app/tests/test_report_store.py ...........................       [ 18%]
backend/app/tests/test_domain_detail_endpoints.py ...................... [ 33%]
........................................................................ [ 81%]
.......                                                                  [ 86%]
backend/app/tests/test_sender_intelligence.py ....................       [100%]

====================== 148 passed, 914 warnings in 10.74s ======================\n- ============================= test session starts ==============================
platform darwin -- Python 3.14.5, pytest-9.1.1, pluggy-1.6.0
rootdir: /private/tmp/dmarq-source-quality.nbzsGH/repo
configfile: pyproject.toml (WARNING: ignoring pytest config in setup.cfg!)
plugins: cov-7.1.0, asyncio-1.4.0, anyio-4.14.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 124 items

backend/app/tests/test_sending_sources_layout.py ...                     [  2%]
backend/app/tests/test_surface_contrast.py ......                        [  7%]
backend/app/tests/test_dashboard_template_security.py .................. [ 21%]
........................................................................ [ 79%]
.........................                                                [100%]

======================= 124 passed, 13 warnings in 1.90s =======================