### PR TITLE
Capture daily health history on domain views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Started domain health history automatically with one persisted score snapshot
+  per domain and day. Existing domains receive their initial trend point when
+  their detail view opens, and later visits reuse that evidence rather than
+  repeating the expensive posture calculation.
 - Kept localized dashboards responsive by preventing translation and Alpine
   rendering from repeatedly rewriting the same text nodes. Language choices in
   the asynchronously rendered account menu now apply and persist after reload.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -4361,7 +4361,15 @@ async def build_domain_health_evidence_export_rows(
             detail="Domain not found",
         )
 
-    if capture_current and not get_settings().DEMO_MODE:
+    snapshot_today = list_health_score_snapshots(
+        db,
+        workspace_id=workspace.id,
+        domain_name=domain_id,
+        start_date=date.today(),
+        end_date=date.today(),
+        limit=1,
+    )
+    if capture_current and not snapshot_today and not get_settings().DEMO_MODE:
         health = await _build_domain_dns_health(db, store, domain_id)
         domain_health = await _build_domain_health_grade(db, domain_id, store)
         summary = store.get_domain_summary(domain_id)
@@ -6766,7 +6774,18 @@ async def get_domain_health_score_history(
             detail="Domain not found",
         )
 
-    if capture_current and not get_settings().DEMO_MODE:
+    # The page requests this endpoint on every visit.  Capture the first
+    # snapshot of the day, then read the persisted evidence on later visits
+    # instead of repeating DNS and report aggregation work.
+    snapshots_today = list_health_score_snapshots(
+        db,
+        workspace_id=workspace.id,
+        domain_name=domain_id,
+        start_date=date.today(),
+        end_date=date.today(),
+        limit=1,
+    )
+    if capture_current and not snapshots_today and not get_settings().DEMO_MODE:
         health = await _build_domain_dns_health(db, store, domain_id)
         domain_health = await _build_domain_health_grade(db, domain_id, store)
         summary = store.get_domain_summary(domain_id)

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -310,6 +310,9 @@ function domainDetailsApp(domainId = '') {
                 } else if (button.matches('[data-domain-detail-refresh-reputation]')) {
                     event.preventDefault();
                     this.refreshSourceReputation();
+                } else if (button.matches('[data-domain-detail-health-history-capture]')) {
+                    event.preventDefault();
+                    this.fetchHealthHistory({ captureCurrent: true });
                 } else if (button.matches('[data-domain-detail-delete]')) {
                     event.preventDefault();
                     this.deleteDomain();
@@ -2852,11 +2855,20 @@ function domainDetailsApp(domainId = '') {
             }
         },
 
-        async fetchHealthHistory() {
+        async fetchHealthHistory(options = {}) {
             this.healthHistory.loading = true;
             this.healthHistory.error = '';
             try {
-                const response = await fetch(`/api/v1/domains/${encodeURIComponent(this.domainId)}/posture/history?capture_current=false&limit=30`);
+                const captureCurrent = options.captureCurrent !== false;
+                const params = new URLSearchParams({
+                    capture_current: captureCurrent ? 'true' : 'false',
+                    limit: '30'
+                });
+                const response = await this.fetchWithTimeout(
+                    `/api/v1/domains/${encodeURIComponent(this.domainId)}/posture/history?${params.toString()}`,
+                    {},
+                    45000
+                );
                 if (!response.ok) {
                     throw new Error('Health score history could not be loaded.');
                 }

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1382,7 +1382,14 @@
                             <p class="mt-3 text-sm text-red-700" x-text="healthHistory.error"></p>
                         </template>
                         <template x-if="!healthHistory.error && !healthHistory.points.length && !healthHistory.loading">
-                            <p class="mt-3 text-sm text-[#5f5c78]">No health history has been captured yet.</p>
+                            <div class="mt-3 space-y-2 text-sm text-[#5f5c78]">
+                                <p>No health snapshot has been captured yet. Capture the current aggregate posture to start this trend.</p>
+                                <button type="button"
+                                        class="btn btn-outline btn-sm"
+                                        data-domain-detail-health-history-capture>
+                                    Capture current health score
+                                </button>
+                            </div>
                         </template>
                     </div>
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2259,7 +2259,8 @@ def test_domain_details_exposes_health_history_without_html_injection():
     script = _domain_details_script()
 
     assert "Health Score Trend" in template
-    assert "/posture/history?capture_current=false" in script
+    assert "capture_current: captureCurrent ? 'true' : 'false'" in script
+    assert "data-domain-detail-health-history-capture" in template
     assert "/posture/evidence/export?capture_current=false" in script
     assert "encodeURIComponent(this.domainId)" in script
     assert 'x-data="domainDetailsApp"' in template

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -769,6 +769,48 @@ def test_domain_health_history_capture_current_snapshot(
     assert data["top_drivers"][0]["title"] == "Keep monitoring"
 
 
+def test_domain_health_history_does_not_recalculate_an_existing_daily_snapshot(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Opening the history repeatedly keeps the daily capture cheap and idempotent."""
+    calls = {"dns": 0, "health": 0}
+
+    async def fake_dns_health(*_args, **_kwargs):
+        calls["dns"] += 1
+        return domains_endpoint.DNSHealthResponse(
+            status="healthy",
+            policy="reject",
+            compliance_rate=100.0,
+            total_emails=10,
+            failed_emails=0,
+            checks=[],
+            recommendations=[],
+        )
+
+    async def fake_domain_grade(_db, domain_id, _store, refresh=False):
+        calls["health"] += 1
+        return {
+            "domain": domain_id,
+            "score": 96,
+            "grade": "A",
+            "status": "healthy",
+            "factors": {},
+            "actions": [],
+        }
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_health", fake_dns_health)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+
+    first = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history")
+    second = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert len(second.json()["points"]) == 1
+    assert calls == {"dns": 1, "health": 1}
+
+
 def test_domain_health_evidence_export_capture_current_snapshot(
     seeded_client: TestClient,
     monkeypatch,


### PR DESCRIPTION
## Summary\n- capture a persisted health snapshot when a domain has none for the current day\n- expose a clear manual capture action for an empty history\n- reuse the daily snapshot on later visits so health history does not trigger repeated DNS/report aggregation\n\n## Validation\n- \n- ============================= test session starts ==============================
platform darwin -- Python 3.14.5, pytest-9.1.1, pluggy-1.6.0
rootdir: /private/tmp/dmarq-health-history.T4mL2p
configfile: pyproject.toml (WARNING: ignoring pytest config in setup.cfg!)
plugins: cov-7.1.0, asyncio-1.4.0, anyio-4.14.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 214 items

backend/app/tests/test_domain_detail_endpoints.py ...................... [ 10%]
........................................................................ [ 43%]
.....                                                                    [ 46%]
backend/app/tests/test_dashboard_template_security.py .................. [ 54%]
........................................................................ [ 88%]
.........................                                                [100%]

====================== 214 passed, 927 warnings in 10.03s ====================== (214 passed)\n\nFixes #840