### PR TITLE
fix: bound source reads to selected report window

### DIFF
--- a/backend/alembic/versions/b6c7d8e9f0a_add_domain_report_end_date_index.py
+++ b/backend/alembic/versions/b6c7d8e9f0a_add_domain_report_end_date_index.py
@@ -1,0 +1,30 @@
+"""Index report windows by domain and end date.
+
+Revision ID: b6c7d8e9f0a
+Revises: a5b6c7d8e9f0
+Create Date: 2026-07-24 16:45:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "b6c7d8e9f0a"
+down_revision: Union[str, Sequence[str], None] = "a5b6c7d8e9f0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Support bounded domain-report reads without scanning report history."""
+    op.create_index(
+        "ix_dmarc_reports_domain_end_date",
+        "dmarc_reports",
+        ["domain_id", "end_date"],
+    )
+
+
+def downgrade() -> None:
+    """Remove the bounded domain-report read index."""
+    op.drop_index("ix_dmarc_reports_domain_end_date", table_name="dmarc_reports")

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -8257,7 +8257,12 @@ async def get_domain_sources(
     and SPF fix hints for sources that fail authentication.
     """
     workspace = _authorized_domain_read_workspace(_auth, db)
-    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
+    domain_name, store = _single_domain_report_store_for_read(
+        db,
+        domain_id,
+        workspace,
+        report_window_days=days,
+    )
 
     source_days = days if days is not None else 30
     sources = store.get_domain_sources(domain_name, days=days)
@@ -8398,7 +8403,12 @@ async def get_domain_source_reputation(
 ):
     """Return passive reputation evidence for observed sender IPs."""
     workspace = _authorized_domain_read_workspace(_auth, db)
-    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
+    domain_name, store = _single_domain_report_store_for_read(
+        db,
+        domain_id,
+        workspace,
+        report_window_days=days,
+    )
 
     reports = store.get_domain_reports(domain_name, days=days)
     sources = store.get_domain_sources(domain_name, days=days)
@@ -8447,7 +8457,12 @@ async def get_domain_source_intelligence(
 ):
     """Return region summaries and source anomaly hints for a domain."""
     workspace = _authorized_domain_read_workspace(_auth, db)
-    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
+    domain_name, store = _single_domain_report_store_for_read(
+        db,
+        domain_id,
+        workspace,
+        report_window_days=days,
+    )
 
     sources = store.get_domain_sources(domain_name, days=days)
     provider = get_default_provider(db)

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -51,6 +51,9 @@ class DMARCReport(Base):
     __table_args__ = (
         # Composite index for domain and date range queries (common dashboard queries)
         Index("ix_dmarc_reports_domain_dates", "domain_id", "begin_date", "end_date"),
+        # Read paths commonly select a domain and then bound or sort by the
+        # report end time. Keep that query indexable without scanning history.
+        Index("ix_dmarc_reports_domain_end_date", "domain_id", "end_date"),
         # Index for finding reports by policy
         Index("ix_dmarc_reports_policy", "policy"),
         # Index for finding recent reports (dashboard statistics)

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -1,4 +1,5 @@
 import json
+import time
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
@@ -377,7 +378,7 @@ def hydrate_domain_report_store_from_db(
         # to a datetime happens to be permissive in SQLite but fails in
         # PostgreSQL and prevents every time-scoped domain read from using its
         # database filter.
-        cutoff = int((datetime.utcnow() - timedelta(days=max(1, int(days)))).timestamp())
+        cutoff = int(time.time()) - (max(1, int(days)) * 24 * 60 * 60)
         query = query.filter(DMARCReport.end_date >= cutoff)
     reports = query.order_by(DMARCReport.end_date.desc()).all()
     for report in reports:

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -1,6 +1,6 @@
 import json
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import case, distinct, func, or_

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -373,7 +373,11 @@ def hydrate_domain_report_store_from_db(
     if workspace_id is not None:
         query = query.filter(Domain.workspace_id == workspace_id)
     if days is not None:
-        cutoff = datetime.utcnow() - timedelta(days=max(1, int(days)))
+        # DMARCReport.end_date is persisted as a Unix timestamp.  Comparing it
+        # to a datetime happens to be permissive in SQLite but fails in
+        # PostgreSQL and prevents every time-scoped domain read from using its
+        # database filter.
+        cutoff = int((datetime.utcnow() - timedelta(days=max(1, int(days)))).timestamp())
         query = query.filter(DMARCReport.end_date >= cutoff)
     reports = query.order_by(DMARCReport.end_date.desc()).all()
     for report in reports:

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -11,7 +11,7 @@ the use of begin_timestamp/end_timestamp integers for date fields.
 import asyncio
 import csv
 import json
-from datetime import date
+from datetime import date, datetime, timedelta
 from io import StringIO
 from types import SimpleNamespace
 
@@ -3321,6 +3321,18 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
     monkeypatch.setattr(domains_endpoint, "hydrate_report_store_from_db", fail_hydrate)
     monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fake_ptr_lookup)
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fake_reputation)
+    hydrated_windows = []
+    original_hydrate_domain = domains_endpoint.hydrate_domain_report_store_from_db
+
+    def track_domain_hydrate(*args, **kwargs):
+        hydrated_windows.append(kwargs.get("days"))
+        return original_hydrate_domain(*args, **kwargs)
+
+    monkeypatch.setattr(
+        domains_endpoint,
+        "hydrate_domain_report_store_from_db",
+        track_domain_hydrate,
+    )
 
     sources = authed_client.get("/api/v1/domains/fast-sources.example/sources?days=3650")
     intelligence = authed_client.get(
@@ -3334,6 +3346,7 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
     assert intelligence.json()["summary"]["messages"] == 4
     assert reputation.status_code == 200
     assert reputation.json()["domain"] == "fast-sources.example"
+    assert hydrated_windows == [3650, 3650, 3650]
 
 
 def test_source_recommendations_cover_common_cases():
@@ -3644,6 +3657,67 @@ def test_get_domain_sources_days_param_accepted(seeded_client: TestClient):
     """The 'days' query parameter is accepted without raising a TypeError."""
     response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=7")
     assert response.status_code == 200
+
+
+def test_source_reads_hydrate_only_the_selected_window(
+    seeded_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Sources and source intelligence do not hydrate unrelated history."""
+    hydrated_windows = []
+    original_hydrate = domains_endpoint.hydrate_domain_report_store_from_db
+
+    def track_hydrate(*args, **kwargs):
+        hydrated_windows.append(kwargs.get("days"))
+        return original_hydrate(*args, **kwargs)
+
+    monkeypatch.setattr(domains_endpoint, "hydrate_domain_report_store_from_db", track_hydrate)
+
+    sources_response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=90")
+    intelligence_response = seeded_client.get(
+        f"/api/v1/domains/{DOMAIN}/source-intelligence?days=7"
+    )
+
+    assert sources_response.status_code == 200
+    assert intelligence_response.status_code == 200
+    assert hydrated_windows == [90, 7]
+
+
+def test_hydrate_domain_report_store_filters_unix_timestamp_windows(db_session):
+    """PostgreSQL-compatible timestamp filtering keeps historical rows out."""
+    workspace = get_or_create_default_workspace(db_session)
+    db_session.add(Domain(name=DOMAIN, workspace_id=workspace.id, active=True))
+    db_session.commit()
+
+    now = int(datetime.utcnow().timestamp())
+    old_report = {
+        **REPORT_DICT_POLICY,
+        "report_id": "historic-source-window",
+        "begin_timestamp": now - int(timedelta(days=91).total_seconds()),
+        "end_timestamp": now - int(timedelta(days=90).total_seconds()),
+    }
+    recent_report = {
+        **REPORT_DICT_POLICY,
+        "report_id": "recent-source-window",
+        "begin_timestamp": now - int(timedelta(days=2).total_seconds()),
+        "end_timestamp": now - int(timedelta(days=1).total_seconds()),
+    }
+    report_persistence.save_parsed_report(db_session, old_report, workspace_id=workspace.id)
+    report_persistence.save_parsed_report(db_session, recent_report, workspace_id=workspace.id)
+    db_session.commit()
+
+    store = ReportStore()
+    loaded = report_persistence.hydrate_domain_report_store_from_db(
+        db_session,
+        store,
+        DOMAIN,
+        workspace_id=workspace.id,
+        days=30,
+    )
+
+    assert loaded == 1
+    assert [report["report_id"] for report in store.get_domain_reports(DOMAIN)] == [
+        "recent-source-window"
+    ]
 
 
 def test_get_domain_sources_unknown_domain_returns_404(authed_client: TestClient):


### PR DESCRIPTION
## What changed

- Applies the selected `days` window before source, source-intelligence, and source-reputation reads hydrate report data.
- Corrects PostgreSQL filtering for Unix-timestamp report dates.
- Adds the `(domain_id, end_date)` index used by bounded reads.

## Why

A 30-day Sending Sources view could hydrate and aggregate the full historic report set, while the same page concurrently loaded source intelligence. On large domains this made normal navigation slow and could fail the remediation flow.

## Validation

- 154 focused domain-detail and report API tests passed.
- Fresh SQLite migration upgrade verified the new index.

Fixes #847.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Domain source, source intelligence, and source reputation views now consistently honor the requested reporting period.
  * Time-based report filtering is now consistent across database environments, ensuring correct inclusion/exclusion of reports.
  * Analytics now exclude reports outside the selected date range.
* **Performance**
  * Added an optimized database index for faster domain lookups by report end date.
* **Tests**
  * Expanded coverage to verify per-endpoint period hydration and correct Unix-timestamp date filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->