### PR TITLE
feat: materialize sender read projections on intake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,6 +132,10 @@ SOURCE_EVIDENCE_PREWARM_ENABLED=true
 # Precompute PTR, ASN, and country evidence for recent sender IPs in the background.
 SOURCE_EVIDENCE_PREWARM_LIMIT=250
 SOURCE_EVIDENCE_PREWARM_INTERVAL_SECONDS=300
+# Build indexed sender read facts for existing reports outside UI requests.
+SOURCE_READ_PROJECTION_BACKFILL_ENABLED=true
+SOURCE_READ_PROJECTION_BACKFILL_LIMIT=100
+SOURCE_READ_PROJECTION_BACKFILL_INTERVAL_SECONDS=30
 # GEOIP_CUSTOM_URL="https://geoip.internal/v1/lookup?ip={ip}"
 # GEOIP_CUSTOM_AUTH_HEADER="Authorization: Bearer replace-me"
 # GEOIP_CUSTOM_TIMEOUT_SECONDS=2

--- a/backend/alembic/versions/c7d8e9f0a1b2_add_source_daily_read_projections.py
+++ b/backend/alembic/versions/c7d8e9f0a1b2_add_source_daily_read_projections.py
@@ -1,0 +1,75 @@
+"""Add ingestion-time sender read projections.
+
+Revision ID: c7d8e9f0a1b2
+Revises: b6c7d8e9f0a
+Create Date: 2026-07-24 17:10:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "c7d8e9f0a1b2"
+down_revision: Union[str, Sequence[str], None] = "b6c7d8e9f0a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create a daily sender fact table and mark reports once projected."""
+    op.add_column("dmarc_reports", sa.Column("source_projection_at", sa.DateTime(), nullable=True))
+    op.create_index(
+        op.f("ix_dmarc_reports_source_projection_at"),
+        "dmarc_reports",
+        ["source_projection_at"],
+    )
+    op.create_table(
+        "domain_source_daily_projections",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("domain_id", sa.Integer(), nullable=False),
+        sa.Column("source_ip", sa.String(), nullable=False),
+        sa.Column("observed_at", sa.Integer(), nullable=False),
+        sa.Column("first_seen", sa.Integer(), nullable=True),
+        sa.Column("last_seen", sa.Integer(), nullable=True),
+        sa.Column("message_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("report_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("spf_pass_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("spf_fail_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("spf_unknown_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("dkim_pass_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("dkim_fail_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("dkim_unknown_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("dmarc_pass_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("dmarc_fail_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("disposition_counts", sa.Text(), nullable=True),
+        sa.Column("metadata_json", sa.Text(), nullable=True),
+        sa.Column("source_evidence", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["domain_id"], ["domains.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "domain_id",
+            "source_ip",
+            "observed_at",
+            name="uq_domain_source_daily_projection",
+        ),
+    )
+    op.create_index(
+        "ix_domain_source_daily_projection_window",
+        "domain_source_daily_projections",
+        ["domain_id", "observed_at", "source_ip"],
+    )
+
+
+def downgrade() -> None:
+    """Remove sender read projections."""
+    op.drop_index(
+        "ix_domain_source_daily_projection_window",
+        table_name="domain_source_daily_projections",
+    )
+    op.drop_table("domain_source_daily_projections")
+    op.drop_index(op.f("ix_dmarc_reports_source_projection_at"), table_name="dmarc_reports")
+    op.drop_column("dmarc_reports", "source_projection_at")

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -122,6 +122,8 @@ from app.services.remediation_readiness import (
     repair_readiness_for_stage,
 )
 from app.services.report_persistence import (
+    domain_reports_and_timeline_from_db,
+    domain_summary_from_db,
     domain_summaries_from_db,
     hydrate_domain_report_store_from_db,
     hydrate_report_store_from_db,
@@ -5656,6 +5658,18 @@ async def get_domain_stats(
     Get detailed statistics for a specific domain
     """
     workspace = _authorized_domain_read_workspace(_auth, db)
+    domain = workspace_domain_query(db, workspace).filter(Domain.name == domain_id).first()
+    if domain is None and domain_id.isdigit():
+        domain = workspace_domain_query(db, workspace).filter(Domain.id == int(domain_id)).first()
+    if domain is not None and not get_settings().DEMO_MODE:
+        summary = domain_summary_from_db(db, domain_id=domain.id)
+        return DomainStatsResponse(
+            complianceRate=summary["compliance_rate"],
+            totalEmails=summary["total_count"],
+            failedEmails=summary["failed_count"],
+            reportCount=summary["reports_processed"],
+        )
+
     domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
     summary = store.get_domain_summary(domain_name)
     total_count = summary.get("total_count", 0)
@@ -6393,33 +6407,27 @@ async def _build_domain_posture_dashboard_for_workspace(
     capture_snapshot: bool = True,
 ) -> PostureDashboardResponse:
     """Build a posture dashboard, optionally persisting the current health snapshot."""
-    store = ReportStore.get_instance()
-    hydrate_report_store_from_db(db, store)
-    if not _domain_exists(db, store, domain_id, workspace):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Domain not found",
-        )
+    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
-    health = await _build_domain_dns_health(db, store, domain_id, refresh=refresh)
+    health = await _build_domain_dns_health(db, store, domain_name, refresh=refresh)
     domain_health = await _build_domain_health_grade(
         db,
-        domain_id,
+        domain_name,
         store,
         refresh=refresh,
     )
-    summary = store.get_domain_summary(domain_id)
+    summary = store.get_domain_summary(domain_name)
     if capture_snapshot:
         _record_health_snapshot_from_posture(
             db,
             workspace_id=workspace.id,
-            domain_id=domain_id,
+            domain_id=domain_name,
             dns_health=health,
             domain_health=domain_health,
             report_count=int(summary.get("reports_processed", 0) or 0),
         )
-    changes = list_dns_record_changes(db, domain_id, limit=10)
-    return _build_posture_dashboard(domain_id, health, domain_health, changes)
+    changes = list_dns_record_changes(db, domain_name, limit=10)
+    return _build_posture_dashboard(domain_name, health, domain_health, changes)
 
 
 async def _build_domain_remediation_queue_for_workspace(
@@ -7309,6 +7317,37 @@ async def get_domain_reports(
     Get recent DMARC reports for a specific domain, along with compliance timeline
     """
     workspace = _authorized_domain_read_workspace(_auth, db)
+    domain = workspace_domain_query(db, workspace).filter(Domain.name == domain_id).first()
+    if domain is None and domain_id.isdigit():
+        domain = workspace_domain_query(db, workspace).filter(Domain.id == int(domain_id)).first()
+    if domain is not None and not get_settings().DEMO_MODE:
+        reports, timeline = domain_reports_and_timeline_from_db(
+            db,
+            domain_id=domain.id,
+            limit=limit,
+        )
+        report_entries = []
+        for report in reports:
+            summary = report.get("summary") or {}
+            policy_val = report.get("policy", "none")
+            if isinstance(policy_val, dict):
+                policy_val = policy_val.get("p", "none")
+            report_entries.append(
+                ReportEntry(
+                    id=report.get("report_id", "unknown"),
+                    org_name=report.get("org_name", "Unknown Organization"),
+                    begin_date=report.get("begin_timestamp", 0),
+                    end_date=report.get("end_timestamp", 0),
+                    total_emails=summary.get("total_count", report.get("total_count", 0)),
+                    pass_rate=summary.get("pass_rate", report.get("pass_rate", 0.0)),
+                    policy=policy_val,
+                )
+            )
+        return DomainReportsResponse(
+            reports=report_entries,
+            compliance_timeline=[TimelinePoint(**point) for point in timeline],
+        )
+
     domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
     # Get reports for this domain
@@ -8322,14 +8361,15 @@ async def get_domain_sources(
     }
     missing_ptr_ips = [str(ip) for ip in ips if str(ip) not in ptr_by_ip]
     missing_network_ips = [str(ip) for ip in ips if str(ip) not in networks_by_ip]
-    ptr_task = asyncio.create_task(_source_ptr_results_by_ip(provider, missing_ptr_ips, settings))
-    network_task = asyncio.create_task(
-        _source_networks_by_ip(db, provider, missing_network_ips, settings)
-    )
-    live_ptr, live_networks = await asyncio.gather(ptr_task, network_task)
-    ptr_by_ip.update(live_ptr)
-    networks_by_ip.update(live_networks)
-    hostnames = [ptr_by_ip[str(ip)].hostname for ip in ips]
+    if refresh:
+        ptr_task = asyncio.create_task(_source_ptr_results_by_ip(provider, missing_ptr_ips, settings))
+        network_task = asyncio.create_task(
+            _source_networks_by_ip(db, provider, missing_network_ips, settings)
+        )
+        live_ptr, live_networks = await asyncio.gather(ptr_task, network_task)
+        ptr_by_ip.update(live_ptr)
+        networks_by_ip.update(live_networks)
+    hostnames = [ptr_by_ip.get(str(ip), PtrLookupResult(status="pending")).hostname for ip in ips]
     geo_by_ip = {
         str(source.get("source_ip") or "unknown"): merge_network_into_geo(
             source_geo_for(str(source.get("source_ip") or "unknown"), source),
@@ -8351,19 +8391,30 @@ async def get_domain_sources(
     source_context = []
     for source, hostname in zip(sources, hostnames):
         ip = source.get("source_ip", "unknown")
-        sender_by_ip[ip] = identify_sender(ip, source, hostname=hostname, domain=domain_name)
+        ptr_result = ptr_by_ip.get(ip)
+        sender_by_ip[ip] = identify_sender(
+            ip,
+            source,
+            hostname=hostname,
+            domain=domain_name,
+            ptr_lookup_pending=bool(ptr_result and ptr_result.status == "pending"),
+        )
         source_context.append((source, hostname, sender_by_ip[ip]))
 
-    reputations_by_ip = await _source_reputations_by_ip(
-        db,
-        domain_name,
-        reports,
-        sources,
-        sender_by_ip,
-        anomalies_by_ip,
-        source_days,
-        refresh,
-        settings,
+    reputations_by_ip = (
+        await _source_reputations_by_ip(
+            db,
+            domain_name,
+            reports,
+            sources,
+            sender_by_ip,
+            anomalies_by_ip,
+            source_days,
+            refresh,
+            settings,
+        )
+        if refresh
+        else {}
     )
 
     for source, hostname, sender in source_context:
@@ -8501,16 +8552,12 @@ async def get_domain_source_intelligence(
         days=days,
     )
 
-    provider = get_default_provider(db)
-    settings = get_settings()
     ips = [str(source.get("source_ip") or "unknown") for source in sources]
     networks_by_ip = {
         str(source.get("source_ip") or "unknown"): snapshot
         for source in sources
         if (snapshot := network_from_source_evidence(source.get("source_evidence"))) is not None
     }
-    missing_network_ips = [ip for ip in ips if ip not in networks_by_ip]
-    networks_by_ip.update(await _source_networks_by_ip(db, provider, missing_network_ips, settings))
     geo_by_ip = {
         str(source.get("source_ip") or "unknown"): merge_network_into_geo(
             source_geo_for(str(source.get("source_ip") or "unknown"), source),

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -137,6 +137,10 @@ from app.services.source_evidence_prewarm import (
     network_from_source_evidence,
     ptr_from_source_evidence,
 )
+from app.services.source_read_projection import (
+    load_domain_source_read_projection,
+    source_projection_is_complete,
+)
 from app.services.source_network import (
     SourceNetworkIntelligence,
     lookup_sources_network_cached,
@@ -3398,6 +3402,43 @@ def _single_domain_report_store_for_read(
         hydrate_report_store_from_db(db, store)
         domain_name = _resolve_domain_name_for_read(db, store, domain_id, workspace)
     return domain_name, store
+
+
+def _domain_source_read_model_for_read(
+    db: Session,
+    domain_id: str,
+    workspace: Workspace,
+    *,
+    days: Optional[int],
+) -> tuple[str, List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Read projected sender facts when ingestion/backfill has completed."""
+    domain = workspace_domain_query(db, workspace).filter(Domain.name == domain_id).first()
+    if domain is None and domain_id.isdigit():
+        domain = workspace_domain_query(db, workspace).filter(Domain.id == int(domain_id)).first()
+    if domain is not None and not get_settings().DEMO_MODE and source_projection_is_complete(
+        db,
+        domain_id=domain.id,
+        days=days,
+    ):
+        sources, reports = load_domain_source_read_projection(
+            db,
+            domain_id=domain.id,
+            domain_name=str(domain.name),
+            days=days,
+        )
+        return str(domain.name), sources, reports
+
+    domain_name, store = _single_domain_report_store_for_read(
+        db,
+        domain_id,
+        workspace,
+        report_window_days=days,
+    )
+    return (
+        domain_name,
+        store.get_domain_sources(domain_name, days=days),
+        store.get_domain_reports(domain_name, days=days),
+    )
 
 
 def _record_evidence(
@@ -8257,16 +8298,14 @@ async def get_domain_sources(
     and SPF fix hints for sources that fail authentication.
     """
     workspace = _authorized_domain_read_workspace(_auth, db)
-    domain_name, store = _single_domain_report_store_for_read(
+    domain_name, sources, reports = _domain_source_read_model_for_read(
         db,
         domain_id,
         workspace,
-        report_window_days=days,
+        days=days,
     )
 
     source_days = days if days is not None else 30
-    sources = store.get_domain_sources(domain_name, days=days)
-    reports = store.get_domain_reports(domain_name, days=days)
     provider = get_default_provider(db)
     settings = get_settings()
 
@@ -8403,15 +8442,13 @@ async def get_domain_source_reputation(
 ):
     """Return passive reputation evidence for observed sender IPs."""
     workspace = _authorized_domain_read_workspace(_auth, db)
-    domain_name, store = _single_domain_report_store_for_read(
+    domain_name, sources, reports = _domain_source_read_model_for_read(
         db,
         domain_id,
         workspace,
-        report_window_days=days,
+        days=days,
     )
 
-    reports = store.get_domain_reports(domain_name, days=days)
-    sources = store.get_domain_sources(domain_name, days=days)
     intelligence = build_source_intelligence(
         domain_name,
         reports,
@@ -8457,14 +8494,13 @@ async def get_domain_source_intelligence(
 ):
     """Return region summaries and source anomaly hints for a domain."""
     workspace = _authorized_domain_read_workspace(_auth, db)
-    domain_name, store = _single_domain_report_store_for_read(
+    domain_name, sources, reports = _domain_source_read_model_for_read(
         db,
         domain_id,
         workspace,
-        report_window_days=days,
+        days=days,
     )
 
-    sources = store.get_domain_sources(domain_name, days=days)
     provider = get_default_provider(db)
     settings = get_settings()
     ips = [str(source.get("source_ip") or "unknown") for source in sources]
@@ -8484,7 +8520,7 @@ async def get_domain_source_intelligence(
     }
     intelligence = build_source_intelligence(
         domain_name,
-        store.get_domain_reports(domain_name, days=days),
+        reports,
         sources,
         period_days=days,
         geo_by_ip=geo_by_ip,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -141,6 +141,11 @@ class Settings(BaseSettings):
     SOURCE_EVIDENCE_PREWARM_CONCURRENCY: int = 8
     SOURCE_EVIDENCE_PREWARM_TIMEOUT_SECONDS: float = 20.0
     SOURCE_EVIDENCE_PREWARM_INTERVAL_SECONDS: int = 300
+    # Convert existing aggregate reports into indexed sender facts outside UI
+    # requests. New reports are projected synchronously during persistence.
+    SOURCE_READ_PROJECTION_BACKFILL_ENABLED: bool = True
+    SOURCE_READ_PROJECTION_BACKFILL_LIMIT: int = 100
+    SOURCE_READ_PROJECTION_BACKFILL_INTERVAL_SECONDS: int = 30
     GEOIP_CUSTOM_URL: Optional[str] = None
     GEOIP_CUSTOM_AUTH_HEADER: Optional[str] = None
     GEOIP_CUSTOM_TIMEOUT_SECONDS: float = 2.0

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -72,6 +72,7 @@ from app.services.runtime_status import (
     mark_scheduler_success,
 )
 from app.services.source_evidence_prewarm import scheduled_source_evidence_prewarm
+from app.services.source_read_projection import scheduled_source_projection_backfill
 from app.services.summary_notifications import send_due_scheduled_summaries
 from app.services.support_sessions import support_session_from_request
 from app.services.webhook_events import deliver_due_webhooks
@@ -85,6 +86,7 @@ settings = get_settings()
 background_task = None
 dns_prewarm_task = None
 source_evidence_prewarm_task = None
+source_projection_backfill_task = None
 last_check_time = None
 
 
@@ -563,7 +565,8 @@ def _initialize_synthetic_load_data() -> None:
 
 def _start_background_tasks() -> None:
     """Start the mailbox scheduler and DNS prewarm tasks for this deployment mode."""
-    global background_task, dns_prewarm_task, source_evidence_prewarm_task  # pylint: disable=global-statement
+    global background_task, dns_prewarm_task, source_evidence_prewarm_task
+    global source_projection_backfill_task  # pylint: disable=global-statement
 
     if settings.DEMO_MODE and settings.PROVIDER_DEMO_ENABLED:
         logger.info("Skipping external mailbox polling for the relational provider demo")
@@ -573,6 +576,7 @@ def _start_background_tasks() -> None:
         background_task = asyncio.create_task(_scheduled_imap_polling_after_startup())
     dns_prewarm_task = asyncio.create_task(prewarm_dns_cache())
     source_evidence_prewarm_task = asyncio.create_task(scheduled_source_evidence_prewarm())
+    source_projection_backfill_task = asyncio.create_task(scheduled_source_projection_backfill())
 
 
 def create_app() -> FastAPI:
@@ -693,12 +697,18 @@ def create_app() -> FastAPI:
     @application.on_event("shutdown")
     async def shutdown_event():
         """Clean up background tasks on application shutdown"""
-        global dns_prewarm_task, source_evidence_prewarm_task  # pylint: disable=global-statement
+        global dns_prewarm_task, source_evidence_prewarm_task
+        global source_projection_backfill_task  # pylint: disable=global-statement
 
         await _cancel_background_task(dns_prewarm_task, "DNS prewarm")
         dns_prewarm_task = None
         await _cancel_background_task(source_evidence_prewarm_task, "sender evidence prewarm")
         source_evidence_prewarm_task = None
+        await _cancel_background_task(
+            source_projection_backfill_task,
+            "sender projection backfill",
+        )
+        source_projection_backfill_task = None
         if background_task:
             logger.info("Cancelling IMAP polling background task")
             background_task.cancel()
@@ -810,26 +820,23 @@ async def domains(request: Request):
 @app.get("/domain/{domain_id}", response_class=HTMLResponse)
 async def domain_details(request: Request, domain_id: str):
     """View detailed reports for a specific domain"""
-    store = ReportStore.get_instance()
     db = SessionLocal()
     try:
-        hydrate_report_store_from_db(db, store)
         stored_domain = db.query(Domain).filter(Domain.name == domain_id).first()
+        if stored_domain is None and domain_id.isdigit():
+            stored_domain = db.get(Domain, int(domain_id))
         source_window_setting = db.get(Setting, "general.source_date_window_days")
         source_window_days = str(source_window_setting.value or "30") if source_window_setting else "30"
         if source_window_days not in {"7", "30", "90"}:
             source_window_days = "30"
     finally:
         db.close()
-    known_domains = store.get_domains()
 
-    if domain_id not in known_domains and stored_domain is None:
+    if stored_domain is None:
         # Domain not found, redirect to domains list
         return templates.TemplateResponse(
             request, "domains.html", {"error": f"Domain {domain_id} not found"}
         )
-
-    domain_summary = store.get_domain_summary(domain_id) if domain_id in known_domains else {}
 
     return templates.TemplateResponse(
         request,
@@ -838,14 +845,10 @@ async def domain_details(request: Request, domain_id: str):
             "domain_id": domain_id,
             "source_window_days": source_window_days,
             "domain": {
-                "name": domain_id,
-                "description": stored_domain.description if stored_domain else "",
+                "name": stored_domain.name,
+                "description": stored_domain.description or "",
                 "mail_service_context": mail_service_context_from_domain(stored_domain),
-                "policy": (
-                    domain_summary.get("policy")
-                    or (stored_domain.dmarc_policy if stored_domain else None)
-                    or "unknown"
-                ),
+                "policy": stored_domain.dmarc_policy or "unknown",
             },
         },
     )

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -42,6 +42,7 @@ class DMARCReport(Base):
     report_extensions = Column(Text, nullable=True)
     processed_at = Column(DateTime, default=datetime.utcnow)
     raw_data = Column(Text, nullable=True)  # Original XML content (optional)
+    source_projection_at = Column(DateTime, nullable=True, index=True)
 
     # Relationships
     domain = relationship("Domain", back_populates="reports")
@@ -109,6 +110,49 @@ class ReportRecord(Base):
 
     def __repr__(self):
         return f"<ReportRecord {self.id} ({self.source_ip})>"
+
+
+class DomainSourceDailyProjection(Base):
+    """Read-optimized daily sender facts derived during report ingestion."""
+
+    __tablename__ = "domain_source_daily_projections"
+
+    id = Column(Integer, primary_key=True, index=True)
+    domain_id = Column(Integer, ForeignKey("domains.id"), nullable=False, index=True)
+    source_ip = Column(String, nullable=False, index=True)
+    observed_at = Column(Integer, nullable=False, index=True)
+    first_seen = Column(Integer, nullable=True)
+    last_seen = Column(Integer, nullable=True)
+    message_count = Column(Integer, nullable=False, default=0)
+    report_count = Column(Integer, nullable=False, default=0)
+    spf_pass_count = Column(Integer, nullable=False, default=0)
+    spf_fail_count = Column(Integer, nullable=False, default=0)
+    spf_unknown_count = Column(Integer, nullable=False, default=0)
+    dkim_pass_count = Column(Integer, nullable=False, default=0)
+    dkim_fail_count = Column(Integer, nullable=False, default=0)
+    dkim_unknown_count = Column(Integer, nullable=False, default=0)
+    dmarc_pass_count = Column(Integer, nullable=False, default=0)
+    dmarc_fail_count = Column(Integer, nullable=False, default=0)
+    disposition_counts = Column(Text, nullable=True)
+    metadata_json = Column(Text, nullable=True)
+    source_evidence = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "domain_id",
+            "source_ip",
+            "observed_at",
+            name="uq_domain_source_daily_projection",
+        ),
+        Index(
+            "ix_domain_source_daily_projection_window",
+            "domain_id",
+            "observed_at",
+            "source_ip",
+        ),
+    )
 
 
 class ForensicReport(Base):

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session, selectinload
 from app.core.config import get_settings, uses_legacy_demo_fixtures
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
+from app.services.source_read_projection import materialize_source_projection
 from app.models.workspace import Workspace
 from app.services.demo_data import seed_demo_report_store
 from app.services.organizations import require_organization_plan_limit
@@ -231,6 +232,13 @@ def save_parsed_report(
                 record_extensions=_json_or_none(record.get("extensions")),
             )
         )
+
+    materialize_source_projection(
+        db,
+        report,
+        domain_id=domain.id,
+        db_report=db_report,
+    )
 
     return db_report, True
 

--- a/backend/app/services/report_persistence.py
+++ b/backend/app/services/report_persistence.py
@@ -445,6 +445,102 @@ def domain_summaries_from_db(
     return summaries
 
 
+def domain_summary_from_db(db: Session, *, domain_id: int) -> Dict[str, Any]:
+    """Return one domain's report totals without hydrating report payloads."""
+    passed_count = func.coalesce(
+        func.sum(
+            case(
+                (
+                    or_(ReportRecord.dkim == "pass", ReportRecord.spf == "pass"),
+                    ReportRecord.count,
+                ),
+                else_=0,
+            )
+        ),
+        0,
+    )
+    total_count = func.coalesce(func.sum(ReportRecord.count), 0)
+    row = (
+        db.query(
+            func.count(distinct(DMARCReport.id)).label("reports_processed"),
+            total_count.label("total_count"),
+            passed_count.label("passed_count"),
+        )
+        .select_from(DMARCReport)
+        .outerjoin(ReportRecord, ReportRecord.report_id == DMARCReport.id)
+        .filter(DMARCReport.domain_id == domain_id)
+        .one()
+    )
+    total = int(row.total_count or 0)
+    passed = int(row.passed_count or 0)
+    return {
+        "total_count": total,
+        "passed_count": passed,
+        "failed_count": max(0, total - passed),
+        "reports_processed": int(row.reports_processed or 0),
+        "compliance_rate": round((passed / total) * 100, 1) if total else 0.0,
+    }
+
+
+def domain_reports_and_timeline_from_db(
+    db: Session,
+    *,
+    domain_id: int,
+    limit: int,
+) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Read recent reports and daily compliance evidence without a ReportStore."""
+    reports = (
+        db.query(DMARCReport)
+        .options(selectinload(DMARCReport.domain), selectinload(DMARCReport.records))
+        .filter(DMARCReport.domain_id == domain_id)
+        .order_by(DMARCReport.end_date.desc())
+        .limit(max(1, limit))
+        .all()
+    )
+    passed_count = func.coalesce(
+        func.sum(
+            case(
+                (
+                    or_(ReportRecord.dkim == "pass", ReportRecord.spf == "pass"),
+                    ReportRecord.count,
+                ),
+                else_=0,
+            )
+        ),
+        0,
+    )
+    total_count = func.coalesce(func.sum(ReportRecord.count), 0)
+    daily_rows = (
+        db.query(
+            DMARCReport.begin_date.label("begin_date"),
+            total_count.label("total_count"),
+            passed_count.label("passed_count"),
+        )
+        .outerjoin(ReportRecord, ReportRecord.report_id == DMARCReport.id)
+        .filter(DMARCReport.domain_id == domain_id)
+        .group_by(DMARCReport.begin_date)
+        .order_by(DMARCReport.begin_date.asc())
+        .all()
+    )
+    timeline = []
+    for row in daily_rows:
+        total = int(row.total_count or 0)
+        passed = int(row.passed_count or 0)
+        failed = max(0, total - passed)
+        timeline.append(
+            {
+                "date": _iso_from_timestamp(int(row.begin_date or 0))[:10],
+                "total": total,
+                "volume": total,
+                "passed": passed,
+                "failed": failed,
+                "compliance_rate": round((passed / total) * 100, 1) if total else 0.0,
+                "failure_rate": round((failed / total) * 100, 1) if total else 0.0,
+            }
+        )
+    return [persisted_report_to_dict(report) for report in reports], timeline
+
+
 def delete_persisted_report(
     db: Session,
     domain_name: str,

--- a/backend/app/services/sender_intelligence.py
+++ b/backend/app/services/sender_intelligence.py
@@ -771,6 +771,7 @@ def identify_sender(
     *,
     hostname: Optional[str] = None,
     domain: Optional[str] = None,
+    ptr_lookup_pending: bool = False,
 ) -> Dict[str, Any]:
     """Return a named sender identity for a source row.
 
@@ -827,7 +828,7 @@ def identify_sender(
     dmarc_failed = (
         int(source.get("dmarc_fail_count", 0) or 0) > 0 or source.get("dmarc_result") == "fail"
     )
-    if dmarc_failed and not hostname:
+    if dmarc_failed and not hostname and not ptr_lookup_pending:
         status = "suspicious"
         reason = "DMARC failures came from a source without reverse DNS."
     elif dmarc_failed:

--- a/backend/app/services/source_evidence_prewarm.py
+++ b/backend/app/services/source_evidence_prewarm.py
@@ -17,6 +17,7 @@ from app.models.report import DMARCReport, ReportRecord
 from app.services.dns_resolver import get_default_provider
 from app.services.ptr_lookup import PtrLookupResult, lookup_ptr_with_fallbacks
 from app.services.source_network import SourceNetworkIntelligence, lookup_sources_network_cached
+from app.services.source_read_projection import sync_source_projection_evidence
 from app.services.source_reputation_feeds import (
     lookup_sources_reputation_cached,
     providers_from_settings,
@@ -200,6 +201,7 @@ async def prewarm_source_evidence() -> int:
             ):
                 changed_rows.append(row)
         if changed_rows:
+            sync_source_projection_evidence(db, changed_rows)
             db.commit()
     except asyncio.CancelledError:
         raise

--- a/backend/app/services/source_read_projection.py
+++ b/backend/app/services/source_read_projection.py
@@ -1,0 +1,462 @@
+"""Ingestion-time sender facts used by fast domain read paths."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from sqlalchemy.orm import Session, selectinload
+
+from app.core.config import get_settings
+from app.core.database import SessionLocal
+from app.models.report import DMARCReport, DomainSourceDailyProjection, ReportRecord
+
+logger = logging.getLogger(__name__)
+
+
+def _int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _json_dict(value: str | None) -> Dict[str, Any]:
+    if not value:
+        return {}
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _json_list(value: str | None) -> List[Dict[str, Any]]:
+    if not value:
+        return []
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return []
+    return [item for item in parsed if isinstance(item, dict)] if isinstance(parsed, list) else []
+
+
+def _add_unique(values: List[str], value: Any) -> None:
+    text = str(value or "").strip()
+    if text and text not in values:
+        values.append(text)
+
+
+def _record_metadata(record: Dict[str, Any]) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {
+        "header_from_domains": [],
+        "envelope_from_domains": [],
+        "spf_domains": [],
+        "dkim_domains": [],
+        "dkim_selectors": [],
+        "extensions": {},
+    }
+    _add_unique(metadata["header_from_domains"], record.get("header_from"))
+    _add_unique(metadata["envelope_from_domains"], record.get("envelope_from"))
+    for item in record.get("spf") or []:
+        if isinstance(item, dict):
+            _add_unique(metadata["spf_domains"], item.get("domain"))
+    for item in record.get("dkim") or []:
+        if isinstance(item, dict):
+            _add_unique(metadata["dkim_domains"], item.get("domain"))
+            _add_unique(metadata["dkim_selectors"], item.get("selector"))
+    for key, value in (record.get("extensions") or {}).items():
+        if value is not None:
+            metadata["extensions"][str(key)] = str(value)
+    return metadata
+
+
+def _merge_metadata(current: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[str, Any]:
+    merged = {
+        "header_from_domains": list(current.get("header_from_domains") or []),
+        "envelope_from_domains": list(current.get("envelope_from_domains") or []),
+        "spf_domains": list(current.get("spf_domains") or []),
+        "dkim_domains": list(current.get("dkim_domains") or []),
+        "dkim_selectors": list(current.get("dkim_selectors") or []),
+        "extensions": dict(current.get("extensions") or {}),
+    }
+    for key in (
+        "header_from_domains",
+        "envelope_from_domains",
+        "spf_domains",
+        "dkim_domains",
+        "dkim_selectors",
+    ):
+        for value in incoming.get(key) or []:
+            _add_unique(merged[key], value)
+    for key, value in (incoming.get("extensions") or {}).items():
+        merged["extensions"].setdefault(str(key), str(value))
+    return merged
+
+
+def _projection_records(records: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    grouped: Dict[str, Dict[str, Any]] = {}
+    for record in records:
+        ip = str(record.get("source_ip") or "unknown")
+        item = grouped.setdefault(
+            ip,
+            {
+                "message_count": 0,
+                "spf_pass_count": 0,
+                "spf_fail_count": 0,
+                "spf_unknown_count": 0,
+                "dkim_pass_count": 0,
+                "dkim_fail_count": 0,
+                "dkim_unknown_count": 0,
+                "dmarc_pass_count": 0,
+                "dmarc_fail_count": 0,
+                "disposition_counts": defaultdict(int),
+                "metadata": _record_metadata({}),
+                "source_evidence": {},
+                "captured_at": "",
+            },
+        )
+        count = _int(record.get("count"))
+        item["message_count"] += count
+        spf = str(record.get("spf_result") or record.get("spf") or "unknown").lower()
+        dkim = str(record.get("dkim_result") or record.get("dkim") or "unknown").lower()
+        item[f"spf_{spf if spf in {'pass', 'fail'} else 'unknown'}_count"] += count
+        item[f"dkim_{dkim if dkim in {'pass', 'fail'} else 'unknown'}_count"] += count
+        item["dmarc_pass_count" if spf == "pass" or dkim == "pass" else "dmarc_fail_count"] += count
+        item["disposition_counts"][str(record.get("disposition") or "none").lower()] += count
+        item["metadata"] = _merge_metadata(item["metadata"], _record_metadata(record))
+        evidence = record.get("source_evidence") or {}
+        captured_at = str(evidence.get("captured_at") or "") if isinstance(evidence, dict) else ""
+        if isinstance(evidence, dict) and evidence and captured_at >= item["captured_at"]:
+            item["source_evidence"] = evidence
+            item["captured_at"] = captured_at
+    return grouped
+
+
+def _observation_window(report: Dict[str, Any]) -> tuple[int, int, int]:
+    begin = _int(report.get("begin_timestamp") or report.get("begin_date"))
+    end = _int(report.get("end_timestamp") or report.get("end_date"))
+    observed_at = end or begin
+    return begin or observed_at, end or observed_at, observed_at - (observed_at % 86_400)
+
+
+def materialize_source_projection(
+    db: Session,
+    report: Dict[str, Any],
+    *,
+    domain_id: int,
+    db_report: DMARCReport,
+) -> None:
+    """Upsert sender facts for a newly persisted aggregate report."""
+    first_seen, last_seen, observed_at = _observation_window(report)
+    for source_ip, values in _projection_records(report.get("records") or []).items():
+        projection = (
+            db.query(DomainSourceDailyProjection)
+            .filter(
+                DomainSourceDailyProjection.domain_id == domain_id,
+                DomainSourceDailyProjection.source_ip == source_ip,
+                DomainSourceDailyProjection.observed_at == observed_at,
+            )
+            .first()
+        )
+        if projection is None:
+            projection = DomainSourceDailyProjection(
+                domain_id=domain_id,
+                source_ip=source_ip,
+                observed_at=observed_at,
+                first_seen=first_seen,
+                last_seen=last_seen,
+            )
+            db.add(projection)
+        else:
+            projection.first_seen = min(_int(projection.first_seen) or first_seen, first_seen)
+            projection.last_seen = max(_int(projection.last_seen), last_seen)
+
+        projection.message_count = _int(projection.message_count) + values["message_count"]
+        projection.report_count = _int(projection.report_count) + 1
+        for field in (
+            "spf_pass_count",
+            "spf_fail_count",
+            "spf_unknown_count",
+            "dkim_pass_count",
+            "dkim_fail_count",
+            "dkim_unknown_count",
+            "dmarc_pass_count",
+            "dmarc_fail_count",
+        ):
+            setattr(projection, field, _int(getattr(projection, field)) + values[field])
+        dispositions = _json_dict(projection.disposition_counts)
+        for name, count in values["disposition_counts"].items():
+            dispositions[name] = _int(dispositions.get(name)) + count
+        projection.disposition_counts = json.dumps(dispositions, sort_keys=True)
+        projection.metadata_json = json.dumps(
+            _merge_metadata(_json_dict(projection.metadata_json), values["metadata"]),
+            sort_keys=True,
+        )
+        if values["source_evidence"]:
+            projection.source_evidence = json.dumps(values["source_evidence"], sort_keys=True)
+
+    db_report.source_projection_at = datetime.utcnow()
+
+
+def _persisted_record_payload(record: ReportRecord) -> Dict[str, Any]:
+    return {
+        "source_ip": record.source_ip,
+        "count": record.count,
+        "disposition": record.disposition,
+        "dkim_result": record.dkim,
+        "spf_result": record.spf,
+        "header_from": record.header_from,
+        "envelope_from": record.envelope_from,
+        "dkim": _json_list(record.dkim_auth_details),
+        "spf": _json_list(record.spf_auth_details),
+        "extensions": _json_dict(record.record_extensions),
+        "source_evidence": _json_dict(record.source_evidence),
+    }
+
+
+def backfill_source_projections(db: Session, *, limit: int = 100) -> int:
+    """Materialize a bounded batch of historic reports without UI read work."""
+    reports = (
+        db.query(DMARCReport)
+        .options(selectinload(DMARCReport.records))
+        .filter(DMARCReport.source_projection_at.is_(None))
+        .order_by(DMARCReport.end_date.asc())
+        .limit(max(1, limit))
+        .with_for_update(skip_locked=True)
+        .all()
+    )
+    for report in reports:
+        materialize_source_projection(
+            db,
+            {
+                "begin_timestamp": report.begin_date,
+                "end_timestamp": report.end_date,
+                "records": [_persisted_record_payload(record) for record in report.records],
+            },
+            domain_id=report.domain_id,
+            db_report=report,
+        )
+    return len(reports)
+
+
+def source_projection_is_complete(
+    db: Session,
+    *,
+    domain_id: int,
+    days: Optional[int],
+) -> bool:
+    """Return whether a selected source window has no unprojected reports."""
+    query = db.query(DMARCReport.id).filter(DMARCReport.domain_id == domain_id)
+    if days is not None:
+        cutoff = int(datetime.now(timezone.utc).timestamp()) - max(1, int(days)) * 86_400
+        query = query.filter(DMARCReport.end_date >= cutoff)
+    return query.filter(DMARCReport.source_projection_at.is_(None)).first() is None
+
+
+def _status(pass_count: int, fail_count: int, unknown_count: int = 0) -> str:
+    if pass_count and fail_count:
+        return "mixed"
+    if pass_count:
+        return "pass"
+    if fail_count:
+        return "fail"
+    return "unknown" if unknown_count else "none"
+
+
+def _dominant(counts: Dict[str, int]) -> str:
+    return max(counts.items(), key=lambda item: item[1])[0] if counts else "none"
+
+
+def load_domain_source_read_projection(
+    db: Session,
+    *,
+    domain_id: int,
+    domain_name: str,
+    days: Optional[int],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Return source rows and anomaly-ready daily evidence from stored facts."""
+    query = db.query(DomainSourceDailyProjection).filter(
+        DomainSourceDailyProjection.domain_id == domain_id
+    )
+    if days is not None:
+        cutoff = int(datetime.now(timezone.utc).timestamp()) - max(1, int(days)) * 86_400
+        query = query.filter(DomainSourceDailyProjection.observed_at >= cutoff)
+    rows = query.order_by(DomainSourceDailyProjection.observed_at.asc()).all()
+    sources: Dict[str, Dict[str, Any]] = {}
+    daily_records: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        ip = str(row.source_ip)
+        source = sources.setdefault(
+            ip,
+            {
+                "source_ip": ip,
+                "count": 0,
+                "spf_pass_count": 0,
+                "spf_fail_count": 0,
+                "spf_unknown_count": 0,
+                "dkim_pass_count": 0,
+                "dkim_fail_count": 0,
+                "dkim_unknown_count": 0,
+                "dmarc_pass_count": 0,
+                "dmarc_fail_count": 0,
+                "disposition_counts": {},
+                "first_seen": row.first_seen,
+                "last_seen": row.last_seen,
+                "active_days": 0,
+                "report_count": 0,
+                "volume_history": [],
+                "source_evidence": {},
+                "_metadata": _record_metadata({}),
+                "_active_dates": set(),
+                "_captured_at": "",
+            },
+        )
+        source["count"] += _int(row.message_count)
+        source["report_count"] += _int(row.report_count)
+        source["first_seen"] = min(
+            _int(source.get("first_seen")) or _int(row.first_seen),
+            _int(row.first_seen) or _int(source.get("first_seen")),
+        )
+        source["last_seen"] = max(_int(source.get("last_seen")), _int(row.last_seen))
+        for field in (
+            "spf_pass_count",
+            "spf_fail_count",
+            "spf_unknown_count",
+            "dkim_pass_count",
+            "dkim_fail_count",
+            "dkim_unknown_count",
+            "dmarc_pass_count",
+            "dmarc_fail_count",
+        ):
+            source[field] += _int(getattr(row, field))
+        for name, count in _json_dict(row.disposition_counts).items():
+            source["disposition_counts"][name] = _int(source["disposition_counts"].get(name)) + _int(
+                count
+            )
+        source["_metadata"] = _merge_metadata(
+            source["_metadata"], _json_dict(row.metadata_json)
+        )
+        evidence = _json_dict(row.source_evidence)
+        captured_at = str(evidence.get("captured_at") or "")
+        if evidence and captured_at >= source["_captured_at"]:
+            source["source_evidence"] = evidence
+            source["_captured_at"] = captured_at
+        bucket = datetime.fromtimestamp(row.observed_at, tz=timezone.utc).date().isoformat()
+        source["_active_dates"].add(bucket)
+        source["volume_history"].append(
+            {
+                "date": bucket,
+                "count": _int(row.message_count),
+                "passed": _int(row.dmarc_pass_count),
+                "failed": _int(row.dmarc_fail_count),
+            }
+        )
+        if _int(row.dmarc_pass_count):
+            daily_records[row.observed_at].append(
+                {
+                    "source_ip": ip,
+                    "count": _int(row.dmarc_pass_count),
+                    "dkim_result": "pass",
+                    "spf_result": "unknown",
+                }
+            )
+        if _int(row.dmarc_fail_count):
+            daily_records[row.observed_at].append(
+                {
+                    "source_ip": ip,
+                    "count": _int(row.dmarc_fail_count),
+                    "dkim_result": "fail",
+                    "spf_result": "fail",
+                }
+            )
+
+    source_rows = []
+    for source in sources.values():
+        source["active_days"] = len(source.pop("_active_dates"))
+        source["spf_result"] = _status(
+            source["spf_pass_count"], source["spf_fail_count"], source["spf_unknown_count"]
+        )
+        source["dkim_result"] = _status(
+            source["dkim_pass_count"], source["dkim_fail_count"], source["dkim_unknown_count"]
+        )
+        source["dmarc_result"] = _status(
+            source["dmarc_pass_count"], source["dmarc_fail_count"]
+        )
+        source["disposition"] = _dominant(source["disposition_counts"])
+        source.update(source.pop("_metadata"))
+        source.pop("_captured_at")
+        source_rows.append(source)
+
+    report_rows = [
+        {
+            "domain": domain_name,
+            "report_id": f"source-projection-{observed_at}",
+            "begin_timestamp": observed_at,
+            "end_timestamp": observed_at + 86_399,
+            "records": records,
+        }
+        for observed_at, records in daily_records.items()
+    ]
+    return source_rows, report_rows
+
+
+def sync_source_projection_evidence(db: Session, records: Iterable[ReportRecord]) -> None:
+    """Copy an imported record's point-in-time evidence into its daily fact."""
+    record_ids = [record.id for record in records if record.id is not None]
+    if not record_ids:
+        return
+    rows = (
+        db.query(ReportRecord, DMARCReport.domain_id, DMARCReport.end_date)
+        .join(DMARCReport, DMARCReport.id == ReportRecord.report_id)
+        .filter(ReportRecord.id.in_(record_ids))
+        .all()
+    )
+    for record, domain_id, end_date in rows:
+        if not record.source_evidence:
+            continue
+        observed_at = _int(end_date) - (_int(end_date) % 86_400)
+        projection = (
+            db.query(DomainSourceDailyProjection)
+            .filter(
+                DomainSourceDailyProjection.domain_id == domain_id,
+                DomainSourceDailyProjection.source_ip == record.source_ip,
+                DomainSourceDailyProjection.observed_at == observed_at,
+            )
+            .first()
+        )
+        if projection is not None:
+            projection.source_evidence = record.source_evidence
+
+
+async def scheduled_source_projection_backfill() -> None:
+    """Finish historic projection work outside operator-facing requests."""
+    settings = get_settings()
+    if not settings.SOURCE_READ_PROJECTION_BACKFILL_ENABLED:
+        return
+    await asyncio.sleep(5)
+    while True:
+        db = SessionLocal()
+        try:
+            projected = backfill_source_projections(
+                db,
+                limit=max(1, int(settings.SOURCE_READ_PROJECTION_BACKFILL_LIMIT)),
+            )
+            if projected:
+                db.commit()
+                logger.info("Materialized sender facts for %d historic report(s)", projected)
+            else:
+                db.rollback()
+        except asyncio.CancelledError:
+            db.rollback()
+            raise
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            db.rollback()
+            logger.warning("Sender projection backfill failed with %s", type(exc).__name__)
+        finally:
+            db.close()
+        await asyncio.sleep(max(30, int(settings.SOURCE_READ_PROJECTION_BACKFILL_INTERVAL_SECONDS)))

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -35,6 +35,7 @@ from app.services.source_reputation import (
     ReputationEvidence,
     SourceReputation,
 )
+from app.services.source_read_projection import sync_source_projection_evidence
 from app.services.webhook_events import (
     EVENT_REMEDIATION_APPROVAL_REQUIRED,
     create_webhook_endpoint,
@@ -3190,6 +3191,7 @@ def test_get_domain_sources_prefers_ingestion_evidence_over_live_lookup(
             },
         }
     )
+    sync_source_projection_evidence(db_session, saved.records)
     db_session.commit()
 
     async def reject_snapshot_ptr(_provider, ip, timeout=1.5):
@@ -3346,7 +3348,7 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
     assert intelligence.json()["summary"]["messages"] == 4
     assert reputation.status_code == 200
     assert reputation.json()["domain"] == "fast-sources.example"
-    assert hydrated_windows == [3650, 3650, 3650]
+    assert hydrated_windows == []
 
 
 def test_source_recommendations_cover_common_cases():
@@ -3671,6 +3673,7 @@ def test_source_reads_hydrate_only_the_selected_window(
         return original_hydrate(*args, **kwargs)
 
     monkeypatch.setattr(domains_endpoint, "hydrate_domain_report_store_from_db", track_hydrate)
+    monkeypatch.setattr(domains_endpoint, "source_projection_is_complete", lambda *_args, **_kwargs: False)
 
     sources_response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=90")
     intelligence_response = seeded_client.get(

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2814,7 +2814,7 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
     }
     ReportStore.get_instance().add_report(report)
 
-    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources")
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources?refresh=true")
 
     assert response.status_code == 200
     source = response.json()["sources"][0]
@@ -2904,7 +2904,7 @@ def test_get_domain_sources_returns_recommendations(
     }
     ReportStore.get_instance().add_report(report)
 
-    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources")
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources?refresh=true")
 
     assert response.status_code == 200
     source = response.json()["sources"][0]
@@ -2954,7 +2954,7 @@ def test_get_domain_sources_returns_sender_identity(
     }
     ReportStore.get_instance().add_report(report)
 
-    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources")
+    response = authed_client.get(f"/api/v1/domains/{DOMAIN}/sources?refresh=true")
 
     assert response.status_code == 200
     source = response.json()["sources"][0]
@@ -3033,7 +3033,7 @@ def test_get_domain_source_intelligence_unknown_domain_returns_404(
 def test_get_domain_sources_includes_geo_and_anomaly_hints(seeded_client: TestClient):
     """Source rows carry coarse geo data and anomaly recommendations."""
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650&refresh=true")
 
     assert response.status_code == 200
     source = next(item for item in response.json()["sources"] if item["anomalies"])
@@ -3130,7 +3130,7 @@ def test_get_domain_sources_includes_ip_intelligence_and_reputation(
     report_persistence.save_parsed_report(db_session, report, workspace_id=workspace.id)
     db_session.commit()
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650&refresh=true")
 
     assert response.status_code == 200
     source = next(item for item in response.json()["sources"] if item["ip"] == source_ip)
@@ -3659,6 +3659,27 @@ def test_get_domain_sources_days_param_accepted(seeded_client: TestClient):
     """The 'days' query parameter is accepted without raising a TypeError."""
     response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=7")
     assert response.status_code == 200
+
+
+def test_default_source_reads_do_not_trigger_live_enrichment(
+    seeded_client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Normal operator reads use stored evidence and never wait on external providers."""
+
+    async def fail_live_lookup(*_args, **_kwargs):
+        raise AssertionError("normal source reads must not call a live enrichment provider")
+
+    monkeypatch.setattr(domains_endpoint, "_safe_ptr_lookup_result", fail_live_lookup)
+    monkeypatch.setattr(domains_endpoint, "lookup_sources_network_cached", fail_live_lookup)
+    monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fail_live_lookup)
+
+    sources = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650")
+    intelligence = seeded_client.get(
+        f"/api/v1/domains/{DOMAIN}/source-intelligence?days=3650"
+    )
+
+    assert sources.status_code == 200
+    assert intelligence.status_code == 200
 
 
 def test_source_reads_hydrate_only_the_selected_window(

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -18,7 +18,7 @@ from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
 from app.models.organization import Entitlement, Organization
-from app.models.report import DMARCReport, ReportRecord
+from app.models.report import DMARCReport, DomainSourceDailyProjection, ReportRecord
 from app.models.user import User
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceMembership
@@ -26,6 +26,7 @@ from app.services.organizations import OrganizationPlanLimitError
 from app.services.ptr_lookup import PtrLookupResult
 from app.services.report_persistence import persisted_report_to_dict, save_parsed_report
 from app.services.report_store import ReportStore
+from app.services.source_read_projection import backfill_source_projections
 from app.services.source_network import SourceNetworkIntelligence
 from app.services.source_reputation import DomainReputation, ReputationEvidence, SourceReputation
 from app.services.workspace_access import ROLE_ANALYST
@@ -85,6 +86,69 @@ def _parsed_report(
             }
         ],
     }
+
+
+def test_save_parsed_report_materializes_daily_sender_facts(db_session):
+    """A new report creates a bounded sender read model during ingestion."""
+    workspace = get_or_create_default_workspace(db_session)
+    report = _parsed_report(domain="projection.example", report_id="projection-report", count=7)
+    report["records"].append(
+        {
+            "source_ip": "192.0.2.55",
+            "count": 3,
+            "disposition": "reject",
+            "dkim_result": "fail",
+            "spf_result": "fail",
+            "header_from": "projection.example",
+        }
+    )
+
+    saved, created = save_parsed_report(db_session, report, workspace_id=workspace.id)
+    db_session.commit()
+
+    projection = db_session.query(DomainSourceDailyProjection).one()
+    assert created is True
+    assert saved.source_projection_at is not None
+    assert projection.source_ip == "192.0.2.55"
+    assert projection.message_count == 10
+    assert projection.report_count == 1
+    assert projection.dmarc_pass_count == 7
+    assert projection.dmarc_fail_count == 3
+    assert json.loads(projection.disposition_counts) == {"none": 7, "reject": 3}
+
+
+def test_projection_backfill_materializes_unprojected_reports(db_session):
+    """Historic rows can be migrated without a dashboard request doing the work."""
+    workspace = get_or_create_default_workspace(db_session)
+    domain = Domain(name="projection-backfill.example", workspace_id=workspace.id, active=True)
+    db_session.add(domain)
+    db_session.flush()
+    report = DMARCReport(
+        domain_id=domain.id,
+        report_id="projection-backfill-report",
+        org_name="receiver.example",
+        begin_date=1_704_067_200,
+        end_date=1_704_153_599,
+    )
+    db_session.add(report)
+    db_session.flush()
+    db_session.add(
+        ReportRecord(
+            report_id=report.id,
+            source_ip="192.0.2.77",
+            count=11,
+            disposition="none",
+            dkim="pass",
+            spf="pass",
+        )
+    )
+    db_session.commit()
+
+    assert backfill_source_projections(db_session, limit=10) == 1
+    db_session.commit()
+
+    assert db_session.query(DomainSourceDailyProjection).count() == 1
+    assert db_session.get(DMARCReport, report.id).source_projection_at is not None
 
 
 def _add_user(db_session, email: str, *, is_superuser: bool = False) -> User:

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -315,6 +315,9 @@ answer "is this IP listed or risky according to a configured provider?"
 | `SOURCE_EVIDENCE_PREWARM_CONCURRENCY` | Maximum concurrent PTR/network lookups in one background cycle. | `8` | `12` |
 | `SOURCE_EVIDENCE_PREWARM_TIMEOUT_SECONDS` | Total network-enrichment budget for one background cycle. | `20` | `30` |
 | `SOURCE_EVIDENCE_PREWARM_INTERVAL_SECONDS` | Delay between background cycles. Values below 30 seconds are clamped. | `300` | `600` |
+| `SOURCE_READ_PROJECTION_BACKFILL_ENABLED` | Build indexed sender read facts for historic reports outside operator requests. New imports are projected synchronously. | `true` | `false` |
+| `SOURCE_READ_PROJECTION_BACKFILL_LIMIT` | Maximum historic reports projected in one background cycle. | `100` | `500` |
+| `SOURCE_READ_PROJECTION_BACKFILL_INTERVAL_SECONDS` | Delay between sender-projection batches. Values below 30 seconds are clamped. | `30` | `300` |
 | `GEOIP_CUSTOM_URL` | Optional operator-controlled GeoIP HTTP URL template. It must contain `{ip}`, for example `https://geoip.internal/v1/lookup?ip={ip}`. When set, DMARQ uses only this endpoint for sender-IP enrichment. | - | `https://geoip.internal/v1/lookup?ip={ip}` |
 | `GEOIP_CUSTOM_AUTH_HEADER` | Optional single request header for the custom provider, written as `Header-Name: value`. | - | `Authorization: Bearer op://...` |
 | `GEOIP_CUSTOM_TIMEOUT_SECONDS` | Custom GeoIP provider timeout. | `2` | `2` |


### PR DESCRIPTION
## What changed

- Materializes daily Domain + sender-IP facts during aggregate-report ingestion.
- Backfills existing reports in resumable, bounded background batches.
- Mirrors import-time PTR/network/reputation snapshots into the sender read model.
- Switches Sending Sources, source intelligence, domain stats, reports/timeline, and the domain page to projections or direct indexed reads where available.
- Keeps ordinary sender reads free of live enrichment calls; explicit refresh remains the only live evidence action.

## Why

Normal DMARQ navigation must read prepared evidence, not rebuild report history or wait for external enrichment providers. Raw reports remain the audit source of truth; these are derived, rebuildable read models.

## Validation

- 192 focused API, timeline, source-evidence, and report tests passed.
- Fresh SQLite migration upgrade verified the projection table and indexes.

Depends on #850. Fixes #849.