### PR TITLE
fix: serialize sender projection writers

### DIFF
--- a/backend/app/services/source_read_projection.py
+++ b/backend/app/services/source_read_projection.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+from sqlalchemy import text
 from sqlalchemy.orm import Session, selectinload
 
 from app.core.config import get_settings
@@ -16,6 +17,21 @@ from app.core.database import SessionLocal
 from app.models.report import DMARCReport, DomainSourceDailyProjection, ReportRecord
 
 logger = logging.getLogger(__name__)
+
+# The daily projection key spans reports, so locking individual report rows is
+# insufficient when two workers handle reports for the same sender/day.
+_SOURCE_PROJECTION_ADVISORY_LOCK_KEY = 1_144_591_954
+
+
+def _acquire_source_projection_write_lock(db: Session) -> None:
+    """Serialize PostgreSQL projection writers while preserving SQLite support."""
+    bind = db.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    db.execute(
+        text("SELECT pg_advisory_xact_lock(:lock_key)"),
+        {"lock_key": _SOURCE_PROJECTION_ADVISORY_LOCK_KEY},
+    )
 
 
 def _int(value: Any) -> int:
@@ -152,6 +168,7 @@ def materialize_source_projection(
     db_report: DMARCReport,
 ) -> None:
     """Upsert sender facts for a newly persisted aggregate report."""
+    _acquire_source_projection_write_lock(db)
     first_seen, last_seen, observed_at = _observation_window(report)
     for source_ip, values in _projection_records(report.get("records") or []).items():
         projection = (

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -27,6 +27,7 @@ from app.services.ptr_lookup import PtrLookupResult
 from app.services.report_persistence import persisted_report_to_dict, save_parsed_report
 from app.services.report_store import ReportStore
 from app.services.source_read_projection import (
+    _acquire_source_projection_write_lock,
     backfill_source_projections,
     load_domain_source_read_projection,
 )
@@ -152,6 +153,32 @@ def test_projection_backfill_materializes_unprojected_reports(db_session):
 
     assert db_session.query(DomainSourceDailyProjection).count() == 1
     assert db_session.get(DMARCReport, report.id).source_projection_at is not None
+
+
+def test_projection_write_lock_serializes_postgres_writers():
+    """Production writers use one transaction-scoped lock for daily aggregates."""
+
+    class FakeSession:
+        def __init__(self, dialect_name):
+            self._bind = SimpleNamespace(dialect=SimpleNamespace(name=dialect_name))
+            self.calls = []
+
+        def get_bind(self):
+            return self._bind
+
+        def execute(self, statement, params):
+            self.calls.append((str(statement), params))
+
+    postgres = FakeSession("postgresql")
+    _acquire_source_projection_write_lock(postgres)
+
+    assert len(postgres.calls) == 1
+    assert "pg_advisory_xact_lock" in postgres.calls[0][0]
+
+    sqlite = FakeSession("sqlite")
+    _acquire_source_projection_write_lock(sqlite)
+
+    assert sqlite.calls == []
 
 
 def test_projection_window_uses_report_end_time(db_session, monkeypatch):

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -30,6 +30,7 @@ from app.services.source_read_projection import (
     _acquire_source_projection_write_lock,
     backfill_source_projections,
     load_domain_source_read_projection,
+    materialize_source_projection,
 )
 from app.services.source_network import SourceNetworkIntelligence
 from app.services.source_reputation import DomainReputation, ReputationEvidence, SourceReputation
@@ -158,6 +159,18 @@ def test_projection_backfill_materializes_unprojected_reports(db_session):
 def test_projection_write_lock_serializes_postgres_writers():
     """Production writers use one transaction-scoped lock for daily aggregates."""
 
+    class FakeQuery:
+        def __init__(self, session):
+            self.session = session
+
+        def filter(self, *_args):
+            self.session.calls.append(("filter", None))
+            return self
+
+        def first(self):
+            self.session.calls.append(("first", None))
+            return None
+
     class FakeSession:
         def __init__(self, dialect_name):
             self._bind = SimpleNamespace(dialect=SimpleNamespace(name=dialect_name))
@@ -169,11 +182,30 @@ def test_projection_write_lock_serializes_postgres_writers():
         def execute(self, statement, params):
             self.calls.append((str(statement), params))
 
+        def query(self, *_args):
+            self.calls.append(("query", None))
+            return FakeQuery(self)
+
+        def add(self, *_args):
+            self.calls.append(("add", None))
+
     postgres = FakeSession("postgresql")
     _acquire_source_projection_write_lock(postgres)
 
     assert len(postgres.calls) == 1
     assert "pg_advisory_xact_lock" in postgres.calls[0][0]
+
+    db_report = DMARCReport()
+    materialize_source_projection(
+        postgres,
+        _parsed_report(domain="projection-lock.example", report_id="projection-lock-report"),
+        domain_id=42,
+        db_report=db_report,
+    )
+
+    materialize_calls = postgres.calls[1:]
+    assert "pg_advisory_xact_lock" in materialize_calls[0][0]
+    assert ("query", None) in materialize_calls
 
     sqlite = FakeSession("sqlite")
     _acquire_source_projection_write_lock(sqlite)


### PR DESCRIPTION
Closes #854

## Fix
- Serialize PostgreSQL sender-projection materialization with a transaction-scoped advisory lock.
- Cover both ingestion and historic backfill because they share the same materialization function.
- Keep SQLite self-hosted installs unchanged.

## Validation
- `pytest backend/app/tests/test_reports_api.py -q --disable-warnings` (53 passed)
- Focused Flake8 and diff validation passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of daily source reporting when multiple background processes update the same data simultaneously.
  * Prevented conflicting concurrent updates that could result in inconsistent projections.

* **Tests**
  * Added coverage verifying synchronized writes on PostgreSQL and compatible behavior on other database types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->