### PR TITLE
fix: render projected data in domain details

### DIFF
--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -452,12 +452,15 @@ function domainDetailsApp(domainId = '') {
         },
 
         async loadInitialData() {
-            await Promise.allSettled([
-                this.fetchDomainStats(),
-                this.fetchReports(),
+            const projectedDataLoads = Promise.allSettled([
                 this.fetchSources({ preserveOnFailure: true }),
                 this.fetchSourceIntelligence({ preserveOnFailure: true })
             ]);
+            await Promise.allSettled([
+                this.fetchDomainStats(),
+                this.fetchReports()
+            ]);
+            void projectedDataLoads;
 
             window.setTimeout(() => {
                 Promise.allSettled([
@@ -3161,12 +3164,7 @@ function domainDetailsApp(domainId = '') {
                 this.lastComplianceTimeline = Array.isArray(data.compliance_timeline)
                     ? data.compliance_timeline
                     : [];
-                try {
-                    this.initComplianceChart(this.lastComplianceTimeline);
-                } catch (chartError) {
-                    // Report rows remain useful even when an optional chart cannot render.
-                    console.error('Error rendering compliance chart:', chartError);
-                }
+                this.renderComplianceChartSafely(this.lastComplianceTimeline);
             } catch (error) {
                 this.reports = [];
                 this.reportsError = error.message || 'Recent reports could not be loaded.';
@@ -3182,7 +3180,16 @@ function domainDetailsApp(domainId = '') {
             this.volumeScale = scale;
             this.persistVolumeScale(scale);
             if (this.lastComplianceTimeline.length) {
-                this.initComplianceChart(this.lastComplianceTimeline);
+                this.renderComplianceChartSafely(this.lastComplianceTimeline);
+            }
+        },
+
+        renderComplianceChartSafely(timeline) {
+            try {
+                this.initComplianceChart(timeline);
+            } catch (chartError) {
+                // Report rows remain useful even when an optional chart cannot render.
+                console.error('Error rendering compliance chart:', chartError);
             }
         },
 
@@ -3269,7 +3276,9 @@ function domainDetailsApp(domainId = '') {
                     ...data,
                     regions: Array.isArray(data.regions) ? data.regions : [],
                     anomalies: Array.isArray(data.anomalies) ? data.anomalies : [],
-                    summary: data.summary && typeof data.summary === 'object' ? data.summary : {},
+                    summary: data.summary && typeof data.summary === 'object' && !Array.isArray(data.summary)
+                        ? data.summary
+                        : {},
                     loading: false,
                     error: ''
                 };

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -182,7 +182,9 @@ function domainDetailsApp(domainId = '') {
         reportsLoading: true,
         reportsError: '',
         sources: [],
-        sourcesLoading: false,
+        // Keep the sender panel in a loading state until the first projection read settles.
+        // Otherwise a slow but successful first response is briefly presented as an empty domain.
+        sourcesLoading: true,
         sourcesError: '',
         sourceReputationRefreshing: false,
         sourceReputationRefreshError: '',
@@ -452,10 +454,7 @@ function domainDetailsApp(domainId = '') {
         async loadInitialData() {
             await Promise.allSettled([
                 this.fetchDomainStats(),
-                this.fetchReports()
-            ]);
-
-            Promise.allSettled([
+                this.fetchReports(),
                 this.fetchSources({ preserveOnFailure: true }),
                 this.fetchSourceIntelligence({ preserveOnFailure: true })
             ]);
@@ -3158,9 +3157,16 @@ function domainDetailsApp(domainId = '') {
                     throw new Error(detail || 'Recent reports could not be loaded.');
                 }
                 const data = await response.json();
-                this.reports = data.reports || [];
-                this.lastComplianceTimeline = data.compliance_timeline || [];
-                this.initComplianceChart(data.compliance_timeline);
+                this.reports = Array.isArray(data.reports) ? data.reports : [];
+                this.lastComplianceTimeline = Array.isArray(data.compliance_timeline)
+                    ? data.compliance_timeline
+                    : [];
+                try {
+                    this.initComplianceChart(this.lastComplianceTimeline);
+                } catch (chartError) {
+                    // Report rows remain useful even when an optional chart cannot render.
+                    console.error('Error rendering compliance chart:', chartError);
+                }
             } catch (error) {
                 this.reports = [];
                 this.reportsError = error.message || 'Recent reports could not be loaded.';
@@ -3223,7 +3229,8 @@ function domainDetailsApp(domainId = '') {
                     throw new Error(detail || 'Sending sources could not be loaded.');
                 }
                 const data = await response.json();
-                this.sources = (data.sources || []).map(source => this.normalizeSource(source));
+                this.sources = (Array.isArray(data.sources) ? data.sources : [])
+                    .map(source => this.normalizeSource(source));
                 this.sourceReputationRefreshError = '';
             } catch (error) {
                 const hasExistingSources = (this.sources || []).length > 0;
@@ -3260,6 +3267,9 @@ function domainDetailsApp(domainId = '') {
                 const data = await response.json();
                 this.sourceIntelligence = {
                     ...data,
+                    regions: Array.isArray(data.regions) ? data.regions : [],
+                    anomalies: Array.isArray(data.anomalies) ? data.anomalies : [],
+                    summary: data.summary && typeof data.summary === 'object' ? data.summary : {},
                     loading: false,
                     error: ''
                 };

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -7,6 +7,7 @@
 
 {% block content %}
 <div class="space-y-6" x-data="domainDetailsApp" data-domain-detail-page data-domain-id="{{ domain_id }}" data-source-window-days="{{ source_window_days }}">
+    <div>
     <nav class="text-sm text-[#5f5c78]">
         <ol class="flex items-center space-x-2">
             <li><a href="/" class="font-semibold hover:text-[#2f9da5]">Dashboard</a></li>
@@ -2344,9 +2345,6 @@
                                 </div>
                             </div>
                         </template>
-                    </div>
-                </div>
-            </div>
             {% endcall %}
         {% endcall %}
         </section>
@@ -3002,6 +3000,7 @@
         </section>
         </details>
     </div>
+</div>
 </div>
 {% endblock %}
 

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -335,6 +335,23 @@ const domainSources = {
   ],
 };
 
+const domainSourceIntelligence = {
+  domain: 'cklnet.com',
+  period_days: 30,
+  recent_days: 14,
+  regions: [
+    {
+      region: 'Europe',
+      country_codes: ['DE'],
+      source_count: 1,
+      message_count: 137,
+      failure_rate: 5.1,
+    },
+  ],
+  anomalies: [],
+  summary: { sources: 2, anomalies: 0 },
+};
+
 const dnsCached = {
   dmarc: true,
   dmarcRecord: 'v=DMARC1; p=reject; rua=mailto:dmarc@cklnet.com',
@@ -618,6 +635,7 @@ async function installApiMocks(page) {
       },
       '/api/v1/domains/cklnet.com/reports': domainReports,
       '/api/v1/domains/cklnet.com/sources': domainSources,
+      '/api/v1/domains/cklnet.com/source-intelligence': domainSourceIntelligence,
       '/api/v1/domains/cklnet.com/dns': dnsCached,
       '/api/v1/domains/cklnet.com/dns/health': {
         status: 'warning',
@@ -1174,7 +1192,7 @@ test('domain detail shows cached DNS evidence and sender reputation context', as
 
   await expect(page.getByRole('heading', { name: 'cklnet.com' })).toBeVisible();
   const dnsEvidence = page.locator('details', {
-    has: page.locator('summary', { hasText: 'DNS and authentication' }),
+    has: page.locator('summary', { hasText: 'Email authentication and DNS fixes' }),
   });
   await dnsEvidence.locator(':scope > summary').click();
   await expect(dnsEvidence.getByText('TXT lookup timed out; showing cached DNS evidence')).toBeVisible();
@@ -1184,6 +1202,7 @@ test('domain detail shows cached DNS evidence and sender reputation context', as
   });
   await sourceIntelligence.locator(':scope > summary').click();
   await expect(sourceIntelligence.getByRole('heading', { name: 'Source Intelligence' })).toBeVisible();
+  await expect(sourceIntelligence.getByText('Europe', { exact: true })).toBeVisible();
   const sendingSources = page.locator('details', {
     has: page.locator('summary', { hasText: 'Sending sources' }),
   });
@@ -1200,6 +1219,12 @@ test('domain detail shows cached DNS evidence and sender reputation context', as
   await expect(sendingSources.getByText('Fix DKIM on owned infrastructure').first()).toBeVisible();
   await expect(page.getByText('Sending sources could not be loaded.')).not.toBeVisible();
   await expect(page.getByText('No data available for this time period')).not.toBeVisible();
+  const recentReports = page.locator('details', {
+    has: page.locator('summary', { hasText: 'Reports' }),
+  });
+  await recentReports.locator(':scope > summary').click();
+  await expect(recentReports.getByRole('heading', { name: 'Recent Reports' })).toBeVisible();
+  await expect(recentReports.getByText('google.com').first()).toBeVisible();
 });
 
 test('reports list and aggregate detail keep source evidence actionable', async ({ page }) => {

--- a/backend/tests/browser/smoke_server.py
+++ b/backend/tests/browser/smoke_server.py
@@ -22,6 +22,8 @@ os.environ.setdefault("SOURCE_NETWORK_ENRICHMENT_ENABLED", "false")
 os.environ.setdefault("SOURCE_REPUTATION_FEEDS_ENABLED", "false")
 
 from app.main import app  # noqa: E402
+from app.core.database import SessionLocal  # noqa: E402
+from app.models.domain import Domain  # noqa: E402
 from app.services.report_store import ReportStore  # noqa: E402
 
 
@@ -95,6 +97,19 @@ def seed_store() -> None:
 
 
 seed_store()
+
+
+@app.on_event("startup")
+async def seed_persisted_domains() -> None:
+    """Persist page-route domains; API data stays mocked by the browser suite."""
+    db = SessionLocal()
+    try:
+        for name, policy in (("cklnet.com", "reject"), ("dmarq.org", "quarantine")):
+            if db.query(Domain).filter(Domain.name == name).first() is None:
+                db.add(Domain(name=name, dmarc_policy=policy, active=True))
+        db.commit()
+    finally:
+        db.close()
 
 
 if __name__ == "__main__":

--- a/backend/tests/browser/smoke_server.py
+++ b/backend/tests/browser/smoke_server.py
@@ -105,8 +105,12 @@ async def seed_persisted_domains() -> None:
     db = SessionLocal()
     try:
         for name, policy in (("cklnet.com", "reject"), ("dmarq.org", "quarantine")):
-            if db.query(Domain).filter(Domain.name == name).first() is None:
-                db.add(Domain(name=name, dmarc_policy=policy, active=True))
+            domain = db.query(Domain).filter(Domain.name == name).first()
+            if domain is None:
+                domain = Domain(name=name)
+                db.add(domain)
+            domain.dmarc_policy = policy
+            domain.active = True
         db.commit()
     finally:
         db.close()


### PR DESCRIPTION
Closes #857

## What changed
- keep the detail-page Alpine scope around Source Intelligence, Sending Sources, and Recent Reports
- wait for the initial projected sender reads and keep optional chart errors from hiding report rows
- normalize projected endpoint payloads before rendering
- add a browser regression covering the rendered region, sender, and report rows

## Validation
- `pytest backend/app/tests -q --disable-warnings --maxfail=1`
- targeted Playwright domain-detail flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented domain details pages from briefly displaying incomplete source data during loading.
  * Improved handling of missing or malformed reports, sources, and source intelligence data.
  * Ensured chart rendering errors do not prevent report information from appearing.
  * Corrected page layout structure around DNS change guidance.

* **Tests**
  * Expanded browser coverage for source intelligence regions and recent reports.
  * Improved smoke-test setup with persisted sample domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->