### PR TITLE
fix: honor plain IMAP mail source settings

### DIFF
--- a/backend/app/api/api_v1/endpoints/imap.py
+++ b/backend/app/api/api_v1/endpoints/imap.py
@@ -71,6 +71,7 @@ async def test_imap_connection(
         port=request.port,
         username=request.username,
         password=request.password,
+        use_ssl=request.ssl,
     )
 
     success, message, stats = imap_client.test_connection()

--- a/backend/app/api/api_v1/endpoints/mail_sources.py
+++ b/backend/app/api/api_v1/endpoints/mail_sources.py
@@ -1167,6 +1167,7 @@ def _fetch_imap_source(source: MailSource, db: Session, days: int) -> Dict[str, 
         username=source.username,
         password=source.password,
         folder=source.folder,
+        use_ssl=source.use_ssl,
         db=db,
         workspace_id=source.workspace_id,
     )
@@ -1881,6 +1882,7 @@ async def test_stored_mail_source(  # noqa: C901
         username=source.username,
         password=source.password,
         folder=source.folder,
+        use_ssl=source.use_ssl,
     )
     success, message, stats = imap_client.test_connection()
 
@@ -1917,6 +1919,7 @@ async def test_connection_adhoc(
         port=request.port,
         username=request.username,
         password=request.password,
+        use_ssl=request.ssl,
     )
     success, message, stats = imap_client.test_connection()
 

--- a/backend/app/services/imap_client.py
+++ b/backend/app/services/imap_client.py
@@ -36,6 +36,7 @@ class IMAPClient:
         password: str = None,
         delete_emails: Optional[bool] = None,
         folder: str = None,
+        use_ssl: bool = True,
         db: Any = None,
         workspace_id: Optional[int] = None,
     ):
@@ -50,6 +51,7 @@ class IMAPClient:
             delete_emails: Whether to delete emails after successful report imports.
                 If omitted, uses DELETE_IMPORTED_EMAILS from settings.
             folder: IMAP mailbox folder to read (if None, uses settings or INBOX)
+            use_ssl: Whether to connect with implicit SSL/TLS.
             db: Optional SQLAlchemy session used to persist imported reports
             workspace_id: Optional workspace that should own imported domains/reports
         """
@@ -67,6 +69,7 @@ class IMAPClient:
             configured_delete = False
         self.delete_emails = configured_delete if delete_emails is None else delete_emails
         self.folder = folder or settings_folder or "INBOX"
+        self.use_ssl = use_ssl
         self.db = db
         self.workspace_id = workspace_id
 
@@ -78,6 +81,11 @@ class IMAPClient:
     def _quoted_folder(self) -> str:
         escaped = self.folder.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{escaped}"'
+
+    def _connect(self) -> imaplib.IMAP4:
+        if self.use_ssl:
+            return imaplib.IMAP4_SSL(self.server, self.port)
+        return imaplib.IMAP4(self.server, self.port)
 
     @staticmethod
     def _mailbox_name_from_list_response(response: str) -> str:
@@ -137,7 +145,7 @@ class IMAPClient:
 
         try:
             # Create IMAP4 connection
-            mail = imaplib.IMAP4_SSL(self.server, self.port)
+            mail = self._connect()
             # Login
             mail.login(self.username, self.password)
 
@@ -183,6 +191,7 @@ class IMAPClient:
                 "available_mailboxes": available_mailboxes,
                 "server": self.server,
                 "port": self.port,
+                "ssl": self.use_ssl,
                 "timestamp": datetime.now().isoformat(),
             }
 
@@ -289,7 +298,7 @@ class IMAPClient:
 
         try:
             # Connect to the mail server
-            mail = imaplib.IMAP4_SSL(self.server, self.port)
+            mail = self._connect()
             mail.login(self.username, self.password)
             mail.select(self._quoted_folder())
 

--- a/backend/app/services/mail_source_backfill_worker.py
+++ b/backend/app/services/mail_source_backfill_worker.py
@@ -300,6 +300,7 @@ def run_imap_backfill_job(db: Session, job: MailSourceBackfillJob) -> bool:
             username=source.username,
             password=source.password,
             folder=source.folder,
+            use_ssl=source.use_ssl,
             db=db,
             workspace_id=source.workspace_id,
         )

--- a/backend/app/tests/test_imap_client.py
+++ b/backend/app/tests/test_imap_client.py
@@ -143,12 +143,14 @@ class TestIMAPClientInit:
                 username="user@example.com",
                 password="secret",
                 delete_emails=True,
+                use_ssl=False,
             )
         assert client.server == "custom.example.com"
         assert client.port == 143
         assert client.username == "user@example.com"
         assert client.password == "secret"
         assert client.delete_emails is True
+        assert client.use_ssl is False
 
     def test_delete_emails_defaults_to_settings(self):
         settings = SimpleNamespace(
@@ -305,7 +307,33 @@ class TestTestConnection:
         assert "successful" in message.lower()
         assert stats["message_count"] == 10
         assert "INBOX" in stats["available_mailboxes"]
+        assert stats["ssl"] is True
         assert stats["dmarc_count_strategy"] == "common_provider_subjects"
+
+    def test_connection_can_use_plain_imap(self):
+        client = IMAPClient(
+            server="imap.example.com",
+            port=143,
+            username="u",
+            password="p",
+            use_ssl=False,
+        )
+        mock_mail = MagicMock()
+        mock_mail.login.return_value = None
+        mock_mail.list.return_value = ("OK", [b'(\\HasNoChildren) "/" INBOX'])
+        mock_mail.select.return_value = ("OK", [b"10"])
+        mock_mail.search.return_value = ("OK", [b""])
+
+        with (
+            patch("imaplib.IMAP4", return_value=mock_mail) as mock_plain_imap,
+            patch("imaplib.IMAP4_SSL") as mock_ssl_imap,
+        ):
+            success, _, stats = client.test_connection()
+
+        assert success is True
+        assert stats["ssl"] is False
+        mock_plain_imap.assert_called_once_with("imap.example.com", 143)
+        mock_ssl_imap.assert_not_called()
 
     def test_connection_counts_standard_google_report_subjects(self):
         client = self._make_client()


### PR DESCRIPTION
Fixes #859.\n\n## Summary\n- add an IMAPClient use_ssl flag and route connections through IMAP4 or IMAP4_SSL accordingly\n- pass saved/ad-hoc mail-source SSL settings through connection tests, manual fetches, backfills, and the legacy IMAP test endpoint\n- cover plain IMAP connection selection in IMAP client tests\n\n## Validation\n- python3 -m py_compile backend/app/services/imap_client.py backend/app/api/api_v1/endpoints/mail_sources.py backend/app/api/api_v1/endpoints/imap.py backend/app/services/mail_source_backfill_worker.py backend/app/tests/test_imap_client.py\n- pytest unavailable in this local environment (python3 reports: No module named pytest)