### PR TITLE
feat: make DNS plans explainable and evidence-backed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- DNS change plans now show the observed value, proposed value, exact tag/value
+  diff, and the lint rationale for every proposed record. Identical values are
+  treated as no-op evidence rather than a misleading DNS change.
+- MTA-STS guidance now includes a copyable `testing` policy-file example at
+  `https://mta-sts.<domain>/.well-known/mta-sts.txt`, populated with observed
+  MX hosts when available. BIMI posture now renders the published logo next to
+  its URL on domain detail and cached domain-list views.
+- DANE guidance now creates one reviewable TLSA `3 1 1` proposal per MX host
+  with cached STARTTLS certificate evidence. DNS plan page reads do not open
+  SMTP connections; bounded certificate probes run during DNS prewarming.
 - Guided workspaces now persist Calm Watch incidents by workspace, with stable
   identity, material-change detection, `actionable_only` notification posture,
   and auditable acknowledge/snooze actions. Protected unknown-source abuse is

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -4793,6 +4793,29 @@ async def _resolve_summary_dns_results(
     return await asyncio.gather(*(_bounded(domain_name) for domain_name in domains))
 
 
+def _cached_bimi_logo_urls(db: Session, domains: List[str]) -> Dict[str, str]:
+    """Return the latest safe BIMI logo URL per domain without resolving DNS."""
+    if not domains:
+        return {}
+    logo_urls: Dict[str, str] = {}
+    cache_rows = (
+        db.query(DNSCache.domain, DNSCache.result_json)
+        .filter(DNSCache.domain.in_(domains), DNSCache.provider.like("%:bimi"))
+        .order_by(DNSCache.domain.asc(), DNSCache.checked_at.desc())
+        .all()
+    )
+    for cache_domain, result_json in cache_rows:
+        if cache_domain in logo_urls:
+            continue
+        try:
+            logo_url = str((json.loads(result_json) or {}).get("logo_url") or "")
+        except (TypeError, ValueError):
+            continue
+        if logo_url.startswith("https://"):
+            logo_urls[cache_domain] = logo_url
+    return logo_urls
+
+
 @router.get("/summary", response_model=DomainSummaryResponse)
 async def get_domains_summary(
     refresh: bool = Query(False, title="Refresh cached DNS results"),
@@ -4861,22 +4884,7 @@ async def get_domains_summary(
         domain.name: domain
         for domain in workspace_domain_query(db, workspace).filter(Domain.name.in_(domains)).all()
     }
-    bimi_logo_urls: Dict[str, str] = {}
-    bimi_cache_rows = (
-        db.query(DNSCache.domain, DNSCache.result_json)
-        .filter(DNSCache.domain.in_(domains), DNSCache.provider.like("%:bimi"))
-        .order_by(DNSCache.domain.asc(), DNSCache.checked_at.desc())
-        .all()
-    )
-    for cache_domain, result_json in bimi_cache_rows:
-        if cache_domain in bimi_logo_urls:
-            continue
-        try:
-            logo_url = str((json.loads(result_json) or {}).get("logo_url") or "")
-        except (TypeError, ValueError):
-            continue
-        if logo_url.startswith("https://"):
-            bimi_logo_urls[cache_domain] = logo_url
+    bimi_logo_urls = _cached_bimi_logo_urls(db, domains)
 
     selectors_by_summary_domain: Dict[str, List[str]] = {}
     for domain_name in domains:

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -23,6 +23,7 @@ from app.core.database import SessionLocal, get_db
 from app.core.redaction import sanitize_for_log
 from app.core.security import require_admin_auth
 from app.models.domain import Domain
+from app.models.dns_cache import DNSCache
 from app.models.report import DMARCReport, ReportRecord
 from app.models.setting import Setting
 from app.models.workspace import Workspace
@@ -542,6 +543,9 @@ class DNSGuidanceRecordResponse(BaseModel):
     what_it_does: Optional[str] = None
     learn_more_url: Optional[str] = None
     learn_more_label: Optional[str] = None
+    supporting_content: Optional[str] = None
+    supporting_content_label: Optional[str] = None
+    supporting_content_url: Optional[str] = None
 
 
 class DNSLintFindingResponse(BaseModel):
@@ -600,6 +604,7 @@ class DNSChangePlanItemResponse(BaseModel):
     applies_automatically: bool = False
     provider_write_available: bool = False
     provider_value_required: bool = False
+    changes: List[str] = Field(default_factory=list)
     safety_notes: List[str] = Field(default_factory=list)
     what_it_does: Optional[str] = None
     learn_more_url: Optional[str] = None
@@ -3905,6 +3910,8 @@ async def _build_domain_dns_guidance(
         provider,
         domain_id,
         refresh=refresh,
+        derive_suggestions=True,
+        allow_live=False,
     )
     mail_service_records = await mail_service_dns_records_for_domain(db, domain_id)
     stored_domain = db.query(Domain).filter(Domain.name == domain_id).first()
@@ -4854,6 +4861,22 @@ async def get_domains_summary(
         domain.name: domain
         for domain in workspace_domain_query(db, workspace).filter(Domain.name.in_(domains)).all()
     }
+    bimi_logo_urls: Dict[str, str] = {}
+    bimi_cache_rows = (
+        db.query(DNSCache.domain, DNSCache.result_json)
+        .filter(DNSCache.domain.in_(domains), DNSCache.provider.like("%:bimi"))
+        .order_by(DNSCache.domain.asc(), DNSCache.checked_at.desc())
+        .all()
+    )
+    for cache_domain, result_json in bimi_cache_rows:
+        if cache_domain in bimi_logo_urls:
+            continue
+        try:
+            logo_url = str((json.loads(result_json) or {}).get("logo_url") or "")
+        except (TypeError, ValueError):
+            continue
+        if logo_url.startswith("https://"):
+            bimi_logo_urls[cache_domain] = logo_url
 
     selectors_by_summary_domain: Dict[str, List[str]] = {}
     for domain_name in domains:
@@ -4908,6 +4931,7 @@ async def get_domains_summary(
             "id": domain_name,
             "domain_name": domain_name,
             "description": stored_domain.description if stored_domain else None,
+            "bimi_logo_url": bimi_logo_urls.get(domain_name),
             "dkim_selectors": manual_selectors_by_domain.get(domain_name, []),
             "dmarc_report_mailbox": (stored_domain.dmarc_report_mailbox if stored_domain else None),
             "total_emails": summary.get("total_count", 0),

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -4816,6 +4816,66 @@ def _cached_bimi_logo_urls(db: Session, domains: List[str]) -> Dict[str, str]:
     return logo_urls
 
 
+def _summary_domains_and_selectors(
+    db: Session,
+    workspace: Workspace,
+    *,
+    demo_mode: bool,
+) -> Tuple[Dict[str, Dict[str, Any]], List[str], Dict[str, List[str]]]:
+    """Load dashboard summaries and report-derived selectors for one workspace."""
+    if demo_mode:
+        store = ReportStore()
+        hydrate_report_store_from_db(db, store, workspace_id=workspace.id)
+        domains = _domain_names_for_summary(
+            db,
+            store,
+            workspace,
+            include_unscoped_report_domains=True,
+        )
+        return (
+            store.get_all_domain_summaries(),
+            domains,
+            {
+                domain_name: _get_selectors_from_reports(store, domain_name)
+                for domain_name in domains
+            },
+        )
+
+    summaries = domain_summaries_from_db(db, workspace_id=workspace.id)
+    domains = list(summaries)
+    return (
+        summaries,
+        domains,
+        _get_report_selectors_map_from_db(db, domains, workspace_id=workspace.id),
+    )
+
+
+def _filter_summary_domains(
+    domains: List[str],
+    summaries: Dict[str, Dict[str, Any]],
+    *,
+    include_empty: bool,
+) -> Tuple[List[str], int, int]:
+    """Apply the include-empty flag while preserving summary counters."""
+
+    def _has_activity(domain_name: str) -> bool:
+        summary = summaries.get(domain_name, {})
+        return bool(
+            int(summary.get("reports_processed", 0) or 0) > 0
+            or int(summary.get("total_count", 0) or 0) > 0
+        )
+
+    empty_domains = [domain_name for domain_name in domains if not _has_activity(domain_name)]
+    if include_empty or not empty_domains:
+        return domains, len(empty_domains), 0
+    hidden = set(empty_domains)
+    return (
+        [domain_name for domain_name in domains if domain_name not in hidden],
+        len(empty_domains),
+        len(empty_domains),
+    )
+
+
 @router.get("/summary", response_model=DomainSummaryResponse)
 async def get_domains_summary(
     refresh: bool = Query(False, title="Refresh cached DNS results"),
@@ -4838,44 +4898,16 @@ async def get_domains_summary(
     workspace = _authorized_domain_read_workspace(_auth, db, selected_workspace_id)
     settings = get_settings()
     demo_mode = settings.DEMO_MODE
-    store: Optional[ReportStore] = None
-    report_selectors_by_domain: Dict[str, List[str]] = {}
-    if demo_mode:
-        store = ReportStore()
-        hydrate_report_store_from_db(
-            db,
-            store,
-            workspace_id=workspace.id,
-        )
-        domains = _domain_names_for_summary(
-            db,
-            store,
-            workspace,
-            include_unscoped_report_domains=True,
-        )
-        summaries = store.get_all_domain_summaries()
-    else:
-        summaries = domain_summaries_from_db(db, workspace_id=workspace.id)
-        domains = list(summaries)
-        report_selectors_by_domain = _get_report_selectors_map_from_db(
-            db,
-            domains,
-            workspace_id=workspace.id,
-        )
-
-    def _has_activity(domain_name: str) -> bool:
-        summary = summaries.get(domain_name, {})
-        return bool(
-            int(summary.get("reports_processed", 0) or 0) > 0
-            or int(summary.get("total_count", 0) or 0) > 0
-        )
-
-    empty_domains = [domain_name for domain_name in domains if not _has_activity(domain_name)]
-    empty_domains_count = len(empty_domains)
-    if not include_empty and empty_domains:
-        hidden = set(empty_domains)
-        domains = [domain_name for domain_name in domains if domain_name not in hidden]
-    empty_domains_hidden = empty_domains_count if not include_empty else 0
+    summaries, domains, report_selectors_by_domain = _summary_domains_and_selectors(
+        db,
+        workspace,
+        demo_mode=demo_mode,
+    )
+    domains, empty_domains_count, empty_domains_hidden = _filter_summary_domains(
+        domains,
+        summaries,
+        include_empty=include_empty,
+    )
 
     # Perform DNS checks for all domains, reusing fresh cached results.
     provider = get_default_provider(db)
@@ -4889,10 +4921,7 @@ async def get_domains_summary(
     selectors_by_summary_domain: Dict[str, List[str]] = {}
     for domain_name in domains:
         manual_selectors = manual_selectors_by_domain.get(domain_name, [])
-        if demo_mode and store is not None:
-            report_selectors = _get_selectors_from_reports(store, domain_name)
-        else:
-            report_selectors = report_selectors_by_domain.get(domain_name, [])
+        report_selectors = report_selectors_by_domain.get(domain_name, [])
         selectors_by_summary_domain[domain_name] = list(
             dict.fromkeys(manual_selectors + report_selectors)
         )

--- a/backend/app/services/bimi.py
+++ b/backend/app/services/bimi.py
@@ -8,11 +8,10 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
-from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS
+from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS, store_dns_cache_result
 from app.services.dns_fallbacks import dns_fallback_candidates
 from app.services.dns_resolver import BaseDNSProvider
 
@@ -199,37 +198,13 @@ async def check_bimi_cached(
 
     result = await check_bimi_with_fallback(domain, provider, selector=normalized_selector)
     payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
-    if row is None:
-        row = DNSCache(
-            domain=domain,
-            provider=provider_name,
-            selectors_key=cache_key,
-            result_json=payload,
-            checked_at=now,
-        )
-        db.add(row)
-    else:
-        row.result_json = payload
-        row.checked_at = now
-
-    try:
-        db.commit()
-    except IntegrityError:
-        db.rollback()
-        row = (
-            db.query(DNSCache)
-            .filter(
-                DNSCache.domain == domain,
-                DNSCache.provider == provider_name,
-                DNSCache.selectors_key == cache_key,
-            )
-            .first()
-        )
-        if row is None:
-            raise
-        row.result_json = payload
-        row.checked_at = now
-        db.commit()
-
-    db.refresh(row)
+    row = store_dns_cache_result(
+        db,
+        row,
+        domain=domain,
+        provider_name=provider_name,
+        selectors_key=cache_key,
+        payload=payload,
+        checked_at=now,
+    )
     return result, False, row.checked_at

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -466,6 +466,7 @@ async def check_dane_cached(
     *,
     port: int = 25,
     derive_suggestions: bool = False,
+    allow_live: bool = True,
     ttl_seconds: int = DEFAULT_DNS_CACHE_TTL_SECONDS,
     refresh: bool = False,
 ) -> Tuple[DANEResult, bool, datetime]:
@@ -487,6 +488,12 @@ async def check_dane_cached(
     )
     if row and not refresh and _is_fresh(row, ttl_seconds, now):
         return _result_from_json(row.result_json), True, row.checked_at
+
+    if derive_suggestions and not allow_live:
+        # Page reads must never open SMTP connections. Startup and scheduled
+        # prewarming populate this cache; absent evidence remains an honest
+        # "not yet captured" state rather than a browser-triggered probe.
+        return DANEResult(port=port), True, now
 
     result = await check_dane_with_fallback(
         normalized_domain,

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -486,14 +486,19 @@ async def check_dane_cached(
         )
         .first()
     )
-    if row and not refresh and _is_fresh(row, ttl_seconds, now):
-        return _result_from_json(row.result_json), True, row.checked_at
-
     if derive_suggestions and not allow_live:
         # Page reads must never open SMTP connections. Startup and scheduled
-        # prewarming populate this cache; absent evidence remains an honest
-        # "not yet captured" state rather than a browser-triggered probe.
+        # prewarming populate this cache. Retain the last captured certificate
+        # evidence even when it is older than the normal DNS TTL: refreshing a
+        # browser view must not discard a useful TLSA proposal or open SMTP.
+        if row:
+            return _result_from_json(row.result_json), True, row.checked_at
+        # Absent evidence remains an honest "not yet captured" state rather
+        # than a browser-triggered probe.
         return DANEResult(port=port), True, now
+
+    if row and not refresh and _is_fresh(row, ttl_seconds, now):
+        return _result_from_json(row.result_json), True, row.checked_at
 
     result = await check_dane_with_fallback(
         normalized_domain,

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -14,11 +14,10 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
-from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS
+from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS, store_dns_cache_result
 from app.services.dns_fallbacks import dns_fallback_candidates
 from app.services.dns_resolver import BaseDNSProvider
 
@@ -507,37 +506,13 @@ async def check_dane_cached(
         derive_suggestions=derive_suggestions,
     )
     payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
-    if row is None:
-        row = DNSCache(
-            domain=normalized_domain,
-            provider=provider_name,
-            selectors_key=cache_key,
-            result_json=payload,
-            checked_at=now,
-        )
-        db.add(row)
-    else:
-        row.result_json = payload
-        row.checked_at = now
-
-    try:
-        db.commit()
-    except IntegrityError:
-        db.rollback()
-        row = (
-            db.query(DNSCache)
-            .filter(
-                DNSCache.domain == normalized_domain,
-                DNSCache.provider == provider_name,
-                DNSCache.selectors_key == cache_key,
-            )
-            .first()
-        )
-        if row is None:
-            raise
-        row.result_json = payload
-        row.checked_at = now
-        db.commit()
-
-    db.refresh(row)
+    row = store_dns_cache_result(
+        db,
+        row,
+        domain=normalized_domain,
+        provider_name=provider_name,
+        selectors_key=cache_key,
+        payload=payload,
+        checked_at=now,
+    )
     return result, False, row.checked_at

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
@@ -199,7 +200,7 @@ def _cache_row(
     )
 
 
-def _store_cache_result(
+def store_dns_cache_result(
     db: Session,
     row: Optional[DNSCache],
     *,
@@ -209,6 +210,26 @@ def _store_cache_result(
     payload: str,
     checked_at: datetime,
 ) -> DNSCache:
+    if db.bind is not None and db.bind.dialect.name == "postgresql":
+        statement = (
+            postgresql_insert(DNSCache)
+            .values(
+                domain=domain,
+                provider=provider_name,
+                selectors_key=selectors_key,
+                result_json=payload,
+                checked_at=checked_at,
+            )
+            .on_conflict_do_update(
+                constraint="uq_dns_cache_lookup",
+                set_={"result_json": payload, "checked_at": checked_at},
+            )
+            .returning(DNSCache.id)
+        )
+        row_id = db.execute(statement).scalar_one()
+        db.commit()
+        return db.query(DNSCache).filter(DNSCache.id == row_id).one()
+
     if row is None:
         row = DNSCache(
             domain=domain,
@@ -240,6 +261,27 @@ def _store_cache_result(
 
     db.refresh(row)
     return row
+
+
+def _store_cache_result(
+    db: Session,
+    row: Optional[DNSCache],
+    *,
+    domain: str,
+    provider_name: str,
+    selectors_key: str,
+    payload: str,
+    checked_at: datetime,
+) -> DNSCache:
+    return store_dns_cache_result(
+        db,
+        row,
+        domain=domain,
+        provider_name=provider_name,
+        selectors_key=selectors_key,
+        payload=payload,
+        checked_at=checked_at,
+    )
 
 
 DNSCandidateResult = Tuple[str, Optional[DomainDNSResult], Optional[Exception]]

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -228,7 +228,12 @@ def store_dns_cache_result(
         )
         row_id = db.execute(statement).scalar_one()
         db.commit()
-        return db.query(DNSCache).filter(DNSCache.id == row_id).one()
+        return (
+            db.query(DNSCache)
+            .populate_existing()
+            .filter(DNSCache.id == row_id)
+            .one()
+        )
 
     if row is None:
         row = DNSCache(

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -1270,34 +1270,40 @@ def _dane_findings(result: DANEResult, targets: List[DNSGuidanceRecord]) -> List
         return []
     detail = "; ".join(warnings or result.errors or ["No DANE/TLSA records were found."])
     evidence = [record.record for record in result.records]
-    if result.status == "fail":
-        publishable_targets = [
-            record for record in dane_targets if "<derive-" not in record.value
-        ]
-        if publishable_targets:
-            findings: List[DNSLintFinding] = []
-            for index, candidate in enumerate(publishable_targets):
-                mx_host = candidate.name.split("._tcp.", 1)[-1]
-                current_values = [
-                    record.record for record in result.records if record.mx_host == mx_host
-                ]
-                findings.append(
-                    _finding(
-                        "dane_missing" if index == 0 else f"dane_missing_{index + 1}",
-                        "info",
-                        "DANE TLSA record is ready for review",
-                        (
-                            f"DMARQ captured a STARTTLS certificate for {mx_host} and "
-                            "derived a publishable TLSA 3 1 1 value."
-                        ),
-                        "Review DNSSEC and the cached certificate evidence before publishing this host-specific TLSA record.",
-                        "TLSA",
-                        candidate.name,
-                        target_record=candidate,
-                        evidence=current_values,
-                    )
+    publishable_targets = [record for record in dane_targets if "<derive-" not in record.value]
+    missing_targets: List[tuple[DNSGuidanceRecord, List[str]]] = []
+    for candidate in publishable_targets:
+        mx_host = candidate.name.split("._tcp.", 1)[-1]
+        current_values = [record.record for record in result.records if record.mx_host == mx_host]
+        if not any(
+            _normalize_dns_value(value) == _normalize_dns_value(candidate.value)
+            for value in current_values
+        ):
+            missing_targets.append((candidate, current_values))
+
+    if missing_targets:
+        findings: List[DNSLintFinding] = []
+        for index, (candidate, current_values) in enumerate(missing_targets):
+            mx_host = candidate.name.split("._tcp.", 1)[-1]
+            findings.append(
+                _finding(
+                    "dane_missing" if index == 0 else f"dane_missing_{index + 1}",
+                    "info",
+                    "DANE TLSA record is ready for review",
+                    (
+                        f"DMARQ captured a STARTTLS certificate for {mx_host} and "
+                        "derived a publishable TLSA 3 1 1 value."
+                    ),
+                    "Review DNSSEC and the cached certificate evidence before publishing this host-specific TLSA record.",
+                    "TLSA",
+                    candidate.name,
+                    target_record=candidate,
+                    evidence=current_values,
                 )
-            return findings
+            )
+        return findings
+
+    if result.status == "fail":
         return [
             _finding(
                 "dane_missing",
@@ -1613,7 +1619,11 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
         if operation == "defer":
             continue
         current_values = list(finding.evidence)
-        if proposed_value and any(
+        # A matching value is only a no-op when it is the sole RRset member.
+        # Consolidation findings (for example, multiple SPF or TLS-RPT TXT
+        # values) still need an update plan even if one member is already the
+        # intended final value.
+        if proposed_value and len(current_values) == 1 and any(
             _normalize_dns_value(value) == _normalize_dns_value(proposed_value)
             for value in current_values
         ):

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -1333,7 +1333,14 @@ def _dane_findings(result: DANEResult, targets: List[DNSGuidanceRecord]) -> List
 
 
 def _normalize_dns_value(value: str) -> str:
-    return " ".join(str(value or "").strip().strip(".").split()).lower()
+    normalized = " ".join(str(value or "").strip().strip(".").split()).lower()
+    tag_parts = _dns_record_parts(normalized)
+    if tag_parts is None:
+        return normalized
+    # DMARC, TLS-RPT, MTA-STS, and BIMI tags are an unordered map. Preserve
+    # the individual values but compare a stable key order so a provider's
+    # formatting alone does not create a misleading DNS change plan.
+    return ";".join(f"{key}={tag_parts[key]}" for key in sorted(tag_parts))
 
 
 async def _current_mail_service_values(

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -27,6 +27,9 @@ class DNSGuidanceRecord:
     what_it_does: Optional[str] = None
     learn_more_url: Optional[str] = None
     learn_more_label: Optional[str] = None
+    supporting_content: Optional[str] = None
+    supporting_content_label: Optional[str] = None
+    supporting_content_url: Optional[str] = None
 
 
 @dataclass
@@ -79,6 +82,7 @@ class DNSChangePlan:
     applies_automatically: bool = False
     provider_write_available: bool = False
     provider_value_required: bool = False
+    changes: List[str] = field(default_factory=list)
     what_it_does: Optional[str] = None
     learn_more_url: Optional[str] = None
     learn_more_label: Optional[str] = None
@@ -128,11 +132,22 @@ def _dmarc_record_value(domain: str, defaults: MailAuthSetupDefaults) -> str:
     )
 
 
+def _mta_sts_policy_example(mx_hosts: List[str]) -> str:
+    """Build a safe first MTA-STS policy from observed MX hosts."""
+    mx_lines = [f"mx: {host}" for host in mx_hosts if host]
+    if not mx_lines:
+        mx_lines = ["mx: <replace-with-your-mx-host>"]
+    return "\n".join(
+        ["version: STSv1", "mode: testing", *mx_lines, "max_age: 86400"]
+    )
+
+
 def _target_records(
     domain: str,
     result: DomainDNSResult,
     *,
     setup_defaults: Optional[MailAuthSetupDefaults] = None,
+    mx_hosts: Optional[List[str]] = None,
 ) -> List[DNSGuidanceRecord]:
     defaults = setup_defaults or MailAuthSetupDefaults()
     dmarc_value = result.dmarc_record or (_dmarc_record_value(domain, defaults))
@@ -180,6 +195,9 @@ def _target_records(
             ),
             learn_more_url="https://www.rfc-editor.org/rfc/rfc8461",
             learn_more_label="Read the MTA-STS standard",
+            supporting_content=_mta_sts_policy_example(mx_hosts or []),
+            supporting_content_label="Policy file to publish first",
+            supporting_content_url=f"https://mta-sts.{domain}/.well-known/mta-sts.txt",
         ),
         DNSGuidanceRecord(
             code="target_tls_rpt",
@@ -216,45 +234,49 @@ def _target_by_code(records: List[DNSGuidanceRecord], code: str) -> DNSGuidanceR
     return next(record for record in records if record.code == code)
 
 
-def _dane_target_record(domain: str, result: DANEResult) -> DNSGuidanceRecord:
-    ready_suggestion = next(
-        (
-            suggestion
-            for suggestion in result.suggested_records
-            if suggestion.status == "ready" and suggestion.record
-        ),
-        None,
-    )
-    mx_host = (
-        ready_suggestion.mx_host
-        if ready_suggestion
-        else result.mx_hosts[0] if result.mx_hosts else f"<mx-host>.{domain}"
-    )
-    value = (
-        ready_suggestion.record
-        if ready_suggestion
-        else "3 1 1 <derive-sha256-spki-from-live-mx-certificate>"
-    )
-    purpose = (
-        f"DANE SMTP TLSA value derived from the live STARTTLS certificate for {mx_host}. "
-        "Publish it only after DNSSEC is signed and validating, and rotate it with "
-        "certificate changes."
-        if ready_suggestion
-        else (
-            "DANE SMTP TLSA certificate pinning for one MX host. The value is not "
-            "guessable: derive one matching TLSA record from each live MX certificate, "
-            "publish it only after DNSSEC is signed and validating, and rotate it with "
-            "certificate changes."
+def _dane_target_records(domain: str, result: DANEResult) -> List[DNSGuidanceRecord]:
+    """Return one publishable TLSA target per MX host with cached certificate evidence."""
+    ready_suggestions = [
+        suggestion
+        for suggestion in result.suggested_records
+        if suggestion.status == "ready" and suggestion.record
+    ]
+    if not ready_suggestions:
+        mx_host = result.mx_hosts[0] if result.mx_hosts else f"<mx-host>.{domain}"
+        return [
+            DNSGuidanceRecord(
+                code="target_dane",
+                record_type="TLSA",
+                name=f"_{result.port}._tcp.{mx_host}",
+                value="3 1 1 <derive-sha256-spki-from-live-mx-certificate>",
+                purpose=(
+                    "DANE SMTP TLSA certificate pinning. DMARQ has not yet captured a "
+                    "usable STARTTLS certificate for this MX host, so it will not propose "
+                    "a DNS value."
+                ),
+                priority="optional",
+            )
+        ]
+
+    targets: List[DNSGuidanceRecord] = []
+    for index, suggestion in enumerate(ready_suggestions):
+        targets.append(
+            DNSGuidanceRecord(
+                code="target_dane" if index == 0 else f"target_dane_{index + 1}",
+                record_type="TLSA",
+                name=suggestion.query_name,
+                value=suggestion.record,
+                purpose=(
+                    f"DANE SMTP TLSA value derived from the live STARTTLS certificate "
+                    f"cached for {suggestion.mx_host}. This is a SHA-256 hash of "
+                    "the certificate public key (SPKI), not a generic certificate hash. "
+                    "Publish only after DNSSEC is signed and validating, and rotate it "
+                    "with certificate changes."
+                ),
+                priority="optional",
+            )
         )
-    )
-    return DNSGuidanceRecord(
-        code="target_dane",
-        record_type="TLSA",
-        name=ready_suggestion.query_name if ready_suggestion else f"_{result.port}._tcp.{mx_host}",
-        value=value,
-        purpose=purpose,
-        priority="optional",
-    )
+    return targets
 
 
 def _finding(
@@ -1241,13 +1263,41 @@ def _actionable_dane_warnings(result: DANEResult) -> List[str]:
 
 
 def _dane_findings(result: DANEResult, targets: List[DNSGuidanceRecord]) -> List[DNSLintFinding]:
-    target = _target_by_code(targets, "target_dane")
+    dane_targets = [record for record in targets if record.code.startswith("target_dane")]
+    target = dane_targets[0]
     warnings = _actionable_dane_warnings(result)
     if result.status == "pass" and not warnings:
         return []
     detail = "; ".join(warnings or result.errors or ["No DANE/TLSA records were found."])
-    evidence = [record.record for record in result.records] or result.mx_hosts
+    evidence = [record.record for record in result.records]
     if result.status == "fail":
+        publishable_targets = [
+            record for record in dane_targets if "<derive-" not in record.value
+        ]
+        if publishable_targets:
+            findings: List[DNSLintFinding] = []
+            for index, candidate in enumerate(publishable_targets):
+                mx_host = candidate.name.split("._tcp.", 1)[-1]
+                current_values = [
+                    record.record for record in result.records if record.mx_host == mx_host
+                ]
+                findings.append(
+                    _finding(
+                        "dane_missing" if index == 0 else f"dane_missing_{index + 1}",
+                        "info",
+                        "DANE TLSA record is ready for review",
+                        (
+                            f"DMARQ captured a STARTTLS certificate for {mx_host} and "
+                            "derived a publishable TLSA 3 1 1 value."
+                        ),
+                        "Review DNSSEC and the cached certificate evidence before publishing this host-specific TLSA record.",
+                        "TLSA",
+                        candidate.name,
+                        target_record=candidate,
+                        evidence=current_values,
+                    )
+                )
+            return findings
         return [
             _finding(
                 "dane_missing",
@@ -1378,7 +1428,7 @@ def _plan_id(finding: DNSLintFinding) -> str:
 
 def _operation_for_finding(finding: DNSLintFinding) -> str:
     code = finding.code
-    if code.endswith("_missing") or code in {"dmarc_missing", "spf_missing"}:
+    if code.endswith("_missing") or code.startswith("dane_missing") or code in {"dmarc_missing", "spf_missing"}:
         return "create"
     if code in {"dkim_selector_stale"}:
         return "review-remove"
@@ -1408,6 +1458,8 @@ def _proposed_value(finding: DNSLintFinding) -> Optional[str]:
     if finding.code == "dkim_selector_stale":
         return None
     if finding.target_record:
+        if "<derive-" in finding.target_record.value:
+            return None
         return finding.target_record.value
     return None
 
@@ -1509,6 +1561,47 @@ def _manual_steps_for_plan(finding: DNSLintFinding, operation: str) -> List[str]
     return list(dict.fromkeys(steps))
 
 
+def _dns_record_parts(value: str) -> Optional[Dict[str, str]]:
+    """Parse semicolon-delimited DNS tag records without rewriting the value."""
+    if ";" not in value or "=" not in value:
+        return None
+    parts: Dict[str, str] = {}
+    for part in value.split(";"):
+        if "=" not in part:
+            continue
+        key, item_value = part.split("=", 1)
+        key = key.strip().lower()
+        if key:
+            parts[key] = item_value.strip()
+    return parts or None
+
+
+def _plan_changes(current_values: List[str], proposed_value: Optional[str]) -> List[str]:
+    """Explain the exact record change an operator is being asked to review."""
+    if not proposed_value:
+        return ["No exact DNS value is available; this item requires manual review."]
+    if not current_values:
+        return ["Create this record; no current value was observed."]
+    current = current_values[0]
+    current_parts = _dns_record_parts(current)
+    proposed_parts = _dns_record_parts(proposed_value)
+    if current_parts is not None and proposed_parts is not None:
+        changes: List[str] = []
+        for key in sorted(set(current_parts) | set(proposed_parts)):
+            before = current_parts.get(key)
+            after = proposed_parts.get(key)
+            if before == after:
+                continue
+            if before is None:
+                changes.append(f"Add {key}={after}.")
+            elif after is None:
+                changes.append(f"Remove {key}={before}.")
+            else:
+                changes.append(f"Change {key} from {before} to {after}.")
+        return changes or ["No value change is required."]
+    return ["Replace the observed value with the proposed value."]
+
+
 def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan]:
     """Create read-only operator change plans from DNS lint findings."""
     plans: List[DNSChangePlan] = []
@@ -1519,6 +1612,12 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
         proposed_value = _proposed_value(finding)
         if operation == "defer":
             continue
+        current_values = list(finding.evidence)
+        if proposed_value and any(
+            _normalize_dns_value(value) == _normalize_dns_value(proposed_value)
+            for value in current_values
+        ):
+            continue
         plans.append(
             DNSChangePlan(
                 plan_id=_plan_id(finding),
@@ -1528,13 +1627,14 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
                 record_type=finding.record_type,
                 name=finding.record_name,
                 proposed_value=proposed_value,
-                current_values=list(finding.evidence),
+                current_values=current_values,
                 rationale=finding.action,
                 risk=_risk_for_finding(finding),
                 rollback=_rollback_for_plan(finding, operation),
                 expected_health_impact=_expected_health_impact(finding),
                 manual_steps=_manual_steps_for_plan(finding, operation),
                 provider_value_required=_provider_value_required(finding),
+                changes=_plan_changes(current_values, proposed_value),
                 what_it_does=(finding.target_record.what_it_does if finding.target_record else None),
                 learn_more_url=(finding.target_record.learn_more_url if finding.target_record else None),
                 learn_more_label=(finding.target_record.learn_more_label if finding.target_record else None),
@@ -1561,7 +1661,12 @@ async def build_dns_guidance(
     """Build typed DNS lint findings and target records for a domain."""
     normalized_domain = domain.strip().strip(".").lower()
     dane_result = dane or DANEResult(errors=["No DANE/TLSA context was evaluated."])
-    targets = _target_records(normalized_domain, result, setup_defaults=setup_defaults)
+    targets = _target_records(
+        normalized_domain,
+        result,
+        setup_defaults=setup_defaults,
+        mx_hosts=dane_result.mx_hosts,
+    )
     if selector_evidence is not None:
         active_selector = next(
             (
@@ -1573,7 +1678,7 @@ async def build_dns_guidance(
         )
         target_dkim = _target_by_code(targets, "target_dkim")
         target_dkim.name = f"{active_selector}._domainkey.{normalized_domain}"
-    targets.append(_dane_target_record(normalized_domain, dane_result))
+    targets.extend(_dane_target_records(normalized_domain, dane_result))
     findings: List[DNSLintFinding] = []
     normalized_selector_evidence = [dict(item) for item in selector_evidence or []]
     findings.extend(_dmarc_findings(normalized_domain, result, targets))

--- a/backend/app/services/dns_prewarm.py
+++ b/backend/app/services/dns_prewarm.py
@@ -13,6 +13,7 @@ from app.core.database import SessionLocal
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
 from app.services.dns_cache import resolve_domain_dns_cached
+from app.services.dane import check_dane_cached
 from app.services.dns_resolver import get_default_provider
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,13 @@ async def _prewarm_domain(domain_id: int, domain_name: str, selectors: List[str]
             provider,
             domain_name,
             selectors=selectors,
+            refresh=True,
+        )
+        await check_dane_cached(
+            db,
+            provider,
+            domain_name,
+            derive_suggestions=True,
             refresh=True,
         )
         logger.info("Prewarmed DNS cache for domain id=%s", domain_id)

--- a/backend/app/services/mta_sts.py
+++ b/backend/app/services/mta_sts.py
@@ -8,11 +8,10 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
-from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS
+from app.services.dns_cache import DEFAULT_DNS_CACHE_TTL_SECONDS, store_dns_cache_result
 from app.services.dns_fallbacks import dns_fallback_candidates
 from app.services.dns_resolver import BaseDNSProvider
 
@@ -234,37 +233,13 @@ async def check_mta_sts_cached(
 
     result = await check_mta_sts_with_fallback(domain, provider)
     payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))
-    if row is None:
-        row = DNSCache(
-            domain=domain,
-            provider=provider_name,
-            selectors_key=_CACHE_KEY,
-            result_json=payload,
-            checked_at=now,
-        )
-        db.add(row)
-    else:
-        row.result_json = payload
-        row.checked_at = now
-
-    try:
-        db.commit()
-    except IntegrityError:
-        db.rollback()
-        row = (
-            db.query(DNSCache)
-            .filter(
-                DNSCache.domain == domain,
-                DNSCache.provider == provider_name,
-                DNSCache.selectors_key == _CACHE_KEY,
-            )
-            .first()
-        )
-        if row is None:
-            raise
-        row.result_json = payload
-        row.checked_at = now
-        db.commit()
-
-    db.refresh(row)
+    row = store_dns_cache_result(
+        db,
+        row,
+        domain=domain,
+        provider_name=provider_name,
+        selectors_key=_CACHE_KEY,
+        payload=payload,
+        checked_at=now,
+    )
     return result, False, row.checked_at

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -3097,6 +3097,24 @@ function domainDetailsApp(domainId = '') {
             }
         },
 
+        mtaStsPolicyExampleRecord() {
+            return (this.dnsGuidance?.target_records || []).find(
+                (record) => record.code === 'target_mta_sts'
+            ) || null;
+        },
+
+        mtaStsPolicyExample() {
+            return this.mtaStsPolicyExampleRecord()?.supporting_content || '';
+        },
+
+        mtaStsPolicyExampleLabel() {
+            return this.mtaStsPolicyExampleRecord()?.supporting_content_label || 'Policy file to publish first';
+        },
+
+        mtaStsPolicyExampleUrl() {
+            return this.mtaStsPolicyExampleRecord()?.supporting_content_url || '';
+        },
+
         async fetchSelectors() {
             try {
                 const response = await fetch(`/api/v1/domains/${this.domainId}/selectors`);

--- a/backend/app/static/js/domains-page.js
+++ b/backend/app/static/js/domains-page.js
@@ -301,6 +301,7 @@ function domainsApp() {
                 emails_count: domain.total_emails,
                 compliance_rate: domain.pass_rate,
                 description: domain.description || '',
+                bimi_logo_url: domain.bimi_logo_url || '',
                 dkim_selectors: Array.isArray(domain.dkim_selectors) ? domain.dkim_selectors : [],
             };
             if (Object.prototype.hasOwnProperty.call(domain, 'dmarc_report_mailbox')) {

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -1920,6 +1920,18 @@
                                     <div><span class="font-medium">Max age:</span> <span x-text="mtaSts.max_age || 'unknown'"></span></div>
                                     <div><span class="font-medium">MX:</span> <span class="font-mono" x-text="mtaSts.mx && mtaSts.mx.length ? mtaSts.mx.join(', ') : 'none'"></span></div>
                                 </div>
+                                <template x-if="mtaStsPolicyExample()">
+                                    <div class="mt-3 rounded border border-base-300 bg-base-100 p-3">
+                                        <p class="text-xs font-semibold" x-text="mtaStsPolicyExampleLabel()"></p>
+                                        <a class="mt-1 block break-all text-xs text-[#1f5f9c] underline"
+                                           :href="mtaStsPolicyExampleUrl()"
+                                           target="_blank"
+                                           rel="noopener noreferrer"
+                                           x-text="mtaStsPolicyExampleUrl()"></a>
+                                        <pre class="mt-2 overflow-x-auto rounded bg-base-200 p-2 text-xs" x-text="mtaStsPolicyExample()"></pre>
+                                        <p class="mt-2 text-xs text-base-content/65">Start with testing mode. Confirm that every MX host is covered before changing mode to enforce, then rotate the TXT id.</p>
+                                    </div>
+                                </template>
                                 <template x-if="mtaSts.errors && mtaSts.errors.length">
                                     <p class="mt-2 text-xs text-red-600" x-text="mtaSts.errors[0]"></p>
                                 </template>
@@ -1945,9 +1957,17 @@
                                 </p>
                                 <div class="grid gap-1">
                                     <div><span class="font-medium">Selector:</span> <span class="font-mono" x-text="bimi.selector || 'default'"></span></div>
-                                    <div><span class="font-medium">Logo:</span> <span class="font-mono break-all" x-text="bimi.logo_url || 'none'"></span></div>
+                                    <div class="flex flex-wrap items-center gap-2"><span class="font-medium">Logo:</span> <a x-show="bimi.logo_url" class="font-mono break-all text-[#1f5f9c] underline" :href="bimi.logo_url" target="_blank" rel="noopener noreferrer" x-text="bimi.logo_url"></a><span x-show="!bimi.logo_url">none</span></div>
                                     <div><span class="font-medium">Certificate:</span> <span class="font-mono break-all" x-text="bimi.certificate_url || 'none'"></span></div>
                                 </div>
+                                <a x-show="bimi.logo_url"
+                                   class="mt-3 inline-flex rounded border border-base-300 bg-white p-2"
+                                   :href="bimi.logo_url"
+                                   target="_blank"
+                                   rel="noopener noreferrer"
+                                   title="Open published BIMI logo">
+                                    <img class="h-12 w-12 object-contain" :src="bimi.logo_url" alt="Published BIMI logo" referrerpolicy="no-referrer" loading="lazy">
+                                </a>
                                 <template x-if="bimi.errors && bimi.errors.length">
                                     <p class="mt-2 text-xs text-red-600" x-text="bimi.errors[0]"></p>
                                 </template>
@@ -2284,6 +2304,22 @@
                                                     </p>
                                                 </div>
                                             </template>
+                                            <div class="mt-2 rounded border border-base-300 bg-base-100 px-3 py-2 text-xs text-base-content/75">
+                                                <p class="font-semibold">What changes</p>
+                                                <template x-if="plan.current_values && plan.current_values.length">
+                                                    <div class="mt-2">
+                                                        <p class="font-medium">Before</p>
+                                                        <template x-for="value in plan.current_values" :key="value">
+                                                            <code class="mt-1 block break-all rounded bg-base-200 p-2" x-text="value"></code>
+                                                        </template>
+                                                    </div>
+                                                </template>
+                                                <template x-if="plan.proposed_value">
+                                                    <div class="mt-2"><p class="font-medium">After</p><code class="mt-1 block break-all rounded bg-base-200 p-2" x-text="plan.proposed_value"></code></div>
+                                                </template>
+                                                <ul class="mt-2 list-disc space-y-1 pl-4"><template x-for="change in plan.changes" :key="change"><li x-text="change"></li></template></ul>
+                                                <p class="mt-2"><span class="font-semibold">Why:</span> <span x-text="plan.rationale"></span></p>
+                                            </div>
                                             <template x-if="plan.what_it_does">
                                                 <div class="mt-2 rounded border border-blue-100 bg-blue-50 px-3 py-2 text-xs text-[#243b5a]">
                                                     <span class="font-semibold">What this does:</span>

--- a/backend/app/templates/domains.html
+++ b/backend/app/templates/domains.html
@@ -65,6 +65,7 @@
                     {% call thead() %}
                         {% call tr() %}
                             {% call th() %}Domain{% endcall %}
+                            {% call th() %}Brand{% endcall %}
                             {% call th() %}DMARC Status{% endcall %}
                             {% call th() %}SPF Status{% endcall %}
                             {% call th() %}DKIM Status{% endcall %}
@@ -74,7 +75,7 @@
                     {% call tbody() %}
                         <template x-if="loading">
                             {% call tr() %}
-                                {% call td(colspan="5", class="text-center") %}
+                                {% call td(colspan="6", class="text-center") %}
                                     <div class="flex items-center justify-center gap-2 py-4 text-muted-foreground" role="status">
                                         <span class="loading loading-spinner loading-sm"></span>
                                         <span>Loading monitored domains...</span>
@@ -84,7 +85,7 @@
                         </template>
                         <template x-if="!loading && loadError">
                             {% call tr() %}
-                                {% call td(colspan="5", class="text-center") %}
+                                {% call td(colspan="6", class="text-center") %}
                                     <div class="flex flex-col items-center gap-3 py-4">
                                         <p class="text-red-700" x-text="loadError"></p>
                                         <button type="button" class="btn btn-outline btn-sm" data-domain-retry-load>
@@ -96,14 +97,14 @@
                         </template>
                         <template x-if="!loading && !loadError && domains.length === 0 && hiddenEmptyDomainCount() === 0">
                             {% call tr() %}
-                                {% call td(colspan="5", class="text-center") %}
+                                {% call td(colspan="6", class="text-center") %}
                                     <p class="py-4 text-muted-foreground">No domains found. Add a domain to get started.</p>
                                 {% endcall %}
                             {% endcall %}
                         </template>
                         <template x-if="showEmptyDomainHint()">
                             {% call tr() %}
-                                {% call td(colspan="5", class="text-center") %}
+                                {% call td(colspan="6", class="text-center") %}
                                     <div class="flex flex-col items-center gap-3 py-5 text-muted-foreground">
                                         <p>All monitored domains are currently hidden because no reports or mail volume have been observed yet.</p>
                                         <button type="button" class="btn btn-outline btn-sm" data-domain-toggle-empty>
@@ -131,6 +132,17 @@
                                               class="max-w-md truncate"
                                               x-text="domain.dns_lookup_error"></span>
                                     </div>
+                                {% endcall %}
+                                {% call td() %}
+                                    <a x-show="domain.bimi_logo_url"
+                                       :href="domain.bimi_logo_url"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex h-9 w-9 items-center justify-center rounded border border-base-300 bg-white p-1"
+                                       title="Open published BIMI logo">
+                                        <img class="h-7 w-7 object-contain" :src="domain.bimi_logo_url" alt="Published BIMI logo" referrerpolicy="no-referrer" loading="lazy">
+                                    </a>
+                                    <span x-show="!domain.bimi_logo_url" class="text-xs text-base-content/45">-</span>
                                 {% endcall %}
                                 {% call td() %}
                                     <div class="flex items-center">

--- a/backend/app/tests/test_dane.py
+++ b/backend/app/tests/test_dane.py
@@ -339,6 +339,25 @@ async def test_check_dane_cached_keeps_live_suggestions_in_separate_cache(
     assert live.suggested_records[0].association_data == "a" * 64
 
 
+@pytest.mark.asyncio
+async def test_check_dane_cached_does_not_open_smtp_when_live_evidence_is_page_read_only(
+    db_session,
+):
+    provider = FakeDANEDNSProvider(mx_hosts=["mx.example.com"])
+
+    result, cached, _ = await check_dane_cached(
+        db_session,
+        provider,
+        "example.com",
+        derive_suggestions=True,
+        allow_live=False,
+    )
+
+    assert cached is True
+    assert result.suggested_records == []
+    provider.lookup_mx.assert_not_awaited()
+
+
 def test_parse_tlsa_record_missing_parts():
     record = parse_tlsa_record(
         "3 1 1",

--- a/backend/app/tests/test_dane.py
+++ b/backend/app/tests/test_dane.py
@@ -358,6 +358,46 @@ async def test_check_dane_cached_does_not_open_smtp_when_live_evidence_is_page_r
     provider.lookup_mx.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_check_dane_cached_retains_live_evidence_for_page_refresh(
+    db_session,
+    monkeypatch,
+):
+    provider = FakeDANEDNSProvider(mx_hosts=["mx.example.com"])
+
+    async def fake_suggestions(mx_hosts, *, port, timeout=5.0):
+        return [
+            TLSASuggestion(
+                query_name="_25._tcp.mx.example.com",
+                mx_host="mx.example.com",
+                record="3 1 1 " + "a" * 64,
+                association_data="a" * 64,
+                status="ready",
+            )
+        ]
+
+    monkeypatch.setattr("app.services.dane._derive_tlsa_suggestions", fake_suggestions)
+    await check_dane_cached(
+        db_session,
+        provider,
+        "example.com",
+        derive_suggestions=True,
+    )
+
+    refreshed, cached, _ = await check_dane_cached(
+        db_session,
+        provider,
+        "example.com",
+        derive_suggestions=True,
+        allow_live=False,
+        refresh=True,
+    )
+
+    assert cached is True
+    assert refreshed.suggested_records[0].record == "3 1 1 " + "a" * 64
+    provider.lookup_mx.assert_awaited_once()
+
+
 def test_parse_tlsa_record_missing_parts():
     record = parse_tlsa_record(
         "3 1 1",

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import IntegrityError
 from app.api.api_v1.endpoints import domains as domains_endpoint
 from app.api.api_v1.endpoints.domains import (
     _domain_names_for_summary,
+    _filter_summary_domains,
     _remediation_loop_state,
     _spf_fix_hint,
 )
@@ -2791,6 +2792,36 @@ def test_summary_endpoint_can_hide_empty_domains_before_dns_work(
     assert filtered_data["empty_domains_hidden"] == 1
     assert [domain["domain_name"] for domain in filtered_data["domains"]] == [DOMAIN]
     assert provider.check_domain.await_count == 1
+
+
+def test_filter_summary_domains_reports_hidden_empty_domains():
+    domains, empty_count, hidden_count = _filter_summary_domains(
+        ["active.example", "empty.example"],
+        {
+            "active.example": {"reports_processed": 1, "total_count": 5},
+            "empty.example": {"reports_processed": 0, "total_count": 0},
+        },
+        include_empty=False,
+    )
+
+    assert domains == ["active.example"]
+    assert empty_count == 1
+    assert hidden_count == 1
+
+
+def test_filter_summary_domains_keeps_empty_domains_when_requested():
+    domains, empty_count, hidden_count = _filter_summary_domains(
+        ["active.example", "empty.example"],
+        {
+            "active.example": {"reports_processed": 0, "total_count": 3},
+            "empty.example": {},
+        },
+        include_empty=True,
+    )
+
+    assert domains == ["active.example", "empty.example"]
+    assert empty_count == 1
+    assert hidden_count == 0
 
 
 def test_summary_endpoint_reuses_prewarmed_dns_evidence_with_different_selectors(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -40,6 +40,7 @@ from app.services.dns_cache import (
     _selectors_key,
     get_latest_cached_domain_dns_evidence,
     resolve_domain_dns_cached,
+    store_dns_cache_result,
 )
 from app.services.dns_provider_detection import detect_dns_provider
 from app.services.dns_resolver import (
@@ -1584,6 +1585,59 @@ async def test_dns_cache_reraises_when_conflict_row_missing(db_session, monkeypa
             DOMAIN,
             selectors=["google"],
         )
+
+
+def test_dns_cache_uses_postgresql_upsert_without_integrity_error_retry():
+    """PostgreSQL cache writes should avoid noisy duplicate-key retries."""
+    cached_row = DNSCache(
+        id=123,
+        domain=DOMAIN,
+        provider="CustomDNSProvider",
+        selectors_key="selector-key",
+        result_json="{}",
+        checked_at=datetime(2026, 7, 27, 9, 0, 0),
+    )
+    executed = {}
+
+    class FakeResult:
+        def scalar_one(self):
+            return cached_row.id
+
+    class FakeQuery:
+        def filter(self, *_args):
+            return self
+
+        def one(self):
+            return cached_row
+
+    class FakeDb:
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+
+        def execute(self, statement):
+            executed["statement"] = statement
+            return FakeResult()
+
+        def commit(self):
+            executed["committed"] = True
+
+        def query(self, model):
+            assert model is DNSCache
+            return FakeQuery()
+
+    row = store_dns_cache_result(
+        FakeDb(),
+        None,
+        domain=DOMAIN,
+        provider_name="CustomDNSProvider",
+        selectors_key="selector-key",
+        payload='{"dmarc":true}',
+        checked_at=datetime(2026, 7, 27, 9, 1, 0),
+    )
+
+    assert row is cached_row
+    assert executed["committed"] is True
+    assert "ON CONFLICT" in str(executed["statement"])
+    assert "uq_dns_cache_lookup" in str(executed["statement"])
 
 
 def test_dns_endpoint_refresh_bypasses_cache(authed_client: TestClient):

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -2296,6 +2296,50 @@ def test_enforcement_recommendation_common_states(
 # ---------------------------------------------------------------------------
 
 
+def test_cached_bimi_logo_urls_uses_latest_safe_cached_logo_only(db_session):
+    """Domain summaries may display BIMI without a live DNS lookup."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    db_session.add_all(
+        [
+            DNSCache(
+                domain=DOMAIN,
+                provider="SystemDNSProvider:bimi",
+                selectors_key="older",
+                result_json=json.dumps({"logo_url": "https://example.com/old.svg"}),
+                checked_at=now - timedelta(minutes=2),
+            ),
+            DNSCache(
+                domain=DOMAIN,
+                provider="SystemDNSProvider:bimi",
+                selectors_key="newer",
+                result_json=json.dumps({"logo_url": "https://example.com/current.svg"}),
+                checked_at=now,
+            ),
+            DNSCache(
+                domain="invalid.example",
+                provider="SystemDNSProvider:bimi",
+                selectors_key="invalid",
+                result_json="not-json",
+                checked_at=now,
+            ),
+            DNSCache(
+                domain="unsafe.example",
+                provider="SystemDNSProvider:bimi",
+                selectors_key="unsafe",
+                result_json=json.dumps({"logo_url": "http://unsafe.example/logo.svg"}),
+                checked_at=now,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    assert domains_endpoint._cached_bimi_logo_urls(db_session, []) == {}
+    assert domains_endpoint._cached_bimi_logo_urls(
+        db_session,
+        [DOMAIN, "invalid.example", "unsafe.example"],
+    ) == {DOMAIN: "https://example.com/current.svg"}
+
+
 def test_summary_includes_dns_fields(authed_client: TestClient, db_session):
     """The summary endpoint should include dmarc_status, spf_status, dkim_status."""
     _persist_minimal_report(db_session)

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1604,6 +1604,10 @@ def test_dns_cache_uses_postgresql_upsert_without_integrity_error_retry():
             return cached_row.id
 
     class FakeQuery:
+        def populate_existing(self):
+            executed["populate_existing"] = True
+            return self
+
         def filter(self, *_args):
             return self
 
@@ -1636,8 +1640,48 @@ def test_dns_cache_uses_postgresql_upsert_without_integrity_error_retry():
 
     assert row is cached_row
     assert executed["committed"] is True
+    assert executed["populate_existing"] is True
     assert "ON CONFLICT" in str(executed["statement"])
     assert "uq_dns_cache_lookup" in str(executed["statement"])
+
+
+def test_dns_cache_store_returns_updated_identity_mapped_row(db_session):
+    """Cache writes should return the refreshed in-session row."""
+    stale_checked_at = datetime(2026, 7, 27, 9, 0, 0)
+    fresh_checked_at = datetime(2026, 7, 27, 9, 1, 0)
+    row = DNSCache(
+        domain=DOMAIN,
+        provider="CustomDNSProvider",
+        selectors_key="selector-key",
+        result_json='{"dmarc":false}',
+        checked_at=stale_checked_at,
+    )
+    db_session.add(row)
+    db_session.commit()
+
+    loaded = (
+        db_session.query(DNSCache)
+        .filter(
+            DNSCache.domain == DOMAIN,
+            DNSCache.provider == "CustomDNSProvider",
+            DNSCache.selectors_key == "selector-key",
+        )
+        .one()
+    )
+
+    updated = store_dns_cache_result(
+        db_session,
+        loaded,
+        domain=DOMAIN,
+        provider_name="CustomDNSProvider",
+        selectors_key="selector-key",
+        payload='{"dmarc":true}',
+        checked_at=fresh_checked_at,
+    )
+
+    assert updated is loaded
+    assert updated.result_json == '{"dmarc":true}'
+    assert updated.checked_at == fresh_checked_at
 
 
 def test_dns_endpoint_refresh_bypasses_cache(authed_client: TestClient):

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -1,8 +1,10 @@
 import pytest
 
 from app.services.bimi import BIMIResult
-from app.services.dane import DANEResult, TLSASuggestion
+from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
 from app.services.dns_guidance import (
+    DNSGuidanceRecord,
+    DNSLintFinding,
     MailAuthSetupDefaults,
     build_dns_change_plans,
     build_dns_guidance,
@@ -156,6 +158,33 @@ async def test_change_plan_shows_dmarc_tag_diff_and_suppresses_noop():
     plans = build_dns_change_plans([finding])
     assert plans[0].current_values == [target]
     assert "Add adkim=r." in plans[0].changes
+
+
+def test_change_plan_keeps_consolidation_when_one_rrset_value_matches():
+    desired = "v=spf1 include:mail.example.com -all"
+    finding = DNSLintFinding(
+        code="spf_multiple_records",
+        severity="error",
+        title="Multiple SPF records found",
+        detail="SPF requires exactly one record.",
+        action="Merge the mechanisms into one SPF record.",
+        record_type="TXT",
+        record_name="example.com",
+        target_record=DNSGuidanceRecord(
+            code="target_spf",
+            record_type="TXT",
+            name="example.com",
+            value=desired,
+            purpose="SPF",
+        ),
+        evidence=[desired, "v=spf1 include:legacy.example.com -all"],
+    )
+
+    plans = build_dns_change_plans([finding])
+
+    assert len(plans) == 1
+    assert plans[0].operation == "consolidate"
+    assert plans[0].current_values == finding.evidence
 
 
 @pytest.mark.asyncio
@@ -355,6 +384,67 @@ async def test_build_dns_guidance_uses_live_tlsa_suggestion_as_dane_target():
     assert target.name == "_25._tcp.mail.example.net"
     assert target.value == "3 1 1 " + "a" * 64
     assert "derived from the live STARTTLS certificate" in target.purpose
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_offers_each_uncovered_mx_tlsa_value():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+    first_value = "3 1 1 " + "a" * 64
+    second_value = "3 1 1 " + "b" * 64
+    dane = DANEResult(
+        status="partial",
+        port=25,
+        mx_hosts=["mx1.example.com", "mx2.example.com"],
+        records=[
+            TLSARecord(
+                query_name="_25._tcp.mx1.example.com",
+                mx_host="mx1.example.com",
+                record=first_value,
+                valid=True,
+            )
+        ],
+        suggested_records=[
+            TLSASuggestion(
+                query_name="_25._tcp.mx1.example.com",
+                mx_host="mx1.example.com",
+                record=first_value,
+                status="ready",
+            ),
+            TLSASuggestion(
+                query_name="_25._tcp.mx2.example.com",
+                mx_host="mx2.example.com",
+                record=second_value,
+                status="ready",
+            ),
+        ],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        dane=dane,
+    )
+
+    plans = [plan for plan in guidance.change_plans if plan.record_type == "TLSA"]
+    assert len(plans) == 1
+    assert plans[0].name == "_25._tcp.mx2.example.com"
+    assert plans[0].proposed_value == second_value
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -188,6 +188,28 @@ def test_change_plan_keeps_consolidation_when_one_rrset_value_matches():
     assert plans[0].current_values == finding.evidence
 
 
+def test_change_plan_suppresses_equivalent_tag_values_in_different_order():
+    finding = DNSLintFinding(
+        code="dmarc_alignment_value_invalid",
+        severity="warning",
+        title="DMARC alignment mode needs review",
+        detail="The DMARC record is otherwise healthy.",
+        action="Use strict alignment for this domain.",
+        record_type="TXT",
+        record_name="_dmarc.example.com",
+        target_record=DNSGuidanceRecord(
+            code="target_dmarc",
+            record_type="TXT",
+            name="_dmarc.example.com",
+            value="v=DMARC1; p=reject; rua=mailto:dmarc@example.com; adkim=s",
+            purpose="DMARC",
+        ),
+        evidence=["rua=mailto:dmarc@example.com; adkim=s; p=reject; v=DMARC1"],
+    )
+
+    assert build_dns_change_plans([finding]) == []
+
+
 def test_plan_changes_ignores_malformed_segments_in_tag_records():
     changes = _plan_changes(
         ["v=DMARC1; malformed-tag; p=none"],

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -6,6 +6,7 @@ from app.services.dns_guidance import (
     DNSGuidanceRecord,
     DNSLintFinding,
     MailAuthSetupDefaults,
+    _plan_changes,
     build_dns_change_plans,
     build_dns_guidance,
 )
@@ -185,6 +186,15 @@ def test_change_plan_keeps_consolidation_when_one_rrset_value_matches():
     assert len(plans) == 1
     assert plans[0].operation == "consolidate"
     assert plans[0].current_values == finding.evidence
+
+
+def test_plan_changes_ignores_malformed_segments_in_tag_records():
+    changes = _plan_changes(
+        ["v=DMARC1; malformed-tag; p=none"],
+        "v=DMARC1; p=reject",
+    )
+
+    assert changes == ["Change p from none to reject."]
 
 
 @pytest.mark.asyncio
@@ -445,6 +455,57 @@ async def test_build_dns_guidance_offers_each_uncovered_mx_tlsa_value():
     assert len(plans) == 1
     assert plans[0].name == "_25._tcp.mx2.example.com"
     assert plans[0].proposed_value == second_value
+
+
+@pytest.mark.asyncio
+async def test_build_dns_guidance_keeps_dane_review_when_covered_hosts_need_review():
+    provider = FakeDNSProvider(
+        {
+            "example.com": ["v=spf1 -all"],
+            "_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"],
+        }
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+    record_value = "3 1 1 " + "a" * 64
+    dane = DANEResult(
+        status="partial",
+        mx_hosts=["mx.example.com"],
+        records=[
+            TLSARecord(
+                query_name="_25._tcp.mx.example.com",
+                mx_host="mx.example.com",
+                record=record_value,
+                valid=True,
+            )
+        ],
+        suggested_records=[
+            TLSASuggestion(
+                query_name="_25._tcp.mx.example.com",
+                mx_host="mx.example.com",
+                record=record_value,
+                status="ready",
+            )
+        ],
+        warnings=["DNSSEC validation still needs operator review."],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        dane=dane,
+    )
+
+    assert "dane_review" in {finding.code for finding in guidance.findings}
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -2,7 +2,11 @@ import pytest
 
 from app.services.bimi import BIMIResult
 from app.services.dane import DANEResult, TLSASuggestion
-from app.services.dns_guidance import MailAuthSetupDefaults, build_dns_guidance
+from app.services.dns_guidance import (
+    MailAuthSetupDefaults,
+    build_dns_change_plans,
+    build_dns_guidance,
+)
 from app.services.dns_resolver import BaseDNSProvider, DomainDNSResult
 from app.services.mta_sts import MTAStsResult
 
@@ -97,6 +101,61 @@ async def test_build_dns_guidance_uses_configured_mail_auth_defaults():
         "pct=50; adkim=s; aspf=s"
     )
     assert targets["target_tls_rpt"].value == "v=TLSRPTv1; rua=mailto:tls-reports@central.example"
+
+
+@pytest.mark.asyncio
+async def test_mta_sts_target_includes_policy_file_with_observed_mx_hosts():
+    provider = FakeDNSProvider({"_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"]})
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="fail"),
+        BIMIResult(status="pass"),
+        dane=DANEResult(mx_hosts=["mx1.example.com", "mx2.example.com"]),
+    )
+
+    target = next(record for record in guidance.target_records if record.code == "target_mta_sts")
+    assert target.supporting_content == (
+        "version: STSv1\nmode: testing\nmx: mx1.example.com\nmx: mx2.example.com\nmax_age: 86400"
+    )
+    assert target.supporting_content_url == "https://mta-sts.example.com/.well-known/mta-sts.txt"
+
+
+@pytest.mark.asyncio
+async def test_change_plan_shows_dmarc_tag_diff_and_suppresses_noop():
+    provider = FakeDNSProvider({"_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"]})
+    target = "v=DMARC1; p=reject; rua=mailto:dmarc@example.com; pct=100"
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record=target,
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+        dmarc_warnings=["DMARC adkim tag should be r or s."],
+    )
+    guidance = await build_dns_guidance(
+        "example.com", provider, dns, MTAStsResult(status="pass"), BIMIResult(status="pass")
+    )
+
+    assert not [plan for plan in guidance.change_plans if plan.finding_code == "dmarc_alignment_value_invalid"]
+
+    finding = next(
+        finding for finding in guidance.findings if finding.code == "dmarc_alignment_value_invalid"
+    )
+    finding.target_record.value = "v=DMARC1; p=reject; rua=mailto:dmarc@example.com; pct=100; adkim=r"
+    plans = build_dns_change_plans([finding])
+    assert plans[0].current_values == [target]
+    assert "Add adkim=r." in plans[0].changes
 
 
 @pytest.mark.asyncio

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -316,11 +316,14 @@ email addresses and domains; secrets and opaque tokens are still redacted in
 every mode. Demo mode keeps these plans template-backed and heavily cached.
 
 The same section also shows a proposed DNS change plan when findings are
-actionable. These plans include the record name, type, proposed value, captured
-current values when available, risk notes, rollback guidance, and expected
-health impact. Operators can copy/paste the records manually, preview a
-provider mutation, or apply safe TXT/CNAME changes through a configured DNS
-provider after explicit browser confirmation.
+actionable. Every plan shows the observed value (**Before**), proposed value
+(**After**), exact tag/value changes, and the lint evidence explaining **Why**
+the change is suggested. If the proposed value already matches DNS, DMARQ
+suppresses the plan rather than presenting a misleading write. Plans also
+include risk notes, rollback guidance, and expected health impact. Operators
+can copy/paste the records manually, preview a provider mutation, or apply safe
+TXT/CNAME changes through a configured DNS provider after explicit browser
+confirmation.
 
 When DMARQ can detect the authoritative DNS provider from nameservers and a
 matching connector is available, the change-plan section highlights the
@@ -400,17 +403,29 @@ When `_mta-sts.<domain>` exists but `mta-sts.<domain>` does not resolve or the H
 
 MTA-STS posture uses the same cached DNS refresh behavior as the existing DNS health checks. Use the DNS refresh action when you publish or update a policy and need DMARQ to re-check immediately.
 
+For a new policy, DMARQ provides a copyable starter policy at the policy URL.
+It begins in `testing` mode and contains every observed MX host. Publish the
+file before changing to `enforce`; then update the `_mta-sts` TXT `id` so
+receivers refetch the policy.
+
 ### DANE/TLSA Posture
 
 When a domain has MX records, DMARQ can inspect passive DANE/TLSA readiness for
 the `_25._tcp.<mx-host>` names on a best-effort basis. The check is read-only:
 it reports whether TLSA records exist, whether their syntax is usable, and
 whether capped live SMTP STARTTLS probing can reach an MX certificate that
-produces an operator-ready `3 1 1` SPKI SHA-256 suggestion.
+produces an operator-ready `3 1 1` SPKI SHA-256 suggestion. When evidence is
+available, DMARQ creates one reviewable suggestion for each reachable MX host,
+because each host has its own `_25._tcp.<mx-host>` record and may use a
+different certificate.
 
 Treat generated TLSA values as review evidence, not an automatic DNS change.
 The operator still needs to confirm DNSSEC posture, MX certificate rotation
 policy, and maintenance timing before publishing or replacing TLSA records.
+The value is the SHA-256 digest of the certificate SubjectPublicKeyInfo (SPKI),
+not a generic certificate fingerprint. To keep page loads fast and avoid new
+network activity while reviewing a domain, DMARQ collects this bounded SMTP
+evidence during DNS prewarming; the page only reads cached evidence.
 
 ### BIMI Readiness
 
@@ -425,7 +440,9 @@ published `sp=` subdomain policy must also enforce.
 
 BIMI posture is read-only. Findings link back to the BIMI TXT record, logo URL,
 certificate URL, and DMARC policy evidence so operators can see which
-prerequisite is blocking readiness.
+prerequisite is blocking readiness. When the published `l=` URL is available,
+DMARQ also displays the logo in the domain detail view and the cached domain
+list; opening it still goes directly to the publisher's HTTPS asset.
 
 ## Domain Groups
 


### PR DESCRIPTION
## What changed\n- show every DNS plan as Before, After, exact value/tag diff, and Why; suppress no-op suggestions\n- provide an MTA-STS testing policy-file example using observed MX hosts\n- render published BIMI logos on domain detail and the cached domain list\n- derive reviewable DANE TLSA 3 1 1 values per cached MX certificate without opening SMTP connections during page reads\n\nCloses #875\nCloses #876\n\n## Validation\n- Docker build\n- 47 focused DNS/DANE/BIMI tests\n- 147 DNS endpoint, security, and prewarm tests\n- JavaScript syntax checks\n- fresh container startup smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DNS change plans now include clear **Before/After** values, **exact tag/value edits**, and a “what changes” callout, while suppressing irrelevant no-op plans.
  * MTA-STS guidance provides a copyable **testing policy example** populated from observed mail servers.
  * BIMI results now surface the **logo (with preview/link)** in both domain lists and details.
  * DANE/TLSA posture now generates **reviewable proposals per eligible mail server**.
* **Documentation**
  * Updated the DNS guidance, DANE/TLSA posture, and BIMI readiness sections to match the new presentation.
* **Tests**
  * Expanded coverage around cached DANE behavior and DNS guidance/plan generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->