### PR TITLE
fix: keep domain posture reads read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,10 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
-- Started domain health history automatically with one persisted score snapshot
-  per domain and day. Existing domains receive their initial trend point when
-  their detail view opens, and later visits reuse that evidence rather than
-  repeating the expensive posture calculation.
+- Made domain health history and evidence exports read-only by default. A page
+  visit cannot create or overwrite a score snapshot; only an explicit DNS
+  refresh or an opt-in maintenance capture may record new evidence.
 - Reworked the domain DNS view into an email-authentication workflow. The next
   safe change and core DMARC, SPF, and DKIM evidence lead the view; provider
   connection details, optional standards, selector management, implementation

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -6400,7 +6400,10 @@ async def get_domain_posture_dashboard(
         workspace=workspace,
         domain_id=domain_id,
         refresh=refresh,
-        capture_snapshot=not get_settings().DEMO_MODE,
+        # A normal page read must not create or overwrite health evidence.
+        # Explicit DNS refresh is the current operator-owned capture path until
+        # the durable posture-refresh worker in #873 takes over.
+        capture_snapshot=bool(refresh and not get_settings().DEMO_MODE),
     )
 
 
@@ -6832,7 +6835,7 @@ async def get_domain_health_score_history(
     start_date: Optional[date] = Query(None, title="Start date for score history"),
     end_date: Optional[date] = Query(None, title="End date for score history"),
     limit: int = Query(120, ge=1, le=400, title="Maximum history points"),
-    capture_current: bool = Query(True, title="Capture today's current posture first"),
+    capture_current: bool = Query(False, title="Capture today's current posture first"),
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
@@ -6853,9 +6856,10 @@ async def get_domain_health_score_history(
             detail="Domain not found",
         )
 
-    # The page requests this endpoint on every visit.  Capture the first
-    # snapshot of the day, then read the persisted evidence on later visits
-    # instead of repeating DNS and report aggregation work.
+    # This endpoint is read-only by default. A page visit must not calculate
+    # new DNS posture or mutate the score history. The opt-in capture path is
+    # retained for controlled maintenance/backfill callers during the #873
+    # snapshot-projection migration.
     snapshots_today = list_health_score_snapshots(
         db,
         workspace_id=workspace.id,
@@ -6906,7 +6910,7 @@ async def export_domain_health_evidence(
     start_date: Optional[date] = Query(None, title="Start date for evidence export"),
     end_date: Optional[date] = Query(None, title="End date for evidence export"),
     limit: int = Query(400, ge=1, le=1000, title="Maximum exported snapshots"),
-    capture_current: bool = Query(True, title="Capture today's current posture first"),
+    capture_current: bool = Query(False, title="Capture today's current posture first"),
     export_format: str = Query(
         "csv",
         alias="format",

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -510,9 +510,7 @@ function domainDetailsApp(domainId = '') {
                     this.fetchDNSRecords({ refresh: true }),
                     this.fetchDNSHealth({ refresh: true }),
                     this.fetchDNSGuidance({ refresh: true }),
-                    this.fetchPosture({ refresh: true }),
                     this.fetchRemediationQueue({ refresh: true }),
-                    this.fetchHealthHistory(),
                     this.fetchMtaSts({ refresh: true }),
                     this.fetchBimi({ refresh: true }),
                     this.fetchSelectors(),
@@ -520,6 +518,8 @@ function domainDetailsApp(domainId = '') {
                     this.fetchSources({ refresh: true, preserveOnFailure: true }),
                     this.fetchSourceIntelligence({ preserveOnFailure: true })
                 ]);
+                await this.fetchPosture({ refresh: true });
+                await this.fetchHealthHistory();
             } finally {
                 this.refreshingPage = false;
             }
@@ -529,9 +529,10 @@ function domainDetailsApp(domainId = '') {
             await Promise.allSettled([
                 this.fetchDNSRecords({ refresh: true, preserveEvidenceOnFailure: true }),
                 this.fetchDNSHealth({ refresh: true }),
-                this.fetchDNSGuidance({ refresh: true }),
-                this.fetchPosture({ refresh: true })
+                this.fetchDNSGuidance({ refresh: true })
             ]);
+            await this.fetchPosture({ refresh: true });
+            await this.fetchHealthHistory();
         },
 
         async refreshSourceReputation() {

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -2925,7 +2925,10 @@ function domainDetailsApp(domainId = '') {
             this.healthHistory.loading = true;
             this.healthHistory.error = '';
             try {
-                const captureCurrent = options.captureCurrent !== false;
+                // Health history is evidence, not a page-load side effect.
+                // Only an explicit caller may request a capture while the
+                // asynchronous posture snapshot worker is introduced.
+                const captureCurrent = options.captureCurrent === true;
                 const params = new URLSearchParams({
                     capture_current: captureCurrent ? 'true' : 'false',
                     limit: '30'

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2354,6 +2354,7 @@ def test_domain_details_exposes_ownership_and_delete_controls_without_html_injec
     assert "data-domain-detail-reload" in script
     assert "data-domain-detail-refresh-dns" in script
     assert "refreshDNSData" in script
+    assert "await this.fetchPosture({ refresh: true });\n            await this.fetchHealthHistory();" in script
     assert "data-domain-detail-delete" in script
     assert "data-domain-detail-verify-ownership" in script
     assert "data-domain-detail-verify-cloudflare" in script

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -754,14 +754,14 @@ def _stub_current_health(monkeypatch):
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
 
 
-def test_domain_health_history_capture_current_snapshot(
+def test_domain_health_history_explicit_capture_current_snapshot(
     seeded_client: TestClient,
     monkeypatch,
 ):
     """Health history can capture today's computed posture before reading history."""
     _stub_current_health(monkeypatch)
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history?capture_current=true")
 
     assert response.status_code == 200
     data = response.json()
@@ -770,7 +770,32 @@ def test_domain_health_history_capture_current_snapshot(
     assert data["top_drivers"][0]["title"] == "Keep monitoring"
 
 
-def test_domain_health_history_does_not_recalculate_an_existing_daily_snapshot(
+def test_domain_health_history_is_read_only_by_default(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Opening history must not create a new DNS or score observation."""
+    calls = {"dns": 0, "health": 0}
+
+    async def fake_dns_health(*_args, **_kwargs):
+        calls["dns"] += 1
+        raise AssertionError("history reads must not resolve DNS")
+
+    async def fake_domain_grade(*_args, **_kwargs):
+        calls["health"] += 1
+        raise AssertionError("history reads must not recalculate health")
+
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_health", fake_dns_health)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history")
+
+    assert response.status_code == 200
+    assert response.json()["points"] == []
+    assert calls == {"dns": 0, "health": 0}
+
+
+def test_domain_health_history_explicit_capture_does_not_recalculate_an_existing_daily_snapshot(
     seeded_client: TestClient,
     monkeypatch,
 ):
@@ -803,8 +828,8 @@ def test_domain_health_history_does_not_recalculate_an_existing_daily_snapshot(
     monkeypatch.setattr(domains_endpoint, "_build_domain_dns_health", fake_dns_health)
     monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_domain_grade)
 
-    first = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history")
-    second = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history")
+    first = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history?capture_current=true")
+    second = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/history?capture_current=true")
 
     assert first.status_code == 200
     assert second.status_code == 200
@@ -812,14 +837,16 @@ def test_domain_health_history_does_not_recalculate_an_existing_daily_snapshot(
     assert calls == {"dns": 1, "health": 1}
 
 
-def test_domain_health_evidence_export_capture_current_snapshot(
+def test_domain_health_evidence_export_explicit_capture_current_snapshot(
     seeded_client: TestClient,
     monkeypatch,
 ):
     """Evidence export can capture the current score before writing CSV."""
     _stub_current_health(monkeypatch)
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture/evidence/export")
+    response = seeded_client.get(
+        f"/api/v1/domains/{DOMAIN}/posture/evidence/export?capture_current=true"
+    )
 
     assert response.status_code == 200
     rows = list(csv.DictReader(StringIO(response.text)))
@@ -828,7 +855,7 @@ def test_domain_health_evidence_export_capture_current_snapshot(
     assert rows[0]["top_actions"] == "low:Keep monitoring"
 
 
-def test_domain_posture_dashboard_records_current_snapshot(
+def test_domain_posture_dashboard_explicit_refresh_records_current_snapshot(
     seeded_client: TestClient,
     db_session,
     monkeypatch,
@@ -836,7 +863,7 @@ def test_domain_posture_dashboard_records_current_snapshot(
     """The posture dashboard records today's health score outside demo mode."""
     _stub_current_health(monkeypatch)
 
-    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture")
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture?refresh=true")
 
     assert response.status_code == 200
     assert response.json()["health"]["score"] == 96
@@ -847,6 +874,26 @@ def test_domain_posture_dashboard_records_current_snapshot(
         domain_name=DOMAIN,
     )
     assert snapshots[-1].score == 96
+
+
+def test_domain_posture_dashboard_is_read_only_without_explicit_refresh(
+    seeded_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """A posture page visit must not add a health-score history point."""
+    _stub_current_health(monkeypatch)
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/posture")
+
+    assert response.status_code == 200
+    workspace = get_or_create_default_workspace(db_session)
+    snapshots = domains_endpoint.list_health_score_snapshots(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name=DOMAIN,
+    )
+    assert snapshots == []
 
 
 def test_domain_remediation_queue_groups_dns_and_health_actions(

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "backend/app/tests/**"

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -94,6 +94,12 @@ summarizes coverage for DMARC, SPF, DKIM, MTA-STS, and BIMI, assigns a simple
 posture score, and shows each recommendation with links back to the DNS record,
 report trend, sending-source table, or posture evidence that triggered it.
 
+Opening the domain, score trend, or evidence export does not refresh DNS or
+write a new score history entry. DMARQ keeps showing the last recorded
+evidence until you choose **Refresh DNS evidence**. That explicit action is
+the current way to collect a new posture observation; a failed refresh must
+not silently turn the previous verified posture into a missing record.
+
 The same surface includes a **What Changed** panel when provider-backed DNS
 change tracking has observed additions, edits, or removals. Those summaries are
 designed for drift review: operators can see the previous and current values


### PR DESCRIPTION
Closes #871\n\nNormal domain posture, health-history, and evidence-export reads no longer calculate or persist score evidence. Only an explicit DNS refresh or opt-in capture may create a snapshot, preventing ordinary navigation from changing a visible grade.\n\nValidation:\n- Docker image build\n- 300 endpoint/detail/template tests passed (27 skipped)\n- Flake8, Python compilation, JavaScript syntax, and diff validation passed