### PR TITLE
fix: keep domain detail reads on cached evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Made normal domain-detail and remediation reads use persisted DNS, MTA-STS,
+  BIMI, DANE, and reputation evidence instead of triggering live enrichment
+  after a cache TTL expires. The UI now reports missing evidence honestly and
+  reserves live network checks for explicit refreshes and background prewarming.
 - Made domain health history and evidence exports read-only by default. A page
   visit cannot create or overwrite a score snapshot; only an explicit DNS
   refresh or an opt-in maintenance capture may record new evidence.

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -8,6 +8,7 @@ import ipaddress
 import json
 import logging
 import secrets
+from contextvars import ContextVar
 from dataclasses import asdict
 from datetime import date, datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
@@ -177,6 +178,10 @@ from app.services.workspaces import (
 from app.utils.domain_validator import normalize_domain_name, validate_domain_config
 
 logger = logging.getLogger(__name__)
+
+# Queue reads run in this request-scoped context so they can never initiate
+# enrichment work. ContextVar is copied into the concurrent queue tasks.
+_CACHED_DNS_READ = ContextVar("cached_dns_read", default=False)
 
 
 def _safe_log_value(value: Any) -> str:
@@ -3612,6 +3617,8 @@ def _bimi_recommendation(
     dmarc_issues: List[str],
     dmarc_evidence: List[DNSHealthEvidence],
 ) -> Optional[DNSHealthRecommendation]:
+    if result.status == "pending":
+        return None
     bimi_evidence = _bimi_check(result, dmarc_ready).evidence
     if result.status == "pass" and dmarc_ready and not result.warnings:
         return None
@@ -3674,6 +3681,8 @@ def _mta_sts_check(result: MTAStsResult) -> DNSHealthCheck:
 
 
 def _mta_sts_recommendation(result: MTAStsResult) -> Optional[DNSHealthRecommendation]:
+    if result.status == "pending":
+        return None
     if result.status == "pass" and not result.warnings:
         return None
     severity = "warning" if result.status == "pass" else "error"
@@ -3721,8 +3730,10 @@ async def _build_domain_dns_health(  # pylint: disable=too-many-locals
     domain_id: str,
     *,
     refresh: bool = False,
+    cached_only: bool = False,
 ) -> DNSHealthResponse:
     """Build the shared DNS/posture health payload for a monitored domain."""
+    cached_only = cached_only or _CACHED_DNS_READ.get()
     manual_selectors = _get_domain_selectors_from_db(db, domain_id)
     selector_evidence = store.get_domain_selector_evidence(
         domain_id,
@@ -3736,26 +3747,58 @@ async def _build_domain_dns_health(  # pylint: disable=too-many-locals
     combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
 
     provider = get_default_provider(db)
-    result, _, _ = await resolve_domain_dns_cached(
-        db,
-        provider,
-        domain_id,
-        selectors=combined_selectors,
-        refresh=refresh,
-    )
+    if cached_only:
+        result = await _resolve_summary_dns_result(
+            db,
+            provider,
+            domain_id,
+            selectors=combined_selectors,
+            refresh=False,
+        )
+    else:
+        result, _, _ = await resolve_domain_dns_cached(
+            db,
+            provider,
+            domain_id,
+            selectors=combined_selectors,
+            refresh=refresh,
+        )
+    summary = store.get_domain_summary(domain_id)
+    if bool(getattr(result, "pending", False)):
+        pending_check = DNSHealthCheck(
+            key="dns_evidence",
+            label="DNS evidence",
+            status="review",
+            message=(
+                "DNS posture has not been captured yet. Use Refresh DNS evidence "
+                "to collect it without blocking this page."
+            ),
+            evidence=[],
+        )
+        return DNSHealthResponse(
+            status="pending",
+            policy="none",
+            compliance_rate=float(summary.get("compliance_rate", 0.0) or 0.0),
+            total_emails=int(summary.get("total_count", 0) or 0),
+            failed_emails=int(summary.get("failed_count", 0) or 0),
+            dns_lookup_status="pending",
+            checks=[pending_check],
+            recommendations=[],
+        )
     mta_sts_result, _, _ = await check_mta_sts_cached(
         db,
         provider,
         domain_id,
         refresh=refresh,
+        allow_live=not cached_only,
     )
     bimi_result, _, _ = await check_bimi_cached(
         db,
         provider,
         domain_id,
         refresh=refresh,
+        allow_live=not cached_only,
     )
-    summary = store.get_domain_summary(domain_id)
     policy = extract_dmarc_policy(result.dmarc_record) or "none"
     bimi_dmarc_ready, bimi_dmarc_issues, bimi_dmarc_evidence = _bimi_dmarc_readiness(
         result.dmarc_record
@@ -3871,8 +3914,10 @@ async def _build_domain_dns_guidance(
     *,
     refresh: bool = False,
     locale: Optional[str] = None,
+    cached_only: bool = False,
 ) -> Dict[str, Any]:
     """Build typed DNS lint findings and target records for a monitored domain."""
+    cached_only = cached_only or _CACHED_DNS_READ.get()
     manual_selectors = _get_domain_selectors_from_db(db, domain_id)
     selector_evidence = store.get_domain_selector_evidence(
         domain_id,
@@ -3886,24 +3931,46 @@ async def _build_domain_dns_guidance(
     combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
 
     provider = get_default_provider(db)
-    dns_result, _, _ = await resolve_domain_dns_cached(
-        db,
-        provider,
-        domain_id,
-        selectors=combined_selectors,
-        refresh=refresh,
-    )
+    if cached_only:
+        dns_result = await _resolve_summary_dns_result(
+            db,
+            provider,
+            domain_id,
+            selectors=combined_selectors,
+            refresh=False,
+        )
+    else:
+        dns_result, _, _ = await resolve_domain_dns_cached(
+            db,
+            provider,
+            domain_id,
+            selectors=combined_selectors,
+            refresh=refresh,
+        )
+    if bool(getattr(dns_result, "pending", False)):
+        return {
+            "domain": domain_id,
+            "status": "pending",
+            "findings": [],
+            "target_records": [],
+            "dns_provider": None,
+            "change_plans": [],
+            "selector_evidence": selector_evidence,
+            "enrichment_pending": True,
+        }
     mta_sts_result, _, _ = await check_mta_sts_cached(
         db,
         provider,
         domain_id,
         refresh=refresh,
+        allow_live=not cached_only,
     )
     bimi_result, _, _ = await check_bimi_cached(
         db,
         provider,
         domain_id,
         refresh=refresh,
+        allow_live=not cached_only,
     )
     dane_result, _, _ = await check_dane_cached(
         db,
@@ -3928,6 +3995,7 @@ async def _build_domain_dns_guidance(
         mail_service_records=mail_service_records,
         setup_defaults=_mail_auth_setup_defaults(db, stored_domain),
         locale=locale or get_settings().default_locale,
+        allow_live=not cached_only,
     )
     return asdict(guidance)
 
@@ -4117,20 +4185,31 @@ async def _build_domain_health_grade(
     store: ReportStore,
     *,
     refresh: bool = False,
+    cached_only: bool = False,
 ) -> Dict[str, Any]:
     """Build the dashboard-grade health object for a domain detail page."""
+    cached_only = cached_only or _CACHED_DNS_READ.get()
     manual_selectors = _get_domain_selectors_from_db(db, domain_id)
     report_selectors = _get_selectors_from_reports(store, domain_id)
     combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
     provider = get_default_provider(db)
     try:
-        dns, _, _ = await resolve_domain_dns_cached(
-            db,
-            provider,
-            domain_id,
-            selectors=combined_selectors,
-            refresh=refresh,
-        )
+        if cached_only:
+            dns = await _resolve_summary_dns_result(
+                db,
+                provider,
+                domain_id,
+                selectors=combined_selectors,
+                refresh=False,
+            )
+        else:
+            dns, _, _ = await resolve_domain_dns_cached(
+                db,
+                provider,
+                domain_id,
+                selectors=combined_selectors,
+                refresh=refresh,
+            )
     except (asyncio.TimeoutError, LookupError, OSError) as exc:
         dns = DomainDNSResult(
             lookup_status="failed",
@@ -4168,6 +4247,7 @@ async def _build_domain_health_grade(
         anomalies_by_ip=intelligence.get("anomalies_by_ip", {}),
         days=30,
         refresh=refresh,
+        allow_live=not cached_only,
     )
     dmarc_policy, dmarc_policy_source = _dmarc_policy_with_source(
         dns,
@@ -6094,6 +6174,7 @@ async def preview_domain_migration_import(
 async def get_domain_dns_records(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached DNS result"),
+    cached_only: bool = Query(False, title="Use stored DNS evidence without a live lookup"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -6119,13 +6200,24 @@ async def get_domain_dns_records(
     combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
 
     provider = get_default_provider(db)
-    result, cached, checked_at = await resolve_domain_dns_cached(
-        db,
-        provider,
-        domain_id,
-        selectors=combined_selectors,
-        refresh=refresh,
-    )
+    if cached_only:
+        result = await _resolve_summary_dns_result(
+            db,
+            provider,
+            domain_id,
+            selectors=combined_selectors,
+            refresh=False,
+        )
+        cached = bool(getattr(result, "cached", False))
+        checked_at = getattr(result, "checked_at", None)
+    else:
+        result, cached, checked_at = await resolve_domain_dns_cached(
+            db,
+            provider,
+            domain_id,
+            selectors=combined_selectors,
+            refresh=refresh,
+        )
 
     return DNSRecordResponse(
         dmarc=result.dmarc,
@@ -6135,7 +6227,7 @@ async def get_domain_dns_records(
         dkim=result.dkim,
         dkimSelectors=result.dkim_selectors,
         cached=cached,
-        checkedAt=checked_at.isoformat(),
+        checkedAt=checked_at.isoformat() if checked_at else None,
         dmarcWarnings=result.dmarc_warnings,
         dmarcSuggestions=result.dmarc_suggestions,
         nameservers=result.nameservers,
@@ -6154,6 +6246,7 @@ async def get_domain_dns_records(
 async def get_domain_dns_lint(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached DNS result"),
+    cached_only: bool = Query(False, title="Use stored DNS evidence without live DNS probes"),
     locale: Optional[str] = Query(None, title="Operator guidance locale"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
@@ -6169,7 +6262,10 @@ async def get_domain_dns_lint(
             detail="Domain not found",
         )
 
-    return await _build_domain_dns_guidance(db, store, domain_id, refresh=refresh, locale=locale)
+    guidance_kwargs: Dict[str, Any] = {"refresh": refresh, "locale": locale}
+    if cached_only:
+        guidance_kwargs["cached_only"] = True
+    return await _build_domain_dns_guidance(db, store, domain_id, **guidance_kwargs)
 
 
 @router.get("/{domain_id}/dns/change-plan", response_model=DNSChangePlanResponse)
@@ -6431,6 +6527,7 @@ async def apply_domain_dns_change_plan(
 async def get_domain_dns_health(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached DNS result"),
+    cached_only: bool = Query(False, title="Use stored DNS evidence without a live lookup"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -6444,13 +6541,17 @@ async def get_domain_dns_health(
             detail="Domain not found",
         )
 
-    return await _build_domain_dns_health(db, store, domain_id, refresh=refresh)
+    health_kwargs: Dict[str, Any] = {"refresh": refresh}
+    if cached_only:
+        health_kwargs["cached_only"] = True
+    return await _build_domain_dns_health(db, store, domain_id, **health_kwargs)
 
 
 @router.get("/{domain_id}/posture", response_model=PostureDashboardResponse)
 async def get_domain_posture_dashboard(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached DNS posture"),
+    cached_only: bool = Query(False, title="Use stored posture evidence without live enrichment"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -6461,6 +6562,7 @@ async def get_domain_posture_dashboard(
         workspace=workspace,
         domain_id=domain_id,
         refresh=refresh,
+        cached_only=cached_only,
         # A normal page read must not create or overwrite health evidence.
         # Explicit DNS refresh is the current operator-owned capture path until
         # the durable posture-refresh worker in #873 takes over.
@@ -6475,17 +6577,18 @@ async def _build_domain_posture_dashboard_for_workspace(
     domain_id: str,
     refresh: bool = False,
     capture_snapshot: bool = True,
+    cached_only: bool = False,
 ) -> PostureDashboardResponse:
     """Build a posture dashboard, optionally persisting the current health snapshot."""
     domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
-    health = await _build_domain_dns_health(db, store, domain_name, refresh=refresh)
-    domain_health = await _build_domain_health_grade(
-        db,
-        domain_name,
-        store,
-        refresh=refresh,
-    )
+    health_kwargs: Dict[str, Any] = {"refresh": refresh}
+    grade_kwargs: Dict[str, Any] = {"refresh": refresh}
+    if cached_only:
+        health_kwargs["cached_only"] = True
+        grade_kwargs["cached_only"] = True
+    health = await _build_domain_dns_health(db, store, domain_name, **health_kwargs)
+    domain_health = await _build_domain_health_grade(db, domain_name, store, **grade_kwargs)
     summary = store.get_domain_summary(domain_name)
     if capture_snapshot:
         _record_health_snapshot_from_posture(
@@ -6500,7 +6603,7 @@ async def _build_domain_posture_dashboard_for_workspace(
     return _build_posture_dashboard(domain_name, health, domain_health, changes)
 
 
-async def _build_domain_remediation_queue_for_workspace(
+async def _build_domain_remediation_queue_for_workspace(  # noqa: C901
     db: Session,
     *,
     workspace: Workspace,
@@ -6541,24 +6644,28 @@ async def _build_domain_remediation_queue_for_workspace(
         "dns_provider": None,
         "enrichment_pending": True,
     }
-    enrichment_tasks = {
-        "health": asyncio.create_task(
-            _build_domain_health_grade(
-                db,
-                domain_name,
-                store,
-                refresh=refresh,
-            )
-        ),
-        "guidance": asyncio.create_task(
-            _build_domain_dns_guidance(
-                db,
-                store,
-                domain_name,
-                refresh=refresh,
-            )
-        ),
-    }
+    cached_read_token = _CACHED_DNS_READ.set(True)
+    try:
+        enrichment_tasks = {
+            "health": asyncio.create_task(
+                _build_domain_health_grade(
+                    db,
+                    domain_name,
+                    store,
+                    refresh=refresh,
+                )
+            ),
+            "guidance": asyncio.create_task(
+                _build_domain_dns_guidance(
+                    db,
+                    store,
+                    domain_name,
+                    refresh=refresh,
+                )
+            ),
+        }
+    finally:
+        _CACHED_DNS_READ.reset(cached_read_token)
     completed, pending = await asyncio.wait(
         set(enrichment_tasks.values()),
         timeout=timeout_seconds,
@@ -7006,6 +7113,7 @@ async def export_domain_health_evidence(
 async def get_domain_mta_sts(
     domain_id: str = Path(..., title="The domain ID or name"),
     refresh: bool = Query(False, title="Refresh cached MTA-STS result"),
+    cached_only: bool = Query(False, title="Use stored MTA-STS evidence without a live check"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -7018,11 +7126,14 @@ async def get_domain_mta_sts(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Domain not found",
         )
+    mta_sts_kwargs: Dict[str, Any] = {"refresh": refresh}
+    if cached_only:
+        mta_sts_kwargs["allow_live"] = False
     result, cached, checked_at = await check_mta_sts_cached(
         db,
         get_default_provider(db),
         domain_id,
-        refresh=refresh,
+        **mta_sts_kwargs,
     )
     return MTAStsResponse(
         status=result.status,
@@ -7044,6 +7155,7 @@ async def get_domain_bimi(
     domain_id: str = Path(..., title="The domain ID or name"),
     selector: str = Query("default", title="BIMI selector"),
     refresh: bool = Query(False, title="Refresh cached BIMI result"),
+    cached_only: bool = Query(False, title="Use stored BIMI evidence without a live lookup"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -7056,12 +7168,14 @@ async def get_domain_bimi(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Domain not found",
         )
+    bimi_kwargs: Dict[str, Any] = {"selector": selector, "refresh": refresh}
+    if cached_only:
+        bimi_kwargs["allow_live"] = False
     result, cached, checked_at = await check_bimi_cached(
         db,
         get_default_provider(db),
         domain_id,
-        selector=selector,
-        refresh=refresh,
+        **bimi_kwargs,
     )
     return BIMIResponse(
         status=result.status,
@@ -7087,6 +7201,7 @@ async def get_domain_dane(
         False,
         title="Derive live SMTP STARTTLS TLSA suggestions",
     ),
+    cached_only: bool = Query(False, title="Use stored DANE evidence without a live lookup"),
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ):
@@ -7099,13 +7214,18 @@ async def get_domain_dane(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Domain not found",
         )
+    dane_kwargs: Dict[str, Any] = {
+        "port": port,
+        "refresh": refresh,
+        "derive_suggestions": derive_suggestions,
+    }
+    if cached_only:
+        dane_kwargs["allow_live"] = False
     result, cached, checked_at = await check_dane_cached(
         db,
         get_default_provider(db),
         domain_id,
-        port=port,
-        refresh=refresh,
-        derive_suggestions=derive_suggestions,
+        **dane_kwargs,
     )
     return DANEResponse(
         status=result.status,

--- a/backend/app/services/bimi.py
+++ b/backend/app/services/bimi.py
@@ -178,8 +178,13 @@ async def check_bimi_cached(
     selector: str = "default",
     ttl_seconds: int = DEFAULT_DNS_CACHE_TTL_SECONDS,
     refresh: bool = False,
+    allow_live: bool = True,
 ) -> Tuple[BIMIResult, bool, datetime]:
-    """Resolve BIMI posture, reusing the shared DNS cache semantics."""
+    """Resolve BIMI posture, reusing the shared DNS cache semantics.
+
+    Opening a domain page is a read operation. It may surface stale captured
+    evidence, but it must not initiate a DNS probe.
+    """
     normalized_selector = (selector or "default").strip().lower()
     cache_key = f"{_CACHE_KEY_PREFIX}:{normalized_selector}"
     now = _utcnow_naive()
@@ -193,8 +198,20 @@ async def check_bimi_cached(
         )
         .first()
     )
-    if row and not refresh and _is_fresh(row, ttl_seconds, now):
+    if row and not refresh and (_is_fresh(row, ttl_seconds, now) or not allow_live):
         return _result_from_json(row.result_json), True, row.checked_at
+
+    if not allow_live:
+        return (
+            BIMIResult(
+                status="pending",
+                selector=normalized_selector,
+                query_name=f"{normalized_selector}._bimi.{domain}",
+                errors=["BIMI evidence has not been captured yet."],
+            ),
+            True,
+            now,
+        )
 
     result = await check_bimi_with_fallback(domain, provider, selector=normalized_selector)
     payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))

--- a/backend/app/services/bimi.py
+++ b/backend/app/services/bimi.py
@@ -198,7 +198,7 @@ async def check_bimi_cached(
         )
         .first()
     )
-    if row and (not refresh and _is_fresh(row, ttl_seconds, now) or not allow_live):
+    if row and ((not refresh and _is_fresh(row, ttl_seconds, now)) or not allow_live):
         return _result_from_json(row.result_json), True, row.checked_at
 
     if not allow_live:

--- a/backend/app/services/bimi.py
+++ b/backend/app/services/bimi.py
@@ -198,7 +198,7 @@ async def check_bimi_cached(
         )
         .first()
     )
-    if row and not refresh and (_is_fresh(row, ttl_seconds, now) or not allow_live):
+    if row and (not refresh and _is_fresh(row, ttl_seconds, now) or not allow_live):
         return _result_from_json(row.result_json), True, row.checked_at
 
     if not allow_live:

--- a/backend/app/services/dane.py
+++ b/backend/app/services/dane.py
@@ -485,11 +485,11 @@ async def check_dane_cached(
         )
         .first()
     )
-    if derive_suggestions and not allow_live:
-        # Page reads must never open SMTP connections. Startup and scheduled
-        # prewarming populate this cache. Retain the last captured certificate
+    if not allow_live:
+        # Page reads must never open DNS or SMTP connections. Startup and
+        # scheduled prewarming populate this cache. Retain the last captured
         # evidence even when it is older than the normal DNS TTL: refreshing a
-        # browser view must not discard a useful TLSA proposal or open SMTP.
+        # browser view must not discard useful posture or open the network.
         if row:
             return _result_from_json(row.result_json), True, row.checked_at
         # Absent evidence remains an honest "not yet captured" state rather

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -786,6 +786,8 @@ async def _spf_findings(
     provider: BaseDNSProvider,
     result: DomainDNSResult,
     targets: List[DNSGuidanceRecord],
+    *,
+    allow_live: bool = True,
 ) -> List[DNSLintFinding]:
     findings: List[DNSLintFinding] = []
     target = _target_by_code(targets, "target_spf")
@@ -803,32 +805,34 @@ async def _spf_findings(
             )
         ]
 
-    try:
-        root_records = await provider.lookup_txt(domain)
-    except LookupError:
-        root_records = []
-    spf_records = [record for record in root_records if record.lower().startswith("v=spf1")]
-    if len(spf_records) > 1:
-        findings.append(
-            _finding(
-                "spf_multiple_records",
-                "error",
-                "Multiple SPF records found",
-                "SPF requires exactly one SPF TXT record at the domain root.",
-                "Merge the mechanisms into a single v=spf1 record.",
-                "TXT",
-                target.name,
-                target_record=target,
-                evidence=spf_records,
+    if allow_live:
+        try:
+            root_records = await provider.lookup_txt(domain)
+        except LookupError:
+            root_records = []
+        spf_records = [record for record in root_records if record.lower().startswith("v=spf1")]
+        if len(spf_records) > 1:
+            findings.append(
+                _finding(
+                    "spf_multiple_records",
+                    "error",
+                    "Multiple SPF records found",
+                    "SPF requires exactly one SPF TXT record at the domain root.",
+                    "Merge the mechanisms into a single v=spf1 record.",
+                    "TXT",
+                    target.name,
+                    target_record=target,
+                    evidence=spf_records,
+                )
             )
-        )
 
     terms = _spf_terms(result.spf_record)
     findings.extend(_spf_all_policy_findings(terms, target, result.spf_record))
     dns_lookup_terms = _spf_dns_lookup_terms(terms)
     findings.extend(_spf_lookup_budget_findings(dns_lookup_terms, target))
     findings.extend(_spf_duplicate_include_findings(terms, target))
-    findings.extend(await _spf_void_lookup_findings(provider, dns_lookup_terms, target))
+    if allow_live:
+        findings.extend(await _spf_void_lookup_findings(provider, dns_lookup_terms, target))
     return findings
 
 
@@ -1087,11 +1091,31 @@ async def _dkim_findings(
     monitored_selectors: Optional[List[str]] = None,
     observed_selectors: Optional[List[str]] = None,
     selector_evidence: Optional[List[Dict[str, object]]] = None,
+    allow_live: bool = True,
 ) -> List[DNSLintFinding]:
     target = _target_by_code(targets, "target_dkim")
     selectors_for_detail = list(
         dict.fromkeys(monitored_selectors or result.selectors_checked or [])
     )
+    if not allow_live:
+        if result.dkim:
+            return []
+        checked = ", ".join(selectors_for_detail)
+        detail = "Cached evidence does not contain a resolving DKIM selector."
+        if checked:
+            detail = f"{detail} Cached selectors: {checked}."
+        return [
+            _finding(
+                "dkim_selector_missing",
+                "warning",
+                "DKIM selector is missing",
+                detail,
+                "Refresh DNS evidence or publish the sending provider's DKIM TXT record.",
+                "TXT",
+                target.name,
+                target_record=target,
+            )
+        ]
     if selectors_for_detail and (result.dkim or selector_evidence is not None):
         return await _dkim_selector_findings(
             provider,
@@ -1113,7 +1137,7 @@ async def _dkim_findings(
             "dkim_selector_missing",
             "warning",
             "DKIM selector is missing",
-            detail,
+            "No DKIM selector resolved for the stored DNS evidence.",
             "Add the sending provider's selector in DMARQ and publish its DKIM TXT record.",
             "TXT",
             target.name,
@@ -1674,6 +1698,7 @@ async def build_dns_guidance(
     mail_service_records: Optional[List[Dict[str, str]]] = None,
     setup_defaults: Optional[MailAuthSetupDefaults] = None,
     locale: Optional[str] = None,
+    allow_live: bool = True,
 ) -> DNSGuidanceResult:
     """Build typed DNS lint findings and target records for a domain."""
     normalized_domain = domain.strip().strip(".").lower()
@@ -1699,7 +1724,15 @@ async def build_dns_guidance(
     findings: List[DNSLintFinding] = []
     normalized_selector_evidence = [dict(item) for item in selector_evidence or []]
     findings.extend(_dmarc_findings(normalized_domain, result, targets))
-    findings.extend(await _spf_findings(normalized_domain, provider, result, targets))
+    findings.extend(
+        await _spf_findings(
+            normalized_domain,
+            provider,
+            result,
+            targets,
+            allow_live=allow_live,
+        )
+    )
     findings.extend(
         await _dkim_findings(
             provider,
@@ -1709,13 +1742,18 @@ async def build_dns_guidance(
             monitored_selectors=monitored_selectors,
             observed_selectors=observed_selectors,
             selector_evidence=normalized_selector_evidence,
+            allow_live=allow_live,
         )
     )
-    findings.extend(_mta_sts_findings(mta_sts, targets))
-    findings.extend(await _tls_rpt_findings(normalized_domain, provider, targets))
-    findings.extend(_bimi_findings(bimi, extract_dmarc_policy(result.dmarc_record), targets))
+    if mta_sts.status != "pending":
+        findings.extend(_mta_sts_findings(mta_sts, targets))
+    if allow_live:
+        findings.extend(await _tls_rpt_findings(normalized_domain, provider, targets))
+    if bimi.status != "pending":
+        findings.extend(_bimi_findings(bimi, extract_dmarc_policy(result.dmarc_record), targets))
     findings.extend(_dane_findings(dane_result, targets))
-    findings.extend(await _mail_service_dns_findings(provider, mail_service_records or []))
+    if allow_live:
+        findings.extend(await _mail_service_dns_findings(provider, mail_service_records or []))
     _localize_default_remediation_steps(findings, locale=locale)
     return DNSGuidanceResult(
         domain=normalized_domain,

--- a/backend/app/services/dns_prewarm.py
+++ b/backend/app/services/dns_prewarm.py
@@ -15,6 +15,8 @@ from app.models.report import DMARCReport, ReportRecord
 from app.services.dns_cache import resolve_domain_dns_cached
 from app.services.dane import check_dane_cached
 from app.services.dns_resolver import get_default_provider
+from app.services.bimi import check_bimi_cached
+from app.services.mta_sts import check_mta_sts_cached
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +43,18 @@ async def _prewarm_domain(domain_id: int, domain_name: str, selectors: List[str]
             provider,
             domain_name,
             selectors=selectors,
+            refresh=True,
+        )
+        await check_mta_sts_cached(
+            db,
+            provider,
+            domain_name,
+            refresh=True,
+        )
+        await check_bimi_cached(
+            db,
+            provider,
+            domain_name,
             refresh=True,
         )
         await check_dane_cached(

--- a/backend/app/services/mta_sts.py
+++ b/backend/app/services/mta_sts.py
@@ -233,7 +233,7 @@ async def check_mta_sts_cached(
         )
         .first()
     )
-    if row and (not refresh and _is_fresh(row, ttl_seconds, now) or not allow_live):
+    if row and ((not refresh and _is_fresh(row, ttl_seconds, now)) or not allow_live):
         return _result_from_json(row.result_json), True, row.checked_at
 
     if not allow_live:

--- a/backend/app/services/mta_sts.py
+++ b/backend/app/services/mta_sts.py
@@ -215,8 +215,13 @@ async def check_mta_sts_cached(
     *,
     ttl_seconds: int = DEFAULT_DNS_CACHE_TTL_SECONDS,
     refresh: bool = False,
+    allow_live: bool = True,
 ) -> Tuple[MTAStsResult, bool, datetime]:
-    """Resolve MTA-STS posture, reusing the shared DNS cache semantics."""
+    """Resolve MTA-STS posture, reusing the shared DNS cache semantics.
+
+    Normal product reads may use the last captured result even after its TTL.
+    They must not turn opening a domain page into an HTTPS or DNS probe.
+    """
     now = _utcnow_naive()
     provider_name = f"{provider.__class__.__name__}:mta-sts"
     row = (
@@ -228,8 +233,19 @@ async def check_mta_sts_cached(
         )
         .first()
     )
-    if row and not refresh and _is_fresh(row, ttl_seconds, now):
+    if row and not refresh and (_is_fresh(row, ttl_seconds, now) or not allow_live):
         return _result_from_json(row.result_json), True, row.checked_at
+
+    if not allow_live:
+        return (
+            MTAStsResult(
+                status="pending",
+                policy_url=f"https://mta-sts.{domain}/.well-known/mta-sts.txt",
+                errors=["MTA-STS evidence has not been captured yet."],
+            ),
+            True,
+            now,
+        )
 
     result = await check_mta_sts_with_fallback(domain, provider)
     payload = json.dumps(asdict(result), sort_keys=True, separators=(",", ":"))

--- a/backend/app/services/mta_sts.py
+++ b/backend/app/services/mta_sts.py
@@ -233,7 +233,7 @@ async def check_mta_sts_cached(
         )
         .first()
     )
-    if row and not refresh and (_is_fresh(row, ttl_seconds, now) or not allow_live):
+    if row and (not refresh and _is_fresh(row, ttl_seconds, now) or not allow_live):
         return _result_from_json(row.result_json), True, row.checked_at
 
     if not allow_live:

--- a/backend/app/services/source_reputation.py
+++ b/backend/app/services/source_reputation.py
@@ -644,6 +644,7 @@ async def build_source_reputation_cached(
     days: int = 30,
     ttl_seconds: int = DEFAULT_DNS_CACHE_TTL_SECONDS,
     refresh: bool = False,
+    allow_live: bool = True,
 ) -> Tuple[DomainReputation, bool, datetime]:
     """Build source reputation with persisted cache semantics."""
     now = _utcnow_naive()
@@ -669,8 +670,24 @@ async def build_source_reputation_cached(
         )
         .first()
     )
-    if row and not refresh and _is_fresh(row, ttl_seconds, now):
+    if row and not refresh and (_is_fresh(row, ttl_seconds, now) or not allow_live):
         return _result_from_json(row.result_json), True, row.checked_at
+
+    if not allow_live:
+        # Keep the overview useful when the background enrichment has not
+        # captured this exact source set yet, without contacting feeds from a
+        # page-read request.
+        return (
+            build_source_reputation(
+                domain,
+                report_rows,
+                source_rows,
+                senders_by_ip=senders_by_ip,
+                anomalies_by_ip=anomalies_by_ip,
+            ),
+            True,
+            now,
+        )
 
     feed_results_by_ip = await lookup_sources_reputation_cached(
         db,

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -2384,8 +2384,9 @@ function domainDetailsApp(domainId = '') {
             this.dnsRecordsLoading = true;
             this.dnsRecordsError = '';
             try {
+                const query = options.refresh ? '?refresh=true' : '?cached_only=true';
                 const response = await this.fetchWithTimeout(
-                    `/api/v1/domains/${this.domainId}/dns${options.refresh ? '?refresh=true' : ''}`,
+                    `/api/v1/domains/${this.domainId}/dns${query}`,
                     {},
                     options.refresh ? 60000 : 45000
                 );
@@ -2411,8 +2412,9 @@ function domainDetailsApp(domainId = '') {
 
         async fetchDNSHealth(options = {}) {
             try {
+                const query = options.refresh ? '?refresh=true' : '?cached_only=true';
                 const response = await fetch(
-                    `/api/v1/domains/${this.domainId}/dns/health${options.refresh ? '?refresh=true' : ''}`
+                    `/api/v1/domains/${this.domainId}/dns/health${query}`
                 );
                 if (response.ok) {
                     this.dnsHealth = await response.json();
@@ -2424,8 +2426,9 @@ function domainDetailsApp(domainId = '') {
 
         async fetchDNSGuidance(options = {}) {
             try {
+                const query = options.refresh ? '?refresh=true' : '?cached_only=true';
                 const response = await fetch(
-                    `/api/v1/domains/${this.domainId}/dns/lint${options.refresh ? '?refresh=true' : ''}`
+                    `/api/v1/domains/${this.domainId}/dns/lint${query}`
                 );
                 if (response.ok) {
                     this.dnsGuidance = await response.json();
@@ -2548,8 +2551,9 @@ function domainDetailsApp(domainId = '') {
 
         async fetchPosture(options = {}) {
             try {
+                const query = options.refresh ? '?refresh=true' : '?cached_only=true';
                 const response = await fetch(
-                    `/api/v1/domains/${this.domainId}/posture${options.refresh ? '?refresh=true' : ''}`
+                    `/api/v1/domains/${this.domainId}/posture${query}`
                 );
                 if (response.ok) {
                     this.posture = await response.json();
@@ -3073,8 +3077,9 @@ function domainDetailsApp(domainId = '') {
 
         async fetchMtaSts(options = {}) {
             try {
+                const query = options.refresh ? '?refresh=true' : '?cached_only=true';
                 const response = await fetch(
-                    `/api/v1/domains/${this.domainId}/dns/mta-sts${options.refresh ? '?refresh=true' : ''}`
+                    `/api/v1/domains/${this.domainId}/dns/mta-sts${query}`
                 );
                 if (response.ok) {
                     this.mtaSts = await response.json();
@@ -3086,8 +3091,9 @@ function domainDetailsApp(domainId = '') {
 
         async fetchBimi(options = {}) {
             try {
+                const query = options.refresh ? '?refresh=true' : '?cached_only=true';
                 const response = await fetch(
-                    `/api/v1/domains/${this.domainId}/dns/bimi${options.refresh ? '?refresh=true' : ''}`
+                    `/api/v1/domains/${this.domainId}/dns/bimi${query}`
                 );
                 if (response.ok) {
                     this.bimi = await response.json();

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1037,6 +1037,25 @@ def test_dns_endpoint_cached_only_reuses_stale_evidence_without_lookup(
     provider.check_domain.assert_not_awaited()
 
 
+def test_dns_endpoint_cached_only_without_cache_returns_pending_without_lookup(
+    authed_client: TestClient,
+):
+    """A cached-only DNS read reports missing evidence without starting DNS work."""
+    provider = AsyncMock(check_domain=AsyncMock(side_effect=AssertionError("live DNS read")))
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.get_default_provider",
+        return_value=provider,
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns?cached_only=true")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["lookupStatus"] == "pending"
+    assert data["checkedAt"] is None
+    provider.check_domain.assert_not_awaited()
+
+
 def test_dns_lint_cached_only_keeps_passive_spf_and_dkim_findings(
     authed_client: TestClient, db_session
 ):
@@ -1952,6 +1971,26 @@ def test_dns_health_skips_optional_recommendations_for_pending_evidence(
     recommendation_types = {item["type"] for item in response.json()["recommendations"]}
     assert "missing_mta_sts" not in recommendation_types
     assert "missing_bimi" not in recommendation_types
+
+
+def test_dns_health_cached_only_without_cache_returns_pending_without_lookup(
+    authed_client: TestClient,
+):
+    """Cached-only health reads stay pending until evidence has been captured."""
+    provider = AsyncMock(check_domain=AsyncMock(side_effect=AssertionError("live DNS read")))
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.get_default_provider",
+        return_value=provider,
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/health?cached_only=true")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "pending"
+    assert data["dns_lookup_status"] == "pending"
+    assert data["recommendations"] == []
+    provider.check_domain.assert_not_awaited()
 
 
 def test_mta_sts_endpoint_returns_cached_posture(authed_client: TestClient):

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1978,10 +1978,47 @@ def test_mta_sts_endpoint_returns_cached_posture(authed_client: TestClient):
     assert data["errors"] == ["No _mta-sts TXT record was found."]
 
 
+def test_mta_sts_endpoint_cached_only_disables_live_lookup(authed_client: TestClient):
+    """A cached-only MTA-STS request passes the no-live guard into the service."""
+    checked_at = datetime(2026, 5, 23, 12, 0, 0)
+    result = MTAStsResult(status="pending")
+    check_cached = AsyncMock(return_value=(result, True, checked_at))
+
+    with patch("app.api.api_v1.endpoints.domains.check_mta_sts_cached", new=check_cached):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/mta-sts?cached_only=true")
+
+    assert response.status_code == 200
+    _, _, domain = check_cached.await_args.args
+    assert domain == DOMAIN
+    assert check_cached.await_args.kwargs["allow_live"] is False
+
+
 def test_mta_sts_endpoint_returns_404_for_unknown_domain(authed_client: TestClient):
     response = authed_client.get("/api/v1/domains/unknown.example.com/dns/mta-sts")
 
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_mta_sts_cached_only_without_cache_returns_pending(db_session):
+    """Read-only MTA-STS requests report missing captured evidence without probing."""
+    provider = AsyncMock()
+
+    with patch(
+        "app.services.mta_sts.check_mta_sts_with_fallback",
+        new=AsyncMock(side_effect=AssertionError("live MTA-STS lookup")),
+    ):
+        result, cached, observed_at = await check_mta_sts_cached(
+            db_session,
+            provider,
+            DOMAIN,
+            allow_live=False,
+        )
+
+    assert cached is True
+    assert observed_at is not None
+    assert result.status == "pending"
+    assert result.errors == ["MTA-STS evidence has not been captured yet."]
 
 
 @pytest.mark.asyncio
@@ -2051,10 +2088,47 @@ def test_bimi_endpoint_returns_cached_posture(authed_client: TestClient):
     assert data["checked_at"] == checked_at.isoformat()
 
 
+def test_bimi_endpoint_cached_only_disables_live_lookup(authed_client: TestClient):
+    """A cached-only BIMI request passes the no-live guard into the service."""
+    checked_at = datetime(2026, 5, 23, 12, 0, 0)
+    result = BIMIResult(status="pending")
+    check_cached = AsyncMock(return_value=(result, True, checked_at))
+
+    with patch("app.api.api_v1.endpoints.domains.check_bimi_cached", new=check_cached):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/bimi?cached_only=true")
+
+    assert response.status_code == 200
+    _, _, domain = check_cached.await_args.args
+    assert domain == DOMAIN
+    assert check_cached.await_args.kwargs["allow_live"] is False
+
+
 def test_bimi_endpoint_returns_404_for_unknown_domain(authed_client: TestClient):
     response = authed_client.get("/api/v1/domains/unknown.example.com/dns/bimi")
 
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_bimi_cached_only_without_cache_returns_pending(db_session):
+    """Read-only BIMI requests report missing captured evidence without probing."""
+    provider = AsyncMock()
+
+    with patch(
+        "app.services.bimi.check_bimi_with_fallback",
+        new=AsyncMock(side_effect=AssertionError("live BIMI lookup")),
+    ):
+        result, cached, observed_at = await check_bimi_cached(
+            db_session,
+            provider,
+            DOMAIN,
+            allow_live=False,
+        )
+
+    assert cached is True
+    assert observed_at is not None
+    assert result.status == "pending"
+    assert result.errors == ["BIMI evidence has not been captured yet."]
 
 
 @pytest.mark.asyncio
@@ -2142,13 +2216,23 @@ def test_dane_endpoint_returns_cached_posture(authed_client: TestClient):
     )
     calls = []
 
-    async def fake_check(db, provider, domain, *, port=25, refresh=False, derive_suggestions=False):
+    async def fake_check(
+        db,
+        provider,
+        domain,
+        *,
+        port=25,
+        refresh=False,
+        derive_suggestions=False,
+        allow_live=True,
+    ):
         calls.append(
             {
                 "domain": domain,
                 "port": port,
                 "refresh": refresh,
                 "derive_suggestions": derive_suggestions,
+                "allow_live": allow_live,
             }
         )
         return (live_result if derive_suggestions else passive_result), True, checked_at
@@ -2160,6 +2244,9 @@ def test_dane_endpoint_returns_cached_posture(authed_client: TestClient):
         response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/dane")
         live_response = authed_client.get(
             f"/api/v1/domains/{DOMAIN}/dns/dane?derive_suggestions=true"
+        )
+        cached_only_response = authed_client.get(
+            f"/api/v1/domains/{DOMAIN}/dns/dane?cached_only=true"
         )
 
     assert response.status_code == 200
@@ -2176,9 +2263,29 @@ def test_dane_endpoint_returns_cached_posture(authed_client: TestClient):
     live_data = live_response.json()
     assert live_data["suggested_records"][0]["record"].startswith("3 1 1 ")
     assert live_data["suggested_records"][0]["status"] == "ready"
+    assert cached_only_response.status_code == 200
     assert calls == [
-        {"domain": DOMAIN, "port": 25, "refresh": False, "derive_suggestions": False},
-        {"domain": DOMAIN, "port": 25, "refresh": False, "derive_suggestions": True},
+        {
+            "domain": DOMAIN,
+            "port": 25,
+            "refresh": False,
+            "derive_suggestions": False,
+            "allow_live": True,
+        },
+        {
+            "domain": DOMAIN,
+            "port": 25,
+            "refresh": False,
+            "derive_suggestions": True,
+            "allow_live": True,
+        },
+        {
+            "domain": DOMAIN,
+            "port": 25,
+            "refresh": False,
+            "derive_suggestions": False,
+            "allow_live": False,
+        },
     ]
 
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -35,7 +35,7 @@ from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services.bimi import BIMIResult
-from app.services.dane import DANEResult, TLSARecord, TLSASuggestion
+from app.services.dane import DANEResult, TLSARecord, TLSASuggestion, check_dane_cached
 from app.services.dns_cache import (
     _selectors_key,
     get_latest_cached_domain_dns_evidence,
@@ -2105,6 +2105,61 @@ def test_dane_endpoint_returns_404_for_unknown_domain(authed_client: TestClient)
     response = authed_client.get("/api/v1/domains/unknown.example.com/dns/dane")
 
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_dane_cached_only_reuses_stale_evidence_even_when_refreshing(db_session):
+    """Read-only DANE requests should keep stale cache rows instead of live probing."""
+    checked_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=2)
+    cached_result = DANEResult(
+        status="pass",
+        port=25,
+        mx_hosts=["mx.example.com"],
+        records=[
+            TLSARecord(
+                query_name="_25._tcp.mx.example.com",
+                mx_host="mx.example.com",
+                record=(
+                    "3 1 1 " "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                ),
+                certificate_usage=3,
+                selector=1,
+                matching_type=1,
+                association_data=(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                ),
+                valid=True,
+            )
+        ],
+    )
+    provider = AsyncMock()
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=f"{provider.__class__.__name__}:dane",
+            selectors_key="dane-v1:25",
+            result_json=json.dumps(asdict(cached_result)),
+            checked_at=checked_at,
+        )
+    )
+    db_session.commit()
+
+    with patch(
+        "app.services.dane.check_dane_with_fallback",
+        new=AsyncMock(side_effect=AssertionError("live DANE lookup")),
+    ):
+        result, cached, observed_at = await check_dane_cached(
+            db_session,
+            provider,
+            DOMAIN,
+            refresh=True,
+            allow_live=False,
+        )
+
+    assert cached is True
+    assert observed_at == checked_at
+    assert result.status == "pass"
+    assert result.mx_hosts == ["mx.example.com"]
 
 
 def test_posture_dashboard_links_recommendations_changes_and_playbooks(

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -1009,6 +1009,79 @@ def test_dns_endpoint_uses_cached_result(authed_client: TestClient, db_session):
     assert db_session.query(DNSCache).count() == 1
 
 
+def test_dns_endpoint_cached_only_reuses_stale_evidence_without_lookup(
+    authed_client: TestClient, db_session
+):
+    """The domain UI can render old captured DNS evidence without probing DNS."""
+    provider = AsyncMock(check_domain=AsyncMock(side_effect=AssertionError("live DNS read")))
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=provider.__class__.__name__,
+            selectors_key=_selectors_key(["google"]),
+            result_json=json.dumps(asdict(MOCK_DNS_RESULT)),
+            checked_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=2),
+        )
+    )
+    db_session.commit()
+
+    with patch(
+        "app.api.api_v1.endpoints.domains.get_default_provider",
+        return_value=provider,
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns?cached_only=true")
+
+    assert response.status_code == 200
+    assert response.json()["dmarc"] is True
+    assert response.json()["cached"] is True
+    provider.check_domain.assert_not_awaited()
+
+
+def test_dns_lint_cached_only_keeps_passive_spf_and_dkim_findings(
+    authed_client: TestClient, db_session
+):
+    """Cached DNS lint still reports passive SPF/DKIM gaps without live probes."""
+    cached_result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+        spf=False,
+        dkim=False,
+        selectors_checked=["google"],
+    )
+    provider = AsyncMock()
+    provider.check_domain = AsyncMock(side_effect=AssertionError("live DNS read"))
+    provider.lookup_txt = AsyncMock(side_effect=AssertionError("live TXT lookup"))
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=provider.__class__.__name__,
+            selectors_key=_selectors_key(["google"]),
+            result_json=json.dumps(asdict(cached_result)),
+            checked_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=2),
+        )
+    )
+    db_session.commit()
+
+    with (
+        patch("app.api.api_v1.endpoints.domains.get_default_provider", return_value=provider),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(MTAStsResult(status="pending"), False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(BIMIResult(status="pending"), False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/lint?cached_only=true")
+
+    assert response.status_code == 200
+    codes = {finding["code"] for finding in response.json()["findings"]}
+    assert {"spf_missing", "dkim_selector_missing"}.issubset(codes)
+    provider.check_domain.assert_not_awaited()
+    provider.lookup_txt.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_dns_cache_recovers_from_concurrent_insert(db_session, monkeypatch):
     """Concurrent DNS widgets should not fail on a duplicate cache insert."""
@@ -1847,6 +1920,38 @@ def test_dns_health_marks_all_missing_records_critical(authed_client: TestClient
     assert recommendation_types.count("missing_mta_sts") == 1
     assert recommendation_types.count("missing_bimi") == 1
     assert any(item["type"] == "policy_needs_more_data" for item in data["recommendations"])
+
+
+def test_dns_health_skips_optional_recommendations_for_pending_evidence(
+    authed_client: TestClient,
+):
+    """Pending optional posture remains unknown instead of speculative repair advice."""
+    result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+        spf=True,
+        spf_record="v=spf1 include:_spf.example.com ~all",
+        dkim=True,
+        selectors_checked=["google"],
+    )
+
+    with (
+        _mock_dns(result),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(MTAStsResult(status="pending"), False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(BIMIResult(status="pending"), False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/health")
+
+    assert response.status_code == 200
+    recommendation_types = {item["type"] for item in response.json()["recommendations"]}
+    assert "missing_mta_sts" not in recommendation_types
+    assert "missing_bimi" not in recommendation_types
 
 
 def test_mta_sts_endpoint_returns_cached_posture(authed_client: TestClient):

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -34,7 +34,7 @@ from app.models.report import DMARCReport, ReportRecord
 from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
-from app.services.bimi import BIMIResult
+from app.services.bimi import BIMIResult, check_bimi_cached
 from app.services.dane import DANEResult, TLSARecord, TLSASuggestion, check_dane_cached
 from app.services.dns_cache import (
     _selectors_key,
@@ -50,7 +50,7 @@ from app.services.dns_resolver import (
     PublicRecursiveDNSProvider,
     SystemDNSProvider,
 )
-from app.services.mta_sts import MTAStsResult
+from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
 from app.services.remediation_dispatch import summarize_remediation_activity
 from app.services.report_persistence import save_parsed_report
 from app.services.report_store import ReportStore
@@ -1984,6 +1984,46 @@ def test_mta_sts_endpoint_returns_404_for_unknown_domain(authed_client: TestClie
     assert response.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_mta_sts_cached_only_reuses_stale_evidence_even_when_refreshing(db_session):
+    """Read-only MTA-STS requests should keep stale cache rows instead of probing."""
+    checked_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=2)
+    cached_result = MTAStsResult(
+        status="pass",
+        dns_record="v=STSv1; id=20260727",
+        policy_url=f"https://mta-sts.{DOMAIN}/.well-known/mta-sts.txt",
+        policy_text="version: STSv1\nmode: testing\nmx: mx.example.com\nmax_age: 86400",
+    )
+    provider = AsyncMock()
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=f"{provider.__class__.__name__}:mta-sts",
+            selectors_key="mta-sts-v1",
+            result_json=json.dumps(asdict(cached_result)),
+            checked_at=checked_at,
+        )
+    )
+    db_session.commit()
+
+    with patch(
+        "app.services.mta_sts.check_mta_sts_with_fallback",
+        new=AsyncMock(side_effect=AssertionError("live MTA-STS lookup")),
+    ):
+        result, cached, observed_at = await check_mta_sts_cached(
+            db_session,
+            provider,
+            DOMAIN,
+            refresh=True,
+            allow_live=False,
+        )
+
+    assert cached is True
+    assert observed_at == checked_at
+    assert result.status == "pass"
+    assert result.dns_record == "v=STSv1; id=20260727"
+
+
 def test_bimi_endpoint_returns_cached_posture(authed_client: TestClient):
     """The domain detail page can fetch BIMI posture with cache metadata."""
     checked_at = datetime(2026, 5, 23, 12, 0, 0)
@@ -2015,6 +2055,47 @@ def test_bimi_endpoint_returns_404_for_unknown_domain(authed_client: TestClient)
     response = authed_client.get("/api/v1/domains/unknown.example.com/dns/bimi")
 
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_bimi_cached_only_reuses_stale_evidence_even_when_refreshing(db_session):
+    """Read-only BIMI requests should keep stale cache rows instead of probing."""
+    checked_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=2)
+    cached_result = BIMIResult(
+        status="pass",
+        selector="default",
+        query_name=f"default._bimi.{DOMAIN}",
+        dns_record="v=BIMI1; l=https://example.com/logo.svg; a=",
+        logo_url="https://example.com/logo.svg",
+    )
+    provider = AsyncMock()
+    db_session.add(
+        DNSCache(
+            domain=DOMAIN,
+            provider=f"{provider.__class__.__name__}:bimi",
+            selectors_key="bimi-v1:default",
+            result_json=json.dumps(asdict(cached_result)),
+            checked_at=checked_at,
+        )
+    )
+    db_session.commit()
+
+    with patch(
+        "app.services.bimi.check_bimi_with_fallback",
+        new=AsyncMock(side_effect=AssertionError("live BIMI lookup")),
+    ):
+        result, cached, observed_at = await check_bimi_cached(
+            db_session,
+            provider,
+            DOMAIN,
+            refresh=True,
+            allow_live=False,
+        )
+
+    assert cached is True
+    assert observed_at == checked_at
+    assert result.status == "pass"
+    assert result.logo_url == "https://example.com/logo.svg"
 
 
 def test_dane_endpoint_returns_cached_posture(authed_client: TestClient):

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -73,6 +73,33 @@ async def test_build_dns_guidance_returns_typed_findings_and_targets():
 
 
 @pytest.mark.asyncio
+async def test_cached_guidance_keeps_proven_core_findings_without_dns_queries():
+    """Cached page reads retain stored SPF/DKIM evidence without resolving DNS."""
+    provider = FakeDNSProvider({})
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        spf=False,
+        dkim=False,
+        selectors_checked=["selector1"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pending"),
+        BIMIResult(status="pending"),
+        allow_live=False,
+    )
+
+    codes = {finding.code for finding in guidance.findings}
+    assert {"spf_missing", "dkim_selector_missing"}.issubset(codes)
+    assert "mta_sts_missing" not in codes
+    assert "bimi_missing" not in codes
+
+
+@pytest.mark.asyncio
 async def test_build_dns_guidance_uses_configured_mail_auth_defaults():
     provider = FakeDNSProvider({})
     dns = DomainDNSResult(

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -14,6 +14,7 @@ import json
 from datetime import date, datetime, timedelta
 from io import StringIO
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -2060,6 +2061,21 @@ def test_domain_remediation_queue_bounds_slow_enrichment(
     assert body["enrichment_pending"] is True
     assert body["items"] == []
     assert elapsed < 2.0
+
+
+def test_domain_remediation_queue_never_starts_live_dns_enrichment(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """Queue reads remain available when no DNS cache has been captured yet."""
+    live_dns = AsyncMock(side_effect=AssertionError("queue must not resolve DNS"))
+    monkeypatch.setattr(domains_endpoint, "resolve_domain_dns_cached", live_dns)
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/remediation")
+
+    assert response.status_code == 200
+    assert response.json()["domain"] == DOMAIN
+    live_dns.assert_not_awaited()
 
 
 def test_domain_remediation_queue_keeps_completed_evidence_when_one_task_times_out(


### PR DESCRIPTION
Closes #882

## Type of change
Performance and reliability fix for domain-detail read paths. No DNS write behavior changes.

## Why
Opening a domain detail page could trigger live DNS, MTA-STS HTTPS, BIMI, DANE, and reputation enrichment after TTL expiry. Those requests competed with the remediation queue and could leave the panel timing out.

## What changed
- Normal UI reads use persisted DNS, MTA-STS, BIMI, DANE, and reputation evidence, including last known stale evidence.
- The remediation queue is request-scoped read-only and cannot initiate live enrichment.
- Explicit refreshes and startup prewarming retain the live enrichment path.
- Stored SPF/DKIM gaps remain actionable without live DNS recursion.
- Missing optional evidence remains pending instead of creating speculative MTA-STS or BIMI repair advice.

## Validation
- `247 passed`: DNS endpoints, domain details, and DNS guidance.
- Python compilation and whitespace checks passed.
- CI covers documented Docker Compose startup, Kubernetes/Helm/Terraform packaging, security scans, and the full test suite.

## Operational impact
Normal page navigation no longer performs external network work. Users can still explicitly refresh evidence, and background prewarming keeps the next read fast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Domain details and remediation views now use saved DNS and security evidence instead of unexpectedly triggering live checks.
  * Missing evidence is clearly shown as pending rather than reported as unavailable or complete.
  * Refreshes and background updates continue to retrieve the latest DNS, MTA-STS, BIMI, DANE, and reputation information.
  * Cached evidence remains available even after its normal freshness period, improving page loading consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->