### PR TITLE
fix: coalesce cached domain posture reads

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3980,7 +3980,11 @@ async def _build_domain_dns_guidance(
         derive_suggestions=True,
         allow_live=False,
     )
-    mail_service_records = await mail_service_dns_records_for_domain(db, domain_id)
+    mail_service_records = await mail_service_dns_records_for_domain(
+        db,
+        domain_id,
+        allow_live=not cached_only,
+    )
     stored_domain = db.query(Domain).filter(Domain.name == domain_id).first()
     guidance = await build_dns_guidance(
         domain_id,
@@ -6578,17 +6582,29 @@ async def _build_domain_posture_dashboard_for_workspace(
     refresh: bool = False,
     capture_snapshot: bool = True,
     cached_only: bool = False,
+    store: Optional[ReportStore] = None,
+    domain_name: Optional[str] = None,
+    health: Optional[DNSHealthResponse] = None,
+    domain_health: Optional[Dict[str, Any]] = None,
 ) -> PostureDashboardResponse:
     """Build a posture dashboard, optionally persisting the current health snapshot."""
-    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
+    if store is None or domain_name is None:
+        domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
 
     health_kwargs: Dict[str, Any] = {"refresh": refresh}
     grade_kwargs: Dict[str, Any] = {"refresh": refresh}
     if cached_only:
         health_kwargs["cached_only"] = True
         grade_kwargs["cached_only"] = True
-    health = await _build_domain_dns_health(db, store, domain_name, **health_kwargs)
-    domain_health = await _build_domain_health_grade(db, domain_name, store, **grade_kwargs)
+    if health is None:
+        health = await _build_domain_dns_health(db, store, domain_name, **health_kwargs)
+    if domain_health is None:
+        domain_health = await _build_domain_health_grade(
+            db,
+            domain_name,
+            store,
+            **grade_kwargs,
+        )
     summary = store.get_domain_summary(domain_name)
     if capture_snapshot:
         _record_health_snapshot_from_posture(
@@ -6601,6 +6617,130 @@ async def _build_domain_posture_dashboard_for_workspace(
         )
     changes = list_dns_record_changes(db, domain_name, limit=10)
     return _build_posture_dashboard(domain_name, health, domain_health, changes)
+
+
+@router.get("/{domain_id}/detail/cached")
+async def get_cached_domain_detail_read_model(  # pylint: disable=too-many-locals
+    domain_id: str = Path(..., title="The domain ID or name"),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+):
+    """Return the cached DNS and posture view from one domain-scoped read model.
+
+    The detail page used to fan out into several overlapping endpoints. Each
+    endpoint hydrated the same report set, which made a cached page read queue
+    behind other synchronous work. This endpoint deliberately shares one
+    domain-scoped store and forbids live DNS/provider/reputation enrichment.
+    """
+    workspace = _authorized_domain_read_workspace(_auth, db)
+    domain_name, store = _single_domain_report_store_for_read(db, domain_id, workspace)
+
+    manual_selectors = _get_domain_selectors_from_db(db, domain_name)
+    report_selectors = _get_selectors_from_reports(store, domain_name)
+    selectors = list(dict.fromkeys(manual_selectors + report_selectors))
+    provider = get_default_provider(db)
+    dns_result = await _resolve_summary_dns_result(
+        db,
+        provider,
+        domain_name,
+        selectors=selectors,
+        refresh=False,
+    )
+    health = await _build_domain_dns_health(
+        db,
+        store,
+        domain_name,
+        cached_only=True,
+    )
+    guidance = await _build_domain_dns_guidance(
+        db,
+        store,
+        domain_name,
+        cached_only=True,
+    )
+    domain_health = await _build_domain_health_grade(
+        db,
+        domain_name,
+        store,
+        cached_only=True,
+    )
+    posture = await _build_domain_posture_dashboard_for_workspace(
+        db,
+        workspace=workspace,
+        domain_id=domain_name,
+        cached_only=True,
+        capture_snapshot=False,
+        store=store,
+        domain_name=domain_name,
+        health=health,
+        domain_health=domain_health,
+    )
+    mta_sts, mta_cached, mta_checked_at = await check_mta_sts_cached(
+        db,
+        provider,
+        domain_name,
+        refresh=False,
+        allow_live=False,
+    )
+    bimi, bimi_cached, bimi_checked_at = await check_bimi_cached(
+        db,
+        provider,
+        domain_name,
+        refresh=False,
+        allow_live=False,
+    )
+
+    return {
+        "domain": domain_name,
+        "freshness": {
+            "mode": "cached",
+            "dns_checked_at": getattr(dns_result, "checked_at", None),
+            "dns_pending": bool(getattr(dns_result, "pending", False)),
+        },
+        "dns": DNSRecordResponse(
+            dmarc=dns_result.dmarc,
+            dmarcRecord=dns_result.dmarc_record,
+            spf=dns_result.spf,
+            spfRecord=dns_result.spf_record,
+            dkim=dns_result.dkim,
+            dkimSelectors=dns_result.dkim_selectors,
+            cached=bool(getattr(dns_result, "cached", False)),
+            checkedAt=(
+                dns_result.checked_at.isoformat()
+                if getattr(dns_result, "checked_at", None)
+                else None
+            ),
+        ),
+        "dns_health": health,
+        "dns_guidance": guidance,
+        "posture": posture,
+        "mta_sts": MTAStsResponse(
+            status=mta_sts.status,
+            dns_record=mta_sts.dns_record,
+            policy_url=mta_sts.policy_url,
+            policy_text=mta_sts.policy_text,
+            mode=mta_sts.mode,
+            max_age=mta_sts.max_age,
+            mx=mta_sts.mx,
+            errors=mta_sts.errors,
+            warnings=mta_sts.warnings,
+            cached=mta_cached,
+            checked_at=mta_checked_at.isoformat() if mta_checked_at else None,
+        ),
+        "bimi": BIMIResponse(
+            status=bimi.status,
+            selector=bimi.selector,
+            query_name=bimi.query_name,
+            dns_record=bimi.dns_record,
+            logo_url=bimi.logo_url,
+            certificate_url=bimi.certificate_url,
+            evidence_url=bimi.evidence_url,
+            errors=bimi.errors,
+            warnings=bimi.warnings,
+            cached=bimi_cached,
+            checked_at=bimi_checked_at.isoformat() if bimi_checked_at else None,
+        ),
+    }
 
 
 async def _build_domain_remediation_queue_for_workspace(  # noqa: C901

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -6710,6 +6710,19 @@ async def get_cached_domain_detail_read_model(  # pylint: disable=too-many-local
                 if getattr(dns_result, "checked_at", None)
                 else None
             ),
+            dmarcWarnings=dns_result.dmarc_warnings,
+            dmarcSuggestions=dns_result.dmarc_suggestions,
+            nameservers=dns_result.nameservers,
+            dnsProvider=asdict(dns_result.dns_provider) if dns_result.dns_provider else None,
+            providerContext=_dns_provider_repair_context(
+                db,
+                dns_provider=(
+                    asdict(dns_result.dns_provider) if dns_result.dns_provider else None
+                ),
+                nameservers=dns_result.nameservers,
+            ),
+            lookupStatus=dns_result.lookup_status,
+            lookupError=dns_result.lookup_error,
         ),
         "dns_health": health,
         "dns_guidance": guidance,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -3915,6 +3915,7 @@ async def _build_domain_dns_guidance(
     refresh: bool = False,
     locale: Optional[str] = None,
     cached_only: bool = False,
+    dns_result: Optional[DomainDNSResult] = None,
 ) -> Dict[str, Any]:
     """Build typed DNS lint findings and target records for a monitored domain."""
     cached_only = cached_only or _CACHED_DNS_READ.get()
@@ -3931,22 +3932,23 @@ async def _build_domain_dns_guidance(
     combined_selectors = list(dict.fromkeys(manual_selectors + report_selectors))
 
     provider = get_default_provider(db)
-    if cached_only:
-        dns_result = await _resolve_summary_dns_result(
-            db,
-            provider,
-            domain_id,
-            selectors=combined_selectors,
-            refresh=False,
-        )
-    else:
-        dns_result, _, _ = await resolve_domain_dns_cached(
-            db,
-            provider,
-            domain_id,
-            selectors=combined_selectors,
-            refresh=refresh,
-        )
+    if dns_result is None:
+        if cached_only:
+            dns_result = await _resolve_summary_dns_result(
+                db,
+                provider,
+                domain_id,
+                selectors=combined_selectors,
+                refresh=False,
+            )
+        else:
+            dns_result, _, _ = await resolve_domain_dns_cached(
+                db,
+                provider,
+                domain_id,
+                selectors=combined_selectors,
+                refresh=refresh,
+            )
     if bool(getattr(dns_result, "pending", False)):
         return {
             "domain": domain_id,
@@ -6605,8 +6607,8 @@ async def _build_domain_posture_dashboard_for_workspace(
             store,
             **grade_kwargs,
         )
-    summary = store.get_domain_summary(domain_name)
     if capture_snapshot:
+        summary = store.get_domain_summary(domain_name)
         _record_health_snapshot_from_posture(
             db,
             workspace_id=workspace.id,
@@ -6657,6 +6659,7 @@ async def get_cached_domain_detail_read_model(  # pylint: disable=too-many-local
         store,
         domain_name,
         cached_only=True,
+        dns_result=dns_result,
     )
     domain_health = await _build_domain_health_grade(
         db,

--- a/backend/app/services/mail_service_imports.py
+++ b/backend/app/services/mail_service_imports.py
@@ -327,10 +327,15 @@ async def mail_service_dns_records_for_domain(
     domain: str,
     *,
     workspace_id: Optional[int] = None,
+    allow_live: bool = True,
 ) -> List[Dict[str, str]]:
-    """Return provider-required DNS records for one sender domain."""
+    """Return provider-required DNS records for one sender domain.
+
+    Provider discovery is an explicit refresh concern. A normal cached domain
+    read must never turn a DNS guidance render into a third-party API call.
+    """
     normalized_domain = domain.strip().strip(".").lower()
-    if not normalized_domain:
+    if not normalized_domain or not allow_live:
         return []
     try:
         domains = await discover_postmark_sender_domains(db, workspace_id=workspace_id)

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -26,6 +26,7 @@ function domainDetailsApp(domainId = '') {
         dnsRecordsError: '',
         cachedDetailReadLoaded: false,
         cachedDetailReadPromise: null,
+        dnsDataGeneration: 0,
         dnsHealth: {
             status: '',
             checks: [],
@@ -2431,6 +2432,9 @@ function domainDetailsApp(domainId = '') {
         },
 
         async fetchDNSRecords(options = {}) {
+            if (options.refresh) {
+                this.dnsDataGeneration += 1;
+            }
             this.dnsRecordsLoading = true;
             this.dnsRecordsError = '';
             try {
@@ -2464,6 +2468,7 @@ function domainDetailsApp(domainId = '') {
             if (this.cachedDetailReadLoaded) return;
             if (this.cachedDetailReadPromise) return this.cachedDetailReadPromise;
 
+            const generation = this.dnsDataGeneration;
             this.dnsRecordsLoading = true;
             this.dnsRecordsError = '';
             this.cachedDetailReadPromise = (async () => {
@@ -2479,6 +2484,9 @@ function domainDetailsApp(domainId = '') {
                         throw new Error(detail || 'Cached domain detail could not be loaded.');
                     }
                     const data = await response.json();
+                    if (generation !== this.dnsDataGeneration) {
+                        return;
+                    }
                     this.dns = data.dns || this.dns;
                     this.dnsHealth = data.dns_health || this.dnsHealth;
                     this.dnsGuidance = data.dns_guidance || this.dnsGuidance;

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -24,6 +24,8 @@ function domainDetailsApp(domainId = '') {
         },
         dnsRecordsLoading: true,
         dnsRecordsError: '',
+        cachedDetailReadLoaded: false,
+        cachedDetailReadPromise: null,
         dnsHealth: {
             status: '',
             checks: [],
@@ -515,21 +517,13 @@ function domainDetailsApp(domainId = '') {
                 requests = [this.fetchDomainOwnership()];
             } else if (sectionId === 'dns-records') {
                 requests = [
+                    this.fetchCachedDomainDetail(),
                     this.fetchDomainOwnership(),
-                    this.fetchDNSRecords(),
-                    this.fetchDNSHealth(),
-                    this.fetchDNSGuidance(),
                     this.fetchDNSProviders(),
-                    this.fetchSelectors(),
-                    this.fetchMtaSts(),
-                    this.fetchBimi()
+                    this.fetchSelectors()
                 ];
             } else if (sectionId === 'posture-dashboard') {
-                requests = [
-                    this.fetchPosture(),
-                    this.fetchMtaSts(),
-                    this.fetchBimi()
-                ];
+                requests = [this.fetchCachedDomainDetail()];
             } else if (sectionId === 'health-score-history') {
                 requests = [this.fetchHealthHistory()];
             } else if (sectionId === 'recent-reports') {
@@ -2464,6 +2458,44 @@ function domainDetailsApp(domainId = '') {
             } finally {
                 this.dnsRecordsLoading = false;
             }
+        },
+
+        async fetchCachedDomainDetail() {
+            if (this.cachedDetailReadLoaded) return;
+            if (this.cachedDetailReadPromise) return this.cachedDetailReadPromise;
+
+            this.dnsRecordsLoading = true;
+            this.dnsRecordsError = '';
+            this.cachedDetailReadPromise = (async () => {
+                try {
+                    const response = await this.fetchWithTimeout(
+                        `/api/v1/domains/${encodeURIComponent(this.domainId)}/detail/cached`,
+                        {},
+                        15000
+                    );
+                    if (!response.ok) {
+                        const data = await response.json().catch(() => ({}));
+                        const detail = typeof data.detail === 'string' ? data.detail : data.detail?.message;
+                        throw new Error(detail || 'Cached domain detail could not be loaded.');
+                    }
+                    const data = await response.json();
+                    this.dns = data.dns || this.dns;
+                    this.dnsHealth = data.dns_health || this.dnsHealth;
+                    this.dnsGuidance = data.dns_guidance || this.dnsGuidance;
+                    this.posture = data.posture || this.posture;
+                    this.mtaSts = data.mta_sts || this.mtaSts;
+                    this.bimi = data.bimi || this.bimi;
+                    this.cachedDetailReadLoaded = true;
+                    this.syncDetectedDnsProvider();
+                } catch (error) {
+                    this.dnsRecordsError = error.message || 'Cached domain detail could not be loaded.';
+                    console.error('Error fetching cached domain detail:', error);
+                } finally {
+                    this.dnsRecordsLoading = false;
+                    this.cachedDetailReadPromise = null;
+                }
+            })();
+            return this.cachedDetailReadPromise;
         },
 
         async fetchDNSHealth(options = {}) {

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2804,8 +2804,14 @@ def test_domain_details_defers_hidden_sections_until_opened_or_linked():
     assert "this.loadDeferredSection('domain-ownership')" in script
     assert "sectionId === 'domain-ownership'" in script
     assert "this.fetchDomainOwnership()" in script
-    assert "this.fetchCachedDomainDetail()" in script
-    assert "this.fetchCachedDomainDetail()" in script
+    dns_records_branch = _template_section_between_markers(
+        script, "sectionId === 'dns-records'", "sectionId === 'posture-dashboard'"
+    )
+    posture_branch = _template_section_between_markers(
+        script, "sectionId === 'posture-dashboard'", "sectionId === 'health-score-history'"
+    )
+    assert "this.fetchCachedDomainDetail()" in dns_records_branch
+    assert "this.fetchCachedDomainDetail()" in posture_branch
     assert "/detail/cached" in script
     assert "cachedDetailReadPromise" in script
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2804,7 +2804,10 @@ def test_domain_details_defers_hidden_sections_until_opened_or_linked():
     assert "this.loadDeferredSection('domain-ownership')" in script
     assert "sectionId === 'domain-ownership'" in script
     assert "this.fetchDomainOwnership()" in script
-    assert "this.fetchDNSRecords()" in script
+    assert "this.fetchCachedDomainDetail()" in script
+    assert "this.fetchCachedDomainDetail()" in script
+    assert "/detail/cached" in script
+    assert "cachedDetailReadPromise" in script
 
 
 def test_domain_details_redirects_to_domain_management_after_delete_success():

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2804,12 +2804,11 @@ def test_domain_details_defers_hidden_sections_until_opened_or_linked():
     assert "this.loadDeferredSection('domain-ownership')" in script
     assert "sectionId === 'domain-ownership'" in script
     assert "this.fetchDomainOwnership()" in script
-    dns_records_branch = _template_section_between_markers(
-        script, "sectionId === 'dns-records'", "sectionId === 'posture-dashboard'"
-    )
-    posture_branch = _template_section_between_markers(
-        script, "sectionId === 'posture-dashboard'", "sectionId === 'health-score-history'"
-    )
+    dns_records_start = script.index("sectionId === 'dns-records'")
+    posture_start = script.index("sectionId === 'posture-dashboard'")
+    history_start = script.index("sectionId === 'health-score-history'")
+    dns_records_branch = script[dns_records_start:posture_start]
+    posture_branch = script[posture_start:history_start]
     assert "this.fetchCachedDomainDetail()" in dns_records_branch
     assert "this.fetchCachedDomainDetail()" in posture_branch
     assert "/detail/cached" in script

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -27,6 +27,7 @@ from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services import report_persistence
 from app.services.bimi import BIMIResult
+from app.services.mta_sts import MTAStsResult
 from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.ptr_lookup import PtrLookupResult
 from app.services.report_store import ReportStore
@@ -895,6 +896,83 @@ def test_domain_posture_dashboard_is_read_only_without_explicit_refresh(
         domain_name=DOMAIN,
     )
     assert snapshots == []
+
+
+def test_cached_domain_detail_combines_dns_and_posture_reads(
+    seeded_client: TestClient,
+    monkeypatch,
+):
+    """The deferred detail UI receives one cached payload, not an endpoint fan-out."""
+    calls = {"dns": 0, "health": 0, "guidance": 0, "grade": 0, "posture": 0}
+
+    async def fake_dns_result(*_args, **kwargs):
+        calls["dns"] += 1
+        assert kwargs["refresh"] is False
+        return domains_endpoint.DomainDNSResult(
+            dmarc=True,
+            dmarc_record="v=DMARC1; p=reject",
+            spf=True,
+            spf_record="v=spf1 -all",
+            dkim=True,
+            dkim_selectors=["selector1"],
+        )
+
+    async def fake_health(*_args, **kwargs):
+        calls["health"] += 1
+        assert kwargs["cached_only"] is True
+        return domains_endpoint.DNSHealthResponse(
+            status="healthy",
+            policy="reject",
+            compliance_rate=100,
+            total_emails=10,
+            failed_emails=0,
+            checks=[],
+            recommendations=[],
+        )
+
+    async def fake_guidance(*_args, **kwargs):
+        calls["guidance"] += 1
+        assert kwargs["cached_only"] is True
+        return {"domain": DOMAIN, "status": "healthy", "findings": [], "change_plans": []}
+
+    async def fake_grade(*_args, **kwargs):
+        calls["grade"] += 1
+        assert kwargs["cached_only"] is True
+        return {"domain": DOMAIN, "score": 96, "grade": "A", "status": "healthy"}
+
+    async def fake_posture(*_args, **kwargs):
+        calls["posture"] += 1
+        assert kwargs["store"] is not None
+        assert kwargs["health"].status == "healthy"
+        assert kwargs["domain_health"]["score"] == 96
+        return {"domain": DOMAIN, "health": {"score": 96, "grade": "A"}}
+
+    monkeypatch.setattr(domains_endpoint, "_resolve_summary_dns_result", fake_dns_result)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_health", fake_health)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_dns_guidance", fake_guidance)
+    monkeypatch.setattr(domains_endpoint, "_build_domain_health_grade", fake_grade)
+    monkeypatch.setattr(
+        domains_endpoint,
+        "_build_domain_posture_dashboard_for_workspace",
+        fake_posture,
+    )
+    monkeypatch.setattr(
+        domains_endpoint,
+        "check_mta_sts_cached",
+        AsyncMock(return_value=(MTAStsResult(status="pass"), True, None)),
+    )
+    monkeypatch.setattr(
+        domains_endpoint,
+        "check_bimi_cached",
+        AsyncMock(return_value=(BIMIResult(status="pass"), True, None)),
+    )
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/detail/cached")
+
+    assert response.status_code == 200
+    assert response.json()["posture"]["health"]["score"] == 96
+    assert response.json()["freshness"]["mode"] == "cached"
+    assert calls == {"dns": 1, "health": 1, "guidance": 1, "grade": 1, "posture": 1}
 
 
 def test_domain_remediation_queue_groups_dns_and_health_actions(

--- a/backend/app/tests/test_mail_service_imports.py
+++ b/backend/app/tests/test_mail_service_imports.py
@@ -360,6 +360,27 @@ def test_mail_service_dns_records_for_domain_is_optional(db_session):
     assert records == []
 
 
+def test_mail_service_dns_records_for_domain_skips_provider_discovery_for_cached_reads(
+    db_session,
+):
+    """Cached domain renders must not turn into Postmark API requests."""
+    discover = AsyncMock()
+    with patch(
+        "app.services.mail_service_imports.discover_postmark_sender_domains",
+        new=discover,
+    ):
+        records = asyncio.run(
+            mail_service_imports.mail_service_dns_records_for_domain(
+                db_session,
+                "example.com",
+                allow_live=False,
+            )
+        )
+
+    assert records == []
+    discover.assert_not_awaited()
+
+
 def test_mail_service_import_treats_existing_global_domain_as_existing(db_session):
     db_session.add(Domain(name="shared.example", active=True, verified=True))
     db_session.commit()


### PR DESCRIPTION
Closes #886

Normal DNS and posture detail reads now use one domain-scoped cached payload instead of fanning out into overlapping endpoints that each rebuild report state. Cached reads no longer invoke Postmark sender discovery or live DNS/provider enrichment; explicit refresh remains the operator-owned live path.

Validation:
- 226 focused tests passed in the application container
- JavaScript syntax check and Python compilation passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cached domain details view that combines DNS records, health, guidance, posture, MTA-STS, and BIMI information.
  * Domain details now load cached information efficiently with duplicate-request prevention.
* **Bug Fixes**
  * Cached reads no longer trigger live DNS provider lookups or third-party enrichment.
  * Improved consistency of DNS freshness and health data in domain details.
* **Tests**
  * Added coverage for cached detail responses and prevention of live lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->