### PR TITLE
feat: separate core mail health from optional posture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Separated core mail health from DMARC protection and optional capability
+  coverage. A healthy domain no longer loses its primary grade merely because
+  BIMI, MTA-STS, or another optional hardening capability is not configured;
+  protection state and monitoring confidence are shown explicitly instead.
 - Made the domain health score a single persisted projection. Posture, history,
   cached detail, and remediation now read the same score, grade, factors,
   actions, and evidence timestamp; background refreshes and explicit operator

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1283,6 +1283,10 @@ class DomainHealthGrade(BaseModel):
     factors: Dict[str, float] = Field(default_factory=dict)
     actions: List[Dict[str, Any]] = Field(default_factory=list)
     evidence_captured_at: Optional[str] = None
+    assessment_version: str = "1"
+    core_mail_health: Dict[str, Any] = Field(default_factory=dict)
+    domain_protection: Dict[str, Any] = Field(default_factory=dict)
+    monitoring_confidence: Dict[str, Any] = Field(default_factory=dict)
 
 
 class PostureDashboardResponse(BaseModel):
@@ -1290,7 +1294,11 @@ class PostureDashboardResponse(BaseModel):
 
     domain: str
     status: str
+    # Retained as a compatibility alias for existing API consumers. It is
+    # capability coverage, not the primary mail-health assessment.
     score: int
+    capability_coverage_score: int
+    capability_coverage_label: str = "Capability coverage"
     health: DomainHealthGrade
     summary: str
     coverage: List[PostureCoverageItem]
@@ -3895,7 +3903,7 @@ async def _build_domain_dns_health(  # pylint: disable=too-many-locals
     failed_checks = [check for check in checks if check.status == "fail"]
     failed_core_checks = [check for check in failed_checks if check.key in {"dmarc", "spf", "dkim"}]
     health_status = "healthy"
-    if failed_checks:
+    if failed_core_checks:
         health_status = "critical" if len(failed_core_checks) >= 2 else "degraded"
     return DNSHealthResponse(
         status=health_status,
@@ -4330,7 +4338,7 @@ def _build_posture_dashboard(
     domain_health: Dict[str, Any],
     changes: List[Dict[str, Any]],
 ) -> PostureDashboardResponse:
-    score = _posture_score(health.checks)
+    capability_coverage_score = _posture_score(health.checks)
     coverage = [
         PostureCoverageItem(
             key=check.key,
@@ -4345,7 +4353,8 @@ def _build_posture_dashboard(
     return PostureDashboardResponse(
         domain=domain_id,
         status=health.status,
-        score=score,
+        score=capability_coverage_score,
+        capability_coverage_score=capability_coverage_score,
         health=domain_health,
         summary=_posture_summary(health),
         coverage=coverage,

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 ACTIVE_POLICIES = {"quarantine", "reject"}
+HEALTH_ASSESSMENT_VERSION = "2"
 
 
 def health_grade(score: int, *, policy: Optional[str] = None, critical_actions: int = 0) -> str:
@@ -98,17 +99,66 @@ def _reputation_factor(domain: Dict[str, Any]) -> float:
 
 
 def _score_cap(domain: Dict[str, Any], confidence: float, *, policy: Optional[str] = None) -> int:
-    policy = policy or _effective_dmarc_policy(domain)
+    """Cap only when evidence is insufficient, not for optional hardening choices.
+
+    DMARC enforcement is important protection context, but it is not a measure
+    of whether intended mail is currently authenticated and delivering.  It is
+    therefore exposed separately instead of suppressing a healthy core result.
+    """
+    del policy
     cap = 100
-    if policy == "quarantine":
-        cap = min(cap, 92)
-    elif policy == "none":
-        cap = min(cap, 74)
-    elif policy not in ACTIVE_POLICIES:
-        cap = min(cap, 59)
     if confidence < 70:
         cap = min(cap, 79)
     return cap
+
+
+def _confidence_band(score: float) -> str:
+    if score >= 90:
+        return "high"
+    if score >= 70:
+        return "medium"
+    return "low"
+
+
+def _domain_protection(policy: str) -> Dict[str, str]:
+    if policy == "reject":
+        return {
+            "status": "enforced",
+            "policy": "reject",
+            "summary": "DMARC enforcement is active for unauthorized use.",
+        }
+    if policy == "quarantine":
+        return {
+            "status": "enforced",
+            "policy": "quarantine",
+            "summary": "DMARC quarantine protection is active while enforcement is staged.",
+        }
+    if policy == "none":
+        return {
+            "status": "monitoring",
+            "policy": "none",
+            "summary": "DMARC is monitoring only; receivers are not asked to enforce failures.",
+        }
+    return {
+        "status": "unprotected",
+        "policy": policy or "missing",
+        "summary": "No usable DMARC protection policy was verified.",
+    }
+
+
+def _monitoring_confidence(domain: Dict[str, Any], score: float) -> Dict[str, Any]:
+    reasons: List[str] = []
+    if domain.get("dns_pending"):
+        reasons.append("DNS evidence refresh is pending.")
+    elif domain.get("dns_lookup_failed"):
+        reasons.append("DNS evidence could not be refreshed; last known report context is retained.")
+    reports = int(domain.get("report_count") or domain.get("reports_processed") or 0)
+    emails = int(domain.get("total_emails") or 0)
+    if reports < 7 or emails < 250:
+        reasons.append("Recent report volume is limited.")
+    if not reasons:
+        reasons.append("Recent report and DNS evidence are sufficient for this assessment.")
+    return {"score": round(score, 1), "band": _confidence_band(score), "reasons": reasons}
 
 
 def _action(
@@ -410,25 +460,38 @@ def score_domain_health(domain: Dict[str, Any]) -> Dict[str, Any]:
     pass_rate = _bounded(domain.get("pass_rate"))
     dns = _dns_factor(domain)
     policy_name = _effective_dmarc_policy(domain)
+    # Retained as an explicitly exported protection dimension for API and
+    # historic evidence compatibility; it is intentionally not weighted into
+    # the core mail-health score.
     policy = _policy_factor(policy_name)
     confidence = _confidence_factor(domain)
     reputation = _reputation_factor(domain)
     raw_score = round(
-        (pass_rate * 0.40)
-        + (dns * 0.20)
-        + (policy * 0.25)
+        (pass_rate * 0.50)
+        + (dns * 0.30)
         + (confidence * 0.10)
-        + (reputation * 0.05)
+        + (reputation * 0.10)
     )
     score = min(raw_score, _score_cap(domain, confidence, policy=policy_name))
     actions = _domain_actions(domain)
     critical_actions = sum(1 for action in actions if action["severity"] == "critical")
-
-    return {
-        "domain": domain.get("domain_name") or domain.get("id"),
+    protection = _domain_protection(policy_name)
+    monitoring_confidence = _monitoring_confidence(domain, confidence)
+    core_health = {
         "score": int(score),
         "grade": health_grade(int(score), policy=policy_name, critical_actions=critical_actions),
         "status": "healthy" if score >= 90 else "attention" if score >= 70 else "critical",
+    }
+
+    return {
+        "domain": domain.get("domain_name") or domain.get("id"),
+        "assessment_version": HEALTH_ASSESSMENT_VERSION,
+        "score": core_health["score"],
+        "grade": core_health["grade"],
+        "status": core_health["status"],
+        "core_mail_health": core_health,
+        "domain_protection": protection,
+        "monitoring_confidence": monitoring_confidence,
         "factors": {
             "dmarc_compliance": round(pass_rate, 1),
             "dns_posture": round(dns, 1),

--- a/backend/app/services/health_score_snapshots.py
+++ b/backend/app/services/health_score_snapshots.py
@@ -49,6 +49,16 @@ def _snapshot_actions(snapshot: HealthScoreSnapshot) -> List[Dict[str, Any]]:
     return [item for item in parsed if isinstance(item, dict)]
 
 
+def _snapshot_evidence(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
+    if not snapshot.evidence_summary:
+        return {}
+    try:
+        parsed = json.loads(snapshot.evidence_summary)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def upsert_health_score_snapshot(
     db: Session,
     *,
@@ -95,10 +105,13 @@ def upsert_health_score_snapshot(
     snapshot.top_actions = json.dumps(actions, sort_keys=True)
     snapshot.evidence_summary = json.dumps(
         {
-            "calculation_version": 1,
+            "calculation_version": health.get("assessment_version") or "1",
             "report_count": snapshot.report_count,
             "total_emails": snapshot.total_emails,
             "failed_emails": snapshot.failed_emails,
+            "core_mail_health": health.get("core_mail_health") or {},
+            "domain_protection": health.get("domain_protection") or {},
+            "monitoring_confidence": health.get("monitoring_confidence") or {},
             "factors": {
                 "dmarc_compliance": _as_int(factors.get("dmarc_compliance")),
                 "dns_posture": snapshot.dns_posture_score,
@@ -137,6 +150,7 @@ def latest_health_score_snapshot(
 
 def snapshot_to_domain_health(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
     """Restore the API health object without recalculating its evidence."""
+    evidence = _snapshot_evidence(snapshot)
     return {
         "domain": snapshot.domain_name,
         "score": snapshot.score,
@@ -151,6 +165,21 @@ def snapshot_to_domain_health(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
         },
         "actions": _snapshot_actions(snapshot),
         "evidence_captured_at": snapshot.updated_at.isoformat(),
+        "assessment_version": str(evidence.get("calculation_version") or "1"),
+        "core_mail_health": evidence.get("core_mail_health") or {
+            "score": snapshot.score,
+            "grade": snapshot.grade,
+            "status": snapshot.status,
+        },
+        "domain_protection": evidence.get("domain_protection") or {
+            "policy": snapshot.policy or "unknown",
+            "status": "unknown",
+        },
+        "monitoring_confidence": evidence.get("monitoring_confidence") or {
+            "score": float(snapshot.report_confidence_score),
+            "band": "unknown",
+            "reasons": [],
+        },
     }
 
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -368,9 +368,9 @@
             {% call card_header() %}
                 <div class="flex items-center justify-between">
                     <div>
-                        {% call card_title() %}Posture Dashboard{% endcall %}
+                        {% call card_title() %}Mail health and security{% endcall %}
                         {% call card_description() %}
-                            Evidence-linked coverage, drift, and operator playbooks
+                            Core mail health, DMARC protection, and optional capabilities
                         {% endcall %}
                     </div>
                     <div class="text-right">
@@ -386,7 +386,7 @@
             {% call card_content() %}
                 <div class="grid gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
                     <div class="rounded-lg bg-[#f4f3f2] p-4">
-                        <div class="text-sm text-[#5f5c78]">Domain health grade</div>
+                        <div class="text-sm text-[#5f5c78]">Core mail health</div>
                         <div class="mt-2 flex items-end gap-3">
                             <div class="text-5xl font-bold text-[#120d36]" x-text="posture.health.grade || '-'"></div>
                             <div class="pb-1 text-sm text-[#5f5c78]">
@@ -395,12 +395,22 @@
                         </div>
                         <div class="mt-3 flex flex-wrap gap-2 text-xs">
                             <span class="rounded bg-white px-2 py-1 font-semibold text-[#272a5f]">
-                                <span x-text="posture.score"></span><span>/100 posture</span>
+                                <span x-text="posture.capability_coverage_score ?? posture.score"></span><span>/100 capability coverage</span>
                             </span>
                             <span class="rounded bg-white px-2 py-1 font-semibold capitalize text-[#272a5f]"
                                   x-text="posture.health.status || 'checking'"></span>
                         </div>
                         <p class="mt-3 text-sm text-[#5f5c78]" x-text="posture.summary"></p>
+                        <div class="mt-3 space-y-1 text-xs text-[#5f5c78]">
+                            <p>
+                                <span class="font-semibold text-[#272a5f]">DMARC protection:</span>
+                                <span class="capitalize" x-text="posture.health.domain_protection?.status || 'checking'"></span>
+                            </p>
+                            <p>
+                                <span class="font-semibold text-[#272a5f]">Monitoring confidence:</span>
+                                <span class="capitalize" x-text="posture.health.monitoring_confidence?.band || 'checking'"></span>
+                            </p>
+                        </div>
                     </div>
                     <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
                         <template x-for="item in posture.coverage" :key="item.key">

--- a/backend/app/tests/test_health_score.py
+++ b/backend/app/tests/test_health_score.py
@@ -11,7 +11,7 @@ def test_health_grade_reserves_a_plus_for_reject_without_critical_actions():
     assert health_grade(99, policy="reject", critical_actions=1) == "A"
 
 
-def test_policy_none_caps_domain_score_and_creates_action():
+def test_policy_none_is_protection_context_not_a_core_mail_health_penalty():
     health = score_domain_health(
         {
             "domain_name": "example.com",
@@ -27,9 +27,43 @@ def test_policy_none_caps_domain_score_and_creates_action():
         }
     )
 
-    assert health["score"] == 74
-    assert health["grade"] == "C"
+    assert health["score"] == 97
+    assert health["grade"] == "A"
+    assert health["assessment_version"] == "2"
+    assert health["core_mail_health"]["score"] == 97
+    assert health["domain_protection"] == {
+        "status": "monitoring",
+        "policy": "none",
+        "summary": "DMARC is monitoring only; receivers are not asked to enforce failures.",
+    }
+    assert health["monitoring_confidence"]["band"] == "high"
     assert any(action["type"] == "policy_none" for action in health["actions"])
+
+
+def test_optional_transport_and_branding_states_do_not_change_core_health():
+    """Optional capabilities are rendered elsewhere and never enter the core score."""
+    baseline = {
+        "domain_name": "homelab.example",
+        "total_emails": 2_000,
+        "failed_count": 0,
+        "pass_rate": 100,
+        "report_count": 20,
+        "dmarc_status": True,
+        "spf_status": True,
+        "dkim_status": True,
+        "dmarc_policy": "reject",
+        "dmarc_warnings": [],
+    }
+
+    no_optional_capabilities = score_domain_health(
+        {**baseline, "mta_sts_status": "not_configured", "bimi_status": "not_configured"}
+    )
+    configured_optional_capabilities = score_domain_health(
+        {**baseline, "mta_sts_status": "pass", "bimi_status": "pass"}
+    )
+
+    assert no_optional_capabilities["score"] == configured_optional_capabilities["score"]
+    assert no_optional_capabilities["grade"] == configured_optional_capabilities["grade"]
 
 
 def test_low_compliance_and_missing_dns_create_prioritized_actions():

--- a/backend/app/tests/test_health_score_snapshots.py
+++ b/backend/app/tests/test_health_score_snapshots.py
@@ -142,6 +142,10 @@ def test_latest_snapshot_restores_the_complete_persisted_health_assessment(db_se
             "score": 90,
             "grade": "A-",
             "status": "healthy",
+            "assessment_version": "2",
+            "core_mail_health": {"score": 90, "grade": "A-", "status": "healthy"},
+            "domain_protection": {"status": "enforced", "policy": "reject"},
+            "monitoring_confidence": {"score": 100, "band": "high", "reasons": ["Fresh"]},
             "factors": {
                 "dmarc_compliance": 100,
                 "dns_posture": 59,
@@ -179,6 +183,9 @@ def test_latest_snapshot_restores_the_complete_persisted_health_assessment(db_se
     assert assessment["factors"]["source_reputation"] == 81
     assert assessment["actions"][0]["next_step"] == "Refresh DNS evidence."
     assert assessment["evidence_captured_at"]
+    assert assessment["assessment_version"] == "2"
+    assert assessment["domain_protection"]["status"] == "enforced"
+    assert assessment["monitoring_confidence"]["band"] == "high"
 
 
 def test_health_score_snapshot_filters_by_date_range(db_session):

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -997,7 +997,11 @@ GET /domains/{domain_id}/posture
 ```
 
 Returns the evidence-first posture dashboard for one domain. The response
-contains the posture score, coverage for DMARC, SPF, DKIM, MTA-STS, and BIMI,
+contains the versioned core mail-health assessment, a separate DMARC protection
+state, monitoring-confidence evidence, and capability coverage for DMARC, SPF,
+DKIM, MTA-STS, and BIMI. `score` remains a compatibility alias for
+`capability_coverage_score`; it is not the primary mail-health grade. Missing
+optional MTA-STS or BIMI capability never lowers core mail health by itself.
 actionable recommendations, recent provider-backed DNS drift summaries, and
 short operator playbooks. Recommendation and playbook evidence links point back
 to the page section that triggered the finding.


### PR DESCRIPTION
Reopens the implementation originally proposed in #890 after GitHub closed that stacked PR when #889 merged. Preserves the original contribution and applies only the core-mail-health separation on top of current main.