### PR TITLE
feat: persist auditable DNS score evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Persisted health evidence now records DNS cache/fallback provenance, resolver
+  route, selector inventory, and factor deltas. The domain detail view explains
+  whether a score movement reflects refreshed evidence rather than an unseen
+  DNS change; DNS-over-HTTPS is explicitly identified as bypassing port-53
+  interception logs.
 - Separated core mail health from DMARC protection and optional capability
   coverage. A healthy domain no longer loses its primary grade merely because
   BIMI, MTA-STS, or another optional hardening capability is not configured;

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1287,6 +1287,8 @@ class DomainHealthGrade(BaseModel):
     core_mail_health: Dict[str, Any] = Field(default_factory=dict)
     domain_protection: Dict[str, Any] = Field(default_factory=dict)
     monitoring_confidence: Dict[str, Any] = Field(default_factory=dict)
+    dns_evidence: Dict[str, Any] = Field(default_factory=dict)
+    change: Dict[str, Any] = Field(default_factory=dict)
 
 
 class PostureDashboardResponse(BaseModel):
@@ -4274,6 +4276,18 @@ async def _build_domain_health_grade(
     dns_evidence_source = _dns_evidence_source(dns)
     dns_pending = bool(getattr(dns, "pending", False))
     dns_lookup_status = _dns_lookup_status(dns)
+    dns_evidence = {
+        "checked_at": (
+            dns.checked_at.isoformat() if getattr(dns, "checked_at", None) else None
+        ),
+        "cache_state": "cached" if getattr(dns, "cached", False) else "fresh",
+        "lookup_status": dns_lookup_status,
+        "lookup_error": dns.lookup_error,
+        "resolver_route": getattr(dns, "resolver_route", None),
+        "resolver_identity": getattr(dns, "resolver_identity", None),
+        "fallback_attempts": list(getattr(dns, "fallback_attempts", []) or []),
+        "selectors_checked": list(getattr(dns, "selectors_checked", []) or []),
+    }
     domain_row = {
         "id": domain_id,
         "domain_name": domain_id,
@@ -4292,6 +4306,7 @@ async def _build_domain_health_grade(
         "dns_lookup_status": dns_lookup_status,
         "dns_lookup_failed": dns_lookup_status == "failed",
         "dns_lookup_error": dns.lookup_error,
+        "dns_evidence": dns_evidence,
         "dmarc_warnings": dns.dmarc_warnings,
         "dmarc_suggestions": dns.dmarc_suggestions,
         "source_reputation": asdict(reputation_result),

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -65,6 +65,9 @@ def _result_from_json(value: str) -> DomainDNSResult:
         dns_provider=detection_from_json(data.get("dns_provider")),
         lookup_status=str(data.get("lookup_status") or "ok"),
         lookup_error=data.get("lookup_error"),
+        resolver_route=data.get("resolver_route"),
+        resolver_identity=data.get("resolver_identity"),
+        fallback_attempts=list(data.get("fallback_attempts") or []),
     )
 
 
@@ -335,7 +338,22 @@ def _fallback_result(
     if task_name != primary_name:
         result.lookup_status = "fallback"
         result.lookup_error = f"No DNS evidence from {primary_name}; using {task_name}."
+        result.resolver_route = "fallback"
+        result.resolver_identity = task_name
+        result.fallback_attempts = list(dict.fromkeys([primary_name, task_name]))
     return result
+
+
+def _resolver_route(provider: BaseDNSProvider) -> str:
+    if isinstance(provider, ConfiguredRecursiveDNSProvider):
+        return "configured_recursive_or_doh"
+    if isinstance(provider, PublicRecursiveDNSProvider):
+        return "public_recursive"
+    if isinstance(provider, SystemDNSProvider):
+        return "system_resolver"
+    if provider.__class__.__name__ in {"CloudflareDNSProvider", "GoogleDNSProvider"}:
+        return "dns_over_https"
+    return "provider_api_or_custom"
 
 
 def _empty_fallback_result(
@@ -529,6 +547,11 @@ async def resolve_domain_dns_cached(
             exc.__class__.__name__,
         )
         return _lookup_failure_result(exc.__class__.__name__, now)
+
+    if not result.resolver_route:
+        result.resolver_route = _resolver_route(provider)
+    if not result.resolver_identity:
+        result.resolver_identity = provider_name
 
     if not _has_dns_evidence(result):
         stale = _best_stale_cached_evidence(

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -158,6 +158,11 @@ class DomainDNSResult:
     dns_provider: Optional[DNSProviderDetection] = None
     lookup_status: str = "ok"
     lookup_error: Optional[str] = None
+    # Resolver provenance is evidence, not a runtime instruction. Persisting
+    # it makes a cached/fallback DNS observation explainable after the fact.
+    resolver_route: Optional[str] = None
+    resolver_identity: Optional[str] = None
+    fallback_attempts: List[str] = field(default_factory=list)
 
 
 def _normalize_dns_name(domain: str) -> str:

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -213,6 +213,15 @@ def _evidence_items(domain: Dict[str, Any]) -> List[Dict[str, str]]:
         items.append({"label": "policy", "value": f"p={domain.get('dmarc_policy')}"})
     if domain.get("dns_lookup_status"):
         items.append({"label": "dns_lookup", "value": str(domain.get("dns_lookup_status"))})
+    dns_evidence = domain.get("dns_evidence") or {}
+    if dns_evidence.get("checked_at"):
+        items.append({"label": "dns_checked_at", "value": str(dns_evidence["checked_at"])})
+    if dns_evidence.get("resolver_route"):
+        items.append({"label": "resolver_route", "value": str(dns_evidence["resolver_route"])})
+    if dns_evidence.get("resolver_identity"):
+        items.append(
+            {"label": "resolver_identity", "value": str(dns_evidence["resolver_identity"])}
+        )
     return items
 
 
@@ -492,6 +501,7 @@ def score_domain_health(domain: Dict[str, Any]) -> Dict[str, Any]:
         "core_mail_health": core_health,
         "domain_protection": protection,
         "monitoring_confidence": monitoring_confidence,
+        "dns_evidence": dict(domain.get("dns_evidence") or {}),
         "factors": {
             "dmarc_compliance": round(pass_rate, 1),
             "dns_posture": round(dns, 1),

--- a/backend/app/services/health_score_snapshots.py
+++ b/backend/app/services/health_score_snapshots.py
@@ -59,6 +59,42 @@ def _snapshot_evidence(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _factor_deltas(
+    previous: Dict[str, Any], current: Dict[str, Any]
+) -> Dict[str, int]:
+    return {
+        key: _as_int(current.get(key)) - _as_int(previous.get(key))
+        for key in sorted(set(previous) | set(current))
+        if _as_int(current.get(key)) != _as_int(previous.get(key))
+    }
+
+
+def _snapshot_change(
+    baseline: Optional[HealthScoreSnapshot],
+    *,
+    factors: Dict[str, Any],
+    score: Any,
+) -> Dict[str, Any]:
+    if baseline is None:
+        return {"kind": "initial_assessment", "score_delta": None, "factor_deltas": {}}
+    previous = _snapshot_evidence(baseline)
+    previous_factors = previous.get("factors") if isinstance(previous.get("factors"), dict) else {}
+    score_delta = _as_int(score) - _as_int(baseline.score)
+    factor_deltas = _factor_deltas(previous_factors, factors)
+    return {
+        "kind": "evidence_refresh",
+        "previous_snapshot_date": baseline.snapshot_date.isoformat(),
+        "previous_evidence_captured_at": baseline.updated_at.isoformat(),
+        "score_delta": score_delta,
+        "factor_deltas": factor_deltas,
+        "reason": (
+            "No scored factor changed; evidence was refreshed."
+            if score_delta == 0 and not factor_deltas
+            else "Score changed because the listed persisted factors changed."
+        ),
+    }
+
+
 def upsert_health_score_snapshot(
     db: Session,
     *,
@@ -84,6 +120,23 @@ def upsert_health_score_snapshot(
             HealthScoreSnapshot.snapshot_date == captured_date,
         )
         .one_or_none()
+    )
+    baseline = existing
+    if baseline is None:
+        baseline = (
+            db.query(HealthScoreSnapshot)
+            .filter(
+                HealthScoreSnapshot.workspace_id == workspace_id,
+                HealthScoreSnapshot.domain_name == domain_name,
+                HealthScoreSnapshot.snapshot_date < captured_date,
+            )
+            .order_by(HealthScoreSnapshot.snapshot_date.desc(), HealthScoreSnapshot.updated_at.desc())
+            .first()
+        )
+    change = _snapshot_change(
+        baseline,
+        factors=factors,
+        score=health.get("score"),
     )
     snapshot = existing or HealthScoreSnapshot(
         workspace_id=workspace_id,
@@ -112,6 +165,8 @@ def upsert_health_score_snapshot(
             "core_mail_health": health.get("core_mail_health") or {},
             "domain_protection": health.get("domain_protection") or {},
             "monitoring_confidence": health.get("monitoring_confidence") or {},
+            "dns_evidence": health.get("dns_evidence") or {},
+            "change": change,
             "factors": {
                 "dmarc_compliance": _as_int(factors.get("dmarc_compliance")),
                 "dns_posture": snapshot.dns_posture_score,
@@ -180,6 +235,8 @@ def snapshot_to_domain_health(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
             "band": "unknown",
             "reasons": [],
         },
+        "dns_evidence": evidence.get("dns_evidence") or {},
+        "change": evidence.get("change") or {},
     }
 
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -411,6 +411,20 @@
                                 <span class="capitalize" x-text="posture.health.monitoring_confidence?.band || 'checking'"></span>
                             </p>
                         </div>
+                        <div class="mt-3 border-t border-[#e6e3e1] pt-3 text-xs text-[#5f5c78]"
+                             x-show="posture.health.change?.reason || posture.health.dns_evidence?.checked_at">
+                            <p class="font-semibold text-[#272a5f]">Why this assessment</p>
+                            <p class="mt-1" x-text="posture.health.change?.reason || 'Current persisted DNS and report evidence.'"></p>
+                            <p class="mt-1" x-show="posture.health.change?.score_delta !== undefined && posture.health.change?.score_delta !== null">
+                                Score change: <span x-text="posture.health.change?.score_delta > 0 ? '+' + posture.health.change.score_delta : posture.health.change.score_delta"></span>
+                            </p>
+                            <p class="mt-1" x-show="posture.health.dns_evidence?.checked_at">
+                                DNS checked: <span x-text="formatIsoDate(posture.health.dns_evidence?.checked_at)"></span>
+                            </p>
+                            <p class="mt-1" x-show="posture.health.dns_evidence?.resolver_route">
+                                Resolution path: <span x-text="humanizeToken(posture.health.dns_evidence?.resolver_route)"></span>
+                            </p>
+                        </div>
                     </div>
                     <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
                         <template x-for="item in posture.coverage" :key="item.key">

--- a/backend/app/tests/test_health_score_snapshots.py
+++ b/backend/app/tests/test_health_score_snapshots.py
@@ -188,6 +188,44 @@ def test_latest_snapshot_restores_the_complete_persisted_health_assessment(db_se
     assert assessment["monitoring_confidence"]["band"] == "high"
 
 
+def test_health_snapshot_explains_dns_provenance_and_factor_delta(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    base_health = {
+        "assessment_version": "2",
+        "score": 92,
+        "grade": "A-",
+        "status": "healthy",
+        "factors": {"dns_posture": 80, "report_confidence": 100},
+        "dns_evidence": {
+            "checked_at": "2026-07-28T09:00:00",
+            "cache_state": "cached",
+            "lookup_status": "ok",
+            "resolver_route": "dns_over_https",
+            "resolver_identity": "CloudflareDNSProvider",
+            "selectors_checked": ["mail"],
+        },
+    }
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name="auditable.example",
+        health=base_health,
+        snapshot_date=date(2026, 7, 27),
+    )
+    snapshot = upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name="auditable.example",
+        health={**base_health, "score": 96, "factors": {"dns_posture": 100, "report_confidence": 100}},
+        snapshot_date=date(2026, 7, 28),
+    )
+
+    assessment = snapshot_to_domain_health(snapshot)
+    assert assessment["dns_evidence"]["resolver_route"] == "dns_over_https"
+    assert assessment["change"]["score_delta"] == 4
+    assert assessment["change"]["factor_deltas"] == {"dns_posture": 20}
+
+
 def test_health_score_snapshot_filters_by_date_range(db_session):
     workspace = get_or_create_default_workspace(db_session)
     for day in range(1, 4):

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1002,7 +1002,11 @@ state, monitoring-confidence evidence, and capability coverage for DMARC, SPF,
 DKIM, MTA-STS, and BIMI. `score` remains a compatibility alias for
 `capability_coverage_score`; it is not the primary mail-health grade. Missing
 optional MTA-STS or BIMI capability never lowers core mail health by itself.
-actionable recommendations, recent provider-backed DNS drift summaries, and
+The persisted `health` object also includes `dns_evidence` (capture time,
+cache state, resolver route, fallback context, and selector inventory) and a
+`change` object with factor deltas. DNS-over-HTTPS routes do not appear in a
+local port-53 interception log. The response also includes actionable
+recommendations, recent provider-backed DNS drift summaries, and
 short operator playbooks. Recommendation and playbook evidence links point back
 to the page section that triggered the finding.
 


### PR DESCRIPTION
Reopens the implementation originally proposed in #891 after GitHub closed that stacked PR as its base was merged. Preserves the original work and applies the DNS provenance and factor-delta improvements on current `main`.