### PR TITLE
fix: restore DNS posture lint gate

### DIFF
--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -492,7 +492,7 @@ async def _resolve_configured_with_fallback(  # noqa: C901
     )
 
 
-async def resolve_domain_dns_cached(
+async def resolve_domain_dns_cached(  # noqa: C901 - cache/fallback state is intentionally co-located
     db: Session,
     provider: BaseDNSProvider,
     domain: str,

--- a/backend/app/services/dns_posture_snapshots.py
+++ b/backend/app/services/dns_posture_snapshots.py
@@ -156,13 +156,6 @@ def capture_dns_posture_snapshot(
     previous = None
     if current.accepted_snapshot_id:
         previous = db.get(DomainDNSPostureSnapshot, current.accepted_snapshot_id)
-    previous_payload: Dict[str, Any] = {}
-    if previous:
-        try:
-            previous_payload = json.loads(previous.result_json)
-        except (TypeError, ValueError, json.JSONDecodeError):
-            previous_payload = {}
-
     lookup_ok = _acceptable_result(result)
     has_evidence = _has_dns_evidence(result)
     if lookup_ok and has_evidence:


### PR DESCRIPTION
Fixes the first-party CI failure after #895: removes an unused snapshot variable and documents the intentional cache/fallback complexity at the function boundary. Validated with targeted DNS tests; GitHub CI will run the repository flake8 command.