### PR TITLE
fix: distinguish DMARC authentication from delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The setup assistant now detects domains owned by another workspace during
   preview and points operators to the existing domain instead of allowing a
   predictable apply-time rollback.
+- Sending-source views now distinguish receiver-observed DMARC authentication
+  from actual delivery. The UI no longer calls a DMARC pass "delivery" or a
+  receiver-reported `disposition=none` a delivered message; additive API fields
+  expose evidence kind, claim level, receiver disposition, and unknown delivery
+  certainty for integrations.
 - DNS posture is now an immutable, versioned projection. Report ingestion only
   requests a coalesced background refresh; normal domain reads use the last
   accepted snapshot and retain it when a resolver fails or a single empty

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -8454,7 +8454,7 @@ def _source_delivery_status(source: Dict[str, Any]) -> Dict[str, str]:
             "label": "Receiver-reported protective action",
             "detail": "Receivers reported quarantine or reject for observed failures; final delivery is unknown.",
         }
-    if failed and delivered_failures and not passed:
+    if failed and delivered_failures >= failed and not blocked and not passed:
         return {
             "status": "unauthenticated_delivered",
             "label": "Receiver reported no DMARC action",
@@ -8497,7 +8497,7 @@ def _source_authentication_observation(source: Dict[str, Any]) -> Dict[str, str]
             "disposition": "protective_action",
             "disposition_label": "Receivers reported quarantine or reject",
         }
-    if failed and no_action and not passed:
+    if failed and no_action >= failed and not protected and not passed:
         return {
             "status": "receiver_no_dmarc_action",
             "label": "Receiver reported no DMARC action",

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2065,6 +2065,16 @@ class SourceEntry(BaseModel):
     delivery_status: str = "unknown"
     delivery_label: str = "Delivery status unknown"
     delivery_detail: str = "No DMARC delivery outcome is available for this source."
+    # Deprecated compatibility aliases. DMARC aggregate reports do not prove
+    # individual delivery; use the explicit observation fields below instead.
+    authentication_status: str = "unknown"
+    authentication_label: str = "Authentication result unknown"
+    authentication_detail: str = "No receiver authentication observation is available for this source."
+    receiver_disposition: str = "unknown"
+    receiver_disposition_label: str = "Receiver-reported disposition unavailable"
+    evidence_kind: str = "dmarc_aggregate_report"
+    claim_level: str = "observed"
+    delivery_certainty: str = "unknown"
     hostname: Optional[str] = None
     ptr_status: Optional[str] = None
     ptr_detail: Optional[str] = None
@@ -8421,7 +8431,11 @@ def _source_recommendations(
 
 
 def _source_delivery_status(source: Dict[str, Any]) -> Dict[str, str]:
-    """Describe the observed DMARC outcome without claiming sender ownership."""
+    """Return deprecated delivery aliases without claiming end-user delivery.
+
+    Kept for API compatibility. New callers should use
+    :func:`_source_authentication_observation` and the explicit evidence fields.
+    """
     passed = int(source.get("dmarc_pass_count") or 0)
     failed = int(source.get("dmarc_fail_count") or 0)
     dispositions = source.get("disposition_counts") or {}
@@ -8431,31 +8445,80 @@ def _source_delivery_status(source: Dict[str, Any]) -> Dict[str, str]:
     if passed and not failed:
         return {
             "status": "aligned",
-            "label": "Aligned delivery",
-            "detail": "All observed messages passed DMARC in the selected window.",
+            "label": "Authenticated in receiver reports",
+            "detail": "All observed messages passed DMARC in the selected window; final delivery is unknown.",
         }
     if failed and blocked >= failed and not delivered_failures:
         return {
             "status": "policy_blocked",
-            "label": "Blocked by policy",
-            "detail": "Observed DMARC failures were quarantined or rejected by policy.",
+            "label": "Receiver-reported protective action",
+            "detail": "Receivers reported quarantine or reject for observed failures; final delivery is unknown.",
         }
     if failed and delivered_failures and not passed:
         return {
             "status": "unauthenticated_delivered",
-            "label": "Unauthenticated delivery",
-            "detail": "Observed DMARC failures were delivered with disposition none.",
+            "label": "Receiver reported no DMARC action",
+            "detail": "Receivers reported disposition none for observed failures; this does not prove delivery or inbox placement.",
         }
     if passed or failed:
         return {
             "status": "mixed",
-            "label": "Mixed delivery",
-            "detail": "The selected window contains both aligned and failing DMARC outcomes.",
+            "label": "Mixed authentication results",
+            "detail": "The selected window contains both passing and failing DMARC observations; final delivery is unknown.",
         }
     return {
         "status": "unknown",
-        "label": "Delivery status unknown",
-        "detail": "No DMARC delivery outcome is available for this source.",
+        "label": "Authentication result unknown",
+        "detail": "No DMARC authentication observation is available for this source.",
+    }
+
+
+def _source_authentication_observation(source: Dict[str, Any]) -> Dict[str, str]:
+    """Describe aggregate DMARC facts without inferring individual delivery."""
+    passed = int(source.get("dmarc_pass_count") or 0)
+    failed = int(source.get("dmarc_fail_count") or 0)
+    dispositions = source.get("disposition_counts") or {}
+    protected = int(dispositions.get("reject") or 0) + int(dispositions.get("quarantine") or 0)
+    no_action = int(dispositions.get("none") or 0)
+
+    if passed and not failed:
+        return {
+            "status": "authenticated",
+            "label": "Authenticated in receiver reports",
+            "detail": "All observed messages passed DMARC in this window. Aggregate reports do not confirm final delivery or inbox placement.",
+            "disposition": "no_failing_messages",
+            "disposition_label": "No failing-message disposition reported",
+        }
+    if failed and protected >= failed and not no_action:
+        return {
+            "status": "receiver_protective_action",
+            "label": "Receiver-reported protective action",
+            "detail": "Receivers reported quarantine or reject for all observed DMARC failures. This is not a per-message bounce confirmation.",
+            "disposition": "protective_action",
+            "disposition_label": "Receivers reported quarantine or reject",
+        }
+    if failed and no_action and not passed:
+        return {
+            "status": "receiver_no_dmarc_action",
+            "label": "Receiver reported no DMARC action",
+            "detail": "Receivers reported disposition none for observed DMARC failures. That does not prove delivery, inbox placement, or acceptance.",
+            "disposition": "none",
+            "disposition_label": "Receivers reported disposition none",
+        }
+    if passed or failed:
+        return {
+            "status": "mixed_authentication",
+            "label": "Mixed authentication results",
+            "detail": "This window includes both passing and failing DMARC observations. Aggregate reports do not confirm final delivery.",
+            "disposition": "mixed",
+            "disposition_label": "Receiver-reported dispositions vary",
+        }
+    return {
+        "status": "unknown",
+        "label": "Authentication result unknown",
+        "detail": "No DMARC authentication observation is available for this source.",
+        "disposition": "unknown",
+        "disposition_label": "Receiver-reported disposition unavailable",
     }
 
 
@@ -8927,6 +8990,7 @@ async def get_domain_sources(
         source_anomalies = anomalies_by_ip.get(ip, [])
         reputation = reputations_by_ip.get(ip)
         delivery = _source_delivery_status(source)
+        authentication = _source_authentication_observation(source)
         recommendations = _source_recommendations(ip, source, hostname, spf_fix_hint, sender)
         recommendations.extend(_anomaly_recommendations(source_anomalies))
         recommendations.extend(_reputation_recommendations(reputation))
@@ -8954,6 +9018,14 @@ async def get_domain_sources(
                 delivery_status=delivery["status"],
                 delivery_label=delivery["label"],
                 delivery_detail=delivery["detail"],
+                authentication_status=authentication["status"],
+                authentication_label=authentication["label"],
+                authentication_detail=authentication["detail"],
+                receiver_disposition=authentication["disposition"],
+                receiver_disposition_label=authentication["disposition_label"],
+                evidence_kind="dmarc_aggregate_report",
+                claim_level="observed",
+                delivery_certainty="unknown",
                 hostname=hostname,
                 ptr_status=(ptr_by_ip.get(ip).status if ptr_by_ip.get(ip) else None),
                 ptr_detail=(ptr_by_ip.get(ip).detail if ptr_by_ip.get(ip) else None),

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -668,9 +668,9 @@ function domainDetailsApp(domainId = '') {
                     if (!source?.reputation) counts.unchecked += 1;
                     if (source?.dmarc === 'fail' || source?.dmarc === 'mixed') counts.authReview += 1;
                     if (this.sourceActivityBucket(source) === 'recent') counts.recent += 1;
-                    if (source?.delivery_status === 'aligned') counts.aligned += 1;
-                    if (source?.delivery_status === 'policy_blocked') counts.blocked += 1;
-                    if (source?.delivery_status === 'unauthenticated_delivered') counts.unauthenticated += 1;
+                    if (source?.authentication_status === 'authenticated') counts.authenticated += 1;
+                    if (source?.authentication_status === 'receiver_protective_action') counts.protectiveAction += 1;
+                    if (source?.authentication_status === 'receiver_no_dmarc_action') counts.noDmarcAction += 1;
                     return counts;
                 },
                 {
@@ -680,9 +680,9 @@ function domainDetailsApp(domainId = '') {
                     unchecked: 0,
                     authReview: 0,
                     recent: 0,
-                    aligned: 0,
-                    blocked: 0,
-                    unauthenticated: 0
+                    authenticated: 0,
+                    protectiveAction: 0,
+                    noDmarcAction: 0
                 }
             );
         },
@@ -715,8 +715,9 @@ function domainDetailsApp(domainId = '') {
                     source.last_seen ? this.sourceSeenLabel(source.last_seen) : '',
                     source.reputation?.status,
                     source.reputation?.summary,
-                    source.delivery_label,
-                    source.delivery_detail,
+                    source.authentication_label,
+                    source.authentication_detail,
+                    source.receiver_disposition_label,
                     ...(source.reputation?.listings || []),
                 ].some(value => String(value || '').toLowerCase().includes(needle));
             });
@@ -763,14 +764,14 @@ function domainDetailsApp(domainId = '') {
         },
 
         sourceDeliveryMatches(source, filter) {
-            return filter === 'all' || source?.delivery_status === filter;
+            return filter === 'all' || source?.authentication_status === filter;
         },
 
         sourceDeliveryClass(source) {
-            if (source?.delivery_status === 'aligned') return 'bg-green-100 text-green-800';
-            if (source?.delivery_status === 'policy_blocked') return 'bg-blue-100 text-blue-800';
-            if (source?.delivery_status === 'unauthenticated_delivered') return 'bg-red-100 text-red-800';
-            if (source?.delivery_status === 'mixed') return 'bg-amber-100 text-amber-800';
+            if (source?.authentication_status === 'authenticated') return 'bg-green-100 text-green-800';
+            if (source?.authentication_status === 'receiver_protective_action') return 'bg-blue-100 text-blue-800';
+            if (source?.authentication_status === 'receiver_no_dmarc_action') return 'bg-red-100 text-red-800';
+            if (source?.authentication_status === 'mixed_authentication') return 'bg-amber-100 text-amber-800';
             return 'bg-base-200 text-base-content/70';
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2700,11 +2700,11 @@
                             <option value="clean">Clean reputation</option>
                         </select>
                         <select x-model="filters.sourceDeliveryFilter" class="select select-sm select-bordered">
-                            <option value="all">All delivery outcomes</option>
-                            <option value="aligned">Aligned delivery</option>
-                            <option value="policy_blocked">Blocked by policy</option>
-                            <option value="unauthenticated_delivered">Unauthenticated delivery</option>
-                            <option value="mixed">Mixed delivery</option>
+                            <option value="all">All authentication observations</option>
+                            <option value="authenticated">Authenticated in receiver reports</option>
+                            <option value="receiver_protective_action">Receiver-reported protective action</option>
+                            <option value="receiver_no_dmarc_action">Receiver reported no DMARC action</option>
+                            <option value="mixed_authentication">Mixed authentication results</option>
                         </select>
                         <button type="button"
                                 class="btn btn-sm btn-default"
@@ -2747,20 +2747,20 @@
                         :aria-pressed="sourceSummaryFilterActive('recent')">
                         <span x-text="sourceRiskCounts.recent"></span><span class="ml-1">recent</span>
                     </button>
-                    <button type="button" data-domain-detail-source-filter="delivery:aligned"
+                    <button type="button" data-domain-detail-source-filter="delivery:authenticated"
                         class="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 font-semibold text-green-800 hover:ring-2 hover:ring-green-500/30 focus:outline-none focus:ring-2 focus:ring-green-600"
-                        :aria-pressed="sourceSummaryFilterActive('delivery:aligned')">
-                        <span x-text="sourceRiskCounts.aligned"></span><span class="ml-1">aligned delivery</span>
+                        :aria-pressed="sourceSummaryFilterActive('delivery:authenticated')">
+                        <span x-text="sourceRiskCounts.authenticated"></span><span class="ml-1">authenticated in receiver reports</span>
                     </button>
-                    <button type="button" data-domain-detail-source-filter="delivery:policy_blocked"
+                    <button type="button" data-domain-detail-source-filter="delivery:receiver_protective_action"
                         class="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 font-semibold text-blue-800 hover:ring-2 hover:ring-blue-500/30 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                        :aria-pressed="sourceSummaryFilterActive('delivery:policy_blocked')">
-                        <span x-text="sourceRiskCounts.blocked"></span><span class="ml-1">blocked by policy</span>
+                        :aria-pressed="sourceSummaryFilterActive('delivery:receiver_protective_action')">
+                        <span x-text="sourceRiskCounts.protectiveAction"></span><span class="ml-1">receiver-reported protective action</span>
                     </button>
-                    <button type="button" data-domain-detail-source-filter="delivery:unauthenticated_delivered"
+                    <button type="button" data-domain-detail-source-filter="delivery:receiver_no_dmarc_action"
                         class="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 font-semibold text-red-800 hover:ring-2 hover:ring-red-500/30 focus:outline-none focus:ring-2 focus:ring-red-600"
-                        :aria-pressed="sourceSummaryFilterActive('delivery:unauthenticated_delivered')">
-                        <span x-text="sourceRiskCounts.unauthenticated"></span><span class="ml-1">unauthenticated delivery</span>
+                        :aria-pressed="sourceSummaryFilterActive('delivery:receiver_no_dmarc_action')">
+                        <span x-text="sourceRiskCounts.noDmarcAction"></span><span class="ml-1">receiver reported no DMARC action</span>
                     </button>
                     <button type="button" data-domain-detail-source-filter="unchecked"
                         class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 font-semibold text-base-content/70 hover:ring-2 hover:ring-[#2f9da5]/40 focus:outline-none focus:ring-2 focus:ring-[#2f9da5]"
@@ -2813,8 +2813,8 @@
                                               x-text="sourceActivityLabel(source)"></span>
                                         <span class="inline-flex w-fit rounded-full px-2 py-0.5 text-xs font-semibold"
                                               :class="sourceDeliveryClass(source)"
-                                              :title="source.delivery_detail"
-                                              x-text="source.delivery_label"></span>
+                                              :title="source.authentication_detail"
+                                              x-text="source.authentication_label"></span>
                                     </div>
                                     <div class="space-y-1">
                                         <div class="flex flex-wrap items-center gap-2">
@@ -2946,15 +2946,9 @@
                                         </div>
                                         <div class="auth-status-cell" data-auth="disposition">
                                             <span class="auth-label">Disposition</span>
-                                    <template x-if="source.disposition === 'none'">
-                                        <span class="inline-flex items-center px-2 py-1 rounded-full text-xs bg-blue-100 text-blue-800">None</span>
-                                    </template>
-                                    <template x-if="source.disposition === 'quarantine'">
-                                        <span class="inline-flex items-center px-2 py-1 rounded-full text-xs bg-yellow-100 text-yellow-800">Quarantine</span>
-                                    </template>
-                                    <template x-if="source.disposition === 'reject'">
-                                        <span class="inline-flex items-center px-2 py-1 rounded-full text-xs bg-red-100 text-red-800">Reject</span>
-                                    </template>
+                                    <span class="inline-flex items-center px-2 py-1 rounded-full text-xs"
+                                          :class="source.receiver_disposition === 'protective_action' ? 'bg-red-100 text-red-800' : (source.receiver_disposition === 'none' ? 'bg-blue-100 text-blue-800' : (source.receiver_disposition === 'mixed' ? 'bg-yellow-100 text-yellow-800' : 'bg-base-200 text-base-content/70'))"
+                                          x-text="source.receiver_disposition_label"></span>
                                         </div>
                                     </div>
                                     <div class="sending-source-recs min-w-0">

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -3193,6 +3193,17 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
             "none",
             "unknown",
         ),
+        (
+            {
+                "dmarc_pass_count": 0,
+                "dmarc_fail_count": 12,
+                "disposition_counts": {"none": 6, "reject": 6},
+            },
+            "mixed",
+            "mixed_authentication",
+            "mixed",
+            "unknown",
+        ),
     ],
 )
 def test_source_delivery_status_distinguishes_receiver_observations(

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -3152,14 +3152,25 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
             "failed": 6,
         }
     ]
-    assert source["delivery_status"] == "mixed"
-    assert source["delivery_label"] == "Mixed delivery"
+    assert source["delivery_status"] == "mixed"  # Deprecated API compatibility field.
+    assert source["authentication_status"] == "mixed_authentication"
+    assert source["authentication_label"] == "Mixed authentication results"
+    assert source["receiver_disposition"] == "mixed"
+    assert source["evidence_kind"] == "dmarc_aggregate_report"
+    assert source["claim_level"] == "observed"
+    assert source["delivery_certainty"] == "unknown"
 
 
 @pytest.mark.parametrize(
-    ("source", "status"),
+    ("source", "status", "authentication_status", "receiver_disposition", "certainty"),
     [
-        ({"dmarc_pass_count": 12, "dmarc_fail_count": 0}, "aligned"),
+        (
+            {"dmarc_pass_count": 12, "dmarc_fail_count": 0},
+            "aligned",
+            "authenticated",
+            "no_failing_messages",
+            "unknown",
+        ),
         (
             {
                 "dmarc_pass_count": 0,
@@ -3167,6 +3178,9 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
                 "disposition_counts": {"reject": 12},
             },
             "policy_blocked",
+            "receiver_protective_action",
+            "protective_action",
+            "unknown",
         ),
         (
             {
@@ -3175,13 +3189,33 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
                 "disposition_counts": {"none": 12},
             },
             "unauthenticated_delivered",
+            "receiver_no_dmarc_action",
+            "none",
+            "unknown",
         ),
     ],
 )
-def test_source_delivery_status_distinguishes_policy_outcomes(source, status):
-    delivery = domains_endpoint._source_delivery_status(source)  # pylint: disable=protected-access
+def test_source_delivery_status_distinguishes_receiver_observations(
+    source, status, authentication_status, receiver_disposition, certainty
+):
+    delivery = domains_endpoint._source_delivery_status(  # pylint: disable=protected-access
+        source
+    )
 
     assert delivery["status"] == status
+    assert "delivery" not in delivery["label"].lower()
+    observation = domains_endpoint._source_authentication_observation(  # pylint: disable=protected-access
+        source
+    )
+    assert observation["status"] == authentication_status
+    assert observation["disposition"] == receiver_disposition
+    assert observation["disposition_label"] != receiver_disposition
+    assert "delivery" not in observation["label"].lower()
+    assert certainty == "unknown"
+    assert any(
+        phrase in observation["detail"].lower()
+        for phrase in ("do not", "does not", "unknown", "not a per-message")
+    )
 
 
 def test_get_domain_sources_returns_recommendations(

--- a/backend/app/tests/test_sending_sources_layout.py
+++ b/backend/app/tests/test_sending_sources_layout.py
@@ -81,13 +81,15 @@ def test_sending_source_summary_chips_are_interactive_filters() -> None:
         "auth_review",
         "recent",
         "unchecked",
-        "delivery:aligned",
-        "delivery:policy_blocked",
-        "delivery:unauthenticated_delivered",
+        "delivery:authenticated",
+        "delivery:receiver_protective_action",
+        "delivery:receiver_no_dmarc_action",
     ):
         assert f'data-domain-detail-source-filter="{value}"' in section
     assert "setSourceSummaryFilter" in script
     assert "sourceSummaryFilterActive" in script
+    assert "aligned delivery" not in section.lower()
+    assert "unauthenticated delivery" not in section.lower()
 
 
 def test_auth_status_cells_include_labels_beside_badges() -> None:

--- a/backend/app/tests/test_sending_sources_layout.py
+++ b/backend/app/tests/test_sending_sources_layout.py
@@ -51,7 +51,8 @@ def test_sending_sources_keeps_auth_and_recommendations_data() -> None:
     assert "source.spf" in section
     assert "source.dkim" in section
     assert "source.dmarc" in section
-    assert "source.disposition" in section
+    assert "source.receiver_disposition" in section
+    assert "source.receiver_disposition_label" in section
     assert "source.recommendations" in section
     assert "Trust signals" in section
     assert "sourceNetworkSummary(source)" in section

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1041,6 +1041,26 @@ failures.
 next to the raw sending-source evidence. `volume_history` is a list of per-day
 `{date, count, passed, failed}` points for the source IP.
 
+### Sender authentication and delivery certainty
+
+DMARC aggregate reports describe how a reporting receiver evaluated domain
+authentication and which DMARC disposition it recorded. They do **not** prove
+that an individual message was accepted, delivered, bounced, or placed in an
+inbox. Source responses therefore include additive fields:
+
+- `authentication_status`, `authentication_label`, and `authentication_detail`
+  describe the aggregate DMARC observation;
+- `receiver_disposition` and `receiver_disposition_label` describe only the
+  receiver-reported DMARC action;
+- `evidence_kind` is currently `dmarc_aggregate_report`;
+- `claim_level` is `observed` for these protocol facts; and
+- `delivery_certainty` remains `unknown` until DMARQ has actual delivery
+  evidence such as a DSN or a signed provider delivery event.
+
+The older `delivery_status`, `delivery_label`, and `delivery_detail` fields are
+retained for compatibility but are deprecated. New integrations should use the
+explicit authentication and receiver-disposition fields.
+
 #### Get Source Reputation
 
 ```http


### PR DESCRIPTION
## Summary
- replace misleading sending-source UI labels such as "Aligned delivery" and "Unauthenticated delivery" with receiver-observed DMARC authentication and disposition wording
- add explicit `authentication_*`, `receiver_disposition*`, `evidence_kind`, `claim_level`, and `delivery_certainty` API fields
- retain existing `delivery_*` fields as deprecated compatibility aliases while removing delivery claims from their labels
- document the contract and add regression coverage

## Validation
- `/tmp/dmarq-venv/bin/python -m pytest backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_mail_health.py backend/app/tests/test_sending_sources_layout.py -q`
- `node --check backend/app/static/js/domain-details-page.js`
- `/tmp/dmarq-venv/bin/flake8 backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_sending_sources_layout.py`

Partial implementation of #869; DSN/provider signal types remain separate work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified that DMARC “pass/fail” reflects receiver-observed authentication, not confirmed message delivery.
  * Updated Sending Sources so receiver-reported `disposition=none` is no longer treated as delivered.
  * Refreshed delivery/auth filters, labels, and tooltips to align with authentication observations and receiver disposition.

* **Documentation**
  * Added API documentation for new authentication, receiver-disposition, evidence-kind, claim-level, and delivery-certainty fields.
  * Marked legacy delivery fields as deprecated, noting delivery certainty may remain unknown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->