### PR TITLE
fix: guide Cloudflare DNS apply flow

### DIFF
--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -46,6 +46,7 @@ function domainDetailsApp(domainId = '') {
         dnsProviders: [
             { id: 'cloudflare', name: 'Cloudflare' }
         ],
+        dnsProviderDetails: [],
         dnsWrite: {
             provider: 'cloudflare',
             allowProviderMismatch: false,
@@ -1165,6 +1166,54 @@ function domainDetailsApp(domainId = '') {
         providerName(providerId) {
             const provider = this.dnsProviders.find(item => item.id === providerId);
             return provider ? provider.name : providerId;
+        },
+
+        get selectedDnsProviderDetail() {
+            const providerId = this.canonicalProviderId(this.dnsWrite.provider);
+            return this.dnsProviderDetails.find(
+                provider => this.canonicalProviderId(provider.id) === providerId
+            ) || null;
+        },
+
+        get dnsWriteProviderConfigured() {
+            return Boolean(this.selectedDnsProviderDetail?.credentials_configured);
+        },
+
+        get dnsWriteProviderSetupHref() {
+            return this.canonicalProviderId(this.dnsWrite.provider) === 'cloudflare'
+                ? '/settings#provider-integrations'
+                : '/settings#provider-integrations';
+        },
+
+        dnsWritePreviewMatches(plan) {
+            const previewProvider = this.canonicalProviderId(this.dnsWrite.preview?.provider);
+            return Boolean(
+                this.dnsWrite.preview &&
+                this.dnsWrite.preview.plan_id === plan.plan_id &&
+                previewProvider === this.canonicalProviderId(this.dnsWrite.provider) &&
+                this.dnsWrite.preview.mutation?.applicable
+            );
+        },
+
+        dnsWriteCanPreview(plan) {
+            return Boolean(plan.provider_write_available && this.dnsWriteProviderConfigured);
+        },
+
+        dnsWriteCanApply(plan) {
+            return this.dnsWriteCanPreview(plan) && this.dnsWritePreviewMatches(plan);
+        },
+
+        dnsWritePreviewHint(plan) {
+            if (!plan.provider_write_available) {
+                return 'This recommendation needs a provider-specific value or a manual change.';
+            }
+            if (!this.dnsWriteProviderConfigured) {
+                return 'Connect the selected provider before creating an exact change preview.';
+            }
+            if (!this.dnsWritePreviewMatches(plan)) {
+                return 'Preview the exact provider mutation before applying it.';
+            }
+            return 'Preview is ready. Review the diff, then apply this one change.';
         },
 
         canonicalProviderId(providerId) {
@@ -2540,6 +2589,7 @@ function domainDetailsApp(domainId = '') {
                 const response = await fetch('/api/v1/domains/dns/providers');
                 if (response.ok) {
                     const data = await response.json();
+                    this.dnsProviderDetails = data.providers || [];
                     const ready = (data.providers || []).filter(provider => provider.status === 'ready');
                     this.dnsProviders = ready.length ? ready : this.dnsProviders;
                     if (!this.dnsProviders.some(provider => provider.id === this.dnsWrite.provider)) {
@@ -2580,6 +2630,17 @@ function domainDetailsApp(domainId = '') {
             ].join('\n');
         },
 
+        dnsWriteErrorMessage(detail, apply) {
+            const message = String(detail || '').trim();
+            const providerId = this.canonicalProviderId(this.dnsWrite.provider);
+            if (providerId === 'cloudflare' && /token is not configured|unauthori[sz]ed|forbidden|permission|authentication|HTTP 40[13]/i.test(message)) {
+                return apply
+                    ? 'Cloudflare could not apply this change. Keep the preview, then update the Cloudflare token or OAuth profile with Zone:Read, DNS:Read, and DNS:Edit for this zone before trying again.'
+                    : 'Cloudflare could not read this zone. Connect Cloudflare or update its token with Zone:Read and DNS:Read for this zone, then preview again.';
+            }
+            return message || 'DNS change could not be prepared';
+        },
+
         async submitDNSChange(plan, apply) {
             this.dnsWrite.loading = true;
             this.dnsWrite.error = '';
@@ -2598,7 +2659,7 @@ function domainDetailsApp(domainId = '') {
                 });
                 const data = await response.json();
                 if (!response.ok) {
-                    this.dnsWrite.error = data.detail || 'DNS change could not be prepared';
+                    this.dnsWrite.error = this.dnsWriteErrorMessage(data.detail, apply);
                     return;
                 }
                 data.plan_id = plan.plan_id;
@@ -2634,7 +2695,8 @@ function domainDetailsApp(domainId = '') {
                 ? this.dnsWrite.preview
                 : null;
             if (!preview) {
-                preview = await this.submitDNSChange(plan, false);
+                this.dnsWrite.message = 'Start with “1. Preview change” so you can review the exact provider mutation before applying it.';
+                return null;
             }
             if (!preview?.mutation) {
                 return null;

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2282,8 +2282,8 @@
                             <div id="dns-change-plan" class="mt-4 border-t border-base-300 pt-4">
                                 <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                                     <div>
-                                        <h4 class="font-semibold">Next safe DNS change</h4>
-                                        <p class="text-xs text-base-content/60">Provider writes require explicit review and approval.</p>
+                                        <h4 class="font-semibold">Apply one DNS change safely</h4>
+                                        <p class="text-xs text-base-content/60">DMARQ never changes DNS in the background. Preview the exact provider change, review it, then confirm one live update.</p>
                                         <p x-show="dnsGuidance.recommended_provider"
                                            class="mt-1 text-xs text-base-content/60">
                                             Recommended provider:
@@ -2301,9 +2301,28 @@
                                             </template>
                                         </select>
                                         <span class="inline-flex w-fit rounded bg-base-200 px-2 py-1 text-xs font-semibold text-base-content/70">
-                                            explicit approval required
+                                            final confirmation required
                                         </span>
                                     </div>
+                                </div>
+                                <div class="mt-3 rounded border border-base-300 bg-base-100 px-3 py-3 text-xs text-base-content/75">
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <p class="font-semibold" x-text="providerName(dnsWrite.provider) + ' connection'"></p>
+                                            <p class="mt-1" x-show="selectedDnsProviderDetail" x-text="selectedDnsProviderDetail?.connection_hint"></p>
+                                        </div>
+                                        <a x-show="!dnsWriteProviderConfigured"
+                                           class="btn btn-xs btn-outline"
+                                           :href="dnsWriteProviderSetupHref">
+                                            Configure provider access
+                                        </a>
+                                    </div>
+                                    <p class="mt-2" x-show="dnsWriteProviderConfigured">
+                                        <span class="font-semibold">Three steps:</span> 1. Preview the exact before/after change. 2. Review the provider zone, value, and rollback. 3. Confirm one live update.
+                                    </p>
+                                    <p class="mt-2" x-show="dnsWriteProviderConfigured && canonicalProviderId(dnsWrite.provider) === 'cloudflare'">
+                                        Cloudflare must grant <span class="font-semibold">Zone:Read</span>, <span class="font-semibold">DNS:Read</span>, and <span class="font-semibold">DNS:Edit</span> for the affected zone. Preview only needs read access; the final apply reveals missing edit access clearly.
+                                    </p>
                                 </div>
                                 <div x-show="dnsProviderMismatch"
                                      class="mt-2 rounded border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-900">
@@ -2390,8 +2409,9 @@
                                             </div>
                                             <div class="mt-3 flex flex-col gap-2 border-t border-base-200 pt-3 sm:flex-row sm:items-center sm:justify-between">
                                                 <div class="text-xs text-base-content/60">
-                                                    <span x-show="plan.provider_write_available">Can be previewed and applied with the selected provider.</span>
+                                                    <span x-show="dnsWriteCanPreview(plan)">Use the three steps at right; only the final confirmation changes live DNS.</span>
                                                     <span x-show="!plan.provider_write_available">Manual-only until the value or operation is safe to automate.</span>
+                                                    <span x-show="plan.provider_write_available && !dnsWriteProviderConfigured" x-text="dnsWritePreviewHint(plan)"></span>
                                                     <ul x-show="plan.safety_notes && plan.safety_notes.length"
                                                         class="mt-1 list-disc space-y-0.5 pl-4">
                                                         <template x-for="note in plan.safety_notes" :key="note">
@@ -2402,32 +2422,46 @@
                                                 <div class="flex flex-wrap gap-2">
                                                     <button
                                                         class="btn btn-xs btn-outline"
-                                                        :disabled="dnsWrite.loading || !plan.provider_write_available"
+                                                        :disabled="dnsWrite.loading || !dnsWriteCanPreview(plan)"
                                                         :data-dns-plan-id="plan.plan_id"
                                                         data-domain-detail-dns-action="preview"
                                                     >
-                                                        Preview
+                                                        1. Preview change
                                                     </button>
                                                     <button
                                                         class="btn btn-xs bg-[#2f9da5] text-white hover:bg-[#272a5f]"
-                                                        :disabled="dnsWrite.loading || !plan.provider_write_available"
+                                                        :disabled="dnsWrite.loading || !dnsWriteCanApply(plan)"
                                                         :data-dns-plan-id="plan.plan_id"
                                                         data-domain-detail-dns-action="apply"
                                                     >
-                                                        Apply
+                                                        3. Apply to <span x-text="providerName(dnsWrite.provider)"></span>
                                                     </button>
                                                 </div>
                                             </div>
                                             <template x-if="dnsWrite.preview && dnsWrite.preview.plan_id === plan.plan_id">
                                                 <div class="mt-3 rounded border border-[#2f9da5]/30 bg-[#2f9da5]/10 p-3 text-xs">
-                                                    <div class="font-semibold">Provider preview</div>
+                                                    <div class="font-semibold">2. Review before applying</div>
                                                     <div class="mt-1 grid gap-1 sm:grid-cols-2">
                                                         <p><span class="font-semibold">Operation:</span> <span x-text="dnsWrite.preview.mutation.operation"></span></p>
                                                         <p><span class="font-semibold">Provider:</span> <span x-text="dnsWrite.preview.provider"></span></p>
                                                         <p><span class="font-semibold">Zone:</span> <span x-text="dnsWrite.preview.mutation.zone_name || dnsWrite.preview.mutation.zone_id || 'provider resolved'"></span></p>
                                                         <p><span class="font-semibold">TTL:</span> <span x-text="dnsWrite.preview.mutation.ttl"></span></p>
                                                     </div>
-                                                    <code class="mt-2 block break-all rounded bg-white/70 p-2" x-text="dnsWrite.preview.mutation.name + ' ' + dnsWrite.preview.mutation.record_type + ' ' + dnsWrite.preview.mutation.content"></code>
+                                                    <div class="mt-2 grid gap-2 sm:grid-cols-2">
+                                                        <div>
+                                                            <p class="font-semibold">Before</p>
+                                                            <template x-if="dnsWrite.preview.mutation.current_values && dnsWrite.preview.mutation.current_values.length">
+                                                                <template x-for="value in dnsWrite.preview.mutation.current_values" :key="value">
+                                                                    <code class="mt-1 block break-all rounded bg-white/70 p-2" x-text="value"></code>
+                                                                </template>
+                                                            </template>
+                                                            <p x-show="!dnsWrite.preview.mutation.current_values || !dnsWrite.preview.mutation.current_values.length" class="mt-1 text-base-content/70">No matching record exists; this will create one.</p>
+                                                        </div>
+                                                        <div>
+                                                            <p class="font-semibold">After</p>
+                                                            <code class="mt-1 block break-all rounded bg-white/70 p-2" x-text="dnsWrite.preview.mutation.content"></code>
+                                                        </div>
+                                                    </div>
                                                     <template x-if="dnsWrite.preview.verification && dnsWrite.preview.verification.status !== 'not_run'">
                                                         <div class="mt-2 rounded bg-white/70 p-2">
                                                             <p>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2309,7 +2309,7 @@
                                     <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                                         <div>
                                             <p class="font-semibold" x-text="providerName(dnsWrite.provider) + ' connection'"></p>
-                                            <p class="mt-1" x-show="selectedDnsProviderDetail" x-text="selectedDnsProviderDetail?.connection_hint"></p>
+                                            <p class="mt-1" x-show="selectedDnsProviderDetail" x-text="pathValue(selectedDnsProviderDetail, 'connection_hint', '')"></p>
                                         </div>
                                         <a x-show="!dnsWriteProviderConfigured"
                                            class="btn btn-xs btn-outline"

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2431,7 +2431,16 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
     assert "providerContextSummary" in script
     assert "providerContextSteps" in script
     assert "providerContextCtaHref" in script
-    assert "/settings#provider-integrations" not in template
+    assert "Apply one DNS change safely" in template
+    assert "Configure provider access" in template
+    assert "1. Preview change" in template
+    assert "2. Review before applying" in template
+    assert "3. Apply to" in template
+    assert "dnsWriteCanApply(plan)" in template
+    assert "dnsWriteProviderConfigured" in template
+    assert "dnsWritePreviewMatches(plan)" in script
+    assert "dnsWriteErrorMessage(detail, apply)" in script
+    assert "Zone:Read, DNS:Read, and DNS:Edit" in script
     assert "x-html" not in template
 
 


### PR DESCRIPTION
Closes #901\n\nThe provider DNS repair UI now exposes a clear three-step path: connect the selected provider, preview the exact mutation, review before/after and rollback, then confirm one live apply.\n\nIt also makes missing Cloudflare credentials or DNS:Edit permissions actionable instead of leaving operators with a generic approval message.\n\nValidated locally:\n- targeted Cloudflare preview/apply and ownership tests\n- domain-detail template safety test\n- JavaScript syntax check