### PR TITLE
fix: unify persisted domain health scores

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -23,8 +23,8 @@ from app.core.config import get_settings, uses_legacy_demo_fixtures
 from app.core.database import SessionLocal, get_db
 from app.core.redaction import sanitize_for_log
 from app.core.security import require_admin_auth
-from app.models.domain import Domain
 from app.models.dns_cache import DNSCache
+from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
 from app.models.setting import Setting
 from app.models.workspace import Workspace
@@ -58,8 +58,8 @@ from app.services.dns_cache import (
     get_latest_cached_domain_dns_evidence,
     resolve_domain_dns_cached,
 )
-from app.services.dns_posture_snapshots import accepted_dns_posture_result
 from app.services.dns_guidance import MailAuthSetupDefaults, build_dns_guidance
+from app.services.dns_posture_snapshots import accepted_dns_posture_result
 from app.services.dns_provider_connectors import (
     provider_connector_metadata,
     provider_connector_registry,
@@ -128,8 +128,8 @@ from app.services.remediation_readiness import (
 )
 from app.services.report_persistence import (
     domain_reports_and_timeline_from_db,
-    domain_summary_from_db,
     domain_summaries_from_db,
+    domain_summary_from_db,
     hydrate_domain_report_store_from_db,
     hydrate_report_store_from_db,
 )
@@ -144,13 +144,13 @@ from app.services.source_evidence_prewarm import (
     network_from_source_evidence,
     ptr_from_source_evidence,
 )
-from app.services.source_read_projection import (
-    load_domain_source_read_projection,
-)
 from app.services.source_network import (
     SourceNetworkIntelligence,
     lookup_sources_network_cached,
     merge_network_into_geo,
+)
+from app.services.source_read_projection import (
+    load_domain_source_read_projection,
 )
 from app.services.source_reputation import (
     SourceReputation,
@@ -4279,9 +4279,7 @@ async def _build_domain_health_grade(
     dns_pending = bool(getattr(dns, "pending", False))
     dns_lookup_status = _dns_lookup_status(dns)
     dns_evidence = {
-        "checked_at": (
-            dns.checked_at.isoformat() if getattr(dns, "checked_at", None) else None
-        ),
+        "checked_at": (dns.checked_at.isoformat() if getattr(dns, "checked_at", None) else None),
         "cache_state": "cached" if getattr(dns, "cached", False) else "fresh",
         "lookup_status": dns_lookup_status,
         "lookup_error": dns.lookup_error,
@@ -5161,7 +5159,33 @@ async def get_domains_summary(
             "dmarc_suggestions": dns.dmarc_suggestions,
             "remediation": {},
         }
-        domain_row["health"] = score_domain_health(domain_row)
+        # The dashboard, domain list, and domain detail page must all present
+        # the same assessment. Normal reads therefore use the latest score
+        # materialized during ingest/refresh, never a new request-time score.
+        # A user-requested refresh is the one explicit exception: it captures
+        # fresh cached DNS evidence and persists the resulting assessment
+        # before returning it. Demo data remains self-contained.
+        if refresh or demo_mode:
+            current_health = score_domain_health(domain_row)
+            if not demo_mode:
+                upsert_health_score_snapshot(
+                    db,
+                    workspace_id=workspace.id,
+                    domain_name=domain_name,
+                    health=current_health,
+                    policy=dmarc_policy,
+                    compliance_rate=summary.get("compliance_rate", 0),
+                    total_emails=summary.get("total_count", 0),
+                    failed_emails=summary.get("failed_count", 0),
+                    report_count=summary.get("reports_processed", 0),
+                )
+            domain_row["health"] = current_health
+        else:
+            domain_row["health"] = _persisted_domain_health(
+                db,
+                workspace_id=workspace.id,
+                domain_name=domain_name,
+            )
         domain_row["remediation_workload"] = _domain_remediation_workload(domain_row)
         domains_list.append(domain_row)
 
@@ -6805,9 +6829,7 @@ async def get_cached_domain_detail_read_model(  # pylint: disable=too-many-local
             dnsProvider=asdict(dns_result.dns_provider) if dns_result.dns_provider else None,
             providerContext=_dns_provider_repair_context(
                 db,
-                dns_provider=(
-                    asdict(dns_result.dns_provider) if dns_result.dns_provider else None
-                ),
+                dns_provider=(asdict(dns_result.dns_provider) if dns_result.dns_provider else None),
                 nameservers=dns_result.nameservers,
             ),
             lookupStatus=dns_result.lookup_status,
@@ -8784,7 +8806,9 @@ async def get_domain_sources(
     missing_ptr_ips = [str(ip) for ip in ips if str(ip) not in ptr_by_ip]
     missing_network_ips = [str(ip) for ip in ips if str(ip) not in networks_by_ip]
     if refresh:
-        ptr_task = asyncio.create_task(_source_ptr_results_by_ip(provider, missing_ptr_ips, settings))
+        ptr_task = asyncio.create_task(
+            _source_ptr_results_by_ip(provider, missing_ptr_ips, settings)
+        )
         network_task = asyncio.create_task(
             _source_networks_by_ip(db, provider, missing_network_ips, settings)
         )

--- a/backend/app/services/health_score_snapshots.py
+++ b/backend/app/services/health_score_snapshots.py
@@ -59,9 +59,102 @@ def _snapshot_evidence(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _factor_deltas(
-    previous: Dict[str, Any], current: Dict[str, Any]
-) -> Dict[str, int]:
+def _legacy_path_to_100(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
+    """Explain a non-perfect snapshot created before path-to-100 existed.
+
+    Older persisted assessments contain the factor scores but not the
+    presentation explanation. Never let that produce the contradictory "96"
+    plus "nothing remains" result in the UI.
+    """
+    remaining_points = max(0, 100 - _as_int(snapshot.score))
+    if not remaining_points:
+        return {
+            "score": _as_int(snapshot.score),
+            "remaining_points": 0,
+            "items": [],
+            "summary": (
+                "Core mail health is at 100/100. Optional hardening and DMARC "
+                "protection are shown separately."
+            ),
+        }
+
+    factors = {
+        "dmarc_compliance": _as_int(snapshot.compliance_rate),
+        "dns_posture": _as_int(snapshot.dns_posture_score),
+        "report_confidence": _as_int(snapshot.report_confidence_score),
+        "source_reputation": _as_int(snapshot.source_reputation_score),
+    }
+    weights = {
+        "dmarc_compliance": 0.50,
+        "dns_posture": 0.30,
+        "report_confidence": 0.10,
+        "source_reputation": 0.10,
+    }
+    labels = {
+        "dmarc_compliance": "Improve observed DMARC compliance",
+        "dns_posture": "Review saved DNS authentication evidence",
+        "report_confidence": "Collect a more representative report window",
+        "source_reputation": "Review saved sender-reputation evidence",
+    }
+    details = {
+        "dmarc_compliance": "Recent aggregate reports still contain DMARC failures.",
+        "dns_posture": "The saved DMARC, SPF, or DKIM evidence is not fully healthy.",
+        "report_confidence": "The current score is bounded by the amount of available report evidence.",
+        "source_reputation": "The saved sender evidence includes unresolved reputation uncertainty.",
+    }
+    items = []
+    for factor, weight in weights.items():
+        deduction = round(max(0, 100 - factors[factor]) * weight, 1)
+        if deduction <= 0:
+            continue
+        items.append(
+            {
+                "id": f"legacy_{factor}",
+                "factor": factor,
+                "title": labels[factor],
+                "kind": "investigation_required",
+                "expected_score_delta": deduction,
+                "detail": details[factor],
+                "next_step": "Open the saved evidence before making a DNS or sender change.",
+                "verification": "A refreshed persisted assessment confirms the updated evidence.",
+                "evidence": [],
+            }
+        )
+    if not items:
+        items.append(
+            {
+                "id": "legacy_assessment_gap",
+                "factor": "assessment",
+                "title": "Review the saved assessment evidence",
+                "kind": "investigation_required",
+                "expected_score_delta": remaining_points,
+                "detail": "This older assessment predates the detailed score explanation.",
+                "next_step": "Refresh the stored DNS and report evidence to capture a full explanation.",
+                "verification": "A new persisted assessment includes its verified path to 100.",
+                "evidence": [],
+            }
+        )
+    items.sort(key=lambda item: float(item["expected_score_delta"]), reverse=True)
+    return {
+        "score": _as_int(snapshot.score),
+        "remaining_points": remaining_points,
+        "items": items,
+        "summary": "These remaining points come from saved assessment evidence. Review the listed evidence before making a change.",
+    }
+
+
+def _snapshot_path_to_100(
+    snapshot: HealthScoreSnapshot, evidence: Dict[str, Any]
+) -> Dict[str, Any]:
+    path = evidence.get("path_to_100")
+    if isinstance(path, dict) and path.get("items"):
+        return path
+    if _as_int(snapshot.score) >= 100:
+        return _legacy_path_to_100(snapshot)
+    return _legacy_path_to_100(snapshot)
+
+
+def _factor_deltas(previous: Dict[str, Any], current: Dict[str, Any]) -> Dict[str, int]:
     return {
         key: _as_int(current.get(key)) - _as_int(previous.get(key))
         for key in sorted(set(previous) | set(current))
@@ -130,7 +223,9 @@ def upsert_health_score_snapshot(
                 HealthScoreSnapshot.domain_name == domain_name,
                 HealthScoreSnapshot.snapshot_date < captured_date,
             )
-            .order_by(HealthScoreSnapshot.snapshot_date.desc(), HealthScoreSnapshot.updated_at.desc())
+            .order_by(
+                HealthScoreSnapshot.snapshot_date.desc(), HealthScoreSnapshot.updated_at.desc()
+            )
             .first()
         )
     change = _snapshot_change(
@@ -222,21 +317,24 @@ def snapshot_to_domain_health(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
         "actions": _snapshot_actions(snapshot),
         "evidence_captured_at": snapshot.updated_at.isoformat(),
         "assessment_version": str(evidence.get("calculation_version") or "1"),
-        "core_mail_health": evidence.get("core_mail_health") or {
+        "core_mail_health": evidence.get("core_mail_health")
+        or {
             "score": snapshot.score,
             "grade": snapshot.grade,
             "status": snapshot.status,
         },
-        "domain_protection": evidence.get("domain_protection") or {
+        "domain_protection": evidence.get("domain_protection")
+        or {
             "policy": snapshot.policy or "unknown",
             "status": "unknown",
         },
-        "monitoring_confidence": evidence.get("monitoring_confidence") or {
+        "monitoring_confidence": evidence.get("monitoring_confidence")
+        or {
             "score": float(snapshot.report_confidence_score),
             "band": "unknown",
             "reasons": [],
         },
-        "path_to_100": evidence.get("path_to_100") or {},
+        "path_to_100": _snapshot_path_to_100(snapshot, evidence),
         "dns_evidence": evidence.get("dns_evidence") or {},
         "change": evidence.get("change") or {},
     }
@@ -317,7 +415,7 @@ def snapshot_to_history_point(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
         "source_reputation_score": snapshot.source_reputation_score,
         "evidence_captured_at": snapshot.updated_at.isoformat(),
         "top_actions": _snapshot_actions(snapshot),
-        "path_to_100": _snapshot_evidence(snapshot).get("path_to_100") or {},
+        "path_to_100": _snapshot_path_to_100(snapshot, _snapshot_evidence(snapshot)),
     }
 
 

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -487,7 +487,11 @@ function domainDetailsApp(domainId = '') {
             await Promise.allSettled([
                 this.fetchDomainStats(),
                 this.fetchReports(),
-                this.fetchRemediationQueue()
+                this.fetchRemediationQueue(),
+                // This is a persisted snapshot query. Loading it here makes
+                // the current score and its remaining points visible in the
+                // overview without triggering DNS or reputation work.
+                this.fetchHealthHistory()
             ]);
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -236,6 +236,48 @@
                     </div>
                 </template>
             </div>
+            <section class="mt-4 rounded-lg border border-[#d7eef0] bg-[#f1fbfc] p-4" aria-labelledby="domain-health-summary-heading">
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                        <p class="text-xs font-semibold uppercase text-[#176d74]">Current mail health</p>
+                        <h2 id="domain-health-summary-heading" class="mt-1 text-lg font-semibold text-[#07071f]">
+                            <span x-show="healthHistory.loading">Loading saved assessment...</span>
+                            <span x-show="!healthHistory.loading && healthHistory.points.length === 0">Assessment pending</span>
+                            <span x-show="!healthHistory.loading && healthHistory.points.length > 0">
+                                <span x-text="latestHealthPoint.score"></span><span>/100</span>
+                                <span class="ml-2 text-sm font-medium text-[#5f5c78]" x-text="latestHealthPoint.grade"></span>
+                            </span>
+                        </h2>
+                        <p class="mt-2 text-sm text-[#5f5c78]"
+                           x-show="!healthHistory.loading && healthHistory.points.length > 0"
+                           x-text="pathValue(latestHealthPoint, 'path_to_100.summary', 'The saved assessment is ready for review.')"></p>
+                        <p class="mt-2 text-sm text-[#5f5c78]"
+                           x-show="!healthHistory.loading && healthHistory.points.length === 0">
+                            DMARQ will show one consistent score after the next report or scheduled evidence refresh.
+                        </p>
+                    </div>
+                    <a href="#health-score-history" class="btn btn-outline btn-sm border-[#176d74] text-[#176d74] hover:bg-white"
+                       x-show="!healthHistory.loading && healthHistory.points.length > 0">
+                        See score evidence
+                    </a>
+                </div>
+                <div class="mt-3 grid gap-2 md:grid-cols-2"
+                     x-show="!healthHistory.loading && pathValue(latestHealthPoint, 'path_to_100.items', []).length > 0">
+                    <template x-for="item in pathValue(latestHealthPoint, 'path_to_100.items', []).slice(0, 2)" :key="item.id">
+                        <div class="rounded-md border border-[#d7eef0] bg-white p-3">
+                            <div class="flex items-start justify-between gap-3">
+                                <p class="font-semibold text-[#120d36]" x-text="item.title"></p>
+                                <span class="shrink-0 text-xs font-semibold text-[#176d74]" x-text="`up to +${item.expected_score_delta}`"></span>
+                            </div>
+                            <p class="mt-1 text-xs text-[#5f5c78]" x-text="item.next_step"></p>
+                        </div>
+                    </template>
+                </div>
+                <p class="mt-3 text-xs font-medium text-[#176d74]"
+                   x-show="!healthHistory.loading && healthHistory.points.length > 0 && pathValue(latestHealthPoint, 'path_to_100.items', []).length === 0">
+                    Core mail health is already at 100. Domain protection and optional hardening are tracked separately.
+                </p>
+            </section>
         </div>
 
         <!-- Ownership proof -->
@@ -395,7 +437,7 @@
                         </div>
                         <div class="mt-3 flex flex-wrap gap-2 text-xs">
                             <span class="rounded bg-white px-2 py-1 font-semibold text-[#272a5f]">
-                                <span x-text="pathValue(posture, 'capability_coverage_score', posture.score)"></span><span>/100 capability coverage</span>
+                                <span x-text="pathValue(posture, 'capability_coverage_score', posture.score)"></span><span>/100 DNS capability coverage, not the health score</span>
                             </span>
                             <span class="rounded bg-white px-2 py-1 font-semibold capitalize text-[#272a5f]"
                                   x-text="posture.health.status || 'checking'"></span>

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -36,7 +36,6 @@ from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services.bimi import BIMIResult, check_bimi_cached
 from app.services.dane import DANEResult, TLSARecord, TLSASuggestion, check_dane_cached
-from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.dns_cache import (
     _selectors_key,
     get_latest_cached_domain_dns_evidence,
@@ -51,6 +50,7 @@ from app.services.dns_resolver import (
     PublicRecursiveDNSProvider,
     SystemDNSProvider,
 )
+from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
 from app.services.remediation_dispatch import summarize_remediation_activity
 from app.services.report_persistence import save_parsed_report
@@ -2762,6 +2762,44 @@ def test_summary_includes_dns_fields(authed_client: TestClient, db_session):
     assert domain["dkim_status"] is True
     assert domain["dmarc_policy"] == "none"
     assert domain["dmarc_report_mailbox"] == "dmarc-example@tenant.example"
+
+
+def test_summary_reads_the_persisted_domain_health_assessment(
+    authed_client: TestClient, db_session, monkeypatch
+):
+    """Portfolio grades must match detail/history rather than recalculate on read."""
+    _persist_minimal_report(db_session)
+    workspace = get_or_create_default_workspace(db_session)
+    upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name=DOMAIN,
+        health={
+            "score": 96,
+            "grade": "A",
+            "status": "healthy",
+            "factors": {"dmarc_compliance": 100, "dns_posture": 90},
+            "actions": [],
+            "path_to_100": {"remaining_points": 4, "items": []},
+        },
+        policy="reject",
+        compliance_rate=100,
+        total_emails=5,
+        failed_emails=0,
+        report_count=1,
+    )
+
+    def forbidden_recompute(*_args, **_kwargs):
+        raise AssertionError("summary reads must not calculate a new health score")
+
+    monkeypatch.setattr(domains_endpoint, "score_domain_health", forbidden_recompute)
+
+    with _mock_dns():
+        response = authed_client.get("/api/v1/domains/summary")
+
+    assert response.status_code == 200
+    assert response.json()["domains"][0]["health"]["score"] == 96
+    assert response.json()["health_summary"]["score"] == 96
 
 
 def test_summary_includes_remediation_activity(authed_client: TestClient, db_session):

--- a/backend/app/tests/test_health_score_snapshots.py
+++ b/backend/app/tests/test_health_score_snapshots.py
@@ -186,6 +186,8 @@ def test_latest_snapshot_restores_the_complete_persisted_health_assessment(db_se
     assert assessment["assessment_version"] == "2"
     assert assessment["domain_protection"]["status"] == "enforced"
     assert assessment["monitoring_confidence"]["band"] == "high"
+    assert assessment["path_to_100"]["remaining_points"] == 10
+    assert assessment["path_to_100"]["items"][0]["factor"] == "dns_posture"
 
 
 def test_health_snapshot_explains_dns_provenance_and_factor_delta(db_session):
@@ -216,7 +218,11 @@ def test_health_snapshot_explains_dns_provenance_and_factor_delta(db_session):
         db_session,
         workspace_id=workspace.id,
         domain_name="auditable.example",
-        health={**base_health, "score": 96, "factors": {"dns_posture": 100, "report_confidence": 100}},
+        health={
+            **base_health,
+            "score": 96,
+            "factors": {"dns_posture": 100, "report_confidence": 100},
+        },
         snapshot_date=date(2026, 7, 28),
     )
 


### PR DESCRIPTION
Closes #903

## What changed
- Domain lists and portfolio health now read the same latest persisted HealthScoreSnapshot as the domain detail and health history.
- A normal summary read no longer calculates a new score. An explicit reload persists the refreshed assessment before returning it; demo data remains self-contained.
- The domain overview now shows the current saved score and the top persisted path-to-100 items directly, without forcing users into advanced/history panels.

## Validation
- `pytest -q backend/app/tests/test_dns_endpoints.py backend/app/tests/test_domain_detail_endpoints.py backend/app/tests/test_health_score.py backend/app/tests/test_health_score_snapshots.py` (251 passed)
- `node --check backend/app/static/js/domain-details-page.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Current mail health” section to domain details, showing the latest score, grade, supporting evidence, and improvement suggestions.
  * Health history now loads when the domain details page opens, making saved assessment results visible immediately.

* **Bug Fixes**
  * Domain summaries now use saved health assessments during normal viewing, while refreshed assessments are recalculated and stored.
  * Improved consistency between displayed domain health scores and persisted results.

* **Tests**
  * Added coverage verifying that saved health assessments are read without unnecessary recalculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->