### PR TITLE
fix: make health score gaps actionable

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1585,6 +1585,7 @@ class HealthScoreHistoryPoint(BaseModel):
     policy_strength_score: int
     report_confidence_score: int
     top_actions: List[Dict[str, Any]] = Field(default_factory=list)
+    path_to_100: Dict[str, Any] = Field(default_factory=dict)
 
 
 class HealthScoreHistoryResponse(BaseModel):

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -493,6 +493,16 @@ def _path_to_100(
         "source_reputation_listed": "#sending-sources",
         "source_reputation_review": "#sending-sources",
     }
+
+    def factor_href(factor: str) -> str:
+        if factor == "dns_posture":
+            return "#dns-records"
+        if factor in {"dmarc_compliance", "source_reputation"}:
+            return "#sending-sources"
+        if factor == "report_confidence":
+            return "#recent-reports"
+        return "#health-score-history"
+
     by_factor: Dict[str, List[Dict[str, Any]]] = {}
     for action in actions:
         factor = action_factor.get(str(action.get("type") or ""))
@@ -553,11 +563,7 @@ def _path_to_100(
                     "next_step": "Open the linked evidence before making a change.",
                     "verification": "A new persisted assessment identifies a specific change or confirms healthy evidence.",
                     "evidence": [],
-                    "href": (
-                        "#recent-reports"
-                        if factor == "report_confidence"
-                        else "#health-score-history"
-                    ),
+                    "href": factor_href(factor),
                 }
             )
     items.sort(key=lambda item: float(item.get("expected_score_delta") or 0), reverse=True)

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -6,6 +6,36 @@ from typing import Any, Dict, List, Optional
 
 ACTIVE_POLICIES = {"quarantine", "reject"}
 HEALTH_ASSESSMENT_VERSION = "3"
+PATH_FACTOR_WEIGHTS = {
+    "dmarc_compliance": 0.50,
+    "dns_posture": 0.30,
+    "report_confidence": 0.10,
+    "source_reputation": 0.10,
+}
+PATH_ACTION_FACTORS = {
+    "missing_dmarc": "dns_posture",
+    "missing_spf": "dns_posture",
+    "missing_dkim": "dns_posture",
+    "dmarc_lint": "dns_posture",
+    "low_compliance": "dmarc_compliance",
+    "source_reputation_listed": "source_reputation",
+    "source_reputation_review": "source_reputation",
+}
+PATH_ACTION_HREFS = {
+    "missing_dmarc": "#dns-records",
+    "missing_spf": "#dns-records",
+    "missing_dkim": "#dns-records",
+    "dmarc_lint": "#dns-records",
+    "low_compliance": "#sending-sources",
+    "source_reputation_listed": "#sending-sources",
+    "source_reputation_review": "#sending-sources",
+}
+PATH_FACTOR_HREFS = {
+    "dmarc_compliance": "#sending-sources",
+    "dns_posture": "#dns-records",
+    "report_confidence": "#recent-reports",
+    "source_reputation": "#sending-sources",
+}
 
 
 def health_grade(score: int, *, policy: Optional[str] = None, critical_actions: int = 0) -> str:
@@ -455,6 +485,72 @@ def _domain_actions(domain: Dict[str, Any]) -> List[Dict[str, Any]]:
     return sorted(actions, key=lambda item: item["score_impact"], reverse=True)
 
 
+def _waiting_for_reports_item(factor: str, remaining: float) -> Dict[str, Any]:
+    return {
+        "id": "wait_for_more_reports",
+        "factor": factor,
+        "title": "Build a more representative report window",
+        "kind": "waiting_for_evidence",
+        "expected_score_delta": remaining,
+        "detail": "This is not a DNS failure. The score will become more certain as DMARQ receives more aggregate reports.",
+        "next_step": "Keep report intake enabled and review again after additional normal mail activity.",
+        "verification": "At least 7 reports and 250 observed messages are available.",
+        "evidence": [],
+        "href": "#recent-reports",
+    }
+
+
+def _path_item_for_action(
+    *,
+    factor: str,
+    action: Dict[str, Any],
+    expected_score_delta: float,
+    primary: bool,
+) -> Dict[str, Any]:
+    action_type = str(action.get("type") or "")
+    return {
+        "id": action_type or factor,
+        "factor": factor,
+        "title": str(action.get("title") or "Improve mail health"),
+        "kind": "action_required",
+        "expected_score_delta": expected_score_delta,
+        "detail": str(action.get("detail") or ""),
+        "next_step": str(action.get("next_step") or ""),
+        "verification": "Refresh the stored DNS and report evidence after the change.",
+        "evidence": list(action.get("evidence") or []),
+        "primary": primary,
+        "href": PATH_ACTION_HREFS.get(action_type, "#health-score-history"),
+    }
+
+
+def _review_path_item(factor: str, remaining: float) -> Dict[str, Any]:
+    return {
+        "id": f"review_{factor}",
+        "factor": factor,
+        "title": "Review the persisted assessment evidence",
+        "kind": "investigation_required",
+        "expected_score_delta": remaining,
+        "detail": "The score has a measurable gap, but DMARQ does not yet have a safe, specific remediation.",
+        "next_step": "Open the linked evidence before making a change.",
+        "verification": "A new persisted assessment identifies a specific change or confirms healthy evidence.",
+        "evidence": [],
+        "href": PATH_FACTOR_HREFS.get(factor, "#health-score-history"),
+    }
+
+
+def _cap_path_items(items: List[Dict[str, Any]], score: int) -> List[Dict[str, Any]]:
+    capped_items = []
+    remaining_budget = float(max(0, 100 - int(score)))
+    for item in items:
+        delta = min(float(item.get("expected_score_delta") or 0), remaining_budget)
+        if delta <= 0:
+            continue
+        item["expected_score_delta"] = int(delta) if delta.is_integer() else round(delta, 1)
+        capped_items.append(item)
+        remaining_budget -= delta
+    return capped_items
+
+
 def _path_to_100(
     *,
     score: int,
@@ -469,113 +565,36 @@ def _path_to_100(
     result deliberately excludes DMARC policy and optional hardening because
     neither is part of the core mail-health score.
     """
-    weights = {
-        "dmarc_compliance": 0.50,
-        "dns_posture": 0.30,
-        "report_confidence": 0.10,
-        "source_reputation": 0.10,
-    }
-    action_factor = {
-        "missing_dmarc": "dns_posture",
-        "missing_spf": "dns_posture",
-        "missing_dkim": "dns_posture",
-        "dmarc_lint": "dns_posture",
-        "low_compliance": "dmarc_compliance",
-        "source_reputation_listed": "source_reputation",
-        "source_reputation_review": "source_reputation",
-    }
-    action_href = {
-        "missing_dmarc": "#dns-records",
-        "missing_spf": "#dns-records",
-        "missing_dkim": "#dns-records",
-        "dmarc_lint": "#dns-records",
-        "low_compliance": "#sending-sources",
-        "source_reputation_listed": "#sending-sources",
-        "source_reputation_review": "#sending-sources",
-    }
-
-    def factor_href(factor: str) -> str:
-        if factor == "dns_posture":
-            return "#dns-records"
-        if factor in {"dmarc_compliance", "source_reputation"}:
-            return "#sending-sources"
-        if factor == "report_confidence":
-            return "#recent-reports"
-        return "#health-score-history"
-
     by_factor: Dict[str, List[Dict[str, Any]]] = {}
     for action in actions:
-        factor = action_factor.get(str(action.get("type") or ""))
+        factor = PATH_ACTION_FACTORS.get(str(action.get("type") or ""))
         if factor:
             by_factor.setdefault(factor, []).append(action)
 
     items: List[Dict[str, Any]] = []
-    for factor, weight in weights.items():
+    for factor, weight in PATH_FACTOR_WEIGHTS.items():
         value = _bounded(factors.get(factor))
         remaining = round(((100.0 - value) * weight), 1)
         if remaining <= 0:
             continue
         related = by_factor.get(factor) or []
         if factor == "report_confidence" and confidence < 100:
-            items.append(
-                {
-                    "id": "wait_for_more_reports",
-                    "factor": factor,
-                    "title": "Build a more representative report window",
-                    "kind": "waiting_for_evidence",
-                    "expected_score_delta": remaining,
-                    "detail": "This is not a DNS failure. The score will become more certain as DMARQ receives more aggregate reports.",
-                    "next_step": "Keep report intake enabled and review again after additional normal mail activity.",
-                    "verification": "At least 7 reports and 250 observed messages are available.",
-                    "evidence": [],
-                    "href": "#recent-reports",
-                }
-            )
+            items.append(_waiting_for_reports_item(factor, remaining))
             continue
         if related:
             for index, action in enumerate(related):
                 items.append(
-                    {
-                        "id": str(action.get("type") or factor),
-                        "factor": factor,
-                        "title": str(action.get("title") or "Improve mail health"),
-                        "kind": "action_required",
-                        "expected_score_delta": round(remaining / len(related), 1),
-                        "detail": str(action.get("detail") or ""),
-                        "next_step": str(action.get("next_step") or ""),
-                        "verification": "Refresh the stored DNS and report evidence after the change.",
-                        "evidence": list(action.get("evidence") or []),
-                        "primary": index == 0,
-                        "href": action_href.get(
-                            str(action.get("type") or ""), "#health-score-history"
-                        ),
-                    }
+                    _path_item_for_action(
+                        factor=factor,
+                        action=action,
+                        expected_score_delta=round(remaining / len(related), 1),
+                        primary=index == 0,
+                    )
                 )
         else:
-            items.append(
-                {
-                    "id": f"review_{factor}",
-                    "factor": factor,
-                    "title": "Review the persisted assessment evidence",
-                    "kind": "investigation_required",
-                    "expected_score_delta": remaining,
-                    "detail": "The score has a measurable gap, but DMARQ does not yet have a safe, specific remediation.",
-                    "next_step": "Open the linked evidence before making a change.",
-                    "verification": "A new persisted assessment identifies a specific change or confirms healthy evidence.",
-                    "evidence": [],
-                    "href": factor_href(factor),
-                }
-            )
+            items.append(_review_path_item(factor, remaining))
     items.sort(key=lambda item: float(item.get("expected_score_delta") or 0), reverse=True)
-    remaining_budget = float(max(0, 100 - int(score)))
-    capped_items = []
-    for item in items:
-        delta = min(float(item.get("expected_score_delta") or 0), remaining_budget)
-        if delta <= 0:
-            continue
-        item["expected_score_delta"] = int(delta) if delta.is_integer() else round(delta, 1)
-        capped_items.append(item)
-        remaining_budget -= delta
+    capped_items = _cap_path_items(items, score)
     return {
         "score": int(score),
         "remaining_points": max(0, 100 - int(score)),

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -518,6 +518,7 @@ def _path_to_100(
                     "next_step": "Keep report intake enabled and review again after additional normal mail activity.",
                     "verification": "At least 7 reports and 250 observed messages are available.",
                     "evidence": [],
+                    "href": "#recent-reports",
                 }
             )
             continue

--- a/backend/app/services/health_score.py
+++ b/backend/app/services/health_score.py
@@ -484,6 +484,15 @@ def _path_to_100(
         "source_reputation_listed": "source_reputation",
         "source_reputation_review": "source_reputation",
     }
+    action_href = {
+        "missing_dmarc": "#dns-records",
+        "missing_spf": "#dns-records",
+        "missing_dkim": "#dns-records",
+        "dmarc_lint": "#dns-records",
+        "low_compliance": "#sending-sources",
+        "source_reputation_listed": "#sending-sources",
+        "source_reputation_review": "#sending-sources",
+    }
     by_factor: Dict[str, List[Dict[str, Any]]] = {}
     for action in actions:
         factor = action_factor.get(str(action.get("type") or ""))
@@ -526,6 +535,9 @@ def _path_to_100(
                         "verification": "Refresh the stored DNS and report evidence after the change.",
                         "evidence": list(action.get("evidence") or []),
                         "primary": index == 0,
+                        "href": action_href.get(
+                            str(action.get("type") or ""), "#health-score-history"
+                        ),
                     }
                 )
         else:
@@ -540,16 +552,30 @@ def _path_to_100(
                     "next_step": "Open the linked evidence before making a change.",
                     "verification": "A new persisted assessment identifies a specific change or confirms healthy evidence.",
                     "evidence": [],
+                    "href": (
+                        "#recent-reports"
+                        if factor == "report_confidence"
+                        else "#health-score-history"
+                    ),
                 }
             )
     items.sort(key=lambda item: float(item.get("expected_score_delta") or 0), reverse=True)
+    remaining_budget = float(max(0, 100 - int(score)))
+    capped_items = []
+    for item in items:
+        delta = min(float(item.get("expected_score_delta") or 0), remaining_budget)
+        if delta <= 0:
+            continue
+        item["expected_score_delta"] = int(delta) if delta.is_integer() else round(delta, 1)
+        capped_items.append(item)
+        remaining_budget -= delta
     return {
         "score": int(score),
         "remaining_points": max(0, 100 - int(score)),
-        "items": items,
+        "items": capped_items,
         "summary": (
             "Core mail health is at 100/100. Optional hardening and DMARC protection are shown separately."
-            if not items
+            if not capped_items
             else "These are the verified core mail-health gaps; optional hardening is shown separately."
         ),
     }

--- a/backend/app/services/health_score_snapshots.py
+++ b/backend/app/services/health_score_snapshots.py
@@ -59,6 +59,69 @@ def _snapshot_evidence(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+_PATH_ACTION_FACTORS = {
+    "missing_dmarc": "dns_posture",
+    "missing_spf": "dns_posture",
+    "missing_dkim": "dns_posture",
+    "dmarc_lint": "dns_posture",
+    "low_compliance": "dmarc_compliance",
+    "source_reputation_listed": "source_reputation",
+    "source_reputation_review": "source_reputation",
+}
+
+
+def _path_href(action_type: Any, factor: Any) -> str:
+    """Point a score explanation at the evidence needed for its next step."""
+    action_type = str(action_type or "")
+    factor = str(factor or "")
+    if (
+        action_type in {"missing_dmarc", "missing_spf", "missing_dkim", "dmarc_lint"}
+        or factor == "dns_posture"
+    ):
+        return "#dns-records"
+    if action_type in {
+        "low_compliance",
+        "source_reputation_listed",
+        "source_reputation_review",
+    } or factor in {
+        "dmarc_compliance",
+        "source_reputation",
+    }:
+        return "#sending-sources"
+    if factor == "report_confidence":
+        return "#recent-reports"
+    return "#health-score-history"
+
+
+def _normalise_path_to_100(snapshot: HealthScoreSnapshot, path: Dict[str, Any]) -> Dict[str, Any]:
+    """Keep score explanations actionable and mathematically honest.
+
+    An action's potential impact can be larger than the domain's remaining
+    score gap. The UI must never imply that a 93/100 domain can gain 18
+    points, and every item must name the section where the evidence lives.
+    """
+    remaining_points = max(0, 100 - _as_int(snapshot.score))
+    items = [dict(item) for item in path.get("items") or [] if isinstance(item, dict)]
+    items.sort(key=lambda item: float(item.get("expected_score_delta") or 0), reverse=True)
+    budget = float(remaining_points)
+    normalised_items = []
+    for item in items:
+        proposed = max(0.0, float(item.get("expected_score_delta") or 0))
+        delta = min(proposed, budget)
+        if delta <= 0:
+            continue
+        item["expected_score_delta"] = int(delta) if delta.is_integer() else round(delta, 1)
+        item["href"] = str(item.get("href") or _path_href(item.get("id"), item.get("factor")))
+        normalised_items.append(item)
+        budget -= delta
+    return {
+        **path,
+        "score": _as_int(snapshot.score),
+        "remaining_points": remaining_points,
+        "items": normalised_items,
+    }
+
+
 def _legacy_path_to_100(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
     """Explain a non-perfect snapshot created before path-to-100 existed.
 
@@ -102,10 +165,38 @@ def _legacy_path_to_100(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
         "report_confidence": "The current score is bounded by the amount of available report evidence.",
         "source_reputation": "The saved sender evidence includes unresolved reputation uncertainty.",
     }
+    actions_by_factor: Dict[str, List[Dict[str, Any]]] = {}
+    for action in _snapshot_actions(snapshot):
+        factor = _PATH_ACTION_FACTORS.get(str(action.get("type") or ""))
+        if factor:
+            actions_by_factor.setdefault(factor, []).append(action)
+
     items = []
     for factor, weight in weights.items():
         deduction = round(max(0, 100 - factors[factor]) * weight, 1)
         if deduction <= 0:
+            continue
+        related_actions = actions_by_factor.get(factor) or []
+        if related_actions:
+            for index, action in enumerate(related_actions):
+                items.append(
+                    {
+                        "id": str(action.get("type") or f"legacy_{factor}"),
+                        "factor": factor,
+                        "title": str(action.get("title") or labels[factor]),
+                        "kind": "action_required",
+                        "expected_score_delta": round(deduction / len(related_actions), 1),
+                        "detail": str(action.get("detail") or details[factor]),
+                        "next_step": str(
+                            action.get("next_step")
+                            or "Open the linked evidence before making a change."
+                        ),
+                        "verification": "A refreshed persisted assessment confirms the updated evidence.",
+                        "evidence": list(action.get("evidence") or []),
+                        "primary": index == 0,
+                        "href": _path_href(action.get("type"), factor),
+                    }
+                )
             continue
         items.append(
             {
@@ -118,6 +209,7 @@ def _legacy_path_to_100(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
                 "next_step": "Open the saved evidence before making a DNS or sender change.",
                 "verification": "A refreshed persisted assessment confirms the updated evidence.",
                 "evidence": [],
+                "href": _path_href(None, factor),
             }
         )
     if not items:
@@ -132,15 +224,19 @@ def _legacy_path_to_100(snapshot: HealthScoreSnapshot) -> Dict[str, Any]:
                 "next_step": "Refresh the stored DNS and report evidence to capture a full explanation.",
                 "verification": "A new persisted assessment includes its verified path to 100.",
                 "evidence": [],
+                "href": "#health-score-history",
             }
         )
     items.sort(key=lambda item: float(item["expected_score_delta"]), reverse=True)
-    return {
-        "score": _as_int(snapshot.score),
-        "remaining_points": remaining_points,
-        "items": items,
-        "summary": "These remaining points come from saved assessment evidence. Review the listed evidence before making a change.",
-    }
+    return _normalise_path_to_100(
+        snapshot,
+        {
+            "score": _as_int(snapshot.score),
+            "remaining_points": remaining_points,
+            "items": items,
+            "summary": "These remaining points come from saved assessment evidence. Review the listed evidence before making a change.",
+        },
+    )
 
 
 def _snapshot_path_to_100(
@@ -148,7 +244,7 @@ def _snapshot_path_to_100(
 ) -> Dict[str, Any]:
     path = evidence.get("path_to_100")
     if isinstance(path, dict) and path.get("items"):
-        return path
+        return _normalise_path_to_100(snapshot, path)
     if _as_int(snapshot.score) >= 100:
         return _legacy_path_to_100(snapshot)
     return _legacy_path_to_100(snapshot)

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -270,6 +270,8 @@
                                 <span class="shrink-0 text-xs font-semibold text-[#176d74]" x-text="`up to +${item.expected_score_delta}`"></span>
                             </div>
                             <p class="mt-1 text-xs text-[#5f5c78]" x-text="item.next_step"></p>
+                            <a :href="item.href || '#health-score-history'"
+                               class="mt-2 inline-flex text-xs font-semibold text-[#176d74] hover:underline">Open relevant evidence</a>
                         </div>
                     </template>
                 </div>
@@ -1509,6 +1511,8 @@
                                             </div>
                                             <p class="mt-1 text-sm text-[#5f5c78]" x-text="item.detail"></p>
                                             <p class="mt-2 text-xs text-[#5f5c78]"><span class="font-semibold">Next:</span> <span x-text="item.next_step"></span></p>
+                                            <a :href="item.href || '#health-score-history'"
+                                               class="mt-2 inline-flex text-xs font-semibold text-[#176d74] hover:underline">Open relevant evidence</a>
                                         </div>
                                     </template>
                                 </div>

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -27,17 +27,17 @@ from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services import report_persistence
 from app.services.bimi import BIMIResult
-from app.services.mta_sts import MTAStsResult
 from app.services.health_score_snapshots import upsert_health_score_snapshot
+from app.services.mta_sts import MTAStsResult
 from app.services.ptr_lookup import PtrLookupResult
 from app.services.report_store import ReportStore
 from app.services.source_network import SourceNetworkIntelligence
+from app.services.source_read_projection import sync_source_projection_evidence
 from app.services.source_reputation import (
     DomainReputation,
     ReputationEvidence,
     SourceReputation,
 )
-from app.services.source_read_projection import sync_source_projection_evidence
 from app.services.webhook_events import (
     EVENT_REMEDIATION_APPROVAL_REQUIRED,
     create_webhook_endpoint,
@@ -525,8 +525,20 @@ def test_domain_health_history_returns_persisted_trend(seeded_client: TestClient
             "score": 88,
             "grade": "B+",
             "status": "attention",
-            "factors": {},
-            "actions": [{"title": "Fix SPF coverage", "severity": "high", "score_impact": 12}],
+            "factors": {
+                "dmarc_compliance": 100,
+                "dns_posture": 100,
+                "report_confidence": 100,
+                "source_reputation": 0,
+            },
+            "actions": [
+                {
+                    "type": "source_reputation_listed",
+                    "title": "Review listed sending IPs",
+                    "severity": "high",
+                    "score_impact": 12,
+                }
+            ],
         },
         policy="quarantine",
         compliance_rate=95,
@@ -543,7 +555,8 @@ def test_domain_health_history_returns_persisted_trend(seeded_client: TestClient
     assert data["current_score"] == 88
     assert data["previous_score"] == 80
     assert data["score_delta"] == 8
-    assert data["points"][1]["top_actions"][0]["title"] == "Fix SPF coverage"
+    assert data["points"][1]["top_actions"][0]["title"] == "Review listed sending IPs"
+    assert data["points"][1]["path_to_100"]["items"][0]["href"] == "#sending-sources"
 
 
 def test_workspace_health_history_returns_persisted_trend(
@@ -3147,9 +3160,7 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
     ],
 )
 def test_source_delivery_status_distinguishes_policy_outcomes(source, status):
-    delivery = domains_endpoint._source_delivery_status(  # pylint: disable=protected-access
-        source
-    )
+    delivery = domains_endpoint._source_delivery_status(source)  # pylint: disable=protected-access
 
     assert delivery["status"] == status
 
@@ -3618,7 +3629,9 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
     intelligence = authed_client.get(
         "/api/v1/domains/fast-sources.example/source-intelligence?days=3650"
     )
-    reputation = authed_client.get("/api/v1/domains/fast-sources.example/source-reputation?days=3650")
+    reputation = authed_client.get(
+        "/api/v1/domains/fast-sources.example/source-reputation?days=3650"
+    )
 
     assert sources.status_code == 200
     assert sources.json()["sources"][0]["ip"] == "203.0.113.42"
@@ -3952,9 +3965,7 @@ def test_default_source_reads_do_not_trigger_live_enrichment(
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fail_live_lookup)
 
     sources = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650")
-    intelligence = seeded_client.get(
-        f"/api/v1/domains/{DOMAIN}/source-intelligence?days=3650"
-    )
+    intelligence = seeded_client.get(f"/api/v1/domains/{DOMAIN}/source-intelligence?days=3650")
 
     assert sources.status_code == 200
     assert intelligence.status_code == 200

--- a/backend/app/tests/test_health_score.py
+++ b/backend/app/tests/test_health_score.py
@@ -110,13 +110,40 @@ def test_path_to_100_excludes_policy_and_optional_hardening():
             "dkim_status": True,
             "dmarc_policy": "none",
             "dmarc_warnings": [],
-            "source_reputation": {"summary": {"total_sources": 1, "highest_risk_score": 0}},
+            "source_reputation": {
+                "summary": {"total_sources": 1, "highest_risk_score": 0}
+            },
         }
     )
 
     assert health["path_to_100"]["remaining_points"] == 0
     assert health["path_to_100"]["items"] == []
     assert health["domain_protection"]["status"] == "monitoring"
+
+
+def test_report_confidence_waiting_item_links_to_recent_reports():
+    health = score_domain_health(
+        {
+            "domain_name": "example.com",
+            "total_emails": 100,
+            "failed_count": 0,
+            "pass_rate": 100,
+            "report_count": 2,
+            "dmarc_status": True,
+            "spf_status": True,
+            "dkim_status": True,
+            "dmarc_policy": "reject",
+            "dmarc_warnings": [],
+            "source_reputation": {"summary": {"total_sources": 1, "highest_risk_score": 0}},
+        }
+    )
+
+    report_item = next(
+        item for item in health["path_to_100"]["items"] if item["factor"] == "report_confidence"
+    )
+
+    assert report_item["kind"] == "waiting_for_evidence"
+    assert report_item["href"] == "#recent-reports"
 
 
 def test_missing_dmarc_scores_worse_than_policy_none():

--- a/backend/app/tests/test_health_score.py
+++ b/backend/app/tests/test_health_score.py
@@ -146,6 +146,31 @@ def test_report_confidence_waiting_item_links_to_recent_reports():
     assert report_item["href"] == "#recent-reports"
 
 
+def test_unmapped_compliance_gap_links_to_sending_sources():
+    health = score_domain_health(
+        {
+            "domain_name": "example.com",
+            "total_emails": 25_000,
+            "failed_count": 1_250,
+            "pass_rate": 95,
+            "report_count": 30,
+            "dmarc_status": True,
+            "spf_status": True,
+            "dkim_status": True,
+            "dmarc_policy": "reject",
+            "dmarc_warnings": [],
+            "source_reputation": {"summary": {"total_sources": 1, "highest_risk_score": 0}},
+        }
+    )
+
+    compliance_item = next(
+        item for item in health["path_to_100"]["items"] if item["factor"] == "dmarc_compliance"
+    )
+
+    assert compliance_item["kind"] == "investigation_required"
+    assert compliance_item["href"] == "#sending-sources"
+
+
 def test_missing_dmarc_scores_worse_than_policy_none():
     """Missing DMARC must penalize more than a real p=none monitoring record."""
     shared = {

--- a/backend/app/tests/test_health_score_snapshots.py
+++ b/backend/app/tests/test_health_score_snapshots.py
@@ -97,6 +97,50 @@ def test_health_score_snapshot_upsert_history_and_export(db_session):
     assert "not exported" not in str(export_rows)
 
 
+def test_legacy_history_path_uses_saved_sender_action_and_caps_remaining_points(db_session):
+    """Older snapshots still lead an operator to the right evidence."""
+    workspace = get_or_create_default_workspace(db_session)
+    snapshot = upsert_health_score_snapshot(
+        db_session,
+        workspace_id=workspace.id,
+        domain_name="example.com",
+        health={
+            "score": 93,
+            "grade": "A",
+            "status": "attention",
+            "factors": {
+                "dmarc_compliance": 100,
+                "dns_posture": 100,
+                "report_confidence": 100,
+                "source_reputation": 0,
+            },
+            "actions": [
+                {
+                    "type": "source_reputation_listed",
+                    "title": "Review listed sending IPs",
+                    "detail": "One or more observed senders require review.",
+                    "next_step": "Open the sender list and verify the listed IPs.",
+                    "score_impact": 18,
+                }
+            ],
+        },
+        policy="reject",
+        compliance_rate=100,
+        total_emails=748,
+        failed_emails=0,
+        report_count=10,
+        snapshot_date=date(2026, 7, 28),
+    )
+
+    point = snapshot_to_history_point(snapshot)
+    item = point["path_to_100"]["items"][0]
+
+    assert point["path_to_100"]["remaining_points"] == 7
+    assert item["title"] == "Review listed sending IPs"
+    assert item["expected_score_delta"] == 7
+    assert item["href"] == "#sending-sources"
+
+
 def test_health_score_snapshot_defensive_serialization(db_session):
     workspace = get_or_create_default_workspace(db_session)
     snapshot = upsert_health_score_snapshot(


### PR DESCRIPTION
Closes #905

## What changed
- Preserve `path_to_100` in the persisted health-history API response.
- Reconstruct actionable paths for older snapshots from their stored factors and drivers.
- Cap an action's displayed score gain to the actual remaining gap.
- Add direct links from each score item to the relevant DNS, sender, report, or history view.

## Root cause
The snapshot serializer produced the structured path, but the Pydantic history-point response model omitted it. The browser therefore retained the score and top driver while receiving no path-to-100 data.

## Validation
- `pytest backend/app/tests -q` (2,194 passed)
- Focused health-score, snapshot, and domain-detail API coverage (130 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Open relevant evidence” links to Path to 100% items in health score previews and history.
  - Health score recommendations now link directly to relevant evidence sections.
  - Improved Path to 100% explanations with clearer actions, verification details, and next steps.

- **Bug Fixes**
  - Score improvements are now capped at the remaining points needed to reach 100%.
  - Recommendations are consistently sorted and linked across current and historical health views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->