### PR TITLE
fix: make DMARC report enrollment actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   proposal adds one `rua` destination while preserving policy, alignment,
   forensic reporting, and all existing aggregate destinations. DMARC policies
   inherited through CNAME remain explicitly manual to avoid destructive record
-  replacement.
+  replacement. Record-kind provenance is persisted for cached reads, and
+  external report destinations must publish their DMARC authorization TXT
+  record before the monitored-domain update becomes apply-ready.
 - The setup assistant now detects domains owned by another workspace during
   preview and points operators to the existing domain instead of allowing a
   predictable apply-time rollback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- A configured per-domain DMARC report mailbox now produces the primary safe
+  DNS change when an existing direct DMARC TXT record does not contain it. The
+  proposal adds one `rua` destination while preserving policy, alignment,
+  forensic reporting, and all existing aggregate destinations. DMARC policies
+  inherited through CNAME remain explicitly manual to avoid destructive record
+  replacement.
+- The setup assistant now detects domains owned by another workspace during
+  preview and points operators to the existing domain instead of allowing a
+  predictable apply-time rollback.
 - DNS posture is now an immutable, versioned projection. Report ingestion only
   requests a coalesced background refresh; normal domain reads use the last
   accepted snapshot and retain it when a resolver fails or a single empty

--- a/backend/app/api/api_v1/endpoints/onboarding.py
+++ b/backend/app/api/api_v1/endpoints/onboarding.py
@@ -18,6 +18,7 @@ from app.services.workspace_onboarding import (
     apply_onboarding_plan,
     build_onboarding_plan,
     list_onboarding_templates,
+    onboarding_plan_domain_conflicts,
     public_onboarding_plan,
 )
 
@@ -105,11 +106,16 @@ async def get_onboarding_templates(
 @router.post("/preview", response_model=OnboardingPlanResponse)
 async def preview_onboarding_plan(
     payload: OnboardingPlanRequest,
+    db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
 ) -> OnboardingPlanResponse:
     """Render an onboarding template without changing the database."""
     require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN)
-    return {"plan": public_onboarding_plan(_build_plan_or_422(payload))}
+    plan = _build_plan_or_422(payload)
+    conflicts = onboarding_plan_domain_conflicts(db, plan)
+    if conflicts:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=conflicts)
+    return {"plan": public_onboarding_plan(plan)}
 
 
 @router.post("/apply", response_model=OnboardingApplyResponse)

--- a/backend/app/api/api_v1/endpoints/onboarding.py
+++ b/backend/app/api/api_v1/endpoints/onboarding.py
@@ -104,7 +104,7 @@ async def get_onboarding_templates(
 
 
 @router.post("/preview", response_model=OnboardingPlanResponse)
-async def preview_onboarding_plan(
+def preview_onboarding_plan(
     payload: OnboardingPlanRequest,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),

--- a/backend/app/services/dns_cache.py
+++ b/backend/app/services/dns_cache.py
@@ -10,8 +10,8 @@ from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.dns_cache import DNSCache
@@ -58,6 +58,8 @@ def _result_from_json(value: str) -> DomainDNSResult:
         selectors_checked=list(data.get("selectors_checked") or []),
         dmarc_policy_domain=data.get("dmarc_policy_domain"),
         dmarc_discovery_method=data.get("dmarc_discovery_method"),
+        dmarc_record_kind=data.get("dmarc_record_kind"),
+        dmarc_cname_target=data.get("dmarc_cname_target"),
         dmarc_tags=dict(data.get("dmarc_tags") or {}),
         dmarc_warnings=list(data.get("dmarc_warnings") or []),
         dmarc_suggestions=list(data.get("dmarc_suggestions") or []),
@@ -231,12 +233,7 @@ def store_dns_cache_result(
         )
         row_id = db.execute(statement).scalar_one()
         db.commit()
-        return (
-            db.query(DNSCache)
-            .populate_existing()
-            .filter(DNSCache.id == row_id)
-            .one()
-        )
+        return db.query(DNSCache).populate_existing().filter(DNSCache.id == row_id).one()
 
     if row is None:
         row = DNSCache(

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -132,14 +132,70 @@ def _dmarc_record_value(domain: str, defaults: MailAuthSetupDefaults) -> str:
     )
 
 
+def _normalize_report_mailbox(value: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized.startswith("mailto:"):
+        normalized = normalized[7:]
+    return normalized.split("!", 1)[0].strip()
+
+
+def _dmarc_has_report_mailbox(record: Optional[str], mailbox: Optional[str]) -> bool:
+    expected = _normalize_report_mailbox(mailbox or "")
+    if not record or not expected:
+        return False
+    parts = _dns_record_parts(record) or {}
+    return any(
+        _normalize_report_mailbox(destination) == expected
+        for destination in (parts.get("rua") or "").split(",")
+        if destination.strip()
+    )
+
+
+def _append_dmarc_report_mailbox(record: str, mailbox: str) -> str:
+    """Add one aggregate-report destination without rewriting unrelated DMARC tags."""
+    normalized_mailbox = _normalize_report_mailbox(mailbox)
+    if not normalized_mailbox or _dmarc_has_report_mailbox(record, normalized_mailbox):
+        return record
+    destination = f"mailto:{normalized_mailbox}"
+    segments = record.split(";")
+    for index, segment in enumerate(segments):
+        if "=" not in segment:
+            continue
+        key, value = segment.split("=", 1)
+        if key.strip().lower() != "rua":
+            continue
+        leading = segment[: len(segment) - len(segment.lstrip())]
+        destinations = value.strip()
+        segments[index] = f"{leading}{key.strip()}={destinations},{destination}"
+        return ";".join(segments)
+    stripped = record.rstrip()
+    separator = " " if stripped.endswith(";") else "; "
+    return f"{stripped}{separator}rua={destination}"
+
+
+def _record_with_value(record: DNSGuidanceRecord, value: str) -> DNSGuidanceRecord:
+    return DNSGuidanceRecord(
+        code=record.code,
+        record_type=record.record_type,
+        name=record.name,
+        value=value,
+        purpose=record.purpose,
+        priority=record.priority,
+        what_it_does=record.what_it_does,
+        learn_more_url=record.learn_more_url,
+        learn_more_label=record.learn_more_label,
+        supporting_content=record.supporting_content,
+        supporting_content_label=record.supporting_content_label,
+        supporting_content_url=record.supporting_content_url,
+    )
+
+
 def _mta_sts_policy_example(mx_hosts: List[str]) -> str:
     """Build a safe first MTA-STS policy from observed MX hosts."""
     mx_lines = [f"mx: {host}" for host in mx_hosts if host]
     if not mx_lines:
         mx_lines = ["mx: <replace-with-your-mx-host>"]
-    return "\n".join(
-        ["version: STSv1", "mode: testing", *mx_lines, "max_age: 86400"]
-    )
+    return "\n".join(["version: STSv1", "mode: testing", *mx_lines, "max_age: 86400"])
 
 
 def _target_records(
@@ -320,6 +376,16 @@ _REMEDIATION_STEPS_EN: Dict[str, List[str]] = {
         "Document or fix any active failures before tightening the DMARC policy.",
         "Only then plan the move from p=none to quarantine or reject.",
     ],
+    "dmarc_report_destination_missing": [
+        "Review the current and proposed DMARC values; policy and existing destinations stay unchanged.",
+        "Preview the provider mutation, then confirm the single TXT update.",
+        "Refresh DNS lint and verify that the DMARQ report mailbox appears in rua.",
+    ],
+    "dmarc_report_destination_inherited": [
+        "Open the authoritative DMARC target referenced by the CNAME.",
+        "Decide whether all domains using that shared policy should send reports to DMARQ.",
+        "Update the shared target manually or replace the CNAME in a separately reviewed migration.",
+    ],
     "spf_missing": [
         "List every platform currently allowed to send mail for this domain.",
         "Publish exactly one root TXT record beginning with v=spf1.",
@@ -434,6 +500,16 @@ _REMEDIATION_STEPS_DE: Dict[str, List[str]] = {
         "Dokumentiere oder behebe alle aktiven Fehlschlaege, bevor du die Policy verschaerfst.",
         "Plane erst danach den Wechsel von p=none zu quarantine oder reject.",
     ],
+    "dmarc_report_destination_missing": [
+        "Pruefe den aktuellen und vorgeschlagenen DMARC-Wert; Policy und bestehende Ziele bleiben unveraendert.",
+        "Pruefe die Provider-Aenderung und bestaetige dann genau dieses TXT-Update.",
+        "Aktualisiere den DNS-Check und bestaetige, dass das DMARQ-Postfach in rua enthalten ist.",
+    ],
+    "dmarc_report_destination_inherited": [
+        "Oeffne das autoritative DMARC-Ziel, auf das der CNAME verweist.",
+        "Entscheide, ob alle Domains mit dieser gemeinsamen Policy Reports an DMARQ senden sollen.",
+        "Aendere das gemeinsame Ziel manuell oder ersetze den CNAME in einer separat geprueften Migration.",
+    ],
     "spf_missing": [
         "Liste alle Plattformen auf, die aktuell fuer diese Domain E-Mail senden duerfen.",
         "Veroeffentliche genau einen TXT-Record an der Domain-Wurzel, der mit v=spf1 beginnt.",
@@ -542,7 +618,12 @@ def _classify_dmarc_warning(message: str) -> str:
 
 
 def _dmarc_findings(
-    domain: str, result: DomainDNSResult, targets: List[DNSGuidanceRecord]
+    domain: str,
+    result: DomainDNSResult,
+    targets: List[DNSGuidanceRecord],
+    *,
+    setup_defaults: Optional[MailAuthSetupDefaults] = None,
+    cname_target: Optional[str] = None,
 ) -> List[DNSLintFinding]:
     findings: List[DNSLintFinding] = []
     target = _target_by_code(targets, "target_dmarc")
@@ -559,6 +640,47 @@ def _dmarc_findings(
                 target_record=target,
             )
         )
+    report_mailbox = (setup_defaults or MailAuthSetupDefaults()).report_mailbox
+    if (
+        result.dmarc_record
+        and report_mailbox
+        and not _dmarc_has_report_mailbox(result.dmarc_record, report_mailbox)
+    ):
+        if cname_target:
+            findings.append(
+                _finding(
+                    "dmarc_report_destination_inherited",
+                    "info",
+                    "DMARC reporting is inherited through a CNAME",
+                    (
+                        f"{target.name} points to {cname_target}. DMARQ will not replace that "
+                        "alias with a TXT record automatically."
+                    ),
+                    "Review the shared DMARC policy target before adding the DMARQ mailbox.",
+                    "CNAME",
+                    target.name,
+                    evidence=[f"{target.name} -> {cname_target}", result.dmarc_record],
+                    primary_eligible=False,
+                )
+            )
+        else:
+            proposed = _append_dmarc_report_mailbox(result.dmarc_record, report_mailbox)
+            findings.append(
+                _finding(
+                    "dmarc_report_destination_missing",
+                    "warning",
+                    "DMARQ is not receiving this domain's aggregate reports",
+                    (
+                        f"The current DMARC rua does not include {report_mailbox}. Existing "
+                        "policy and report destinations can remain unchanged."
+                    ),
+                    "Add only the DMARQ report mailbox to rua, then verify report intake.",
+                    "TXT",
+                    target.name,
+                    target_record=_record_with_value(target, proposed),
+                    evidence=[result.dmarc_record],
+                )
+            )
     for warning in result.dmarc_warnings:
         findings.append(
             _finding(
@@ -1465,7 +1587,13 @@ def _plan_id(finding: DNSLintFinding) -> str:
 
 def _operation_for_finding(finding: DNSLintFinding) -> str:
     code = finding.code
-    if code.endswith("_missing") or code.startswith("dane_missing") or code in {"dmarc_missing", "spf_missing"}:
+    if code == "dmarc_report_destination_missing":
+        return "update"
+    if (
+        code.endswith("_missing")
+        or code.startswith("dane_missing")
+        or code in {"dmarc_missing", "spf_missing"}
+    ):
         return "create"
     if code in {"dkim_selector_stale"}:
         return "review-remove"
@@ -1509,6 +1637,10 @@ def _risk_for_finding(finding: DNSLintFinding) -> str:
         ),
         "dmarc_monitoring_policy": (
             "Enforcement changes can reject legitimate mail if sender alignment is not ready."
+        ),
+        "dmarc_report_destination_missing": (
+            "Low mail-flow risk: this adds one aggregate-report destination without changing "
+            "policy, alignment, or existing destinations. A typo can prevent DMARQ intake."
         ),
         "spf_missing": "Medium risk if legitimate senders are omitted from the SPF record.",
         "spf_multiple_records": (
@@ -1654,9 +1786,13 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
         # Consolidation findings (for example, multiple SPF or TLS-RPT TXT
         # values) still need an update plan even if one member is already the
         # intended final value.
-        if proposed_value and len(current_values) == 1 and any(
-            _normalize_dns_value(value) == _normalize_dns_value(proposed_value)
-            for value in current_values
+        if (
+            proposed_value
+            and len(current_values) == 1
+            and any(
+                _normalize_dns_value(value) == _normalize_dns_value(proposed_value)
+                for value in current_values
+            )
         ):
             continue
         plans.append(
@@ -1676,9 +1812,15 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
                 manual_steps=_manual_steps_for_plan(finding, operation),
                 provider_value_required=_provider_value_required(finding),
                 changes=_plan_changes(current_values, proposed_value),
-                what_it_does=(finding.target_record.what_it_does if finding.target_record else None),
-                learn_more_url=(finding.target_record.learn_more_url if finding.target_record else None),
-                learn_more_label=(finding.target_record.learn_more_label if finding.target_record else None),
+                what_it_does=(
+                    finding.target_record.what_it_does if finding.target_record else None
+                ),
+                learn_more_url=(
+                    finding.target_record.learn_more_url if finding.target_record else None
+                ),
+                learn_more_label=(
+                    finding.target_record.learn_more_label if finding.target_record else None
+                ),
             )
         )
     return plans
@@ -1723,7 +1865,28 @@ async def build_dns_guidance(
     targets.extend(_dane_target_records(normalized_domain, dane_result))
     findings: List[DNSLintFinding] = []
     normalized_selector_evidence = [dict(item) for item in selector_evidence or []]
-    findings.extend(_dmarc_findings(normalized_domain, result, targets))
+    dmarc_cname_target: Optional[str] = None
+    if (
+        allow_live
+        and result.dmarc_record
+        and (setup_defaults or MailAuthSetupDefaults()).report_mailbox
+    ):
+        cname_lookup = getattr(provider, "lookup_cname", None)
+        if callable(cname_lookup):
+            try:
+                value = await cname_lookup(f"_dmarc.{normalized_domain}")
+            except LookupError:
+                value = None
+            dmarc_cname_target = value if isinstance(value, str) and value else None
+    findings.extend(
+        _dmarc_findings(
+            normalized_domain,
+            result,
+            targets,
+            setup_defaults=setup_defaults,
+            cname_target=dmarc_cname_target,
+        )
+    )
     findings.extend(
         await _spf_findings(
             normalized_domain,

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -166,7 +166,8 @@ def _append_dmarc_report_mailbox(record: str, mailbox: str) -> str:
             continue
         leading = segment[: len(segment) - len(segment.lstrip())]
         destinations = value.strip()
-        segments[index] = f"{leading}{key.strip()}={destinations},{destination}"
+        updated_destinations = f"{destinations},{destination}" if destinations else destination
+        segments[index] = f"{leading}{key.strip()}={updated_destinations}"
         return ";".join(segments)
     stripped = record.rstrip()
     separator = " " if stripped.endswith(";") else "; "
@@ -386,6 +387,16 @@ _REMEDIATION_STEPS_EN: Dict[str, List[str]] = {
         "Decide whether all domains using that shared policy should send reports to DMARQ.",
         "Update the shared target manually or replace the CNAME in a separately reviewed migration.",
     ],
+    "dmarc_report_destination_provenance_unknown": [
+        "Refresh DNS evidence so DMARQ can distinguish a direct TXT record from an alias.",
+        "Review the authoritative record type before preparing any provider write.",
+        "Continue only after the direct TXT record or inherited policy is confirmed.",
+    ],
+    "dmarc_report_destination_authorization_missing": [
+        "Open the DNS zone that owns the external report mailbox domain.",
+        "Publish the exact external-report authorization TXT record shown in this finding.",
+        "Refresh DNS guidance, then preview the additive rua update on the monitored domain.",
+    ],
     "spf_missing": [
         "List every platform currently allowed to send mail for this domain.",
         "Publish exactly one root TXT record beginning with v=spf1.",
@@ -510,6 +521,16 @@ _REMEDIATION_STEPS_DE: Dict[str, List[str]] = {
         "Entscheide, ob alle Domains mit dieser gemeinsamen Policy Reports an DMARQ senden sollen.",
         "Aendere das gemeinsame Ziel manuell oder ersetze den CNAME in einer separat geprueften Migration.",
     ],
+    "dmarc_report_destination_provenance_unknown": [
+        "Aktualisiere die DNS-Evidenz, damit DMARQ direkten TXT-Record und Alias unterscheiden kann.",
+        "Pruefe den autoritativen Record-Typ, bevor eine Provider-Aenderung vorbereitet wird.",
+        "Fahre erst fort, wenn direkter TXT-Record oder geerbte Policy bestaetigt ist.",
+    ],
+    "dmarc_report_destination_authorization_missing": [
+        "Oeffne die DNS-Zone der Domain des externen Report-Postfachs.",
+        "Veroeffentliche den in diesem Finding gezeigten Autorisierungs-TXT-Record.",
+        "Aktualisiere die DNS-Evidenz und pruefe dann das additive rua-Update.",
+    ],
     "spf_missing": [
         "Liste alle Plattformen auf, die aktuell fuer diese Domain E-Mail senden duerfen.",
         "Veroeffentliche genau einen TXT-Record an der Domain-Wurzel, der mit v=spf1 beginnt.",
@@ -623,7 +644,10 @@ def _dmarc_findings(
     targets: List[DNSGuidanceRecord],
     *,
     setup_defaults: Optional[MailAuthSetupDefaults] = None,
+    record_kind: Optional[str] = None,
     cname_target: Optional[str] = None,
+    report_authorization: Optional[bool] = None,
+    report_authorization_name: Optional[str] = None,
 ) -> List[DNSLintFinding]:
     findings: List[DNSLintFinding] = []
     target = _target_by_code(targets, "target_dmarc")
@@ -646,20 +670,67 @@ def _dmarc_findings(
         and report_mailbox
         and not _dmarc_has_report_mailbox(result.dmarc_record, report_mailbox)
     ):
-        if cname_target:
+        if record_kind in {"cname", "treewalk"}:
+            inherited_target = cname_target or result.dmarc_policy_domain or "the parent policy"
             findings.append(
                 _finding(
                     "dmarc_report_destination_inherited",
                     "info",
-                    "DMARC reporting is inherited through a CNAME",
+                    "DMARC reporting is inherited",
                     (
-                        f"{target.name} points to {cname_target}. DMARQ will not replace that "
-                        "alias with a TXT record automatically."
+                        f"The effective policy comes from {inherited_target}. DMARQ will not "
+                        "replace an alias or inherited policy automatically."
                     ),
                     "Review the shared DMARC policy target before adding the DMARQ mailbox.",
-                    "CNAME",
+                    "CNAME" if record_kind == "cname" else "TXT",
                     target.name,
-                    evidence=[f"{target.name} -> {cname_target}", result.dmarc_record],
+                    evidence=[
+                        f"{target.name} -> {inherited_target}",
+                        result.dmarc_record,
+                    ],
+                    primary_eligible=False,
+                )
+            )
+        elif record_kind != "txt":
+            findings.append(
+                _finding(
+                    "dmarc_report_destination_provenance_unknown",
+                    "info",
+                    "Refresh DNS before preparing this report enrollment",
+                    (
+                        "Cached evidence does not yet prove whether the effective DMARC record "
+                        "is a direct TXT record or an inherited alias."
+                    ),
+                    "Refresh DNS evidence before offering any automatic TXT update.",
+                    "TXT",
+                    target.name,
+                    evidence=[result.dmarc_record],
+                    primary_eligible=False,
+                )
+            )
+        elif report_authorization is not True:
+            authorization_name = report_authorization_name or "the external destination zone"
+            authorization_target = DNSGuidanceRecord(
+                code="target_dmarc_external_report_authorization",
+                record_type="TXT",
+                name=authorization_name,
+                value="v=DMARC1",
+                purpose="Authorize aggregate DMARC reports to the external mailbox domain.",
+            )
+            findings.append(
+                _finding(
+                    "dmarc_report_destination_authorization_missing",
+                    "warning",
+                    "The external report mailbox is not authorized yet",
+                    (
+                        f"Receivers require a DMARC authorization TXT record at "
+                        f"{authorization_name} before they can send reports to {report_mailbox}."
+                    ),
+                    "Authorize the destination domain first, then add it to rua.",
+                    "TXT",
+                    authorization_name,
+                    target_record=authorization_target,
+                    evidence=[],
                     primary_eligible=False,
                 )
             )
@@ -1642,6 +1713,10 @@ def _risk_for_finding(finding: DNSLintFinding) -> str:
             "Low mail-flow risk: this adds one aggregate-report destination without changing "
             "policy, alignment, or existing destinations. A typo can prevent DMARQ intake."
         ),
+        "dmarc_report_destination_authorization_missing": (
+            "Low mail-flow risk, but the external destination will not receive reports until "
+            "its authorization TXT record is published."
+        ),
         "spf_missing": "Medium risk if legitimate senders are omitted from the SPF record.",
         "spf_multiple_records": (
             "Medium risk: merging records incorrectly can remove an active sender."
@@ -1826,6 +1901,62 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
     return plans
 
 
+async def _dmarc_record_provenance(
+    domain: str,
+    provider: BaseDNSProvider,
+    result: DomainDNSResult,
+    *,
+    allow_live: bool,
+) -> tuple[Optional[str], Optional[str]]:
+    """Return persisted record-kind evidence, refreshing it only when requested."""
+    record_kind = result.dmarc_record_kind
+    cname_target = result.dmarc_cname_target
+    if not allow_live or not result.dmarc_record:
+        return record_kind, cname_target
+    cname_lookup = getattr(provider, "lookup_cname", None)
+    if not callable(cname_lookup):
+        return record_kind, cname_target
+    try:
+        value = await cname_lookup(f"_dmarc.{domain}")
+    except LookupError:
+        value = None
+    cname_target = value if isinstance(value, str) and value else None
+    return ("cname" if cname_target else "txt"), cname_target
+
+
+async def _dmarc_report_authorization(
+    domain: str,
+    provider: BaseDNSProvider,
+    result: DomainDNSResult,
+    report_mailbox: Optional[str],
+    *,
+    allow_live: bool,
+) -> tuple[Optional[bool], Optional[str]]:
+    """Return whether an external aggregate-report destination is authorized."""
+    if not result.dmarc_record or not report_mailbox:
+        return None, None
+
+    mailbox_domain = _normalize_report_mailbox(report_mailbox).rsplit("@", 1)[-1]
+    mailbox_domain = mailbox_domain.strip().strip(".")
+    policy_domain = (result.dmarc_policy_domain or domain).strip().strip(".")
+    if mailbox_domain == policy_domain:
+        return True, None
+    if not mailbox_domain:
+        return None, None
+
+    authorization_name = f"{policy_domain}._report._dmarc.{mailbox_domain}"
+    if not allow_live:
+        return None, authorization_name
+    try:
+        authorization_records = await provider.lookup_txt(authorization_name)
+    except LookupError:
+        authorization_records = []
+    authorized = any(
+        record.strip().lower().startswith("v=dmarc1") for record in authorization_records
+    )
+    return authorized, authorization_name
+
+
 async def build_dns_guidance(
     domain: str,
     provider: BaseDNSProvider,
@@ -1865,26 +1996,30 @@ async def build_dns_guidance(
     targets.extend(_dane_target_records(normalized_domain, dane_result))
     findings: List[DNSLintFinding] = []
     normalized_selector_evidence = [dict(item) for item in selector_evidence or []]
-    dmarc_cname_target: Optional[str] = None
-    if (
-        allow_live
-        and result.dmarc_record
-        and (setup_defaults or MailAuthSetupDefaults()).report_mailbox
-    ):
-        cname_lookup = getattr(provider, "lookup_cname", None)
-        if callable(cname_lookup):
-            try:
-                value = await cname_lookup(f"_dmarc.{normalized_domain}")
-            except LookupError:
-                value = None
-            dmarc_cname_target = value if isinstance(value, str) and value else None
+    dmarc_record_kind, dmarc_cname_target = await _dmarc_record_provenance(
+        normalized_domain,
+        provider,
+        result,
+        allow_live=allow_live,
+    )
+    report_mailbox = (setup_defaults or MailAuthSetupDefaults()).report_mailbox
+    report_authorization, report_authorization_name = await _dmarc_report_authorization(
+        normalized_domain,
+        provider,
+        result,
+        report_mailbox,
+        allow_live=allow_live,
+    )
     findings.extend(
         _dmarc_findings(
             normalized_domain,
             result,
             targets,
             setup_defaults=setup_defaults,
+            record_kind=dmarc_record_kind,
             cname_target=dmarc_cname_target,
+            report_authorization=report_authorization,
+            report_authorization_name=report_authorization_name,
         )
     )
     findings.extend(

--- a/backend/app/services/dns_resolver.py
+++ b/backend/app/services/dns_resolver.py
@@ -151,6 +151,8 @@ class DomainDNSResult:
     selectors_checked: List[str] = field(default_factory=list)
     dmarc_policy_domain: Optional[str] = None
     dmarc_discovery_method: Optional[str] = None
+    dmarc_record_kind: Optional[str] = None
+    dmarc_cname_target: Optional[str] = None
     dmarc_tags: Dict[str, str] = field(default_factory=dict)
     dmarc_warnings: List[str] = field(default_factory=list)
     dmarc_suggestions: List[str] = field(default_factory=list)
@@ -541,6 +543,17 @@ class BaseDNSProvider(ABC):
         ) = await asyncio.gather(dmarc_coro, spf_coro, dkim_coro, ns_coro)
 
         dmarc_tags = dmarc_tags or {}
+        dmarc_record_kind: Optional[str] = None
+        dmarc_cname_target: Optional[str] = None
+        if dmarc_record and dmarc_policy_domain:
+            if dmarc_discovery_method == "treewalk":
+                dmarc_record_kind = "treewalk"
+            else:
+                try:
+                    dmarc_cname_target = await self.lookup_cname(f"_dmarc.{dmarc_policy_domain}")
+                except LookupError:
+                    dmarc_cname_target = None
+                dmarc_record_kind = "cname" if dmarc_cname_target else "txt"
         warnings, suggestions = _lint_dmarc_tags(
             dmarc_tags,
             checked_domain=_normalize_dns_name(domain),
@@ -569,6 +582,8 @@ class BaseDNSProvider(ABC):
             selectors_checked=all_selectors,
             dmarc_policy_domain=dmarc_policy_domain,
             dmarc_discovery_method=dmarc_discovery_method,
+            dmarc_record_kind=dmarc_record_kind,
+            dmarc_cname_target=dmarc_cname_target,
             dmarc_tags=dmarc_tags,
             dmarc_warnings=warnings,
             dmarc_suggestions=suggestions,

--- a/backend/app/services/workspace_onboarding.py
+++ b/backend/app/services/workspace_onboarding.py
@@ -678,6 +678,24 @@ def _apply_domains(
     return results
 
 
+def onboarding_plan_domain_conflicts(db: Session, plan: Dict[str, Any]) -> List[str]:
+    """Return domain conflicts that would make an onboarding apply roll back."""
+    names = [item["name"] for item in plan.get("domains", []) if item.get("name")]
+    if not names:
+        return []
+    workspace = db.query(Workspace).filter(Workspace.slug == plan["workspace"]["slug"]).first()
+    workspace_id = workspace.id if workspace else None
+    domains = db.query(Domain).filter(Domain.name.in_(names)).all()
+    return [
+        (
+            f"Domain {domain.name} is already owned by another workspace. "
+            f"Open /domains/{domain.name} to configure the existing domain."
+        )
+        for domain in domains
+        if workspace_id is None or domain.workspace_id != workspace_id
+    ]
+
+
 def _apply_mail_sources(
     db: Session,
     *,

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -687,7 +687,7 @@ def test_dns_lint_endpoint_plans_additive_rua_for_existing_dmarc_record(
         Domain(
             name=DOMAIN,
             active=True,
-            dmarc_report_mailbox="dmarc-example@tenant.example",
+            dmarc_report_mailbox="dmarc-example@example.com",
         )
     )
     db_session.commit()
@@ -720,7 +720,7 @@ def test_dns_lint_endpoint_plans_additive_rua_for_existing_dmarc_record(
     assert plan["current_values"] == [current]
     assert plan["proposed_value"] == (
         "v=DMARC1; p=reject; "
-        "rua=mailto:existing@example.net,mailto:dmarc-example@tenant.example; aspf=s"
+        "rua=mailto:existing@example.net,mailto:dmarc-example@example.com; aspf=s"
     )
     assert plan["provider_value_required"] is False
 

--- a/backend/app/tests/test_dns_endpoints.py
+++ b/backend/app/tests/test_dns_endpoints.py
@@ -679,6 +679,52 @@ def test_dns_lint_endpoint_prefers_domain_dmarc_mailbox_override(
     )
 
 
+def test_dns_lint_endpoint_plans_additive_rua_for_existing_dmarc_record(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(
+        Domain(
+            name=DOMAIN,
+            active=True,
+            dmarc_report_mailbox="dmarc-example@tenant.example",
+        )
+    )
+    db_session.commit()
+    current = "v=DMARC1; p=reject; rua=mailto:existing@example.net; aspf=s"
+    result = DomainDNSResult(
+        dmarc=True,
+        dmarc_record=current,
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+
+    with (
+        _mock_dns(result),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_mta_sts_cached",
+            new=AsyncMock(return_value=(MTAStsResult(status="pass"), False, None)),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.check_bimi_cached",
+            new=AsyncMock(return_value=(BIMIResult(status="pass"), False, None)),
+        ),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/lint")
+
+    assert response.status_code == 200
+    plan = response.json()["change_plans"][0]
+    assert plan["finding_code"] == "dmarc_report_destination_missing"
+    assert plan["current_values"] == [current]
+    assert plan["proposed_value"] == (
+        "v=DMARC1; p=reject; "
+        "rua=mailto:existing@example.net,mailto:dmarc-example@tenant.example; aspf=s"
+    )
+    assert plan["provider_value_required"] is False
+
+
 def test_update_domain_persists_dmarc_report_mailbox_override(authed_client: TestClient):
     create_response = authed_client.post("/api/v1/domains/domains", json={"name": DOMAIN})
     assert create_response.status_code == 201

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -134,8 +134,101 @@ async def test_build_dns_guidance_uses_configured_mail_auth_defaults():
 
 
 @pytest.mark.asyncio
+async def test_existing_dmarc_record_gets_additive_report_destination_plan_first():
+    provider = FakeDNSProvider({})
+    current = (
+        "v=DMARC1; p=reject; rua=mailto:existing@example.net; "
+        "ruf=mailto:forensic@example.net; aspf=s"
+    )
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record=current,
+        spf=True,
+        spf_record="v=spf1 -all",
+        dkim=True,
+        dkim_selectors=["selector1"],
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="reports@example.com"),
+    )
+
+    plan = guidance.change_plans[0]
+    assert plan.finding_code == "dmarc_report_destination_missing"
+    assert plan.operation == "update"
+    assert plan.current_values == [current]
+    assert plan.proposed_value == (
+        "v=DMARC1; p=reject; "
+        "rua=mailto:existing@example.net,mailto:reports@example.com; "
+        "ruf=mailto:forensic@example.net; aspf=s"
+    )
+    assert plan.changes == [
+        "Change rua from mailto:existing@example.net to "
+        "mailto:existing@example.net,mailto:reports@example.com."
+    ]
+    assert "p=reject" in plan.proposed_value
+    assert "ruf=mailto:forensic@example.net" in plan.proposed_value
+
+
+@pytest.mark.asyncio
+async def test_existing_dmarc_report_destination_is_not_duplicated():
+    provider = FakeDNSProvider({})
+    current = "v=DMARC1; p=none; rua=mailto:reports@example.com!10m"
+    dns = DomainDNSResult(dmarc=True, dmarc_record=current, spf=True)
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="REPORTS@example.com"),
+    )
+
+    assert "dmarc_report_destination_missing" not in {finding.code for finding in guidance.findings}
+    assert "dmarc_report_destination_missing" not in {
+        plan.finding_code for plan in guidance.change_plans
+    }
+
+
+@pytest.mark.asyncio
+async def test_cname_dmarc_policy_does_not_offer_destructive_txt_replacement():
+    provider = FakeDNSProvider({})
+    provider._cnames["_dmarc.example.com"] = "_dmarc.shared.example.net"
+    current = "v=DMARC1; p=reject; rua=mailto:shared@example.net"
+    dns = DomainDNSResult(dmarc=True, dmarc_record=current, spf=True)
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="reports@example.com"),
+    )
+
+    finding = next(
+        item for item in guidance.findings if item.code == "dmarc_report_destination_inherited"
+    )
+    assert finding.primary_eligible is False
+    assert "_dmarc.shared.example.net" in finding.detail
+    assert not [
+        plan
+        for plan in guidance.change_plans
+        if plan.name == "_dmarc.example.com" and plan.proposed_value != current
+    ]
+
+
+@pytest.mark.asyncio
 async def test_mta_sts_target_includes_policy_file_with_observed_mx_hosts():
-    provider = FakeDNSProvider({"_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"]})
+    provider = FakeDNSProvider(
+        {"_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"]}
+    )
     dns = DomainDNSResult(
         dmarc=True,
         dmarc_record="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
@@ -162,7 +255,9 @@ async def test_mta_sts_target_includes_policy_file_with_observed_mx_hosts():
 
 @pytest.mark.asyncio
 async def test_change_plan_shows_dmarc_tag_diff_and_suppresses_noop():
-    provider = FakeDNSProvider({"_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"]})
+    provider = FakeDNSProvider(
+        {"_smtp._tls.example.com": ["v=TLSRPTv1; rua=mailto:tls@example.com"]}
+    )
     target = "v=DMARC1; p=reject; rua=mailto:dmarc@example.com; pct=100"
     dns = DomainDNSResult(
         dmarc=True,
@@ -177,12 +272,18 @@ async def test_change_plan_shows_dmarc_tag_diff_and_suppresses_noop():
         "example.com", provider, dns, MTAStsResult(status="pass"), BIMIResult(status="pass")
     )
 
-    assert not [plan for plan in guidance.change_plans if plan.finding_code == "dmarc_alignment_value_invalid"]
+    assert not [
+        plan
+        for plan in guidance.change_plans
+        if plan.finding_code == "dmarc_alignment_value_invalid"
+    ]
 
     finding = next(
         finding for finding in guidance.findings if finding.code == "dmarc_alignment_value_invalid"
     )
-    finding.target_record.value = "v=DMARC1; p=reject; rua=mailto:dmarc@example.com; pct=100; adkim=r"
+    finding.target_record.value = (
+        "v=DMARC1; p=reject; rua=mailto:dmarc@example.com; pct=100; adkim=r"
+    )
     plans = build_dns_change_plans([finding])
     assert plans[0].current_values == [target]
     assert "Add adkim=r." in plans[0].changes

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -197,6 +197,140 @@ async def test_existing_dmarc_report_destination_is_not_duplicated():
 
 
 @pytest.mark.asyncio
+async def test_empty_rua_tag_gets_one_valid_report_destination():
+    provider = FakeDNSProvider({})
+    current = "v=DMARC1; p=none; rua=   ; aspf=r"
+    dns = DomainDNSResult(dmarc=True, dmarc_record=current, spf=True)
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="reports@example.com"),
+    )
+
+    plan = next(
+        item
+        for item in guidance.change_plans
+        if item.finding_code == "dmarc_report_destination_missing"
+    )
+    assert "rua=mailto:reports@example.com" in plan.proposed_value
+    assert "rua=," not in plan.proposed_value
+
+
+@pytest.mark.asyncio
+async def test_cached_unknown_dmarc_record_kind_stays_manual_only():
+    provider = FakeDNSProvider({})
+    current = "v=DMARC1; p=none; rua=mailto:existing@example.com"
+    dns = DomainDNSResult(dmarc=True, dmarc_record=current, spf=True)
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="reports@example.com"),
+        allow_live=False,
+    )
+
+    finding = next(
+        item
+        for item in guidance.findings
+        if item.code == "dmarc_report_destination_provenance_unknown"
+    )
+    assert finding.primary_eligible is False
+    assert "dmarc_report_destination_missing" not in {
+        plan.finding_code for plan in guidance.change_plans
+    }
+
+
+@pytest.mark.asyncio
+async def test_cached_confirmed_direct_dmarc_record_keeps_additive_plan():
+    provider = FakeDNSProvider({})
+    current = "v=DMARC1; p=none; rua=mailto:existing@example.com"
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record=current,
+        dmarc_record_kind="txt",
+        spf=True,
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="reports@example.com"),
+        allow_live=False,
+    )
+
+    assert guidance.change_plans[0].finding_code == "dmarc_report_destination_missing"
+
+
+@pytest.mark.asyncio
+async def test_external_report_destination_requires_authorization_first():
+    provider = FakeDNSProvider({})
+    current = "v=DMARC1; p=reject; rua=mailto:existing@example.com"
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record=current,
+        dmarc_policy_domain="example.com",
+        spf=True,
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="reports@tenant.example"),
+    )
+
+    finding = next(
+        item
+        for item in guidance.findings
+        if item.code == "dmarc_report_destination_authorization_missing"
+    )
+    assert finding.record_name == "example.com._report._dmarc.tenant.example"
+    assert finding.target_record.value == "v=DMARC1"
+    assert finding.primary_eligible is False
+    assert "dmarc_report_destination_missing" not in {
+        plan.finding_code for plan in guidance.change_plans
+    }
+
+
+@pytest.mark.asyncio
+async def test_authorized_external_report_destination_gets_additive_plan():
+    authorization_name = "example.com._report._dmarc.tenant.example"
+    provider = FakeDNSProvider({authorization_name: ["v=DMARC1"]})
+    current = "v=DMARC1; p=reject; rua=mailto:existing@example.com"
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record=current,
+        dmarc_policy_domain="example.com",
+        spf=True,
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="reports@tenant.example"),
+    )
+
+    plan = guidance.change_plans[0]
+    assert plan.finding_code == "dmarc_report_destination_missing"
+    assert "mailto:reports@tenant.example" in plan.proposed_value
+
+
+@pytest.mark.asyncio
 async def test_cname_dmarc_policy_does_not_offer_destructive_txt_replacement():
     provider = FakeDNSProvider({})
     provider._cnames["_dmarc.example.com"] = "_dmarc.shared.example.net"
@@ -222,6 +356,35 @@ async def test_cname_dmarc_policy_does_not_offer_destructive_txt_replacement():
         for plan in guidance.change_plans
         if plan.name == "_dmarc.example.com" and plan.proposed_value != current
     ]
+
+
+@pytest.mark.asyncio
+async def test_cached_cname_dmarc_policy_keeps_inherited_finding():
+    provider = FakeDNSProvider({})
+    current = "v=DMARC1; p=reject; rua=mailto:shared@example.net"
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record=current,
+        dmarc_record_kind="cname",
+        dmarc_cname_target="_dmarc.shared.example.net",
+        spf=True,
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="reports@example.com"),
+        allow_live=False,
+    )
+
+    finding = next(
+        item for item in guidance.findings if item.code == "dmarc_report_destination_inherited"
+    )
+    assert finding.primary_eligible is False
+    assert "_dmarc.shared.example.net" in finding.detail
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_resolver.py
+++ b/backend/app/tests/test_dns_resolver.py
@@ -19,9 +19,9 @@ from app.services.dns_resolver import (
     AkamaiETPDNSProvider,
     BaseDNSProvider,
     CloudflareDNSProvider,
-    DegradedResolverDNSProvider,
     ConfiguredRecursiveDNSProvider,
     CustomDNSProvider,
+    DegradedResolverDNSProvider,
     DemoDNSProvider,
     DNS4EUProtectiveDNSProvider,
     DNS4EUUnfilteredDNSProvider,
@@ -44,9 +44,15 @@ from app.services.dns_resolver import (
 class FakeDNSProvider(BaseDNSProvider):
     """Concrete provider backed by a simple dict for deterministic tests."""
 
-    def __init__(self, records: dict, nameservers: list[str] | None = None):
+    def __init__(
+        self,
+        records: dict,
+        nameservers: list[str] | None = None,
+        cnames: dict[str, str] | None = None,
+    ):
         self._records = records
         self._nameservers = nameservers or []
+        self._cnames = cnames or {}
 
     async def lookup_txt(self, name: str):
         if name in self._records:
@@ -55,6 +61,9 @@ class FakeDNSProvider(BaseDNSProvider):
 
     async def lookup_ns(self, domain: str):
         return list(self._nameservers)
+
+    async def lookup_cname(self, name: str):
+        return self._cnames.get(name)
 
 
 # ---------------------------------------------------------------------------
@@ -519,6 +528,24 @@ async def test_check_domain_all_present():
     assert result.spf is True
     assert result.dkim is True
     assert result.dkim_selectors == ["google"]
+    assert result.dmarc_record_kind == "txt"
+    assert result.dmarc_cname_target is None
+
+
+@pytest.mark.asyncio
+async def test_check_domain_persists_dmarc_cname_provenance():
+    provider = FakeDNSProvider(
+        {
+            "_dmarc.example.com": ["v=DMARC1; p=reject; rua=mailto:dmarc@example.com"],
+        },
+        cnames={"_dmarc.example.com": "_dmarc.shared.example.net"},
+    )
+
+    result = await provider.check_domain("example.com", selectors=[])
+
+    assert result.dmarc is True
+    assert result.dmarc_record_kind == "cname"
+    assert result.dmarc_cname_target == "_dmarc.shared.example.net"
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_workspace_onboarding.py
+++ b/backend/app/tests/test_workspace_onboarding.py
@@ -112,6 +112,46 @@ def test_onboarding_rejects_invalid_domain(authed_client: TestClient):
     assert "invalid domain" in str(response.json()["detail"])
 
 
+def test_onboarding_preview_rejects_domain_owned_by_another_workspace(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Preview reports the same predictable domain conflict as apply."""
+    organization = Organization(slug="other", name="Other", active=True)
+    workspace = Workspace(slug="other", name="Other", organization=organization, active=True)
+    db_session.add_all([organization, workspace])
+    db_session.flush()
+    db_session.add(Domain(workspace_id=workspace.id, name="example.com", active=True))
+    db_session.commit()
+
+    response = authed_client.post("/api/v1/onboarding/preview", json=_standard_payload())
+
+    assert response.status_code == 409
+    detail = " ".join(response.json()["detail"])
+    assert "Domain example.com is already owned by another workspace" in detail
+    assert "/domains/example.com" in detail
+    assert db_session.query(Organization).filter(Organization.slug == "client-one").count() == 0
+
+
+def test_onboarding_preview_allows_domain_already_in_target_workspace(
+    authed_client: TestClient,
+    db_session: Session,
+):
+    """Re-running setup for the same workspace remains idempotent."""
+    organization = Organization(slug="client-one", name="Client One", active=True)
+    workspace = Workspace(
+        slug="client-one", name="Client One", organization=organization, active=True
+    )
+    db_session.add_all([organization, workspace])
+    db_session.flush()
+    db_session.add(Domain(workspace_id=workspace.id, name="example.com", active=True))
+    db_session.commit()
+
+    response = authed_client.post("/api/v1/onboarding/preview", json=_standard_payload())
+
+    assert response.status_code == 200
+
+
 def test_dns_only_onboarding_tasks_document_future_report_inbox(authed_client: TestClient):
     """DNS-only onboarding still returns actionable setup tasks."""
     response = authed_client.post(

--- a/docs/reference/workspaces.md
+++ b/docs/reference/workspaces.md
@@ -127,7 +127,9 @@ with `POST /api/v1/onboarding/apply`.
 The onboarding response and audit records redact secret-like fields, including
 passwords, OAuth secrets, tokens, and API keys. Existing domains and mail
 sources are treated idempotently; duplicate domains owned by another workspace
-are rejected to keep ownership unambiguous.
+are rejected to keep ownership unambiguous. The preview performs this ownership
+check before Apply is enabled and points the operator to the existing domain
+configuration rather than failing after a seemingly successful preview.
 
 Notification defaults currently seed the existing notification settings table.
 They intentionally avoid Apprise target URLs, so operators still add and test

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -331,6 +331,11 @@ DMARQ proposes adding only that mailbox to `rua`; the current policy, alignment
 settings, `ruf`, and existing `rua` destinations remain unchanged. This report
 enrollment plan is shown before optional MTA-STS, BIMI, or DANE hardening.
 
+If the report mailbox uses a different domain, receivers require that
+destination domain to authorize reports first. DMARQ checks the required
+`<policy-domain>._report._dmarc.<destination-domain>` TXT record and keeps the
+`rua` update manual until a `v=DMARC1` authorization value is visible.
+
 When `_dmarc.<domain>` is a CNAME, DMARQ does not replace it automatically with
 a TXT record. The shared policy target may serve several domains, so the UI
 identifies the target and keeps the change manual until the operator decides

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -325,6 +325,17 @@ can copy/paste the records manually, preview a provider mutation, or apply safe
 TXT/CNAME changes through a configured DNS provider after explicit browser
 confirmation.
 
+Set a **DMARC report mailbox override** on the domain when DMARQ should receive
+that domain's aggregate reports. If a direct DMARC TXT record already exists,
+DMARQ proposes adding only that mailbox to `rua`; the current policy, alignment
+settings, `ruf`, and existing `rua` destinations remain unchanged. This report
+enrollment plan is shown before optional MTA-STS, BIMI, or DANE hardening.
+
+When `_dmarc.<domain>` is a CNAME, DMARQ does not replace it automatically with
+a TXT record. The shared policy target may serve several domains, so the UI
+identifies the target and keeps the change manual until the operator decides
+whether to update the shared policy or migrate the alias separately.
+
 When DMARQ can detect the authoritative DNS provider from nameservers and a
 matching connector is available, the change-plan section highlights the
 recommended provider. Each plan also includes safety notes that explain why the


### PR DESCRIPTION
## Description

Makes DMARC report enrollment a safe, actionable wizard flow for existing domains. DMARQ now prepares an additive `rua` update that preserves the current policy and all existing report destinations, while refusing automatic writes when the effective policy is inherited or DNS provenance is unclear.

The production browser smoke test also exposed a late cross-workspace ownership error. Preview now reports that conflict before the user applies the onboarding plan.

## Related Issue

Closes #908
Closes #909
Closes #910

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- Detect cross-workspace domain ownership conflicts during onboarding preview.
- Create a reviewable DMARC report-enrollment plan from the per-domain report mailbox setting.
- Preserve the current DMARC policy, tags, whitespace, and existing `rua` destinations; append only the missing mailbox.
- Persist direct-TXT, CNAME, and tree-walk provenance with cached DNS evidence.
- Keep CNAME, inherited-policy, and unknown-provenance cases manual-only so DMARQ cannot replace an alias with TXT accidentally.
- Require and explain the RFC external-report authorization TXT record before adding an external mailbox destination.
- Document the browser workflow and safety behavior.

## Testing Performed

### Test Environment

- Python Version: 3.13.13
- Database: repository test fixtures (SQLite) plus provider/resolver doubles
- OS: macOS

### Test Steps

1. Reproduced the production onboarding flow for an existing domain with Cloudflare connected.
2. Verified preview detects cross-workspace ownership before apply.
3. Exercised additive `rua`, empty `rua`, deduplication, direct TXT, cached provenance, CNAME, tree-walk, and external authorization cases.
4. Ran all DNS/onboarding regression tests and the complete backend suite.

### Test Results

```text
276 focused tests passed
2206 full-suite tests passed
Black, isort, Flake8, and git diff --check passed
```

## Screenshots (if applicable)

The final browser acceptance will run against production after the release is deployed: refresh DNS evidence, inspect the exact before/after Cloudflare mutation, preview it, explicitly confirm one additive update, and verify the published TXT record.

## Security Considerations

- [x] This PR has been reviewed for security vulnerabilities
- [x] No sensitive data is exposed
- [x] Input validation is implemented
- [x] Authentication/authorization is properly handled

Automatic DNS writes remain human-approved. Inherited or ambiguous DMARC records never produce an automatic TXT update.

## Performance Impact

- [x] No significant performance impact

DNS provenance is persisted with the existing DNS evidence. Live external authorization lookup runs only during live guidance refresh.

## Documentation

- [x] Updated relevant documentation
- [x] Added inline code comments for complex logic
- [x] Updated API documentation (if applicable)
- [ ] Updated README.md (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## AI Assistance (if applicable)

- [x] AI tools were used
- [x] All AI-generated code has been reviewed for security and correctness
- [x] Tests were added for AI-generated code

## Additional Notes

The production smoke test intentionally stopped before any DNS write when the old release failed to produce a safe additive plan. The deployed release is the final gate for a real provider preview and explicit confirmation.

## Breaking Changes

None.

## Deployment Notes

No migration is required. After deployment, refresh DNS evidence once for an existing domain so cached direct-TXT/CNAME provenance is available before preparing a provider write.
