### PR TITLE
fix: enable DNS provider previews on domain pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Authenticated domain DNS guidance now carries the same provider-preview
+  readiness as the dedicated change-plan API, so concrete TXT/CNAME repairs
+  can be previewed and explicitly approved from the domain page instead of
+  being incorrectly labelled manual-only.
 - A configured per-domain DMARC report mailbox now produces the primary safe
   DNS change when an existing direct DMARC TXT record does not contain it. The
   proposal adds one `rua` destination while preserving policy, alignment,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -6780,6 +6780,7 @@ async def get_cached_domain_detail_read_model(  # pylint: disable=too-many-local
         cached_only=True,
         dns_result=dns_result,
     )
+    guidance["change_plans"] = _with_dns_plan_write_state(guidance["change_plans"])
     domain_health = _persisted_domain_health(
         db,
         workspace_id=workspace.id,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1054,6 +1054,24 @@ def _dns_plan_safety_notes(plan: Dict[str, Any], *, provider_write_available: bo
     return notes or ["Manual review is required before this DNS change can be automated."]
 
 
+def _with_dns_plan_write_state(plans: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Add the authenticated provider-preview state consumed by the domain UI."""
+    annotated_plans = []
+    for plan in plans:
+        provider_write_available = _dns_plan_provider_write_available(plan)
+        annotated_plans.append(
+            {
+                **plan,
+                "provider_write_available": provider_write_available,
+                "safety_notes": _dns_plan_safety_notes(
+                    plan,
+                    provider_write_available=provider_write_available,
+                ),
+            }
+        )
+    return annotated_plans
+
+
 def _dns_change_plan_safety_notes(
     *, recommended_provider: Optional[str], available_providers: List[str]
 ) -> List[str]:
@@ -6373,7 +6391,9 @@ async def get_domain_dns_lint(
     guidance_kwargs: Dict[str, Any] = {"refresh": refresh, "locale": locale}
     if cached_only:
         guidance_kwargs["cached_only"] = True
-    return await _build_domain_dns_guidance(db, store, domain_id, **guidance_kwargs)
+    guidance = await _build_domain_dns_guidance(db, store, domain_id, **guidance_kwargs)
+    guidance["change_plans"] = _with_dns_plan_write_state(guidance["change_plans"])
+    return guidance
 
 
 @router.get("/{domain_id}/dns/change-plan", response_model=DNSChangePlanResponse)
@@ -6400,19 +6420,7 @@ async def get_domain_dns_change_plan(
         guidance.get("dns_provider"),
         available_providers,
     )
-    plans = []
-    for plan in guidance["change_plans"]:
-        provider_write_available = _dns_plan_provider_write_available(plan)
-        plans.append(
-            {
-                **plan,
-                "provider_write_available": provider_write_available,
-                "safety_notes": _dns_plan_safety_notes(
-                    plan,
-                    provider_write_available=provider_write_available,
-                ),
-            }
-        )
+    plans = _with_dns_plan_write_state(guidance["change_plans"])
     return DNSChangePlanResponse(
         domain=guidance["domain"],
         status=guidance["status"],

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -3003,6 +3003,27 @@ def test_dns_change_plan_marks_apply_ready_records(authed_client: TestClient, db
     ]
 
 
+def test_dns_lint_marks_apply_ready_records_for_domain_ui(authed_client: TestClient, db_session):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _dns_plan()
+    plan["current_values"] = ["v=DMARC1; p=none"]
+
+    with patch(
+        "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+        new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+    ):
+        response = authed_client.get(f"/api/v1/domains/{DOMAIN}/dns/lint")
+
+    assert response.status_code == 200
+    change_plan = response.json()["change_plans"][0]
+    assert change_plan["provider_write_available"] is True
+    assert change_plan["safety_notes"] == [
+        "Preview the provider mutation before applying this DNS change.",
+        "Existing provider values will be shown in the preview before approval.",
+    ]
+
+
 def test_dns_change_plan_recommends_detected_provider(authed_client: TestClient, db_session):
     db_session.add(Domain(name=DOMAIN))
     db_session.commit()

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -27,17 +27,17 @@ from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services import report_persistence
 from app.services.bimi import BIMIResult
-from app.services.mta_sts import MTAStsResult
 from app.services.health_score_snapshots import upsert_health_score_snapshot
+from app.services.mta_sts import MTAStsResult
 from app.services.ptr_lookup import PtrLookupResult
 from app.services.report_store import ReportStore
 from app.services.source_network import SourceNetworkIntelligence
+from app.services.source_read_projection import sync_source_projection_evidence
 from app.services.source_reputation import (
     DomainReputation,
     ReputationEvidence,
     SourceReputation,
 )
-from app.services.source_read_projection import sync_source_projection_evidence
 from app.services.webhook_events import (
     EVENT_REMEDIATION_APPROVAL_REQUIRED,
     create_webhook_endpoint,
@@ -987,7 +987,20 @@ def test_cached_domain_detail_combines_dns_and_posture_reads(
     async def fake_guidance(*_args, **kwargs):
         calls["guidance"] += 1
         assert kwargs["cached_only"] is True
-        return {"domain": DOMAIN, "status": "healthy", "findings": [], "change_plans": []}
+        return {
+            "domain": DOMAIN,
+            "status": "attention",
+            "findings": [],
+            "change_plans": [
+                {
+                    "operation": "update",
+                    "record_type": "TXT",
+                    "proposed_value": "v=DMARC1; p=none; rua=mailto:dmarc@example.com",
+                    "provider_value_required": False,
+                    "current_values": ["v=DMARC1; p=none"],
+                }
+            ],
+        }
 
     async def fake_posture(*_args, **kwargs):
         calls["posture"] += 1
@@ -1026,6 +1039,12 @@ def test_cached_domain_detail_combines_dns_and_posture_reads(
 
     assert response.status_code == 200
     assert response.json()["posture"]["health"]["score"] == 96
+    cached_plan = response.json()["dns_guidance"]["change_plans"][0]
+    assert cached_plan["provider_write_available"] is True
+    assert cached_plan["safety_notes"] == [
+        "Preview the provider mutation before applying this DNS change.",
+        "Existing provider values will be shown in the preview before approval.",
+    ]
     assert response.json()["freshness"]["mode"] == "cached"
     assert calls == {"dns": 1, "health": 1, "guidance": 1, "grade": 0, "posture": 1}
 
@@ -3147,9 +3166,7 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
     ],
 )
 def test_source_delivery_status_distinguishes_policy_outcomes(source, status):
-    delivery = domains_endpoint._source_delivery_status(  # pylint: disable=protected-access
-        source
-    )
+    delivery = domains_endpoint._source_delivery_status(source)  # pylint: disable=protected-access
 
     assert delivery["status"] == status
 
@@ -3618,7 +3635,9 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
     intelligence = authed_client.get(
         "/api/v1/domains/fast-sources.example/source-intelligence?days=3650"
     )
-    reputation = authed_client.get("/api/v1/domains/fast-sources.example/source-reputation?days=3650")
+    reputation = authed_client.get(
+        "/api/v1/domains/fast-sources.example/source-reputation?days=3650"
+    )
 
     assert sources.status_code == 200
     assert sources.json()["sources"][0]["ip"] == "203.0.113.42"
@@ -3952,9 +3971,7 @@ def test_default_source_reads_do_not_trigger_live_enrichment(
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fail_live_lookup)
 
     sources = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650")
-    intelligence = seeded_client.get(
-        f"/api/v1/domains/{DOMAIN}/source-intelligence?days=3650"
-    )
+    intelligence = seeded_client.get(f"/api/v1/domains/{DOMAIN}/source-intelligence?days=3650")
 
     assert sources.status_code == 200
     assert intelligence.status_code == 200

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -27,17 +27,17 @@ from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
 from app.services import report_persistence
 from app.services.bimi import BIMIResult
-from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.mta_sts import MTAStsResult
+from app.services.health_score_snapshots import upsert_health_score_snapshot
 from app.services.ptr_lookup import PtrLookupResult
 from app.services.report_store import ReportStore
 from app.services.source_network import SourceNetworkIntelligence
-from app.services.source_read_projection import sync_source_projection_evidence
 from app.services.source_reputation import (
     DomainReputation,
     ReputationEvidence,
     SourceReputation,
 )
+from app.services.source_read_projection import sync_source_projection_evidence
 from app.services.webhook_events import (
     EVENT_REMEDIATION_APPROVAL_REQUIRED,
     create_webhook_endpoint,
@@ -3166,7 +3166,9 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
     ],
 )
 def test_source_delivery_status_distinguishes_policy_outcomes(source, status):
-    delivery = domains_endpoint._source_delivery_status(source)  # pylint: disable=protected-access
+    delivery = domains_endpoint._source_delivery_status(  # pylint: disable=protected-access
+        source
+    )
 
     assert delivery["status"] == status
 
@@ -3635,9 +3637,7 @@ def test_source_detail_endpoints_use_single_domain_persisted_reports(
     intelligence = authed_client.get(
         "/api/v1/domains/fast-sources.example/source-intelligence?days=3650"
     )
-    reputation = authed_client.get(
-        "/api/v1/domains/fast-sources.example/source-reputation?days=3650"
-    )
+    reputation = authed_client.get("/api/v1/domains/fast-sources.example/source-reputation?days=3650")
 
     assert sources.status_code == 200
     assert sources.json()["sources"][0]["ip"] == "203.0.113.42"
@@ -3971,7 +3971,9 @@ def test_default_source_reads_do_not_trigger_live_enrichment(
     monkeypatch.setattr(domains_endpoint, "build_source_reputation_cached", fail_live_lookup)
 
     sources = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources?days=3650")
-    intelligence = seeded_client.get(f"/api/v1/domains/{DOMAIN}/source-intelligence?days=3650")
+    intelligence = seeded_client.get(
+        f"/api/v1/domains/{DOMAIN}/source-intelligence?days=3650"
+    )
 
     assert sources.status_code == 200
     assert intelligence.status_code == 200


### PR DESCRIPTION
## Description
Fixes the production domain-detail workflow where safe DNS plans were incorrectly shown as manual-only even though Cloudflare OAuth was connected with DNS write scope.

## Related Issue
Follow-up to #911 found during the production browser acceptance test.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Changes Made
- Annotate authenticated DNS lint change plans with the same provider-preview readiness used by the dedicated change-plan API.
- Reuse one helper so lint and change-plan responses cannot drift.
- Add regression coverage for the domain-page response and update the changelog.

## Testing Performed

### Test Environment
- Python Version: 3.13.13
- Database: SQLite test database
- OS: macOS

### Test Steps
1. Reproduce on production with Cloudflare OAuth connected and `dns.write` granted.
2. Verify `/dns/lint` contained the concrete additive DMARC plan but returned `provider_write_available: false`.
3. Run the complete Cloudflare DNS and DNS endpoint test modules after the fix.

### Test Results
```
269 passed
black --check: clean
isort --check-only: clean
flake8: clean
```

## Security Considerations
- [x] This PR has been reviewed for security vulnerabilities
- [x] No sensitive data is exposed
- [x] Authentication/authorization is properly handled

Write authorization remains unchanged: the authenticated provider preview, exact before/after mutation, and explicit final approval are still required. Public/read-only APIs are unchanged.

## Performance Impact
- [x] No significant performance impact

No extra API request or DNS lookup is added.

## Documentation
- [x] Updated relevant documentation
- [x] No API documentation changes needed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing focused tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## AI Assistance
- [x] AI tools were used
- [x] All AI-generated code has been reviewed for security and correctness
- [x] Tests were added for AI-generated code

## Breaking Changes
None.

## Deployment Notes
No migration or configuration change required. Deploy normally, then refresh DNS evidence on a domain with a connected DNS provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authenticated domain DNS guidance now correctly reflects provider-preview readiness.
  * Concrete TXT/CNAME repairs are shown as previewable and explicitly approvable from the domain page instead of manual-only.

* **Tests**
  * Added coverage confirming provider mutation previews and existing-provider values are displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->