### PR TITLE
fix: support safe DMARC CNAME-to-TXT migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   DNS change when an existing direct DMARC TXT record does not contain it. The
   proposal adds one `rua` destination while preserving policy, alignment,
   forensic reporting, and all existing aggregate destinations. DMARC policies
-  inherited through CNAME remain explicitly manual to avoid destructive record
-  replacement. Record-kind provenance is persisted for cached reads, and
-  external report destinations must publish their DMARC authorization TXT
+  inherited through CNAME now get a separately reviewed record-type migration:
+  DMARQ copies the effective policy into a local TXT record, adds only the local
+  `rua`, leaves the shared target untouched, binds apply to the previewed CNAME
+  baseline, and records CNAME rollback evidence. Provider readback plus
+  Cloudflare and Google public DNS agreement are required before the migration
+  is marked verified. Record-kind provenance is persisted for cached reads,
+  and external report destinations must publish their DMARC authorization TXT
   record before the monitored-domain update becomes apply-ready.
 - The setup assistant now detects domains owned by another workspace during
   preview and points operators to the existing domain instead of allowing a

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -1145,6 +1145,7 @@ class DNSWriteApplyRequest(BaseModel):
     expected_record_type: Optional[str] = None
     expected_current_values: Optional[List[str]] = None
     expected_record_id: Optional[str] = None
+    expected_proposed_value: Optional[str] = None
 
 
 class DNSWriteMutationResponse(BaseModel):
@@ -6626,6 +6627,7 @@ async def apply_domain_dns_change_plan(
                 payload.expected_record_type is None
                 or payload.expected_current_values is None
                 or payload.expected_record_id is None
+                or payload.expected_proposed_value is None
             ):
                 raise DNSProviderWriteError(
                     "Preview this record-type migration again before applying it; "
@@ -6643,6 +6645,7 @@ async def apply_domain_dns_change_plan(
                 expected_record_type=payload.expected_record_type,
                 expected_current_values=payload.expected_current_values,
                 expected_record_id=payload.expected_record_id,
+                expected_proposed_value=payload.expected_proposed_value,
             )
     except DNSProviderWriteError as exc:
         raise HTTPException(

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -569,6 +569,10 @@ class DNSLintFindingResponse(BaseModel):
     evidence: List[str] = Field(default_factory=list)
     remediation_steps: List[str] = Field(default_factory=list)
     primary_eligible: bool = True
+    current_record_type: Optional[str] = None
+    current_record_values: List[str] = Field(default_factory=list)
+    effective_value: Optional[str] = None
+    shared_record_target: Optional[str] = None
 
 
 class DKIMSelectorEvidenceResponse(BaseModel):
@@ -616,6 +620,9 @@ class DNSChangePlanItemResponse(BaseModel):
     what_it_does: Optional[str] = None
     learn_more_url: Optional[str] = None
     learn_more_label: Optional[str] = None
+    current_record_type: Optional[str] = None
+    effective_value: Optional[str] = None
+    shared_record_target: Optional[str] = None
 
 
 class DNSChangePlanResponse(BaseModel):
@@ -1135,6 +1142,9 @@ class DNSWriteApplyRequest(BaseModel):
     allow_provider_mismatch: bool = False
     value: Optional[str] = None
     ttl: int = Field(default=1, ge=1, le=86400)
+    expected_record_type: Optional[str] = None
+    expected_current_values: Optional[List[str]] = None
+    expected_record_id: Optional[str] = None
 
 
 class DNSWriteMutationResponse(BaseModel):
@@ -1150,6 +1160,8 @@ class DNSWriteMutationResponse(BaseModel):
     zone_name: Optional[str] = None
     record_id: Optional[str] = None
     current_values: List[str] = Field(default_factory=list)
+    current_record_type: Optional[str] = None
+    effective_value: Optional[str] = None
     applicable: bool
     blocked_reason: Optional[str] = None
 
@@ -1161,6 +1173,7 @@ class DNSWriteVerificationResponse(BaseModel):
     verified: bool
     checked_values: List[str] = Field(default_factory=list)
     message: str = ""
+    resolver_checks: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class DNSWriteRollbackResponse(BaseModel):
@@ -1169,6 +1182,7 @@ class DNSWriteRollbackResponse(BaseModel):
     summary: str
     steps: List[str] = Field(default_factory=list)
     previous_values: List[str] = Field(default_factory=list)
+    previous_record_type: Optional[str] = None
     record_type: str
     name: str
     provider: str
@@ -6453,6 +6467,7 @@ def _dns_write_rollback_guidance(plan: Dict[str, Any], result: Any) -> Dict[str,
     """Return manual rollback guidance for a prepared or applied DNS mutation."""
     mutation = result.mutation
     previous_values = list(mutation.current_values or [])
+    previous_record_type = mutation.current_record_type or mutation.record_type
     summary = str(plan.get("rollback") or "").strip()
     if not summary:
         summary = "Review provider history and restore the previous DNS value if needed."
@@ -6465,7 +6480,15 @@ def _dns_write_rollback_guidance(plan: Dict[str, Any], result: Any) -> Dict[str,
             "Refresh DMARQ DNS evidence and confirm the domain returns to the intended state.",
         ]
     elif mutation.operation == "update":
-        if previous_values:
+        if previous_values and previous_record_type != mutation.record_type:
+            steps = [
+                f"Open {mutation.provider} DNS for the zone that contains {mutation.name}.",
+                f"Replace the {mutation.record_type} record named {mutation.name} with {previous_record_type}.",
+                "Restore the previous target shown in DMARQ's rollback evidence.",
+                "Do not edit the shared DMARC target.",
+                "Refresh DMARQ DNS evidence and confirm the restored alias is visible.",
+            ]
+        elif previous_values:
             steps = [
                 f"Open {mutation.provider} DNS for the zone that contains {mutation.name}.",
                 f"Edit the {mutation.record_type} record named {mutation.name}.",
@@ -6495,6 +6518,7 @@ def _dns_write_rollback_guidance(plan: Dict[str, Any], result: Any) -> Dict[str,
         "summary": summary,
         "steps": steps,
         "previous_values": previous_values,
+        "previous_record_type": previous_record_type,
         "record_type": mutation.record_type,
         "name": mutation.name,
         "provider": mutation.provider,
@@ -6593,6 +6617,20 @@ async def apply_domain_dns_change_plan(
                 ttl=payload.ttl,
             )
         else:
+            record_type_replacement = bool(
+                plan.get("current_record_type")
+                and str(plan.get("current_record_type")).upper()
+                != str(plan.get("record_type") or "").upper()
+            )
+            if record_type_replacement and (
+                payload.expected_record_type is None
+                or payload.expected_current_values is None
+                or payload.expected_record_id is None
+            ):
+                raise DNSProviderWriteError(
+                    "Preview this record-type migration again before applying it; "
+                    "the reviewed provider baseline is required"
+                )
             _require_verified_domain_for_dns_write(db, workspace, resolved_domain)
             result = await apply_dns_write(
                 db,
@@ -6602,6 +6640,9 @@ async def apply_domain_dns_change_plan(
                 provider_id=payload.provider,
                 value_override=payload.value,
                 ttl=payload.ttl,
+                expected_record_type=payload.expected_record_type,
+                expected_current_values=payload.expected_current_values,
+                expected_record_id=payload.expected_record_id,
             )
     except DNSProviderWriteError as exc:
         raise HTTPException(

--- a/backend/app/services/dns_guidance.py
+++ b/backend/app/services/dns_guidance.py
@@ -59,6 +59,10 @@ class DNSLintFinding:
     evidence: List[str] = field(default_factory=list)
     remediation_steps: List[str] = field(default_factory=list)
     primary_eligible: bool = True
+    current_record_type: Optional[str] = None
+    current_record_values: List[str] = field(default_factory=list)
+    effective_value: Optional[str] = None
+    shared_record_target: Optional[str] = None
 
 
 @dataclass
@@ -86,6 +90,9 @@ class DNSChangePlan:
     what_it_does: Optional[str] = None
     learn_more_url: Optional[str] = None
     learn_more_label: Optional[str] = None
+    current_record_type: Optional[str] = None
+    effective_value: Optional[str] = None
+    shared_record_target: Optional[str] = None
 
 
 @dataclass
@@ -349,6 +356,10 @@ def _finding(
     evidence: Optional[List[str]] = None,
     remediation_steps: Optional[List[str]] = None,
     primary_eligible: bool = True,
+    current_record_type: Optional[str] = None,
+    current_record_values: Optional[List[str]] = None,
+    effective_value: Optional[str] = None,
+    shared_record_target: Optional[str] = None,
 ) -> DNSLintFinding:
     return DNSLintFinding(
         code=code,
@@ -362,6 +373,10 @@ def _finding(
         evidence=list(evidence or []),
         remediation_steps=list(remediation_steps or _default_remediation_steps(code)),
         primary_eligible=primary_eligible,
+        current_record_type=current_record_type,
+        current_record_values=list(current_record_values or []),
+        effective_value=effective_value,
+        shared_record_target=shared_record_target,
     )
 
 
@@ -386,6 +401,11 @@ _REMEDIATION_STEPS_EN: Dict[str, List[str]] = {
         "Open the authoritative DMARC target referenced by the CNAME.",
         "Decide whether all domains using that shared policy should send reports to DMARQ.",
         "Update the shared target manually or replace the CNAME in a separately reviewed migration.",
+    ],
+    "dmarc_report_destination_cname_migration": [
+        "Review the local CNAME, the inherited effective policy, and the proposed local TXT policy.",
+        "Preview the single provider record-type replacement and confirm the CNAME baseline is unchanged.",
+        "Apply only after approval, then verify provider readback and public DNS propagation.",
     ],
     "dmarc_report_destination_provenance_unknown": [
         "Refresh DNS evidence so DMARQ can distinguish a direct TXT record from an alias.",
@@ -520,6 +540,11 @@ _REMEDIATION_STEPS_DE: Dict[str, List[str]] = {
         "Oeffne das autoritative DMARC-Ziel, auf das der CNAME verweist.",
         "Entscheide, ob alle Domains mit dieser gemeinsamen Policy Reports an DMARQ senden sollen.",
         "Aendere das gemeinsame Ziel manuell oder ersetze den CNAME in einer separat geprueften Migration.",
+    ],
+    "dmarc_report_destination_cname_migration": [
+        "Pruefe den lokalen CNAME, die geerbte wirksame Policy und den vorgeschlagenen lokalen TXT-Record.",
+        "Pruefe den einmaligen Record-Typ-Wechsel beim Provider und bestaetige die unveraenderte CNAME-Baseline.",
+        "Wende die Aenderung erst nach Freigabe an und pruefe danach Provider-Readback und oeffentliche DNS-Aufloesung.",
     ],
     "dmarc_report_destination_provenance_unknown": [
         "Aktualisiere die DNS-Evidenz, damit DMARQ direkten TXT-Record und Alias unterscheiden kann.",
@@ -670,7 +695,37 @@ def _dmarc_findings(
         and report_mailbox
         and not _dmarc_has_report_mailbox(result.dmarc_record, report_mailbox)
     ):
-        if record_kind in {"cname", "treewalk"}:
+        if record_kind == "cname" and cname_target and report_authorization is True:
+            proposed = _append_dmarc_report_mailbox(result.dmarc_record, report_mailbox)
+            migration_target = _record_with_value(target, proposed)
+            findings.append(
+                _finding(
+                    "dmarc_report_destination_cname_migration",
+                    "info",
+                    "Move this domain to a local DMARC policy",
+                    (
+                        f"{target.name} is a CNAME to {cname_target}. Editing that shared target "
+                        "could change reporting for other domains, so DMARQ will instead replace "
+                        "this domain's CNAME with an equivalent local TXT policy."
+                    ),
+                    (
+                        f"Replace only the local CNAME with a TXT record and add {report_mailbox} "
+                        "to rua; keep every inherited policy tag and existing report destination."
+                    ),
+                    "TXT",
+                    target.name,
+                    target_record=migration_target,
+                    evidence=[
+                        f"{target.name} CNAME {cname_target}",
+                        f"Inherited effective policy: {result.dmarc_record}",
+                    ],
+                    current_record_type="CNAME",
+                    current_record_values=[cname_target],
+                    effective_value=result.dmarc_record,
+                    shared_record_target=cname_target,
+                )
+            )
+        elif record_kind in {"cname", "treewalk"}:
             inherited_target = cname_target or result.dmarc_policy_domain or "the parent policy"
             findings.append(
                 _finding(
@@ -1658,7 +1713,10 @@ def _plan_id(finding: DNSLintFinding) -> str:
 
 def _operation_for_finding(finding: DNSLintFinding) -> str:
     code = finding.code
-    if code == "dmarc_report_destination_missing":
+    if code in {
+        "dmarc_report_destination_missing",
+        "dmarc_report_destination_cname_migration",
+    }:
         return "update"
     if (
         code.endswith("_missing")
@@ -1712,6 +1770,11 @@ def _risk_for_finding(finding: DNSLintFinding) -> str:
         "dmarc_report_destination_missing": (
             "Low mail-flow risk: this adds one aggregate-report destination without changing "
             "policy, alignment, or existing destinations. A typo can prevent DMARQ intake."
+        ),
+        "dmarc_report_destination_cname_migration": (
+            "Low policy risk when the inherited policy is copied exactly. The reviewed change "
+            "replaces one local CNAME with one TXT record; an incomplete copy could alter DMARC "
+            "behavior, so provider drift and public DNS verification are mandatory."
         ),
         "dmarc_report_destination_authorization_missing": (
             "Low mail-flow risk, but the external destination will not receive reports until "
@@ -1767,6 +1830,12 @@ def _risk_for_finding(finding: DNSLintFinding) -> str:
 
 
 def _rollback_for_plan(finding: DNSLintFinding, operation: str) -> str:
+    if finding.code == "dmarc_report_destination_cname_migration":
+        target = finding.shared_record_target or "the previously captured shared target"
+        return (
+            f"Replace the local TXT record with the previous CNAME to {target}; "
+            "do not edit the shared target."
+        )
     if operation == "create":
         return f"Delete the newly created {finding.record_type} record at {finding.record_name}."
     if operation == "review-remove":
@@ -1856,7 +1925,7 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
         proposed_value = _proposed_value(finding)
         if operation == "defer":
             continue
-        current_values = list(finding.evidence)
+        current_values = list(finding.current_record_values or finding.evidence)
         # A matching value is only a no-op when it is the sole RRset member.
         # Consolidation findings (for example, multiple SPF or TLS-RPT TXT
         # values) still need an update plan even if one member is already the
@@ -1870,6 +1939,20 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
             )
         ):
             continue
+        changes = _plan_changes(current_values, proposed_value)
+        if finding.current_record_type and finding.current_record_type != finding.record_type:
+            value_changes = _plan_changes(
+                [finding.effective_value] if finding.effective_value else [],
+                proposed_value,
+            )
+            changes = [
+                (
+                    f"Replace the {finding.current_record_type} record with one "
+                    f"{finding.record_type} record at the same owner name."
+                ),
+                *value_changes,
+                "Leave the shared DMARC target unchanged.",
+            ]
         plans.append(
             DNSChangePlan(
                 plan_id=_plan_id(finding),
@@ -1886,7 +1969,7 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
                 expected_health_impact=_expected_health_impact(finding),
                 manual_steps=_manual_steps_for_plan(finding, operation),
                 provider_value_required=_provider_value_required(finding),
-                changes=_plan_changes(current_values, proposed_value),
+                changes=changes,
                 what_it_does=(
                     finding.target_record.what_it_does if finding.target_record else None
                 ),
@@ -1896,6 +1979,9 @@ def build_dns_change_plans(findings: List[DNSLintFinding]) -> List[DNSChangePlan
                 learn_more_label=(
                     finding.target_record.learn_more_label if finding.target_record else None
                 ),
+                current_record_type=finding.current_record_type,
+                effective_value=finding.effective_value,
+                shared_record_target=finding.shared_record_target,
             )
         )
     return plans

--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -66,6 +66,14 @@ class DNSProviderWriteError(ValueError):
     """Raised when a provider write cannot be safely prepared or applied."""
 
 
+def _normalize_reviewed_values(values: List[str], record_type: str) -> List[str]:
+    """Normalize reviewed provider values for safe preview/apply baseline checks."""
+    normalized = [str(value) for value in values]
+    if record_type.upper() == "CNAME":
+        return [value.rstrip(".").lower() for value in normalized]
+    return normalized
+
+
 @dataclass
 class DNSWriteMutation:
     """Concrete provider mutation derived from a DMARQ DNS change plan."""
@@ -706,6 +714,23 @@ class LexiconDNSWriteProvider:
                     "Multiple provider records match this name/type; merge them manually first"
                 ),
             )
+        if _is_record_type_replacement(plan) and current:
+            return DNSWriteMutation(
+                operation=str(plan["operation"]).lower(),
+                record_type=record_type,
+                name=record_name,
+                content=value,
+                ttl=ttl,
+                provider=self.provider_id,
+                record_id=str(current[0].get("id") or ""),
+                current_values=current_values,
+                current_record_type=current_record_type,
+                effective_value=plan.get("effective_value"),
+                blocked_reason=(
+                    "Lexicon providers do not support reviewed record-type replacements; "
+                    "use Cloudflare or migrate this record manually"
+                ),
+            )
         operation = (
             "noop"
             if not _is_record_type_replacement(plan) and current_values == [value]
@@ -978,6 +1003,7 @@ async def apply_dns_write(
     expected_record_type: Optional[str] = None,
     expected_current_values: Optional[List[str]] = None,
     expected_record_id: Optional[str] = None,
+    expected_proposed_value: Optional[str] = None,
 ) -> DNSWriteResult:
     """Apply one provider-backed DNS mutation after validation."""
     if get_settings().DEMO_MODE:
@@ -998,9 +1024,17 @@ async def apply_dns_write(
             raise DNSProviderWriteError(
                 "Provider record type changed after preview; refresh and review the change again"
             )
-    if expected_current_values is not None and mutation.current_values != expected_current_values:
+    if expected_current_values is not None:
+        record_type = str(mutation.current_record_type or mutation.record_type).upper()
+        actual_values = _normalize_reviewed_values(mutation.current_values, record_type)
+        reviewed_values = _normalize_reviewed_values(expected_current_values, record_type)
+        if actual_values != reviewed_values:
+            raise DNSProviderWriteError(
+                "Provider values changed after preview; refresh and review the change again"
+            )
+    if expected_proposed_value is not None and mutation.content != expected_proposed_value:
         raise DNSProviderWriteError(
-            "Provider values changed after preview; refresh and review the change again"
+            "Proposed DNS value changed after preview; refresh and review the change again"
         )
     if expected_record_id is not None and mutation.record_id != expected_record_id:
         raise DNSProviderWriteError(

--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -82,6 +82,8 @@ class DNSWriteMutation:
     zone_name: Optional[str] = None
     record_id: Optional[str] = None
     current_values: List[str] = field(default_factory=list)
+    current_record_type: Optional[str] = None
+    effective_value: Optional[str] = None
     blocked_reason: Optional[str] = None
 
     @property
@@ -100,6 +102,8 @@ class DNSWriteMutation:
             "zone_name": self.zone_name,
             "record_id": self.record_id,
             "current_values": self.current_values,
+            "current_record_type": self.current_record_type,
+            "effective_value": self.effective_value,
             "applicable": self.applicable,
             "blocked_reason": self.blocked_reason,
         }
@@ -113,6 +117,7 @@ class DNSWriteVerification:
     verified: bool
     checked_values: List[str] = field(default_factory=list)
     message: str = ""
+    resolver_checks: List[Dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -120,6 +125,7 @@ class DNSWriteVerification:
             "verified": self.verified,
             "checked_values": self.checked_values,
             "message": self.message,
+            "resolver_checks": self.resolver_checks,
         }
 
 
@@ -256,6 +262,43 @@ def _validate_plan_for_automation(plan: Dict[str, Any]) -> None:
         )
 
 
+def _current_record_type(plan: Dict[str, Any]) -> str:
+    """Return the provider record type expected before the reviewed change."""
+    return str(plan.get("current_record_type") or plan.get("record_type") or "").upper()
+
+
+def _is_record_type_replacement(plan: Dict[str, Any]) -> bool:
+    return _current_record_type(plan) != str(plan.get("record_type") or "").upper()
+
+
+def _baseline_block_reason(*, plan: Dict[str, Any], records: List[Dict[str, Any]]) -> Optional[str]:
+    """Reject a record-type replacement unless the provider matches the reviewed baseline."""
+    if not _is_record_type_replacement(plan):
+        return None
+    expected_type = _current_record_type(plan)
+    expected_values = [str(value) for value in plan.get("current_values") or []]
+    if len(records) != 1:
+        return (
+            "The reviewed record-type migration requires exactly one provider record at this "
+            "owner name; refresh DNS evidence before trying again"
+        )
+    actual = records[0]
+    actual_type = str(actual.get("type") or "").upper()
+    actual_value = str(actual.get("content") or "")
+    if expected_type == "CNAME":
+        actual_values = [actual_value.rstrip(".").lower()]
+        normalized_expected_values = [value.rstrip(".").lower() for value in expected_values]
+    else:
+        actual_values = [actual_value]
+        normalized_expected_values = expected_values
+    if actual_type != expected_type or actual_values != normalized_expected_values:
+        return (
+            "Provider state differs from the reviewed CNAME baseline; refresh and preview the "
+            "migration again before applying"
+        )
+    return None
+
+
 def _verification_from_records(
     *,
     mutation: DNSWriteMutation,
@@ -272,20 +315,38 @@ def _verification_from_records(
             == mutation.name.rstrip(".").lower()
         )
     ]
-    verified = mutation.content in checked_values
+    conflicting_previous_records = [
+        record
+        for record in records
+        if mutation.current_record_type
+        and mutation.current_record_type != mutation.record_type
+        and str(record.get("type") or "").upper() == mutation.current_record_type
+        and (
+            not record.get("name")
+            or str(record.get("name") or "").rstrip(".").lower()
+            == mutation.name.rstrip(".").lower()
+        )
+    ]
+    verified = mutation.content in checked_values and not conflicting_previous_records
     if verified:
         return DNSWriteVerification(
             status="verified",
             verified=True,
             checked_values=checked_values,
-            message="Provider API returned the expected DNS record after apply.",
+            message=(
+                "Provider API returned the expected DNS record after apply and no previous "
+                "record type remains at the owner name."
+                if mutation.current_record_type
+                and mutation.current_record_type != mutation.record_type
+                else "Provider API returned the expected DNS record after apply."
+            ),
         )
     return DNSWriteVerification(
         status="failed",
         verified=False,
         checked_values=checked_values,
         message=(
-            "Provider API did not return the expected DNS record after apply; "
+            "Provider API did not return the expected DNS record exclusively after apply; "
             "verify propagation and provider state before treating this as repaired."
         ),
     )
@@ -302,6 +363,102 @@ def _noop_verification(mutation: DNSWriteMutation) -> DNSWriteVerification:
             "Provider already has the expected DNS value."
             if verified
             else "Provider preview marked this record unchanged, but the expected value was not present."
+        ),
+    )
+
+
+async def _public_resolver_record_check(
+    mutation: DNSWriteMutation, nameserver: str
+) -> Dict[str, Any]:
+    """Check one public resolver for the new TXT and absence of the replaced CNAME."""
+    import dns.asyncresolver  # pylint: disable=import-outside-toplevel
+    import dns.exception  # pylint: disable=import-outside-toplevel
+    import dns.resolver  # pylint: disable=import-outside-toplevel
+
+    resolver = dns.asyncresolver.Resolver(configure=False)
+    resolver.nameservers = [nameserver]
+    resolver.timeout = 2.0
+    resolver.lifetime = 3.0
+    values: List[str] = []
+    previous_type_present = False
+    try:
+        answer = await resolver.resolve(mutation.name, mutation.record_type)
+        for record in answer:
+            strings = getattr(record, "strings", None)
+            if strings is not None:
+                values.append(b"".join(strings).decode("utf-8", errors="replace"))
+            else:
+                values.append(str(record).strip().strip('"'))
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+        values = []
+    except (dns.exception.DNSException, OSError) as exc:
+        return {
+            "resolver": nameserver,
+            "status": "unavailable",
+            "verified": False,
+            "values": [],
+            "message": str(exc),
+        }
+
+    if mutation.current_record_type and mutation.current_record_type != mutation.record_type:
+        try:
+            await resolver.resolve(mutation.name, mutation.current_record_type)
+            previous_type_present = True
+        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+            previous_type_present = False
+        except (dns.exception.DNSException, OSError) as exc:
+            return {
+                "resolver": nameserver,
+                "status": "unavailable",
+                "verified": False,
+                "values": values,
+                "message": str(exc),
+            }
+
+    verified = mutation.content in values and not previous_type_present
+    return {
+        "resolver": nameserver,
+        "status": "verified" if verified else "propagation_pending",
+        "verified": verified,
+        "values": values,
+        "previous_type_present": previous_type_present,
+        "message": (
+            "Expected record type and value are visible; the previous type is absent."
+            if verified
+            else "Public DNS does not yet agree with the reviewed provider state."
+        ),
+    }
+
+
+async def _verify_public_record_type_replacement(
+    mutation: DNSWriteMutation, verification: DNSWriteVerification
+) -> DNSWriteVerification:
+    """Require Cloudflare and Google public DNS agreement for record-type replacements."""
+    if (
+        not verification.verified
+        or not mutation.current_record_type
+        or mutation.current_record_type == mutation.record_type
+    ):
+        return verification
+    checks = await asyncio.gather(
+        *(
+            _public_resolver_record_check(mutation, nameserver)
+            for nameserver in ("1.1.1.1", "8.8.8.8")
+        )
+    )
+    public_verified = all(bool(check.get("verified")) for check in checks)
+    return DNSWriteVerification(
+        status="verified" if public_verified else "propagation_pending",
+        verified=public_verified,
+        checked_values=verification.checked_values,
+        resolver_checks=list(checks),
+        message=(
+            "Provider readback and both public resolvers agree on the replacement."
+            if public_verified
+            else (
+                "Provider readback is correct, but both public resolvers do not agree yet. "
+                "Wait for propagation and refresh DNS evidence before treating this as complete."
+            )
         ),
     )
 
@@ -325,13 +482,67 @@ class CloudflareDNSWriteProvider:
         record_type = str(plan["record_type"]).upper()
         record_name = str(plan["name"])
         zone = await get_zone_for_domain(db, domain)
-        matches = [
+        owner_matches = [
             record
             for record in zone.get("records", [])
-            if str(record.get("type") or "").upper() == record_type
-            and str(record.get("name") or "").rstrip(".").lower() == record_name.rstrip(".").lower()
+            if str(record.get("name") or "").rstrip(".").lower() == record_name.rstrip(".").lower()
         ]
+        replacement = _is_record_type_replacement(plan)
+        matches = (
+            owner_matches
+            if replacement
+            else [
+                record
+                for record in owner_matches
+                if str(record.get("type") or "").upper() == record_type
+            ]
+        )
         current_values = [str(record.get("content") or "") for record in matches]
+        if not replacement and len(owner_matches) != len(matches):
+            conflicting_types = sorted(
+                {
+                    str(record.get("type") or "").upper()
+                    for record in owner_matches
+                    if str(record.get("type") or "").upper() != record_type
+                }
+            )
+            return DNSWriteMutation(
+                operation=str(plan["operation"]).lower(),
+                record_type=record_type,
+                name=record_name,
+                content=value,
+                ttl=ttl,
+                provider=self.provider_id,
+                zone_id=zone.get("id"),
+                zone_name=zone.get("name"),
+                current_values=current_values,
+                current_record_type=_current_record_type(plan),
+                effective_value=plan.get("effective_value"),
+                blocked_reason=(
+                    "A conflicting provider record exists at this owner name "
+                    f"({', '.join(conflicting_types)}); use an explicit reviewed record-type "
+                    "migration instead of creating a conflicting record"
+                ),
+            )
+        baseline_block = _baseline_block_reason(plan=plan, records=matches)
+        if baseline_block:
+            return DNSWriteMutation(
+                operation=str(plan["operation"]).lower(),
+                record_type=record_type,
+                name=record_name,
+                content=value,
+                ttl=ttl,
+                provider=self.provider_id,
+                zone_id=zone.get("id"),
+                zone_name=zone.get("name"),
+                record_id=matches[0].get("id") if len(matches) == 1 else None,
+                current_values=current_values,
+                current_record_type=(
+                    str(matches[0].get("type") or "").upper() if len(matches) == 1 else None
+                ),
+                effective_value=plan.get("effective_value"),
+                blocked_reason=baseline_block,
+            )
         if len(matches) > 1:
             return DNSWriteMutation(
                 operation=str(plan["operation"]).lower(),
@@ -343,11 +554,13 @@ class CloudflareDNSWriteProvider:
                 zone_id=zone.get("id"),
                 zone_name=zone.get("name"),
                 current_values=current_values,
+                current_record_type=_current_record_type(plan),
+                effective_value=plan.get("effective_value"),
                 blocked_reason=(
                     "Multiple provider records match this name/type; merge them manually first"
                 ),
             )
-        if matches and current_values[0] == value:
+        if matches and not replacement and current_values[0] == value:
             operation = "noop"
         elif matches:
             operation = "update"
@@ -364,6 +577,10 @@ class CloudflareDNSWriteProvider:
             zone_name=zone.get("name"),
             record_id=matches[0].get("id") if matches else None,
             current_values=current_values,
+            current_record_type=(
+                str(matches[0].get("type") or "").upper() if matches else _current_record_type(plan)
+            ),
+            effective_value=plan.get("effective_value"),
         )
 
     async def apply_mutation(
@@ -418,6 +635,7 @@ class CloudflareDNSWriteProvider:
             records=records,
         )
         verification = _verification_from_records(mutation=mutation, records=records)
+        verification = await _verify_public_record_type_replacement(mutation, verification)
         return DNSWriteResult(
             provider=self.provider_id,
             dry_run=False,
@@ -450,13 +668,29 @@ class LexiconDNSWriteProvider:
         value = _plan_value(plan, value_override)
         record_type = str(plan["record_type"]).upper()
         record_name = str(plan["name"])
+        current_record_type = _current_record_type(plan)
         current = await asyncio.to_thread(
             self._list_records,
             domain,
-            record_type,
+            current_record_type,
             record_name,
         )
         current_values = [str(record.get("content") or "") for record in current]
+        baseline_block = _baseline_block_reason(plan=plan, records=current)
+        if baseline_block:
+            return DNSWriteMutation(
+                operation=str(plan["operation"]).lower(),
+                record_type=record_type,
+                name=record_name,
+                content=value,
+                ttl=ttl,
+                provider=self.provider_id,
+                record_id=str(current[0].get("id") or "") if len(current) == 1 else None,
+                current_values=current_values,
+                current_record_type=current_record_type,
+                effective_value=plan.get("effective_value"),
+                blocked_reason=baseline_block,
+            )
         if len(current) > 1:
             return DNSWriteMutation(
                 operation=str(plan["operation"]).lower(),
@@ -466,11 +700,17 @@ class LexiconDNSWriteProvider:
                 ttl=ttl,
                 provider=self.provider_id,
                 current_values=current_values,
+                current_record_type=current_record_type,
+                effective_value=plan.get("effective_value"),
                 blocked_reason=(
                     "Multiple provider records match this name/type; merge them manually first"
                 ),
             )
-        operation = "noop" if current_values == [value] else ("update" if current else "create")
+        operation = (
+            "noop"
+            if not _is_record_type_replacement(plan) and current_values == [value]
+            else ("update" if current else "create")
+        )
         return DNSWriteMutation(
             operation=operation,
             record_type=record_type,
@@ -480,6 +720,8 @@ class LexiconDNSWriteProvider:
             provider=self.provider_id,
             record_id=str(current[0].get("id") or "") if current else None,
             current_values=current_values,
+            current_record_type=current_record_type,
+            effective_value=plan.get("effective_value"),
         )
 
     async def apply_mutation(
@@ -511,13 +753,23 @@ class LexiconDNSWriteProvider:
             mutation.record_type,
             mutation.name,
         )
+        if mutation.current_record_type and mutation.current_record_type != mutation.record_type:
+            previous_type_records = await asyncio.to_thread(
+                self._list_records,
+                domain,
+                mutation.current_record_type,
+                mutation.name,
+            )
+            records = [*records, *previous_type_records]
+        verification = _verification_from_records(mutation=mutation, records=records)
+        verification = await _verify_public_record_type_replacement(mutation, verification)
         return DNSWriteResult(
             provider=self.provider_id,
             dry_run=False,
             applied=True,
             mutation=mutation,
             provider_result={"ok": True},
-            verification=_verification_from_records(mutation=mutation, records=records),
+            verification=verification,
         )
 
     def _client_config(self, domain: str):
@@ -608,6 +860,8 @@ def _demo_dns_mutation(
         zone_name=domain,
         record_id=demo_record_id if operation == "update" else None,
         current_values=list(plan.get("current_values") or []),
+        current_record_type=_current_record_type(plan),
+        effective_value=plan.get("effective_value"),
     )
 
 
@@ -721,6 +975,9 @@ async def apply_dns_write(
     provider_id: str,
     value_override: Optional[str] = None,
     ttl: int = 1,
+    expected_record_type: Optional[str] = None,
+    expected_current_values: Optional[List[str]] = None,
+    expected_record_id: Optional[str] = None,
 ) -> DNSWriteResult:
     """Apply one provider-backed DNS mutation after validation."""
     if get_settings().DEMO_MODE:
@@ -735,6 +992,20 @@ async def apply_dns_write(
         value_override=value_override,
         ttl=ttl,
     )
+    if expected_record_type is not None:
+        actual_type = str(mutation.current_record_type or mutation.record_type).upper()
+        if actual_type != str(expected_record_type).upper():
+            raise DNSProviderWriteError(
+                "Provider record type changed after preview; refresh and review the change again"
+            )
+    if expected_current_values is not None and mutation.current_values != expected_current_values:
+        raise DNSProviderWriteError(
+            "Provider values changed after preview; refresh and review the change again"
+        )
+    if expected_record_id is not None and mutation.record_id != expected_record_id:
+        raise DNSProviderWriteError(
+            "Provider record identity changed after preview; refresh and review the change again"
+        )
     result = await provider.apply_mutation(db, domain=domain, mutation=mutation)
     db.flush()
     return result

--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -271,6 +271,13 @@ def _is_record_type_replacement(plan: Dict[str, Any]) -> bool:
     return _current_record_type(plan) != str(plan.get("record_type") or "").upper()
 
 
+def _normalized_values(record_type: str, values: List[str]) -> List[str]:
+    """Normalize provider values only where DNS syntax permits equivalent forms."""
+    if str(record_type).upper() == "CNAME":
+        return [str(value).rstrip(".").lower() for value in values]
+    return [str(value) for value in values]
+
+
 def _baseline_block_reason(*, plan: Dict[str, Any], records: List[Dict[str, Any]]) -> Optional[str]:
     """Reject a record-type replacement unless the provider matches the reviewed baseline."""
     if not _is_record_type_replacement(plan):
@@ -285,12 +292,8 @@ def _baseline_block_reason(*, plan: Dict[str, Any], records: List[Dict[str, Any]
     actual = records[0]
     actual_type = str(actual.get("type") or "").upper()
     actual_value = str(actual.get("content") or "")
-    if expected_type == "CNAME":
-        actual_values = [actual_value.rstrip(".").lower()]
-        normalized_expected_values = [value.rstrip(".").lower() for value in expected_values]
-    else:
-        actual_values = [actual_value]
-        normalized_expected_values = expected_values
+    actual_values = _normalized_values(expected_type, [actual_value])
+    normalized_expected_values = _normalized_values(expected_type, expected_values)
     if actual_type != expected_type or actual_values != normalized_expected_values:
         return (
             "Provider state differs from the reviewed CNAME baseline; refresh and preview the "
@@ -362,7 +365,10 @@ def _noop_verification(mutation: DNSWriteMutation) -> DNSWriteVerification:
         message=(
             "Provider already has the expected DNS value."
             if verified
-            else "Provider preview marked this record unchanged, but the expected value was not present."
+            else (
+                "Provider preview marked this record unchanged, but the expected value was not "
+                "present."
+            )
         ),
     )
 
@@ -691,6 +697,24 @@ class LexiconDNSWriteProvider:
                 effective_value=plan.get("effective_value"),
                 blocked_reason=baseline_block,
             )
+        if _is_record_type_replacement(plan):
+            return DNSWriteMutation(
+                operation=str(plan["operation"]).lower(),
+                record_type=record_type,
+                name=record_name,
+                content=value,
+                ttl=ttl,
+                provider=self.provider_id,
+                record_id=str(current[0].get("id") or "") if current else None,
+                current_values=current_values,
+                current_record_type=current_record_type,
+                effective_value=plan.get("effective_value"),
+                blocked_reason=(
+                    f"Provider '{self.provider_id}' cannot safely replace a DNS record type "
+                    "through the generic connector. Remove the CNAME and create the reviewed "
+                    "TXT record manually, or use a provider connector with atomic type changes."
+                ),
+            )
         if len(current) > 1:
             return DNSWriteMutation(
                 operation=str(plan["operation"]).lower(),
@@ -998,10 +1022,14 @@ async def apply_dns_write(
             raise DNSProviderWriteError(
                 "Provider record type changed after preview; refresh and review the change again"
             )
-    if expected_current_values is not None and mutation.current_values != expected_current_values:
-        raise DNSProviderWriteError(
-            "Provider values changed after preview; refresh and review the change again"
-        )
+    if expected_current_values is not None:
+        comparison_type = str(expected_record_type or mutation.current_record_type or "")
+        actual_values = _normalized_values(comparison_type, mutation.current_values)
+        reviewed_values = _normalized_values(comparison_type, expected_current_values)
+        if actual_values != reviewed_values:
+            raise DNSProviderWriteError(
+                "Provider values changed after preview; refresh and review the change again"
+            )
     if expected_record_id is not None and mutation.record_id != expected_record_id:
         raise DNSProviderWriteError(
             "Provider record identity changed after preview; refresh and review the change again"

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -2611,6 +2611,7 @@ function domainDetailsApp(domainId = '') {
             const previousValues = mutation.current_values || [];
             const previousText = previousValues.length ? previousValues.join('\n') : 'None captured by the provider preview.';
             const proposedText = mutation.content || 'No proposed value available.';
+            const previousType = mutation.current_record_type || mutation.record_type || 'unknown';
             const rollbackText = preview?.rollback?.summary || 'Review provider history before reverting this DNS record.';
             const provider = this.providerName(preview?.provider || mutation.provider || this.dnsWrite.provider);
             return [
@@ -2619,11 +2620,12 @@ function domainDetailsApp(domainId = '') {
                 `Provider: ${provider}`,
                 `Operation: ${mutation.operation || 'unknown'}`,
                 `Record: ${mutation.name || 'unknown'}`,
-                `Type: ${mutation.record_type || 'unknown'}`,
+                `Record type: ${previousType}${previousType !== mutation.record_type ? ` -> ${mutation.record_type}` : ''}`,
                 `TTL: ${mutation.ttl || 'provider default'}`,
                 '',
-                'Previous value:',
+                `Previous ${previousType} value:`,
                 previousText,
+                ...(mutation.effective_value ? ['', 'Inherited effective DMARC policy:', mutation.effective_value] : []),
                 '',
                 'Proposed value:',
                 proposedText,
@@ -2658,7 +2660,10 @@ function domainDetailsApp(domainId = '') {
                         provider: this.dnsWrite.provider,
                         allow_provider_mismatch: this.dnsWrite.allowProviderMismatch,
                         dry_run: !apply,
-                        confirm: apply
+                        confirm: apply,
+                        expected_record_type: apply ? this.dnsWrite.preview?.mutation?.current_record_type : null,
+                        expected_current_values: apply ? this.dnsWrite.preview?.mutation?.current_values : null,
+                        expected_record_id: apply ? this.dnsWrite.preview?.mutation?.record_id : null
                     })
                 });
                 const data = await response.json();

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -2663,7 +2663,8 @@ function domainDetailsApp(domainId = '') {
                         confirm: apply,
                         expected_record_type: apply ? this.dnsWrite.preview?.mutation?.current_record_type : null,
                         expected_current_values: apply ? this.dnsWrite.preview?.mutation?.current_values : null,
-                        expected_record_id: apply ? this.dnsWrite.preview?.mutation?.record_id : null
+                        expected_record_id: apply ? this.dnsWrite.preview?.mutation?.record_id : null,
+                        expected_proposed_value: apply ? this.dnsWrite.preview?.mutation?.content : null
                     })
                 });
                 const data = await response.json();

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2419,14 +2419,21 @@
                                                 <p class="font-semibold">What changes</p>
                                                 <template x-if="plan.current_values && plan.current_values.length">
                                                     <div class="mt-2">
-                                                        <p class="font-medium">Before</p>
+                                                        <p class="font-medium">Before <span x-show="plan.current_record_type" x-text="'(' + plan.current_record_type + ')' "></span></p>
                                                         <template x-for="value in plan.current_values" :key="value">
                                                             <code class="mt-1 block break-all rounded bg-base-200 p-2" x-text="value"></code>
                                                         </template>
                                                     </div>
                                                 </template>
+                                                <template x-if="plan.effective_value">
+                                                    <div class="mt-2">
+                                                        <p class="font-medium">Inherited effective DMARC policy</p>
+                                                        <code class="mt-1 block break-all rounded bg-base-200 p-2" x-text="plan.effective_value"></code>
+                                                        <p class="mt-1 text-base-content/65">This shared target is evidence only and will not be edited.</p>
+                                                    </div>
+                                                </template>
                                                 <template x-if="plan.proposed_value">
-                                                    <div class="mt-2"><p class="font-medium">After</p><code class="mt-1 block break-all rounded bg-base-200 p-2" x-text="plan.proposed_value"></code></div>
+                                                    <div class="mt-2"><p class="font-medium">After <span x-text="'(' + plan.record_type + ')' "></span></p><code class="mt-1 block break-all rounded bg-base-200 p-2" x-text="plan.proposed_value"></code></div>
                                                 </template>
                                                 <ul class="mt-2 list-disc space-y-1 pl-4"><template x-for="change in plan.changes" :key="change"><li x-text="change"></li></template></ul>
                                                 <p class="mt-2"><span class="font-semibold">Why:</span> <span x-text="plan.rationale"></span></p>
@@ -2491,7 +2498,7 @@
                                                     </div>
                                                     <div class="mt-2 grid gap-2 sm:grid-cols-2">
                                                         <div>
-                                                            <p class="font-semibold">Before</p>
+                                                            <p class="font-semibold">Before <span x-show="dnsWrite.preview.mutation.current_record_type" x-text="'(' + dnsWrite.preview.mutation.current_record_type + ')' "></span></p>
                                                             <template x-if="dnsWrite.preview.mutation.current_values && dnsWrite.preview.mutation.current_values.length">
                                                                 <template x-for="value in dnsWrite.preview.mutation.current_values" :key="value">
                                                                     <code class="mt-1 block break-all rounded bg-white/70 p-2" x-text="value"></code>
@@ -2500,10 +2507,16 @@
                                                             <p x-show="!dnsWrite.preview.mutation.current_values || !dnsWrite.preview.mutation.current_values.length" class="mt-1 text-base-content/70">No matching record exists; this will create one.</p>
                                                         </div>
                                                         <div>
-                                                            <p class="font-semibold">After</p>
+                                                            <p class="font-semibold">After <span x-text="'(' + dnsWrite.preview.mutation.record_type + ')' "></span></p>
                                                             <code class="mt-1 block break-all rounded bg-white/70 p-2" x-text="dnsWrite.preview.mutation.content"></code>
                                                         </div>
                                                     </div>
+                                                    <template x-if="dnsWrite.preview.mutation.effective_value">
+                                                        <div class="mt-2 rounded bg-white/70 p-2">
+                                                            <p class="font-semibold">Inherited effective DMARC policy (unchanged shared target)</p>
+                                                            <code class="mt-1 block break-all" x-text="dnsWrite.preview.mutation.effective_value"></code>
+                                                        </div>
+                                                    </template>
                                                     <template x-if="dnsWrite.preview.verification && dnsWrite.preview.verification.status !== 'not_run'">
                                                         <div class="mt-2 rounded bg-white/70 p-2">
                                                             <p>
@@ -2522,7 +2535,7 @@
                                                             </p>
                                                             <template x-if="dnsWrite.preview.rollback.previous_values && dnsWrite.preview.rollback.previous_values.length">
                                                                 <div class="mt-2">
-                                                                    <p class="font-semibold">Previous value</p>
+                                                                    <p class="font-semibold">Previous <span x-text="dnsWrite.preview.rollback.previous_record_type || dnsWrite.preview.rollback.record_type"></span> value</p>
                                                                     <template x-for="value in dnsWrite.preview.rollback.previous_values" :key="value">
                                                                         <code class="mt-1 block break-all rounded bg-base-200 p-2" x-text="value"></code>
                                                                     </template>

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -39,6 +39,7 @@ from app.services.dns_provider_writes import (
     CloudflareDNSWriteProvider,
     DNSProviderWriteError,
     DNSWriteMutation,
+    DNSWriteVerification,
     LexiconDNSWriteProvider,
 )
 from app.services.organizations import OrganizationPlanLimitError
@@ -2911,6 +2912,29 @@ def _dns_plan(plan_id="dmarc-missing-example-com-txt", operation="create", propo
     }
 
 
+def _cname_migration_plan():
+    current = "v=DMARC1; p=reject; rua=mailto:shared@example.net; aspf=s"
+    return {
+        **_dns_plan(
+            plan_id="dmarc-report-destination-cname-migration-dmarc-example-com-txt",
+            operation="update",
+            proposed_value=(
+                "v=DMARC1; p=reject; "
+                "rua=mailto:shared@example.net,mailto:dmarc@example.com; aspf=s"
+            ),
+        ),
+        "finding_code": "dmarc_report_destination_cname_migration",
+        "current_record_type": "CNAME",
+        "current_values": ["_dmarc.shared.example.net"],
+        "effective_value": current,
+        "shared_record_target": "_dmarc.shared.example.net",
+        "rollback": (
+            "Replace the local TXT record with the previous CNAME to "
+            "_dmarc.shared.example.net; do not edit the shared target."
+        ),
+    }
+
+
 def _dns_guidance_with_plan(plan):
     return {
         "domain": DOMAIN,
@@ -3174,6 +3198,88 @@ def test_dns_change_plan_apply_dry_run_returns_cloudflare_mutation(
     assert data["rollback"]["name"] == f"_dmarc.{DOMAIN}"
     assert data["rollback"]["requires_manual_review"] is True
     assert "Delete the created record" in " ".join(data["rollback"]["steps"])
+
+
+def test_dns_change_plan_previews_cname_to_txt_replacement(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _cname_migration_plan()
+    records = [
+        _record(
+            "dmarc-cname",
+            "CNAME",
+            f"_dmarc.{DOMAIN}",
+            "_dmarc.shared.example.net.",
+        )
+    ]
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": records}),
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={"plan_id": plan["plan_id"], "provider": "cloudflare"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mutation"]["operation"] == "update"
+    assert data["mutation"]["record_id"] == "dmarc-cname"
+    assert data["mutation"]["current_record_type"] == "CNAME"
+    assert data["mutation"]["record_type"] == "TXT"
+    assert data["mutation"]["current_values"] == ["_dmarc.shared.example.net."]
+    assert data["mutation"]["effective_value"] == plan["effective_value"]
+    assert data["rollback"]["previous_record_type"] == "CNAME"
+    assert "Replace the TXT record" in " ".join(data["rollback"]["steps"])
+    assert "Do not edit the shared" in " ".join(data["rollback"]["steps"])
+
+
+def test_dns_change_plan_blocks_cname_migration_when_provider_baseline_drifted(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN))
+    db_session.commit()
+    plan = _cname_migration_plan()
+    records = [
+        _record(
+            "dmarc-cname",
+            "CNAME",
+            f"_dmarc.{DOMAIN}",
+            "_dmarc.changed.example.net",
+        )
+    ]
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": records}),
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={"plan_id": plan["plan_id"], "provider": "cloudflare"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["mutation"]["applicable"] is False
+    assert (
+        "differs from the reviewed CNAME baseline" in response.json()["mutation"]["blocked_reason"]
+    )
 
 
 def test_dns_change_plan_apply_uses_resolved_domain_for_provider_calls(
@@ -3465,6 +3571,99 @@ def test_dns_change_plan_apply_updates_cloudflare_and_audits(
     assert audit_details["verification"]["status"] == "verified"
     assert audit_details["verification"]["verified"] is True
     assert audit_details["rollback"]["previous_values"] == ["v=DMARC1; p=none"]
+
+
+def test_dns_change_plan_applies_reviewed_cname_to_txt_migration_and_audits(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN, verified=True))
+    db_session.commit()
+    plan = _cname_migration_plan()
+    original = _record(
+        "dmarc-cname",
+        "CNAME",
+        f"_dmarc.{DOMAIN}",
+        "_dmarc.shared.example.net",
+    )
+    provider = FakeWriteCloudflareProvider(
+        zones=[{"id": "zone-1", "name": DOMAIN}],
+        records=[original],
+    )
+
+    async def keep_provider_verification(_mutation, verification):
+        return verification
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": [original]}),
+        ),
+        patch(
+            "app.services.dns_provider_writes.build_cloudflare_provider",
+            return_value=provider,
+        ),
+        patch(
+            "app.services.dns_provider_writes._verify_public_record_type_replacement",
+            new=keep_provider_verification,
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={
+                "plan_id": plan["plan_id"],
+                "provider": "cloudflare",
+                "dry_run": False,
+                "confirm": True,
+                "expected_record_type": "CNAME",
+                "expected_current_values": ["_dmarc.shared.example.net"],
+                "expected_record_id": "dmarc-cname",
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["applied"] is True
+    assert data["verification"]["verified"] is True
+    assert provider.updated[0]["id"] == "dmarc-cname"
+    assert provider.updated[0]["type"] == "TXT"
+    assert provider.updated[0]["content"] == plan["proposed_value"]
+    assert data["rollback"]["previous_record_type"] == "CNAME"
+    audit = db_session.query(WorkspaceAuditLog).one()
+    details = json.loads(audit.details)
+    assert details["mutation"]["current_record_type"] == "CNAME"
+    assert details["mutation"]["effective_value"] == plan["effective_value"]
+    assert details["rollback"]["previous_record_type"] == "CNAME"
+
+
+def test_dns_change_plan_requires_reviewed_baseline_for_cname_migration_apply(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN, verified=True))
+    db_session.commit()
+    plan = _cname_migration_plan()
+
+    with patch(
+        "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+        new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={
+                "plan_id": plan["plan_id"],
+                "provider": "cloudflare",
+                "dry_run": False,
+                "confirm": True,
+            },
+        )
+
+    assert response.status_code == 422
+    assert "Preview this record-type migration again" in response.json()["detail"]
 
 
 def test_dns_change_plan_apply_reports_unverified_provider_readback(
@@ -3782,6 +3981,91 @@ def test_cloudflare_write_provider_creates_record_and_syncs_history(db_session):
     assert result.verification.verified is True
     assert result.changes[0]["change_type"] == "added"
     assert db_session.query(DNSRecordChange).count() == 1
+
+
+def test_record_type_replacement_waits_for_both_public_resolvers():
+    mutation = DNSWriteMutation(
+        operation="update",
+        record_type="TXT",
+        name=f"_dmarc.{DOMAIN}",
+        content="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        ttl=1,
+        provider="cloudflare",
+        current_record_type="CNAME",
+        current_values=["_dmarc.shared.example.net"],
+    )
+    provider_verification = DNSWriteVerification(
+        status="verified",
+        verified=True,
+        checked_values=[mutation.content],
+    )
+
+    async def resolver_check(_mutation, nameserver):
+        return {
+            "resolver": nameserver,
+            "status": "verified" if nameserver == "1.1.1.1" else "propagation_pending",
+            "verified": nameserver == "1.1.1.1",
+            "values": [mutation.content] if nameserver == "1.1.1.1" else [],
+        }
+
+    with patch(
+        "app.services.dns_provider_writes._public_resolver_record_check",
+        new=resolver_check,
+    ):
+        verification = asyncio.run(
+            dns_provider_writes._verify_public_record_type_replacement(  # pylint: disable=protected-access
+                mutation,
+                provider_verification,
+            )
+        )
+
+    assert verification.status == "propagation_pending"
+    assert verification.verified is False
+    assert len(verification.resolver_checks) == 2
+    assert "both public resolvers do not agree yet" in verification.message
+
+
+def test_record_type_replacement_is_verified_when_both_public_resolvers_agree():
+    mutation = DNSWriteMutation(
+        operation="update",
+        record_type="TXT",
+        name=f"_dmarc.{DOMAIN}",
+        content="v=DMARC1; p=reject; rua=mailto:dmarc@example.com",
+        ttl=1,
+        provider="cloudflare",
+        current_record_type="CNAME",
+        current_values=["_dmarc.shared.example.net"],
+    )
+    provider_verification = DNSWriteVerification(
+        status="verified",
+        verified=True,
+        checked_values=[mutation.content],
+    )
+
+    async def resolver_check(_mutation, nameserver):
+        return {
+            "resolver": nameserver,
+            "status": "verified",
+            "verified": True,
+            "values": [mutation.content],
+            "previous_type_present": False,
+        }
+
+    with patch(
+        "app.services.dns_provider_writes._public_resolver_record_check",
+        new=resolver_check,
+    ):
+        verification = asyncio.run(
+            dns_provider_writes._verify_public_record_type_replacement(  # pylint: disable=protected-access
+                mutation,
+                provider_verification,
+            )
+        )
+
+    assert verification.status == "verified"
+    assert verification.verified is True
+    assert len(verification.resolver_checks) == 2
+    assert "both public resolvers agree" in verification.message
 
 
 def test_cloudflare_write_provider_blocks_inapplicable_mutation(db_session):

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -3620,8 +3620,9 @@ def test_dns_change_plan_applies_reviewed_cname_to_txt_migration_and_audits(
                 "dry_run": False,
                 "confirm": True,
                 "expected_record_type": "CNAME",
-                "expected_current_values": ["_dmarc.shared.example.net"],
+                "expected_current_values": ["_dmarc.shared.example.net."],
                 "expected_record_id": "dmarc-cname",
+                "expected_proposed_value": plan["proposed_value"],
             },
         )
 
@@ -3638,6 +3639,56 @@ def test_dns_change_plan_applies_reviewed_cname_to_txt_migration_and_audits(
     assert details["mutation"]["current_record_type"] == "CNAME"
     assert details["mutation"]["effective_value"] == plan["effective_value"]
     assert details["rollback"]["previous_record_type"] == "CNAME"
+
+
+def test_dns_change_plan_apply_rejects_tampered_cname_migration_value(
+    authed_client: TestClient,
+    db_session,
+):
+    db_session.add(Domain(name=DOMAIN, verified=True))
+    db_session.commit()
+    plan = _cname_migration_plan()
+    original = _record(
+        "dmarc-cname",
+        "CNAME",
+        f"_dmarc.{DOMAIN}",
+        "_dmarc.shared.example.net",
+    )
+
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains._build_domain_dns_guidance",
+            new=AsyncMock(return_value=_dns_guidance_with_plan(plan)),
+        ),
+        patch(
+            "app.services.dns_provider_writes.get_zone_for_domain",
+            new=AsyncMock(return_value={"id": "zone-1", "name": DOMAIN, "records": [original]}),
+        ),
+        patch(
+            "app.services.dns_provider_writes.build_cloudflare_provider",
+            return_value=FakeWriteCloudflareProvider(
+                zones=[{"id": "zone-1", "name": DOMAIN}],
+                records=[original],
+            ),
+        ),
+    ):
+        response = authed_client.post(
+            f"/api/v1/domains/{DOMAIN}/dns/change-plan/apply",
+            json={
+                "plan_id": plan["plan_id"],
+                "provider": "cloudflare",
+                "dry_run": False,
+                "confirm": True,
+                "value": "v=DMARC1; p=reject",
+                "expected_record_type": "CNAME",
+                "expected_current_values": ["_dmarc.shared.example.net"],
+                "expected_record_id": "dmarc-cname",
+                "expected_proposed_value": plan["proposed_value"],
+            },
+        )
+
+    assert response.status_code == 422
+    assert "Proposed DNS value changed after preview" in response.json()["detail"]
 
 
 def test_dns_change_plan_requires_reviewed_baseline_for_cname_migration_apply(
@@ -4230,6 +4281,28 @@ def test_lexicon_write_provider_blocks_duplicate_records(db_session):
     assert mutation.applicable is False
     assert mutation.current_values == ["v=DMARC1; p=none", "v=DMARC1; p=reject"]
     assert "Multiple provider records" in mutation.blocked_reason
+
+
+def test_lexicon_write_provider_blocks_record_type_replacements(db_session):
+    provider = LexiconDNSWriteProvider("route53")
+    provider._list_records = lambda domain, record_type, record_name: [  # pylint: disable=protected-access
+        {"id": "record-1", "content": "_dmarc.shared.example.net"}
+    ]
+
+    with patch("app.services.dns_provider_writes.lexicon_runtime_available", return_value=True):
+        mutation = asyncio.run(
+            provider.prepare_mutation(
+                db_session,
+                domain=DOMAIN,
+                plan=_cname_migration_plan(),
+                value_override=None,
+                ttl=1,
+            )
+        )
+
+    assert mutation.applicable is False
+    assert mutation.record_id == "record-1"
+    assert "record-type replacements" in mutation.blocked_reason
 
 
 def test_cloudflare_discover_denies_user_without_workspace_membership(

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -7,6 +7,8 @@ import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import dns.exception
+import dns.resolver
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -3584,7 +3586,7 @@ def test_dns_change_plan_applies_reviewed_cname_to_txt_migration_and_audits(
         "dmarc-cname",
         "CNAME",
         f"_dmarc.{DOMAIN}",
-        "_dmarc.shared.example.net",
+        "_DMARC.SHARED.EXAMPLE.NET.",
     )
     provider = FakeWriteCloudflareProvider(
         zones=[{"id": "zone-1", "name": DOMAIN}],
@@ -4068,6 +4070,121 @@ def test_record_type_replacement_is_verified_when_both_public_resolvers_agree():
     assert "both public resolvers agree" in verification.message
 
 
+class _FakePublicResolver:
+    def __init__(self, answers):
+        self.answers = answers
+        self.nameservers = []
+        self.timeout = 0
+        self.lifetime = 0
+
+    async def resolve(self, _name, record_type):
+        result = self.answers[record_type]
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+def _public_resolver_check(mutation, answers):
+    resolver = _FakePublicResolver(answers)
+    with patch("dns.asyncresolver.Resolver", return_value=resolver):
+        return asyncio.run(
+            dns_provider_writes._public_resolver_record_check(  # pylint: disable=protected-access
+                mutation,
+                "1.1.1.1",
+            )
+        )
+
+
+def test_public_resolver_check_joins_txt_strings_and_accepts_absent_previous_type():
+    mutation = DNSWriteMutation(
+        operation="update",
+        record_type="TXT",
+        name=f"_dmarc.{DOMAIN}",
+        content="v=DMARC1; p=reject",
+        ttl=1,
+        provider="cloudflare",
+        current_record_type="CNAME",
+    )
+
+    result = _public_resolver_check(
+        mutation,
+        {
+            "TXT": [SimpleNamespace(strings=(b"v=DMARC1; ", b"p=reject"))],
+            "CNAME": dns.resolver.NoAnswer(),
+        },
+    )
+
+    assert result["verified"] is True
+    assert result["values"] == [mutation.content]
+    assert result["previous_type_present"] is False
+
+
+@pytest.mark.parametrize("missing_answer", ["nxdomain", "noanswer"])
+def test_public_resolver_check_treats_missing_expected_record_as_pending(missing_answer):
+    missing = dns.resolver.NXDOMAIN() if missing_answer == "nxdomain" else dns.resolver.NoAnswer()
+    mutation = DNSWriteMutation(
+        operation="update",
+        record_type="TXT",
+        name=f"_dmarc.{DOMAIN}",
+        content="v=DMARC1; p=reject",
+        ttl=1,
+        provider="cloudflare",
+        current_record_type="CNAME",
+    )
+
+    result = _public_resolver_check(
+        mutation,
+        {"TXT": missing, "CNAME": dns.resolver.NoAnswer()},
+    )
+
+    assert result["status"] == "propagation_pending"
+    assert result["verified"] is False
+    assert result["values"] == []
+
+
+@pytest.mark.parametrize("lookup_error", [OSError("offline"), pytest.param("timeout", id="dns")])
+def test_public_resolver_check_reports_lookup_errors_as_unavailable(lookup_error):
+    error = dns.exception.Timeout() if lookup_error == "timeout" else lookup_error
+    mutation = DNSWriteMutation(
+        operation="update",
+        record_type="TXT",
+        name=f"_dmarc.{DOMAIN}",
+        content="v=DMARC1; p=reject",
+        ttl=1,
+        provider="cloudflare",
+        current_record_type="CNAME",
+    )
+
+    result = _public_resolver_check(mutation, {"TXT": error})
+
+    assert result["status"] == "unavailable"
+    assert result["verified"] is False
+
+
+def test_public_resolver_check_rejects_visible_previous_record_type():
+    mutation = DNSWriteMutation(
+        operation="update",
+        record_type="TXT",
+        name=f"_dmarc.{DOMAIN}",
+        content="v=DMARC1; p=reject",
+        ttl=1,
+        provider="cloudflare",
+        current_record_type="CNAME",
+    )
+
+    result = _public_resolver_check(
+        mutation,
+        {
+            "TXT": [SimpleNamespace(strings=(mutation.content.encode(),))],
+            "CNAME": [SimpleNamespace()],
+        },
+    )
+
+    assert result["status"] == "propagation_pending"
+    assert result["previous_type_present"] is True
+    assert result["verified"] is False
+
+
 def test_cloudflare_write_provider_blocks_inapplicable_mutation(db_session):
     provider = CloudflareDNSWriteProvider()
     mutation = DNSWriteMutation(
@@ -4183,6 +4300,32 @@ def test_lexicon_write_provider_rejects_failed_apply(db_session):
         )
         with pytest.raises(DNSProviderWriteError, match="did not apply"):
             asyncio.run(provider.apply_mutation(db_session, domain=DOMAIN, mutation=mutation))
+
+
+def test_lexicon_write_provider_blocks_record_type_replacements(db_session):
+    provider = LexiconDNSWriteProvider("route53")
+    provider._list_records = lambda domain, record_type, record_name: [  # pylint: disable=protected-access
+        {
+            "id": "record-1",
+            "type": "CNAME",
+            "name": f"_dmarc.{DOMAIN}",
+            "content": "_dmarc.shared.example.net.",
+        }
+    ]
+
+    with patch("app.services.dns_provider_writes.lexicon_runtime_available", return_value=True):
+        mutation = asyncio.run(
+            provider.prepare_mutation(
+                db_session,
+                domain=DOMAIN,
+                plan=_cname_migration_plan(),
+                value_override=None,
+                ttl=300,
+            )
+        )
+
+    assert mutation.applicable is False
+    assert "cannot safely replace a DNS record type" in mutation.blocked_reason
 
 
 def test_lexicon_write_provider_prepares_noop_for_matching_record(db_session):

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2441,6 +2441,11 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
     assert "dnsWritePreviewMatches(plan)" in script
     assert "dnsWriteErrorMessage(detail, apply)" in script
     assert "Zone:Read, DNS:Read, and DNS:Edit" in script
+    assert "Inherited effective DMARC policy" in template
+    assert "previous_record_type" in template
+    assert "expected_record_type" in script
+    assert "expected_current_values" in script
+    assert "expected_record_id" in script
     assert "x-html" not in template
 
 

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2446,6 +2446,7 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
     assert "expected_record_type" in script
     assert "expected_current_values" in script
     assert "expected_record_id" in script
+    assert "expected_proposed_value" in script
     assert "x-html" not in template
 
 

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -331,7 +331,7 @@ async def test_authorized_external_report_destination_gets_additive_plan():
 
 
 @pytest.mark.asyncio
-async def test_cname_dmarc_policy_does_not_offer_destructive_txt_replacement():
+async def test_cname_dmarc_policy_offers_safe_local_txt_migration():
     provider = FakeDNSProvider({})
     provider._cnames["_dmarc.example.com"] = "_dmarc.shared.example.net"
     current = "v=DMARC1; p=reject; rua=mailto:shared@example.net"
@@ -347,15 +347,29 @@ async def test_cname_dmarc_policy_does_not_offer_destructive_txt_replacement():
     )
 
     finding = next(
-        item for item in guidance.findings if item.code == "dmarc_report_destination_inherited"
+        item
+        for item in guidance.findings
+        if item.code == "dmarc_report_destination_cname_migration"
     )
-    assert finding.primary_eligible is False
-    assert "_dmarc.shared.example.net" in finding.detail
-    assert not [
-        plan
-        for plan in guidance.change_plans
-        if plan.name == "_dmarc.example.com" and plan.proposed_value != current
-    ]
+    assert finding.primary_eligible is True
+    assert finding.current_record_type == "CNAME"
+    assert finding.current_record_values == ["_dmarc.shared.example.net"]
+    assert finding.effective_value == current
+    plan = next(
+        item
+        for item in guidance.change_plans
+        if item.finding_code == "dmarc_report_destination_cname_migration"
+    )
+    assert plan.operation == "update"
+    assert plan.current_record_type == "CNAME"
+    assert plan.record_type == "TXT"
+    assert plan.current_values == ["_dmarc.shared.example.net"]
+    assert plan.effective_value == current
+    assert plan.proposed_value == (
+        "v=DMARC1; p=reject; " "rua=mailto:shared@example.net,mailto:reports@example.com"
+    )
+    assert "Leave the shared DMARC target unchanged." in plan.changes
+    assert "previous CNAME" in plan.rollback
 
 
 @pytest.mark.asyncio
@@ -381,10 +395,71 @@ async def test_cached_cname_dmarc_policy_keeps_inherited_finding():
     )
 
     finding = next(
+        item
+        for item in guidance.findings
+        if item.code == "dmarc_report_destination_cname_migration"
+    )
+    assert finding.primary_eligible is True
+    assert "_dmarc.shared.example.net" in finding.detail
+    assert guidance.change_plans[0].current_record_type == "CNAME"
+
+
+@pytest.mark.asyncio
+async def test_treewalk_policy_does_not_offer_record_type_migration():
+    provider = FakeDNSProvider({})
+    current = "v=DMARC1; p=reject; rua=mailto:shared@example.net"
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record=current,
+        dmarc_record_kind="treewalk",
+        dmarc_policy_domain="example.com",
+        spf=True,
+    )
+
+    guidance = await build_dns_guidance(
+        "mail.example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="reports@mail.example.com"),
+        allow_live=False,
+    )
+
+    assert "dmarc_report_destination_cname_migration" not in {
+        item.code for item in guidance.findings
+    }
+    inherited = next(
         item for item in guidance.findings if item.code == "dmarc_report_destination_inherited"
     )
-    assert finding.primary_eligible is False
-    assert "_dmarc.shared.example.net" in finding.detail
+    assert inherited.primary_eligible is False
+
+
+@pytest.mark.asyncio
+async def test_cname_policy_with_local_mailbox_is_already_complete():
+    provider = FakeDNSProvider({})
+    current = "v=DMARC1; p=reject; rua=mailto:reports@example.com"
+    dns = DomainDNSResult(
+        dmarc=True,
+        dmarc_record=current,
+        dmarc_record_kind="cname",
+        dmarc_cname_target="_dmarc.shared.example.net",
+        spf=True,
+    )
+
+    guidance = await build_dns_guidance(
+        "example.com",
+        provider,
+        dns,
+        MTAStsResult(status="pass"),
+        BIMIResult(status="pass"),
+        setup_defaults=MailAuthSetupDefaults(report_mailbox="reports@example.com"),
+        allow_live=False,
+    )
+
+    assert "dmarc_report_destination_cname_migration" not in {
+        item.code for item in guidance.findings
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -401,7 +401,12 @@ async def test_cached_cname_dmarc_policy_keeps_inherited_finding():
     )
     assert finding.primary_eligible is True
     assert "_dmarc.shared.example.net" in finding.detail
-    assert guidance.change_plans[0].current_record_type == "CNAME"
+    plan = next(
+        item
+        for item in guidance.change_plans
+        if item.finding_code == "dmarc_report_destination_cname_migration"
+    )
+    assert plan.current_record_type == "CNAME"
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_dns_guidance.py
+++ b/backend/app/tests/test_dns_guidance.py
@@ -401,7 +401,12 @@ async def test_cached_cname_dmarc_policy_keeps_inherited_finding():
     )
     assert finding.primary_eligible is True
     assert "_dmarc.shared.example.net" in finding.detail
-    assert guidance.change_plans[0].current_record_type == "CNAME"
+    migration_plan = next(
+        plan
+        for plan in guidance.change_plans
+        if plan.finding_code == "dmarc_report_destination_cname_migration"
+    )
+    assert migration_plan.current_record_type == "CNAME"
 
 
 @pytest.mark.asyncio

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -802,8 +802,11 @@ history where the provider supports it. Apply responses also include a
 `1.1.1.1` and `8.8.8.8`; provider success alone leaves the result in
 `propagation_pending`. Treat a repair as complete only when
 `verification.verified=true`;
-otherwise the mutation was submitted but the provider readback did not yet show
-the expected DNS value. The same response includes a `rollback` object with a
+`false` means either that provider readback did not return the exclusive expected
+value, or that provider readback succeeded while one or both public resolvers have
+not converged yet. Inspect `verification.status`, `message`, and `resolver_checks`
+to distinguish a failed provider readback from `propagation_pending`; do not roll
+back solely because public DNS is still propagating. The same response includes a `rollback` object with a
 summary, manual steps, captured `previous_values` when available, and
 `previous_record_type` for record-type migrations, plus
 `requires_manual_review=true`. DMARQ does not automatically roll back provider

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -782,10 +782,11 @@ change plans. This flow does not modify Postmark or DNS records.
 `POST /domains/{domain_id}/dns/change-plan/apply` accepts
 `plan_id`, `provider`, `dry_run`, `confirm`, optional `value`, `ttl`, and
 `allow_provider_mismatch`. Record-type migrations additionally submit the
-previewed `expected_record_type`, `expected_current_values`, and
-`expected_record_id`, so apply fails closed if provider state changed after
-review. Calls default to dry-run. Real writes require
-`dry_run=false` and `confirm=true`, and are limited to safe TXT/CNAME
+previewed `expected_record_type`, `expected_current_values`,
+`expected_record_id`, and `expected_proposed_value`, so apply fails closed if
+provider state or the reviewed proposed value changed after review. Calls
+default to dry-run. Real writes require `dry_run=false` and `confirm=true`,
+and are limited to safe TXT/CNAME
 create/update plans that already have a concrete value. In demo mode, confirmed
 applies return a simulated provider result and verification evidence without
 contacting a DNS provider or changing live DNS. If
@@ -802,8 +803,9 @@ history where the provider supports it. Apply responses also include a
 `1.1.1.1` and `8.8.8.8`; provider success alone leaves the result in
 `propagation_pending`. Treat a repair as complete only when
 `verification.verified=true`;
-otherwise the mutation was submitted but the provider readback did not yet show
-the expected DNS value. The same response includes a `rollback` object with a
+otherwise the mutation was submitted but provider readback did not show the
+expected DNS value, or provider readback succeeded while public resolver
+propagation has not converged yet. The same response includes a `rollback` object with a
 summary, manual steps, captured `previous_values` when available, and
 `previous_record_type` for record-type migrations, plus
 `requires_manual_review=true`. DMARQ does not automatically roll back provider

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -781,7 +781,10 @@ change plans. This flow does not modify Postmark or DNS records.
 
 `POST /domains/{domain_id}/dns/change-plan/apply` accepts
 `plan_id`, `provider`, `dry_run`, `confirm`, optional `value`, `ttl`, and
-`allow_provider_mismatch`. Calls default to dry-run. Real writes require
+`allow_provider_mismatch`. Record-type migrations additionally submit the
+previewed `expected_record_type`, `expected_current_values`, and
+`expected_record_id`, so apply fails closed if provider state changed after
+review. Calls default to dry-run. Real writes require
 `dry_run=false` and `confirm=true`, and are limited to safe TXT/CNAME
 create/update plans that already have a concrete value. In demo mode, confirmed
 applies return a simulated provider result and verification evidence without
@@ -795,10 +798,14 @@ Applied changes are written to the workspace audit log, including provider
 mismatch override details when present, and refresh provider-backed DNS change
 history where the provider supports it. Apply responses also include a
 `verification` object with `status`, `verified`, `checked_values`, and
-`message`. Treat a repair as complete only when `verification.verified=true`;
+`message`. CNAME-to-TXT migrations also include per-resolver checks for
+`1.1.1.1` and `8.8.8.8`; provider success alone leaves the result in
+`propagation_pending`. Treat a repair as complete only when
+`verification.verified=true`;
 otherwise the mutation was submitted but the provider readback did not yet show
 the expected DNS value. The same response includes a `rollback` object with a
 summary, manual steps, captured `previous_values` when available, and
+`previous_record_type` for record-type migrations, plus
 `requires_manual_review=true`. DMARQ does not automatically roll back provider
 writes; operators should use this evidence to restore the prior value only
 after confirming the rollback is still safe.

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -336,10 +336,16 @@ destination domain to authorize reports first. DMARQ checks the required
 `<policy-domain>._report._dmarc.<destination-domain>` TXT record and keeps the
 `rua` update manual until a `v=DMARC1` authorization value is visible.
 
-When `_dmarc.<domain>` is a CNAME, DMARQ does not replace it automatically with
-a TXT record. The shared policy target may serve several domains, so the UI
-identifies the target and keeps the change manual until the operator decides
-whether to update the shared policy or migrate the alias separately.
+When `_dmarc.<domain>` is a CNAME, DMARQ never edits the shared target merely
+to enroll one domain. Instead, the change plan can prepare a domain-local
+migration: it shows the CNAME and target, the inherited effective policy, and a
+local TXT policy that preserves every tag and existing destination while adding
+only the configured mailbox to `rua`. Preview binds the final confirmation to
+the exact provider record ID, type, and value. If that baseline changes, apply
+stops and requires a fresh preview. A confirmed provider operation replaces the
+local CNAME with the TXT record; rollback restores the previous CNAME. DMARQ
+marks the migration verified only after provider readback and both `1.1.1.1`
+and `8.8.8.8` show the TXT value without the old CNAME.
 
 When DMARQ can detect the authoritative DNS provider from nameservers and a
 matching connector is available, the change-plan section highlights the


### PR DESCRIPTION
## Description

Adds a safe, approval-only DMARC CNAME-to-TXT migration when a domain inherits policy from a shared CNAME but needs its own report mailbox. DMARQ copies the effective policy to a local TXT record, preserves existing tags and destinations, adds only the local aggregate-report destination, and leaves the shared target unchanged.

## Related Issue

Closes #913

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Security fix
- [ ] Breaking change

## Changes Made

- Show the current CNAME, shared target, inherited policy, proposed local TXT, exact delta, reason, and rollback.
- Bind live apply to the reviewed record type, values, provider record ID, and proposed value; abort on drift or conflicts.
- Support atomic Cloudflare CNAME-to-TXT updates and block unsafe generic Lexicon type replacements.
- Verify provider readback plus 1.1.1.1 and 8.8.8.8 convergence without treating propagation delay as an apply failure.
- Persist sanitized mutation, verification, and rollback evidence in the workspace audit log.
- Document the workflow and API contract.

## Testing Performed

### Test Environment

- Python: 3.14 locally; CI uses 3.13
- Database: isolated test database
- OS: macOS locally; Linux in CI

### Test Results

- Full local suite: 2,222 tests collected, no failures recorded
- Focused DNS/UI suite after final review merge: 312 passed
- Black, isort, Flake8, JavaScript syntax, and diff checks passed
- CI Docker greenfield, Security, Dependency Review, CodeQL, and Helm/Terraform gates passed on the initial commit; final CI is rerunning

## Security Considerations

- [x] Reviewed for DNS write safety
- [x] No sensitive data is exposed
- [x] Preview/apply inputs are validated against provider state
- [x] Existing authentication and authorization remain enforced
- [x] No background or unapproved DNS write is introduced

## Performance Impact

- [x] No significant performance impact
- Public resolver checks run only after an approved record-type replacement.

## Documentation

- [x] Updated user guide
- [x] Updated API documentation
- [x] Updated changelog

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated
- [x] Tests cover migration, drift, tampering, provider restrictions, resolver convergence, and rollback evidence
- [x] Existing and new tests pass locally

## AI Assistance

- [x] AI tools were used
- [x] All generated changes were reviewed for security and correctness
- [x] Tests were added for generated code

## Deployment Notes

No migration or configuration change is required. The feature remains preview-first and requires explicit confirmation. No live DNS record was changed during validation.
