### PR TITLE
feat: add Cloudflare DMARC email relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a deployable Cloudflare Email Worker relay for installations that
+  already use a DMARQ Gmail or IMAP source. The relay accepts one configured
+  collector address, preserves the raw report attachments, and forwards only
+  to a Cloudflare-verified destination mailbox.
 - DNS change plans now show the observed value, proposed value, exact tag/value
   diff, and the lint rationale for every proposed record. Identical values are
   treated as no-op evidence rather than a misleading DNS change.
@@ -59,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path that exercises the complete lifecycle.
 
 ### Fixed
+- Gmail report discovery now includes DMARC messages classified as spam while
+  continuing to exclude Trash. This keeps Cloudflare Email Worker relays and
+  other legitimate automated forwarders from silently starving report intake.
 - Authenticated domain DNS guidance now carries the same provider-preview
   readiness as the dedicated change-plan API, so concrete TXT/CNAME repairs
   can be previewed and explicitly approved from the domain page instead of

--- a/backend/app/services/gmail_client.py
+++ b/backend/app/services/gmail_client.py
@@ -57,7 +57,7 @@ GMAIL_SCOPES = [
 # ---------------------------------------------------------------------------
 
 DMARC_GMAIL_QUERY = (
-    "((has:attachment (filename:zip OR filename:gz OR filename:xml)) "
+    "-in:trash ((has:attachment (filename:zip OR filename:gz OR filename:xml)) "
     'OR subject:"DMARC failure" OR subject:"failure report" OR subject:forensic OR subject:ruf) '
     "(subject:dmarc OR subject:report OR subject:rua OR subject:submitter "
     'OR subject:"aggregate report" OR subject:"domain report" '
@@ -319,6 +319,10 @@ class GmailClient:
                 "userId": "me",
                 "q": self._search_query(days),
                 "maxResults": _PAGE_SIZE,
+                # Aggregate reports can be classified as spam because they are
+                # automated and frequently forwarded by a collector. Trash is
+                # still excluded explicitly in DMARC_GMAIL_QUERY.
+                "includeSpamTrash": True,
             }
             if page_token:
                 kwargs["pageToken"] = page_token

--- a/backend/app/tests/test_gmail_client.py
+++ b/backend/app/tests/test_gmail_client.py
@@ -325,6 +325,9 @@ class TestListDmarcMessageIds:
         }
         ids = client._list_dmarc_message_ids(service)
         assert ids == ["id1", "id2"]
+        kwargs = service.users.return_value.messages.return_value.list.call_args.kwargs
+        assert kwargs["includeSpamTrash"] is True
+        assert "-in:trash" in kwargs["q"]
 
     def test_follows_next_page_token(self):
         client = _make_client()

--- a/deploy/cloudflare/dmarc-email-relay/.gitignore
+++ b/deploy/cloudflare/dmarc-email-relay/.gitignore
@@ -1,0 +1,2 @@
+.wrangler/
+node_modules/

--- a/deploy/cloudflare/dmarc-email-relay/README.md
+++ b/deploy/cloudflare/dmarc-email-relay/README.md
@@ -1,0 +1,35 @@
+# Cloudflare DMARC Email Relay
+
+This Email Worker provides a low-dependency Cloudflare intake path for an
+existing DMARQ mailbox source:
+
+```text
+DMARC reporter -> dmarc@example.com -> Email Worker -> connected mailbox -> DMARQ
+```
+
+The Worker preserves the original RFC 822 message and its XML, ZIP, or GZIP
+attachments. It only accepts the configured collector recipient and forwards
+to a destination address that has already been verified in Cloudflare Email
+Routing.
+
+## Configure
+
+1. Copy `wrangler.jsonc` and replace both example addresses.
+2. Verify `DESTINATION_ADDRESS` in Cloudflare Email Routing.
+3. Deploy the Worker with `npx wrangler deploy`.
+4. Create a custom Email Routing rule from `COLLECTOR_ADDRESS` to the Worker.
+5. Add the collector to each domain's DMARC `rua` tag without removing existing
+   destinations.
+6. For an external collector domain, publish the required authorization TXT
+   record at `<policy-domain>._report._dmarc.<collector-domain>`.
+7. Trigger the connected DMARQ mailbox source and confirm the report is
+   imported.
+
+Run the isolated unit tests with `npm test`.
+
+## Direct webhook alternative
+
+For installations that should not depend on a mailbox, use the authenticated
+raw-message Worker documented in
+[`docs/cloudflare-email-worker-inbound-webhook.md`](../../../docs/cloudflare-email-worker-inbound-webhook.md).
+That mode requires the same `WEBHOOK_SECRET` in DMARQ and the Worker.

--- a/deploy/cloudflare/dmarc-email-relay/README.md
+++ b/deploy/cloudflare/dmarc-email-relay/README.md
@@ -21,7 +21,8 @@ Routing.
 5. Add the collector to each domain's DMARC `rua` tag without removing existing
    destinations.
 6. For an external collector domain, publish the required authorization TXT
-   record at `<policy-domain>._report._dmarc.<collector-domain>`.
+   record at `<policy-domain>._report._dmarc.<collector-domain>` with the exact
+   TXT value `v=DMARC1;`.
 7. Trigger the connected DMARQ mailbox source and confirm the report is
    imported.
 

--- a/deploy/cloudflare/dmarc-email-relay/package.json
+++ b/deploy/cloudflare/dmarc-email-relay/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "dmarq-cloudflare-email-relay",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/deploy/cloudflare/dmarc-email-relay/src/index.js
+++ b/deploy/cloudflare/dmarc-email-relay/src/index.js
@@ -1,0 +1,28 @@
+function normalizedAddress(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+export default {
+  async email(message, env) {
+    const collectorAddress = normalizedAddress(env.COLLECTOR_ADDRESS);
+    const destinationAddress = normalizedAddress(env.DESTINATION_ADDRESS);
+
+    if (!collectorAddress || !destinationAddress) {
+      message.setReject("DMARC collector configuration is incomplete");
+      return;
+    }
+
+    if (normalizedAddress(message.to) !== collectorAddress) {
+      message.setReject("Recipient is not configured for this DMARC collector");
+      return;
+    }
+
+    await message.forward(
+      destinationAddress,
+      new Headers({
+        "X-DMARQ-Collector": "cloudflare-email-relay",
+        "X-DMARQ-Original-Recipient": collectorAddress,
+      }),
+    );
+  },
+};

--- a/deploy/cloudflare/dmarc-email-relay/test/index.test.js
+++ b/deploy/cloudflare/dmarc-email-relay/test/index.test.js
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "../src/index.js";
+
+function emailMessage(to) {
+  return {
+    to,
+    forwarded: [],
+    rejected: null,
+    async forward(destination, headers) {
+      this.forwarded.push({ destination, headers });
+    },
+    setReject(reason) {
+      this.rejected = reason;
+    },
+  };
+}
+
+const env = {
+  COLLECTOR_ADDRESS: "dmarc@example.com",
+  DESTINATION_ADDRESS: "reports@example.net",
+};
+
+test("forwards the configured collector recipient with trace headers", async () => {
+  const message = emailMessage("DMARC@example.com");
+
+  await worker.email(message, env);
+
+  assert.equal(message.rejected, null);
+  assert.equal(message.forwarded.length, 1);
+  assert.equal(message.forwarded[0].destination, "reports@example.net");
+  assert.equal(
+    message.forwarded[0].headers.get("X-DMARQ-Collector"),
+    "cloudflare-email-relay",
+  );
+  assert.equal(
+    message.forwarded[0].headers.get("X-DMARQ-Original-Recipient"),
+    "dmarc@example.com",
+  );
+});
+
+test("rejects mail addressed to a different recipient", async () => {
+  const message = emailMessage("other@example.com");
+
+  await worker.email(message, env);
+
+  assert.match(message.rejected, /Recipient is not configured/);
+  assert.equal(message.forwarded.length, 0);
+});
+
+test("rejects mail when the relay configuration is incomplete", async () => {
+  const message = emailMessage("dmarc@example.com");
+
+  await worker.email(message, { ...env, DESTINATION_ADDRESS: "" });
+
+  assert.match(message.rejected, /configuration is incomplete/);
+  assert.equal(message.forwarded.length, 0);
+});

--- a/deploy/cloudflare/dmarc-email-relay/wrangler.jsonc
+++ b/deploy/cloudflare/dmarc-email-relay/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "dmarq-email-ingest",
+  "main": "src/index.js",
+  "compatibility_date": "2026-07-29",
+  "vars": {
+    "COLLECTOR_ADDRESS": "dmarc@example.com",
+    "DESTINATION_ADDRESS": "verified-dmarc-mailbox@example.com"
+  }
+}

--- a/docs/cloudflare-email-worker-inbound-webhook.md
+++ b/docs/cloudflare-email-worker-inbound-webhook.md
@@ -24,6 +24,16 @@ DMARQ POST /api/v1/webhook/email  or  /api/v1/webhook/email/raw
 DMARC attachment import (no DNS writes)
 ```
 
+If DMARQ already polls a Gmail or IMAP mailbox, the repository also includes a
+secretless relay Worker under
+[`deploy/cloudflare/dmarc-email-relay`](../deploy/cloudflare/dmarc-email-relay/README.md).
+It preserves the raw message and forwards it to a Cloudflare-verified mailbox,
+where the normal DMARQ mailbox source imports the attachment. Use the direct
+webhook flow below when the deployment should not depend on a mailbox.
+The Gmail connector searches the spam folder for matching DMARC attachments
+because automated or forwarded aggregate reports can be classified there;
+messages in Trash remain excluded.
+
 1. Configure Email Routing for the address that receives DMARC reports (for
    example `dmarc-reports@example.com`).
 2. Bind an Email Worker to that route.


### PR DESCRIPTION
## Summary
- add a deployable Cloudflare Email Worker relay for an existing DMARQ mailbox source
- search Gmail Spam for tightly matched DMARC reports while continuing to exclude Trash
- document the mailbox relay and direct webhook alternatives

## Live evidence
- deployed dmarq-email-ingest and routed only dmarc@dmarq.org
- Poste.io delivered the smoke message to Cloudflare over TLS
- Worker execution completed successfully and forwarded the unchanged XML attachment
- Gmail classified the forwarded smoke message as Spam, reproducing the intake gap fixed here
- smoke report reuses an existing production report id, so it cannot change production aggregates

## Validation
- 89 Gmail/backfill tests
- 3 isolated Worker tests
- Black and git diff --check