### PR TITLE
feat: guide DKIM repair from stored mailflow evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Domain sender views now start with a report-backed mailflow diagnosis. DMARQ
+  maps Header From, Envelope From, SPF domains, DKIM signing domains, and
+  selectors from stored ingest projections; distinguishes missing or
+  intermittent aligned DKIM from rejected unknown senders; and provides a
+  provider-neutral repair checklist whose closure gate is a fresh aligned DKIM
+  pass. Provider access is optional, and aggregate reports are not presented as
+  proof of message delivery or a specific server-side root cause.
 - Added a deployable Cloudflare Email Worker relay for installations that
   already use a DMARQ Gmail or IMAP source. The relay accepts one configured
   collector address, preserves the raw report attachments, and forwards only

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -106,6 +106,7 @@ from app.services.mail_service_imports import (
     preview_mail_service_import,
     supported_mail_service_import_providers,
 )
+from app.services.mailflow_assessment import build_domain_mailflow_assessment
 from app.services.migration_import import preview_migration_import
 from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
 from app.services.organizations import (
@@ -2041,6 +2042,54 @@ class SourceVolumeHistoryEntry(BaseModel):
     failed: int = 0
 
 
+class MailflowIdentity(BaseModel):
+    """Report-backed authentication identity for one sending path."""
+
+    source_ip: str
+    sender_name: str
+    sender_status: str
+    status: str
+    label: str
+    detail: str
+    message_count: int = 0
+    header_from_domains: List[str] = Field(default_factory=list)
+    envelope_from_domains: List[str] = Field(default_factory=list)
+    spf_domains: List[str] = Field(default_factory=list)
+    dkim_domains: List[str] = Field(default_factory=list)
+    dkim_selectors: List[str] = Field(default_factory=list)
+    spf_alignment: str = "unknown"
+    dkim_alignment: str = "unknown"
+    dmarc_status: str = "unknown"
+    receiver_disposition: str = "none"
+    intended_mail_impact: str = "unknown"
+    evidence_level: str = "observed"
+    provider_evidence_status: str = "not_connected"
+    next_step: str
+    verification_condition: str
+
+
+class DomainMailflowAssessment(BaseModel):
+    """Focused DKIM diagnosis derived from stored aggregate-report facts."""
+
+    domain: str
+    status: str
+    title: str
+    summary: str
+    next_step: str
+    cta_label: str
+    cta_href: str
+    confidence: str
+    evidence_scope: str
+    known_facts: List[str] = Field(default_factory=list)
+    inferences: List[str] = Field(default_factory=list)
+    unknowns: List[str] = Field(default_factory=list)
+    repair_steps: List[str] = Field(default_factory=list)
+    verification_condition: str
+    primary_source_ip: Optional[str] = None
+    counts: Dict[str, int] = Field(default_factory=dict)
+    flows: List[MailflowIdentity] = Field(default_factory=list)
+
+
 class SourceEntry(BaseModel):
     """Summary of a sending source"""
 
@@ -2069,7 +2118,9 @@ class SourceEntry(BaseModel):
     # individual delivery; use the explicit observation fields below instead.
     authentication_status: str = "unknown"
     authentication_label: str = "Authentication result unknown"
-    authentication_detail: str = "No receiver authentication observation is available for this source."
+    authentication_detail: str = (
+        "No receiver authentication observation is available for this source."
+    )
     receiver_disposition: str = "unknown"
     receiver_disposition_label: str = "Receiver-reported disposition unavailable"
     evidence_kind: str = "dmarc_aggregate_report"
@@ -2085,6 +2136,7 @@ class SourceEntry(BaseModel):
     reputation: Optional[SourceReputationResponse] = None
     spf_fix_hint: Optional[str] = None
     recommendations: List[SourceRecommendation] = Field(default_factory=list)
+    mailflow: Optional[MailflowIdentity] = None
 
 
 class DomainReportsResponse(BaseModel):
@@ -2098,6 +2150,7 @@ class DomainSourcesResponse(BaseModel):
     """Domain sending sources"""
 
     sources: List[SourceEntry]
+    mailflow_assessment: DomainMailflowAssessment
 
 
 class SourceIntelligenceResponse(BaseModel):
@@ -8964,6 +9017,16 @@ async def get_domain_sources(
         )
         source_context.append((source, hostname, sender_by_ip[ip]))
 
+    mailflow_assessment = build_domain_mailflow_assessment(
+        domain_name,
+        sources,
+        sender_by_ip,
+    )
+    mailflow_by_ip = {
+        str(flow.get("source_ip") or "unknown"): flow
+        for flow in mailflow_assessment.get("flows") or []
+    }
+
     reputations_by_ip = (
         await _source_reputations_by_ip(
             db,
@@ -9049,10 +9112,14 @@ async def get_domain_sources(
                 ),
                 spf_fix_hint=spf_fix_hint,
                 recommendations=recommendations,
+                mailflow=mailflow_by_ip.get(str(ip)),
             )
         )
 
-    return DomainSourcesResponse(sources=source_entries)
+    return DomainSourcesResponse(
+        sources=source_entries,
+        mailflow_assessment=DomainMailflowAssessment(**mailflow_assessment),
+    )
 
 
 @router.get("/{domain_id}/source-reputation", response_model=DomainSourceReputationResponse)

--- a/backend/app/services/mailflow_assessment.py
+++ b/backend/app/services/mailflow_assessment.py
@@ -85,6 +85,15 @@ def _flow(source: Dict[str, Any], sender: Dict[str, Any]) -> Dict[str, Any]:
             "that this tenant is authorized for the domain."
         )
         next_step = "No immediate action; keep monitoring"
+    elif sender.get("status") == "known" and dmarc_fail:
+        status = "investigate_alignment"
+        label = "Review alignment for this known sender"
+        intended_mail_impact = "unknown"
+        detail = (
+            f"This known sending service failed DMARC for {dmarc_fail} message(s), "
+            "but the aggregate report does not identify the provider-side cause."
+        )
+        next_step = "Review SPF and DKIM alignment for this sending service"
     elif dmarc_fail:
         status = "investigate_source"
         label = "Confirm whether this source is yours"
@@ -121,7 +130,11 @@ def _flow(source: Dict[str, Any], sender: Dict[str, Any]) -> Dict[str, Any]:
         "dmarc_status": str(source.get("dmarc_result") or "unknown"),
         "receiver_disposition": str(source.get("disposition") or "none"),
         "intended_mail_impact": intended_mail_impact,
-        "evidence_level": "observed",
+        "evidence_level": (
+            "inferred"
+            if status in {"likely_unauthorized", "investigate_alignment", "investigate_source"}
+            else "observed"
+        ),
         "provider_evidence_status": "not_connected",
         "next_step": next_step,
         "verification_condition": (
@@ -144,10 +157,11 @@ def build_domain_mailflow_assessment(
     priority = {
         "aligned_dkim_not_observed": 0,
         "intermittent_dkim_alignment": 1,
-        "investigate_source": 2,
-        "likely_unauthorized": 3,
-        "healthy": 4,
-        "insufficient_evidence": 5,
+        "investigate_alignment": 2,
+        "investigate_source": 3,
+        "likely_unauthorized": 4,
+        "healthy": 5,
+        "insufficient_evidence": 6,
     }
     flows.sort(key=lambda item: (priority.get(item["status"], 99), -item["message_count"]))
     counts = {key: sum(flow["status"] == key for flow in flows) for key in priority}
@@ -156,7 +170,8 @@ def build_domain_mailflow_assessment(
     investigate = [
         flow
         for flow in flows
-        if flow["status"] in {"intermittent_dkim_alignment", "investigate_source"}
+        if flow["status"]
+        in {"intermittent_dkim_alignment", "investigate_alignment", "investigate_source"}
     ]
     if actionable:
         primary = actionable[0]
@@ -203,6 +218,33 @@ def build_domain_mailflow_assessment(
         next_step = "Keep report intake running"
         confidence = "Not enough evidence"
 
+    inferences = []
+    unknowns = []
+    if actionable:
+        inferences.append(
+            "A missing aligned DKIM pass can indicate disabled signing, a missing key, or the wrong signing domain."
+        )
+        unknowns.append(
+            "The exact provider-side root cause remains unknown without provider evidence."
+        )
+    if counts["likely_unauthorized"]:
+        inferences.append(
+            "Protective handling of an unaligned source suggests unauthorized use, but does not prove ownership."
+        )
+        unknowns.append(
+            "Whether the protected source belongs to an approved sender remains unknown."
+        )
+    if counts["investigate_alignment"]:
+        inferences.append(
+            "Provider recognition identifies a known service, but does not explain its DMARC failure."
+        )
+        unknowns.append("The failing SPF or DKIM identity remains unknown from aggregate evidence.")
+    if counts["investigate_source"]:
+        inferences.append("The failing source may be legitimate, but ownership is not established.")
+        unknowns.append(
+            "Whether the source belongs to an approved sending service remains unknown."
+        )
+
     return {
         "domain": domain,
         "status": status,
@@ -220,18 +262,8 @@ def build_domain_mailflow_assessment(
             f"{len(flows)} active source path(s) were observed in the selected window.",
             f"{len(actionable)} path(s) need DKIM alignment repair.",
         ],
-        "inferences": (
-            [
-                "A missing aligned DKIM pass can indicate disabled signing, a missing key, or the wrong signing domain."
-            ]
-            if actionable
-            else []
-        ),
-        "unknowns": (
-            ["The exact provider-side root cause remains unknown without provider evidence."]
-            if actionable
-            else []
-        ),
+        "inferences": inferences,
+        "unknowns": unknowns,
         "repair_steps": (
             [
                 "Open the sending service's domain settings and confirm DKIM signing is enabled.",

--- a/backend/app/services/mailflow_assessment.py
+++ b/backend/app/services/mailflow_assessment.py
@@ -1,0 +1,248 @@
+"""Report-backed mailflow identity and DKIM alignment guidance.
+
+The service only interprets ingestion-time source projections. It never
+performs DNS, provider, reputation, or delivery lookups on a UI read.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+
+def _count(value: object) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _values(source: Dict[str, Any], key: str) -> list[str]:
+    return sorted({str(value).strip() for value in source.get(key) or [] if str(value).strip()})
+
+
+def _protective_disposition(source: Dict[str, Any]) -> bool:
+    failed = _count(source.get("dmarc_fail_count"))
+    dispositions = source.get("disposition_counts") or {}
+    protected = _count(dispositions.get("reject")) + _count(dispositions.get("quarantine"))
+    return failed > 0 and protected >= failed
+
+
+def _alignment_status(pass_count: int, fail_count: int) -> str:
+    if pass_count and fail_count:
+        return "mixed"
+    if pass_count:
+        return "pass"
+    if fail_count:
+        return "not_observed"
+    return "unknown"
+
+
+def _flow(source: Dict[str, Any], sender: Dict[str, Any]) -> Dict[str, Any]:
+    messages = _count(source.get("count"))
+    spf_pass = _count(source.get("spf_pass_count"))
+    spf_fail = _count(source.get("spf_fail_count"))
+    dkim_pass = _count(source.get("dkim_pass_count"))
+    dkim_fail = _count(source.get("dkim_fail_count"))
+    dmarc_fail = _count(source.get("dmarc_fail_count"))
+    recognized = sender.get("status") == "known" or spf_pass > 0
+    protected = _protective_disposition(source)
+
+    if recognized and dkim_pass == 0 and dkim_fail > 0:
+        status = "aligned_dkim_not_observed"
+        label = "Aligned DKIM not observed"
+        intended_mail_impact = "likely_affected" if dmarc_fail else "fragile"
+        detail = (
+            f"Receivers evaluated {dkim_fail} message(s) without aligned DKIM. "
+            "DMARQ cannot tell from aggregate reports alone whether signing is disabled, "
+            "a key is missing, or a signature uses the wrong domain."
+        )
+        next_step = "Confirm DKIM signing for this domain in the sending service"
+    elif recognized and dkim_pass > 0 and dkim_fail > 0:
+        status = "intermittent_dkim_alignment"
+        label = "DKIM alignment is intermittent"
+        intended_mail_impact = "likely_affected"
+        detail = (
+            f"Aligned DKIM passed for {dkim_pass} message(s) and failed for {dkim_fail}. "
+            "Compare the affected sending path, signing domain, and selector."
+        )
+        next_step = "Compare failing and passing DKIM paths"
+    elif recognized and dkim_pass > 0:
+        status = "healthy"
+        label = "Aligned DKIM observed"
+        intended_mail_impact = "likely_not_affected"
+        detail = f"Receivers reported aligned DKIM for {dkim_pass} message(s)."
+        next_step = "Keep report intake running"
+    elif not recognized and protected:
+        status = "likely_unauthorized"
+        label = "Likely unauthorized use"
+        intended_mail_impact = "likely_not_affected"
+        detail = (
+            f"An unrecognized source failed DMARC for {dmarc_fail} message(s), and receivers "
+            "reported quarantine or reject. Do not authorize it unless an owner is confirmed."
+        )
+        next_step = "No immediate action; keep monitoring"
+    elif dmarc_fail:
+        status = "investigate_source"
+        label = "Confirm whether this source is yours"
+        intended_mail_impact = "unknown"
+        detail = (
+            f"This source failed DMARC for {dmarc_fail} message(s), but DMARQ cannot yet "
+            "link it to an approved sending service."
+        )
+        next_step = "Classify the source before changing DNS"
+    else:
+        status = "insufficient_evidence"
+        label = "More report evidence needed"
+        intended_mail_impact = "unknown"
+        detail = (
+            "The selected window does not contain enough authentication evidence for this path."
+        )
+        next_step = "Keep report intake running"
+
+    return {
+        "source_ip": str(source.get("source_ip") or "unknown"),
+        "sender_name": str(sender.get("name") or "Unknown sender"),
+        "sender_status": str(sender.get("status") or "unknown"),
+        "status": status,
+        "label": label,
+        "detail": detail,
+        "message_count": messages,
+        "header_from_domains": _values(source, "header_from_domains"),
+        "envelope_from_domains": _values(source, "envelope_from_domains"),
+        "spf_domains": _values(source, "spf_domains"),
+        "dkim_domains": _values(source, "dkim_domains"),
+        "dkim_selectors": _values(source, "dkim_selectors"),
+        "spf_alignment": _alignment_status(spf_pass, spf_fail),
+        "dkim_alignment": _alignment_status(dkim_pass, dkim_fail),
+        "dmarc_status": str(source.get("dmarc_result") or "unknown"),
+        "receiver_disposition": str(source.get("disposition") or "none"),
+        "intended_mail_impact": intended_mail_impact,
+        "evidence_level": "observed",
+        "provider_evidence_status": "not_connected",
+        "next_step": next_step,
+        "verification_condition": (
+            "A fresh aggregate report shows an aligned DKIM pass for this sending path."
+        ),
+    }
+
+
+def build_domain_mailflow_assessment(
+    domain: str,
+    sources: Iterable[Dict[str, Any]],
+    sender_by_ip: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build one domain summary plus per-source mailflow identity facts."""
+    flows = [
+        _flow(source, sender_by_ip.get(str(source.get("source_ip") or "unknown"), {}))
+        for source in sources
+        if _count(source.get("count")) > 0
+    ]
+    priority = {
+        "aligned_dkim_not_observed": 0,
+        "intermittent_dkim_alignment": 1,
+        "investigate_source": 2,
+        "likely_unauthorized": 3,
+        "healthy": 4,
+        "insufficient_evidence": 5,
+    }
+    flows.sort(key=lambda item: (priority.get(item["status"], 99), -item["message_count"]))
+    counts = {key: sum(flow["status"] == key for flow in flows) for key in priority}
+
+    actionable = [
+        flow
+        for flow in flows
+        if flow["status"] in {"aligned_dkim_not_observed", "intermittent_dkim_alignment"}
+    ]
+    investigate = [flow for flow in flows if flow["status"] == "investigate_source"]
+    if actionable:
+        primary = actionable[0]
+        status = "action_required"
+        title = "Repair DKIM signing for an active mailflow"
+        summary = (
+            f"DMARQ observed {len(actionable)} active path(s) for {domain} without reliable "
+            "aligned DKIM. Mail may still pass through SPF, but forwarding can break that path."
+        )
+        next_step = primary["next_step"]
+        confidence = "High" if primary["sender_status"] == "known" else "Medium"
+    elif investigate:
+        primary = investigate[0]
+        status = "investigation_required"
+        title = "Classify a failing sender before changing DNS"
+        summary = (
+            f"DMARQ observed {len(investigate)} failing path(s) for {domain} that are not yet "
+            "linked to an approved sender."
+        )
+        next_step = primary["next_step"]
+        confidence = "Medium"
+    elif flows and counts["healthy"]:
+        primary = next(flow for flow in flows if flow["status"] == "healthy")
+        status = "healthy"
+        title = "Aligned DKIM is working"
+        summary = f"DMARQ observed aligned DKIM on active mailflow paths for {domain}."
+        next_step = "Keep report intake running"
+        confidence = "High"
+    elif flows and counts["likely_unauthorized"]:
+        primary = next(flow for flow in flows if flow["status"] == "likely_unauthorized")
+        status = "no_action_likely_unauthorized_use"
+        title = "Unrecognized failing mail is being protected"
+        summary = (
+            "Receivers reported protective handling for unrecognized sources. "
+            "No DKIM repair should be made for those sources without an owner."
+        )
+        next_step = "No immediate action; keep monitoring"
+        confidence = "Medium"
+    else:
+        primary = None
+        status = "insufficient_evidence"
+        title = "Waiting for mailflow evidence"
+        summary = f"No active report-backed mailflow is available for {domain} in this window."
+        next_step = "Keep report intake running"
+        confidence = "Not enough evidence"
+
+    return {
+        "domain": domain,
+        "status": status,
+        "title": title,
+        "summary": summary,
+        "next_step": next_step,
+        "cta_label": "Review DKIM repair" if actionable else "Review mailflow evidence",
+        "cta_href": "#mailflow-diagnosis",
+        "confidence": confidence,
+        "evidence_scope": (
+            "Aggregate DMARC reports prove receiver authentication observations, not final delivery. "
+            "A provider connection is optional and only strengthens the root-cause evidence."
+        ),
+        "known_facts": [
+            f"{len(flows)} active source path(s) were observed in the selected window.",
+            f"{len(actionable)} path(s) need DKIM alignment repair.",
+        ],
+        "inferences": (
+            [
+                "A missing aligned DKIM pass can indicate disabled signing, a missing key, or the wrong signing domain."
+            ]
+            if actionable
+            else []
+        ),
+        "unknowns": (
+            ["The exact provider-side root cause remains unknown without provider evidence."]
+            if actionable
+            else []
+        ),
+        "repair_steps": (
+            [
+                "Open the sending service's domain settings and confirm DKIM signing is enabled.",
+                f"Generate or rotate a domain-specific key for {domain} if no usable key exists.",
+                "Publish the exact selector._domainkey TXT or CNAME value supplied by the sender.",
+                "Verify the public record, then send or forward one controlled message.",
+                "Keep the repair open until a fresh DMARC report shows aligned DKIM passing.",
+            ]
+            if actionable
+            else []
+        ),
+        "verification_condition": (
+            "A fresh aggregate report shows aligned DKIM passing on the affected path."
+        ),
+        "primary_source_ip": primary["source_ip"] if primary else None,
+        "counts": counts,
+        "flows": flows,
+    }

--- a/backend/app/services/mailflow_assessment.py
+++ b/backend/app/services/mailflow_assessment.py
@@ -44,10 +44,12 @@ def _flow(source: Dict[str, Any], sender: Dict[str, Any]) -> Dict[str, Any]:
     dkim_pass = _count(source.get("dkim_pass_count"))
     dkim_fail = _count(source.get("dkim_fail_count"))
     dmarc_fail = _count(source.get("dmarc_fail_count"))
-    recognized = sender.get("status") == "known" or spf_pass > 0
     protected = _protective_disposition(source)
+    fully_spf_aligned_without_dkim = (
+        messages > 0 and spf_pass == messages and dkim_pass == 0 and dkim_fail == messages
+    )
 
-    if recognized and dkim_pass == 0 and dkim_fail > 0:
+    if fully_spf_aligned_without_dkim:
         status = "aligned_dkim_not_observed"
         label = "Aligned DKIM not observed"
         intended_mail_impact = "likely_affected" if dmarc_fail else "fragile"
@@ -57,28 +59,30 @@ def _flow(source: Dict[str, Any], sender: Dict[str, Any]) -> Dict[str, Any]:
             "a key is missing, or a signature uses the wrong domain."
         )
         next_step = "Confirm DKIM signing for this domain in the sending service"
-    elif recognized and dkim_pass > 0 and dkim_fail > 0:
+    elif dkim_pass > 0 and dkim_fail > 0:
         status = "intermittent_dkim_alignment"
-        label = "DKIM alignment is intermittent"
-        intended_mail_impact = "likely_affected"
+        label = "Separate mixed DKIM identities"
+        intended_mail_impact = "unknown"
         detail = (
             f"Aligned DKIM passed for {dkim_pass} message(s) and failed for {dkim_fail}. "
-            "Compare the affected sending path, signing domain, and selector."
+            "This source-IP projection combines observed domains and selectors, so it cannot "
+            "identify which value belongs to the failures."
         )
-        next_step = "Compare failing and passing DKIM paths"
-    elif recognized and dkim_pass > 0:
+        next_step = "Separate the failing identity before changing DKIM"
+    elif dkim_pass > 0:
         status = "healthy"
         label = "Aligned DKIM observed"
         intended_mail_impact = "likely_not_affected"
         detail = f"Receivers reported aligned DKIM for {dkim_pass} message(s)."
         next_step = "Keep report intake running"
-    elif not recognized and protected:
+    elif protected:
         status = "likely_unauthorized"
         label = "Likely unauthorized use"
         intended_mail_impact = "likely_not_affected"
         detail = (
-            f"An unrecognized source failed DMARC for {dmarc_fail} message(s), and receivers "
-            "reported quarantine or reject. Do not authorize it unless an owner is confirmed."
+            f"A source without aligned SPF or DKIM failed DMARC for {dmarc_fail} message(s), "
+            "and receivers reported quarantine or reject. A provider match alone does not prove "
+            "that this tenant is authorized for the domain."
         )
         next_step = "No immediate action; keep monitoring"
     elif dmarc_fail:
@@ -148,12 +152,12 @@ def build_domain_mailflow_assessment(
     flows.sort(key=lambda item: (priority.get(item["status"], 99), -item["message_count"]))
     counts = {key: sum(flow["status"] == key for flow in flows) for key in priority}
 
-    actionable = [
+    actionable = [flow for flow in flows if flow["status"] == "aligned_dkim_not_observed"]
+    investigate = [
         flow
         for flow in flows
-        if flow["status"] in {"aligned_dkim_not_observed", "intermittent_dkim_alignment"}
+        if flow["status"] in {"intermittent_dkim_alignment", "investigate_source"}
     ]
-    investigate = [flow for flow in flows if flow["status"] == "investigate_source"]
     if actionable:
         primary = actionable[0]
         status = "action_required"
@@ -167,10 +171,10 @@ def build_domain_mailflow_assessment(
     elif investigate:
         primary = investigate[0]
         status = "investigation_required"
-        title = "Classify a failing sender before changing DNS"
+        title = "Separate the failing mailflow identity"
         summary = (
-            f"DMARQ observed {len(investigate)} failing path(s) for {domain} that are not yet "
-            "linked to an approved sender."
+            f"DMARQ observed {len(investigate)} path(s) for {domain} whose failing identity "
+            "cannot be isolated from the source-IP projection."
         )
         next_step = primary["next_step"]
         confidence = "Medium"

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -186,6 +186,17 @@ function domainDetailsApp(domainId = '') {
         reportsLoading: true,
         reportsError: '',
         sources: [],
+        mailflowAssessment: {
+            status: 'loading',
+            title: 'Loading mailflow evidence...',
+            summary: '',
+            next_step: '',
+            confidence: '',
+            evidence_scope: '',
+            repair_steps: [],
+            flows: [],
+            counts: {}
+        },
         // Keep the sender panel in a loading state until the first projection read settles.
         // Otherwise a slow but successful first response is briefly presented as an empty domain.
         sourcesLoading: true,
@@ -2116,6 +2127,55 @@ function domainDetailsApp(domainId = '') {
             return 'bg-blue-500';
         },
 
+        mailflowStatusClass(status) {
+            if (status === 'healthy') return 'bg-green-100 text-green-800';
+            if (status === 'action_required') return 'bg-red-100 text-red-800';
+            if (status === 'investigation_required') return 'bg-amber-100 text-amber-800';
+            if (status === 'no_action_likely_unauthorized_use') return 'bg-blue-100 text-blue-800';
+            return 'bg-gray-100 text-gray-700';
+        },
+
+        mailflowStatusLabel(status) {
+            return {
+                healthy: 'Healthy',
+                action_required: 'Action required',
+                investigation_required: 'Needs classification',
+                no_action_likely_unauthorized_use: 'Protected',
+                insufficient_evidence: 'Waiting for evidence'
+            }[status] || 'Review';
+        },
+
+        mailflowIdentityValues(flow) {
+            const values = [];
+            const add = (label, entries) => {
+                if (Array.isArray(entries) && entries.length) {
+                    values.push(`${label}: ${entries.join(', ')}`);
+                }
+            };
+            add('Header From', flow?.header_from_domains);
+            add('Envelope From', flow?.envelope_from_domains);
+            add('SPF domain', flow?.spf_domains);
+            add('DKIM domain', flow?.dkim_domains);
+            add('Selector', flow?.dkim_selectors);
+            return values;
+        },
+
+        mailflowAlignmentClass(value) {
+            if (value === 'pass') return 'bg-green-100 text-green-800';
+            if (value === 'mixed') return 'bg-amber-100 text-amber-800';
+            if (value === 'not_observed') return 'bg-red-100 text-red-800';
+            return 'bg-gray-100 text-gray-700';
+        },
+
+        mailflowAlignmentLabel(value) {
+            return {
+                pass: 'aligned pass',
+                mixed: 'mixed',
+                not_observed: 'not observed',
+                unknown: 'unknown'
+            }[value] || value;
+        },
+
         senderStatusClass(status) {
             if (status === 'known') return 'bg-green-100 text-green-800';
             if (status === 'ambiguous') return 'bg-yellow-100 text-yellow-800';
@@ -3435,6 +3495,17 @@ function domainDetailsApp(domainId = '') {
                 const data = await response.json();
                 this.sources = (Array.isArray(data.sources) ? data.sources : [])
                     .map(source => this.normalizeSource(source));
+                this.mailflowAssessment = data.mailflow_assessment || {
+                    status: 'insufficient_evidence',
+                    title: 'Waiting for mailflow evidence',
+                    summary: 'No report-backed mailflow assessment is available for this window.',
+                    next_step: 'Keep report intake running',
+                    confidence: 'Not enough evidence',
+                    evidence_scope: '',
+                    repair_steps: [],
+                    flows: [],
+                    counts: {}
+                };
                 this.sourceReputationRefreshError = '';
             } catch (error) {
                 const hasExistingSources = (this.sources || []).length > 0;

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2784,7 +2784,7 @@
                                                     <span class="font-mono text-xs" x-text="flow.source_ip"></span>
                                                     <span class="text-sm font-semibold" x-text="flow.sender_name"></span>
                                                     <span class="rounded px-2 py-0.5 text-xs font-semibold"
-                                                          :class="mailflowStatusClass(flow.status === 'healthy' ? 'healthy' : (flow.status === 'likely_unauthorized' ? 'no_action_likely_unauthorized_use' : (flow.status === 'investigate_source' ? 'investigation_required' : 'action_required')))"
+                                                          :class="mailflowStatusClass(flow.status === 'healthy' ? 'healthy' : (flow.status === 'likely_unauthorized' ? 'no_action_likely_unauthorized_use' : (['intermittent_dkim_alignment', 'investigate_alignment', 'investigate_source'].includes(flow.status) ? 'investigation_required' : (flow.status === 'insufficient_evidence' ? 'insufficient_evidence' : 'action_required'))))"
                                                           x-text="flow.label"></span>
                                                 </div>
                                                 <p class="mt-1 text-xs text-muted-foreground" x-text="flow.detail"></p>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2717,6 +2717,99 @@
                 </div>
             {% endcall %}
             {% call card_content() %}
+                <section id="mailflow-diagnosis" class="mb-5 border-b border-base-300 pb-5" aria-labelledby="mailflow-diagnosis-heading">
+                    <template x-if="sourcesLoading">
+                        <div class="flex items-center gap-2 text-sm text-muted-foreground" role="status">
+                            <span class="loading loading-spinner loading-sm"></span>
+                            <span>Reading saved mailflow evidence...</span>
+                        </div>
+                    </template>
+                    <template x-if="!sourcesLoading && !sourcesError">
+                        <div>
+                            <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                                <div class="min-w-0">
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <p class="text-xs font-semibold uppercase text-[#5f5c78]">Mailflow diagnosis</p>
+                                        <span class="rounded px-2 py-1 text-xs font-semibold"
+                                              :class="mailflowStatusClass(mailflowAssessment.status)"
+                                              x-text="mailflowStatusLabel(mailflowAssessment.status)"></span>
+                                        <span class="text-xs text-muted-foreground">
+                                            Confidence: <span x-text="mailflowAssessment.confidence"></span>
+                                        </span>
+                                    </div>
+                                    <h3 id="mailflow-diagnosis-heading" class="mt-2 text-base font-semibold text-[#07071f]" x-text="mailflowAssessment.title"></h3>
+                                    <p class="mt-1 max-w-4xl text-sm text-[#45505f]" x-text="mailflowAssessment.summary"></p>
+                                    <p class="mt-3 text-sm text-[#120d36]">
+                                        <span class="font-semibold">Next step: </span>
+                                        <span x-text="mailflowAssessment.next_step"></span>
+                                    </p>
+                                </div>
+                                <a x-show="mailflowAssessment.status === 'action_required'"
+                                   href="#mailflow-repair"
+                                   class="btn btn-sm shrink-0 border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f]">
+                                    Review DKIM repair
+                                </a>
+                            </div>
+
+                            <details id="mailflow-repair"
+                                     class="mt-4 rounded-md border border-base-300 bg-[var(--dmarq-surface-section)]"
+                                     :open="mailflowAssessment.status === 'action_required'"
+                                     x-show="mailflowAssessment.repair_steps && mailflowAssessment.repair_steps.length">
+                                <summary class="cursor-pointer px-3 py-2 text-sm font-semibold text-[#272a5f]">
+                                    Repair and verification steps
+                                </summary>
+                                <div class="border-t border-base-300 px-3 py-3">
+                                    <ol class="list-decimal space-y-2 pl-5 text-sm text-[#45505f]">
+                                        <template x-for="(step, index) in mailflowAssessment.repair_steps" :key="'mailflow-step-' + index">
+                                            <li x-text="step"></li>
+                                        </template>
+                                    </ol>
+                                    <p class="mt-3 text-xs font-medium text-[#176d74]">
+                                        <span>Verified when: </span><span x-text="mailflowAssessment.verification_condition"></span>
+                                    </p>
+                                    <p class="mt-2 text-xs text-muted-foreground" x-text="mailflowAssessment.evidence_scope"></p>
+                                </div>
+                            </details>
+
+                            <details class="mt-3" x-show="mailflowAssessment.flows && mailflowAssessment.flows.length">
+                                <summary class="cursor-pointer text-sm font-semibold text-[#272a5f]">
+                                    Mailflow identities
+                                    <span class="ml-1 font-normal text-muted-foreground" x-text="'(' + mailflowAssessment.flows.length + ')' "></span>
+                                </summary>
+                                <div class="mt-3 divide-y divide-base-300 border-y border-base-300">
+                                    <template x-for="flow in mailflowAssessment.flows" :key="flow.source_ip">
+                                        <div class="grid gap-2 py-3 md:grid-cols-[minmax(0,1fr)_auto]">
+                                            <div class="min-w-0">
+                                                <div class="flex flex-wrap items-center gap-2">
+                                                    <span class="font-mono text-xs" x-text="flow.source_ip"></span>
+                                                    <span class="text-sm font-semibold" x-text="flow.sender_name"></span>
+                                                    <span class="rounded px-2 py-0.5 text-xs font-semibold"
+                                                          :class="mailflowStatusClass(flow.status === 'healthy' ? 'healthy' : (flow.status === 'likely_unauthorized' ? 'no_action_likely_unauthorized_use' : (flow.status === 'investigate_source' ? 'investigation_required' : 'action_required')))"
+                                                          x-text="flow.label"></span>
+                                                </div>
+                                                <p class="mt-1 text-xs text-muted-foreground" x-text="flow.detail"></p>
+                                                <div class="mt-2 flex flex-wrap gap-1.5">
+                                                    <template x-for="value in mailflowIdentityValues(flow)" :key="value">
+                                                        <span class="rounded bg-base-200 px-2 py-1 text-xs text-base-content/75" x-text="value"></span>
+                                                    </template>
+                                                </div>
+                                            </div>
+                                            <div class="flex flex-wrap items-start gap-2 text-xs md:justify-end">
+                                                <span class="rounded px-2 py-1 font-semibold" :class="mailflowAlignmentClass(flow.spf_alignment)">
+                                                    SPF <span x-text="mailflowAlignmentLabel(flow.spf_alignment)"></span>
+                                                </span>
+                                                <span class="rounded px-2 py-1 font-semibold" :class="mailflowAlignmentClass(flow.dkim_alignment)">
+                                                    DKIM <span x-text="mailflowAlignmentLabel(flow.dkim_alignment)"></span>
+                                                </span>
+                                                <span class="rounded bg-base-200 px-2 py-1 font-semibold" x-text="formatLargeNumber(flow.message_count) + ' messages'"></span>
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
+                            </details>
+                        </div>
+                    </template>
+                </section>
                 <p x-show="sourceReputationRefreshError"
                    x-cloak
                    class="mb-4 rounded-md border border-[#ffcfbd] bg-[#fff2ec] px-3 py-2 text-sm text-[#8a2d0d]"

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2753,6 +2753,48 @@ def test_get_domain_sources_returns_200(seeded_client: TestClient):
     assert source["spf"] == "pass"
     assert source["dkim"] == "pass"
     assert source["dmarc"] == "pass"
+    assert source["mailflow"]["dkim_alignment"] == "pass"
+    assert data["mailflow_assessment"]["status"] == "healthy"
+    assert data["mailflow_assessment"]["flows"][0]["header_from_domains"] == [DOMAIN]
+
+
+def test_get_domain_sources_guides_dkim_repair_from_stored_report_facts(
+    seeded_client: TestClient,
+    db_session,
+):
+    """An SPF-aligned path with failing DKIM gets a bounded repair workflow."""
+    report = {
+        **REPORT_DICT_POLICY,
+        "report_id": "rpt-dkim-missing",
+        "records": [
+            {
+                "source_ip": "192.0.2.44",
+                "count": 8,
+                "disposition": "none",
+                "dkim_result": "fail",
+                "spf_result": "pass",
+                "header_from": DOMAIN,
+                "envelope_from": f"bounce.{DOMAIN}",
+                "dkim": [{"domain": DOMAIN, "selector": "mail", "result": "fail"}],
+                "spf": [{"domain": DOMAIN, "scope": "mfrom", "result": "pass"}],
+            }
+        ],
+        "summary": {"total_count": 8, "passed_count": 8, "failed_count": 0},
+    }
+    report_persistence.save_parsed_report(db_session, report)
+    db_session.commit()
+
+    response = seeded_client.get(f"/api/v1/domains/{DOMAIN}/sources")
+
+    assert response.status_code == 200
+    data = response.json()
+    assessment = data["mailflow_assessment"]
+    assert assessment["status"] == "action_required"
+    assert assessment["repair_steps"]
+    affected = next(source for source in data["sources"] if source["ip"] == "192.0.2.44")
+    assert affected["mailflow"]["status"] == "aligned_dkim_not_observed"
+    assert affected["mailflow"]["dkim_selectors"] == ["mail"]
+    assert affected["mailflow"]["provider_evidence_status"] == "not_connected"
 
 
 def test_get_domain_migration_readiness_projects_parallel_cutover_state(
@@ -3209,14 +3251,14 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
 def test_source_delivery_status_distinguishes_receiver_observations(
     source, status, authentication_status, receiver_disposition, certainty
 ):
-    delivery = domains_endpoint._source_delivery_status(  # pylint: disable=protected-access
-        source
-    )
+    delivery = domains_endpoint._source_delivery_status(source)  # pylint: disable=protected-access
 
     assert delivery["status"] == status
     assert "delivery" not in delivery["label"].lower()
-    observation = domains_endpoint._source_authentication_observation(  # pylint: disable=protected-access
-        source
+    observation = (
+        domains_endpoint._source_authentication_observation(  # pylint: disable=protected-access
+            source
+        )
     )
     assert observation["status"] == authentication_status
     assert observation["disposition"] == receiver_disposition

--- a/backend/app/tests/test_mailflow_assessment.py
+++ b/backend/app/tests/test_mailflow_assessment.py
@@ -1,0 +1,109 @@
+"""Tests for the report-backed domain mailflow diagnosis."""
+
+from app.services.mailflow_assessment import build_domain_mailflow_assessment
+
+
+def _source(**overrides):
+    source = {
+        "source_ip": "192.0.2.10",
+        "count": 12,
+        "spf_pass_count": 12,
+        "spf_fail_count": 0,
+        "dkim_pass_count": 0,
+        "dkim_fail_count": 12,
+        "dmarc_pass_count": 12,
+        "dmarc_fail_count": 0,
+        "dmarc_result": "pass",
+        "disposition": "none",
+        "disposition_counts": {"none": 12},
+        "header_from_domains": ["example.com"],
+        "envelope_from_domains": ["bounce.example.com"],
+        "spf_domains": ["example.com"],
+        "dkim_domains": [],
+        "dkim_selectors": [],
+    }
+    source.update(overrides)
+    return source
+
+
+def test_spf_aligned_path_without_dkim_gets_guided_repair():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [_source()],
+        {"192.0.2.10": {"name": "Unknown sender", "status": "unknown"}},
+    )
+
+    assert result["status"] == "action_required"
+    assert result["counts"]["aligned_dkim_not_observed"] == 1
+    assert result["repair_steps"]
+    assert result["flows"][0]["spf_alignment"] == "pass"
+    assert result["flows"][0]["dkim_alignment"] == "not_observed"
+    assert result["flows"][0]["provider_evidence_status"] == "not_connected"
+    assert "cannot tell" in result["flows"][0]["detail"]
+
+
+def test_unknown_rejected_spoofer_does_not_get_dkim_repair():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [
+            _source(
+                spf_pass_count=0,
+                spf_fail_count=7,
+                dkim_fail_count=7,
+                dmarc_pass_count=0,
+                dmarc_fail_count=7,
+                dmarc_result="fail",
+                disposition="reject",
+                disposition_counts={"reject": 7},
+            )
+        ],
+        {"192.0.2.10": {"name": "Unknown sender", "status": "unknown"}},
+    )
+
+    assert result["status"] == "no_action_likely_unauthorized_use"
+    assert result["repair_steps"] == []
+    assert result["flows"][0]["status"] == "likely_unauthorized"
+
+
+def test_known_sender_with_aligned_dkim_is_healthy():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [_source(dkim_pass_count=12, dkim_fail_count=0)],
+        {"192.0.2.10": {"name": "Owned infrastructure", "status": "known"}},
+    )
+
+    assert result["status"] == "healthy"
+    assert result["flows"][0]["status"] == "healthy"
+    assert result["flows"][0]["dkim_alignment"] == "pass"
+
+
+def test_zero_traffic_is_ignored():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [_source(count=0, spf_pass_count=0, dkim_fail_count=0)],
+        {},
+    )
+
+    assert result["status"] == "insufficient_evidence"
+    assert result["flows"] == []
+
+
+def test_mixed_dkim_path_requires_investigation_and_preserves_identity_map():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [
+            _source(
+                dkim_pass_count=8,
+                dkim_fail_count=4,
+                dkim_domains=["example.com", "relay.example.net"],
+                dkim_selectors=["mail", "relay"],
+            )
+        ],
+        {"192.0.2.10": {"name": "Owned infrastructure", "status": "known"}},
+    )
+
+    flow = result["flows"][0]
+    assert flow["status"] == "intermittent_dkim_alignment"
+    assert flow["dkim_domains"] == ["example.com", "relay.example.net"]
+    assert flow["dkim_selectors"] == ["mail", "relay"]
+    assert result["verification_condition"].startswith("A fresh aggregate report")

--- a/backend/app/tests/test_mailflow_assessment.py
+++ b/backend/app/tests/test_mailflow_assessment.py
@@ -63,6 +63,9 @@ def test_unknown_rejected_spoofer_does_not_get_dkim_repair():
     assert result["status"] == "no_action_likely_unauthorized_use"
     assert result["repair_steps"] == []
     assert result["flows"][0]["status"] == "likely_unauthorized"
+    assert result["flows"][0]["evidence_level"] == "inferred"
+    assert result["inferences"]
+    assert result["unknowns"]
 
 
 def test_known_provider_without_alignment_does_not_get_dkim_repair():
@@ -97,6 +100,45 @@ def test_known_sender_with_aligned_dkim_is_healthy():
     assert result["status"] == "healthy"
     assert result["flows"][0]["status"] == "healthy"
     assert result["flows"][0]["dkim_alignment"] == "pass"
+
+
+def test_aligned_dkim_is_healthy_without_provider_recognition():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [_source(spf_pass_count=0, spf_fail_count=12, dkim_pass_count=12, dkim_fail_count=0)],
+        {"192.0.2.10": {"name": "Unclassified sender", "status": "unknown"}},
+    )
+
+    assert result["status"] == "healthy"
+    assert result["flows"][0]["status"] == "healthy"
+
+
+def test_known_sender_dmarc_failure_requests_alignment_review():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [
+            _source(
+                spf_pass_count=0,
+                spf_fail_count=12,
+                dkim_pass_count=0,
+                dkim_fail_count=0,
+                dmarc_pass_count=0,
+                dmarc_fail_count=12,
+                dmarc_result="fail",
+                disposition="none",
+                disposition_counts={"none": 12},
+            )
+        ],
+        {"192.0.2.10": {"name": "Known provider", "status": "known"}},
+    )
+
+    flow = result["flows"][0]
+    assert result["status"] == "investigation_required"
+    assert flow["status"] == "investigate_alignment"
+    assert flow["evidence_level"] == "inferred"
+    assert "known sending service" in flow["detail"]
+    assert result["inferences"]
+    assert result["unknowns"]
 
 
 def test_zero_traffic_is_ignored():

--- a/backend/app/tests/test_mailflow_assessment.py
+++ b/backend/app/tests/test_mailflow_assessment.py
@@ -65,6 +65,28 @@ def test_unknown_rejected_spoofer_does_not_get_dkim_repair():
     assert result["flows"][0]["status"] == "likely_unauthorized"
 
 
+def test_known_provider_without_alignment_does_not_get_dkim_repair():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [
+            _source(
+                spf_pass_count=0,
+                spf_fail_count=7,
+                dkim_fail_count=7,
+                dmarc_pass_count=0,
+                dmarc_fail_count=7,
+                dmarc_result="fail",
+                disposition="reject",
+                disposition_counts={"reject": 7},
+            )
+        ],
+        {"192.0.2.10": {"name": "Shared provider", "status": "known"}},
+    )
+
+    assert result["status"] == "no_action_likely_unauthorized_use"
+    assert result["repair_steps"] == []
+
+
 def test_known_sender_with_aligned_dkim_is_healthy():
     result = build_domain_mailflow_assessment(
         "example.com",
@@ -88,7 +110,7 @@ def test_zero_traffic_is_ignored():
     assert result["flows"] == []
 
 
-def test_mixed_dkim_path_requires_investigation_and_preserves_identity_map():
+def test_mixed_dkim_path_requires_identity_correlation_before_repair():
     result = build_domain_mailflow_assessment(
         "example.com",
         [
@@ -106,4 +128,6 @@ def test_mixed_dkim_path_requires_investigation_and_preserves_identity_map():
     assert flow["status"] == "intermittent_dkim_alignment"
     assert flow["dkim_domains"] == ["example.com", "relay.example.net"]
     assert flow["dkim_selectors"] == ["mail", "relay"]
-    assert result["verification_condition"].startswith("A fresh aggregate report")
+    assert "cannot identify which value" in flow["detail"]
+    assert result["status"] == "investigation_required"
+    assert result["repair_steps"] == []

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -333,6 +333,76 @@ const domainSources = {
       volume_history: [{ date: '2026-07-02', count: 137, passed: 130, failed: 7 }],
     },
   ],
+  mailflow_assessment: {
+    domain: 'cklnet.com',
+    status: 'action_required',
+    title: 'Repair DKIM signing for an active mailflow',
+    summary: 'DMARQ observed one active path for cklnet.com without reliable aligned DKIM.',
+    next_step: 'Compare failing and passing DKIM paths',
+    cta_label: 'Review DKIM repair',
+    cta_href: '#mailflow-diagnosis',
+    confidence: 'High',
+    evidence_scope: 'Aggregate DMARC reports prove receiver authentication observations, not final delivery.',
+    known_facts: ['2 active source paths were observed in the selected window.'],
+    inferences: ['The owned path has intermittent DKIM alignment.'],
+    unknowns: ['The exact provider-side root cause remains unknown without provider evidence.'],
+    repair_steps: [
+      'Confirm DKIM signing is enabled for cklnet.com in the sending service.',
+      'Publish the exact selector record supplied by the sender.',
+      'Send or forward one controlled message.',
+    ],
+    verification_condition: 'A fresh aggregate report shows aligned DKIM passing on the affected path.',
+    primary_source_ip: '2a01:4f8:c17:311b::1',
+    counts: { healthy: 1, intermittent_dkim_alignment: 1 },
+    flows: [
+      {
+        source_ip: '50.31.205.203',
+        sender_name: 'Postmark',
+        sender_status: 'known',
+        status: 'healthy',
+        label: 'Aligned DKIM observed',
+        detail: 'Receivers reported aligned DKIM for 2736 messages.',
+        message_count: 2736,
+        header_from_domains: ['cklnet.com'],
+        envelope_from_domains: ['pm.mtasv.net'],
+        spf_domains: ['pm.mtasv.net'],
+        dkim_domains: ['cklnet.com'],
+        dkim_selectors: ['pm'],
+        spf_alignment: 'pass',
+        dkim_alignment: 'pass',
+        dmarc_status: 'pass',
+        receiver_disposition: 'none',
+        intended_mail_impact: 'likely_not_affected',
+        evidence_level: 'observed',
+        provider_evidence_status: 'not_connected',
+        next_step: 'Keep report intake running',
+        verification_condition: 'Keep receiving aligned DKIM passes.',
+      },
+      {
+        source_ip: '2a01:4f8:c17:311b::1',
+        sender_name: 'Owned infrastructure',
+        sender_status: 'known',
+        status: 'intermittent_dkim_alignment',
+        label: 'DKIM alignment is intermittent',
+        detail: 'Aligned DKIM passed for 130 messages and failed for 7.',
+        message_count: 137,
+        header_from_domains: ['cklnet.com'],
+        envelope_from_domains: ['cklnet.com'],
+        spf_domains: ['cklnet.com'],
+        dkim_domains: ['cklnet.com'],
+        dkim_selectors: ['mail'],
+        spf_alignment: 'pass',
+        dkim_alignment: 'mixed',
+        dmarc_status: 'mixed',
+        receiver_disposition: 'none',
+        intended_mail_impact: 'likely_affected',
+        evidence_level: 'observed',
+        provider_evidence_status: 'not_connected',
+        next_step: 'Compare failing and passing DKIM paths',
+        verification_condition: 'A fresh aggregate report shows aligned DKIM passing.',
+      },
+    ],
+  },
 };
 
 const domainSourceIntelligence = {
@@ -1185,6 +1255,27 @@ test('onboarding page keeps setup controls wired without inline handlers', async
   await page.getByRole('button', { name: 'Preview tasks' }).click();
   await expect(page.getByText('Preview is ready. Review the task list before applying setup.')).toBeVisible();
   await expect(page.getByText('Review DNS posture')).toBeVisible();
+});
+
+test('domain sender view guides DKIM repair from saved mailflow evidence', async ({ page }) => {
+  await page.goto('/domains/cklnet.com#sending-sources');
+
+  const sendingSources = page.locator('details', {
+    has: page.locator('summary', { hasText: 'Sending sources' }),
+  });
+  await expect(sendingSources).toHaveAttribute('open', '');
+  await expect(sendingSources.getByRole('heading', { name: 'Repair DKIM signing for an active mailflow' })).toBeVisible();
+  await expect(sendingSources.getByText('Next step: Compare failing and passing DKIM paths')).toBeVisible();
+  await expect(sendingSources.getByText('Confirm DKIM signing is enabled for cklnet.com')).toBeVisible();
+  await sendingSources.getByText('Mailflow identities').click();
+  await expect(sendingSources.getByText('DKIM domain: cklnet.com').first()).toBeVisible();
+  await expect(sendingSources.getByText('Selector: mail')).toBeVisible();
+  await expect(sendingSources.getByText('Aligned DKIM observed')).toBeVisible();
+  await expect(sendingSources.getByText('DKIM alignment is intermittent')).toBeVisible();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/domains/cklnet.com#sending-sources');
+  await expect(page.getByRole('heading', { name: 'Repair DKIM signing for an active mailflow' })).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
 });
 
 test('domain detail shows cached DNS evidence and sender reputation context', async ({ page }) => {

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -309,12 +309,12 @@ const domainSources = {
       hostname: sourceOwned.hostname,
       total_count: 137,
       count: 137,
-      dmarc: 'mixed',
-      dmarc_result: 'mixed',
+      dmarc: 'pass',
+      dmarc_result: 'pass',
       spf: 'pass',
       spf_result: 'pass',
-      dkim: 'mixed',
-      dkim_result: 'mixed',
+      dkim: 'fail',
+      dkim_result: 'fail',
       disposition: 'none',
       last_seen: 1782950399,
       first_seen: 1754352000,
@@ -330,7 +330,7 @@ const domainSources = {
           action: 'Publish or repair the mail selector for mx1.cklnet.com.',
         },
       ],
-      volume_history: [{ date: '2026-07-02', count: 137, passed: 130, failed: 7 }],
+      volume_history: [{ date: '2026-07-02', count: 137, passed: 137, failed: 0 }],
     },
   ],
   mailflow_assessment: {
@@ -338,13 +338,13 @@ const domainSources = {
     status: 'action_required',
     title: 'Repair DKIM signing for an active mailflow',
     summary: 'DMARQ observed one active path for cklnet.com without reliable aligned DKIM.',
-    next_step: 'Compare failing and passing DKIM paths',
+    next_step: 'Confirm DKIM signing for this domain in the sending service',
     cta_label: 'Review DKIM repair',
     cta_href: '#mailflow-diagnosis',
     confidence: 'High',
     evidence_scope: 'Aggregate DMARC reports prove receiver authentication observations, not final delivery.',
     known_facts: ['2 active source paths were observed in the selected window.'],
-    inferences: ['The owned path has intermittent DKIM alignment.'],
+    inferences: ['The owned path passes through SPF but has no aligned DKIM pass.'],
     unknowns: ['The exact provider-side root cause remains unknown without provider evidence.'],
     repair_steps: [
       'Confirm DKIM signing is enabled for cklnet.com in the sending service.',
@@ -353,7 +353,7 @@ const domainSources = {
     ],
     verification_condition: 'A fresh aggregate report shows aligned DKIM passing on the affected path.',
     primary_source_ip: '2a01:4f8:c17:311b::1',
-    counts: { healthy: 1, intermittent_dkim_alignment: 1 },
+    counts: { healthy: 1, aligned_dkim_not_observed: 1 },
     flows: [
       {
         source_ip: '50.31.205.203',
@@ -382,9 +382,9 @@ const domainSources = {
         source_ip: '2a01:4f8:c17:311b::1',
         sender_name: 'Owned infrastructure',
         sender_status: 'known',
-        status: 'intermittent_dkim_alignment',
-        label: 'DKIM alignment is intermittent',
-        detail: 'Aligned DKIM passed for 130 messages and failed for 7.',
+        status: 'aligned_dkim_not_observed',
+        label: 'Aligned DKIM not observed',
+        detail: 'Receivers evaluated 137 messages without aligned DKIM.',
         message_count: 137,
         header_from_domains: ['cklnet.com'],
         envelope_from_domains: ['cklnet.com'],
@@ -392,13 +392,13 @@ const domainSources = {
         dkim_domains: ['cklnet.com'],
         dkim_selectors: ['mail'],
         spf_alignment: 'pass',
-        dkim_alignment: 'mixed',
-        dmarc_status: 'mixed',
+        dkim_alignment: 'not_observed',
+        dmarc_status: 'pass',
         receiver_disposition: 'none',
-        intended_mail_impact: 'likely_affected',
+        intended_mail_impact: 'fragile',
         evidence_level: 'observed',
         provider_evidence_status: 'not_connected',
-        next_step: 'Compare failing and passing DKIM paths',
+        next_step: 'Confirm DKIM signing for this domain in the sending service',
         verification_condition: 'A fresh aggregate report shows aligned DKIM passing.',
       },
     ],
@@ -1265,13 +1265,13 @@ test('domain sender view guides DKIM repair from saved mailflow evidence', async
   });
   await expect(sendingSources).toHaveAttribute('open', '');
   await expect(sendingSources.getByRole('heading', { name: 'Repair DKIM signing for an active mailflow' })).toBeVisible();
-  await expect(sendingSources.getByText('Next step: Compare failing and passing DKIM paths')).toBeVisible();
+  await expect(sendingSources.getByText('Next step: Confirm DKIM signing for this domain in the sending service')).toBeVisible();
   await expect(sendingSources.getByText('Confirm DKIM signing is enabled for cklnet.com')).toBeVisible();
   await sendingSources.getByText('Mailflow identities').click();
   await expect(sendingSources.getByText('DKIM domain: cklnet.com').first()).toBeVisible();
   await expect(sendingSources.getByText('Selector: mail')).toBeVisible();
   await expect(sendingSources.getByText('Aligned DKIM observed')).toBeVisible();
-  await expect(sendingSources.getByText('DKIM alignment is intermittent')).toBeVisible();
+  await expect(sendingSources.getByText('Aligned DKIM not observed')).toBeVisible();
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/domains/cklnet.com#sending-sources');
   await expect(page.getByRole('heading', { name: 'Repair DKIM signing for an active mailflow' })).toBeVisible();

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -277,7 +277,13 @@ a private key, or signed with the wrong domain. DMARQ therefore labels that
 root cause as unknown unless optional provider evidence confirms it. Private
 DKIM keys are never requested or imported. Unknown sources that fail DMARC and
 are already quarantined or rejected are kept as evidence without receiving a
-misleading DKIM repair recommendation.
+misleading DKIM repair recommendation. A recognized provider name does not by
+itself prove that the observed tenant is authorized for the domain.
+
+Daily source projections group observations by source IP. If one IP has both
+passing and failing DKIM outcomes, DMARQ shows the observed identity values but
+does not claim that a particular selector caused the failure. It asks the
+operator to separate the failing identity before changing DKIM.
 
 The domain detail page groups sending sources into regions, reverse DNS
 hostnames, ASNs, BGP prefixes, registries, and likely network operators when

--- a/docs/user_guide/domains.md
+++ b/docs/user_guide/domains.md
@@ -257,6 +257,28 @@ directly to that part of the domain detail page.
 
 ### Source Intelligence
 
+The **Sending Sources** section begins with a focused mailflow diagnosis built
+from the same daily facts that DMARQ stores during report ingestion. It maps the
+observed Header From, Envelope From, aligned SPF domain, DKIM signing domain,
+and DKIM selector for each source path. This read does not contact DNS,
+reputation services, or the sending provider.
+
+When an active or SPF-authorized path has no aligned DKIM pass, DMARQ explains
+that the path may be relying on SPF alone and gives one repair sequence:
+
+1. Confirm that DKIM signing is enabled for the domain in the sending service.
+2. Generate or rotate a domain-specific key if no usable key exists.
+3. Publish the exact selector record supplied by that service.
+4. Send or forward a controlled message after public DNS resolves the record.
+5. Keep the repair open until a fresh aggregate report shows aligned DKIM.
+
+Aggregate reports cannot prove whether the provider has disabled signing, lost
+a private key, or signed with the wrong domain. DMARQ therefore labels that
+root cause as unknown unless optional provider evidence confirms it. Private
+DKIM keys are never requested or imported. Unknown sources that fail DMARC and
+are already quarantined or rejected are kept as evidence without receiving a
+misleading DKIM repair recommendation.
+
 The domain detail page groups sending sources into regions, reverse DNS
 hostnames, ASNs, BGP prefixes, registries, and likely network operators when
 that evidence is available from reports or cached sender-network enrichment.


### PR DESCRIPTION
## What changed
- derive a deterministic per-domain mailflow diagnosis from persisted report projections
- distinguish missing or intermittent aligned DKIM from rejected unknown senders
- guide operators through provider-neutral DKIM repair and verify completion with a fresh aggregate report
- surface Header From, Envelope From, SPF domains, DKIM domains, selectors, alignment and volume without removing detailed sender evidence
- document the evidence and provider boundaries

## Why
Forwarded and self-hosted mailflows could fail DKIM while still passing through SPF, but DMARQ exposed the raw facts without explaining whether intended mail was affected or what to do next. The new assessment uses only saved ingest evidence, keeps provider access optional, and never presents aggregate reports as delivery proof.

## Validation
- `2236 passed` in the complete backend suite
- focused Playwright test passed on desktop and 390x844 mobile, including overflow check
- Python formatting, JavaScript syntax, and diff checks passed

## Safety
This change performs no DNS or provider writes and does not request private DKIM keys.

Closes #916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mailflow diagnosis to domain sending sources, including sender identities, SPF/DKIM alignment, status, confidence, and message impact.
  * Added guided DKIM repair and verification steps for actionable alignment issues.
  * Added health indicators for healthy, intermittent, unknown, and potentially unauthorized sending sources.
  * Added evidence scope, known facts, inferences, and unknowns to clarify diagnosis limitations.

* **Documentation**
  * Documented the Sending Sources workflow, evidence limitations, and provider-neutral DKIM remediation guidance.

* **Tests**
  * Added coverage for mailflow classifications, repair guidance, and responsive browser display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->