### PR TITLE
feat: add truthful mail signal taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Guided assessments, domain mailflow diagnoses, and sending-source responses
+  now expose a versioned protocol-aware mail-signal contract. DMARC
+  authentication and receiver-reported policy actions remain separate from
+  inferred conclusions and future DSN/provider delivery evidence, with stable
+  evidence references, claim levels, delivery certainty, and aggregate-safe
+  privacy metadata. Deprecated delivery aliases remain available for existing
+  API clients.
 - Guided setup now recommends one report-intake path from the operator's saved
   goals and persisted source/import state, with manual upload, local IMAP,
   Proton Mail Bridge, Gmail, Microsoft 365, Cloudflare Worker, AWS SES/Lambda,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -11,7 +11,7 @@ import secrets
 from contextvars import ContextVar
 from dataclasses import asdict
 from datetime import date, datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Request, status
 from fastapi.responses import JSONResponse, Response
@@ -2043,6 +2043,18 @@ class SourceVolumeHistoryEntry(BaseModel):
     failed: int = 0
 
 
+ClaimLevel = Literal["observed", "derived", "inferred", "operator_reported", "unknown"]
+DeliveryCertainty = Literal[
+    "not_applicable",
+    "authentication_only",
+    "receiver_disposition_reported",
+    "transport_failure_reported",
+    "non_delivery_reported",
+    "delivery_reported",
+    "inferred_only",
+]
+
+
 class MailflowIdentity(BaseModel):
     """Report-backed authentication identity for one sending path."""
 
@@ -2064,8 +2076,8 @@ class MailflowIdentity(BaseModel):
     receiver_disposition: str = "none"
     intended_mail_impact: str = "unknown"
     evidence_level: str = "observed"
-    claim_level: str = "observed"
-    delivery_certainty: str = "authentication_only"
+    claim_level: ClaimLevel = "observed"
+    delivery_certainty: DeliveryCertainty = "authentication_only"
     signals: List[Dict[str, Any]] = Field(default_factory=list)
     provider_evidence_status: str = "not_connected"
     next_step: str
@@ -2128,8 +2140,8 @@ class SourceEntry(BaseModel):
     receiver_disposition: str = "unknown"
     receiver_disposition_label: str = "Receiver-reported disposition unavailable"
     evidence_kind: str = "dmarc_aggregate_report"
-    claim_level: str = "observed"
-    delivery_certainty: str = "unknown"
+    claim_level: ClaimLevel = "observed"
+    delivery_certainty: DeliveryCertainty = "authentication_only"
     signals: List[Dict[str, Any]] = Field(default_factory=list)
     hostname: Optional[str] = None
     ptr_status: Optional[str] = None

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -106,6 +106,7 @@ from app.services.mail_service_imports import (
     preview_mail_service_import,
     supported_mail_service_import_providers,
 )
+from app.services.mail_signals import build_dmarc_source_signals
 from app.services.mailflow_assessment import build_domain_mailflow_assessment
 from app.services.migration_import import preview_migration_import
 from app.services.mta_sts import MTAStsResult, check_mta_sts_cached
@@ -2063,6 +2064,9 @@ class MailflowIdentity(BaseModel):
     receiver_disposition: str = "none"
     intended_mail_impact: str = "unknown"
     evidence_level: str = "observed"
+    claim_level: str = "observed"
+    delivery_certainty: str = "authentication_only"
+    signals: List[Dict[str, Any]] = Field(default_factory=list)
     provider_evidence_status: str = "not_connected"
     next_step: str
     verification_condition: str
@@ -2112,8 +2116,8 @@ class SourceEntry(BaseModel):
     dmarc_fail_count: int = 0
     disposition_counts: Dict[str, int] = Field(default_factory=dict)
     delivery_status: str = "unknown"
-    delivery_label: str = "Delivery status unknown"
-    delivery_detail: str = "No DMARC delivery outcome is available for this source."
+    delivery_label: str = "Authentication result unknown"
+    delivery_detail: str = "No aggregate DMARC authentication observation is available."
     # Deprecated compatibility aliases. DMARC aggregate reports do not prove
     # individual delivery; use the explicit observation fields below instead.
     authentication_status: str = "unknown"
@@ -2126,6 +2130,7 @@ class SourceEntry(BaseModel):
     evidence_kind: str = "dmarc_aggregate_report"
     claim_level: str = "observed"
     delivery_certainty: str = "unknown"
+    signals: List[Dict[str, Any]] = Field(default_factory=list)
     hostname: Optional[str] = None
     ptr_status: Optional[str] = None
     ptr_detail: Optional[str] = None
@@ -9021,6 +9026,7 @@ async def get_domain_sources(
         domain_name,
         sources,
         sender_by_ip,
+        workspace_id=workspace.id,
     )
     mailflow_by_ip = {
         str(flow.get("source_ip") or "unknown"): flow
@@ -9054,6 +9060,20 @@ async def get_domain_sources(
         reputation = reputations_by_ip.get(ip)
         delivery = _source_delivery_status(source)
         authentication = _source_authentication_observation(source)
+        signals = build_dmarc_source_signals(
+            source,
+            workspace_id=workspace.id,
+            domain=domain_name,
+            evidence_refs=source.get("evidence_refs") or (),
+        )
+        delivery_certainty = (
+            "receiver_disposition_reported"
+            if any(
+                signal["family"] == "dmarc_reported_disposition" and signal["outcome"] != "unknown"
+                for signal in signals
+            )
+            else "authentication_only"
+        )
         recommendations = _source_recommendations(ip, source, hostname, spf_fix_hint, sender)
         recommendations.extend(_anomaly_recommendations(source_anomalies))
         recommendations.extend(_reputation_recommendations(reputation))
@@ -9088,12 +9108,15 @@ async def get_domain_sources(
                 receiver_disposition_label=authentication["disposition_label"],
                 evidence_kind="dmarc_aggregate_report",
                 claim_level="observed",
-                delivery_certainty="unknown",
+                delivery_certainty=delivery_certainty,
+                signals=signals,
                 hostname=hostname,
                 ptr_status=(ptr_by_ip.get(ip).status if ptr_by_ip.get(ip) else None),
                 ptr_detail=(ptr_by_ip.get(ip).detail if ptr_by_ip.get(ip) else None),
                 evidence_captured_at=str(
-                    (source.get("source_evidence") or {}).get("captured_at") or ""
+                    (source.get("source_evidence") or {}).get("captured_at")
+                    or source.get("captured_at")
+                    or ""
                 )
                 or None,
                 sender=SenderIdentity(**sender),

--- a/backend/app/services/mail_health.py
+++ b/backend/app/services/mail_health.py
@@ -66,6 +66,10 @@ def _merge_source_rows(
             {
                 "domain": domain.name,
                 "source_ip": str(row.source_ip),
+                "spf_pass_count": 0,
+                "spf_fail_count": 0,
+                "dkim_pass_count": 0,
+                "dkim_fail_count": 0,
                 "dmarc_pass_count": 0,
                 "dmarc_fail_count": 0,
                 "disposition_counts": defaultdict(int),
@@ -76,25 +80,43 @@ def _merge_source_rows(
                 "window_end": None,
                 "evidence_refs": [],
                 "report_generators": [],
+                "header_from_domains": [],
+                "envelope_from_domains": [],
+                "spf_domains": [],
+                "dkim_domains": [],
+                "dkim_selectors": [],
             },
         )
+        source["spf_pass_count"] += _count(row.spf_pass_count)
+        source["spf_fail_count"] += _count(row.spf_fail_count)
+        source["dkim_pass_count"] += _count(row.dkim_pass_count)
+        source["dkim_fail_count"] += _count(row.dkim_fail_count)
         source["dmarc_pass_count"] += _count(row.dmarc_pass_count)
         source["dmarc_fail_count"] += _count(row.dmarc_fail_count)
         source["window_start"] = (
-            row.observed_at
+            row.first_seen or row.observed_at
             if source["window_start"] is None
-            else min(source["window_start"], row.observed_at)
+            else min(source["window_start"], row.first_seen or row.observed_at)
         )
         source["window_end"] = (
-            row.observed_at
+            row.last_seen or row.observed_at
             if source["window_end"] is None
-            else max(source["window_end"], row.observed_at)
+            else max(source["window_end"], row.last_seen or row.observed_at)
         )
         source["evidence_refs"].append(f"domain_source_daily_projection:{row.id}")
-        for generator in _as_dict(row.metadata_json).get("report_generators") or []:
-            normalized = str(generator).strip()
-            if normalized and normalized not in source["report_generators"]:
-                source["report_generators"].append(normalized)
+        metadata = _as_dict(row.metadata_json)
+        for field in (
+            "report_generators",
+            "header_from_domains",
+            "envelope_from_domains",
+            "spf_domains",
+            "dkim_domains",
+            "dkim_selectors",
+        ):
+            for value in metadata.get(field) or []:
+                normalized = str(value).strip()
+                if normalized and normalized not in source[field]:
+                    source[field].append(normalized)
         for disposition, count in _as_dict(row.disposition_counts).items():
             source["disposition_counts"][str(disposition).lower()] += _count(count)
         evidence = _as_dict(row.source_evidence)
@@ -135,9 +157,18 @@ def _assessment(
     watch_condition: str | None = None,
     supporting_signals: list[Dict[str, Any]] | None = None,
     conclusion_claim_level: str = "inferred",
+    derived_facts: list[str] | None = None,
 ) -> Dict[str, Any]:
+    derived_fact_set = set(derived_facts or [])
     observed_claims = [
-        {"claim_level": "observed", "statement": statement} for statement in known_facts or []
+        {"claim_level": "observed", "statement": statement}
+        for statement in known_facts or []
+        if statement not in derived_fact_set
+    ]
+    derived_claims = [
+        {"claim_level": "derived", "statement": statement}
+        for statement in known_facts or []
+        if statement in derived_fact_set
     ]
     inferred_claims = [
         {"claim_level": "inferred", "statement": statement} for statement in inferences or []
@@ -174,7 +205,7 @@ def _assessment(
         "delivery_certainty": "inferred_only",
         "signal_schema_version": MAIL_SIGNAL_SCHEMA_VERSION,
         "supporting_signals": supporting_signals or [],
-        "claims": observed_claims + inferred_claims + unknown_claims,
+        "claims": observed_claims + derived_claims + inferred_claims + unknown_claims,
     }
 
 
@@ -204,6 +235,7 @@ def build_workspace_mail_health_assessment(
     )
     sources = _merge_source_rows(rows)
     if not sources:
+        no_evidence_fact = "No projected sender facts were found for the selected date window."
         return _assessment(
             outcome="insufficient_evidence",
             title="Waiting for DMARC report data",
@@ -218,7 +250,8 @@ def build_workspace_mail_health_assessment(
             evidence_scope="No report-backed authentication evidence is available yet.",
             intended_mail_impact="unknown",
             urgency="monitor",
-            known_facts=["No projected sender facts were found for the selected date window."],
+            known_facts=[no_evidence_fact],
+            derived_facts=[no_evidence_fact],
             inferences=["DMARQ cannot assess mail authentication health yet."],
             unknowns=["How receivers evaluate mail from this domain."],
             verification_condition="Ingest an aggregate DMARC report for this domain.",
@@ -264,6 +297,9 @@ def build_workspace_mail_health_assessment(
         identity = source["identity"]
         passed = _count(source["dmarc_pass_count"])
         changed = " It also passed authentication in this selected period." if passed else ""
+        sender_match_fact = (
+            f"{identity.get('name') or 'A known sender'} matched a known sender profile."
+        )
         return _assessment(
             outcome="action_required",
             title=f"Check {identity.get('name') or 'a known sender'} authentication",
@@ -287,9 +323,10 @@ def build_workspace_mail_health_assessment(
             intended_mail_impact="likely_affected",
             urgency="timely",
             known_facts=[
-                f"{identity.get('name') or 'A known sender'} matched a known sender profile.",
+                sender_match_fact,
                 f"Aggregate reports recorded {_count(source['dmarc_fail_count'])} authentication failure(s).",
             ],
+            derived_facts=[sender_match_fact],
             inferences=["This sender may affect mail you intend to send."],
             unknowns=["Whether each affected message was delivered, bounced, or read."],
             verification_condition="Fresh reports show the sender authenticating without DMARC failures.",
@@ -298,6 +335,9 @@ def build_workspace_mail_health_assessment(
 
     if unknown_protected and not unknown_failing:
         source = max(unknown_protected, key=lambda item: _count(item["dmarc_fail_count"]))
+        unmatched_fact = (
+            "The source did not match a known provider or owned-infrastructure profile."
+        )
         return _assessment(
             outcome="no_action_likely_unauthorized_use",
             title="Likely unauthorized use is being blocked",
@@ -320,9 +360,10 @@ def build_workspace_mail_health_assessment(
             intended_mail_impact="likely_not_affected",
             urgency="none",
             known_facts=[
-                "The source did not match a known provider or owned-infrastructure profile.",
+                unmatched_fact,
                 "Receiver reports recorded protective quarantine or reject handling for all observed failures.",
             ],
+            derived_facts=[unmatched_fact],
             inferences=[
                 "This is likely unauthorized use rather than a fault in your known sending setup."
             ],
@@ -337,6 +378,7 @@ def build_workspace_mail_health_assessment(
 
     if unknown_failing:
         source = max(unknown_failing, key=lambda item: _count(item["dmarc_fail_count"]))
+        unmatched_fact = "The source did not match a known sender profile."
         return _assessment(
             outcome="investigation_required",
             title="Identify an unrecognized sending source",
@@ -358,9 +400,10 @@ def build_workspace_mail_health_assessment(
             intended_mail_impact="unknown",
             urgency="timely",
             known_facts=[
-                "The source did not match a known sender profile.",
+                unmatched_fact,
                 f"Aggregate reports recorded {_count(source['dmarc_fail_count'])} authentication failure(s).",
             ],
+            derived_facts=[unmatched_fact],
             inferences=["DMARQ cannot yet tell whether this source belongs to your mail estate."],
             unknowns=["Whether the source is an approved sender and its final delivery outcome."],
             verification_condition="Classify the source or collect fresh report evidence that identifies its owner.",

--- a/backend/app/services/mail_health.py
+++ b/backend/app/services/mail_health.py
@@ -17,6 +17,11 @@ from sqlalchemy.orm import Session
 from app.models.domain import Domain
 from app.models.report import DomainSourceDailyProjection
 from app.models.workspace import Workspace
+from app.services.mail_signals import (
+    MAIL_SIGNAL_SCHEMA_VERSION,
+    build_dmarc_source_signals,
+    build_intake_window_signal,
+)
 from app.services.sender_intelligence import identify_sender
 
 
@@ -50,7 +55,9 @@ def _hostname(evidence: Dict[str, Any]) -> str | None:
     return None
 
 
-def _merge_source_rows(rows: Iterable[tuple[Domain, DomainSourceDailyProjection]]) -> Dict[str, Any]:
+def _merge_source_rows(
+    rows: Iterable[tuple[Domain, DomainSourceDailyProjection]],
+) -> Dict[str, Any]:
     sources: Dict[tuple[str, str], Dict[str, Any]] = {}
     for domain, row in rows:
         key = (domain.name, str(row.source_ip))
@@ -64,10 +71,30 @@ def _merge_source_rows(rows: Iterable[tuple[Domain, DomainSourceDailyProjection]
                 "disposition_counts": defaultdict(int),
                 "source_evidence": {},
                 "captured_at": "",
+                "workspace_id": domain.workspace_id,
+                "window_start": None,
+                "window_end": None,
+                "evidence_refs": [],
+                "report_generators": [],
             },
         )
         source["dmarc_pass_count"] += _count(row.dmarc_pass_count)
         source["dmarc_fail_count"] += _count(row.dmarc_fail_count)
+        source["window_start"] = (
+            row.observed_at
+            if source["window_start"] is None
+            else min(source["window_start"], row.observed_at)
+        )
+        source["window_end"] = (
+            row.observed_at
+            if source["window_end"] is None
+            else max(source["window_end"], row.observed_at)
+        )
+        source["evidence_refs"].append(f"domain_source_daily_projection:{row.id}")
+        for generator in _as_dict(row.metadata_json).get("report_generators") or []:
+            normalized = str(generator).strip()
+            if normalized and normalized not in source["report_generators"]:
+                source["report_generators"].append(normalized)
         for disposition, count in _as_dict(row.disposition_counts).items():
             source["disposition_counts"][str(disposition).lower()] += _count(count)
         evidence = _as_dict(row.source_evidence)
@@ -76,6 +103,15 @@ def _merge_source_rows(rows: Iterable[tuple[Domain, DomainSourceDailyProjection]
             source["source_evidence"] = evidence
             source["captured_at"] = captured_at
     return sources
+
+
+def _source_signals(source: Dict[str, Any]) -> list[Dict[str, Any]]:
+    return build_dmarc_source_signals(
+        source,
+        workspace_id=source.get("workspace_id"),
+        domain=str(source.get("domain") or ""),
+        evidence_refs=source.get("evidence_refs") or (),
+    )
 
 
 def _assessment(
@@ -97,7 +133,18 @@ def _assessment(
     verification_condition: str = "Review fresh report evidence before changing mail or DNS settings.",
     no_action_reason: str | None = None,
     watch_condition: str | None = None,
+    supporting_signals: list[Dict[str, Any]] | None = None,
+    conclusion_claim_level: str = "inferred",
 ) -> Dict[str, Any]:
+    observed_claims = [
+        {"claim_level": "observed", "statement": statement} for statement in known_facts or []
+    ]
+    inferred_claims = [
+        {"claim_level": "inferred", "statement": statement} for statement in inferences or []
+    ]
+    unknown_claims = [
+        {"claim_level": "unknown", "statement": statement} for statement in unknowns or []
+    ]
     return {
         "outcome": outcome,
         "title": title,
@@ -123,6 +170,11 @@ def _assessment(
         "no_action_reason": no_action_reason,
         "watch_condition": watch_condition,
         "claim_type": "aggregate_dmarc_authentication",
+        "claim_level": conclusion_claim_level,
+        "delivery_certainty": "inferred_only",
+        "signal_schema_version": MAIL_SIGNAL_SCHEMA_VERSION,
+        "supporting_signals": supporting_signals or [],
+        "claims": observed_claims + inferred_claims + unknown_claims,
     }
 
 
@@ -171,6 +223,15 @@ def build_workspace_mail_health_assessment(
             unknowns=["How receivers evaluate mail from this domain."],
             verification_condition="Ingest an aggregate DMARC report for this domain.",
             watch_condition="DMARQ will reassess when a report is imported.",
+            supporting_signals=[
+                build_intake_window_signal(
+                    workspace_id=workspace.id,
+                    window_start=start_ts,
+                    window_end=end_ts,
+                    has_evidence=False,
+                )
+            ],
+            conclusion_claim_level="derived",
         )
 
     known_failing: list[Dict[str, Any]] = []
@@ -232,6 +293,7 @@ def build_workspace_mail_health_assessment(
             inferences=["This sender may affect mail you intend to send."],
             unknowns=["Whether each affected message was delivered, bounced, or read."],
             verification_condition="Fresh reports show the sender authenticating without DMARC failures.",
+            supporting_signals=_source_signals(source),
         )
 
     if unknown_protected and not unknown_failing:
@@ -261,11 +323,16 @@ def build_workspace_mail_health_assessment(
                 "The source did not match a known provider or owned-infrastructure profile.",
                 "Receiver reports recorded protective quarantine or reject handling for all observed failures.",
             ],
-            inferences=["This is likely unauthorized use rather than a fault in your known sending setup."],
-            unknowns=["Who operated the unrecognized source and the final outcome of individual messages."],
+            inferences=[
+                "This is likely unauthorized use rather than a fault in your known sending setup."
+            ],
+            unknowns=[
+                "Who operated the unrecognized source and the final outcome of individual messages."
+            ],
             verification_condition="Known senders remain healthy and no new evidence links this source to your mail estate.",
             no_action_reason="Receivers already reported protective handling and no known sender failures were found.",
             watch_condition="DMARQ will surface a new action if the pattern changes or a known sender fails.",
+            supporting_signals=_source_signals(source),
         )
 
     if unknown_failing:
@@ -297,10 +364,15 @@ def build_workspace_mail_health_assessment(
             inferences=["DMARQ cannot yet tell whether this source belongs to your mail estate."],
             unknowns=["Whether the source is an approved sender and its final delivery outcome."],
             verification_condition="Classify the source or collect fresh report evidence that identifies its owner.",
+            supporting_signals=_source_signals(source),
         )
 
     observed_passes = sum(_count(source["dmarc_pass_count"]) for source in sources.values())
     if not observed_passes:
+        source = max(
+            sources.values(),
+            key=lambda item: _count(item["dmarc_pass_count"]) + _count(item["dmarc_fail_count"]),
+        )
         return _assessment(
             outcome="insufficient_evidence",
             title="Waiting for usable DMARC authentication evidence",
@@ -318,13 +390,18 @@ def build_workspace_mail_health_assessment(
             evidence_scope="Sender activity alone is not enough to assess mail authentication health.",
             intended_mail_impact="unknown",
             urgency="monitor",
-            known_facts=["Projected sender records contain no successful or failed DMARC authentication counts."],
+            known_facts=[
+                "Projected sender records contain no successful or failed DMARC authentication counts."
+            ],
             inferences=["Sender activity by itself is not enough to assess mail health."],
             unknowns=["Whether receivers accept or reject mail from these sources."],
             verification_condition="A later report includes successful or failed DMARC authentication results.",
             watch_condition="DMARQ will reassess when usable authentication evidence arrives.",
+            supporting_signals=_source_signals(source),
+            conclusion_claim_level="derived",
         )
 
+    source = max(sources.values(), key=lambda item: _count(item["dmarc_pass_count"]))
     return _assessment(
         outcome="healthy",
         title="Known senders are authenticating successfully",
@@ -334,16 +411,21 @@ def build_workspace_mail_health_assessment(
         next_step="Keep report intake running",
         href="/reports",
         confidence="High",
-        reasons=["Projected sender facts contain successful DMARC authentication and no failure counts."],
+        reasons=[
+            "Projected sender facts contain successful DMARC authentication and no failure counts."
+        ],
         evidence_scope=(
             "Aggregate DMARC reports show authentication results, not a guarantee of inbox placement or delivery."
         ),
         intended_mail_impact="likely_not_affected",
         urgency="none",
-        known_facts=["Projected sender facts contain successful DMARC authentication and no reported failures."],
+        known_facts=[
+            "Projected sender facts contain successful DMARC authentication and no reported failures."
+        ],
         inferences=["Known sender activity appears healthy in the selected evidence window."],
         unknowns=["Inbox placement and individual delivery outcomes."],
         verification_condition="Continue receiving aggregate reports without a new authentication failure pattern.",
         no_action_reason="No current authentication failures were found in the selected evidence window.",
         watch_condition="DMARQ will notify when a meaningful sender or authentication change appears.",
+        supporting_signals=_source_signals(source),
     )

--- a/backend/app/services/mail_health.py
+++ b/backend/app/services/mail_health.py
@@ -157,6 +157,7 @@ def _assessment(
     watch_condition: str | None = None,
     supporting_signals: list[Dict[str, Any]] | None = None,
     conclusion_claim_level: str = "inferred",
+    delivery_certainty: str = "inferred_only",
     derived_facts: list[str] | None = None,
 ) -> Dict[str, Any]:
     derived_fact_set = set(derived_facts or [])
@@ -202,7 +203,7 @@ def _assessment(
         "watch_condition": watch_condition,
         "claim_type": "aggregate_dmarc_authentication",
         "claim_level": conclusion_claim_level,
-        "delivery_certainty": "inferred_only",
+        "delivery_certainty": delivery_certainty,
         "signal_schema_version": MAIL_SIGNAL_SCHEMA_VERSION,
         "supporting_signals": supporting_signals or [],
         "claims": observed_claims + derived_claims + inferred_claims + unknown_claims,
@@ -265,6 +266,7 @@ def build_workspace_mail_health_assessment(
                 )
             ],
             conclusion_claim_level="derived",
+            delivery_certainty="not_applicable",
         )
 
     known_failing: list[Dict[str, Any]] = []
@@ -442,6 +444,7 @@ def build_workspace_mail_health_assessment(
             watch_condition="DMARQ will reassess when usable authentication evidence arrives.",
             supporting_signals=_source_signals(source),
             conclusion_claim_level="derived",
+            delivery_certainty="not_applicable",
         )
 
     source = max(sources.values(), key=lambda item: _count(item["dmarc_pass_count"]))

--- a/backend/app/services/mail_health_incidents.py
+++ b/backend/app/services/mail_health_incidents.py
@@ -49,10 +49,15 @@ def _material_state(assessment: Dict[str, Any]) -> str:
             "confidence": assessment.get("confidence"),
             "claim_level": assessment.get("claim_level"),
             "delivery_certainty": assessment.get("delivery_certainty"),
-            "supporting_signal_ids": sorted(
-                str(signal.get("signal_id"))
+            "supporting_signal_semantics": sorted(
+                (
+                    str(signal.get("family") or ""),
+                    str(signal.get("signal_type") or ""),
+                    str(signal.get("outcome") or ""),
+                    str(signal.get("claim_level") or ""),
+                    str(signal.get("delivery_certainty") or ""),
+                )
                 for signal in assessment.get("supporting_signals") or []
-                if signal.get("signal_id")
             ),
             "next_action": assessment.get("next_action", {}).get("href"),
             "assessment_version": assessment.get("assessment_version"),

--- a/backend/app/services/mail_health_incidents.py
+++ b/backend/app/services/mail_health_incidents.py
@@ -47,13 +47,22 @@ def _material_state(assessment: Dict[str, Any]) -> str:
             "intended_mail_impact": assessment.get("intended_mail_impact"),
             "urgency": assessment.get("urgency"),
             "confidence": assessment.get("confidence"),
+            "claim_level": assessment.get("claim_level"),
+            "delivery_certainty": assessment.get("delivery_certainty"),
+            "supporting_signal_ids": sorted(
+                str(signal.get("signal_id"))
+                for signal in assessment.get("supporting_signals") or []
+                if signal.get("signal_id")
+            ),
             "next_action": assessment.get("next_action", {}).get("href"),
             "assessment_version": assessment.get("assessment_version"),
         }
     )
 
 
-def incident_to_dict(row: MailHealthIncident, *, notification_reason: Optional[str] = None) -> Dict[str, Any]:
+def incident_to_dict(
+    row: MailHealthIncident, *, notification_reason: Optional[str] = None
+) -> Dict[str, Any]:
     try:
         assessment = json.loads(row.assessment)
     except (TypeError, ValueError, json.JSONDecodeError):
@@ -71,7 +80,9 @@ def incident_to_dict(row: MailHealthIncident, *, notification_reason: Optional[s
         "assessment": assessment,
         "first_seen_at": row.first_seen_at.isoformat() if row.first_seen_at else None,
         "last_seen_at": row.last_seen_at.isoformat() if row.last_seen_at else None,
-        "last_material_change_at": row.last_material_change_at.isoformat() if row.last_material_change_at else None,
+        "last_material_change_at": (
+            row.last_material_change_at.isoformat() if row.last_material_change_at else None
+        ),
         "last_notified_at": row.last_notified_at.isoformat() if row.last_notified_at else None,
         "last_notification_reason": row.last_notification_reason,
         "snoozed_until": row.snoozed_until.isoformat() if row.snoozed_until else None,
@@ -240,7 +251,11 @@ def record_mail_health_assessment(
             evidence="A fresh report-backed assessment no longer found this actionable state.",
         )
         db.commit()
-        return {"incident": None, "notification_reason": None, "resolved": [incident_to_dict(row) for row in resolved]}
+        return {
+            "incident": None,
+            "notification_reason": None,
+            "resolved": [incident_to_dict(row) for row in resolved],
+        }
 
     key = _incident_key(workspace, assessment)
     state_hash = _material_state(assessment)
@@ -270,17 +285,28 @@ def record_mail_health_assessment(
 
     db.flush()
     reason = _should_notify(
-        workspace, assessment, is_new=is_new, materially_changed=materially_changed, now=now, row=row
+        workspace,
+        assessment,
+        is_new=is_new,
+        materially_changed=materially_changed,
+        now=now,
+        row=row,
     )
     if reason:
         row.last_notified_at = now
         row.last_notification_reason = reason
     db.commit()
     db.refresh(row)
-    return {"incident": incident_to_dict(row, notification_reason=reason), "notification_reason": reason, "resolved": []}
+    return {
+        "incident": incident_to_dict(row, notification_reason=reason),
+        "notification_reason": reason,
+        "resolved": [],
+    }
 
 
-def list_mail_health_incidents(db: Session, *, workspace: Workspace, limit: int = 50) -> List[Dict[str, Any]]:
+def list_mail_health_incidents(
+    db: Session, *, workspace: Workspace, limit: int = 50
+) -> List[Dict[str, Any]]:
     rows = (
         db.query(MailHealthIncident)
         .filter(MailHealthIncident.workspace_id == workspace.id)
@@ -303,7 +329,9 @@ def update_incident_operator_state(
 ) -> Dict[str, Any]:
     row = (
         db.query(MailHealthIncident)
-        .filter(MailHealthIncident.id == incident_id, MailHealthIncident.workspace_id == workspace.id)
+        .filter(
+            MailHealthIncident.id == incident_id, MailHealthIncident.workspace_id == workspace.id
+        )
         .one_or_none()
     )
     if row is None:
@@ -325,7 +353,10 @@ def update_incident_operator_state(
         entity_type="mail_health_incident",
         entity_id=row.id,
         entity_name=row.domain,
-        details={"status": row.status, "snoozed_until": row.snoozed_until.isoformat() if row.snoozed_until else None},
+        details={
+            "status": row.status,
+            "snoozed_until": row.snoozed_until.isoformat() if row.snoozed_until else None,
+        },
         auth_context=auth_context,
     )
     db.commit()

--- a/backend/app/services/mail_signals.py
+++ b/backend/app/services/mail_signals.py
@@ -1,0 +1,286 @@
+"""Versioned, protocol-aware evidence signals for mail-health interpretation.
+
+The signal envelope keeps protocol observations separate from DMARQ's
+interpretation.  It is intentionally serializable and provider-neutral so the
+same contract can later carry TLS-RPT, DSN, and provider delivery events
+without re-labelling aggregate DMARC evidence as delivery evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+MAIL_SIGNAL_SCHEMA_VERSION = "dmarq.mail_signal.v1"
+
+SIGNAL_FAMILIES = frozenset(
+    {
+        "dmarc_authentication",
+        "dmarc_reported_disposition",
+        "dmarc_failure_detail",
+        "smtp_tls_report",
+        "dsn_delivery_status",
+        "provider_delivery_event",
+        "dns_posture",
+        "intake_health",
+        "operator_reported_symptom",
+    }
+)
+
+CLAIM_LEVELS = frozenset({"observed", "derived", "inferred", "operator_reported", "unknown"})
+
+DELIVERY_CERTAINTIES = frozenset(
+    {
+        "not_applicable",
+        "authentication_only",
+        "receiver_disposition_reported",
+        "transport_failure_reported",
+        "non_delivery_reported",
+        "delivery_reported",
+        "inferred_only",
+    }
+)
+
+PRIVACY_CLASSES = frozenset({"aggregate", "redacted", "restricted"})
+
+
+def _stable_signal_id(parts: Mapping[str, Any]) -> str:
+    encoded = json.dumps(parts, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _bounded_count(value: object) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _string_values(value: object) -> list[str]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return []
+    return sorted({str(item).strip() for item in value if str(item).strip()})
+
+
+@dataclass(frozen=True)
+class MailSignal:
+    """Common envelope for observed, derived, and operator-reported evidence."""
+
+    family: str
+    signal_type: str
+    outcome: str
+    claim_level: str
+    delivery_certainty: str
+    source_system: str
+    workspace_id: int | None = None
+    domain: str | None = None
+    correlation_key: str | None = None
+    observed_at: str | None = None
+    window_start: int | None = None
+    window_end: int | None = None
+    reason_code: str | None = None
+    count: int = 0
+    confidence: str = "high"
+    confidence_reasons: tuple[str, ...] = field(default_factory=tuple)
+    freshness: str = "current"
+    privacy_classification: str = "aggregate"
+    evidence_refs: tuple[str, ...] = field(default_factory=tuple)
+    guidance_key: str | None = None
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: str = MAIL_SIGNAL_SCHEMA_VERSION
+    signal_id: str = ""
+
+    def __post_init__(self) -> None:
+        if self.family not in SIGNAL_FAMILIES:
+            raise ValueError(f"Unsupported mail-signal family: {self.family}")
+        if self.claim_level not in CLAIM_LEVELS:
+            raise ValueError(f"Unsupported claim level: {self.claim_level}")
+        if self.delivery_certainty not in DELIVERY_CERTAINTIES:
+            raise ValueError(f"Unsupported delivery certainty: {self.delivery_certainty}")
+        if self.privacy_classification not in PRIVACY_CLASSES:
+            raise ValueError(
+                f"Unsupported mail-signal privacy classification: {self.privacy_classification}"
+            )
+        if not self.signal_id:
+            object.__setattr__(
+                self,
+                "signal_id",
+                _stable_signal_id(
+                    {
+                        "schema_version": self.schema_version,
+                        "workspace_id": self.workspace_id,
+                        "domain": self.domain,
+                        "family": self.family,
+                        "signal_type": self.signal_type,
+                        "correlation_key": self.correlation_key,
+                        "window_start": self.window_start,
+                        "window_end": self.window_end,
+                        "evidence_refs": self.evidence_refs,
+                    }
+                ),
+            )
+        object.__setattr__(self, "count", _bounded_count(self.count))
+
+    def to_dict(self) -> dict[str, Any]:
+        result = asdict(self)
+        result["confidence_reasons"] = list(self.confidence_reasons)
+        result["evidence_refs"] = list(self.evidence_refs)
+        result["payload"] = dict(self.payload)
+        return result
+
+
+def make_mail_signal(**values: Any) -> MailSignal:
+    """Build and validate one signal from a typed source adapter."""
+    return MailSignal(**values)
+
+
+def _disposition_outcome(dispositions: Mapping[str, Any]) -> tuple[str, int]:
+    normalized = {
+        str(key).strip().lower(): _bounded_count(value)
+        for key, value in dispositions.items()
+        if _bounded_count(value)
+    }
+    if not normalized:
+        return "unknown", 0
+    if len(normalized) == 1:
+        outcome, count = next(iter(normalized.items()))
+        return outcome if outcome in {"none", "quarantine", "reject"} else "other", count
+    return "mixed", sum(normalized.values())
+
+
+def build_dmarc_source_signals(
+    source: Mapping[str, Any],
+    *,
+    workspace_id: int | None,
+    domain: str,
+    evidence_refs: Sequence[str] = (),
+) -> list[dict[str, Any]]:
+    """Return separate authentication and receiver-disposition observations."""
+    passed = _bounded_count(source.get("dmarc_pass_count"))
+    failed = _bounded_count(source.get("dmarc_fail_count"))
+    if passed and failed:
+        authentication_outcome = "mixed"
+    elif passed:
+        authentication_outcome = "pass"
+    elif failed:
+        authentication_outcome = "fail"
+    else:
+        authentication_outcome = "unknown"
+
+    source_ip = str(source.get("source_ip") or "unknown")
+    correlation_key = f"{domain}:{source_ip}"
+    common = {
+        "workspace_id": workspace_id,
+        "domain": domain,
+        "correlation_key": correlation_key,
+        "window_start": source.get("window_start"),
+        "window_end": source.get("window_end"),
+        "observed_at": str(source.get("captured_at") or "") or None,
+        "source_system": "dmarc_aggregate_report",
+        "claim_level": "observed",
+        "privacy_classification": "aggregate",
+        "evidence_refs": tuple(sorted({str(item) for item in evidence_refs if str(item)})),
+    }
+    authentication = make_mail_signal(
+        **common,
+        family="dmarc_authentication",
+        signal_type="aggregate_authentication_result",
+        outcome=authentication_outcome,
+        reason_code=f"dmarc_authentication_{authentication_outcome}",
+        count=passed + failed,
+        delivery_certainty="authentication_only",
+        guidance_key=f"mail_signal.dmarc_authentication.{authentication_outcome}",
+        payload={
+            "source_ip": source_ip,
+            "passed": passed,
+            "failed": failed,
+            "spf_passed": _bounded_count(source.get("spf_pass_count")),
+            "spf_failed": _bounded_count(source.get("spf_fail_count")),
+            "dkim_passed": _bounded_count(source.get("dkim_pass_count")),
+            "dkim_failed": _bounded_count(source.get("dkim_fail_count")),
+            "header_from_domains": _string_values(source.get("header_from_domains")),
+            "envelope_from_domains": _string_values(source.get("envelope_from_domains")),
+            "spf_domains": _string_values(source.get("spf_domains")),
+            "dkim_domains": _string_values(source.get("dkim_domains")),
+            "dkim_selectors": _string_values(source.get("dkim_selectors")),
+            "report_generators": _string_values(source.get("report_generators")),
+        },
+    )
+
+    disposition_outcome, disposition_count = _disposition_outcome(
+        source.get("disposition_counts") or {}
+    )
+    disposition = make_mail_signal(
+        **common,
+        family="dmarc_reported_disposition",
+        signal_type="aggregate_receiver_disposition",
+        outcome=disposition_outcome,
+        reason_code=f"dmarc_reported_disposition_{disposition_outcome}",
+        count=disposition_count,
+        delivery_certainty="receiver_disposition_reported",
+        guidance_key=f"mail_signal.dmarc_reported_disposition.{disposition_outcome}",
+        payload={
+            "source_ip": source_ip,
+            "dispositions": {
+                str(key).lower(): _bounded_count(value)
+                for key, value in (source.get("disposition_counts") or {}).items()
+            },
+        },
+    )
+    return [authentication.to_dict(), disposition.to_dict()]
+
+
+def build_intake_window_signal(
+    *, workspace_id: int | None, window_start: int, window_end: int, has_evidence: bool
+) -> dict[str, Any]:
+    """Describe only whether persisted report evidence exists in a selected window."""
+    outcome = "report_evidence_available" if has_evidence else "no_report_evidence_in_window"
+    return make_mail_signal(
+        family="intake_health",
+        signal_type="report_evidence_window",
+        outcome=outcome,
+        claim_level="derived",
+        delivery_certainty="not_applicable",
+        source_system="dmarq_projection",
+        workspace_id=workspace_id,
+        window_start=window_start,
+        window_end=window_end,
+        reason_code=outcome,
+        count=1 if has_evidence else 0,
+        confidence="high",
+        evidence_refs=(f"workspace:{workspace_id}",) if workspace_id is not None else (),
+        guidance_key=f"mail_signal.intake_health.{outcome}",
+    ).to_dict()
+
+
+def guided_signal_statement(signal: Mapping[str, Any]) -> str:
+    """Render a truthful English fallback from a normalized guidance key."""
+    family = str(signal.get("family") or "")
+    outcome = str(signal.get("outcome") or "unknown")
+    if family == "dmarc_authentication" and outcome == "pass":
+        return "The receiver recognized this use of the domain as authenticated."
+    if family == "dmarc_authentication" and outcome == "fail":
+        return "The receiver reported that this mail did not pass domain authentication."
+    if family == "dmarc_reported_disposition" and outcome in {"reject", "quarantine"}:
+        return f"The reporting receiver recorded DMARC disposition {outcome}."
+    if family == "dmarc_reported_disposition" and outcome == "none":
+        return "The reporting receiver recorded no DMARC policy action for the failure."
+    if family == "smtp_tls_report":
+        return "A sending system reported a TLS delivery-path result."
+    if (
+        family == "dsn_delivery_status"
+        and signal.get("delivery_certainty") == "non_delivery_reported"
+    ):
+        return "The sending system reported non-delivery."
+    if family == "provider_delivery_event" and outcome == "delivered":
+        return "The provider reported delivery according to its own event semantics."
+    if family == "intake_health" and outcome == "no_report_evidence_in_window":
+        return "DMARQ has no persisted report evidence in the selected window."
+    return "DMARQ has structured evidence, but no plain-language statement is defined yet."
+
+
+def signal_families() -> Iterable[str]:
+    """Expose the stable taxonomy without leaking mutable internal state."""
+    return tuple(sorted(SIGNAL_FAMILIES))

--- a/backend/app/services/mail_signals.py
+++ b/backend/app/services/mail_signals.py
@@ -255,18 +255,32 @@ def build_intake_window_signal(
     ).to_dict()
 
 
+def _dmarc_signal_statement(family: str, outcome: str) -> str | None:
+    authentication = {
+        "pass": "The receiver recognized this use of the domain as authenticated.",
+        "fail": "The receiver reported that this mail did not pass domain authentication.",
+        "mixed": "The receiver reported both authenticated and unauthenticated mail from this source.",
+    }
+    dispositions = {
+        "reject": "The reporting receiver recorded DMARC disposition reject.",
+        "quarantine": "The reporting receiver recorded DMARC disposition quarantine.",
+        "none": "The reporting receiver recorded no DMARC policy action for the failure.",
+        "mixed": "The reporting receiver recorded more than one DMARC disposition for this source.",
+    }
+    if family == "dmarc_authentication":
+        return authentication.get(outcome)
+    if family == "dmarc_reported_disposition":
+        return dispositions.get(outcome)
+    return None
+
+
 def guided_signal_statement(signal: Mapping[str, Any]) -> str:
     """Render a truthful English fallback from a normalized guidance key."""
     family = str(signal.get("family") or "")
     outcome = str(signal.get("outcome") or "unknown")
-    if family == "dmarc_authentication" and outcome == "pass":
-        return "The receiver recognized this use of the domain as authenticated."
-    if family == "dmarc_authentication" and outcome == "fail":
-        return "The receiver reported that this mail did not pass domain authentication."
-    if family == "dmarc_reported_disposition" and outcome in {"reject", "quarantine"}:
-        return f"The reporting receiver recorded DMARC disposition {outcome}."
-    if family == "dmarc_reported_disposition" and outcome == "none":
-        return "The reporting receiver recorded no DMARC policy action for the failure."
+    dmarc_statement = _dmarc_signal_statement(family, outcome)
+    if dmarc_statement:
+        return dmarc_statement
     if family == "smtp_tls_report":
         return "A sending system reported a TLS delivery-path result."
     if (

--- a/backend/app/services/mailflow_assessment.py
+++ b/backend/app/services/mailflow_assessment.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable
 
+from app.services.mail_signals import build_dmarc_source_signals
+
 
 def _count(value: object) -> int:
     try:
@@ -37,7 +39,13 @@ def _alignment_status(pass_count: int, fail_count: int) -> str:
     return "unknown"
 
 
-def _flow(source: Dict[str, Any], sender: Dict[str, Any]) -> Dict[str, Any]:
+def _flow(
+    source: Dict[str, Any],
+    sender: Dict[str, Any],
+    *,
+    workspace_id: int | None,
+    domain: str,
+) -> Dict[str, Any]:
     messages = _count(source.get("count"))
     spf_pass = _count(source.get("spf_pass_count"))
     spf_fail = _count(source.get("spf_fail_count"))
@@ -112,6 +120,17 @@ def _flow(source: Dict[str, Any], sender: Dict[str, Any]) -> Dict[str, Any]:
         )
         next_step = "Keep report intake running"
 
+    evidence_level = (
+        "inferred"
+        if status in {"likely_unauthorized", "investigate_alignment", "investigate_source"}
+        else "observed"
+    )
+    signals = build_dmarc_source_signals(
+        source,
+        workspace_id=workspace_id,
+        domain=domain,
+        evidence_refs=source.get("evidence_refs") or (),
+    )
     return {
         "source_ip": str(source.get("source_ip") or "unknown"),
         "sender_name": str(sender.get("name") or "Unknown sender"),
@@ -130,11 +149,12 @@ def _flow(source: Dict[str, Any], sender: Dict[str, Any]) -> Dict[str, Any]:
         "dmarc_status": str(source.get("dmarc_result") or "unknown"),
         "receiver_disposition": str(source.get("disposition") or "none"),
         "intended_mail_impact": intended_mail_impact,
-        "evidence_level": (
-            "inferred"
-            if status in {"likely_unauthorized", "investigate_alignment", "investigate_source"}
-            else "observed"
+        "evidence_level": evidence_level,
+        "claim_level": evidence_level,
+        "delivery_certainty": (
+            "inferred_only" if evidence_level == "inferred" else "authentication_only"
         ),
+        "signals": signals,
         "provider_evidence_status": "not_connected",
         "next_step": next_step,
         "verification_condition": (
@@ -147,10 +167,17 @@ def build_domain_mailflow_assessment(
     domain: str,
     sources: Iterable[Dict[str, Any]],
     sender_by_ip: Dict[str, Dict[str, Any]],
+    *,
+    workspace_id: int | None = None,
 ) -> Dict[str, Any]:
     """Build one domain summary plus per-source mailflow identity facts."""
     flows = [
-        _flow(source, sender_by_ip.get(str(source.get("source_ip") or "unknown"), {}))
+        _flow(
+            source,
+            sender_by_ip.get(str(source.get("source_ip") or "unknown"), {}),
+            workspace_id=workspace_id,
+            domain=domain,
+        )
         for source in sources
         if _count(source.get("count")) > 0
     ]

--- a/backend/app/services/mailflow_assessment.py
+++ b/backend/app/services/mailflow_assessment.py
@@ -120,11 +120,12 @@ def _flow(
         )
         next_step = "Keep report intake running"
 
-    evidence_level = (
-        "inferred"
-        if status in {"likely_unauthorized", "investigate_alignment", "investigate_source"}
-        else "observed"
-    )
+    if status in {"likely_unauthorized", "investigate_alignment", "investigate_source"}:
+        evidence_level = "inferred"
+    elif status == "insufficient_evidence":
+        evidence_level = "unknown"
+    else:
+        evidence_level = "observed"
     signals = build_dmarc_source_signals(
         source,
         workspace_id=workspace_id,
@@ -152,7 +153,9 @@ def _flow(
         "evidence_level": evidence_level,
         "claim_level": evidence_level,
         "delivery_certainty": (
-            "inferred_only" if evidence_level == "inferred" else "authentication_only"
+            "inferred_only"
+            if evidence_level == "inferred"
+            else "not_applicable" if evidence_level == "unknown" else "authentication_only"
         ),
         "signals": signals,
         "provider_evidence_status": "not_connected",

--- a/backend/app/services/source_read_projection.py
+++ b/backend/app/services/source_read_projection.py
@@ -358,14 +358,14 @@ def load_domain_source_read_projection(
         )
         source["last_seen"] = max(_int(source.get("last_seen")), _int(row.last_seen))
         source["window_start"] = (
-            row.observed_at
+            row.first_seen or row.observed_at
             if source["window_start"] is None
-            else min(source["window_start"], row.observed_at)
+            else min(source["window_start"], row.first_seen or row.observed_at)
         )
         source["window_end"] = (
-            row.observed_at
+            row.last_seen or row.observed_at
             if source["window_end"] is None
-            else max(source["window_end"], row.observed_at)
+            else max(source["window_end"], row.last_seen or row.observed_at)
         )
         source["evidence_refs"].append(f"domain_source_daily_projection:{row.id}")
         for field in (

--- a/backend/app/services/source_read_projection.py
+++ b/backend/app/services/source_read_projection.py
@@ -265,6 +265,7 @@ def backfill_source_projections(db: Session, *, limit: int = 100) -> int:
             db,
             {
                 "org_name": report.org_name,
+                "email": report.source_email,
                 "begin_timestamp": report.begin_date,
                 "end_timestamp": report.end_date,
                 "records": [_persisted_record_payload(record) for record in report.records],

--- a/backend/app/services/source_read_projection.py
+++ b/backend/app/services/source_read_projection.py
@@ -74,6 +74,7 @@ def _record_metadata(record: Dict[str, Any]) -> Dict[str, Any]:
         "spf_domains": [],
         "dkim_domains": [],
         "dkim_selectors": [],
+        "report_generators": [],
         "extensions": {},
     }
     _add_unique(metadata["header_from_domains"], record.get("header_from"))
@@ -98,6 +99,7 @@ def _merge_metadata(current: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[s
         "spf_domains": list(current.get("spf_domains") or []),
         "dkim_domains": list(current.get("dkim_domains") or []),
         "dkim_selectors": list(current.get("dkim_selectors") or []),
+        "report_generators": list(current.get("report_generators") or []),
         "extensions": dict(current.get("extensions") or {}),
     }
     for key in (
@@ -106,6 +108,7 @@ def _merge_metadata(current: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[s
         "spf_domains",
         "dkim_domains",
         "dkim_selectors",
+        "report_generators",
     ):
         for value in incoming.get(key) or []:
             _add_unique(merged[key], value)
@@ -114,7 +117,9 @@ def _merge_metadata(current: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[s
     return merged
 
 
-def _projection_records(records: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+def _projection_records(
+    records: Iterable[Dict[str, Any]], *, report_generator: str | None = None
+) -> Dict[str, Dict[str, Any]]:
     grouped: Dict[str, Dict[str, Any]] = {}
     for record in records:
         ip = str(record.get("source_ip") or "unknown")
@@ -137,6 +142,7 @@ def _projection_records(records: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str
             },
         )
         count = _int(record.get("count"))
+        _add_unique(item["metadata"]["report_generators"], report_generator)
         item["message_count"] += count
         spf = str(record.get("spf_result") or record.get("spf") or "unknown").lower()
         dkim = str(record.get("dkim_result") or record.get("dkim") or "unknown").lower()
@@ -174,7 +180,10 @@ def materialize_source_projection(
     # report before looking up the next daily aggregate.
     db.flush()
     first_seen, last_seen, observed_at = _observation_window(report)
-    for source_ip, values in _projection_records(report.get("records") or []).items():
+    for source_ip, values in _projection_records(
+        report.get("records") or [],
+        report_generator=str(report.get("org_name") or report.get("email") or "") or None,
+    ).items():
         projection = (
             db.query(DomainSourceDailyProjection)
             .filter(
@@ -255,6 +264,7 @@ def backfill_source_projections(db: Session, *, limit: int = 100) -> int:
         materialize_source_projection(
             db,
             {
+                "org_name": report.org_name,
                 "begin_timestamp": report.begin_date,
                 "end_timestamp": report.end_date,
                 "records": [_persisted_record_payload(record) for record in report.records],
@@ -335,6 +345,9 @@ def load_domain_source_read_projection(
                 "_metadata": _record_metadata({}),
                 "_active_dates": set(),
                 "_captured_at": "",
+                "window_start": None,
+                "window_end": None,
+                "evidence_refs": [],
             },
         )
         source["count"] += _int(row.message_count)
@@ -344,6 +357,17 @@ def load_domain_source_read_projection(
             _int(row.first_seen) or _int(source.get("first_seen")),
         )
         source["last_seen"] = max(_int(source.get("last_seen")), _int(row.last_seen))
+        source["window_start"] = (
+            row.observed_at
+            if source["window_start"] is None
+            else min(source["window_start"], row.observed_at)
+        )
+        source["window_end"] = (
+            row.observed_at
+            if source["window_end"] is None
+            else max(source["window_end"], row.observed_at)
+        )
+        source["evidence_refs"].append(f"domain_source_daily_projection:{row.id}")
         for field in (
             "spf_pass_count",
             "spf_fail_count",
@@ -356,12 +380,10 @@ def load_domain_source_read_projection(
         ):
             source[field] += _int(getattr(row, field))
         for name, count in _json_dict(row.disposition_counts).items():
-            source["disposition_counts"][name] = _int(source["disposition_counts"].get(name)) + _int(
-                count
-            )
-        source["_metadata"] = _merge_metadata(
-            source["_metadata"], _json_dict(row.metadata_json)
-        )
+            source["disposition_counts"][name] = _int(
+                source["disposition_counts"].get(name)
+            ) + _int(count)
+        source["_metadata"] = _merge_metadata(source["_metadata"], _json_dict(row.metadata_json))
         evidence = _json_dict(row.source_evidence)
         captured_at = str(evidence.get("captured_at") or "")
         if evidence and captured_at >= source["_captured_at"]:
@@ -405,12 +427,10 @@ def load_domain_source_read_projection(
         source["dkim_result"] = _status(
             source["dkim_pass_count"], source["dkim_fail_count"], source["dkim_unknown_count"]
         )
-        source["dmarc_result"] = _status(
-            source["dmarc_pass_count"], source["dmarc_fail_count"]
-        )
+        source["dmarc_result"] = _status(source["dmarc_pass_count"], source["dmarc_fail_count"])
         source["disposition"] = _dominant(source["disposition_counts"])
         source.update(source.pop("_metadata"))
-        source.pop("_captured_at")
+        source["captured_at"] = source.pop("_captured_at") or None
         source_rows.append(source)
 
     report_rows = [

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -3200,7 +3200,13 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
     assert source["receiver_disposition"] == "mixed"
     assert source["evidence_kind"] == "dmarc_aggregate_report"
     assert source["claim_level"] == "observed"
-    assert source["delivery_certainty"] == "unknown"
+    assert source["delivery_certainty"] == "receiver_disposition_reported"
+    assert {signal["family"] for signal in source["signals"]} == {
+        "dmarc_authentication",
+        "dmarc_reported_disposition",
+    }
+    assert all(signal["claim_level"] == "observed" for signal in source["signals"])
+    assert all(signal["delivery_certainty"] != "delivery_reported" for signal in source["signals"])
 
 
 @pytest.mark.parametrize(

--- a/backend/app/tests/test_mail_health.py
+++ b/backend/app/tests/test_mail_health.py
@@ -76,6 +76,18 @@ def test_known_sender_failures_are_actionable_without_claiming_delivery(db_sessi
     assert result["next_action"]["href"] == result["href"]
     assert "do not prove" in result["evidence_scope"]
     assert result["claim_type"] == "aggregate_dmarc_authentication"
+    assert result["claim_level"] == "inferred"
+    assert result["delivery_certainty"] == "inferred_only"
+    assert result["signal_schema_version"] == "dmarq.mail_signal.v1"
+    assert {signal["family"] for signal in result["supporting_signals"]} == {
+        "dmarc_authentication",
+        "dmarc_reported_disposition",
+    }
+    assert {claim["claim_level"] for claim in result["claims"]} == {
+        "observed",
+        "inferred",
+        "unknown",
+    }
 
 
 def test_unknown_rejected_source_is_quietly_classified_as_likely_unauthorized_use(db_session):
@@ -136,6 +148,9 @@ def test_empty_workspace_requests_report_intake_before_any_technical_work(db_ses
 
     assert result["outcome"] == "insufficient_evidence"
     assert result["href"] == "/mail-sources"
+    assert result["claim_level"] == "derived"
+    assert result["supporting_signals"][0]["family"] == "intake_health"
+    assert result["supporting_signals"][0]["delivery_certainty"] == "not_applicable"
 
 
 def test_sender_activity_without_authentication_results_is_not_reported_healthy(db_session):
@@ -167,3 +182,4 @@ def test_successful_authentication_evidence_is_reported_as_healthy(db_session):
     assert result["confidence"] == "High"
     assert result["intended_mail_impact"] == "likely_not_affected"
     assert result["urgency"] == "none"
+    assert result["supporting_signals"][0]["delivery_certainty"] == "authentication_only"

--- a/backend/app/tests/test_mail_health.py
+++ b/backend/app/tests/test_mail_health.py
@@ -17,6 +17,13 @@ def _projection(
     failed: int = 0,
     disposition_counts: dict | None = None,
     hostname: str | None = None,
+    first_seen: int | None = None,
+    last_seen: int | None = None,
+    metadata: dict | None = None,
+    spf_passed: int = 0,
+    spf_failed: int = 0,
+    dkim_passed: int = 0,
+    dkim_failed: int = 0,
 ) -> DomainSourceDailyProjection:
     evidence = {"captured_at": "2026-07-26T12:00:00Z"}
     if hostname:
@@ -25,13 +32,18 @@ def _projection(
         domain_id=domain_id,
         source_ip=ip,
         observed_at=int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp()),
-        first_seen=int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp()),
-        last_seen=int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp()),
+        first_seen=first_seen or int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp()),
+        last_seen=last_seen or int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp()),
         message_count=passed + failed,
         report_count=1,
+        spf_pass_count=spf_passed,
+        spf_fail_count=spf_failed,
+        dkim_pass_count=dkim_passed,
+        dkim_fail_count=dkim_failed,
         dmarc_pass_count=passed,
         dmarc_fail_count=failed,
         disposition_counts=json.dumps(disposition_counts or {}),
+        metadata_json=json.dumps(metadata or {}),
         source_evidence=json.dumps(evidence),
     )
 
@@ -85,8 +97,68 @@ def test_known_sender_failures_are_actionable_without_claiming_delivery(db_sessi
     }
     assert {claim["claim_level"] for claim in result["claims"]} == {
         "observed",
+        "derived",
         "inferred",
         "unknown",
+    }
+
+
+def test_health_signals_keep_protocol_counts_identities_and_report_boundaries(db_session):
+    workspace = Workspace(slug="guided-signal-detail", name="Guided signal detail")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    first_seen = int(datetime(2026, 7, 25, 3, 15, tzinfo=timezone.utc).timestamp())
+    last_seen = int(datetime(2026, 7, 25, 21, 45, tzinfo=timezone.utc).timestamp())
+    db_session.add(
+        _projection(
+            domain.id,
+            ip="203.0.113.10",
+            passed=8,
+            failed=2,
+            disposition_counts={"none": 8, "reject": 2},
+            hostname="mta1.mtasv.net",
+            first_seen=first_seen,
+            last_seen=last_seen,
+            spf_passed=7,
+            spf_failed=3,
+            dkim_passed=8,
+            dkim_failed=2,
+            metadata={
+                "header_from_domains": ["example.test"],
+                "envelope_from_domains": ["bounce.example.test"],
+                "spf_domains": ["bounce.example.test"],
+                "dkim_domains": ["example.test"],
+                "dkim_selectors": ["selector1"],
+                "report_generators": ["receiver.example"],
+            },
+        )
+    )
+    db_session.commit()
+
+    result = _assessment(db_session, workspace)
+    authentication = next(
+        signal
+        for signal in result["supporting_signals"]
+        if signal["family"] == "dmarc_authentication"
+    )
+
+    assert authentication["window_start"] == first_seen
+    assert authentication["window_end"] == last_seen
+    assert authentication["payload"] == {
+        "source_ip": "203.0.113.10",
+        "passed": 8,
+        "failed": 2,
+        "spf_passed": 7,
+        "spf_failed": 3,
+        "dkim_passed": 8,
+        "dkim_failed": 2,
+        "header_from_domains": ["example.test"],
+        "envelope_from_domains": ["bounce.example.test"],
+        "spf_domains": ["bounce.example.test"],
+        "dkim_domains": ["example.test"],
+        "dkim_selectors": ["selector1"],
+        "report_generators": ["receiver.example"],
     }
 
 

--- a/backend/app/tests/test_mail_health.py
+++ b/backend/app/tests/test_mail_health.py
@@ -221,6 +221,7 @@ def test_empty_workspace_requests_report_intake_before_any_technical_work(db_ses
     assert result["outcome"] == "insufficient_evidence"
     assert result["href"] == "/mail-sources"
     assert result["claim_level"] == "derived"
+    assert result["delivery_certainty"] == "not_applicable"
     assert result["supporting_signals"][0]["family"] == "intake_health"
     assert result["supporting_signals"][0]["delivery_certainty"] == "not_applicable"
 
@@ -238,6 +239,7 @@ def test_sender_activity_without_authentication_results_is_not_reported_healthy(
     assert result["outcome"] == "insufficient_evidence"
     assert result["next_step"] == "Review report intake"
     assert "not enough" in result["evidence_scope"].lower()
+    assert result["delivery_certainty"] == "not_applicable"
 
 
 def test_successful_authentication_evidence_is_reported_as_healthy(db_session):

--- a/backend/app/tests/test_mail_health_incidents.py
+++ b/backend/app/tests/test_mail_health_incidents.py
@@ -24,7 +24,16 @@ def _assessment(outcome="action_required", domain="example.test"):
         "assessment_version": "v1",
         "claim_level": "inferred",
         "delivery_certainty": "inferred_only",
-        "supporting_signals": [{"signal_id": "signal-a"}],
+        "supporting_signals": [
+            {
+                "signal_id": "signal-a",
+                "family": "dmarc_authentication",
+                "signal_type": "aggregate_authentication_result",
+                "outcome": "fail",
+                "claim_level": "observed",
+                "delivery_certainty": "authentication_only",
+            }
+        ],
         "next_action": {"href": f"/domains/{domain}#sending-sources"},
     }
 
@@ -68,6 +77,24 @@ def test_changed_evidence_certainty_is_a_material_notification_change(db_session
     assert first["notification_reason"] == "created"
     assert changed["notification_reason"] == "material_change"
     assert changed["incident"]["assessment"]["delivery_certainty"] == "non_delivery_reported"
+
+
+def test_rolling_evidence_row_ids_do_not_trigger_a_material_notification(db_session):
+    workspace = Workspace(slug="calm-evidence-window", name="Calm evidence window")
+    db_session.add(workspace)
+    db_session.commit()
+
+    first = record_mail_health_assessment(db_session, workspace=workspace, assessment=_assessment())
+    shifted_window = _assessment()
+    shifted_window["supporting_signals"][0]["signal_id"] = "signal-from-next-window"
+    repeated = record_mail_health_assessment(
+        db_session,
+        workspace=workspace,
+        assessment=shifted_window,
+    )
+
+    assert first["notification_reason"] == "created"
+    assert repeated["notification_reason"] is None
 
 
 def test_protected_unknown_use_is_persisted_but_suppressed_by_default(db_session):

--- a/backend/app/tests/test_mail_health_incidents.py
+++ b/backend/app/tests/test_mail_health_incidents.py
@@ -16,10 +16,15 @@ def _assessment(outcome="action_required", domain="example.test"):
     return {
         "outcome": outcome,
         "domain": domain,
-        "intended_mail_impact": "likely_affected" if outcome == "action_required" else "likely_not_affected",
+        "intended_mail_impact": (
+            "likely_affected" if outcome == "action_required" else "likely_not_affected"
+        ),
         "urgency": "timely" if outcome == "action_required" else "none",
         "confidence": "High",
         "assessment_version": "v1",
+        "claim_level": "inferred",
+        "delivery_certainty": "inferred_only",
+        "supporting_signals": [{"signal_id": "signal-a"}],
         "next_action": {"href": f"/domains/{domain}#sending-sources"},
     }
 
@@ -30,15 +35,39 @@ def test_actionable_incident_notifies_only_when_created_or_materially_changed(db
     db_session.commit()
 
     first = record_mail_health_assessment(db_session, workspace=workspace, assessment=_assessment())
-    repeated = record_mail_health_assessment(db_session, workspace=workspace, assessment=_assessment())
+    repeated = record_mail_health_assessment(
+        db_session, workspace=workspace, assessment=_assessment()
+    )
     changed_assessment = _assessment()
     changed_assessment["urgency"] = "urgent"
-    changed = record_mail_health_assessment(db_session, workspace=workspace, assessment=changed_assessment)
+    changed = record_mail_health_assessment(
+        db_session, workspace=workspace, assessment=changed_assessment
+    )
 
     assert first["notification_reason"] == "created"
     assert repeated["notification_reason"] is None
     assert changed["notification_reason"] == "material_change"
     assert db_session.query(MailHealthIncident).count() == 1
+
+
+def test_changed_evidence_certainty_is_a_material_notification_change(db_session):
+    workspace = Workspace(slug="calm-evidence-change", name="Calm evidence change")
+    db_session.add(workspace)
+    db_session.commit()
+
+    first = record_mail_health_assessment(db_session, workspace=workspace, assessment=_assessment())
+    changed_assessment = _assessment()
+    changed_assessment["delivery_certainty"] = "non_delivery_reported"
+    changed_assessment["supporting_signals"] = [{"signal_id": "dsn-signal-b"}]
+    changed = record_mail_health_assessment(
+        db_session,
+        workspace=workspace,
+        assessment=changed_assessment,
+    )
+
+    assert first["notification_reason"] == "created"
+    assert changed["notification_reason"] == "material_change"
+    assert changed["incident"]["assessment"]["delivery_certainty"] == "non_delivery_reported"
 
 
 def test_protected_unknown_use_is_persisted_but_suppressed_by_default(db_session):
@@ -63,8 +92,12 @@ def test_incident_identity_is_workspace_scoped(db_session):
     db_session.add_all([first_workspace, second_workspace])
     db_session.commit()
 
-    first = record_mail_health_assessment(db_session, workspace=first_workspace, assessment=_assessment())
-    second = record_mail_health_assessment(db_session, workspace=second_workspace, assessment=_assessment())
+    first = record_mail_health_assessment(
+        db_session, workspace=first_workspace, assessment=_assessment()
+    )
+    second = record_mail_health_assessment(
+        db_session, workspace=second_workspace, assessment=_assessment()
+    )
 
     assert first["incident"]["incident_key"] != second["incident"]["incident_key"]
     assert db_session.query(MailHealthIncident).count() == 2
@@ -74,7 +107,9 @@ def test_acknowledge_and_snooze_do_not_mark_an_incident_resolved(db_session):
     workspace = Workspace(slug="calm-operator", name="Calm Operator")
     db_session.add(workspace)
     db_session.commit()
-    result = record_mail_health_assessment(db_session, workspace=workspace, assessment=_assessment())
+    result = record_mail_health_assessment(
+        db_session, workspace=workspace, assessment=_assessment()
+    )
     incident_id = result["incident"]["id"]
 
     acknowledged = update_incident_operator_state(
@@ -155,7 +190,9 @@ def test_invalid_operator_action_and_malformed_assessment_are_safe(db_session):
     workspace = Workspace(slug="calm-invalid", name="Calm Invalid")
     db_session.add(workspace)
     db_session.commit()
-    created = record_mail_health_assessment(db_session, workspace=workspace, assessment=_assessment())
+    created = record_mail_health_assessment(
+        db_session, workspace=workspace, assessment=_assessment()
+    )
     row = db_session.query(MailHealthIncident).one()
     row.assessment = "not-json"
     db_session.commit()
@@ -178,13 +215,19 @@ def test_invalid_operator_action_and_malformed_assessment_are_safe(db_session):
 
 
 def test_disabled_and_active_snooze_suppress_notification_but_keep_incidents(db_session):
-    disabled = Workspace(slug="calm-disabled", name="Calm Disabled", notification_posture="disabled")
+    disabled = Workspace(
+        slug="calm-disabled", name="Calm Disabled", notification_posture="disabled"
+    )
     snoozed_workspace = Workspace(slug="calm-snoozed", name="Calm Snoozed")
     db_session.add_all([disabled, snoozed_workspace])
     db_session.commit()
 
-    disabled_result = record_mail_health_assessment(db_session, workspace=disabled, assessment=_assessment())
-    created = record_mail_health_assessment(db_session, workspace=snoozed_workspace, assessment=_assessment())
+    disabled_result = record_mail_health_assessment(
+        db_session, workspace=disabled, assessment=_assessment()
+    )
+    created = record_mail_health_assessment(
+        db_session, workspace=snoozed_workspace, assessment=_assessment()
+    )
     update_incident_operator_state(
         db_session,
         workspace=snoozed_workspace,
@@ -196,7 +239,9 @@ def test_disabled_and_active_snooze_suppress_notification_but_keep_incidents(db_
     )
     changed = _assessment()
     changed["urgency"] = "urgent"
-    snoozed_result = record_mail_health_assessment(db_session, workspace=snoozed_workspace, assessment=changed)
+    snoozed_result = record_mail_health_assessment(
+        db_session, workspace=snoozed_workspace, assessment=changed
+    )
 
     assert disabled_result["notification_reason"] is None
     assert snoozed_result["notification_reason"] is None
@@ -208,12 +253,21 @@ def test_operator_state_rejects_missing_incident_and_snooze_timestamp(db_session
     other_workspace = Workspace(slug="calm-missing-other", name="Calm Missing Other")
     db_session.add_all([workspace, other_workspace])
     db_session.commit()
-    foreign = record_mail_health_assessment(db_session, workspace=other_workspace, assessment=_assessment(domain="other.test"))
+    foreign = record_mail_health_assessment(
+        db_session, workspace=other_workspace, assessment=_assessment(domain="other.test")
+    )
 
     for kwargs, message in (
         ({"incident_id": 9999, "action": "acknowledge", "snoozed_until": None}, "not found"),
         ({"incident_id": 9999, "action": "snooze", "snoozed_until": None}, "not found"),
-        ({"incident_id": foreign["incident"]["id"], "action": "acknowledge", "snoozed_until": None}, "not found"),
+        (
+            {
+                "incident_id": foreign["incident"]["id"],
+                "action": "acknowledge",
+                "snoozed_until": None,
+            },
+            "not found",
+        ),
     ):
         try:
             update_incident_operator_state(
@@ -228,7 +282,9 @@ def test_operator_state_rejects_missing_incident_and_snooze_timestamp(db_session
         else:
             raise AssertionError("A cross-workspace incident must not be writable.")
 
-    created = record_mail_health_assessment(db_session, workspace=workspace, assessment=_assessment())
+    created = record_mail_health_assessment(
+        db_session, workspace=workspace, assessment=_assessment()
+    )
     try:
         update_incident_operator_state(
             db_session,

--- a/backend/app/tests/test_mail_signals.py
+++ b/backend/app/tests/test_mail_signals.py
@@ -135,6 +135,8 @@ def test_dmarc_source_creates_separate_authentication_and_disposition_signals():
     assert disposition["outcome"] == "mixed"
     assert disposition["delivery_certainty"] == "receiver_disposition_reported"
     assert disposition["evidence_refs"] == ["domain_source_daily_projection:10"]
+    assert "authenticated and unauthenticated" in guided_signal_statement(authentication)
+    assert "more than one DMARC disposition" in guided_signal_statement(disposition)
 
 
 def test_missing_report_window_is_a_derived_intake_fact_not_a_delivery_claim():

--- a/backend/app/tests/test_mail_signals.py
+++ b/backend/app/tests/test_mail_signals.py
@@ -1,0 +1,190 @@
+"""Contract tests for protocol-aware mail-health signals."""
+
+import pytest
+
+from app.services.mail_signals import (
+    CLAIM_LEVELS,
+    DELIVERY_CERTAINTIES,
+    MAIL_SIGNAL_SCHEMA_VERSION,
+    SIGNAL_FAMILIES,
+    build_dmarc_source_signals,
+    build_intake_window_signal,
+    guided_signal_statement,
+    make_mail_signal,
+    signal_families,
+)
+
+
+def test_signal_taxonomy_covers_current_and_planned_evidence_families():
+    assert set(signal_families()) == SIGNAL_FAMILIES
+    assert SIGNAL_FAMILIES == {
+        "dmarc_authentication",
+        "dmarc_reported_disposition",
+        "dmarc_failure_detail",
+        "smtp_tls_report",
+        "dsn_delivery_status",
+        "provider_delivery_event",
+        "dns_posture",
+        "intake_health",
+        "operator_reported_symptom",
+    }
+    assert "observed" in CLAIM_LEVELS
+    assert "operator_reported" in CLAIM_LEVELS
+    assert "authentication_only" in DELIVERY_CERTAINTIES
+    assert "non_delivery_reported" in DELIVERY_CERTAINTIES
+
+
+@pytest.mark.parametrize("family", sorted(SIGNAL_FAMILIES))
+def test_common_envelope_accepts_every_versioned_signal_family(family):
+    signal = make_mail_signal(
+        family=family,
+        signal_type="contract_test",
+        outcome="unknown",
+        claim_level="unknown",
+        delivery_certainty="not_applicable",
+        source_system="test",
+        evidence_refs=("test:1",),
+    ).to_dict()
+
+    assert signal["schema_version"] == MAIL_SIGNAL_SCHEMA_VERSION
+    assert signal["family"] == family
+    assert len(signal["signal_id"]) == 64
+
+
+def test_signal_identity_is_stable_but_changes_with_immutable_evidence_reference():
+    values = {
+        "family": "dns_posture",
+        "signal_type": "dmarc_record",
+        "outcome": "present",
+        "claim_level": "observed",
+        "delivery_certainty": "not_applicable",
+        "source_system": "dns_posture_snapshot",
+        "workspace_id": 7,
+        "domain": "example.test",
+        "evidence_refs": ("dns_posture_snapshot:41",),
+    }
+    first = make_mail_signal(**values)
+    repeated = make_mail_signal(**values)
+    changed = make_mail_signal(**{**values, "evidence_refs": ("dns_posture_snapshot:42",)})
+
+    assert first.signal_id == repeated.signal_id
+    assert first.signal_id != changed.signal_id
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("family", "smtp_guess", "family"),
+        ("claim_level", "probably", "claim level"),
+        ("delivery_certainty", "maybe_delivered", "delivery certainty"),
+        ("privacy_classification", "public_body", "privacy classification"),
+    ],
+)
+def test_common_envelope_rejects_unknown_contract_values(field, value, message):
+    values = {
+        "family": "dns_posture",
+        "signal_type": "contract_test",
+        "outcome": "unknown",
+        "claim_level": "unknown",
+        "delivery_certainty": "not_applicable",
+        "source_system": "test",
+    }
+    values[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        make_mail_signal(**values)
+
+
+def test_dmarc_source_creates_separate_authentication_and_disposition_signals():
+    signals = build_dmarc_source_signals(
+        {
+            "source_ip": "192.0.2.10",
+            "dmarc_pass_count": 4,
+            "dmarc_fail_count": 6,
+            "disposition_counts": {"none": 2, "reject": 4},
+            "window_start": 100,
+            "window_end": 200,
+            "captured_at": "2026-07-30T00:00:00Z",
+            "spf_pass_count": 3,
+            "spf_fail_count": 7,
+            "dkim_pass_count": 4,
+            "dkim_fail_count": 6,
+            "header_from_domains": ["example.test"],
+            "dkim_domains": ["example.test"],
+            "dkim_selectors": ["mail"],
+            "report_generators": ["Receiver A"],
+        },
+        workspace_id=3,
+        domain="example.test",
+        evidence_refs=("domain_source_daily_projection:10",),
+    )
+
+    authentication, disposition = signals
+    assert authentication["family"] == "dmarc_authentication"
+    assert authentication["outcome"] == "mixed"
+    assert authentication["delivery_certainty"] == "authentication_only"
+    assert authentication["payload"]["source_ip"] == "192.0.2.10"
+    assert authentication["payload"]["passed"] == 4
+    assert authentication["payload"]["failed"] == 6
+    assert authentication["payload"]["spf_passed"] == 3
+    assert authentication["payload"]["dkim_failed"] == 6
+    assert authentication["payload"]["header_from_domains"] == ["example.test"]
+    assert authentication["payload"]["dkim_selectors"] == ["mail"]
+    assert authentication["payload"]["report_generators"] == ["Receiver A"]
+    assert disposition["family"] == "dmarc_reported_disposition"
+    assert disposition["outcome"] == "mixed"
+    assert disposition["delivery_certainty"] == "receiver_disposition_reported"
+    assert disposition["evidence_refs"] == ["domain_source_daily_projection:10"]
+
+
+def test_missing_report_window_is_a_derived_intake_fact_not_a_delivery_claim():
+    signal = build_intake_window_signal(
+        workspace_id=5,
+        window_start=100,
+        window_end=200,
+        has_evidence=False,
+    )
+
+    assert signal["family"] == "intake_health"
+    assert signal["claim_level"] == "derived"
+    assert signal["delivery_certainty"] == "not_applicable"
+    assert "no persisted report evidence" in guided_signal_statement(signal)
+
+
+@pytest.mark.parametrize(
+    ("signal", "expected", "forbidden"),
+    [
+        (
+            {
+                "family": "dmarc_authentication",
+                "outcome": "pass",
+                "delivery_certainty": "authentication_only",
+            },
+            "authenticated",
+            "delivered",
+        ),
+        (
+            {
+                "family": "dmarc_reported_disposition",
+                "outcome": "reject",
+                "delivery_certainty": "receiver_disposition_reported",
+            },
+            "recorded",
+            "bounced",
+        ),
+        (
+            {
+                "family": "provider_delivery_event",
+                "outcome": "delivered",
+                "delivery_certainty": "delivery_reported",
+            },
+            "provider reported",
+            "inbox",
+        ),
+    ],
+)
+def test_guided_wording_matrix_preserves_protocol_boundaries(signal, expected, forbidden):
+    statement = guided_signal_statement(signal).lower()
+
+    assert expected in statement
+    assert forbidden not in statement

--- a/backend/app/tests/test_mailflow_assessment.py
+++ b/backend/app/tests/test_mailflow_assessment.py
@@ -164,6 +164,28 @@ def test_zero_traffic_is_ignored():
     assert result["flows"] == []
 
 
+def test_insufficient_flow_evidence_is_unknown_not_an_authentication_claim():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [
+            _source(
+                count=3,
+                spf_pass_count=0,
+                spf_fail_count=0,
+                dkim_pass_count=0,
+                dkim_fail_count=0,
+                dmarc_fail_count=0,
+            )
+        ],
+        {},
+    )
+
+    flow = result["flows"][0]
+    assert flow["status"] == "insufficient_evidence"
+    assert flow["claim_level"] == "unknown"
+    assert flow["delivery_certainty"] == "not_applicable"
+
+
 def test_mixed_dkim_path_requires_identity_correlation_before_repair():
     result = build_domain_mailflow_assessment(
         "example.com",

--- a/backend/app/tests/test_mailflow_assessment.py
+++ b/backend/app/tests/test_mailflow_assessment.py
@@ -39,6 +39,12 @@ def test_spf_aligned_path_without_dkim_gets_guided_repair():
     assert result["flows"][0]["spf_alignment"] == "pass"
     assert result["flows"][0]["dkim_alignment"] == "not_observed"
     assert result["flows"][0]["provider_evidence_status"] == "not_connected"
+    assert result["flows"][0]["claim_level"] == "observed"
+    assert result["flows"][0]["delivery_certainty"] == "authentication_only"
+    assert {signal["family"] for signal in result["flows"][0]["signals"]} == {
+        "dmarc_authentication",
+        "dmarc_reported_disposition",
+    }
     assert "cannot tell" in result["flows"][0]["detail"]
 
 
@@ -64,6 +70,12 @@ def test_unknown_rejected_spoofer_does_not_get_dkim_repair():
     assert result["repair_steps"] == []
     assert result["flows"][0]["status"] == "likely_unauthorized"
     assert result["flows"][0]["evidence_level"] == "inferred"
+    assert result["flows"][0]["claim_level"] == "inferred"
+    assert result["flows"][0]["delivery_certainty"] == "inferred_only"
+    assert all(
+        signal["delivery_certainty"] != "delivery_reported"
+        for signal in result["flows"][0]["signals"]
+    )
     assert result["inferences"]
     assert result["unknowns"]
 

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -26,13 +26,13 @@ from app.services.organizations import OrganizationPlanLimitError
 from app.services.ptr_lookup import PtrLookupResult
 from app.services.report_persistence import persisted_report_to_dict, save_parsed_report
 from app.services.report_store import ReportStore
+from app.services.source_network import SourceNetworkIntelligence
 from app.services.source_read_projection import (
     _acquire_source_projection_write_lock,
     backfill_source_projections,
     load_domain_source_read_projection,
     materialize_source_projection,
 )
-from app.services.source_network import SourceNetworkIntelligence
 from app.services.source_reputation import DomainReputation, ReputationEvidence, SourceReputation
 from app.services.workspace_access import ROLE_ANALYST
 from app.services.workspaces import get_or_create_default_workspace
@@ -120,6 +120,7 @@ def test_save_parsed_report_materializes_daily_sender_facts(db_session):
     assert projection.dmarc_pass_count == 7
     assert projection.dmarc_fail_count == 3
     assert json.loads(projection.disposition_counts) == {"none": 7, "reject": 3}
+    assert json.loads(projection.metadata_json)["report_generators"] == ["Workspace Test Org"]
 
 
 def test_projection_backfill_materializes_unprojected_reports(db_session):
@@ -154,6 +155,8 @@ def test_projection_backfill_materializes_unprojected_reports(db_session):
 
     assert db_session.query(DomainSourceDailyProjection).count() == 1
     assert db_session.get(DMARCReport, report.id).source_projection_at is not None
+    projection = db_session.query(DomainSourceDailyProjection).one()
+    assert json.loads(projection.metadata_json)["report_generators"] == ["receiver.example"]
 
 
 def test_projection_backfill_merges_same_sender_day_within_one_batch(db_session):
@@ -172,7 +175,7 @@ def test_projection_backfill_merges_same_sender_day_within_one_batch(db_session)
     second = DMARCReport(
         domain_id=domain.id,
         report_id="projection-batch-second",
-        org_name="receiver.example",
+        org_name="receiver-two.example",
         begin_date=1_704_067_200,
         end_date=1_704_153_599,
     )
@@ -206,7 +209,14 @@ def test_projection_backfill_merges_same_sender_day_within_one_batch(db_session)
     projection = db_session.query(DomainSourceDailyProjection).one()
     assert projection.message_count == 20
     assert projection.report_count == 2
-    assert db_session.query(DMARCReport).filter(DMARCReport.source_projection_at.is_(None)).count() == 0
+    assert json.loads(projection.metadata_json)["report_generators"] == [
+        "receiver.example",
+        "receiver-two.example",
+    ]
+    assert (
+        db_session.query(DMARCReport).filter(DMARCReport.source_projection_at.is_(None)).count()
+        == 0
+    )
 
 
 def test_projection_write_lock_serializes_postgres_writers():
@@ -273,7 +283,9 @@ def test_projection_write_lock_serializes_postgres_writers():
 def test_projection_window_uses_report_end_time(db_session, monkeypatch):
     """A report remains visible until its actual DMARC reporting window ends."""
     workspace = get_or_create_default_workspace(db_session)
-    report = _parsed_report(domain="projection-window.example", report_id="projection-window", count=4)
+    report = _parsed_report(
+        domain="projection-window.example", report_id="projection-window", count=4
+    )
     report["begin_timestamp"] = 1_704_146_400
     report["end_timestamp"] = 1_704_239_999
     report["begin_date"] = report["begin_timestamp"]

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -159,6 +159,40 @@ def test_projection_backfill_materializes_unprojected_reports(db_session):
     assert json.loads(projection.metadata_json)["report_generators"] == ["receiver.example"]
 
 
+def test_projection_backfill_uses_source_email_when_org_name_is_empty(db_session):
+    workspace = get_or_create_default_workspace(db_session)
+    domain = Domain(name="projection-email.example", workspace_id=workspace.id, active=True)
+    db_session.add(domain)
+    db_session.flush()
+    report = DMARCReport(
+        domain_id=domain.id,
+        report_id="projection-email-fallback",
+        org_name="",
+        source_email="reports@receiver.example",
+        begin_date=1_704_067_200,
+        end_date=1_704_153_599,
+    )
+    db_session.add(report)
+    db_session.flush()
+    db_session.add(
+        ReportRecord(
+            report_id=report.id,
+            source_ip="192.0.2.78",
+            count=4,
+            disposition="none",
+            dkim="pass",
+            spf="pass",
+        )
+    )
+    db_session.commit()
+
+    assert backfill_source_projections(db_session, limit=10) == 1
+    db_session.commit()
+
+    projection = db_session.query(DomainSourceDailyProjection).one()
+    assert json.loads(projection.metadata_json)["report_generators"] == ["reports@receiver.example"]
+
+
 def test_projection_backfill_merges_same_sender_day_within_one_batch(db_session):
     """A single historic batch may contain several reports for one daily sender fact."""
     workspace = get_or_create_default_workspace(db_session)

--- a/docs/product/guided-mail-health.md
+++ b/docs/product/guided-mail-health.md
@@ -80,6 +80,13 @@ Guidance intentionally describes aggregate DMARC reports as authentication and
 receiver-policy evidence. It does not present them as proof of an individual
 bounce, inbox placement, or read event.
 
+Assessments and source rows expose these boundaries through the versioned
+[`dmarq.mail_signal.v1` contract](../reference/mail-signal-contract.md).
+Observed authentication, receiver-reported disposition, DMARQ inference, and
+unknown delivery outcome remain separate facts. Later DSN or provider-event
+adapters can add stronger delivery evidence without reinterpreting historical
+aggregate reports.
+
 ## Intake choices
 
 The setup assistant returns a versioned

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1077,12 +1077,17 @@ inbox. Source responses therefore include additive fields:
   receiver-reported DMARC action;
 - `evidence_kind` is currently `dmarc_aggregate_report`;
 - `claim_level` is `observed` for these protocol facts; and
-- `delivery_certainty` remains `unknown` until DMARQ has actual delivery
-  evidence such as a DSN or a signed provider delivery event.
+- `delivery_certainty` is `authentication_only` when only authentication is
+  observed, or `receiver_disposition_reported` when the receiver also recorded
+  a DMARC action. Neither value claims individual delivery.
+- `signals` contains separate versioned authentication and receiver-disposition
+  envelopes with stable evidence references.
 
 The older `delivery_status`, `delivery_label`, and `delivery_detail` fields are
 retained for compatibility but are deprecated. New integrations should use the
-explicit authentication and receiver-disposition fields.
+explicit authentication and receiver-disposition fields. See the
+[Mail signal contract](mail-signal-contract.md) for claim levels, delivery
+certainty, privacy boundaries, and future DSN/provider-event adapters.
 
 #### Get Source Reputation
 

--- a/docs/reference/mail-signal-contract.md
+++ b/docs/reference/mail-signal-contract.md
@@ -1,0 +1,106 @@
+# Mail Signal Contract
+
+DMARQ keeps protocol observations separate from product interpretation. This
+prevents an aggregate DMARC report from being presented as proof that an
+individual message was delivered, bounced, read, or placed in an inbox.
+
+The versioned `dmarq.mail_signal.v1` envelope is returned with guided
+mail-health assessments, domain mailflow diagnoses, and sending-source rows.
+It is additive: existing API fields remain available while integrations move
+to the explicit signal contract.
+
+## Common envelope
+
+Every signal includes:
+
+- a stable `signal_id` and `schema_version`;
+- `family`, `signal_type`, and protocol-specific `outcome`;
+- `claim_level`: `observed`, `derived`, `inferred`, `operator_reported`, or
+  `unknown`;
+- `delivery_certainty`, which limits what DMARQ may say about delivery;
+- source system, workspace/domain correlation, evidence window, and freshness;
+- aggregate-safe evidence references and payload;
+- a stable `guidance_key` for localized explanation.
+
+Raw message bodies, mailbox credentials, tokens, and recipient addresses do
+not belong in this envelope. Current DMARC signals use the `aggregate` privacy
+classification.
+
+## Signal families
+
+| Family | What it means |
+| --- | --- |
+| `dmarc_authentication` | A receiver's aggregate SPF/DKIM alignment evaluation |
+| `dmarc_reported_disposition` | The DMARC policy action recorded by the reporting receiver |
+| `dmarc_failure_detail` | Failure-report evidence, when explicitly available |
+| `smtp_tls_report` | TLS-RPT transport-path evidence |
+| `dsn_delivery_status` | A delivery status notification from a sending system |
+| `provider_delivery_event` | An event with the provider's documented semantics |
+| `dns_posture` | Stored DNS posture evidence |
+| `intake_health` | Persisted report-intake availability or failure |
+| `operator_reported_symptom` | A symptom entered by an operator, not independently verified |
+
+The last four mail-protocol families reserve a stable contract for later
+adapters. A family being defined does not imply that every connector currently
+produces it.
+
+## Delivery certainty
+
+`delivery_certainty` is deliberately more precise than a generic status:
+
+- `authentication_only`: DMARC authentication evidence, no delivery claim;
+- `receiver_disposition_reported`: a receiver recorded `none`, `quarantine`,
+  or `reject`, but this is not a per-message bounce claim;
+- `transport_failure_reported`: a TLS transport failure was reported;
+- `non_delivery_reported`: a DSN or equivalent explicitly reported
+  non-delivery;
+- `delivery_reported`: a provider explicitly reported delivery according to
+  its own event definition, not inbox placement or reading;
+- `inferred_only`: DMARQ formed an interpretation from supporting facts;
+- `not_applicable`: the signal is operational evidence rather than a delivery
+  observation.
+
+## DMARC example
+
+One aggregate sender row produces two signals rather than one ambiguous
+"delivery" value:
+
+```json
+[
+  {
+    "family": "dmarc_authentication",
+    "outcome": "mixed",
+    "claim_level": "observed",
+    "delivery_certainty": "authentication_only",
+    "payload": {"passed": 40, "failed": 2}
+  },
+  {
+    "family": "dmarc_reported_disposition",
+    "outcome": "reject",
+    "claim_level": "observed",
+    "delivery_certainty": "receiver_disposition_reported",
+    "payload": {"dispositions": {"reject": 2}}
+  }
+]
+```
+
+A guided conclusion built from these observations is separately marked
+`inferred`. It must state what is known, what is inferred, what remains
+unknown, and what evidence would verify the next action.
+
+## Compatibility
+
+The sending-source API retains `delivery_status`, `delivery_label`, and
+`delivery_detail` for compatibility. They describe historical aggregate
+authentication categories and are deprecated. New clients should use
+`authentication_*`, `receiver_disposition*`, `claim_level`,
+`delivery_certainty`, and `signals`.
+
+## Standards boundary
+
+DMARQ continues to parse legacy RFC 7489 aggregate reports while using the
+separated terminology of RFC 9989 (DMARC), RFC 9990 (aggregate reporting), and
+RFC 9991 (failure reporting). Legacy `pct` and `ri` values may be retained as
+historic report metadata, but they are not treated as controls for DMARQ's
+notification volume or as proof that a report should have arrived. A missing
+report is evaluated from persisted intake and coverage evidence instead.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
     - Release Checklist: deployment/release-checklist.md
   - Technical Reference:
     - API Reference: reference/api.md
+    - Mail Signal Contract: reference/mail-signal-contract.md
     - Cloudflare Email Worker Webhook: cloudflare-email-worker-inbound-webhook.md
     - Ecosystem Integration Matrix: reference/ecosystem-integrations.md
     - Provider Integrations: reference/provider-integrations.md


### PR DESCRIPTION
## Summary

- add the versioned `dmarq.mail_signal.v1` envelope for DMARC authentication, receiver disposition, failure detail, TLS-RPT, DSN, provider events, DNS posture, intake health, and operator-reported symptoms
- expose explicit claim levels, delivery certainty, evidence windows/references, report-generator provenance, and aggregate-safe payloads through guided assessments, mailflow diagnoses, source responses, and Calm Watch material-change detection
- preserve deprecated delivery aliases for API compatibility while documenting the truthful replacement contract and standards boundary

## Type of change

- New backward-compatible evidence contract
- Correctness fixes for projection provenance and assessment certainty
- Documentation and regression coverage

## Changes made

- DMARC authentication remains separate from receiver-reported disposition and never claims delivery
- empty evidence windows are explicitly `not_applicable`, while inferred conclusions remain distinguishable from observed facts
- historical projection backfills retain report-generator email provenance and true report-window boundaries
- API response models reject claim levels or delivery certainty values outside the documented taxonomy

## Testing performed

- complete backend suite: `2300 passed`
- final review and domain/API regression suite: `204 passed`
- focused wording, assessment, and projection suite: `84 passed`
- Black, isort, flake8, and `git diff --check` pass for changed files
- CI validates Docker greenfield startup, Helm/Terraform, dependency review, CodeQL, and security checks

## Deployment and security

This is additive and contains no DNS writes, live provider mutation, schema migration, or destructive behavior. Signal payloads are aggregate-safe and do not expose message bodies or credentials.

Closes #869
