### PR TITLE
feat: add deterministic mail health interpretation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Mail-health interpretation now uses a deterministic, versioned assessment
+  contract with stable outcome, impact, urgency and confidence bands, explicit
+  facts/inferences/unknowns, evidence windows, one safe next action, and
+  sanitized signal references. It compares the previous bounded report window
+  to prioritize a regressing legitimate sender, treats expected forwarding and
+  quiet low-volume domains without unsafe SPF advice, and directs reported
+  bounces with DMARC passes to DSN/SMTP/provider evidence. Exact domain/source
+  classifications are workspace-scoped, append-only audit decisions that
+  affect future assessments without rewriting report history. The same
+  assessment is available through the read-only public API and MCP tool.
 - Guided assessments, domain mailflow diagnoses, and sending-source responses
   now expose a versioned protocol-aware mail-signal contract. DMARC
   authentication and receiver-reported policy actions remain separate from

--- a/backend/app/api/api_v1/endpoints/mcp.py
+++ b/backend/app/api/api_v1/endpoints/mcp.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -21,6 +21,7 @@ from app.services.ai_assistance import (
 from app.services.alert_history import alert_history_summary, list_workspace_alert_history
 from app.services.api_tokens import MCP_READ_SCOPE
 from app.services.export_catalog import build_export_catalog
+from app.services.mail_health import build_workspace_mail_health_assessment
 from app.services.organizations import require_organization_feature
 from app.services.report_persistence import hydrate_report_store_from_db
 from app.services.report_store import ReportStore
@@ -80,6 +81,20 @@ READ_ONLY_TOOLS = [
                 "days": {"type": "integer", "minimum": 1, "maximum": 365, "default": 30},
             },
             "required": ["domain"],
+        },
+        "readOnlyHint": True,
+    },
+    {
+        "name": "mail_health_assessment",
+        "description": (
+            "Return one deterministic mail-health conclusion with confidence, evidence, "
+            "unknowns, and the safest next action."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "days": {"type": "integer", "minimum": 1, "maximum": 365, "default": 30}
+            },
         },
         "readOnlyHint": True,
     },
@@ -372,10 +387,39 @@ def _call_workspace_usage_tool(
     return build_workspace_usage_summary(db, workspace)
 
 
+def _call_mail_health_assessment_tool(
+    arguments: Dict[str, Any],
+    *,
+    db: Session,
+    auth_context: Dict[str, Any],
+    workspace_id: Optional[int],
+) -> Dict[str, Any]:
+    """Return the versioned assessment through the existing read-only dispatcher."""
+    days = _tool_days(arguments)
+    workspace = resolve_authorized_workspace(
+        db,
+        auth_context,
+        PERMISSION_REPORTS_READ,
+        selected_workspace_id=workspace_id,
+    )
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=days)
+    return {
+        "days": days,
+        "assessment": build_workspace_mail_health_assessment(
+            db,
+            workspace=workspace,
+            start_ts=int(start.timestamp()),
+            end_ts=int(end.timestamp()),
+        ),
+    }
+
+
 READ_ONLY_SYNC_HANDLERS = {
     "action_proposals": _call_action_proposals_tool,
     "alert_history": _call_alert_history_tool,
     "export_catalog": _call_export_catalog_tool,
+    "mail_health_assessment": _call_mail_health_assessment_tool,
     "workspace_usage": _call_workspace_usage_tool,
 }
 

--- a/backend/app/api/api_v1/endpoints/public.py
+++ b/backend/app/api/api_v1/endpoints/public.py
@@ -1,6 +1,6 @@
 """Stable read-only public API endpoints."""
 
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
@@ -18,10 +18,32 @@ from app.services.api_tokens import (
     READ_TLS_SCOPE,
 )
 from app.services.export_catalog import build_export_catalog
+from app.services.mail_health import build_workspace_mail_health_assessment
 from app.services.workspace_access import PERMISSION_REPORTS_READ, resolve_authorized_workspace
 from app.services.workspace_usage import build_workspace_usage_summary
 
 router = APIRouter()
+
+
+@router.get("/mail-health/assessment")
+async def public_mail_health_assessment(
+    days: int = Query(30, ge=1, le=365),
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_api_token_scope(READ_REPORTS_SCOPE)),
+):
+    """Return one sanitized, deterministic assessment from stored evidence."""
+    workspace = resolve_authorized_workspace(db, _auth, PERMISSION_REPORTS_READ)
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=days)
+    return {
+        "days": days,
+        "assessment": build_workspace_mail_health_assessment(
+            db,
+            workspace=workspace,
+            start_ts=int(start.timestamp()),
+            end_ts=int(end.timestamp()),
+        ),
+    }
 
 
 @router.get("/domains", response_model=domains.DomainSummaryResponse)

--- a/backend/app/api/api_v1/endpoints/workspaces.py
+++ b/backend/app/api/api_v1/endpoints/workspaces.py
@@ -50,6 +50,11 @@ from app.services.report_intake_recommendation import (
     build_report_intake_recommendation,
 )
 from app.services.route53_dns import get_route53_dns_credentials
+from app.services.sender_classifications import (
+    SENDER_CLASSIFICATIONS,
+    latest_sender_classifications,
+    record_sender_classification,
+)
 from app.services.workspace_access import (
     PERMISSION_REPORTS_READ,
     PERMISSION_REPORTS_WRITE,
@@ -121,6 +126,15 @@ class IncidentActionUpdate(BaseModel):
     action: str
     note: Optional[str] = None
     snoozed_until: Optional[datetime] = None
+
+
+class SenderClassificationUpdate(BaseModel):
+    """One exact, auditable domain/source interpretation from an operator."""
+
+    domain: str
+    source_ip: str
+    classification: str
+    reason: Optional[str] = Field(default=None, max_length=500)
 
 
 def _guidance_payload(workspace: Workspace, user: Optional[User] = None) -> Dict[str, Any]:
@@ -1077,6 +1091,61 @@ async def get_mail_health_incidents(
         selected_workspace_id=parse_selected_workspace_id(selected_workspace),
     )
     return {"incidents": list_mail_health_incidents(db, workspace=workspace, limit=limit)}
+
+
+@router.get("/mail-health/sender-classifications")
+async def get_sender_classifications(
+    domain: Optional[str] = None,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> Dict[str, Any]:
+    """List the latest classification without exposing superseded audit internals."""
+    workspace = resolve_authorized_workspace(
+        db,
+        _auth,
+        PERMISSION_REPORTS_READ,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    rows = latest_sender_classifications(db, workspace=workspace, domain=domain)
+    return {
+        "classifications": list(rows.values()),
+        "allowed_classifications": sorted(SENDER_CLASSIFICATIONS),
+    }
+
+
+@router.put("/mail-health/sender-classifications")
+async def update_sender_classification(
+    request: Request,
+    payload: SenderClassificationUpdate,
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+    selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
+) -> Dict[str, Any]:
+    """Append a sender decision that affects future assessments, never report history."""
+    workspace = resolve_authorized_workspace(
+        db,
+        _auth,
+        PERMISSION_REPORTS_WRITE,
+        selected_workspace_id=parse_selected_workspace_id(selected_workspace),
+    )
+    try:
+        classification = record_sender_classification(
+            db,
+            workspace=workspace,
+            domain=payload.domain,
+            source_ip=payload.source_ip,
+            classification=payload.classification,
+            reason=payload.reason,
+            auth_context=_auth,
+            request=request,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    return {"classification": classification}
 
 
 @router.post("/mail-health/incidents/evaluate")

--- a/backend/app/services/export_catalog.py
+++ b/backend/app/services/export_catalog.py
@@ -36,6 +36,13 @@ PUBLIC_EXPORT_ENDPOINTS = [
         "description": "Workspace-level DMARC usage, alert, source, and import counts.",
     },
     {
+        "key": "mail_health_assessment",
+        "method": "GET",
+        "path": "/api/v1/public/mail-health/assessment",
+        "scope": READ_REPORTS_SCOPE,
+        "description": "Deterministic mail-health interpretation from stored aggregate evidence.",
+    },
+    {
         "key": "domain_reports",
         "method": "GET",
         "path_template": "/api/v1/public/domains/{domain}/reports",
@@ -178,6 +185,11 @@ MCP_EXPORT_TOOLS = [
     {
         "name": "workspace_usage",
         "description": "Return workspace-level DMARC usage, source, alert, and import counts.",
+        "read_only": True,
+    },
+    {
+        "name": "mail_health_assessment",
+        "description": "Return deterministic mail-health guidance from stored aggregate evidence.",
         "read_only": True,
     },
 ]

--- a/backend/app/services/mail_health.py
+++ b/backend/app/services/mail_health.py
@@ -715,42 +715,6 @@ def build_workspace_mail_health_assessment(
             supporting_signals=_source_signals(source),
         )
 
-    if forwarding_failing:
-        source = max(forwarding_failing, key=lambda item: _count(item["dmarc_fail_count"]))
-        return assessment(
-            outcome="monitor",
-            title="Review an expected forwarding path",
-            summary=(
-                f"An operator marked {source['source_ip']} as expected forwarding for "
-                f"{source['domain']}. Forwarding can break SPF while DKIM still preserves alignment; "
-                "do not add the intermediary IP to SPF without sender-side evidence."
-            ),
-            next_step="Review forwarding and DKIM evidence",
-            href=f"/domains/{source['domain']}#sending-sources",
-            confidence="Medium",
-            reasons=[
-                "An operator classified this exact source as expected forwarding.",
-                "Aggregate DMARC evidence alone cannot identify the forwarding configuration.",
-            ],
-            evidence_scope="The assessment uses stored report and operator evidence only.",
-            domain=source["domain"],
-            intended_mail_impact="possible",
-            urgency="monitor",
-            known_facts=[
-                "The source has an auditable expected-forwarding classification.",
-                f"Aggregate reports recorded {_count(source['dmarc_fail_count'])} authentication failure(s).",
-            ],
-            derived_facts=["The source has an auditable expected-forwarding classification."],
-            inferences=[
-                "SPF failure may be caused by forwarding rather than an unauthorized sender."
-            ],
-            unknowns=["Whether aligned DKIM survives the forwarding path for each message stream."],
-            verification_condition="Fresh reports or forwarding-system evidence isolate the aligned DKIM path.",
-            watch_condition="Escalate if aligned DKIM also regresses or intended mail is reported missing.",
-            supporting_signals=_source_signals(source),
-            conclusion_key="mail_health.expected_forwarding",
-        )
-
     unauthorized_source = _priority_unauthorized_source(
         confirmed_unauthorized, unknown_protected, unknown_failing
     )
@@ -790,6 +754,42 @@ def build_workspace_mail_health_assessment(
             unknowns=["Whether the source is an approved sender and its final delivery outcome."],
             verification_condition="Classify the source or collect fresh report evidence that identifies its owner.",
             supporting_signals=_source_signals(source),
+        )
+
+    if forwarding_failing:
+        source = max(forwarding_failing, key=lambda item: _count(item["dmarc_fail_count"]))
+        return assessment(
+            outcome="monitor",
+            title="Review an expected forwarding path",
+            summary=(
+                f"An operator marked {source['source_ip']} as expected forwarding for "
+                f"{source['domain']}. Forwarding can break SPF while DKIM still preserves alignment; "
+                "do not add the intermediary IP to SPF without sender-side evidence."
+            ),
+            next_step="Review forwarding and DKIM evidence",
+            href=f"/domains/{source['domain']}#sending-sources",
+            confidence="Medium",
+            reasons=[
+                "An operator classified this exact source as expected forwarding.",
+                "Aggregate DMARC evidence alone cannot identify the forwarding configuration.",
+            ],
+            evidence_scope="The assessment uses stored report and operator evidence only.",
+            domain=source["domain"],
+            intended_mail_impact="possible",
+            urgency="monitor",
+            known_facts=[
+                "The source has an auditable expected-forwarding classification.",
+                f"Aggregate reports recorded {_count(source['dmarc_fail_count'])} authentication failure(s).",
+            ],
+            derived_facts=["The source has an auditable expected-forwarding classification."],
+            inferences=[
+                "SPF failure may be caused by forwarding rather than an unauthorized sender."
+            ],
+            unknowns=["Whether aligned DKIM survives the forwarding path for each message stream."],
+            verification_condition="Fresh reports or forwarding-system evidence isolate the aligned DKIM path.",
+            watch_condition="Escalate if aligned DKIM also regresses or intended mail is reported missing.",
+            supporting_signals=_source_signals(source),
+            conclusion_key="mail_health.expected_forwarding",
         )
 
     observed_passes = sum(_count(source["dmarc_pass_count"]) for source in sources.values())

--- a/backend/app/services/mail_health.py
+++ b/backend/app/services/mail_health.py
@@ -163,6 +163,14 @@ def _assessment(
         {"claim_level": "unknown", "statement": statement} for statement in unknowns or []
     ]
     resolved_conclusion_key = conclusion_key or f"mail_health.{outcome}"
+    evidence_digest = hashlib.sha256(
+        json.dumps(
+            supporting_signals or [],
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
     assessment_scope = json.dumps(
         {
             "workspace_id": workspace_id,
@@ -176,6 +184,7 @@ def _assessment(
                 for signal in supporting_signals or []
                 if signal.get("signal_id")
             ),
+            "evidence_digest": evidence_digest,
             "algorithm_version": ASSESSMENT_ALGORITHM_VERSION,
         },
         sort_keys=True,
@@ -545,6 +554,14 @@ def _contextual_assessment(
     **values: Any,
 ) -> Dict[str, Any]:
     """Apply shared scope and freshness rules to one deterministic conclusion."""
+    selected_signals = values.get("supporting_signals") or []
+    selected_evidence_at = max(
+        (_count(signal.get("window_end")) for signal in selected_signals),
+        default=0,
+    )
+    if selected_evidence_at:
+        freshness_at = selected_evidence_at
+        freshness = "stale" if end_ts - selected_evidence_at > 7 * 86_400 else "current"
     if freshness == "stale":
         values["confidence"] = {"High": "Medium", "Medium": "Low"}.get(
             str(values.get("confidence") or ""), values.get("confidence")
@@ -692,14 +709,18 @@ def build_workspace_mail_health_assessment(
         end_ts=end_ts,
     )
     newest_evidence_at = max(
-        (_count(source.get("window_end")) for source in sources.values()),
-        default=0,
+        (_count(source.get("window_end")) for source in sources.values()), default=0
     )
     freshness = (
         "stale" if newest_evidence_at and end_ts - newest_evidence_at > 7 * 86_400 else "current"
     )
     for source in sources.values():
-        source["freshness"] = freshness
+        source_evidence_at = _count(source.get("window_end"))
+        source["freshness"] = (
+            "stale"
+            if source_evidence_at and end_ts - source_evidence_at > 7 * 86_400
+            else "current"
+        )
     window_seconds = max(1, end_ts - start_ts)
     previous_sources = _previous_pass_counts(
         db,
@@ -796,7 +817,8 @@ def build_workspace_mail_health_assessment(
                 *([regression_fact] if regression_fact else []),
                 f"Aggregate reports recorded {_count(source['dmarc_fail_count'])} authentication failure(s).",
             ],
-            derived_facts=[sender_match_fact],
+            derived_facts=[] if operator_legitimate else [sender_match_fact],
+            operator_reported_facts=[sender_match_fact] if operator_legitimate else [],
             inferences=["This sender may affect mail you intend to send."],
             unknowns=["Whether each affected message was delivered, bounced, or read."],
             verification_condition="Fresh reports show the sender authenticating without DMARC failures.",

--- a/backend/app/services/mail_health.py
+++ b/backend/app/services/mail_health.py
@@ -8,13 +8,17 @@ not proof that an individual message was delivered or bounced.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections import defaultdict
+from datetime import datetime, timezone
+from functools import partial
 from typing import Any, Dict, Iterable
 
 from sqlalchemy.orm import Session
 
 from app.models.domain import Domain
+from app.models.mail_source import MailSource
 from app.models.report import DomainSourceDailyProjection
 from app.models.workspace import Workspace
 from app.services.mail_signals import (
@@ -22,7 +26,11 @@ from app.services.mail_signals import (
     build_dmarc_source_signals,
     build_intake_window_signal,
 )
+from app.services.sender_classifications import latest_sender_classifications
 from app.services.sender_intelligence import identify_sender
+
+ASSESSMENT_SCHEMA_VERSION = "dmarq.mail_health_assessment.v2"
+ASSESSMENT_ALGORITHM_VERSION = "deterministic-2026-07"
 
 
 def _as_dict(value: object) -> Dict[str, Any]:
@@ -53,6 +61,33 @@ def _hostname(evidence: Dict[str, Any]) -> str | None:
         if value:
             return value
     return None
+
+
+def _confidence_band(confidence: str) -> str:
+    normalized = str(confidence or "").strip().lower()
+    if normalized in {"high", "medium", "low"}:
+        return normalized
+    return "low"
+
+
+def _impact_band(value: str) -> str:
+    return {
+        "likely_affected": "likely",
+        "likely_not_affected": "unlikely",
+        "possible": "possible",
+    }.get(value, "unknown")
+
+
+def _urgency_band(value: str) -> str:
+    return {
+        "urgent": "now",
+        "now": "now",
+        "timely": "soon",
+        "soon": "soon",
+        "monitor": "watch",
+        "watch": "watch",
+        "none": "none",
+    }.get(value, "watch")
 
 
 def _merge_source_rows(
@@ -159,6 +194,11 @@ def _assessment(
     conclusion_claim_level: str = "inferred",
     delivery_certainty: str = "inferred_only",
     derived_facts: list[str] | None = None,
+    workspace_id: int | None = None,
+    window_start: int | None = None,
+    window_end: int | None = None,
+    freshness: str = "current",
+    conclusion_key: str | None = None,
 ) -> Dict[str, Any]:
     derived_fact_set = set(derived_facts or [])
     observed_claims = [
@@ -177,25 +217,49 @@ def _assessment(
     unknown_claims = [
         {"claim_level": "unknown", "statement": statement} for statement in unknowns or []
     ]
+    assessment_scope = (
+        f"{workspace_id}:{domain or 'workspace'}:{outcome}:{ASSESSMENT_ALGORITHM_VERSION}"
+    )
+    assessment_id = hashlib.sha256(assessment_scope.encode("utf-8")).hexdigest()
     return {
+        "schema_version": ASSESSMENT_SCHEMA_VERSION,
+        "assessment_id": assessment_id,
+        "workspace_id": workspace_id,
         "outcome": outcome,
         "title": title,
         "summary": summary,
         "next_step": next_step,
         "href": href,
         "confidence": confidence,
+        "confidence_band": _confidence_band(confidence),
+        "confidence_reasons": reasons,
         "reasons": reasons,
         "evidence_scope": evidence_scope,
         "domain": domain,
         "intended_mail_impact": intended_mail_impact,
+        "intended_mail_impact_band": _impact_band(intended_mail_impact),
         "urgency": urgency,
+        "urgency_band": _urgency_band(urgency),
         "assessment_version": "v1",
+        "assessment_algorithm_version": ASSESSMENT_ALGORITHM_VERSION,
+        "evidence_window": {"start": window_start, "end": window_end},
+        "freshness": freshness,
+        "freshness_at": (
+            datetime.fromtimestamp(window_end, tz=timezone.utc).isoformat() if window_end else None
+        ),
+        "conclusion": {
+            "key": conclusion_key or f"mail_health.{outcome}",
+            "parameters": {"domain": domain} if domain else {},
+        },
         "known_facts": known_facts or [],
         "inferences": inferences or [],
         "unknowns": unknowns or [],
         "next_action": {
             "label": next_step,
             "href": href,
+            "action_type": "open_evidence",
+            "explanation": summary,
+            "prerequisites": [],
             "safety_boundary": "Review report-backed evidence before changing DNS or sender settings.",
         },
         "verification_condition": verification_condition,
@@ -210,6 +274,173 @@ def _assessment(
     }
 
 
+def _projection_rows(
+    db: Session,
+    *,
+    workspace_id: int,
+    start_ts: int,
+    end_ts: int,
+    ordered: bool = False,
+) -> list[tuple[Domain, DomainSourceDailyProjection]]:
+    """Read one bounded projection window without enrichment side effects."""
+    query = (
+        db.query(Domain, DomainSourceDailyProjection)
+        .join(DomainSourceDailyProjection, DomainSourceDailyProjection.domain_id == Domain.id)
+        .filter(
+            Domain.workspace_id == workspace_id,
+            DomainSourceDailyProjection.observed_at >= start_ts,
+            DomainSourceDailyProjection.observed_at < end_ts,
+        )
+    )
+    if ordered:
+        query = query.order_by(
+            Domain.name.asc(),
+            DomainSourceDailyProjection.source_ip.asc(),
+            DomainSourceDailyProjection.observed_at.asc(),
+            DomainSourceDailyProjection.id.asc(),
+        )
+    return query.all()
+
+
+def _workspace_mail_context(workspace: Workspace) -> Dict[str, Any]:
+    """Parse the persisted interview context and ignore malformed legacy values."""
+    try:
+        value = json.loads(workspace.guidance_mail_context or "{}")
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _classify_failing_sources(
+    sources: Dict[tuple[str, str], Dict[str, Any]],
+    *,
+    previous_sources: Dict[tuple[str, str], Dict[str, Any]],
+    classifications: Dict[tuple[str, str], Dict[str, Any]],
+) -> tuple[
+    list[Dict[str, Any]],
+    list[Dict[str, Any]],
+    list[Dict[str, Any]],
+    list[Dict[str, Any]],
+]:
+    """Group failing sources using stored evidence and auditable operator decisions."""
+    known: list[Dict[str, Any]] = []
+    forwarding: list[Dict[str, Any]] = []
+    protected: list[Dict[str, Any]] = []
+    unknown: list[Dict[str, Any]] = []
+    for source in sources.values():
+        failed = _count(source["dmarc_fail_count"])
+        if not failed:
+            continue
+        operator_decision = classifications.get((source["domain"], source["source_ip"]))
+        operator_classification = (
+            str(operator_decision.get("classification") or "") if operator_decision else ""
+        )
+        source["operator_classification"] = operator_classification
+        source["operator_classification_evidence"] = operator_decision
+        previous = previous_sources.get((source["domain"], source["source_ip"]), {})
+        source["previous_pass_count"] = _count(previous.get("dmarc_pass_count"))
+        if operator_classification == "expected_forwarding":
+            forwarding.append(source)
+            continue
+        identity = identify_sender(
+            source["source_ip"],
+            source,
+            hostname=_hostname(source["source_evidence"]),
+            domain=source["domain"],
+            ptr_lookup_pending=bool(source["source_evidence"].get("ptr_retry_pending")),
+        )
+        source["identity"] = identity
+        if operator_classification == "legitimate" or (
+            identity.get("status") == "known"
+            and operator_classification not in {"unauthorized", "stale"}
+        ):
+            known.append(source)
+            continue
+        dispositions = source["disposition_counts"]
+        protected_count = _count(dispositions.get("reject")) + _count(
+            dispositions.get("quarantine")
+        )
+        (protected if protected_count >= failed else unknown).append(source)
+    return known, forwarding, protected, unknown
+
+
+def _no_source_assessment(
+    *,
+    workspace: Workspace,
+    start_ts: int,
+    end_ts: int,
+    low_volume_wait: bool,
+) -> Dict[str, Any]:
+    """Explain an empty window without turning report absence into an outage."""
+    no_evidence_fact = "No projected sender facts were found for the selected date window."
+    summary = "DMARQ has no aggregate authentication evidence in this period yet. "
+    summary += "Connect a report mailbox or upload a report to begin monitoring."
+    if low_volume_wait:
+        summary = (
+            "Report intake is connected and this domain is expected to send little mail. "
+            "No urgent failure is implied; wait for the next receiver report."
+        )
+    return _assessment(
+        workspace_id=workspace.id,
+        window_start=start_ts,
+        window_end=end_ts,
+        outcome="monitor" if low_volume_wait else "insufficient_evidence",
+        title="Waiting for DMARC report data",
+        summary=summary,
+        next_step="Keep report intake running" if low_volume_wait else "Connect a report mailbox",
+        href="/mail-sources",
+        confidence="Low",
+        reasons=[no_evidence_fact],
+        evidence_scope="No report-backed authentication evidence is available yet.",
+        intended_mail_impact="unknown",
+        urgency="monitor",
+        known_facts=[no_evidence_fact],
+        derived_facts=[no_evidence_fact],
+        inferences=["DMARQ cannot assess mail authentication health yet."],
+        unknowns=["How receivers evaluate mail from this domain."],
+        verification_condition="Ingest an aggregate DMARC report for this domain.",
+        watch_condition="DMARQ will reassess when a report is imported.",
+        supporting_signals=[
+            build_intake_window_signal(
+                workspace_id=workspace.id,
+                window_start=start_ts,
+                window_end=end_ts,
+                has_evidence=False,
+            )
+        ],
+        conclusion_claim_level="derived",
+        delivery_certainty="not_applicable",
+    )
+
+
+def _only_protected_failures(
+    protected: list[Dict[str, Any]], unknown: list[Dict[str, Any]]
+) -> bool:
+    return bool(protected) and not unknown
+
+
+def _contextual_assessment(
+    *,
+    workspace_id: int,
+    start_ts: int,
+    end_ts: int,
+    freshness: str,
+    **values: Any,
+) -> Dict[str, Any]:
+    """Apply shared scope and freshness rules to one deterministic conclusion."""
+    if freshness == "stale":
+        values["confidence"] = {"High": "Medium", "Medium": "Low"}.get(
+            str(values.get("confidence") or ""), values.get("confidence")
+        )
+    values.setdefault("freshness", freshness)
+    return _assessment(
+        workspace_id=workspace_id,
+        window_start=start_ts,
+        window_end=end_ts,
+        **values,
+    )
+
+
 def build_workspace_mail_health_assessment(
     db: Session,
     *,
@@ -218,91 +449,84 @@ def build_workspace_mail_health_assessment(
     end_ts: int,
 ) -> Dict[str, Any]:
     """Return one plain-language assessment from indexed aggregate-report facts."""
-    rows = (
-        db.query(Domain, DomainSourceDailyProjection)
-        .join(DomainSourceDailyProjection, DomainSourceDailyProjection.domain_id == Domain.id)
-        .filter(
-            Domain.workspace_id == workspace.id,
-            DomainSourceDailyProjection.observed_at >= start_ts,
-            DomainSourceDailyProjection.observed_at < end_ts,
-        )
-        .order_by(
-            Domain.name.asc(),
-            DomainSourceDailyProjection.source_ip.asc(),
-            DomainSourceDailyProjection.observed_at.asc(),
-            DomainSourceDailyProjection.id.asc(),
-        )
-        .all()
+
+    rows = _projection_rows(
+        db,
+        workspace_id=workspace.id,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        ordered=True,
     )
     sources = _merge_source_rows(rows)
+    newest_evidence_at = max(
+        (_count(source.get("window_end")) for source in sources.values()),
+        default=0,
+    )
+    freshness = (
+        "stale" if newest_evidence_at and end_ts - newest_evidence_at > 7 * 86_400 else "current"
+    )
+    window_seconds = max(1, end_ts - start_ts)
+    previous_rows = _projection_rows(
+        db,
+        workspace_id=workspace.id,
+        start_ts=start_ts - window_seconds,
+        end_ts=start_ts,
+    )
+    previous_sources = _merge_source_rows(previous_rows)
+    classifications = latest_sender_classifications(db, workspace=workspace)
+    mail_context = _workspace_mail_context(workspace)
+    enabled_source_count = (
+        db.query(MailSource)
+        .filter(MailSource.workspace_id == workspace.id, MailSource.enabled.is_(True))
+        .count()
+    )
     if not sources:
-        no_evidence_fact = "No projected sender facts were found for the selected date window."
-        return _assessment(
-            outcome="insufficient_evidence",
-            title="Waiting for DMARC report data",
-            summary=(
-                "DMARQ has no aggregate authentication evidence in this period yet. "
-                "Connect a report mailbox or upload a report to begin monitoring."
-            ),
-            next_step="Connect a report mailbox",
-            href="/mail-sources",
-            confidence="Not enough evidence",
-            reasons=["No projected sender facts were found for the selected date window."],
-            evidence_scope="No report-backed authentication evidence is available yet.",
-            intended_mail_impact="unknown",
-            urgency="monitor",
-            known_facts=[no_evidence_fact],
-            derived_facts=[no_evidence_fact],
-            inferences=["DMARQ cannot assess mail authentication health yet."],
-            unknowns=["How receivers evaluate mail from this domain."],
-            verification_condition="Ingest an aggregate DMARC report for this domain.",
-            watch_condition="DMARQ will reassess when a report is imported.",
-            supporting_signals=[
-                build_intake_window_signal(
-                    workspace_id=workspace.id,
-                    window_start=start_ts,
-                    window_end=end_ts,
-                    has_evidence=False,
-                )
-            ],
-            conclusion_claim_level="derived",
-            delivery_certainty="not_applicable",
+        return _no_source_assessment(
+            workspace=workspace,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            low_volume_wait=bool(enabled_source_count and mail_context.get("low_volume")),
         )
+    assessment = partial(
+        _contextual_assessment,
+        workspace_id=workspace.id,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        freshness=freshness,
+    )
 
-    known_failing: list[Dict[str, Any]] = []
-    unknown_protected: list[Dict[str, Any]] = []
-    unknown_failing: list[Dict[str, Any]] = []
-    for source in sources.values():
-        failed = _count(source["dmarc_fail_count"])
-        if not failed:
-            continue
-        hostname = _hostname(source["source_evidence"])
-        identity = identify_sender(
-            source["source_ip"],
-            source,
-            hostname=hostname,
-            domain=source["domain"],
-            ptr_lookup_pending=bool(source["source_evidence"].get("ptr_retry_pending")),
+    known_failing, forwarding_failing, unknown_protected, unknown_failing = (
+        _classify_failing_sources(
+            sources,
+            previous_sources=previous_sources,
+            classifications=classifications,
         )
-        source["identity"] = identity
-        if identity.get("status") == "known":
-            known_failing.append(source)
-            continue
-        dispositions = source["disposition_counts"]
-        if _count(dispositions.get("reject")) + _count(dispositions.get("quarantine")) >= failed:
-            unknown_protected.append(source)
-        else:
-            unknown_failing.append(source)
+    )
 
     if known_failing:
-        source = max(known_failing, key=lambda item: _count(item["dmarc_fail_count"]))
+        source = max(
+            known_failing,
+            key=lambda item: (
+                bool(item.get("previous_pass_count")),
+                _count(item["dmarc_fail_count"]),
+            ),
+        )
         identity = source["identity"]
         passed = _count(source["dmarc_pass_count"])
         changed = " It also passed authentication in this selected period." if passed else ""
+        operator_legitimate = source.get("operator_classification") == "legitimate"
         sender_match_fact = (
-            f"{identity.get('name') or 'A known sender'} matched a known sender profile."
+            "An operator classified this exact domain and source IP as legitimate."
+            if operator_legitimate
+            else f"{identity.get('name') or 'A known sender'} matched a known sender profile."
         )
-        return _assessment(
+        previous_passes = _count(source.get("previous_pass_count"))
+        regression_fact = (
+            f"The same source passed DMARC for {previous_passes} message(s) in the previous window."
+            if previous_passes
+            else None
+        )
+        return assessment(
             outcome="action_required",
             title=f"Check {identity.get('name') or 'a known sender'} authentication",
             summary=(
@@ -312,7 +536,7 @@ def build_workspace_mail_health_assessment(
             ),
             next_step="Review the sender evidence and authentication result",
             href=f"/domains/{source['domain']}#sending-sources",
-            confidence="High" if passed else "Medium",
+            confidence="High" if previous_passes or (passed and operator_legitimate) else "Medium",
             reasons=[
                 "The sender matches a known provider or owned infrastructure profile.",
                 f"Aggregate reports recorded {_count(source['dmarc_fail_count'])} DMARC authentication failure(s).",
@@ -326,6 +550,7 @@ def build_workspace_mail_health_assessment(
             urgency="timely",
             known_facts=[
                 sender_match_fact,
+                *([regression_fact] if regression_fact else []),
                 f"Aggregate reports recorded {_count(source['dmarc_fail_count'])} authentication failure(s).",
             ],
             derived_facts=[sender_match_fact],
@@ -335,12 +560,48 @@ def build_workspace_mail_health_assessment(
             supporting_signals=_source_signals(source),
         )
 
-    if unknown_protected and not unknown_failing:
+    if forwarding_failing:
+        source = max(forwarding_failing, key=lambda item: _count(item["dmarc_fail_count"]))
+        return assessment(
+            outcome="monitor",
+            title="Review an expected forwarding path",
+            summary=(
+                f"An operator marked {source['source_ip']} as expected forwarding for "
+                f"{source['domain']}. Forwarding can break SPF while DKIM still preserves alignment; "
+                "do not add the intermediary IP to SPF without sender-side evidence."
+            ),
+            next_step="Review forwarding and DKIM evidence",
+            href=f"/domains/{source['domain']}#sending-sources",
+            confidence="Medium",
+            reasons=[
+                "An operator classified this exact source as expected forwarding.",
+                "Aggregate DMARC evidence alone cannot identify the forwarding configuration.",
+            ],
+            evidence_scope="The assessment uses stored report and operator evidence only.",
+            domain=source["domain"],
+            intended_mail_impact="possible",
+            urgency="monitor",
+            known_facts=[
+                "The source has an auditable expected-forwarding classification.",
+                f"Aggregate reports recorded {_count(source['dmarc_fail_count'])} authentication failure(s).",
+            ],
+            derived_facts=["The source has an auditable expected-forwarding classification."],
+            inferences=[
+                "SPF failure may be caused by forwarding rather than an unauthorized sender."
+            ],
+            unknowns=["Whether aligned DKIM survives the forwarding path for each message stream."],
+            verification_condition="Fresh reports or forwarding-system evidence isolate the aligned DKIM path.",
+            watch_condition="Escalate if aligned DKIM also regresses or intended mail is reported missing.",
+            supporting_signals=_source_signals(source),
+            conclusion_key="mail_health.expected_forwarding",
+        )
+
+    if _only_protected_failures(unknown_protected, unknown_failing):
         source = max(unknown_protected, key=lambda item: _count(item["dmarc_fail_count"]))
         unmatched_fact = (
             "The source did not match a known provider or owned-infrastructure profile."
         )
-        return _assessment(
+        return assessment(
             outcome="no_action_likely_unauthorized_use",
             title="Likely unauthorized use is being blocked",
             summary=(
@@ -350,7 +611,7 @@ def build_workspace_mail_health_assessment(
             ),
             next_step="Review source evidence",
             href=f"/domains/{source['domain']}#sending-sources",
-            confidence="Medium",
+            confidence="High" if mail_context.get("domain_sends_mail") is False else "Medium",
             reasons=[
                 "The source could not be matched to a known provider or owned infrastructure.",
                 "Receiver reports recorded quarantine or reject for all observed failures.",
@@ -381,7 +642,7 @@ def build_workspace_mail_health_assessment(
     if unknown_failing:
         source = max(unknown_failing, key=lambda item: _count(item["dmarc_fail_count"]))
         unmatched_fact = "The source did not match a known sender profile."
-        return _assessment(
+        return assessment(
             outcome="investigation_required",
             title="Identify an unrecognized sending source",
             summary=(
@@ -418,7 +679,7 @@ def build_workspace_mail_health_assessment(
             sources.values(),
             key=lambda item: _count(item["dmarc_pass_count"]) + _count(item["dmarc_fail_count"]),
         )
-        return _assessment(
+        return assessment(
             outcome="insufficient_evidence",
             title="Waiting for usable DMARC authentication evidence",
             summary=(
@@ -448,7 +709,39 @@ def build_workspace_mail_health_assessment(
         )
 
     source = max(sources.values(), key=lambda item: _count(item["dmarc_pass_count"]))
-    return _assessment(
+    if mail_context.get("bounce_available") and observed_passes:
+        return assessment(
+            outcome="insufficient_evidence",
+            title="DMARC passes do not explain the reported bounce",
+            summary=(
+                "Receivers reported successful DMARC authentication, but the operator also reported "
+                "a bounce. Use the SMTP response, DSN, or sending-provider event to diagnose delivery."
+            ),
+            next_step="Review the bounce or provider delivery event",
+            href=f"/domains/{source['domain']}#sending-sources",
+            confidence="High",
+            reasons=[
+                "Aggregate reports show DMARC authentication passes.",
+                "The workspace interview records that bounce evidence is available.",
+            ],
+            evidence_scope="Authentication success is not proof of delivery or inbox placement.",
+            domain=source["domain"],
+            intended_mail_impact="possible",
+            urgency="timely",
+            known_facts=[
+                "Aggregate reports contain successful DMARC authentication.",
+                "The operator reported that bounce evidence is available.",
+            ],
+            derived_facts=["The operator reported that bounce evidence is available."],
+            inferences=["The reported delivery problem requires evidence outside aggregate DMARC."],
+            unknowns=[
+                "The SMTP status and rejecting system are not present in aggregate DMARC data."
+            ],
+            verification_condition="Identify the SMTP status, receiver, timestamp, and affected sender.",
+            supporting_signals=_source_signals(source),
+            conclusion_key="mail_health.dmarc_pass_bounce_mismatch",
+        )
+    return assessment(
         outcome="healthy",
         title="Known senders are authenticating successfully",
         summary=(

--- a/backend/app/services/mail_health.py
+++ b/backend/app/services/mail_health.py
@@ -13,7 +13,8 @@ import json
 from collections import defaultdict
 from datetime import datetime, timezone
 from functools import partial
-from typing import Any, Dict, Iterable
+from ipaddress import ip_address
+from typing import Any, Callable, Dict, Iterable
 
 from sqlalchemy.orm import Session
 
@@ -90,17 +91,26 @@ def _urgency_band(value: str) -> str:
     }.get(value, "watch")
 
 
+def _canonical_source_ip(value: object) -> str:
+    raw_value = str(value or "").strip()
+    try:
+        return str(ip_address(raw_value))
+    except ValueError:
+        return raw_value
+
+
 def _merge_source_rows(
     rows: Iterable[tuple[Domain, DomainSourceDailyProjection]],
 ) -> Dict[str, Any]:
     sources: Dict[tuple[str, str], Dict[str, Any]] = {}
     for domain, row in rows:
-        key = (domain.name, str(row.source_ip))
+        normalized_ip = _canonical_source_ip(row.source_ip)
+        key = (domain.name, normalized_ip)
         source = sources.setdefault(
             key,
             {
                 "domain": domain.name,
-                "source_ip": str(row.source_ip),
+                "source_ip": normalized_ip,
                 "spf_pass_count": 0,
                 "spf_fail_count": 0,
                 "dkim_pass_count": 0,
@@ -194,6 +204,7 @@ def _assessment(
     conclusion_claim_level: str = "inferred",
     delivery_certainty: str = "inferred_only",
     derived_facts: list[str] | None = None,
+    operator_reported_facts: list[str] | None = None,
     workspace_id: int | None = None,
     window_start: int | None = None,
     window_end: int | None = None,
@@ -201,10 +212,11 @@ def _assessment(
     conclusion_key: str | None = None,
 ) -> Dict[str, Any]:
     derived_fact_set = set(derived_facts or [])
+    operator_fact_set = set(operator_reported_facts or [])
     observed_claims = [
         {"claim_level": "observed", "statement": statement}
         for statement in known_facts or []
-        if statement not in derived_fact_set
+        if statement not in derived_fact_set and statement not in operator_fact_set
     ]
     derived_claims = [
         {"claim_level": "derived", "statement": statement}
@@ -213,6 +225,10 @@ def _assessment(
     ]
     inferred_claims = [
         {"claim_level": "inferred", "statement": statement} for statement in inferences or []
+    ]
+    operator_claims = [
+        {"claim_level": "operator_reported", "statement": statement}
+        for statement in operator_reported_facts or []
     ]
     unknown_claims = [
         {"claim_level": "unknown", "statement": statement} for statement in unknowns or []
@@ -270,7 +286,9 @@ def _assessment(
         "delivery_certainty": delivery_certainty,
         "signal_schema_version": MAIL_SIGNAL_SCHEMA_VERSION,
         "supporting_signals": supporting_signals or [],
-        "claims": observed_claims + derived_claims + inferred_claims + unknown_claims,
+        "claims": (
+            observed_claims + derived_claims + operator_claims + inferred_claims + unknown_claims
+        ),
     }
 
 
@@ -321,10 +339,12 @@ def _classify_failing_sources(
     list[Dict[str, Any]],
     list[Dict[str, Any]],
     list[Dict[str, Any]],
+    list[Dict[str, Any]],
 ]:
     """Group failing sources using stored evidence and auditable operator decisions."""
     known: list[Dict[str, Any]] = []
     forwarding: list[Dict[str, Any]] = []
+    unauthorized: list[Dict[str, Any]] = []
     protected: list[Dict[str, Any]] = []
     unknown: list[Dict[str, Any]] = []
     for source in sources.values():
@@ -341,6 +361,9 @@ def _classify_failing_sources(
         source["previous_pass_count"] = _count(previous.get("dmarc_pass_count"))
         if operator_classification == "expected_forwarding":
             forwarding.append(source)
+            continue
+        if operator_classification == "unauthorized":
+            unauthorized.append(source)
             continue
         identity = identify_sender(
             source["source_ip"],
@@ -361,7 +384,7 @@ def _classify_failing_sources(
             dispositions.get("quarantine")
         )
         (protected if protected_count >= failed else unknown).append(source)
-    return known, forwarding, protected, unknown
+    return known, forwarding, unauthorized, protected, unknown
 
 
 def _no_source_assessment(
@@ -413,10 +436,21 @@ def _no_source_assessment(
     )
 
 
-def _only_protected_failures(
-    protected: list[Dict[str, Any]], unknown: list[Dict[str, Any]]
-) -> bool:
-    return bool(protected) and not unknown
+def _priority_unauthorized_source(
+    confirmed: list[Dict[str, Any]],
+    protected: list[Dict[str, Any]],
+    unknown: list[Dict[str, Any]],
+) -> Dict[str, Any] | None:
+    candidates = confirmed + protected
+    if not candidates or (not confirmed and unknown):
+        return None
+    return max(
+        candidates,
+        key=lambda item: (
+            item.get("operator_classification") == "unauthorized",
+            _count(item["dmarc_fail_count"]),
+        ),
+    )
 
 
 def _contextual_assessment(
@@ -439,6 +473,123 @@ def _contextual_assessment(
         window_end=end_ts,
         **values,
     )
+
+
+def _unauthorized_use_assessment(
+    assessment: Callable[..., Dict[str, Any]],
+    source: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Distinguish confirmed unauthorized use from likely blocked spoofing."""
+    failed = _count(source["dmarc_fail_count"])
+    dispositions = source["disposition_counts"]
+    protected_count = _count(dispositions.get("reject")) + _count(dispositions.get("quarantine"))
+    explicit = source.get("operator_classification") == "unauthorized"
+    operator_fact = "An operator classified this exact domain and source IP as unauthorized."
+    if explicit and protected_count < failed:
+        return assessment(
+            outcome="action_required",
+            title="Protect the domain from confirmed unauthorized use",
+            summary=(
+                f"An operator classified {source['source_ip']} as unauthorized for "
+                f"{source['domain']}, but receivers did not report protective handling for all "
+                f"{failed} authentication failure(s). Review policy readiness before tightening DMARC."
+            ),
+            next_step="Review domain protection and known-sender readiness",
+            href=f"/domains/{source['domain']}#remediation-queue",
+            confidence="High",
+            reasons=[
+                "The exact source has an auditable unauthorized classification.",
+                "Receiver reports did not consistently record quarantine or reject handling.",
+            ],
+            evidence_scope="The ownership decision is operator-reported; policy handling comes from aggregate receiver reports.",
+            domain=source["domain"],
+            intended_mail_impact="likely_not_affected",
+            urgency="timely",
+            known_facts=[
+                operator_fact,
+                f"Aggregate reports recorded {failed} authentication failure(s).",
+            ],
+            operator_reported_facts=[operator_fact],
+            inferences=[
+                "Current policy may not consistently protect against this unauthorized use."
+            ],
+            unknowns=["The final delivery outcome of individual messages."],
+            verification_condition=(
+                "Known senders remain healthy and fresh receiver reports record protective handling "
+                "for the unauthorized source."
+            ),
+            supporting_signals=_source_signals(source),
+            conclusion_key="mail_health.confirmed_unauthorized_use_unprotected",
+        )
+
+    unmatched_fact = (
+        operator_fact
+        if explicit
+        else "The source did not match a known provider or owned-infrastructure profile."
+    )
+    return assessment(
+        outcome="no_action_likely_unauthorized_use",
+        title=(
+            "Confirmed unauthorized use is being blocked"
+            if explicit
+            else "Likely unauthorized use is being blocked"
+        ),
+        summary=(
+            f"The unauthorized source had {failed} authentication failure(s) for "
+            f"{source['domain']}, and receivers applied your protective DMARC policy. "
+            "Known sender failures were not found in this period."
+            if explicit
+            else f"An unrecognized source had {failed} authentication failure(s) for "
+            f"{source['domain']}, and receivers applied your protective DMARC policy. "
+            "Known sender failures were not found in this period."
+        ),
+        next_step="Review source evidence",
+        href=f"/domains/{source['domain']}#sending-sources",
+        confidence="High" if explicit else "Medium",
+        reasons=[
+            (
+                "The exact source has an auditable unauthorized classification."
+                if explicit
+                else "The source could not be matched to known sending infrastructure."
+            ),
+            "Receiver reports recorded quarantine or reject for all observed failures.",
+        ],
+        evidence_scope="This is an interpretation of aggregate receiver reports, not proof of a specific delivery outcome.",
+        domain=source["domain"],
+        intended_mail_impact="likely_not_affected",
+        urgency="none",
+        known_facts=[
+            unmatched_fact,
+            "Receiver reports recorded protective quarantine or reject handling for all observed failures.",
+        ],
+        derived_facts=[] if explicit else [unmatched_fact],
+        operator_reported_facts=[operator_fact] if explicit else [],
+        inferences=["This does not currently appear to be a fault in your intended sending setup."],
+        unknowns=["The final outcome of individual messages."],
+        verification_condition="Known senders remain healthy and policy remains protective.",
+        no_action_reason="Receivers reported protective handling and no known sender failures were found.",
+        watch_condition="DMARQ will surface a new action if the pattern or known-sender health changes.",
+        supporting_signals=_source_signals(source),
+        conclusion_key="mail_health.confirmed_unauthorized_use_blocked" if explicit else None,
+    )
+
+
+def _bounce_context_source(
+    sources: Dict[tuple[str, str], Dict[str, Any]], mail_context: Dict[str, Any]
+) -> Dict[str, Any] | None:
+    """Match a reported bounce only to the domains selected in the interview."""
+    if not mail_context.get("bounce_available"):
+        return None
+    selected_domains = {
+        str(domain).strip().lower().rstrip(".") for domain in mail_context.get("domains") or []
+    }
+    candidates = [
+        source
+        for source in sources.values()
+        if _count(source["dmarc_pass_count"])
+        and (not selected_domains or source["domain"] in selected_domains)
+    ]
+    return max(candidates, key=lambda item: _count(item["dmarc_pass_count"]), default=None)
 
 
 def build_workspace_mail_health_assessment(
@@ -495,12 +646,16 @@ def build_workspace_mail_health_assessment(
         freshness=freshness,
     )
 
-    known_failing, forwarding_failing, unknown_protected, unknown_failing = (
-        _classify_failing_sources(
-            sources,
-            previous_sources=previous_sources,
-            classifications=classifications,
-        )
+    (
+        known_failing,
+        forwarding_failing,
+        confirmed_unauthorized,
+        unknown_protected,
+        unknown_failing,
+    ) = _classify_failing_sources(
+        sources,
+        previous_sources=previous_sources,
+        classifications=classifications,
     )
 
     if known_failing:
@@ -596,48 +751,12 @@ def build_workspace_mail_health_assessment(
             conclusion_key="mail_health.expected_forwarding",
         )
 
-    if _only_protected_failures(unknown_protected, unknown_failing):
-        source = max(unknown_protected, key=lambda item: _count(item["dmarc_fail_count"]))
-        unmatched_fact = (
-            "The source did not match a known provider or owned-infrastructure profile."
-        )
-        return assessment(
-            outcome="no_action_likely_unauthorized_use",
-            title="Likely unauthorized use is being blocked",
-            summary=(
-                f"An unrecognized source had {_count(source['dmarc_fail_count'])} authentication failure(s) "
-                f"for {source['domain']}, and receivers applied your protective DMARC policy. "
-                "Known sender failures were not found in this period."
-            ),
-            next_step="Review source evidence",
-            href=f"/domains/{source['domain']}#sending-sources",
-            confidence="High" if mail_context.get("domain_sends_mail") is False else "Medium",
-            reasons=[
-                "The source could not be matched to a known provider or owned infrastructure.",
-                "Receiver reports recorded quarantine or reject for all observed failures.",
-            ],
-            evidence_scope=(
-                "This is an interpretation of aggregate receiver reports, not proof of a specific delivery outcome."
-            ),
-            domain=source["domain"],
-            intended_mail_impact="likely_not_affected",
-            urgency="none",
-            known_facts=[
-                unmatched_fact,
-                "Receiver reports recorded protective quarantine or reject handling for all observed failures.",
-            ],
-            derived_facts=[unmatched_fact],
-            inferences=[
-                "This is likely unauthorized use rather than a fault in your known sending setup."
-            ],
-            unknowns=[
-                "Who operated the unrecognized source and the final outcome of individual messages."
-            ],
-            verification_condition="Known senders remain healthy and no new evidence links this source to your mail estate.",
-            no_action_reason="Receivers already reported protective handling and no known sender failures were found.",
-            watch_condition="DMARQ will surface a new action if the pattern changes or a known sender fails.",
-            supporting_signals=_source_signals(source),
-        )
+    unauthorized_source = _priority_unauthorized_source(
+        confirmed_unauthorized, unknown_protected, unknown_failing
+    )
+    if unauthorized_source:
+        source = unauthorized_source
+        return _unauthorized_use_assessment(assessment, source)
 
     if unknown_failing:
         source = max(unknown_failing, key=lambda item: _count(item["dmarc_fail_count"]))
@@ -708,8 +827,9 @@ def build_workspace_mail_health_assessment(
             delivery_certainty="not_applicable",
         )
 
-    source = max(sources.values(), key=lambda item: _count(item["dmarc_pass_count"]))
-    if mail_context.get("bounce_available") and observed_passes:
+    bounce_source = _bounce_context_source(sources, mail_context)
+    if bounce_source:
+        source = bounce_source
         return assessment(
             outcome="insufficient_evidence",
             title="DMARC passes do not explain the reported bounce",
@@ -741,6 +861,7 @@ def build_workspace_mail_health_assessment(
             supporting_signals=_source_signals(source),
             conclusion_key="mail_health.dmarc_pass_bounce_mismatch",
         )
+    source = max(sources.values(), key=lambda item: _count(item["dmarc_pass_count"]))
     return assessment(
         outcome="healthy",
         title="Known senders are authenticating successfully",

--- a/backend/app/services/mail_health.py
+++ b/backend/app/services/mail_health.py
@@ -14,8 +14,9 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from functools import partial
 from ipaddress import ip_address
-from typing import Any, Callable, Dict, Iterable
+from typing import Any, Callable, Dict
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.models.domain import Domain
@@ -99,79 +100,6 @@ def _canonical_source_ip(value: object) -> str:
         return raw_value
 
 
-def _merge_source_rows(
-    rows: Iterable[tuple[Domain, DomainSourceDailyProjection]],
-) -> Dict[str, Any]:
-    sources: Dict[tuple[str, str], Dict[str, Any]] = {}
-    for domain, row in rows:
-        normalized_ip = _canonical_source_ip(row.source_ip)
-        key = (domain.name, normalized_ip)
-        source = sources.setdefault(
-            key,
-            {
-                "domain": domain.name,
-                "source_ip": normalized_ip,
-                "spf_pass_count": 0,
-                "spf_fail_count": 0,
-                "dkim_pass_count": 0,
-                "dkim_fail_count": 0,
-                "dmarc_pass_count": 0,
-                "dmarc_fail_count": 0,
-                "disposition_counts": defaultdict(int),
-                "source_evidence": {},
-                "captured_at": "",
-                "workspace_id": domain.workspace_id,
-                "window_start": None,
-                "window_end": None,
-                "evidence_refs": [],
-                "report_generators": [],
-                "header_from_domains": [],
-                "envelope_from_domains": [],
-                "spf_domains": [],
-                "dkim_domains": [],
-                "dkim_selectors": [],
-            },
-        )
-        source["spf_pass_count"] += _count(row.spf_pass_count)
-        source["spf_fail_count"] += _count(row.spf_fail_count)
-        source["dkim_pass_count"] += _count(row.dkim_pass_count)
-        source["dkim_fail_count"] += _count(row.dkim_fail_count)
-        source["dmarc_pass_count"] += _count(row.dmarc_pass_count)
-        source["dmarc_fail_count"] += _count(row.dmarc_fail_count)
-        source["window_start"] = (
-            row.first_seen or row.observed_at
-            if source["window_start"] is None
-            else min(source["window_start"], row.first_seen or row.observed_at)
-        )
-        source["window_end"] = (
-            row.last_seen or row.observed_at
-            if source["window_end"] is None
-            else max(source["window_end"], row.last_seen or row.observed_at)
-        )
-        source["evidence_refs"].append(f"domain_source_daily_projection:{row.id}")
-        metadata = _as_dict(row.metadata_json)
-        for field in (
-            "report_generators",
-            "header_from_domains",
-            "envelope_from_domains",
-            "spf_domains",
-            "dkim_domains",
-            "dkim_selectors",
-        ):
-            for value in metadata.get(field) or []:
-                normalized = str(value).strip()
-                if normalized and normalized not in source[field]:
-                    source[field].append(normalized)
-        for disposition, count in _as_dict(row.disposition_counts).items():
-            source["disposition_counts"][str(disposition).lower()] += _count(count)
-        evidence = _as_dict(row.source_evidence)
-        captured_at = str(evidence.get("captured_at") or "")
-        if evidence and captured_at >= source["captured_at"]:
-            source["source_evidence"] = evidence
-            source["captured_at"] = captured_at
-    return sources
-
-
 def _source_signals(source: Dict[str, Any]) -> list[Dict[str, Any]]:
     return build_dmarc_source_signals(
         source,
@@ -209,6 +137,7 @@ def _assessment(
     window_start: int | None = None,
     window_end: int | None = None,
     freshness: str = "current",
+    freshness_at: int | None = None,
     conclusion_key: str | None = None,
 ) -> Dict[str, Any]:
     derived_fact_set = set(derived_facts or [])
@@ -233,8 +162,24 @@ def _assessment(
     unknown_claims = [
         {"claim_level": "unknown", "statement": statement} for statement in unknowns or []
     ]
-    assessment_scope = (
-        f"{workspace_id}:{domain or 'workspace'}:{outcome}:{ASSESSMENT_ALGORITHM_VERSION}"
+    resolved_conclusion_key = conclusion_key or f"mail_health.{outcome}"
+    assessment_scope = json.dumps(
+        {
+            "workspace_id": workspace_id,
+            "domain": domain,
+            "outcome": outcome,
+            "conclusion_key": resolved_conclusion_key,
+            "window_start": window_start,
+            "window_end": window_end,
+            "signal_ids": sorted(
+                str(signal.get("signal_id"))
+                for signal in supporting_signals or []
+                if signal.get("signal_id")
+            ),
+            "algorithm_version": ASSESSMENT_ALGORITHM_VERSION,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
     )
     assessment_id = hashlib.sha256(assessment_scope.encode("utf-8")).hexdigest()
     return {
@@ -261,10 +206,12 @@ def _assessment(
         "evidence_window": {"start": window_start, "end": window_end},
         "freshness": freshness,
         "freshness_at": (
-            datetime.fromtimestamp(window_end, tz=timezone.utc).isoformat() if window_end else None
+            datetime.fromtimestamp(freshness_at, tz=timezone.utc).isoformat()
+            if freshness_at
+            else None
         ),
         "conclusion": {
-            "key": conclusion_key or f"mail_health.{outcome}",
+            "key": resolved_conclusion_key,
             "parameters": {"domain": domain} if domain else {},
         },
         "known_facts": known_facts or [],
@@ -292,32 +239,167 @@ def _assessment(
     }
 
 
-def _projection_rows(
+def _aggregated_projection_sources(
     db: Session,
     *,
     workspace_id: int,
     start_ts: int,
     end_ts: int,
-    ordered: bool = False,
-) -> list[tuple[Domain, DomainSourceDailyProjection]]:
-    """Read one bounded projection window without enrichment side effects."""
-    query = (
-        db.query(Domain, DomainSourceDailyProjection)
-        .join(DomainSourceDailyProjection, DomainSourceDailyProjection.domain_id == Domain.id)
+) -> Dict[tuple[str, str], Dict[str, Any]]:
+    """Aggregate counters in SQL and load only compact evidence fields per day."""
+    projection = DomainSourceDailyProjection
+    grouped_rows = (
+        db.query(
+            Domain.name.label("domain_name"),
+            Domain.workspace_id.label("workspace_id"),
+            projection.source_ip.label("source_ip"),
+            func.sum(projection.spf_pass_count).label("spf_pass_count"),
+            func.sum(projection.spf_fail_count).label("spf_fail_count"),
+            func.sum(projection.dkim_pass_count).label("dkim_pass_count"),
+            func.sum(projection.dkim_fail_count).label("dkim_fail_count"),
+            func.sum(projection.dmarc_pass_count).label("dmarc_pass_count"),
+            func.sum(projection.dmarc_fail_count).label("dmarc_fail_count"),
+            func.min(func.coalesce(projection.first_seen, projection.observed_at)).label(
+                "window_start"
+            ),
+            func.max(func.coalesce(projection.last_seen, projection.observed_at)).label(
+                "window_end"
+            ),
+        )
+        .join(projection, projection.domain_id == Domain.id)
         .filter(
             Domain.workspace_id == workspace_id,
-            DomainSourceDailyProjection.observed_at >= start_ts,
-            DomainSourceDailyProjection.observed_at < end_ts,
+            projection.observed_at >= start_ts,
+            projection.observed_at < end_ts,
         )
+        .group_by(Domain.name, Domain.workspace_id, projection.source_ip)
+        .all()
     )
-    if ordered:
-        query = query.order_by(
-            Domain.name.asc(),
-            DomainSourceDailyProjection.source_ip.asc(),
-            DomainSourceDailyProjection.observed_at.asc(),
-            DomainSourceDailyProjection.id.asc(),
+    sources: Dict[tuple[str, str], Dict[str, Any]] = {}
+    for row in grouped_rows:
+        normalized_ip = _canonical_source_ip(row.source_ip)
+        key = (row.domain_name, normalized_ip)
+        source = sources.setdefault(
+            key,
+            {
+                "domain": row.domain_name,
+                "source_ip": normalized_ip,
+                "spf_pass_count": 0,
+                "spf_fail_count": 0,
+                "dkim_pass_count": 0,
+                "dkim_fail_count": 0,
+                "dmarc_pass_count": 0,
+                "dmarc_fail_count": 0,
+                "disposition_counts": defaultdict(int),
+                "source_evidence": {},
+                "captured_at": "",
+                "workspace_id": row.workspace_id,
+                "window_start": None,
+                "window_end": None,
+                "evidence_refs": [],
+                "report_generators": [],
+                "header_from_domains": [],
+                "envelope_from_domains": [],
+                "spf_domains": [],
+                "dkim_domains": [],
+                "dkim_selectors": [],
+            },
         )
-    return query.all()
+        for field in (
+            "spf_pass_count",
+            "spf_fail_count",
+            "dkim_pass_count",
+            "dkim_fail_count",
+            "dmarc_pass_count",
+            "dmarc_fail_count",
+        ):
+            source[field] += _count(getattr(row, field))
+        source["window_start"] = (
+            _count(row.window_start)
+            if source["window_start"] is None
+            else min(source["window_start"], _count(row.window_start))
+        )
+        source["window_end"] = max(
+            _count(source["window_end"]),
+            _count(row.window_end),
+        )
+
+    detail_rows = (
+        db.query(
+            Domain.name.label("domain_name"),
+            projection.source_ip.label("source_ip"),
+            projection.id.label("projection_id"),
+            projection.disposition_counts.label("disposition_counts"),
+            projection.metadata_json.label("metadata_json"),
+            projection.source_evidence.label("source_evidence"),
+        )
+        .join(projection, projection.domain_id == Domain.id)
+        .filter(
+            Domain.workspace_id == workspace_id,
+            projection.observed_at >= start_ts,
+            projection.observed_at < end_ts,
+        )
+        .all()
+    )
+    for row in detail_rows:
+        key = (row.domain_name, _canonical_source_ip(row.source_ip))
+        source = sources.get(key)
+        if source is None:
+            continue
+        source["evidence_refs"].append(f"domain_source_daily_projection:{row.projection_id}")
+        metadata = _as_dict(row.metadata_json)
+        for field in (
+            "report_generators",
+            "header_from_domains",
+            "envelope_from_domains",
+            "spf_domains",
+            "dkim_domains",
+            "dkim_selectors",
+        ):
+            for value in metadata.get(field) or []:
+                normalized = str(value).strip()
+                if normalized and normalized not in source[field]:
+                    source[field].append(normalized)
+        for disposition, count in _as_dict(row.disposition_counts).items():
+            source["disposition_counts"][str(disposition).lower()] += _count(count)
+        evidence = _as_dict(row.source_evidence)
+        captured_at = str(evidence.get("captured_at") or "")
+        if evidence and captured_at >= source["captured_at"]:
+            source["source_evidence"] = evidence
+            source["captured_at"] = captured_at
+    return sources
+
+
+def _previous_pass_counts(
+    db: Session,
+    *,
+    workspace_id: int,
+    start_ts: int,
+    end_ts: int,
+) -> Dict[tuple[str, str], Dict[str, int]]:
+    """Read only the previous-window pass counter used for regression detection."""
+    projection = DomainSourceDailyProjection
+    rows = (
+        db.query(
+            Domain.name.label("domain_name"),
+            projection.source_ip.label("source_ip"),
+            func.sum(projection.dmarc_pass_count).label("previous_pass_count"),
+        )
+        .join(projection, projection.domain_id == Domain.id)
+        .filter(
+            Domain.workspace_id == workspace_id,
+            projection.observed_at >= start_ts,
+            projection.observed_at < end_ts,
+        )
+        .group_by(Domain.name, projection.source_ip)
+        .all()
+    )
+    previous: Dict[tuple[str, str], Dict[str, int]] = {}
+    for row in rows:
+        key = (row.domain_name, _canonical_source_ip(row.source_ip))
+        target = previous.setdefault(key, {"dmarc_pass_count": 0})
+        target["dmarc_pass_count"] += _count(row.previous_pass_count)
+    return previous
 
 
 def _workspace_mail_context(workspace: Workspace) -> Dict[str, Any]:
@@ -442,7 +524,7 @@ def _priority_unauthorized_source(
     unknown: list[Dict[str, Any]],
 ) -> Dict[str, Any] | None:
     candidates = confirmed + protected
-    if not candidates or (not confirmed and unknown):
+    if not candidates or unknown:
         return None
     return max(
         candidates,
@@ -459,6 +541,7 @@ def _contextual_assessment(
     start_ts: int,
     end_ts: int,
     freshness: str,
+    freshness_at: int | None,
     **values: Any,
 ) -> Dict[str, Any]:
     """Apply shared scope and freshness rules to one deterministic conclusion."""
@@ -467,6 +550,7 @@ def _contextual_assessment(
             str(values.get("confidence") or ""), values.get("confidence")
         )
     values.setdefault("freshness", freshness)
+    values.setdefault("freshness_at", freshness_at)
     return _assessment(
         workspace_id=workspace_id,
         window_start=start_ts,
@@ -601,14 +685,12 @@ def build_workspace_mail_health_assessment(
 ) -> Dict[str, Any]:
     """Return one plain-language assessment from indexed aggregate-report facts."""
 
-    rows = _projection_rows(
+    sources = _aggregated_projection_sources(
         db,
         workspace_id=workspace.id,
         start_ts=start_ts,
         end_ts=end_ts,
-        ordered=True,
     )
-    sources = _merge_source_rows(rows)
     newest_evidence_at = max(
         (_count(source.get("window_end")) for source in sources.values()),
         default=0,
@@ -616,14 +698,15 @@ def build_workspace_mail_health_assessment(
     freshness = (
         "stale" if newest_evidence_at and end_ts - newest_evidence_at > 7 * 86_400 else "current"
     )
+    for source in sources.values():
+        source["freshness"] = freshness
     window_seconds = max(1, end_ts - start_ts)
-    previous_rows = _projection_rows(
+    previous_sources = _previous_pass_counts(
         db,
         workspace_id=workspace.id,
         start_ts=start_ts - window_seconds,
         end_ts=start_ts,
     )
-    previous_sources = _merge_source_rows(previous_rows)
     classifications = latest_sender_classifications(db, workspace=workspace)
     mail_context = _workspace_mail_context(workspace)
     enabled_source_count = (
@@ -644,6 +727,7 @@ def build_workspace_mail_health_assessment(
         start_ts=start_ts,
         end_ts=end_ts,
         freshness=freshness,
+        freshness_at=newest_evidence_at or None,
     )
 
     (
@@ -693,7 +777,11 @@ def build_workspace_mail_health_assessment(
             href=f"/domains/{source['domain']}#sending-sources",
             confidence="High" if previous_passes or (passed and operator_legitimate) else "Medium",
             reasons=[
-                "The sender matches a known provider or owned infrastructure profile.",
+                (
+                    "An operator classified this exact domain and source IP as legitimate."
+                    if operator_legitimate
+                    else "The sender matches a known provider or owned infrastructure profile."
+                ),
                 f"Aggregate reports recorded {_count(source['dmarc_fail_count'])} DMARC authentication failure(s).",
             ],
             evidence_scope=(

--- a/backend/app/services/mail_health_incidents.py
+++ b/backend/app/services/mail_health_incidents.py
@@ -129,16 +129,18 @@ def _resolve_active_incidents(
     domain: Optional[str],
     now: datetime,
     evidence: str,
+    workspace_wide: bool = False,
 ) -> List[MailHealthIncident]:
     query = db.query(MailHealthIncident).filter(
         MailHealthIncident.workspace_id == workspace.id,
         MailHealthIncident.status.in_(["open", "acknowledged", "snoozed"]),
     )
-    query = query.filter(
-        MailHealthIncident.domain == domain
-        if domain is not None
-        else MailHealthIncident.domain.is_(None)
-    )
+    if not workspace_wide:
+        query = query.filter(
+            MailHealthIncident.domain == domain
+            if domain is not None
+            else MailHealthIncident.domain.is_(None)
+        )
     resolved = query.all()
     for row in resolved:
         row.status = "resolved"
@@ -260,13 +262,17 @@ def record_mail_health_assessment(
         )
     )
 
-    if outcome in {"healthy", "insufficient_evidence"} or waiting_for_report_data:
+    if waiting_for_report_data:
+        return {"incident": None, "notification_reason": None, "resolved": []}
+
+    if outcome in {"healthy", "insufficient_evidence"}:
         resolved = _resolve_active_incidents(
             db,
             workspace=workspace,
             domain=domain,
             now=now,
             evidence="A fresh report-backed assessment no longer found this actionable state.",
+            workspace_wide=outcome == "healthy" and domain is None,
         )
         db.commit()
         return {

--- a/backend/app/services/mail_health_incidents.py
+++ b/backend/app/services/mail_health_incidents.py
@@ -134,8 +134,11 @@ def _resolve_active_incidents(
         MailHealthIncident.workspace_id == workspace.id,
         MailHealthIncident.status.in_(["open", "acknowledged", "snoozed"]),
     )
-    if domain:
-        query = query.filter(MailHealthIncident.domain == domain)
+    query = query.filter(
+        MailHealthIncident.domain == domain
+        if domain is not None
+        else MailHealthIncident.domain.is_(None)
+    )
     resolved = query.all()
     for row in resolved:
         row.status = "resolved"
@@ -247,7 +250,17 @@ def record_mail_health_assessment(
     outcome = str(assessment.get("outcome") or "insufficient_evidence")
     domain = assessment.get("domain")
 
-    if outcome in {"healthy", "insufficient_evidence"}:
+    waiting_for_report_data = (
+        outcome == "monitor"
+        and domain is None
+        and any(
+            signal.get("family") == "intake_health"
+            and signal.get("outcome") == "no_report_evidence_in_window"
+            for signal in assessment.get("supporting_signals") or []
+        )
+    )
+
+    if outcome in {"healthy", "insufficient_evidence"} or waiting_for_report_data:
         resolved = _resolve_active_incidents(
             db,
             workspace=workspace,

--- a/backend/app/services/mail_signals.py
+++ b/backend/app/services/mail_signals.py
@@ -180,6 +180,7 @@ def build_dmarc_source_signals(
         "observed_at": str(source.get("captured_at") or "") or None,
         "source_system": "dmarc_aggregate_report",
         "claim_level": "observed",
+        "freshness": str(source.get("freshness") or "current"),
         "privacy_classification": "aggregate",
         "evidence_refs": tuple(sorted({str(item) for item in evidence_refs if str(item)})),
     }

--- a/backend/app/services/sender_classifications.py
+++ b/backend/app/services/sender_classifications.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.models.workspace import Workspace
 from app.models.workspace_access import WorkspaceAuditLog
-from app.services.workspace_audit import audit_log_to_dict, record_workspace_audit_log
+from app.services.workspace_audit import record_workspace_audit_log
 from app.utils.domain_validator import normalize_domain_name, validate_domain
 
 SENDER_CLASSIFICATIONS = {
@@ -50,6 +50,21 @@ def _details(row: WorkspaceAuditLog) -> Dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _classification_projection(
+    row: WorkspaceAuditLog, *, details: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Return the decision fields needed by report readers, without audit internals."""
+    values = details if details is not None else _details(row)
+    return {
+        "domain": str(values.get("domain") or ""),
+        "source_ip": str(values.get("source_ip") or ""),
+        "classification": str(values.get("classification") or ""),
+        "reason": str(values.get("reason") or "") or None,
+        "scope": "exact_domain_source",
+        "classified_at": row.created_at.isoformat() if row.created_at else None,
+    }
+
+
 def latest_sender_classifications(
     db: Session,
     *,
@@ -73,14 +88,7 @@ def latest_sender_classifications(
         classification = str(details.get("classification") or "")
         if not all(key) or classification not in SENDER_CLASSIFICATIONS or key in result:
             continue
-        result[key] = {
-            **audit_log_to_dict(row),
-            "domain": key[0],
-            "source_ip": key[1],
-            "classification": classification,
-            "reason": str(details.get("reason") or "") or None,
-            "scope": "exact_domain_source",
-        }
+        result[key] = _classification_projection(row, details=details)
     return result
 
 
@@ -122,11 +130,4 @@ def record_sender_classification(
         request=request,
         commit=True,
     )
-    return {
-        **audit_log_to_dict(row),
-        "domain": normalized_domain,
-        "source_ip": normalized_ip,
-        "classification": normalized_classification,
-        "reason": normalized_reason,
-        "scope": "exact_domain_source",
-    }
+    return _classification_projection(row)

--- a/backend/app/services/sender_classifications.py
+++ b/backend/app/services/sender_classifications.py
@@ -1,0 +1,132 @@
+"""Auditable operator classifications for report-backed sending sources."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from ipaddress import ip_address
+from typing import Any, Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.workspace import Workspace
+from app.models.workspace_access import WorkspaceAuditLog
+from app.services.workspace_audit import audit_log_to_dict, record_workspace_audit_log
+from app.utils.domain_validator import normalize_domain_name, validate_domain
+
+SENDER_CLASSIFICATIONS = {
+    "legitimate",
+    "unknown",
+    "unauthorized",
+    "expected_forwarding",
+    "stale",
+}
+SENDER_CLASSIFICATION_ACTION = "mail_health.sender_classified"
+SENDER_CLASSIFICATION_ENTITY = "mail_sender_classification"
+
+
+def _scope_id(domain: str, source_ip: str) -> str:
+    value = f"{domain}|{source_ip}"
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def normalize_sender_scope(domain: str, source_ip: str) -> tuple[str, str]:
+    """Validate one exact domain/source scope without performing network I/O."""
+    normalized_domain = normalize_domain_name(domain)
+    if not validate_domain(normalized_domain, check_dns=False)[0]:
+        raise ValueError("A valid domain is required")
+    try:
+        normalized_ip = str(ip_address(str(source_ip).strip()))
+    except ValueError as exc:
+        raise ValueError("A valid source IP address is required") from exc
+    return normalized_domain, normalized_ip
+
+
+def _details(row: WorkspaceAuditLog) -> Dict[str, Any]:
+    try:
+        value = json.loads(row.details or "{}")
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def latest_sender_classifications(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domain: Optional[str] = None,
+) -> Dict[tuple[str, str], Dict[str, Any]]:
+    """Return the latest decision per exact domain/IP scope."""
+    query = db.query(WorkspaceAuditLog).filter(
+        WorkspaceAuditLog.workspace_id == workspace.id,
+        WorkspaceAuditLog.action == SENDER_CLASSIFICATION_ACTION,
+        WorkspaceAuditLog.entity_type == SENDER_CLASSIFICATION_ENTITY,
+    )
+    if domain:
+        normalized_domain = normalize_domain_name(domain)
+        query = query.filter(WorkspaceAuditLog.entity_name == normalized_domain)
+    rows = query.order_by(WorkspaceAuditLog.created_at.desc(), WorkspaceAuditLog.id.desc()).all()
+    result: Dict[tuple[str, str], Dict[str, Any]] = {}
+    for row in rows:
+        details = _details(row)
+        key = (str(details.get("domain") or ""), str(details.get("source_ip") or ""))
+        classification = str(details.get("classification") or "")
+        if not all(key) or classification not in SENDER_CLASSIFICATIONS or key in result:
+            continue
+        result[key] = {
+            **audit_log_to_dict(row),
+            "domain": key[0],
+            "source_ip": key[1],
+            "classification": classification,
+            "reason": str(details.get("reason") or "") or None,
+            "scope": "exact_domain_source",
+        }
+    return result
+
+
+def record_sender_classification(
+    db: Session,
+    *,
+    workspace: Workspace,
+    domain: str,
+    source_ip: str,
+    classification: str,
+    reason: Optional[str],
+    auth_context: Optional[Dict[str, Any]],
+    request: Any = None,
+) -> Dict[str, Any]:
+    """Append one decision; never mutate report or prior classification evidence."""
+    normalized_domain, normalized_ip = normalize_sender_scope(domain, source_ip)
+    normalized_classification = str(classification or "").strip().lower()
+    if normalized_classification not in SENDER_CLASSIFICATIONS:
+        raise ValueError(
+            "Unsupported classification. Use one of: " + ", ".join(sorted(SENDER_CLASSIFICATIONS))
+        )
+    normalized_reason = str(reason or "").strip()[:500] or None
+    row = record_workspace_audit_log(
+        db,
+        workspace=workspace,
+        action=SENDER_CLASSIFICATION_ACTION,
+        entity_type=SENDER_CLASSIFICATION_ENTITY,
+        entity_id=_scope_id(normalized_domain, normalized_ip),
+        entity_name=normalized_domain,
+        details={
+            "domain": normalized_domain,
+            "source_ip": normalized_ip,
+            "classification": normalized_classification,
+            "reason": normalized_reason,
+            "scope": "exact_domain_source",
+            "historical_report_evidence_changed": False,
+        },
+        auth_context=auth_context,
+        request=request,
+        commit=True,
+    )
+    return {
+        **audit_log_to_dict(row),
+        "domain": normalized_domain,
+        "source_ip": normalized_ip,
+        "classification": normalized_classification,
+        "reason": normalized_reason,
+        "scope": "exact_domain_source",
+    }

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -1182,6 +1182,13 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
             auth_context=auth_context,
             workspace_id=None,
         )
+        assessment_result = await mcp_endpoint._call_read_only_tool(
+            "mail_health_assessment",
+            {"days": "30"},
+            db=db_session,
+            auth_context=auth_context,
+            workspace_id=None,
+        )
         dns_lint_result = await mcp_endpoint._call_read_only_tool(
             "dns_lint",
             {"domain": DOMAIN, "refresh": True},
@@ -1235,6 +1242,8 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
     assert listed["domains"][0]["domain"] == DOMAIN
     assert posture_result["grade"] == "A"
     assert source_result["sources"] == []
+    assert assessment_result["assessment"]["schema_version"] == ("dmarq.mail_health_assessment.v2")
+    assert assessment_result["assessment"]["supporting_signals"]
     assert dns_lint_result["status"] == "attention"
     assert dns_plan_result.read_only is True
     assert dns_plan_result.provider_write_available is False
@@ -1267,14 +1276,11 @@ async def test_mcp_read_only_tool_dispatch_covers_new_domain_tools(db_session: S
         == "read_only_blocked"
     )
     assert (
-        remediation_result.items[0].provider_repair_plan.apply_confirmation["confirm_phrase"]
-        == ""
+        remediation_result.items[0].provider_repair_plan.apply_confirmation["confirm_phrase"] == ""
     )
     assert (
         "public_read_only_response"
-        in remediation_result.items[0].provider_repair_plan.apply_confirmation[
-            "blocked_reasons"
-        ]
+        in remediation_result.items[0].provider_repair_plan.apply_confirmation["blocked_reasons"]
     )
     assert (
         "omits provider write endpoints"

--- a/backend/app/tests/test_mail_health.py
+++ b/backend/app/tests/test_mail_health.py
@@ -356,6 +356,43 @@ def test_expected_forwarding_never_recommends_adding_intermediary_to_spf(db_sess
     assert "SPF" not in result["next_action"]["label"]
 
 
+def test_expected_forwarding_does_not_hide_an_unrecognized_unprotected_failure(db_session):
+    workspace = Workspace(slug="guided-forwarding-mixed", name="Guided forwarding mixed")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    db_session.add_all(
+        [
+            _projection(
+                domain.id,
+                ip="198.51.100.45",
+                failed=20,
+                disposition_counts={"none": 20},
+            ),
+            _projection(
+                domain.id,
+                ip="198.51.100.47",
+                failed=2,
+                disposition_counts={"none": 2},
+            ),
+        ]
+    )
+    record_sender_classification(
+        db_session,
+        workspace=workspace,
+        domain="example.test",
+        source_ip="198.51.100.45",
+        classification="expected_forwarding",
+        reason="Known list forwarder",
+        auth_context={"auth_type": "disabled"},
+    )
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "investigation_required"
+    assert result["supporting_signals"][0]["payload"]["source_ip"] == "198.51.100.47"
+
+
 def test_explicit_unauthorized_source_does_not_request_classification_again(db_session):
     workspace = Workspace(slug="guided-unauthorized", name="Guided unauthorized")
     domain = Domain(name="example.test", workspace=workspace)

--- a/backend/app/tests/test_mail_health.py
+++ b/backend/app/tests/test_mail_health.py
@@ -4,9 +4,11 @@ import json
 from datetime import datetime, timezone
 
 from app.models.domain import Domain
+from app.models.mail_source import MailSource
 from app.models.report import DomainSourceDailyProjection
 from app.models.workspace import Workspace
 from app.services.mail_health import build_workspace_mail_health_assessment
+from app.services.sender_classifications import record_sender_classification
 
 
 def _projection(
@@ -24,6 +26,7 @@ def _projection(
     spf_failed: int = 0,
     dkim_passed: int = 0,
     dkim_failed: int = 0,
+    observed_at: int | None = None,
 ) -> DomainSourceDailyProjection:
     evidence = {"captured_at": "2026-07-26T12:00:00Z"}
     if hostname:
@@ -31,7 +34,7 @@ def _projection(
     return DomainSourceDailyProjection(
         domain_id=domain_id,
         source_ip=ip,
-        observed_at=int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp()),
+        observed_at=observed_at or int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp()),
         first_seen=first_seen or int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp()),
         last_seen=last_seen or int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp()),
         message_count=passed + failed,
@@ -82,6 +85,14 @@ def test_known_sender_failures_are_actionable_without_claiming_delivery(db_sessi
     assert result["intended_mail_impact"] == "likely_affected"
     assert result["urgency"] == "timely"
     assert result["assessment_version"] == "v1"
+    assert result["schema_version"] == "dmarq.mail_health_assessment.v2"
+    assert result["assessment_algorithm_version"] == "deterministic-2026-07"
+    assert result["assessment_id"]
+    assert result["confidence_band"] in {"high", "medium", "low"}
+    assert result["intended_mail_impact_band"] == "likely"
+    assert result["urgency_band"] == "soon"
+    assert result["evidence_window"]["start"]
+    assert result["conclusion"]["key"]
     assert result["known_facts"]
     assert result["inferences"]
     assert result["unknowns"]
@@ -257,3 +268,155 @@ def test_successful_authentication_evidence_is_reported_as_healthy(db_session):
     assert result["intended_mail_impact"] == "likely_not_affected"
     assert result["urgency"] == "none"
     assert result["supporting_signals"][0]["delivery_certainty"] == "authentication_only"
+
+
+def test_operator_legitimate_sender_with_previous_passes_is_prioritized_as_regression(db_session):
+    workspace = Workspace(slug="guided-regression", name="Guided regression")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    prior = int(datetime(2026, 6, 25, tzinfo=timezone.utc).timestamp())
+    current = int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp())
+    db_session.add_all(
+        [
+            _projection(
+                domain.id,
+                ip="198.51.100.44",
+                passed=24,
+                observed_at=prior,
+                first_seen=prior,
+                last_seen=prior,
+            ),
+            _projection(
+                domain.id,
+                ip="198.51.100.44",
+                failed=3,
+                disposition_counts={"none": 3},
+                observed_at=current,
+                first_seen=current,
+                last_seen=current,
+            ),
+            _projection(
+                domain.id,
+                ip="198.51.100.99",
+                failed=300,
+                disposition_counts={"none": 300},
+                observed_at=current,
+                first_seen=current,
+                last_seen=current,
+            ),
+        ]
+    )
+    record_sender_classification(
+        db_session,
+        workspace=workspace,
+        domain="example.test",
+        source_ip="198.51.100.44",
+        classification="legitimate",
+        reason="Primary transactional sender",
+        auth_context={"auth_type": "disabled"},
+    )
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "action_required"
+    assert result["confidence_band"] == "high"
+    assert "previous window" in " ".join(result["known_facts"])
+    assert result["supporting_signals"][0]["payload"]["source_ip"] == "198.51.100.44"
+
+
+def test_expected_forwarding_never_recommends_adding_intermediary_to_spf(db_session):
+    workspace = Workspace(slug="guided-forwarding", name="Guided forwarding")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    db_session.add(
+        _projection(
+            domain.id,
+            ip="198.51.100.45",
+            failed=8,
+            disposition_counts={"none": 8},
+        )
+    )
+    record_sender_classification(
+        db_session,
+        workspace=workspace,
+        domain="example.test",
+        source_ip="198.51.100.45",
+        classification="expected_forwarding",
+        reason="Known list forwarder",
+        auth_context={"auth_type": "disabled"},
+    )
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "monitor"
+    assert result["conclusion"]["key"] == "mail_health.expected_forwarding"
+    assert "do not add" in result["summary"].lower()
+    assert "SPF" not in result["next_action"]["label"]
+
+
+def test_connected_low_volume_workspace_without_reports_is_a_watch_state(db_session):
+    workspace = Workspace(
+        slug="guided-low-volume",
+        name="Guided low volume",
+        guidance_mail_context='{"low_volume":true}',
+    )
+    db_session.add(workspace)
+    db_session.flush()
+    db_session.add(
+        MailSource(workspace_id=workspace.id, name="Reports", method="IMAP", enabled=True)
+    )
+    db_session.commit()
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "monitor"
+    assert result["urgency_band"] == "watch"
+    assert result["next_action"]["href"] == "/mail-sources"
+    assert "No urgent failure" in result["summary"]
+
+
+def test_dmarc_pass_with_operator_reported_bounce_requires_delivery_evidence(db_session):
+    workspace = Workspace(
+        slug="guided-bounce-mismatch",
+        name="Guided bounce mismatch",
+        guidance_mail_context='{"bounce_available":true}',
+    )
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    db_session.add(_projection(domain.id, ip="203.0.113.26", passed=12))
+    db_session.commit()
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "insufficient_evidence"
+    assert result["conclusion"]["key"] == "mail_health.dmarc_pass_bounce_mismatch"
+    assert "SMTP" in result["summary"]
+    assert result["delivery_certainty"] == "inferred_only"
+
+
+def test_stale_report_evidence_limits_confidence(db_session):
+    workspace = Workspace(slug="guided-stale", name="Guided stale")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    stale = int(datetime(2026, 7, 10, tzinfo=timezone.utc).timestamp())
+    db_session.add(
+        _projection(
+            domain.id,
+            ip="203.0.113.26",
+            passed=12,
+            observed_at=stale,
+            first_seen=stale,
+            last_seen=stale,
+        )
+    )
+    db_session.commit()
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "healthy"
+    assert result["freshness"] == "stale"
+    assert result["confidence_band"] == "medium"

--- a/backend/app/tests/test_mail_health.py
+++ b/backend/app/tests/test_mail_health.py
@@ -380,6 +380,10 @@ def test_operator_legitimate_sender_with_previous_passes_is_prioritized_as_regre
     assert "operator classified" in " ".join(result["confidence_reasons"]).lower()
     assert "known provider" not in " ".join(result["confidence_reasons"]).lower()
     assert result["supporting_signals"][0]["payload"]["source_ip"] == "198.51.100.44"
+    classification_claim = next(
+        claim for claim in result["claims"] if "operator classified" in claim["statement"].lower()
+    )
+    assert classification_claim["claim_level"] == "operator_reported"
 
 
 def test_expected_forwarding_never_recommends_adding_intermediary_to_spf(db_session):
@@ -635,6 +639,46 @@ def test_stale_report_evidence_limits_confidence(db_session):
     assert {signal["freshness"] for signal in result["supporting_signals"]} == {"stale"}
 
 
+def test_selected_stale_source_is_not_masked_by_unrelated_fresh_evidence(db_session):
+    workspace = Workspace(slug="guided-selected-stale", name="Guided selected stale")
+    stale_domain = Domain(name="stale.test", workspace=workspace)
+    fresh_domain = Domain(name="fresh.test", workspace=workspace)
+    db_session.add_all([workspace, stale_domain, fresh_domain])
+    db_session.flush()
+    stale = int(datetime(2026, 7, 10, tzinfo=timezone.utc).timestamp())
+    fresh = int(datetime(2026, 7, 29, tzinfo=timezone.utc).timestamp())
+    db_session.add_all(
+        [
+            _projection(
+                stale_domain.id,
+                ip="203.0.113.26",
+                failed=4,
+                hostname="mta1.mtasv.net",
+                observed_at=stale,
+                first_seen=stale,
+                last_seen=stale,
+            ),
+            _projection(
+                fresh_domain.id,
+                ip="203.0.113.27",
+                passed=100,
+                observed_at=fresh,
+                first_seen=fresh,
+                last_seen=fresh,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "action_required"
+    assert result["domain"] == "stale.test"
+    assert result["freshness"] == "stale"
+    assert result["freshness_at"] == datetime.fromtimestamp(stale, tz=timezone.utc).isoformat()
+    assert {signal["freshness"] for signal in result["supporting_signals"]} == {"stale"}
+
+
 def test_assessment_id_identifies_the_exact_evidence_window(db_session):
     workspace = Workspace(slug="guided-assessment-id", name="Guided assessment ID")
     domain = Domain(name="example.test", workspace=workspace)
@@ -658,3 +702,24 @@ def test_assessment_id_identifies_the_exact_evidence_window(db_session):
 
     assert first["assessment_id"] == repeated["assessment_id"]
     assert first["assessment_id"] != shifted["assessment_id"]
+
+
+def test_assessment_id_changes_when_existing_projection_evidence_changes(db_session):
+    workspace = Workspace(slug="guided-assessment-revision", name="Guided revision")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    projection = _projection(domain.id, ip="203.0.113.26", passed=12)
+    db_session.add(projection)
+    db_session.commit()
+
+    first = _assessment(db_session, workspace)
+    projection.dmarc_pass_count = 13
+    projection.message_count = 13
+    db_session.commit()
+    revised = _assessment(db_session, workspace)
+
+    assert (
+        first["supporting_signals"][0]["signal_id"] == revised["supporting_signals"][0]["signal_id"]
+    )
+    assert first["assessment_id"] != revised["assessment_id"]

--- a/backend/app/tests/test_mail_health.py
+++ b/backend/app/tests/test_mail_health.py
@@ -356,6 +356,66 @@ def test_expected_forwarding_never_recommends_adding_intermediary_to_spf(db_sess
     assert "SPF" not in result["next_action"]["label"]
 
 
+def test_explicit_unauthorized_source_does_not_request_classification_again(db_session):
+    workspace = Workspace(slug="guided-unauthorized", name="Guided unauthorized")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    db_session.add(
+        _projection(
+            domain.id,
+            ip="198.51.100.46",
+            failed=9,
+            disposition_counts={"none": 9},
+        )
+    )
+    record_sender_classification(
+        db_session,
+        workspace=workspace,
+        domain="example.test",
+        source_ip="198.51.100.46",
+        classification="unauthorized",
+        reason="Confirmed outside the mail estate",
+        auth_context={"auth_type": "disabled"},
+    )
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "action_required"
+    assert result["conclusion"]["key"] == "mail_health.confirmed_unauthorized_use_unprotected"
+    assert "classif" not in result["next_action"]["label"].lower()
+    assert any(claim["claim_level"] == "operator_reported" for claim in result["claims"])
+
+
+def test_ipv6_operator_classification_matches_noncanonical_projection_spelling(db_session):
+    workspace = Workspace(slug="guided-ipv6", name="Guided IPv6")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    db_session.add(
+        _projection(
+            domain.id,
+            ip="2001:0db8:0000:0000:0000:0000:0000:0001",
+            failed=2,
+            disposition_counts={"none": 2},
+        )
+    )
+    record_sender_classification(
+        db_session,
+        workspace=workspace,
+        domain="example.test",
+        source_ip="2001:db8::1",
+        classification="legitimate",
+        reason="Owned IPv6 sender",
+        auth_context={"auth_type": "disabled"},
+    )
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "action_required"
+    assert result["supporting_signals"][0]["payload"]["source_ip"] == "2001:db8::1"
+
+
 def test_connected_low_volume_workspace_without_reports_is_a_watch_state(db_session):
     workspace = Workspace(
         slug="guided-low-volume",
@@ -395,6 +455,26 @@ def test_dmarc_pass_with_operator_reported_bounce_requires_delivery_evidence(db_
     assert result["conclusion"]["key"] == "mail_health.dmarc_pass_bounce_mismatch"
     assert "SMTP" in result["summary"]
     assert result["delivery_certainty"] == "inferred_only"
+
+
+def test_bounce_context_does_not_claim_an_unselected_domain_explains_the_bounce(db_session):
+    workspace = Workspace(
+        slug="guided-bounce-domain",
+        name="Guided bounce domain",
+        guidance_mail_context='{"bounce_available":true,"domains":["bounce.test"]}',
+    )
+    bounce_domain = Domain(name="bounce.test", workspace=workspace)
+    healthy_domain = Domain(name="healthy.test", workspace=workspace)
+    db_session.add_all([workspace, bounce_domain, healthy_domain])
+    db_session.flush()
+    db_session.add(_projection(healthy_domain.id, ip="203.0.113.40", passed=40))
+    db_session.commit()
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "healthy"
+    assert result["domain"] is None
+    assert result["conclusion"]["key"] != "mail_health.dmarc_pass_bounce_mismatch"
 
 
 def test_stale_report_evidence_limits_confidence(db_session):

--- a/backend/app/tests/test_mail_health.py
+++ b/backend/app/tests/test_mail_health.py
@@ -173,6 +173,61 @@ def test_health_signals_keep_protocol_counts_identities_and_report_boundaries(db
     }
 
 
+def test_projection_reader_aggregates_daily_counters_and_compact_evidence(db_session):
+    workspace = Workspace(slug="guided-sql-aggregate", name="Guided SQL aggregate")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    first_day = int(datetime(2026, 7, 24, tzinfo=timezone.utc).timestamp())
+    second_day = int(datetime(2026, 7, 25, tzinfo=timezone.utc).timestamp())
+    db_session.add_all(
+        [
+            _projection(
+                domain.id,
+                ip="203.0.113.10",
+                passed=3,
+                disposition_counts={"none": 3},
+                hostname="mta1.mtasv.net",
+                observed_at=first_day,
+                first_seen=first_day,
+                last_seen=first_day,
+                metadata={"dkim_selectors": ["first"]},
+            ),
+            _projection(
+                domain.id,
+                ip="203.0.113.10",
+                failed=2,
+                disposition_counts={"reject": 2},
+                hostname="mta1.mtasv.net",
+                observed_at=second_day,
+                first_seen=second_day,
+                last_seen=second_day,
+                metadata={"dkim_selectors": ["second"]},
+            ),
+        ]
+    )
+    db_session.commit()
+
+    result = _assessment(db_session, workspace)
+    authentication = next(
+        signal
+        for signal in result["supporting_signals"]
+        if signal["family"] == "dmarc_authentication"
+    )
+    disposition = next(
+        signal
+        for signal in result["supporting_signals"]
+        if signal["family"] == "dmarc_reported_disposition"
+    )
+
+    assert authentication["payload"]["passed"] == 3
+    assert authentication["payload"]["failed"] == 2
+    assert authentication["payload"]["dkim_selectors"] == ["first", "second"]
+    assert authentication["window_start"] == first_day
+    assert authentication["window_end"] == second_day
+    assert disposition["payload"]["dispositions"] == {"none": 3, "reject": 2}
+
+
 def test_unknown_rejected_source_is_quietly_classified_as_likely_unauthorized_use(db_session):
     workspace = Workspace(slug="guided-unknown", name="Guided unknown")
     domain = Domain(name="example.test", workspace=workspace)
@@ -322,6 +377,8 @@ def test_operator_legitimate_sender_with_previous_passes_is_prioritized_as_regre
     assert result["outcome"] == "action_required"
     assert result["confidence_band"] == "high"
     assert "previous window" in " ".join(result["known_facts"])
+    assert "operator classified" in " ".join(result["confidence_reasons"]).lower()
+    assert "known provider" not in " ".join(result["confidence_reasons"]).lower()
     assert result["supporting_signals"][0]["payload"]["source_ip"] == "198.51.100.44"
 
 
@@ -422,6 +479,43 @@ def test_explicit_unauthorized_source_does_not_request_classification_again(db_s
     assert result["conclusion"]["key"] == "mail_health.confirmed_unauthorized_use_unprotected"
     assert "classif" not in result["next_action"]["label"].lower()
     assert any(claim["claim_level"] == "operator_reported" for claim in result["claims"])
+
+
+def test_unknown_unprotected_failure_outranks_confirmed_blocked_abuse(db_session):
+    workspace = Workspace(slug="guided-unauthorized-mixed", name="Guided unauthorized mixed")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    db_session.add_all(
+        [
+            _projection(
+                domain.id,
+                ip="198.51.100.46",
+                failed=90,
+                disposition_counts={"reject": 90},
+            ),
+            _projection(
+                domain.id,
+                ip="198.51.100.47",
+                failed=2,
+                disposition_counts={"none": 2},
+            ),
+        ]
+    )
+    record_sender_classification(
+        db_session,
+        workspace=workspace,
+        domain="example.test",
+        source_ip="198.51.100.46",
+        classification="unauthorized",
+        reason="Confirmed abuse already blocked by receivers",
+        auth_context={"auth_type": "disabled"},
+    )
+
+    result = _assessment(db_session, workspace)
+
+    assert result["outcome"] == "investigation_required"
+    assert result["supporting_signals"][0]["payload"]["source_ip"] == "198.51.100.47"
 
 
 def test_ipv6_operator_classification_matches_noncanonical_projection_spelling(db_session):
@@ -537,3 +631,30 @@ def test_stale_report_evidence_limits_confidence(db_session):
     assert result["outcome"] == "healthy"
     assert result["freshness"] == "stale"
     assert result["confidence_band"] == "medium"
+    assert result["freshness_at"] == datetime.fromtimestamp(stale, tz=timezone.utc).isoformat()
+    assert {signal["freshness"] for signal in result["supporting_signals"]} == {"stale"}
+
+
+def test_assessment_id_identifies_the_exact_evidence_window(db_session):
+    workspace = Workspace(slug="guided-assessment-id", name="Guided assessment ID")
+    domain = Domain(name="example.test", workspace=workspace)
+    db_session.add_all([workspace, domain])
+    db_session.flush()
+    db_session.add(_projection(domain.id, ip="203.0.113.26", passed=12))
+    db_session.commit()
+    start = int(datetime(2026, 7, 1, tzinfo=timezone.utc).timestamp())
+    first_end = int(datetime(2026, 7, 30, tzinfo=timezone.utc).timestamp())
+    second_end = int(datetime(2026, 7, 31, tzinfo=timezone.utc).timestamp())
+
+    first = build_workspace_mail_health_assessment(
+        db_session, workspace=workspace, start_ts=start, end_ts=first_end
+    )
+    repeated = build_workspace_mail_health_assessment(
+        db_session, workspace=workspace, start_ts=start, end_ts=first_end
+    )
+    shifted = build_workspace_mail_health_assessment(
+        db_session, workspace=workspace, start_ts=start, end_ts=second_end
+    )
+
+    assert first["assessment_id"] == repeated["assessment_id"]
+    assert first["assessment_id"] != shifted["assessment_id"]

--- a/backend/app/tests/test_mail_health_incidents.py
+++ b/backend/app/tests/test_mail_health_incidents.py
@@ -196,6 +196,30 @@ def test_all_signals_can_notify_a_protected_unknown_source(db_session):
     assert result["notification_reason"] == "created"
 
 
+def test_low_volume_waiting_state_is_not_persisted_or_notified(db_session):
+    workspace = Workspace(
+        slug="calm-low-volume", name="Calm low volume", notification_posture="all_signals"
+    )
+    db_session.add(workspace)
+    db_session.commit()
+    waiting = _assessment("monitor", domain=None)
+    waiting["supporting_signals"] = [
+        {
+            "family": "intake_health",
+            "outcome": "no_report_evidence_in_window",
+        }
+    ]
+
+    result = record_mail_health_assessment(
+        db_session,
+        workspace=workspace,
+        assessment=waiting,
+    )
+
+    assert result == {"incident": None, "notification_reason": None, "resolved": []}
+    assert db_session.query(MailHealthIncident).count() == 0
+
+
 def test_new_outcome_resolves_the_previous_incident_for_one_domain(db_session):
     workspace = Workspace(slug="calm-supersede", name="Calm Supersede")
     db_session.add(workspace)

--- a/backend/app/tests/test_mail_health_incidents.py
+++ b/backend/app/tests/test_mail_health_incidents.py
@@ -220,6 +220,52 @@ def test_low_volume_waiting_state_is_not_persisted_or_notified(db_session):
     assert db_session.query(MailHealthIncident).count() == 0
 
 
+def test_waiting_state_does_not_resolve_an_existing_workspace_incident(db_session):
+    workspace = Workspace(slug="calm-wait-existing", name="Calm wait existing")
+    db_session.add(workspace)
+    db_session.commit()
+    created = record_mail_health_assessment(
+        db_session,
+        workspace=workspace,
+        assessment=_assessment("investigation_required", domain=None),
+    )
+    waiting = _assessment("monitor", domain=None)
+    waiting["supporting_signals"] = [
+        {"family": "intake_health", "outcome": "no_report_evidence_in_window"}
+    ]
+
+    result = record_mail_health_assessment(
+        db_session,
+        workspace=workspace,
+        assessment=waiting,
+    )
+
+    assert result == {"incident": None, "notification_reason": None, "resolved": []}
+    assert created["incident"]["id"] == db_session.query(MailHealthIncident).one().id
+    assert db_session.query(MailHealthIncident).one().status == "open"
+
+
+def test_workspace_healthy_assessment_resolves_all_domain_incidents(db_session):
+    workspace = Workspace(slug="calm-workspace-healthy", name="Calm workspace healthy")
+    db_session.add(workspace)
+    db_session.commit()
+    for domain in ("one.test", "two.test"):
+        record_mail_health_assessment(
+            db_session,
+            workspace=workspace,
+            assessment=_assessment(domain=domain),
+        )
+
+    result = record_mail_health_assessment(
+        db_session,
+        workspace=workspace,
+        assessment={"outcome": "healthy", "domain": None},
+    )
+
+    assert len(result["resolved"]) == 2
+    assert {row.status for row in db_session.query(MailHealthIncident).all()} == {"resolved"}
+
+
 def test_new_outcome_resolves_the_previous_incident_for_one_domain(db_session):
     workspace = Workspace(slug="calm-supersede", name="Calm Supersede")
     db_session.add(workspace)

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -31,9 +31,9 @@ from app.services.organizations import (
     ensure_subscription,
     get_or_create_starter_plan,
 )
+from app.services.ptr_lookup import PtrLookupResult
 from app.services.report_persistence import save_parsed_report
 from app.services.report_store import ReportStore
-from app.services.ptr_lookup import PtrLookupResult
 from app.services.workspace_access import (
     ROLE_ANALYST,
     ROLE_WORKSPACE_OWNER,
@@ -324,6 +324,28 @@ def test_public_domains_summary_uses_scoped_token_context(client: TestClient, db
 
     assert response.status_code == 200
     assert response.json()["domains"][0]["domain_name"] == DOMAIN
+
+
+def test_public_mail_health_assessment_exposes_sanitized_structured_evidence(
+    client: TestClient,
+    db_session,
+):
+    _persist_report(db_session)
+    created = create_api_token(db_session, name="health bot", scopes=[READ_REPORTS_SCOPE])
+
+    response = client.get(
+        "/api/v1/public/mail-health/assessment?days=30",
+        headers={"X-API-Key": created.secret},
+    )
+
+    assert response.status_code == 200
+    assessment = response.json()["assessment"]
+    assert assessment["schema_version"] == "dmarq.mail_health_assessment.v2"
+    assert assessment["assessment_id"]
+    assert assessment["next_action"]["safety_boundary"]
+    assert assessment["supporting_signals"]
+    assert all("evidence_refs" in signal for signal in assessment["supporting_signals"])
+    assert "raw_data" not in str(assessment)
 
 
 def test_public_export_catalog_lists_available_exports_and_token_usage(

--- a/backend/app/tests/test_public_api.py
+++ b/backend/app/tests/test_public_api.py
@@ -374,6 +374,10 @@ def test_public_export_catalog_lists_available_exports_and_token_usage(
     endpoint_by_key = {endpoint["key"]: endpoint for endpoint in body["public_endpoints"]}
     assert endpoint_by_key["domain_reports"]["available"] is True
     assert endpoint_by_key["health_evidence_export"]["available"] is True
+    assert endpoint_by_key["mail_health_assessment"]["available"] is True
+    assert endpoint_by_key["mail_health_assessment"]["path"] == (
+        "/api/v1/public/mail-health/assessment"
+    )
     assert endpoint_by_key["tls_report_summary"]["available"] is False
     assert body["domains"][0]["domain"] == DOMAIN
     assert (
@@ -383,6 +387,7 @@ def test_public_export_catalog_lists_available_exports_and_token_usage(
     assert body["mcp"]["available"] is False
     assert "export_catalog" in {tool["name"] for tool in body["mcp"]["tools"]}
     assert "workspace_usage" in {tool["name"] for tool in body["mcp"]["tools"]}
+    assert "mail_health_assessment" in {tool["name"] for tool in body["mcp"]["tools"]}
 
 
 def test_public_export_catalog_accepts_tls_or_mcp_scope_without_domain_leak(

--- a/backend/app/tests/test_workspace_guidance.py
+++ b/backend/app/tests/test_workspace_guidance.py
@@ -1134,3 +1134,84 @@ def test_diagnostic_plan_uses_latest_report_for_current_failure_action(
     assert payload["evidence"]["message_count"] == 75
     assert payload["evidence"]["failed_message_count"] == 0
     assert payload["current_action"]["id"] == "open_domain"
+
+
+def test_sender_classification_is_workspace_scoped_audited_and_replaceable(
+    authed_client: TestClient,
+    db_session,
+):
+    workspace = Workspace(slug="sender-decisions", name="Sender decisions")
+    other = Workspace(slug="sender-decisions-other", name="Other sender decisions")
+    db_session.add_all([workspace, other])
+    db_session.commit()
+    headers = {"X-DMARQ-Workspace-ID": str(workspace.id)}
+
+    created = authed_client.put(
+        "/api/v1/workspaces/mail-health/sender-classifications",
+        headers=headers,
+        json={
+            "domain": "Example.COM",
+            "source_ip": "2001:0db8::1",
+            "classification": "expected_forwarding",
+            "reason": "Known mailing-list forwarder",
+        },
+    )
+    replaced = authed_client.put(
+        "/api/v1/workspaces/mail-health/sender-classifications",
+        headers=headers,
+        json={
+            "domain": "example.com",
+            "source_ip": "2001:db8::1",
+            "classification": "legitimate",
+            "reason": "Confirmed by the mail owner",
+        },
+    )
+    listed = authed_client.get(
+        "/api/v1/workspaces/mail-health/sender-classifications?domain=example.com",
+        headers=headers,
+    )
+    other_list = authed_client.get(
+        "/api/v1/workspaces/mail-health/sender-classifications",
+        headers={"X-DMARQ-Workspace-ID": str(other.id)},
+    )
+
+    assert created.status_code == 200
+    assert replaced.status_code == 200
+    assert listed.status_code == 200
+    assert listed.json()["classifications"] == [replaced.json()["classification"]]
+    assert listed.json()["classifications"][0]["source_ip"] == "2001:db8::1"
+    assert listed.json()["classifications"][0]["classification"] == "legitimate"
+    assert other_list.json()["classifications"] == []
+    assert (
+        db_session.query(WorkspaceAuditLog)
+        .filter(WorkspaceAuditLog.action == "mail_health.sender_classified")
+        .count()
+        == 2
+    )
+
+
+def test_sender_classification_rejects_invalid_scope_and_value(
+    authed_client: TestClient,
+):
+    for payload in (
+        {
+            "domain": "not a domain",
+            "source_ip": "192.0.2.1",
+            "classification": "legitimate",
+        },
+        {
+            "domain": "example.com",
+            "source_ip": "not-an-ip",
+            "classification": "legitimate",
+        },
+        {
+            "domain": "example.com",
+            "source_ip": "192.0.2.1",
+            "classification": "trusted_forever",
+        },
+    ):
+        response = authed_client.put(
+            "/api/v1/workspaces/mail-health/sender-classifications",
+            json=payload,
+        )
+        assert response.status_code == 422

--- a/backend/app/tests/test_workspace_guidance.py
+++ b/backend/app/tests/test_workspace_guidance.py
@@ -1181,6 +1181,14 @@ def test_sender_classification_is_workspace_scoped_audited_and_replaceable(
     assert listed.json()["classifications"] == [replaced.json()["classification"]]
     assert listed.json()["classifications"][0]["source_ip"] == "2001:db8::1"
     assert listed.json()["classifications"][0]["classification"] == "legitimate"
+    assert set(listed.json()["classifications"][0]) == {
+        "domain",
+        "source_ip",
+        "classification",
+        "reason",
+        "scope",
+        "classified_at",
+    }
     assert other_list.json()["classifications"] == []
     assert (
         db_session.query(WorkspaceAuditLog)

--- a/docs/product/guided-mail-health.md
+++ b/docs/product/guided-mail-health.md
@@ -125,11 +125,13 @@ delivery lookups.
 The `dmarq.mail_health_assessment.v2` response also compares the immediately
 preceding bounded evidence window. A legitimate source that previously passed
 and now fails is prioritized ahead of a larger anonymous failure count. Its
-machine-readable contract contains a stable assessment ID, outcome, impact,
-urgency and confidence bands, freshness, known facts, inferences, unknowns,
-one safe next action, verification condition, and aggregate-safe evidence
-references. Localized prose is presentation data, not the stored source of
-truth.
+machine-readable contract contains an assessment ID, outcome, impact, urgency
+and confidence bands, freshness, known facts, inferences, unknowns, one safe
+next action, verification condition, and aggregate-safe evidence references.
+The ID is stable for the exact workspace, domain, conclusion, evidence window,
+supporting signal set, and algorithm version; a new window or changed evidence
+produces a new ID. Localized prose is presentation data, not the stored source
+of truth.
 
 Operators can classify one exact domain/source-IP pair as `legitimate`,
 `unknown`, `unauthorized`, `expected_forwarding`, or `stale`. Each decision is

--- a/docs/product/guided-mail-health.md
+++ b/docs/product/guided-mail-health.md
@@ -122,10 +122,38 @@ delivery lookups.
   presented as likely unauthorized use with no immediate configuration change.
 - Missing report evidence directs the operator to report intake.
 
+The `dmarq.mail_health_assessment.v2` response also compares the immediately
+preceding bounded evidence window. A legitimate source that previously passed
+and now fails is prioritized ahead of a larger anonymous failure count. Its
+machine-readable contract contains a stable assessment ID, outcome, impact,
+urgency and confidence bands, freshness, known facts, inferences, unknowns,
+one safe next action, verification condition, and aggregate-safe evidence
+references. Localized prose is presentation data, not the stored source of
+truth.
+
+Operators can classify one exact domain/source-IP pair as `legitimate`,
+`unknown`, `unauthorized`, `expected_forwarding`, or `stale`. Each decision is
+append-only in the workspace audit trail with actor, time, reason, and scope.
+The latest decision affects future assessments but never changes historical
+DMARC reports. Expected forwarding produces a forwarding/DKIM review and never
+suggests adding an intermediary IP to SPF without sender-side evidence.
+
+If intake is connected and the saved profile says a domain is low-volume, an
+empty current window is a watch state rather than an urgent failure. If the
+operator reports a bounce while aggregate reports show DMARC passes, DMARQ
+returns insufficient delivery evidence and points to the SMTP response, DSN,
+or provider event instead of claiming that authentication proves delivery.
+
 The assessment deliberately says that aggregate DMARC reports record receiver
 authentication and policy evaluation. They do **not** prove whether an
 individual message was delivered, bounced, placed in spam, or read. Delivery
 claims require later DSN or provider-delivery evidence.
+
+Read-only integrations receive the same structured assessment from
+`GET /api/v1/public/mail-health/assessment?days=30` or the MCP
+`mail_health_assessment` tool. Normal reads query bounded persisted projections
+and audit decisions only; they perform no live DNS, network, reputation, or
+provider enrichment.
 
 ## Next increments
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -361,8 +361,8 @@ presentation separate from workspace-owned facts and never accept secrets.
 | `PUT /workspaces/guidance/workspace-profile` | Replace the validated workspace profile with write access; resumable drafts are quiet and completing the interview creates a sanitized audit event |
 | `GET /workspaces/guidance/diagnostic-plan` | With `reports:read`, build one localized next step from persisted workspace evidence without provider, DNS, or mailbox I/O |
 | `GET /workspaces/guidance/report-intake-recommendation` | With `reports:read`, rank supported intake paths and return localized data-flow, availability, first-report, and verification evidence without returning credentials or performing provider I/O |
-| `GET /workspaces/mail-health/sender-classifications` | List the latest auditable decision for each exact domain/source-IP scope |
-| `PUT /workspaces/mail-health/sender-classifications` | Append a `legitimate`, `unknown`, `unauthorized`, `expected_forwarding`, or `stale` decision; report history is never mutated |
+| `GET /workspaces/mail-health/sender-classifications` | With `reports:read`, list the latest auditable decision for each exact domain/source-IP scope |
+| `PUT /workspaces/mail-health/sender-classifications` | With `reports:write`, append a `legitimate`, `unknown`, `unauthorized`, `expected_forwarding`, or `stale` decision; report history is never mutated |
 
 The workspace profile accepts ordered values from the documented goal and
 sovereignty enums. The first installation goal is the primary goal used by the

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -361,6 +361,8 @@ presentation separate from workspace-owned facts and never accept secrets.
 | `PUT /workspaces/guidance/workspace-profile` | Replace the validated workspace profile with write access; resumable drafts are quiet and completing the interview creates a sanitized audit event |
 | `GET /workspaces/guidance/diagnostic-plan` | With `reports:read`, build one localized next step from persisted workspace evidence without provider, DNS, or mailbox I/O |
 | `GET /workspaces/guidance/report-intake-recommendation` | With `reports:read`, rank supported intake paths and return localized data-flow, availability, first-report, and verification evidence without returning credentials or performing provider I/O |
+| `GET /workspaces/mail-health/sender-classifications` | List the latest auditable decision for each exact domain/source-IP scope |
+| `PUT /workspaces/mail-health/sender-classifications` | Append a `legitimate`, `unknown`, `unauthorized`, `expected_forwarding`, or `stale` decision; report history is never mutated |
 
 The workspace profile accepts ordered values from the documented goal and
 sovereignty enums. The first installation goal is the primary goal used by the
@@ -1088,6 +1090,24 @@ retained for compatibility but are deprecated. New integrations should use the
 explicit authentication and receiver-disposition fields. See the
 [Mail signal contract](mail-signal-contract.md) for claim levels, delivery
 certainty, privacy boundaries, and future DSN/provider-event adapters.
+
+### Deterministic mail-health assessment
+
+```http
+GET /public/mail-health/assessment?days=30
+```
+
+Requires `reports:read` and returns the same sanitized
+`dmarq.mail_health_assessment.v2` contract used by the guided dashboard. The
+response includes a stable assessment ID, algorithm version, evidence window
+and freshness, outcome, normalized impact/urgency/confidence bands, structured
+conclusion key, known facts, inferences, unknowns, one safe next action,
+verification condition, and supporting mail-signal references. Raw report data,
+message bodies, credentials, and superseded audit details are not returned.
+
+The MCP tool `mail_health_assessment` accepts the same bounded `days` value.
+Both paths query persisted report projections and sender-classification audit
+rows only; they never trigger DNS, PTR, reputation, provider, or AI calls.
 
 #### Get Source Reputation
 


### PR DESCRIPTION
## Summary

- add the versioned `dmarq.mail_health_assessment.v2` contract with one deterministic conclusion, impact, urgency, confidence, evidence window, unknowns, verification condition, and safe next action
- prioritize a previously healthy legitimate sender over high-volume anonymous noise, while treating protected spoofing as a first-class no-action outcome
- persist exact domain/source operator classifications as append-only workspace audit decisions without rewriting report history
- handle expected forwarding, low-volume domains, stale evidence, and DMARC-pass/bounce mismatches without unsafe SPF or delivery claims
- expose the sanitized assessment through the public API and a read-only MCP tool, using only persisted projections and audit rows

## Type of change

- Backward-compatible product interpretation contract
- Read-only API and MCP capability
- Workspace-scoped operator decision API
- Documentation and scenario-matrix tests

## Testing performed

- complete backend suite before final rebase: `2311 passed`
- post-rebase signal/assessment/API/MCP/guidance suite: `140 passed`
- focused new feature suite: `111 passed`
- Black, isort, flake8, and `git diff --check` pass

## Safety and deployment

The UI/API read path performs no DNS, PTR, reputation, mailbox, provider, or AI calls. Operator decisions are append-only and scoped to one workspace plus exact domain/source IP. This change contains no DNS writes, live provider mutations, schema migrations, or destructive behavior.

Closes #866


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic mail-health assessments with outcome, impact, urgency, confidence, evidence windows, and safe next actions.
  * Added public API and read-only MCP access for mail-health assessments.
  * Added workspace tools to review and record sender classifications with audit history.
  * Improved handling of forwarding, unauthorized senders, stale reports, low-volume data, and bounce-related evidence.

* **Documentation**
  * Documented assessment behavior, sender classifications, API endpoints, and MCP access.

* **Bug Fixes**
  * Corrected incident filtering and prevented monitoring-only states from creating or notifying incidents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->