### PR TITLE
feat: centralize skill-adaptive mail health guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Guided mail-health presentation now comes from one versioned English/German
+  catalog instead of template-specific wording. Watch, Diagnose, and Evidence
+  combine with guided, standard, or expert detail over the same immutable
+  assessment and permissions; the dashboard progressively reveals why,
+  observations, unknowns, and exact evidence without hiding the primary action
+  or changing the classic opt-in boundary.
 - Mail-health interpretation now uses a deterministic, versioned assessment
   contract with stable outcome, impact, urgency and confidence bands, explicit
   facts/inferences/unknowns, evidence windows, one safe next action, and

--- a/backend/app/api/api_v1/endpoints/stats.py
+++ b/backend/app/api/api_v1/endpoints/stats.py
@@ -2,16 +2,20 @@ from datetime import date, datetime, time, timedelta, timezone
 from math import ceil
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Request, status
 from sqlalchemy.orm import Session
 
 from app.core.config import get_settings, uses_legacy_demo_fixtures
 from app.core.database import get_db
+from app.core.localization import resolve_request_locale
 from app.core.security import require_admin_auth
 from app.services.demo_data import build_demo_dashboard_statistics
+from app.services.guidance_profile import resolve_guidance_profile
 from app.services.mail_health import build_workspace_mail_health_assessment
+from app.services.mail_health_guidance import render_mail_health_guidance
 from app.services.workspace_access import (
     PERMISSION_REPORTS_READ,
+    _auth_user,
     parse_selected_workspace_id,
     resolve_authorized_workspace,
 )
@@ -177,6 +181,7 @@ def resolve_dashboard_date_range(
 
 @router.get("/mail-health/summary")
 async def get_mail_health_summary(
+    request: Request,
     db: Session = Depends(get_db),
     _auth: dict = Depends(require_admin_auth),
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
@@ -202,7 +207,19 @@ async def get_mail_health_summary(
         start_ts=int(datetime.fromisoformat(date_range["start_at"]).timestamp()),
         end_ts=int(datetime.fromisoformat(date_range["end_at"]).timestamp()),
     )
-    return {"date_range": date_range, "assessment": assessment}
+    settings = get_settings()
+    profile = resolve_guidance_profile(
+        workspace,
+        _auth_user(db, _auth),
+        available=bool(settings.GUIDED_MAIL_HEALTH_UI_ENABLED),
+    )
+    assessment["presentation"] = render_mail_health_guidance(
+        assessment,
+        locale=resolve_request_locale(request, default=settings.default_locale),
+        depth=profile["depth"],
+        context=profile["context"],
+    )
+    return {"date_range": date_range, "assessment": assessment, "guidance_profile": profile}
 
 
 @router.get("/dashboard")

--- a/backend/app/services/mail_health_guidance.py
+++ b/backend/app/services/mail_health_guidance.py
@@ -1,0 +1,304 @@
+"""Localized presentation of immutable mail-health assessments.
+
+Assessment facts and authorization never vary by presentation preference.  This
+catalog only controls wording and progressive disclosure for the current task.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from app.core.localization import normalize_locale
+from app.services.guidance_profile import EXPLANATION_DEPTHS, WORK_CONTEXTS
+
+GUIDANCE_CATALOG_VERSION = "2026-07-v1"
+
+PRIMARY_CONCLUSIONS = (
+    "mail_health.action_required",
+    "mail_health.investigation_required",
+    "mail_health.no_action_likely_unauthorized_use",
+    "mail_health.monitor",
+    "mail_health.insufficient_evidence",
+    "mail_health.healthy",
+    "mail_health.confirmed_unauthorized_use_blocked",
+    "mail_health.confirmed_unauthorized_use_unprotected",
+    "mail_health.expected_forwarding",
+    "mail_health.dmarc_pass_bounce_mismatch",
+)
+
+
+def _entry(
+    headline: str,
+    conclusion: str,
+    why: str,
+    action: str,
+    verification: str,
+    *,
+    no_action: str = "",
+) -> Dict[str, str]:
+    return {
+        "headline": headline,
+        "conclusion": conclusion,
+        "why_it_matters": why,
+        "next_action_label": action,
+        "verification_text": verification,
+        "no_action_explanation": no_action,
+    }
+
+
+CATALOG: Dict[str, Dict[str, Dict[str, str]]] = {
+    "en": {
+        "mail_health.action_required": _entry(
+            "Intended mail may be affected",
+            "A sender you use is failing DMARC authentication.",
+            "Messages from this sender may be rejected or treated as suspicious.",
+            "Review the affected sender",
+            "Fresh reports show this sender authenticating without DMARC failures.",
+        ),
+        "mail_health.investigation_required": _entry(
+            "Identify an unrecognized sender",
+            "DMARQ cannot yet tell whether this failing source belongs to you.",
+            "Classifying it prevents unsafe DNS changes and unnecessary alerts.",
+            "Classify the sender",
+            "The source is classified or fresh evidence identifies its owner.",
+        ),
+        "mail_health.no_action_likely_unauthorized_use": _entry(
+            "Likely spoofing is being handled",
+            "An unrecognized sender failed authentication and receivers applied your policy.",
+            "This does not currently look like a fault in your intended mail flow.",
+            "Review the evidence",
+            "Known senders remain healthy and the protective policy remains effective.",
+            no_action="No immediate configuration change is required.",
+        ),
+        "mail_health.monitor": _entry(
+            "Keep monitoring",
+            "DMARQ is waiting for a meaningful change or more evidence.",
+            "No urgent failure is established from the current report data.",
+            "Review monitoring evidence",
+            "DMARQ reassesses when new report evidence arrives.",
+            no_action="No immediate action is required.",
+        ),
+        "mail_health.insufficient_evidence": _entry(
+            "More evidence is needed",
+            "Aggregate DMARC data cannot answer this question yet.",
+            "DMARQ avoids guessing about delivery or sender ownership.",
+            "Open the next evidence source",
+            "The required report, bounce, or provider evidence is available.",
+        ),
+        "mail_health.healthy": _entry(
+            "Mail authentication looks healthy",
+            "Current reports show successful authentication without a failure pattern.",
+            "DMARQ will keep watching for meaningful sender or authentication changes.",
+            "Review recent reports",
+            "Report intake remains current and no new authentication failures appear.",
+            no_action="No action is required now.",
+        ),
+        "mail_health.confirmed_unauthorized_use_blocked": _entry(
+            "Confirmed abuse is being blocked",
+            "A source marked unauthorized failed authentication and receivers applied policy.",
+            "Your intended sending setup does not currently appear affected.",
+            "Review the blocked source",
+            "Known senders remain healthy and receivers keep applying protective policy.",
+            no_action="No immediate configuration change is required.",
+        ),
+        "mail_health.confirmed_unauthorized_use_unprotected": _entry(
+            "Protect against confirmed unauthorized use",
+            "A source marked unauthorized was not consistently quarantined or rejected.",
+            "Domain protection may be incomplete, but known senders must be safe first.",
+            "Review protection readiness",
+            "Fresh reports show protective handling while known senders remain healthy.",
+        ),
+        "mail_health.expected_forwarding": _entry(
+            "Check an expected forwarding path",
+            "Forwarding may explain SPF failure, but aligned DKIM still needs evidence.",
+            "Adding an intermediary to SPF without sender-side proof can weaken protection.",
+            "Review forwarding evidence",
+            "Fresh reports isolate the expected forwarding path and aligned DKIM result.",
+        ),
+        "mail_health.dmarc_pass_bounce_mismatch": _entry(
+            "DMARC does not explain the reported bounce",
+            "Authentication passed, so the SMTP response or provider event is needed.",
+            "DMARC proves neither delivery nor inbox placement.",
+            "Review bounce evidence",
+            "The SMTP status, receiver, timestamp, and affected sender are identified.",
+        ),
+    },
+    "de": {
+        "mail_health.action_required": _entry(
+            "Beabsichtigte E-Mails könnten betroffen sein",
+            "Ein von dir genutzter Absender besteht die DMARC-Authentifizierung nicht.",
+            "Nachrichten dieses Absenders könnten abgewiesen oder als verdächtig behandelt werden.",
+            "Betroffenen Absender prüfen",
+            "Neue Reports zeigen diesen Absender ohne DMARC-Fehler.",
+        ),
+        "mail_health.investigation_required": _entry(
+            "Unbekannten Absender zuordnen",
+            "DMARQ weiß noch nicht, ob diese fehlerhafte Quelle zu dir gehört.",
+            "Eine Zuordnung verhindert riskante DNS-Änderungen und unnötige Warnungen.",
+            "Absender zuordnen",
+            "Die Quelle ist klassifiziert oder neue Nachweise zeigen ihren Eigentümer.",
+        ),
+        "mail_health.no_action_likely_unauthorized_use": _entry(
+            "Wahrscheinliches Spoofing wird abgewehrt",
+            "Ein unbekannter Absender ist gescheitert und Empfänger haben deine Richtlinie angewendet.",
+            "Derzeit deutet nichts auf einen Fehler in deinem beabsichtigten Mailversand hin.",
+            "Nachweise prüfen",
+            "Bekannte Absender bleiben gesund und die Schutzrichtlinie bleibt wirksam.",
+            no_action="Aktuell ist keine Konfigurationsänderung nötig.",
+        ),
+        "mail_health.monitor": _entry(
+            "Weiter beobachten",
+            "DMARQ wartet auf eine relevante Änderung oder weitere Nachweise.",
+            "Die aktuellen Reports belegen keinen dringenden Fehler.",
+            "Überwachungsdaten prüfen",
+            "DMARQ bewertet den Zustand mit neuen Reports erneut.",
+            no_action="Aktuell ist keine unmittelbare Aktion nötig.",
+        ),
+        "mail_health.insufficient_evidence": _entry(
+            "Weitere Nachweise erforderlich",
+            "Aggregierte DMARC-Daten beantworten diese Frage noch nicht.",
+            "DMARQ rät nicht über Zustellung oder Absenderzuordnung.",
+            "Nächste Nachweisquelle öffnen",
+            "Der erforderliche Report, Bounce oder Provider-Nachweis liegt vor.",
+        ),
+        "mail_health.healthy": _entry(
+            "Mailauthentifizierung sieht gesund aus",
+            "Aktuelle Reports zeigen erfolgreiche Authentifizierung ohne Fehlermuster.",
+            "DMARQ beobachtet relevante Änderungen bei Absendern und Authentifizierung weiter.",
+            "Aktuelle Reports prüfen",
+            "Der Report-Eingang bleibt aktuell und es treten keine neuen Authentifizierungsfehler auf.",
+            no_action="Derzeit ist keine Aktion nötig.",
+        ),
+        "mail_health.confirmed_unauthorized_use_blocked": _entry(
+            "Bestätigter Missbrauch wird blockiert",
+            "Eine als unautorisiert markierte Quelle scheitert und Empfänger wenden die Richtlinie an.",
+            "Dein beabsichtigter Mailversand scheint derzeit nicht betroffen.",
+            "Blockierte Quelle prüfen",
+            "Bekannte Absender bleiben gesund und Empfänger wenden die Schutzrichtlinie weiter an.",
+            no_action="Aktuell ist keine Konfigurationsänderung nötig.",
+        ),
+        "mail_health.confirmed_unauthorized_use_unprotected": _entry(
+            "Vor bestätigtem Missbrauch schützen",
+            "Eine unautorisierte Quelle wurde nicht durchgehend abgewiesen oder isoliert.",
+            "Der Domainschutz könnte unvollständig sein; bekannte Absender müssen zuerst sicher sein.",
+            "Schutzbereitschaft prüfen",
+            "Neue Reports zeigen Schutzmaßnahmen und weiterhin gesunde bekannte Absender.",
+        ),
+        "mail_health.expected_forwarding": _entry(
+            "Erwartete Weiterleitung prüfen",
+            "Weiterleitung kann SPF-Fehler erklären; für ausgerichtetes DKIM fehlen noch Nachweise.",
+            "Eine ungeprüfte SPF-Freigabe des Zwischenservers kann den Schutz schwächen.",
+            "Weiterleitungsnachweise prüfen",
+            "Neue Reports grenzen den Weiterleitungspfad und das ausgerichtete DKIM-Ergebnis ein.",
+        ),
+        "mail_health.dmarc_pass_bounce_mismatch": _entry(
+            "DMARC erklärt den gemeldeten Bounce nicht",
+            "Die Authentifizierung war erfolgreich; benötigt wird die SMTP-Antwort oder das Provider-Ereignis.",
+            "DMARC beweist weder Zustellung noch Posteingangsplatzierung.",
+            "Bounce-Nachweis prüfen",
+            "SMTP-Status, Empfänger, Zeitpunkt und betroffener Absender sind identifiziert.",
+        ),
+    },
+}
+
+
+def render_mail_health_guidance(
+    assessment: Mapping[str, Any], *, locale: str, depth: str, context: str
+) -> Dict[str, Any]:
+    """Render presentation metadata without changing assessment facts."""
+    resolved_locale = normalize_locale(locale)
+    resolved_depth = depth if depth in EXPLANATION_DEPTHS else "standard"
+    resolved_context = context if context in WORK_CONTEXTS else "watch"
+    conclusion_key = str((assessment.get("conclusion") or {}).get("key") or "")
+    entry = CATALOG.get(resolved_locale, {}).get(conclusion_key) or CATALOG["en"].get(
+        conclusion_key
+    )
+    if entry is None:
+        entry = _entry(
+            str(assessment.get("title") or "Review mail health"),
+            str(assessment.get("summary") or "DMARQ has new mail-health evidence."),
+            "Review the linked evidence before changing mail or DNS settings.",
+            str(assessment.get("next_step") or "Review evidence"),
+            str(assessment.get("verification_condition") or "Review fresh report evidence."),
+        )
+    evidence_context = resolved_context == "evidence"
+    expert_depth = resolved_depth == "expert"
+    diagnose_context = resolved_context == "diagnose"
+    return {
+        "catalog_version": GUIDANCE_CATALOG_VERSION,
+        "locale": resolved_locale,
+        "depth": resolved_depth,
+        "context": resolved_context,
+        **entry,
+        "impact_label": _impact_label(assessment, resolved_locale),
+        "urgency_label": _urgency_label(assessment, resolved_locale),
+        "confidence_label": _confidence_label(assessment, resolved_locale),
+        "evidence_disclosure_label": (
+            "Technische Nachweise anzeigen"
+            if resolved_locale == "de"
+            else "Show technical evidence"
+        ),
+        "show_why": resolved_depth != "guided" or diagnose_context or evidence_context,
+        "show_observations": diagnose_context or evidence_context or expert_depth,
+        "show_inferences": evidence_context or expert_depth,
+        "show_unknowns": evidence_context or expert_depth,
+        "show_exact_evidence": evidence_context or expert_depth,
+    }
+
+
+def _impact_label(assessment: Mapping[str, Any], locale: str) -> str:
+    key = str(assessment.get("intended_mail_impact") or "unknown")
+    labels = {
+        "en": {
+            "likely_affected": "Intended mail may be affected",
+            "likely_not_affected": "Intended mail does not appear affected",
+            "possible": "Intended mail could be affected",
+            "unknown": "Impact on intended mail is not known yet",
+        },
+        "de": {
+            "likely_affected": "Beabsichtigte E-Mails könnten betroffen sein",
+            "likely_not_affected": "Beabsichtigte E-Mails scheinen nicht betroffen",
+            "possible": "Beabsichtigte E-Mails könnten betroffen sein",
+            "unknown": "Auswirkung auf beabsichtigte E-Mails noch unbekannt",
+        },
+    }
+    return labels[locale].get(key, labels[locale]["unknown"])
+
+
+def _urgency_label(assessment: Mapping[str, Any], locale: str) -> str:
+    key = str(assessment.get("urgency") or "monitor")
+    labels = {
+        "en": {
+            "urgent": "Act now",
+            "timely": "Action recommended soon",
+            "monitor": "Keep monitoring",
+            "none": "No immediate action required",
+        },
+        "de": {
+            "urgent": "Jetzt handeln",
+            "timely": "Zeitnahe Aktion empfohlen",
+            "monitor": "Weiter beobachten",
+            "none": "Keine unmittelbare Aktion nötig",
+        },
+    }
+    return labels[locale].get(key, labels[locale]["monitor"])
+
+
+def _confidence_label(assessment: Mapping[str, Any], locale: str) -> str:
+    value = str(assessment.get("confidence") or "Not enough evidence")
+    if locale == "en":
+        return value
+    return {
+        "High": "Hoch",
+        "Medium": "Mittel",
+        "Low": "Niedrig",
+        "Not enough evidence": "Nicht genügend Nachweise",
+    }.get(value, value)
+
+
+def missing_catalog_entries() -> Dict[str, list[str]]:
+    """Return catalog gaps for tests and startup diagnostics."""
+    return {
+        locale: [key for key in PRIMARY_CONCLUSIONS if key not in entries]
+        for locale, entries in CATALOG.items()
+    }

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -291,7 +291,9 @@ function dashboardApp() {
         },
 
         get guidedMailHealthVerification() {
-            return this.guidedMailHealth?.verification_condition || '';
+            return this.guidedMailHealthPresentation?.verification_text
+                || this.guidedMailHealth?.verification_condition
+                || '';
         },
 
         get guidedMailHealthEvidenceScope() {

--- a/backend/app/static/js/dashboard-page.js
+++ b/backend/app/static/js/dashboard-page.js
@@ -229,15 +229,15 @@ function dashboardApp() {
         },
 
         get guidedMailHealthTitle() {
-            return this.guidedMailHealth?.title || 'Checking mail health';
+            return this.guidedMailHealth?.presentation?.headline || this.guidedMailHealth?.title || this.t('Checking mail health');
         },
 
         get guidedMailHealthSummary() {
-            return this.guidedMailHealth?.summary || '';
+            return this.guidedMailHealth?.presentation?.conclusion || this.guidedMailHealth?.summary || '';
         },
 
         get guidedMailHealthNextStep() {
-            return this.guidedMailHealth?.next_step || 'Review reports';
+            return this.guidedMailHealth?.presentation?.next_action_label || this.guidedMailHealth?.next_step || this.t('Review reports');
         },
 
         get guidedMailHealthHref() {
@@ -245,10 +245,11 @@ function dashboardApp() {
         },
 
         get guidedMailHealthConfidence() {
-            return this.guidedMailHealth?.confidence || 'Not enough evidence';
+            return this.guidedMailHealth?.presentation?.confidence_label || this.guidedMailHealth?.confidence || this.t('Not enough evidence');
         },
 
         get guidedMailHealthImpact() {
+            if (this.guidedMailHealth?.presentation?.impact_label) return this.guidedMailHealth.presentation.impact_label;
             const impact = this.guidedMailHealth?.intended_mail_impact;
             return {
                 likely_affected: 'Your intended mail may be affected',
@@ -258,6 +259,7 @@ function dashboardApp() {
         },
 
         get guidedMailHealthUrgency() {
+            if (this.guidedMailHealth?.presentation?.urgency_label) return this.guidedMailHealth.presentation.urgency_label;
             const urgency = this.guidedMailHealth?.urgency;
             return {
                 timely: 'Action recommended soon',
@@ -294,6 +296,22 @@ function dashboardApp() {
 
         get guidedMailHealthEvidenceScope() {
             return this.guidedMailHealth?.evidence_scope || '';
+        },
+
+        get guidedMailHealthPresentation() {
+            return this.guidedMailHealth?.presentation || {};
+        },
+
+        get guidedMailHealthWhy() {
+            return this.guidedMailHealthPresentation.why_it_matters || '';
+        },
+
+        get guidedMailHealthNoAction() {
+            return this.guidedMailHealthPresentation.no_action_explanation || this.guidedMailHealth?.no_action_reason || '';
+        },
+
+        get guidedMailHealthEvidenceLabel() {
+            return this.guidedMailHealthPresentation.evidence_disclosure_label || this.t('Show technical evidence');
         },
 
         get showDashboardNextAction() {
@@ -828,6 +846,9 @@ function dashboardApp() {
                 if (!response.ok) throw new Error('Could not load the guided mail-health assessment.');
                 const data = await response.json();
                 this.guidedMailHealth = data.assessment || null;
+                const profile = data.guidance_profile || {};
+                this.guidanceDepth = profile.depth || this.guidanceDepth;
+                this.guidanceContext = profile.context || this.guidanceContext;
             } catch (error) {
                 console.error('Could not load guided mail health:', error);
                 this.guidedMailHealth = null;

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -48,6 +48,8 @@
                 <h2 id="guided-mail-health-heading" class="mt-1 text-2xl font-semibold text-[#07071f]"
                     x-text="guidedMailHealthTitle"></h2>
                 <p class="mt-2 max-w-3xl text-sm leading-6 text-[#45505f]" x-text="guidedMailHealthSummary"></p>
+                <p x-show="guidedMailHealthWhy" x-cloak class="mt-2 max-w-3xl text-sm leading-6 text-[#45505f]" x-text="guidedMailHealthWhy"></p>
+                <p x-show="guidedMailHealthNoAction" x-cloak class="mt-3 max-w-3xl rounded border border-[#cfe9dd] bg-white px-3 py-2 text-sm font-semibold text-[#276749]" x-text="guidedMailHealthNoAction"></p>
                 <div class="mt-3 flex flex-wrap gap-2 text-xs font-semibold text-[#45505f]">
                     <span class="rounded-full bg-white px-3 py-1" x-text="guidedMailHealthImpact"></span>
                     <span class="rounded-full bg-white px-3 py-1" x-text="guidedMailHealthUrgency"></span>
@@ -59,30 +61,30 @@
                     <button type="button" class="btn btn-sm" :class="guidanceContextButtonClass('diagnose')" :aria-pressed="guidanceContext === 'diagnose'" data-guidance-context="diagnose">Diagnose</button>
                     <button type="button" class="btn btn-sm" :class="guidanceContextButtonClass('evidence')" :aria-pressed="guidanceContext === 'evidence'" data-guidance-context="evidence">Evidence</button>
                 </div>
-                <div x-show="guidanceContext === 'diagnose'" x-cloak class="mt-4 max-w-3xl rounded border border-[#d7e8df] bg-white p-3 text-sm text-[#45505f]">
+                <div x-show="guidedMailHealthPresentation.show_observations && guidanceContext === 'diagnose'" x-cloak class="mt-4 max-w-3xl rounded border border-[#d7e8df] bg-white p-3 text-sm text-[#45505f]">
                     <p class="font-semibold text-[#272a5f]">What DMARQ observed</p>
                     <ul class="mt-1 list-disc space-y-1 pl-5" role="list">
                         <template x-for="fact in guidedMailHealthKnownFacts" :key="fact"><li x-text="fact"></li></template>
                     </ul>
                     <p class="mt-3 text-xs leading-5"><span class="font-semibold">How to verify: </span><span x-text="guidedMailHealthVerification"></span></p>
                 </div>
-                <div x-show="guidanceContext === 'evidence'" x-cloak class="mt-4 max-w-3xl rounded border border-[#d7e8df] bg-white p-3 text-sm text-[#45505f]">
+                <div x-show="guidedMailHealthPresentation.show_exact_evidence && guidanceContext === 'evidence'" x-cloak class="mt-4 max-w-3xl rounded border border-[#d7e8df] bg-white p-3 text-sm text-[#45505f]">
                     <p class="font-semibold text-[#272a5f]">Technical record</p>
                     <p class="mt-1">Review the sender, report, and authentication evidence linked to this assessment.</p>
-                    <a :href="guidedMailHealthHref" class="btn btn-outline btn-sm mt-3">Open linked evidence</a>
+                    <a :href="guidedMailHealthHref" class="btn btn-outline btn-sm mt-3" x-text="guidedMailHealthEvidenceLabel"></a>
                 </div>
-                <details class="mt-4 max-w-3xl rounded border border-[#d7e8df] bg-white p-3 text-sm text-[#45505f]">
-                    <summary class="cursor-pointer font-semibold text-[#272a5f]">Why DMARQ says this</summary>
+                <details x-show="guidedMailHealthPresentation.show_why" x-cloak class="mt-4 max-w-3xl rounded border border-[#d7e8df] bg-white p-3 text-sm text-[#45505f]">
+                    <summary class="cursor-pointer font-semibold text-[#272a5f]" x-text="guidedMailHealthEvidenceLabel"></summary>
                     <p class="mt-3 font-semibold text-[#272a5f]">What DMARQ observed</p>
                     <ul class="mt-1 list-disc space-y-1 pl-5" role="list">
                         <template x-for="fact in guidedMailHealthKnownFacts" :key="fact"><li x-text="fact"></li></template>
                     </ul>
-                    <p class="mt-3 font-semibold text-[#272a5f]">What this likely means</p>
-                    <ul class="mt-1 list-disc space-y-1 pl-5" role="list">
+                    <p x-show="guidedMailHealthPresentation.show_inferences" class="mt-3 font-semibold text-[#272a5f]">What this likely means</p>
+                    <ul x-show="guidedMailHealthPresentation.show_inferences" class="mt-1 list-disc space-y-1 pl-5" role="list">
                         <template x-for="inference in guidedMailHealthInferences" :key="inference"><li x-text="inference"></li></template>
                     </ul>
-                    <p class="mt-3 font-semibold text-[#272a5f]">What remains unknown</p>
-                    <ul class="mt-1 list-disc space-y-1 pl-5" role="list">
+                    <p x-show="guidedMailHealthPresentation.show_unknowns" class="mt-3 font-semibold text-[#272a5f]">What remains unknown</p>
+                    <ul x-show="guidedMailHealthPresentation.show_unknowns" class="mt-1 list-disc space-y-1 pl-5" role="list">
                         <template x-for="unknown in guidedMailHealthUnknowns" :key="unknown"><li x-text="unknown"></li></template>
                     </ul>
                     <p class="mt-3 text-xs leading-5"><span class="font-semibold">How to verify: </span><span x-text="guidedMailHealthVerification"></span></p>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -68,7 +68,7 @@
                     </ul>
                     <p class="mt-3 text-xs leading-5"><span class="font-semibold">How to verify: </span><span x-text="guidedMailHealthVerification"></span></p>
                 </div>
-                <div x-show="guidedMailHealthPresentation.show_exact_evidence && guidanceContext === 'evidence'" x-cloak class="mt-4 max-w-3xl rounded border border-[#d7e8df] bg-white p-3 text-sm text-[#45505f]">
+                <div x-show="guidedMailHealthPresentation.show_exact_evidence" x-cloak class="mt-4 max-w-3xl rounded border border-[#d7e8df] bg-white p-3 text-sm text-[#45505f]">
                     <p class="font-semibold text-[#272a5f]">Technical record</p>
                     <p class="mt-1">Review the sender, report, and authentication evidence linked to this assessment.</p>
                     <a :href="guidedMailHealthHref" class="btn btn-outline btn-sm mt-3" x-text="guidedMailHealthEvidenceLabel"></a>

--- a/backend/app/tests/test_mail_health_guidance.py
+++ b/backend/app/tests/test_mail_health_guidance.py
@@ -1,0 +1,70 @@
+"""Contract tests for localized, skill-adaptive mail-health presentation."""
+
+from copy import deepcopy
+
+from app.services.mail_health_guidance import (
+    CATALOG,
+    PRIMARY_CONCLUSIONS,
+    missing_catalog_entries,
+    render_mail_health_guidance,
+)
+
+
+def _assessment(key: str) -> dict:
+    return {
+        "assessment_id": "stable-facts",
+        "outcome": "healthy",
+        "title": "Source title",
+        "summary": "Source summary",
+        "next_step": "Source action",
+        "confidence": "High",
+        "intended_mail_impact": "likely_not_affected",
+        "urgency": "none",
+        "conclusion": {"key": key, "parameters": {}},
+        "known_facts": ["Observed fact"],
+        "supporting_signals": [{"signal_id": "signal-1"}],
+    }
+
+
+def test_primary_catalog_is_complete_in_english_and_german():
+    assert missing_catalog_entries() == {"en": [], "de": []}
+    for locale in ("en", "de"):
+        for key in PRIMARY_CONCLUSIONS:
+            assert (
+                all(CATALOG[locale][key].values())
+                or CATALOG[locale][key]["no_action_explanation"] == ""
+            )
+
+
+def test_all_context_and_depth_combinations_preserve_assessment_facts():
+    for key in PRIMARY_CONCLUSIONS:
+        assessment = _assessment(key)
+        original = deepcopy(assessment)
+        for locale in ("en", "de"):
+            for depth in ("guided", "standard", "expert"):
+                for context in ("watch", "diagnose", "evidence"):
+                    presentation = render_mail_health_guidance(
+                        assessment, locale=locale, depth=depth, context=context
+                    )
+                    assert presentation["headline"]
+                    assert presentation["next_action_label"]
+                    assert presentation["verification_text"]
+                    assert presentation["locale"] == locale
+        assert assessment == original
+
+
+def test_evidence_and_expert_reveal_exact_evidence_without_changing_authorization():
+    assessment = _assessment("mail_health.healthy")
+    guided_watch = render_mail_health_guidance(
+        assessment, locale="en", depth="guided", context="watch"
+    )
+    expert_watch = render_mail_health_guidance(
+        assessment, locale="en", depth="expert", context="watch"
+    )
+    guided_evidence = render_mail_health_guidance(
+        assessment, locale="en", depth="guided", context="evidence"
+    )
+
+    assert guided_watch["show_exact_evidence"] is False
+    assert expert_watch["show_exact_evidence"] is True
+    assert guided_evidence["show_exact_evidence"] is True

--- a/backend/app/tests/test_stats_endpoints.py
+++ b/backend/app/tests/test_stats_endpoints.py
@@ -46,6 +46,20 @@ class TestDashboardStatistics:
         data = response.json()
         assert data["assessment"]["outcome"] == "insufficient_evidence"
         assert data["assessment"]["claim_type"] == "aggregate_dmarc_authentication"
+        assert data["assessment"]["presentation"]["locale"] == "en"
+        assert data["guidance_profile"]["context"] in {"watch", "diagnose", "evidence"}
+
+    def test_mail_health_summary_localizes_primary_guidance_without_changing_facts(
+        self, authed_client: TestClient
+    ):
+        english = authed_client.get("/api/v1/stats/mail-health/summary?lang=en").json()
+        german = authed_client.get("/api/v1/stats/mail-health/summary?lang=de").json()
+
+        assert english["assessment"]["assessment_id"] == german["assessment"]["assessment_id"]
+        assert german["assessment"]["presentation"]["locale"] == "de"
+        assert german["assessment"]["presentation"]["headline"] == (
+            "Weitere Nachweise erforderlich"
+        )
 
     def test_dashboard_response_contains_api_version(self, authed_client: TestClient):
         response = authed_client.get("/api/v1/stats/dashboard")

--- a/docs/product/guided-mail-health.md
+++ b/docs/product/guided-mail-health.md
@@ -167,3 +167,18 @@ read-only assessment:
 - **Evidence** links directly to the unchanged sender or report evidence.
 
 No context changes the underlying evidence, permissions, or DNS write safety.
+
+## Presentation catalog
+
+The dashboard does not invent assessment wording in its template or browser
+code. The server attaches a `presentation` object generated from the versioned
+English/German guidance catalog, the effective personal profile, and the
+request locale. It contains the headline, conclusion, intended-mail impact,
+urgency, confidence label, rationale, one action, verification text, optional
+no-action explanation, and explicit visibility rules for supporting detail.
+
+All primary assessment conclusion keys must exist in both languages. Automated
+contract tests render every primary conclusion through all three contexts and
+all three explanation depths, and verify that the underlying assessment ID,
+facts, signals, and authorization inputs remain unchanged. English remains the
+fallback for future non-primary keys until their catalog entry is added.


### PR DESCRIPTION
Closes part of #867

## Summary
- add a versioned English/German presentation catalog for every primary mail-health conclusion
- render Watch, Diagnose, and Evidence at guided, standard, or expert depth over the same immutable assessment
- keep one primary action prominent while progressively revealing rationale, observations, unknowns, and exact evidence
- retain the classic dashboard and existing opt-in feature flag

## Validation
- 2,329 backend tests passed
- 144 focused guidance/stats/template tests passed
- Node syntax, Black, isort, and diff checks passed

## Safety
Presentation only: no DNS writes, provider calls, permission changes, or evidence mutation.