### PR TITLE
fix: complete guided remediation consistency wave

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,8 @@ labels: 'bug'
 assignees: ''
 ---
 
+Please describe the issue in English so it can be triaged consistently.
+
 ## Bug Description
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,8 @@ labels: 'enhancement'
 assignees: ''
 ---
 
+Please describe the request in English so it can be triaged consistently.
+
 ## Feature Description
 A clear and concise description of the feature you'd like to see.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           ./scripts/bootstrap-docker-env.sh
           ./scripts/verify-docker-compose.sh
 
+      - name: Enforce English canonical source language
+        run: python3 scripts/check-english-canonical.py
+
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicit progressive-enrichment action instead of blocking the report view.
 - Report detail no longer starts progressive enrichment silently after load;
   missing evidence is explained in the page and can be requested explicitly.
+- Domain sending-source counts now come from one versioned backend snapshot, so
+  filter chips and source rows share the same saved time window and reference clock.
 - Remediation queue entries now expose one clear primary action for the current finding; lifecycle, notification, readiness, and provider internals remain available in the evidence details.
 - Mail source cards now surface the latest import diagnosis and direct operators to the affected import history when a report attachment cannot be parsed.
 - DNS repair previews now report progress and failures inside the affected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - English is now documented as the canonical source language, issue templates
   request English, and CI checks new operator-facing source paths for accidental
   German literals while allowing explicit locale resources.
+- Domain remediation and sender projections now expose one deterministic evidence
+  version, period, and freshness state so filters, counters, score drivers, and
+  queue decisions can be traced to the same persisted report window.
 - DMARQ now ingests RFC delivery-status notifications from IMAP, Gmail,
   Microsoft 365, the raw-email webhook, and manual upload, plus authenticated
   provider-neutral delivery webhooks. Recipient addresses and correlation IDs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for a newer aligned pass before treating it as fixed. Forwarding services,
   including Cloudflare Email Routing, explicitly warn against adding shared
   relay IPs to SPF.
+- Sender classifications now flow into the domain mailflow diagnosis as well as
+  source rows and scheduled health assessment, so an expected forwarding path is
+  treated consistently and never becomes an SPF authorization recommendation.
 - DMARQ now ingests RFC delivery-status notifications from IMAP, Gmail,
   Microsoft 365, the raw-email webhook, and manual upload, plus authenticated
   provider-neutral delivery webhooks. Recipient addresses and correlation IDs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings setup guidance now reads the live domain, report-source, report, and
   notification state, advances one actionable step at a time, and marks optional
   notification setup separately from required intake prerequisites.
+- English is now documented as the canonical source language, issue templates
+  request English, and CI checks new operator-facing source paths for accidental
+  German literals while allowing explicit locale resources.
 - DMARQ now ingests RFC delivery-status notifications from IMAP, Gmail,
   Microsoft 365, the raw-email webhook, and manual upload, plus authenticated
   provider-neutral delivery webhooks. Recipient addresses and correlation IDs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sender classifications now flow into the domain mailflow diagnosis as well as
   source rows and scheduled health assessment, so an expected forwarding path is
   treated consistently and never becomes an SPF authorization recommendation.
+- Settings setup guidance now reads the live domain, report-source, report, and
+  notification state, advances one actionable step at a time, and marks optional
+  notification setup separately from required intake prerequisites.
 - DMARQ now ingests RFC delivery-status notifications from IMAP, Gmail,
   Microsoft 365, the raw-email webhook, and manual upload, plus authenticated
   provider-neutral delivery webhooks. Recipient addresses and correlation IDs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DNS provider previews now explicitly state that they are read-only, show the
   exact Before/After review step, and confirm that no live DNS change occurred
   until the final apply action.
+- Normal report-detail reads now use persisted report/source evidence only;
+  PTR, ASN/geo, and reputation enrichment runs during ingest or through an
+  explicit progressive-enrichment action instead of blocking the report view.
+- Report detail no longer starts progressive enrichment silently after load;
+  missing evidence is explained in the page and can be requested explicitly.
 - Remediation queue entries now expose one clear primary action for the current finding; lifecycle, notification, readiness, and provider internals remain available in the evidence details.
 - Mail source cards now surface the latest import diagnosis and direct operators to the affected import history when a report attachment cannot be parsed.
 - DNS repair previews now report progress and failures inside the affected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Remediation queues now keep core DMARC and mail-health actions ahead of optional
+  MTA-STS, TLS-RPT, BIMI, and DANE hardening, and label the scope in the primary
+  domain action so the next step is unambiguous.
+- DNS provider previews now explicitly state that they are read-only, show the
+  exact Before/After review step, and confirm that no live DNS change occurred
+  until the final apply action.
 - Remediation queue entries now expose one clear primary action for the current finding; lifecycle, notification, readiness, and provider internals remain available in the evidence details.
 - Mail source cards now surface the latest import diagnosis and direct operators to the affected import history when a report attachment cannot be parsed.
 - DNS repair previews now report progress and failures inside the affected

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,17 @@ This project and everyone participating in it is governed by our Code of Conduct
 
 ## How Can I Contribute?
 
+### Canonical language
+
+English is DMARQ's canonical source language for issues, pull requests, source
+code, tests, API contracts, logs, documentation, and UI copy. German and future
+languages belong in explicit translation catalogs or language-specific
+documentation. Reason codes and API enum values must never be translated.
+
+Please write new issue and pull request content in English. The CI check
+python3 scripts/check-english-canonical.py rejects accidental German operator
+copy outside approved locale resources.
+
 ### Reporting Bugs
 
 Before creating bug reports, please check the existing issues list as you might find that you don't need to create one. When you are creating a bug report, please include as many details as possible:

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -8826,13 +8826,7 @@ def _source_delivery_status(source: Dict[str, Any]) -> Dict[str, str]:
     }
 
 
-def _source_snapshot(source_entries: List[SourceEntry], *, days: int) -> Dict[str, Any]:  # noqa: C901
-    """Return one canonical, versioned source view for rows and summary chips.
-
-    The UI may filter the returned rows locally, but it must not derive headline
-    counts from a different clock or a different projection than the API.
-    """
-    rows = [entry.model_dump() for entry in source_entries]
+def _source_snapshot_bounds(rows: List[Dict[str, Any]]) -> Tuple[int, int, int]:
     timestamps = [
         int(value)
         for row in rows
@@ -8848,6 +8842,10 @@ def _source_snapshot(source_entries: List[SourceEntry], *, days: int) -> Dict[st
         (int(row["last_seen"]) for row in rows if str(row.get("last_seen", "")).isdigit()),
         default=0,
     )
+    return as_of, first_seen, last_seen
+
+
+def _source_snapshot_counts(rows: List[Dict[str, Any]], *, as_of: int) -> Dict[str, int]:
     counts = {
         "total": len(rows),
         "risky": 0,
@@ -8863,26 +8861,31 @@ def _source_snapshot(source_entries: List[SourceEntry], *, days: int) -> Dict[st
         reputation = row.get("reputation") or {}
         reputation_status = str(reputation.get("status") or "")
         risk_score = float(reputation.get("risk_score") or 0)
-        if reputation_status in {"listed", "critical", "suspicious"} or risk_score >= 50:
-            counts["risky"] += 1
-        if reputation_status == "listed":
-            counts["listed"] += 1
-        if not row.get("reputation"):
-            counts["unchecked"] += 1
-        if row.get("dmarc") in {"fail", "mixed"}:
-            counts["auth_review"] += 1
+        counts["risky"] += int(
+            reputation_status in {"listed", "critical", "suspicious"} or risk_score >= 50
+        )
+        counts["listed"] += int(reputation_status == "listed")
+        counts["unchecked"] += int(not row.get("reputation"))
+        counts["auth_review"] += int(row.get("dmarc") in {"fail", "mixed"})
         last = row.get("last_seen")
-        if as_of and str(last).isdigit():
-            age_days = max(0, (as_of - int(last)) // 86400)
-            if age_days <= 14:
-                counts["recent"] += 1
+        if as_of and str(last).isdigit() and (as_of - int(last)) // 86400 <= 14:
+            counts["recent"] += 1
         status = row.get("authentication_status")
-        if status == "authenticated":
-            counts["authenticated"] += 1
-        elif status == "receiver_protective_action":
-            counts["protective_action"] += 1
-        elif status == "receiver_no_dmarc_action":
-            counts["no_dmarc_action"] += 1
+        counts["authenticated"] += int(status == "authenticated")
+        counts["protective_action"] += int(status == "receiver_protective_action")
+        counts["no_dmarc_action"] += int(status == "receiver_no_dmarc_action")
+    return counts
+
+
+def _source_snapshot(source_entries: List[SourceEntry], *, days: int) -> Dict[str, Any]:
+    """Return one canonical, versioned source view for rows and summary chips.
+
+    The UI may filter the returned rows locally, but it must not derive headline
+    counts from a different clock or a different projection than the API.
+    """
+    rows = [entry.model_dump() for entry in source_entries]
+    as_of, first_seen, last_seen = _source_snapshot_bounds(rows)
+    counts = _source_snapshot_counts(rows, as_of=as_of)
     version = source_projection_version(rows, days=days)
     return {
         "version": version,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -9402,6 +9402,7 @@ async def get_domain_sources(
         sources,
         sender_by_ip,
         workspace_id=workspace.id,
+        classifications=classifications,
     )
     mailflow_by_ip = {
         str(flow.get("source_ip") or "unknown"): flow

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -91,6 +91,10 @@ from app.services.dns_zone_baselines import (
     preview_zone_baseline,
     save_zone_baseline,
 )
+from app.services.evidence_snapshot import (
+    build_domain_evidence_snapshot,
+    source_projection_version,
+)
 from app.services.health_score import build_health_summary, score_domain_health
 from app.services.health_score_snapshots import (
     aggregate_workspace_health_points,
@@ -1670,6 +1674,7 @@ class RemediationQueueResponse(BaseModel):
     domain: str
     status: str
     summary: Dict[str, int]
+    snapshot: Dict[str, Any] = Field(default_factory=dict)
     loop: Dict[str, Any] = Field(default_factory=dict)
     completion: RemediationCompletionGate = Field(default_factory=RemediationCompletionGate)
     items: List[RemediationQueueItem]
@@ -7372,6 +7377,15 @@ async def _build_domain_remediation_queue_for_workspace(  # noqa: C901
         available_write_providers=available_providers,
         recommended_provider=recommended_provider,
     )
+    # Keep queue counters tied to the same persisted report projection used by
+    # the sender view. This is a read-only fingerprint; it never performs DNS
+    # or reputation work in the request path.
+    source_rows = store.get_domain_sources(domain_name, days=30)
+    queue["snapshot"] = build_domain_evidence_snapshot(
+        domain_health,
+        source_rows,
+        days=30,
+    )
     if guidance.get("enrichment_pending") or domain_health.get("enrichment_pending"):
         queue = {
             **queue,
@@ -8869,28 +8883,7 @@ def _source_snapshot(source_entries: List[SourceEntry], *, days: int) -> Dict[st
             counts["protective_action"] += 1
         elif status == "receiver_no_dmarc_action":
             counts["no_dmarc_action"] += 1
-    version_payload = {
-        "days": int(days),
-        "as_of": as_of,
-        "first_seen": first_seen,
-        "last_seen": last_seen,
-        "counts": counts,
-        "rows": [
-            {
-                "ip": row.get("ip"),
-                "count": row.get("count", 0),
-                "first_seen": row.get("first_seen"),
-                "last_seen": row.get("last_seen"),
-                "dmarc": row.get("dmarc"),
-                "authentication_status": row.get("authentication_status"),
-                "reputation": (row.get("reputation") or {}).get("status"),
-            }
-            for row in rows
-        ],
-    }
-    version = hashlib.sha256(
-        json.dumps(version_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()[:16]
+    version = source_projection_version(rows, days=days)
     return {
         "version": version,
         "period_days": int(days),
@@ -9518,10 +9511,28 @@ async def get_domain_sources(
             )
         )
 
+    source_snapshot = _source_snapshot(source_entries, days=source_days)
+    evidence_snapshot = build_domain_evidence_snapshot(
+        _persisted_domain_health(
+            db,
+            workspace_id=workspace.id,
+            domain_name=domain_name,
+        ),
+        source_entries,
+        days=source_days,
+    )
+    source_snapshot = {
+        **source_snapshot,
+        "version": evidence_snapshot["version"],
+        "source_version": evidence_snapshot["source_version"],
+        "health_version": evidence_snapshot["health_version"],
+        "captured_at": evidence_snapshot["captured_at"],
+        "stale": evidence_snapshot["stale"],
+    }
     return DomainSourcesResponse(
         sources=source_entries,
         mailflow_assessment=DomainMailflowAssessment(**mailflow_assessment),
-        snapshot=_source_snapshot(source_entries, days=source_days),
+        snapshot=source_snapshot,
     )
 
 

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -8826,7 +8826,7 @@ def _source_delivery_status(source: Dict[str, Any]) -> Dict[str, str]:
     }
 
 
-def _source_snapshot(source_entries: List[SourceEntry], *, days: int) -> Dict[str, Any]:
+def _source_snapshot(source_entries: List[SourceEntry], *, days: int) -> Dict[str, Any]:  # noqa: C901
     """Return one canonical, versioned source view for rows and summary chips.
 
     The UI may filter the returned rows locally, but it must not derive headline

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -2298,6 +2298,7 @@ class DomainSourcesResponse(BaseModel):
 
     sources: List[SourceEntry]
     mailflow_assessment: DomainMailflowAssessment
+    snapshot: Dict[str, Any] = Field(default_factory=dict)
 
 
 class SourceIntelligenceResponse(BaseModel):
@@ -8811,6 +8812,95 @@ def _source_delivery_status(source: Dict[str, Any]) -> Dict[str, str]:
     }
 
 
+def _source_snapshot(source_entries: List[SourceEntry], *, days: int) -> Dict[str, Any]:
+    """Return one canonical, versioned source view for rows and summary chips.
+
+    The UI may filter the returned rows locally, but it must not derive headline
+    counts from a different clock or a different projection than the API.
+    """
+    rows = [entry.model_dump() for entry in source_entries]
+    timestamps = [
+        int(value)
+        for row in rows
+        for value in (row.get("last_seen"), row.get("first_seen"))
+        if value is not None and str(value).isdigit()
+    ]
+    as_of = max(timestamps, default=0)
+    first_seen = min(
+        (int(row["first_seen"]) for row in rows if str(row.get("first_seen", "")).isdigit()),
+        default=0,
+    )
+    last_seen = max(
+        (int(row["last_seen"]) for row in rows if str(row.get("last_seen", "")).isdigit()),
+        default=0,
+    )
+    counts = {
+        "total": len(rows),
+        "risky": 0,
+        "listed": 0,
+        "auth_review": 0,
+        "unchecked": 0,
+        "recent": 0,
+        "authenticated": 0,
+        "protective_action": 0,
+        "no_dmarc_action": 0,
+    }
+    for row in rows:
+        reputation = row.get("reputation") or {}
+        reputation_status = str(reputation.get("status") or "")
+        risk_score = float(reputation.get("risk_score") or 0)
+        if reputation_status in {"listed", "critical", "suspicious"} or risk_score >= 50:
+            counts["risky"] += 1
+        if reputation_status == "listed":
+            counts["listed"] += 1
+        if not row.get("reputation"):
+            counts["unchecked"] += 1
+        if row.get("dmarc") in {"fail", "mixed"}:
+            counts["auth_review"] += 1
+        last = row.get("last_seen")
+        if as_of and str(last).isdigit():
+            age_days = max(0, (as_of - int(last)) // 86400)
+            if age_days <= 14:
+                counts["recent"] += 1
+        status = row.get("authentication_status")
+        if status == "authenticated":
+            counts["authenticated"] += 1
+        elif status == "receiver_protective_action":
+            counts["protective_action"] += 1
+        elif status == "receiver_no_dmarc_action":
+            counts["no_dmarc_action"] += 1
+    version_payload = {
+        "days": int(days),
+        "as_of": as_of,
+        "first_seen": first_seen,
+        "last_seen": last_seen,
+        "counts": counts,
+        "rows": [
+            {
+                "ip": row.get("ip"),
+                "count": row.get("count", 0),
+                "first_seen": row.get("first_seen"),
+                "last_seen": row.get("last_seen"),
+                "dmarc": row.get("dmarc"),
+                "authentication_status": row.get("authentication_status"),
+                "reputation": (row.get("reputation") or {}).get("status"),
+            }
+            for row in rows
+        ],
+    }
+    version = hashlib.sha256(
+        json.dumps(version_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    return {
+        "version": version,
+        "period_days": int(days),
+        "as_of": as_of,
+        "first_seen": first_seen,
+        "last_seen": last_seen,
+        "counts": counts,
+    }
+
+
 def _source_authentication_observation(source: Dict[str, Any]) -> Dict[str, str]:
     """Describe aggregate DMARC facts without inferring individual delivery."""
     passed = int(source.get("dmarc_pass_count") or 0)
@@ -9430,6 +9520,7 @@ async def get_domain_sources(
     return DomainSourcesResponse(
         sources=source_entries,
         mailflow_assessment=DomainMailflowAssessment(**mailflow_assessment),
+        snapshot=_source_snapshot(source_entries, days=source_days),
     )
 
 

--- a/backend/app/api/api_v1/endpoints/reports.py
+++ b/backend/app/api/api_v1/endpoints/reports.py
@@ -870,6 +870,7 @@ async def _report_reputations_by_ip(
     refresh: bool,
     settings: Any,
     hydrate: bool = False,
+    allow_live: bool = False,
 ) -> tuple[Optional[DomainReputation], Dict[str, SourceReputation], str]:
     """Build reputation evidence with a hard detail-path timeout."""
     try:
@@ -883,6 +884,7 @@ async def _report_reputations_by_ip(
                 anomalies_by_ip={},
                 days=1,
                 refresh=refresh,
+                allow_live=allow_live,
             ),
             timeout=(
                 max(0.5, float(settings.SOURCE_REPUTATION_DETAIL_TIMEOUT_SECONDS) * 2)
@@ -1228,32 +1230,35 @@ async def get_report_by_id(
 
     missing_ptr_ips = [ip for ip in unique_ips if ip not in ptr_by_ip]
     missing_network_ips = [ip for ip in unique_ips if ip not in networks_by_ip]
-    ptr_task = asyncio.create_task(
-        _report_ptrs_by_ip(
-            provider,
-            missing_ptr_ips,
-            settings,
-            hydrate=hydrate_enrichment,
+    if hydrate_enrichment:
+        ptr_task = asyncio.create_task(
+            _report_ptrs_by_ip(
+                provider,
+                missing_ptr_ips,
+                settings,
+                hydrate=True,
+            )
         )
-    )
-    network_task = asyncio.create_task(
-        _report_networks_by_ip(
-            db,
-            provider,
-            missing_network_ips,
-            settings,
-            hydrate=hydrate_enrichment,
+        network_task = asyncio.create_task(
+            _report_networks_by_ip(
+                db,
+                provider,
+                missing_network_ips,
+                settings,
+                hydrate=True,
+            )
         )
-    )
-    (live_ptr, ptr_status), (live_networks, network_status) = await asyncio.gather(
-        ptr_task, network_task
-    )
-    ptr_by_ip.update(live_ptr)
-    networks_by_ip.update(live_networks)
-    if not missing_ptr_ips:
-        ptr_status = "complete"
-    if not missing_network_ips:
-        network_status = "complete"
+        (live_ptr, ptr_status), (live_networks, network_status) = await asyncio.gather(
+            ptr_task, network_task
+        )
+        ptr_by_ip.update(live_ptr)
+        networks_by_ip.update(live_networks)
+    else:
+        # Normal report reads are projection reads. Missing point-in-time
+        # enrichment is completed by the ingest/scheduler path, never by a
+        # synchronous page request.
+        ptr_status = "complete" if not missing_ptr_ips else "pending"
+        network_status = "complete" if not missing_network_ips else "pending"
     hostnames = [(ptr_by_ip.get(ip).hostname if ptr_by_ip.get(ip) else None) for ip in ips]
     if ptr_status == "complete":
         if any((ptr_by_ip.get(ip) and ptr_by_ip[ip].transient) for ip in unique_ips):
@@ -1280,6 +1285,7 @@ async def get_report_by_id(
         refresh=refresh_reputation,
         settings=settings,
         hydrate=hydrate_enrichment,
+        allow_live=hydrate_enrichment or refresh_reputation,
     )
 
     # Normalize records

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -29,6 +29,9 @@ from app.core.credential_encryption import decrypt_secret, encrypt_secret, is_en
 from app.core.database import get_db
 from app.core.security import require_admin_auth
 from app.models.setting import Setting
+from app.models.domain import Domain
+from app.models.mail_source import MailSource
+from app.models.report import DMARCReport
 from app.services.account_milestone import build_account_milestone_readiness
 from app.services.dns_resolver import resolver_profile_status
 from app.services.ai_assistance import AI_DEFAULTS
@@ -871,6 +874,77 @@ async def list_settings(
         query = query.filter(Setting.category == category)
     rows = query.order_by(Setting.category, Setting.key).all()
     return [_row_to_dict(row) for row in rows]
+
+
+@router.get("/setup-state")
+async def get_setup_state(
+    db: Session = Depends(get_db),
+    _auth: dict = Depends(require_admin_auth),
+) -> Dict[str, Any]:
+    """Return the smallest actionable setup checklist from current product state."""
+    _seed_defaults(db)
+    domain_count = db.query(Domain).filter(Domain.active.is_(True)).count()
+    source_count = db.query(MailSource).count()
+    enabled_source_count = db.query(MailSource).filter(MailSource.enabled.is_(True)).count()
+    report_count = db.query(DMARCReport).count()
+    notification_enabled = (
+        _setting_plain_or_default(db, "notifications.apprise_enabled") == "true"
+        and bool(_setting_plain_or_default(db, "notifications.apprise_urls").strip())
+    )
+    checklist = [
+        {
+            "key": "report_source",
+            "title": "Connect report intake",
+            "ready": enabled_source_count > 0,
+            "status": "Ready" if enabled_source_count else "Next",
+            "evidence": f"{enabled_source_count} enabled source(s)" if source_count else "No report mailbox configured",
+            "href": "/mail-sources",
+            "action": "Open mail sources",
+        },
+        {
+            "key": "domain",
+            "title": "Add a monitored domain",
+            "ready": domain_count > 0,
+            "status": "Ready" if domain_count else "Next",
+            "evidence": f"{domain_count} active domain(s)",
+            "href": "/domains",
+            "action": "Open domains",
+        },
+        {
+            "key": "reports",
+            "title": "Receive the first report",
+            "ready": report_count > 0,
+            "status": "Ready" if report_count else "Waiting",
+            "evidence": f"{report_count} report(s) stored" if report_count else "No reports stored yet",
+            "href": "/reports",
+            "action": "Open reports",
+        },
+        {
+            "key": "notifications",
+            "title": "Choose notifications",
+            "ready": notification_enabled,
+            "status": "Ready" if notification_enabled else "Optional",
+            "evidence": "A notification target is configured" if notification_enabled else "No notification target configured",
+            "href": "#notification-settings",
+            "action": "Configure notifications",
+        },
+    ]
+    next_item = next((item for item in checklist if not item["ready"] and item["status"] != "Optional"), None)
+    if next_item:
+        next_step = next_item["title"]
+    elif not notification_enabled:
+        next_step = "Notifications are optional; choose a target when you want alerts."
+    else:
+        next_step = "Foundational setup is complete. Review your domain health next."
+    return {
+        "domains": domain_count,
+        "sources": source_count,
+        "enabled_sources": enabled_source_count,
+        "reports": report_count,
+        "notifications_configured": notification_enabled,
+        "checklist": checklist,
+        "next_step": next_step,
+    }
 
 
 @router.post("/notifications/test", response_model=NotificationTestResponse)

--- a/backend/app/services/evidence_snapshot.py
+++ b/backend/app/services/evidence_snapshot.py
@@ -1,0 +1,80 @@
+"""Build deterministic metadata for the persisted domain evidence projection."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+
+def _timestamp(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def source_projection_version(rows: Iterable[Mapping[str, Any]], *, days: int) -> str:
+    """Return a stable version for the persisted sender projection.
+
+    Raw report rows and API source rows use different field names, so the
+    fingerprint intentionally includes only shared persisted facts. Enrichment
+    and presentation changes must not make the saved evidence appear newer.
+    """
+    normalized = []
+    for row in rows:
+        if hasattr(row, "model_dump"):
+            row = row.model_dump()
+        normalized.append(
+            {
+                "ip": row.get("ip") or row.get("source_ip") or "unknown",
+                "count": int(row.get("count") or 0),
+                "first_seen": _timestamp(row.get("first_seen")),
+                "last_seen": _timestamp(row.get("last_seen")),
+                "dmarc": row.get("dmarc") or row.get("dmarc_result") or "unknown",
+                "spf": row.get("spf") or row.get("spf_result") or "unknown",
+                "dkim": row.get("dkim") or row.get("dkim_result") or "unknown",
+                "disposition": row.get("disposition") or "none",
+            }
+        )
+    normalized.sort(key=lambda item: (str(item["ip"]), item["first_seen"], item["last_seen"]))
+    encoded = json.dumps(
+        {"days": int(days), "rows": normalized},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def build_domain_evidence_snapshot(
+    health: Mapping[str, Any],
+    source_rows: Iterable[Mapping[str, Any]],
+    *,
+    days: int,
+    captured_at: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Return one identity shared by score, queue, and sender projections."""
+    source_rows = list(source_rows)
+    source_version = source_projection_version(source_rows, days=days)
+    evidence_captured_at = str(health.get("evidence_captured_at") or captured_at or "") or None
+    health_payload = {
+        "assessment_version": str(health.get("assessment_version") or "1"),
+        "evidence_captured_at": evidence_captured_at,
+        "score": health.get("score"),
+        "factors": health.get("factors") or {},
+        "path_to_100": health.get("path_to_100") or {},
+        "source_version": source_version,
+        "period_days": int(days),
+    }
+    version = hashlib.sha256(
+        json.dumps(health_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    return {
+        "version": version,
+        "health_version": str(health.get("assessment_version") or "1"),
+        "source_version": source_version,
+        "period_days": int(days),
+        "captured_at": evidence_captured_at,
+        "stale": not bool(evidence_captured_at),
+        "source_rows": len(source_rows),
+    }

--- a/backend/app/services/mailflow_assessment.py
+++ b/backend/app/services/mailflow_assessment.py
@@ -45,6 +45,7 @@ def _flow(
     *,
     workspace_id: int | None,
     domain: str,
+    operator_classification: str = "",
 ) -> Dict[str, Any]:
     messages = _count(source.get("count"))
     spf_pass = _count(source.get("spf_pass_count"))
@@ -57,7 +58,25 @@ def _flow(
         messages > 0 and spf_pass == messages and dkim_pass == 0 and dkim_fail == messages
     )
 
-    if fully_spf_aligned_without_dkim:
+    if operator_classification == "expected_forwarding":
+        status = "expected_forwarding"
+        label = "Expected forwarding path"
+        intended_mail_impact = "likely_affected" if dmarc_fail else "fragile"
+        detail = (
+            "An operator classified this exact source as expected forwarding. "
+            "Forwarding commonly breaks SPF; preserve aligned DKIM on the original sender."
+        )
+        next_step = "Review the forwarding rule and verify aligned DKIM in a newer report"
+    elif operator_classification == "unauthorized":
+        status = "likely_unauthorized"
+        label = "Marked unauthorized"
+        intended_mail_impact = "likely_not_affected"
+        detail = (
+            "An operator classified this exact source as unauthorized. Keep it outside SPF "
+            "and monitor the receiver disposition in newer reports."
+        )
+        next_step = "No DNS authorization; keep monitoring for recurrence"
+    elif fully_spf_aligned_without_dkim:
         status = "aligned_dkim_not_observed"
         label = "Aligned DKIM not observed"
         intended_mail_impact = "likely_affected" if dmarc_fail else "fragile"
@@ -136,6 +155,7 @@ def _flow(
         "source_ip": str(source.get("source_ip") or "unknown"),
         "sender_name": str(sender.get("name") or "Unknown sender"),
         "sender_status": str(sender.get("status") or "unknown"),
+        "operator_classification": operator_classification or None,
         "status": status,
         "label": label,
         "detail": detail,
@@ -172,6 +192,7 @@ def build_domain_mailflow_assessment(
     sender_by_ip: Dict[str, Dict[str, Any]],
     *,
     workspace_id: int | None = None,
+    classifications: Dict[tuple[str, str], Dict[str, Any]] | None = None,
 ) -> Dict[str, Any]:
     """Build one domain summary plus per-source mailflow identity facts."""
     flows = [
@@ -180,12 +201,19 @@ def build_domain_mailflow_assessment(
             sender_by_ip.get(str(source.get("source_ip") or "unknown"), {}),
             workspace_id=workspace_id,
             domain=domain,
+            operator_classification=str(
+                (classifications or {}).get(
+                    (domain, str(source.get("source_ip") or "unknown")), {}
+                ).get("classification")
+                or ""
+            ),
         )
         for source in sources
         if _count(source.get("count")) > 0
     ]
     priority = {
         "aligned_dkim_not_observed": 0,
+        "expected_forwarding": 1,
         "intermittent_dkim_alignment": 1,
         "investigate_alignment": 2,
         "investigate_source": 3,
@@ -223,6 +251,16 @@ def build_domain_mailflow_assessment(
         )
         next_step = primary["next_step"]
         confidence = "Medium"
+    elif flows and counts["expected_forwarding"]:
+        primary = next(flow for flow in flows if flow["status"] == "expected_forwarding")
+        status = "investigation_required"
+        title = "Review an expected forwarding path"
+        summary = (
+            "This source is marked as expected forwarding. Do not add its shared relay IP "
+            "to SPF; verify aligned DKIM on the original sender instead."
+        )
+        next_step = primary["next_step"]
+        confidence = "High"
     elif flows and counts["healthy"]:
         primary = next(flow for flow in flows if flow["status"] == "healthy")
         status = "healthy"

--- a/backend/app/services/mailflow_assessment.py
+++ b/backend/app/services/mailflow_assessment.py
@@ -39,7 +39,7 @@ def _alignment_status(pass_count: int, fail_count: int) -> str:
     return "unknown"
 
 
-def _flow(
+def _flow(  # noqa: C901
     source: Dict[str, Any],
     sender: Dict[str, Any],
     *,

--- a/backend/app/services/provider_console.py
+++ b/backend/app/services/provider_console.py
@@ -123,18 +123,18 @@ def _recommended_action(
     report_count: int,
 ) -> str:
     if not domains:
-        return "Erste Versanddomain anlegen und den DNS-Besitz bestätigen."
+        return "Add the first sending domain and confirm DNS ownership."
     if report_count == 0:
-        return "Report-Mailbox verbinden und den ersten DMARC-Report importieren."
+        return "Connect the report mailbox and import the first DMARC report."
     if health == "critical":
         return (
-            "Fehlgeschlagene Sender priorisieren und DKIM/SPF vor einer Policy-Änderung reparieren."
+            "Prioritize failing senders and repair DKIM/SPF before changing policy."
         )
     if any((domain.dmarc_policy or "none") == "none" for domain in domains):
-        return "Unbekannte Sender klären und anschließend die DMARC-Policy verschärfen."
+        return "Classify unknown senders, then strengthen the DMARC policy."
     if any((domain.dmarc_policy or "none") != "reject" for domain in domains):
-        return "Reject-Rollout vorbereiten und nach der Änderung sieben Tage überwachen."
-    return "Aktuelle Policy beibehalten und neue Senderabweichungen überwachen."
+        return "Prepare the reject rollout and monitor for seven days after the change."
+    return "Keep the current policy and monitor for new sender changes."
 
 
 def _user_rows(
@@ -209,15 +209,15 @@ def _domain_rows(
         )
         findings: List[str] = []
         if not domain.verified:
-            findings.append("DNS-Besitz ist noch nicht bestätigt.")
+            findings.append("DNS ownership has not been confirmed yet.")
         if messages == 0:
-            findings.append("Für die letzten 30 Tage liegen keine Reports vor.")
+            findings.append("No reports were received in the last 30 days.")
         elif compliance_rate < 95:
-            findings.append("Authentifizierungsquote liegt unter 95 %.")
+            findings.append("Authentication rate is below 95%.")
         if (domain.dmarc_policy or "none") == "none":
-            findings.append("DMARC befindet sich noch im Monitoring-Modus.")
+            findings.append("DMARC is still in monitoring mode.")
         if not findings:
-            findings.append("Keine akuten Findings; Policy und neue Sender weiter überwachen.")
+            findings.append("No urgent findings; continue monitoring policy and new senders.")
         last_report = max(
             (report.processed_at for report in reports if report.processed_at), default=None
         )
@@ -324,7 +324,7 @@ def _account_payload(  # pylint: disable=too-many-locals
     primary_contact = next(
         (user for user in users if user["role"] in {"organization_owner", "workspace_owner"}),
         users[0] if users else None,
-    ) or {"name": "Nicht zugewiesen", "email": "Nicht zugewiesen"}
+        ) or {"name": "Unassigned", "email": "Unassigned"}
     subscriptions = sorted(
         organization.subscriptions,
         key=lambda subscription: (subscription.created_at or datetime.min, subscription.id),
@@ -362,13 +362,13 @@ def _account_payload(  # pylint: disable=too-many-locals
         "status": account_status,
         "health": health,
         "plan_code": plan.code if plan is not None else "unconfigured",
-        "plan_label": plan.name if plan is not None else "Kein Plan",
+        "plan_label": plan.name if plan is not None else "No plan configured",
         "created_at": _iso(organization.created_at),
         "last_activity_at": _iso(max((report.processed_at for report in reports), default=None)),
         "primary_contact": {
             "name": primary_contact["name"],
             "email": primary_contact["email"],
-            "phone": "Im Identity Provider verwaltet",
+            "phone": "Managed in the identity provider",
         },
         "billing": {
             "status": _billing_status(subscription),
@@ -385,7 +385,7 @@ def _account_payload(  # pylint: disable=too-many-locals
                 else (
                     billing_account.external_customer_id
                     if billing_account
-                    else "Nicht konfiguriert"
+                    else "Not configured"
                 )
             ),
             "billing_contact": (
@@ -441,7 +441,7 @@ def _account_payload(  # pylint: disable=too-many-locals
         "settings": {
             "report_mailbox": next(
                 (domain.dmarc_report_mailbox for domain in domains if domain.dmarc_report_mailbox),
-                "Nicht konfiguriert",
+                "Not configured",
             ),
             "timezone": "Europe/Berlin",
             "weekly_digest": True,
@@ -572,7 +572,7 @@ def build_provider_console(
     operator = operator or {
         "id": "site-manager",
         "name": "Site Manager",
-        "email": "Aktuelle Sitzung",
+        "email": "Current session",
         "role": "site_manager",
     }
     monthly_messages = sum(account["usage"]["messages_30d"] for account in accounts)
@@ -642,13 +642,13 @@ def build_provider_console(
         "support_access_demo": {
             "mode": "audited_workspace_session",
             "operator": operator,
-            "reason": "Kundensupport und Konfigurationsprüfung",
+            "reason": "Customer support and configuration review",
             "allowed_targets": allowed_targets,
             "safeguards": [
-                "Zeitlich begrenzte, signierte Sitzung",
-                "Operator, Zielbenutzer, Workspace und Grund werden protokolliert",
-                "Die API-Berechtigungen entsprechen der Rolle des Zielbenutzers",
-                "Die Sitzung ist fest an genau einen Kunden-Workspace gebunden",
+                "Time-limited, signed session",
+                "Operator, target user, workspace, and reason are logged",
+                "API permissions match the target user's role",
+                "The session is bound to exactly one customer workspace",
             ],
             "audit_events": [],
         },

--- a/backend/app/services/remediation_queue.py
+++ b/backend/app/services/remediation_queue.py
@@ -26,6 +26,17 @@ STATE_PRIORITY = {
     "investigate": 20,
     "informational": 10,
 }
+OPTIONAL_HARDENING_CODES = {
+    "mta_sts_missing",
+    "mta_sts_review",
+    "tls_rpt_missing",
+    "tls_rpt_multiple_records",
+    "tls_rpt_rua_missing",
+    "bimi_missing",
+    "bimi_dmarc_not_enforced",
+    "dane_missing",
+    "dane_review",
+}
 TRACKS = (
     "provider_preview",
     "manual_dns",
@@ -454,6 +465,17 @@ def _priority_score(item: Dict[str, Any]) -> int:
     return severity + state + automation + min(impact, 50)
 
 
+def _is_optional_hardening_item(item: Dict[str, Any]) -> bool:
+    """Keep optional transport/brand hardening behind core mail-health work."""
+    if str(item.get("source") or "") != "dns_lint":
+        return False
+    finding_code = str(item.get("finding_code") or "").lower()
+    item_id = str(item.get("id") or "").lower()
+    return finding_code in OPTIONAL_HARDENING_CODES or any(
+        token in item_id for token in ("mta-sts", "tls-rpt", "bimi", "dane")
+    )
+
+
 def _priority_band(item: Dict[str, Any], *, score: Optional[int] = None) -> str:
     if score is None:
         score = int(item.get("priority_score") or _priority_score(item))
@@ -822,6 +844,14 @@ def _evidence_refresh_for_item(domain: str, item: Dict[str, Any]) -> Dict[str, A
 
 def _apply_loop_metadata(domain: str, items: List[Dict[str, Any]]) -> None:
     for item in items:
+        optional_hardening = _is_optional_hardening_item(item)
+        item["scope"] = "optional_hardening" if optional_hardening else "core_mail_health"
+        item["priority_group"] = "optional_hardening" if optional_hardening else "core_mail_health"
+        item["priority_reason"] = (
+            "Optional transport, brand, or DNS hardening is shown after active DMARC mail-health blockers."
+            if optional_hardening
+            else "Active mail-health and DMARC evidence takes priority over optional hardening."
+        )
         item["incident_type"] = _incident_type_for_item(item)
         item["loop_state"] = _loop_state_for_item(item)
         item["remediation_track"] = _remediation_track(item)
@@ -1188,6 +1218,7 @@ def _dns_item(
         "blast_radius": f"DNS record {plan.get('name')} ({plan.get('record_type')})",
         "prerequisites": prerequisites,
         "expected_health_score_impact": str(plan.get("expected_health_impact") or ""),
+        "finding_code": str(plan.get("finding_code") or ""),
         "automation": {
             "eligible": automation_ready,
             "requires_approval": True,
@@ -1366,6 +1397,7 @@ def _health_item(domain: str, action: Dict[str, Any]) -> Dict[str, Any]:
         "prerequisites": playbook["prerequisites"],
         "completion_criteria": playbook["completion_criteria"],
         "expected_health_score_impact": str(action.get("score_impact") or 0),
+        "finding_code": str(action.get("type") or ""),
         "automation": {
             "eligible": False,
             "requires_approval": True,
@@ -1703,6 +1735,7 @@ def build_remediation_queue(
     _attach_notification_profiles(domain, items)
     items.sort(
         key=lambda item: (
+            item.get("priority_group") != "core_mail_health",
             item["state"] != "approval_ready",
             -SEVERITY_RANK.get(item["severity"], 0),
             -int(item.get("priority_score") or 0),

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -924,12 +924,21 @@ function domainDetailsApp(domainId = '') {
         },
 
         get primaryRemediationScopeNote() {
+            if (this.primaryRemediationItem?.priority_reason) {
+                return this.primaryRemediationItem.priority_reason;
+            }
             const itemId = String(this.primaryRemediationItem?.id || '').toLowerCase();
             const optionalPosture = ['bimi', 'mta_sts', 'mta-sts', 'tls_rpt', 'tls-rpt'];
             if (optionalPosture.some(token => itemId.includes(token))) {
                 return 'No higher-priority DMARC authentication blocker is active. This is an optional posture improvement.';
             }
             return 'DMARQ prioritizes active DMARC failures, sender alignment, and enforcement blockers before optional posture work.';
+        },
+
+        get primaryRemediationScopeLabel() {
+            return this.primaryRemediationItem?.scope === 'optional_hardening'
+                ? 'Optional hardening'
+                : 'Core mail health';
         },
 
         get primaryRemediationReadinessContext() {
@@ -2885,7 +2894,7 @@ function domainDetailsApp(domainId = '') {
             this.dnsWrite.error = '';
             this.dnsWrite.message = apply
                 ? `Applying this change to ${this.providerName(this.dnsWrite.provider)}...`
-                : `Preparing a ${this.providerName(this.dnsWrite.provider)} preview...`;
+                : `Preparing the exact ${this.providerName(this.dnsWrite.provider)} preview...`;
             try {
                 const response = await fetch(`/api/v1/domains/${this.domainId}/dns/change-plan/apply`, {
                     method: 'POST',
@@ -2923,7 +2932,7 @@ function domainDetailsApp(domainId = '') {
                     ? (data.verification?.verified
                         ? 'DNS change verified by the provider. Refreshing DNS evidence now.'
                         : 'DNS change submitted, but provider verification is not complete. Review the verification details before treating it as repaired.')
-                    : 'Preview ready. Review the provider mutation before applying.';
+                    : 'Preview ready. Review the Before/After change below. No live DNS change has been made.';
                 if (apply) {
                     await this.refreshDNSData();
                 }

--- a/backend/app/static/js/domain-details-page.js
+++ b/backend/app/static/js/domain-details-page.js
@@ -218,6 +218,12 @@ function domainDetailsApp(domainId = '') {
             loading: true,
             error: ''
         },
+        sourceSnapshot: {
+            version: '',
+            period_days: 30,
+            as_of: 0,
+            counts: {}
+        },
         sourceIntelligenceRefreshError: '',
         ownership: {
             loading: false,
@@ -737,6 +743,20 @@ function domainDetailsApp(domainId = '') {
         },
 
         get sourceRiskCounts() {
+            const snapshotCounts = this.sourceSnapshot?.counts || {};
+            if (Object.prototype.hasOwnProperty.call(snapshotCounts, 'total')) {
+                return {
+                    total: Number(snapshotCounts.total || 0),
+                    risky: Number(snapshotCounts.risky || 0),
+                    listed: Number(snapshotCounts.listed || 0),
+                    unchecked: Number(snapshotCounts.unchecked || 0),
+                    authReview: Number(snapshotCounts.auth_review || 0),
+                    recent: Number(snapshotCounts.recent || 0),
+                    authenticated: Number(snapshotCounts.authenticated || 0),
+                    protectiveAction: Number(snapshotCounts.protective_action || 0),
+                    noDmarcAction: Number(snapshotCounts.no_dmarc_action || 0)
+                };
+            }
             return (this.sources || []).reduce(
                 (counts, source) => {
                     counts.total += 1;
@@ -861,8 +881,9 @@ function domainDetailsApp(domainId = '') {
         sourceActivityBucket(source) {
             if (!source?.last_seen) return 'unknown';
             const date = new Date(Number(source.last_seen) * 1000);
-            if (Number.isNaN(date.getTime())) return 'unknown';
-            const diffDays = Math.floor((Date.now() - date.getTime()) / 86400000);
+            const asOf = Number(this.sourceSnapshot?.as_of || 0) * 1000;
+            if (Number.isNaN(date.getTime()) || !asOf) return 'unknown';
+            const diffDays = Math.floor((asOf - date.getTime()) / 86400000);
             if (diffDays <= 14) return 'recent';
             if (diffDays <= 90) return 'older';
             return 'stale';
@@ -3695,6 +3716,9 @@ function domainDetailsApp(domainId = '') {
                 const data = await response.json();
                 this.sources = (Array.isArray(data.sources) ? data.sources : [])
                     .map(source => this.normalizeSource(source));
+                this.sourceSnapshot = data.snapshot && typeof data.snapshot === 'object'
+                    ? data.snapshot
+                    : { version: '', period_days: this.sourceDateWindow(), as_of: 0, counts: {} };
                 this.mailflowAssessment = data.mailflow_assessment || {
                     status: 'insufficient_evidence',
                     title: 'Waiting for mailflow evidence',

--- a/backend/app/static/js/report-detail-page.js
+++ b/backend/app/static/js/report-detail-page.js
@@ -46,6 +46,12 @@ function reportDetailApp(reportId = '') {
                     return;
                 }
 
+                const hydrateButton = event.target.closest('[data-report-hydrate-enrichment]');
+                if (hydrateButton && root.contains(hydrateButton)) {
+                    this.hydrateEnrichment();
+                    return;
+                }
+
                 const riskFilterButton = event.target.closest('[data-report-risk-filter]');
                 if (riskFilterButton && root.contains(riskFilterButton)) {
                     this.setRecordRiskFilter(riskFilterButton.dataset.reportRiskFilter || 'all');
@@ -118,9 +124,6 @@ function reportDetailApp(reportId = '') {
                     }
                     if (!refreshReputation) {
                         this.reputationRefreshError = '';
-                    }
-                    if (!refreshReputation && this.report?.enrichment?.pending) {
-                        this.hydrateEnrichment();
                     }
                 } else if (response.status === 404) {
                     if (!refreshReputation) {

--- a/backend/app/static/js/settings-page.js
+++ b/backend/app/static/js/settings-page.js
@@ -66,6 +66,10 @@ function settingsApp() {
         testingAIConnection: false,
         loadingAccountReadiness: false,
         accountReadiness: null,
+        setupState: {
+            checklist: [],
+            next_step: 'Loading setup state...'
+        },
         resolverStatus: null,
         aiProviderProfiles: [],
         aiConnectionResult: null,
@@ -232,6 +236,7 @@ function settingsApp() {
                 const map = {};
                 rows.forEach(r => { map[r.key] = r.value ?? ''; });
                 this.s = map;
+                await this.loadSetupState(false);
                 this.applyCloudflareOAuthQueryState();
                 await this.loadResolverStatus(false);
                 await this.loadAlertHistory(false);
@@ -261,6 +266,16 @@ function settingsApp() {
                 if (showFlash) this.showFlash('Error loading account readiness: ' + err.message, false);
             } finally {
                 this.loadingAccountReadiness = false;
+            }
+        },
+
+        async loadSetupState(showFlash = true) {
+            try {
+                const res = await fetch('/api/v1/settings/setup-state', { headers: this.apiHeaders() });
+                if (!res.ok) throw new Error(res.statusText);
+                this.setupState = await res.json();
+            } catch (err) {
+                if (showFlash) this.showFlash('Error loading setup state: ' + err.message, false);
             }
         },
 

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2496,7 +2496,7 @@
                                                         :data-dns-plan-id="plan.plan_id"
                                                         data-domain-detail-dns-action="preview"
                                                     >
-                                                        <span x-show="!(dnsWriteIsActive(plan) && dnsWrite.loading)">1. Preview exact change</span>
+                                                        <span x-show="!(dnsWriteIsActive(plan) && dnsWrite.loading)">1. Preview change</span>
                                                         <span x-show="dnsWriteIsActive(plan) && dnsWrite.loading" class="inline-flex items-center gap-1">
                                                             <span class="loading loading-spinner loading-xs" aria-hidden="true"></span>
                                                             Preparing preview...

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -123,6 +123,9 @@
                                       :class="repairReadinessClass(primaryRemediationItem.repair_progression)"
                                       x-text="repairReadinessLabel(primaryRemediationItem.repair_progression)"></span>
                                 <span class="rounded px-2 py-1 text-xs font-semibold"
+                                      :class="primaryRemediationItem.scope === 'optional_hardening' ? 'bg-slate-100 text-slate-700' : 'bg-[#e7f7f3] text-[#0f6b4d]'"
+                                      x-text="primaryRemediationScopeLabel"></span>
+                                <span class="rounded px-2 py-1 text-xs font-semibold"
                                       :class="primaryRemediationVerificationStatusClass"
                                       x-text="primaryRemediationVerificationStatusLabel"></span>
                             </div>
@@ -2493,7 +2496,7 @@
                                                         :data-dns-plan-id="plan.plan_id"
                                                         data-domain-detail-dns-action="preview"
                                                     >
-                                                        <span x-show="!(dnsWriteIsActive(plan) && dnsWrite.loading)">1. Preview change</span>
+                                                        <span x-show="!(dnsWriteIsActive(plan) && dnsWrite.loading)">1. Preview exact change</span>
                                                         <span x-show="dnsWriteIsActive(plan) && dnsWrite.loading" class="inline-flex items-center gap-1">
                                                             <span class="loading loading-spinner loading-xs" aria-hidden="true"></span>
                                                             Preparing preview...
@@ -2541,6 +2544,7 @@
                                             <template x-if="dnsWrite.preview && dnsWrite.preview.plan_id === plan.plan_id">
                                                 <div class="mt-3 rounded border border-[#2f9da5]/30 bg-[#2f9da5]/10 p-3 text-xs">
                                                     <div class="font-semibold">2. Review before applying</div>
+                                                    <p class="mt-1 text-base-content/70">This is a read-only preview. Nothing has changed in DNS yet.</p>
                                                     <div class="mt-1 grid gap-1 sm:grid-cols-2">
                                                         <p><span class="font-semibold">Operation:</span> <span x-text="dnsWrite.preview.mutation.operation"></span></p>
                                                         <p><span class="font-semibold">Provider:</span> <span x-text="dnsWrite.preview.provider"></span></p>

--- a/backend/app/templates/domain_details.html
+++ b/backend/app/templates/domain_details.html
@@ -2912,6 +2912,10 @@
                         <span x-text="sourceRiskCounts.unchecked"></span><span class="ml-1">unchecked reputation</span>
                     </button>
                 </div>
+                <p class="mb-4 text-xs text-muted-foreground" x-show="!sourcesLoading && !sourcesError && sourceSnapshot.version">
+                    Source snapshot <span class="font-mono" x-text="sourceSnapshot.version"></span>
+                    · counts and rows from the same saved window
+                </p>
                 <div class="sending-sources-list space-y-3" data-sending-sources-list>
                         <template x-if="sources.length === 0">
                             <div class="rounded-lg border border-base-300 bg-base-100 px-4 py-6 text-center" data-sending-sources-empty>

--- a/backend/app/templates/report_detail.html
+++ b/backend/app/templates/report_detail.html
@@ -88,6 +88,22 @@
                     <button type="button" class="btn btn-sm" :class="guidanceContextButtonClass('diagnose')" :aria-pressed="guidanceContext === 'diagnose'" data-report-guidance-context="diagnose">Diagnose</button>
                     <button type="button" class="btn btn-sm" :class="guidanceContextButtonClass('evidence')" :aria-pressed="guidanceContext === 'evidence'" data-report-guidance-context="evidence">Evidence</button>
                 </div>
+                <div x-show="report.enrichment && report.enrichment.pending"
+                     x-cloak
+                     class="mt-4 flex flex-col gap-3 rounded-md border border-[#d7eef0] bg-[#f1fbfc] p-3 text-sm sm:flex-row sm:items-center sm:justify-between"
+                     role="status"
+                     aria-live="polite">
+                    <div>
+                        <p class="font-semibold text-[#120d36]">Some sender enrichment is not stored yet.</p>
+                        <p class="mt-1 text-xs text-[#5f5c78]">This report loaded from persisted evidence. Ask DMARQ to perform optional live enrichment only when you need it.</p>
+                    </div>
+                    <button type="button"
+                            class="btn btn-sm border-0 bg-[#2f9da5] text-white hover:bg-[#272a5f]"
+                            data-report-hydrate-enrichment
+                            :disabled="enrichmentHydrating">
+                        <span x-text="enrichmentHydrating ? 'Loading enrichment...' : 'Load missing enrichment'"></span>
+                    </button>
+                </div>
             </div>
 
             <section class="rounded-lg border border-[#d8edf0] bg-[#f3fbfc] p-5 shadow-sm"

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -47,19 +47,26 @@
                 <p class="text-sm font-semibold uppercase tracking-wide text-[#2f9da6]">Recommended setup</p>
                 <h1 class="mt-1 text-2xl font-bold text-[#120d36]">Finish the next safe setup step</h1>
                 <p class="mt-2 max-w-3xl text-sm text-[#5f5c78]">
-                    Connect the mailbox that receives DMARC reports first. Add domains and DNS automation only after report intake is working.
+                    <span x-text="setupState.next_step">Connect report intake first.</span>
                 </p>
             </div>
             <div class="flex flex-wrap gap-2">
-                <a href="/mail-sources" class="btn btn-primary btn-md">Connect report mailbox</a>
-                <a href="/domains" class="btn btn-outline btn-md">Add or review domains</a>
+                <template x-for="item in setupState.checklist" :key="item.key">
+                    <a x-show="item.status === 'Next'" :href="item.href" class="btn btn-primary btn-md" x-text="item.action"></a>
+                </template>
+                <a href="/domains" class="btn btn-outline btn-md">Review domains</a>
             </div>
         </div>
         <ol class="mt-5 grid gap-2 border-t border-[#e6e3e1] pt-4 text-sm sm:grid-cols-2 xl:grid-cols-4">
-            <li class="flex items-center gap-3"><span class="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-[#272a5f] text-xs font-bold text-white">1</span><a class="font-semibold text-[#120d36] hover:text-[#2f9da5]" href="/mail-sources">Connect reports</a></li>
-            <li class="flex items-center gap-3"><span class="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-[#edf7f7] text-xs font-bold text-[#247982]">2</span><a class="font-semibold text-[#120d36] hover:text-[#2f9da5]" href="/domains">Add domains</a></li>
-            <li class="flex items-center gap-3"><span class="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-[#edf7f7] text-xs font-bold text-[#247982]">3</span><a class="font-semibold text-[#120d36] hover:text-[#2f9da5]" href="#provider-integrations">Review DNS</a></li>
-            <li class="flex items-center gap-3"><span class="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-[#edf7f7] text-xs font-bold text-[#247982]">4</span><a class="font-semibold text-[#120d36] hover:text-[#2f9da5]" href="#notification-settings">Choose notifications</a></li>
+            <template x-for="(item, index) in setupState.checklist" :key="item.key">
+                <li class="flex items-center gap-3">
+                    <span class="grid h-7 w-7 shrink-0 place-items-center rounded-full text-xs font-bold"
+                          :class="item.ready ? 'bg-[#edf7f7] text-[#247982]' : (item.status === 'Next' ? 'bg-[#272a5f] text-white' : 'bg-[#f4f3f2] text-[#8a879e]')"
+                          x-text="index + 1"></span>
+                    <a class="font-semibold text-[#120d36] hover:text-[#2f9da5]" :href="item.href" x-text="item.title"></a>
+                    <span class="text-xs text-[#8a879e]" x-text="item.status"></span>
+                </li>
+            </template>
         </ol>
     </header>
 

--- a/backend/app/templates/settings.html
+++ b/backend/app/templates/settings.html
@@ -54,7 +54,8 @@
                 <template x-for="item in setupState.checklist" :key="item.key">
                     <a x-show="item.status === 'Next'" :href="item.href" class="btn btn-primary btn-md" x-text="item.action"></a>
                 </template>
-                <a href="/domains" class="btn btn-outline btn-md">Review domains</a>
+                <a href="/mail-sources" class="btn btn-outline btn-md">Connect report mailbox</a>
+                <a href="/domains" class="btn btn-outline btn-md">Add or review domains</a>
             </div>
         </div>
         <ol class="mt-5 grid gap-2 border-t border-[#e6e3e1] pt-4 text-sm sm:grid-cols-2 xl:grid-cols-4">

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2437,7 +2437,7 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
     assert "providerContextCtaHref" in script
     assert "Apply one DNS change safely" in template
     assert "Configure provider access" in template
-    assert "1. Preview exact change" in template
+    assert "1. Preview change" in template
     assert "2. Review before applying" in template
     assert "3. Apply to" in template
     assert "dnsWriteCanApply(plan)" in template

--- a/backend/app/tests/test_dashboard_template_security.py
+++ b/backend/app/tests/test_dashboard_template_security.py
@@ -2020,11 +2020,12 @@ def test_report_detail_uses_external_page_script_for_csp_migration():
     assert "normalizeReport" in script
     assert "hydrateEnrichment" in script
     assert "enrichmentHydrating" in script
+    assert "data-report-hydrate-enrichment" in template
     assert "const controller = new AbortController();" in script
     assert "{ signal: controller.signal }" in script
     assert "source_details: next.records?.[index]?.source_details" in script
     assert "...next," not in script
-    assert "report?.enrichment?.pending" in script
+    assert "data-report-hydrate-enrichment" in script
     assert "reportDomainUrl" in script
     assert "?." not in template
     assert "??" not in template
@@ -2436,7 +2437,7 @@ def test_domain_details_exposes_dns_provider_repair_context_without_html_injecti
     assert "providerContextCtaHref" in script
     assert "Apply one DNS change safely" in template
     assert "Configure provider access" in template
-    assert "1. Preview change" in template
+    assert "1. Preview exact change" in template
     assert "2. Review before applying" in template
     assert "3. Apply to" in template
     assert "dnsWriteCanApply(plan)" in template

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -1203,6 +1203,9 @@ def test_domain_remediation_queue_groups_dns_and_health_actions(
     assert data["summary"]["approval_ready"] == 1
     assert data["summary"]["investigate"] == 1
     assert data["summary"]["provider_fix_available"] == 1
+    assert data["snapshot"]["version"]
+    assert data["snapshot"]["source_version"]
+    assert data["snapshot"]["period_days"] == 30
     assert data["loop"]["status"] == "approval_required"
     assert data["loop"]["what_dmarq_can_fix"] == 1
     assert data["loop"]["what_needs_investigation"] == 1

--- a/backend/app/tests/test_domain_detail_endpoints.py
+++ b/backend/app/tests/test_domain_detail_endpoints.py
@@ -2756,6 +2756,9 @@ def test_get_domain_sources_returns_200(seeded_client: TestClient):
     assert source["mailflow"]["dkim_alignment"] == "pass"
     assert data["mailflow_assessment"]["status"] == "healthy"
     assert data["mailflow_assessment"]["flows"][0]["header_from_domains"] == [DOMAIN]
+    assert data["snapshot"]["version"]
+    assert data["snapshot"]["counts"]["total"] == 1
+    assert data["snapshot"]["counts"]["authenticated"] == 1
 
 
 def test_get_domain_sources_guides_dkim_repair_from_stored_report_facts(
@@ -3183,6 +3186,10 @@ def test_get_domain_sources_returns_rollup_counts(authed_client: TestClient):
     assert source["dmarc_fail_count"] == 6
     assert source["disposition_counts"] == {"none": 4, "quarantine": 6}
     assert source["first_seen"] == REPORT_DICT_POLICY["begin_timestamp"]
+    snapshot = response.json()["snapshot"]
+    assert snapshot["counts"]["total"] == 1
+    assert snapshot["counts"]["auth_review"] == 1
+    assert snapshot["period_days"] == 30
     assert source["last_seen"] == REPORT_DICT_POLICY["end_timestamp"]
     assert source["active_days"] == 1
     assert source["report_count"] == 1

--- a/backend/app/tests/test_evidence_snapshot.py
+++ b/backend/app/tests/test_evidence_snapshot.py
@@ -1,0 +1,85 @@
+"""Tests for deterministic persisted evidence identities."""
+
+from app.services.evidence_snapshot import (
+    build_domain_evidence_snapshot,
+    source_projection_version,
+)
+
+
+def test_source_projection_version_normalizes_report_and_api_field_names():
+    report_row = {
+        "source_ip": "192.0.2.20",
+        "count": "4",
+        "first_seen": "not-a-timestamp",
+        "last_seen": None,
+        "dmarc_result": "fail",
+        "spf_result": "pass",
+        "dkim_result": "fail",
+        "disposition": None,
+    }
+    api_row = {
+        "ip": "192.0.2.20",
+        "count": 4,
+        "first_seen": 0,
+        "last_seen": 0,
+        "dmarc": "fail",
+        "spf": "pass",
+        "dkim": "fail",
+        "disposition": "none",
+    }
+
+    assert source_projection_version([report_row], days=30) == source_projection_version(
+        [api_row], days=30
+    )
+    assert source_projection_version([api_row], days=30) != source_projection_version(
+        [api_row], days=7
+    )
+
+
+def test_source_projection_version_accepts_model_dump_rows_and_is_order_independent():
+    class Row:
+        def model_dump(self):
+            return {"ip": "192.0.2.10", "count": 1}
+
+    rows = [{"ip": "192.0.2.11", "count": 2}, Row()]
+    assert source_projection_version(rows, days=30) == source_projection_version(
+        list(reversed(rows)), days=30
+    )
+
+
+def test_domain_evidence_snapshot_uses_health_capture_before_fallback():
+    snapshot = build_domain_evidence_snapshot(
+        {
+            "assessment_version": 3,
+            "evidence_captured_at": "2026-07-31T12:00:00Z",
+            "score": 92,
+            "factors": {"dmarc": 100},
+            "path_to_100": {"remaining": 8},
+        },
+        [{"ip": "192.0.2.10", "count": 5}],
+        days=30,
+        captured_at="fallback",
+    )
+
+    assert snapshot["captured_at"] == "2026-07-31T12:00:00Z"
+    assert snapshot["stale"] is False
+    assert snapshot["health_version"] == "3"
+    assert snapshot["source_rows"] == 1
+    assert len(snapshot["version"]) == 16
+
+
+def test_domain_evidence_snapshot_marks_missing_capture_stale():
+    snapshot = build_domain_evidence_snapshot(
+        {"score": None},
+        [],
+        days=30,
+        captured_at="2026-07-31T12:00:00Z",
+    )
+
+    assert snapshot["captured_at"] == "2026-07-31T12:00:00Z"
+    assert snapshot["stale"] is False
+    assert snapshot["health_version"] == "1"
+
+    stale = build_domain_evidence_snapshot({"score": None}, [], days=30)
+    assert stale["captured_at"] is None
+    assert stale["stale"] is True

--- a/backend/app/tests/test_mailflow_assessment.py
+++ b/backend/app/tests/test_mailflow_assessment.py
@@ -153,6 +153,23 @@ def test_known_sender_dmarc_failure_requests_alignment_review():
     assert result["unknowns"]
 
 
+def test_expected_forwarding_classification_is_used_by_domain_mailflow_view():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [_source(spf_pass_count=0, spf_fail_count=12, dkim_pass_count=12, dkim_fail_count=0)],
+        {"192.0.2.10": {"name": "Cloudflare Email Routing", "status": "known"}},
+        classifications={
+            ("example.com", "192.0.2.10"): {"classification": "expected_forwarding"}
+        },
+    )
+
+    assert result["status"] == "investigation_required"
+    assert result["counts"]["expected_forwarding"] == 1
+    assert result["flows"][0]["status"] == "expected_forwarding"
+    assert result["flows"][0]["operator_classification"] == "expected_forwarding"
+    assert "Do not add its shared relay IP" in result["summary"]
+
+
 def test_zero_traffic_is_ignored():
     result = build_domain_mailflow_assessment(
         "example.com",

--- a/backend/app/tests/test_mailflow_assessment.py
+++ b/backend/app/tests/test_mailflow_assessment.py
@@ -158,9 +158,7 @@ def test_expected_forwarding_classification_is_used_by_domain_mailflow_view():
         "example.com",
         [_source(spf_pass_count=0, spf_fail_count=12, dkim_pass_count=12, dkim_fail_count=0)],
         {"192.0.2.10": {"name": "Cloudflare Email Routing", "status": "known"}},
-        classifications={
-            ("example.com", "192.0.2.10"): {"classification": "expected_forwarding"}
-        },
+        classifications={("example.com", "192.0.2.10"): {"classification": "expected_forwarding"}},
     )
 
     assert result["status"] == "investigation_required"
@@ -168,6 +166,19 @@ def test_expected_forwarding_classification_is_used_by_domain_mailflow_view():
     assert result["flows"][0]["status"] == "expected_forwarding"
     assert result["flows"][0]["operator_classification"] == "expected_forwarding"
     assert "Do not add its shared relay IP" in result["summary"]
+
+
+def test_unauthorized_classification_is_explained_without_dns_authorization():
+    result = build_domain_mailflow_assessment(
+        "example.com",
+        [_source(spf_pass_count=0, spf_fail_count=12, dmarc_pass_count=0, dmarc_fail_count=12)],
+        {"192.0.2.10": {"name": "Unknown sender", "status": "unknown"}},
+        classifications={("example.com", "192.0.2.10"): {"classification": "unauthorized"}},
+    )
+
+    assert result["flows"][0]["status"] == "likely_unauthorized"
+    assert result["flows"][0]["operator_classification"] == "unauthorized"
+    assert result["flows"][0]["next_step"] == "No DNS authorization; keep monitoring for recurrence"
 
 
 def test_zero_traffic_is_ignored():

--- a/backend/app/tests/test_remediation_queue.py
+++ b/backend/app/tests/test_remediation_queue.py
@@ -562,6 +562,57 @@ def test_remediation_queue_prioritizes_provider_ready_dns_plan():
     ]
 
 
+def test_remediation_queue_keeps_optional_hardening_after_core_mail_health():
+    queue = build_remediation_queue(
+        domain="example.com",
+        health={
+            "actions": [
+                {
+                    "type": "low_compliance",
+                    "severity": "low",
+                    "title": "Investigate failing sender",
+                    "detail": "A known sender is failing DMARC.",
+                    "score_impact": 2,
+                }
+            ]
+        },
+        dns_guidance={
+            "findings": [
+                {
+                    "code": "mta_sts_missing",
+                    "severity": "error",
+                    "title": "Publish MTA-STS",
+                    "detail": "MTA-STS is not configured.",
+                }
+            ],
+            "change_plans": [
+                {
+                    "plan_id": "mta-sts",
+                    "finding_code": "mta_sts_missing",
+                    "severity": "error",
+                    "operation": "create",
+                    "record_type": "TXT",
+                    "name": "_mta-sts.example.com",
+                    "proposed_value": "v=STSv1; id=20260731",
+                    "current_values": [],
+                    "rationale": "Publish an MTA-STS policy identifier.",
+                    "expected_health_impact": "Low",
+                }
+            ],
+        },
+        available_write_providers=["cloudflare"],
+        recommended_provider="cloudflare",
+    )
+
+    assert [item["id"] for item in queue["items"]] == [
+        "health:low_compliance",
+        "dns:mta-sts",
+    ]
+    assert queue["items"][0]["scope"] == "core_mail_health"
+    assert queue["items"][1]["scope"] == "optional_hardening"
+    assert "optional" in queue["items"][1]["priority_reason"].lower()
+
+
 def test_remediation_queue_keeps_placeholder_plan_manual():
     queue = build_remediation_queue(
         domain="example.com",

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -1252,7 +1252,7 @@ def test_get_report_by_id_includes_source_intelligence_and_reputation(
     monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", fake_reputation)
     monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", fake_networks)
 
-    response = authed_client.get("/api/v1/reports/source-intel-report")
+    response = authed_client.get("/api/v1/reports/source-intel-report?hydrate_enrichment=true")
 
     assert response.status_code == 200
     record = response.json()["records"][0]
@@ -1661,7 +1661,9 @@ def test_get_report_by_id_dedupes_ptr_lookups_for_repeated_source_ips(
     monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", fake_networks)
 
     started = time.monotonic()
-    response = authed_client.get("/api/v1/reports/large-ptr-dedupe-report")
+    response = authed_client.get(
+        "/api/v1/reports/large-ptr-dedupe-report?hydrate_enrichment=true"
+    )
     elapsed = time.monotonic() - started
 
     assert response.status_code == 200
@@ -1736,6 +1738,45 @@ def test_report_detail_prefers_point_in_time_source_evidence(
     assert body["enrichment"]["network"] == "complete"
     assert body["records"][0]["source_details"]["hostname"] == "stored.example.net"
     assert body["records"][0]["source_details"]["asn"] == "AS64500"
+
+
+def test_default_report_detail_does_not_live_enrich_missing_projection_evidence(
+    authed_client: TestClient,
+    db_session,
+    monkeypatch,
+):
+    """A normal report read must remain a fast projection read."""
+    workspace = get_or_create_default_workspace(db_session)
+    _persist_parsed_report(
+        db_session,
+        _parsed_report(domain="projection-only.example", report_id="projection-only-report"),
+        workspace_id=workspace.id,
+    )
+    calls = {"ptr": 0, "network": 0, "reputation": 0}
+
+    async def unexpected_ptr(*_args, **_kwargs):
+        calls["ptr"] += 1
+        raise AssertionError("default report reads must not resolve PTR live")
+
+    async def unexpected_network(*_args, **_kwargs):
+        calls["network"] += 1
+        raise AssertionError("default report reads must not resolve network data live")
+
+    async def cached_only_reputation(*_args, **kwargs):
+        calls["reputation"] += 1
+        assert kwargs["allow_live"] is False
+        raise AssertionError("cache-only reputation should not query feeds")
+
+    monkeypatch.setattr(reports_endpoint, "_resolve_ptr_result", unexpected_ptr)
+    monkeypatch.setattr(reports_endpoint, "lookup_sources_network_cached", unexpected_network)
+    monkeypatch.setattr(reports_endpoint, "build_source_reputation_cached", cached_only_reputation)
+
+    response = authed_client.get("/api/v1/reports/projection-only-report")
+
+    assert response.status_code == 200
+    assert response.json()["enrichment"]["status"] == "partial"
+    assert response.json()["enrichment"]["pending"] is True
+    assert calls == {"ptr": 0, "network": 0, "reputation": 1}
 
 
 def test_report_ptr_enrichment_is_capped_and_preserves_completed_lookups(monkeypatch):
@@ -1849,14 +1890,14 @@ def test_get_report_by_id_bounds_slow_network_enrichment(
     assert body["enrichment"]["pending"] is True
     assert body["enrichment"]["status"] == "partial"
     assert elapsed < 3.0
-    assert len(set(network_calls)) <= 40
-    assert network_timeouts == [1.0]
+    assert network_calls == []
+    assert network_timeouts == []
 
     hydrated = authed_client.get(
         "/api/v1/reports/large-network-timeout-report?hydrate_enrichment=true"
     )
     assert hydrated.status_code == 200
-    assert network_timeouts == [1.0, 4.0]
+    assert network_timeouts == [4.0]
 
 
 def test_get_report_by_id_not_found(authed_client: TestClient):

--- a/backend/app/tests/test_settings.py
+++ b/backend/app/tests/test_settings.py
@@ -384,7 +384,7 @@ class TestSettingsAPI:
                 "settings": {
                     "dmarc.default_policy": "quarantine",
                     "dmarc.default_percentage": "80",
-        }
+                }
             },
         )
         assert res.status_code == 200

--- a/backend/app/tests/test_settings.py
+++ b/backend/app/tests/test_settings.py
@@ -13,6 +13,7 @@ from app.models.alert import AlertConfigurationAudit, AlertHistory
 from app.models.api_token import APIToken
 from app.models.domain import Domain
 from app.models.report import DMARCReport, ReportRecord
+from app.models.mail_source import MailSource
 from app.models.setting import Setting
 from app.models.workspace import Workspace
 from app.services.account_milestone import (
@@ -185,6 +186,35 @@ class TestSettingsAPI:
             "support_access",
         }.issubset(keys)
 
+    def test_setup_state_is_derived_from_current_domains_sources_and_reports(
+        self,
+        authed_client: TestClient,
+        db_session: Session,
+    ):
+        """The setup CTA advances only when the underlying product state is ready."""
+        response = authed_client.get("/api/v1/settings/setup-state")
+        assert response.status_code == 200
+        assert response.json()["checklist"][0]["status"] == "Next"
+
+        domain = _add_domain(db_session, "setup-state.example")
+        db_session.add(MailSource(name="Reports", method="IMAP", enabled=True))
+        _add_report_record(
+            db_session,
+            domain,
+            report_id="setup-state-report",
+            days_ago=0,
+            source_ip="192.0.2.44",
+            count=1,
+        )
+        db_session.commit()
+
+        data = authed_client.get("/api/v1/settings/setup-state").json()
+        assert data["domains"] == 1
+        assert data["enabled_sources"] == 1
+        assert data["reports"] == 1
+        assert all(item["ready"] for item in data["checklist"][:3])
+        assert data["checklist"][3]["status"] == "Optional"
+
     def test_account_readiness_auth_mode_detection(self):
         """The milestone summary reflects each supported auth mode signal."""
         assert _auth_mode(Settings(AUTH_DISABLED=True)) == "disabled"
@@ -354,7 +384,7 @@ class TestSettingsAPI:
                 "settings": {
                     "dmarc.default_policy": "quarantine",
                     "dmarc.default_percentage": "80",
-                }
+        }
             },
         )
         assert res.status_code == 200

--- a/backend/tests/browser/live-dmarc-flows.spec.js
+++ b/backend/tests/browser/live-dmarc-flows.spec.js
@@ -1901,6 +1901,7 @@ test('domain detail shows cached DNS evidence and sender reputation context', as
   await page.goto('/domains/cklnet.com');
 
   await expect(page.getByRole('heading', { name: 'cklnet.com' })).toBeVisible();
+  await page.getByRole('button', { name: 'Evidence' }).click();
   const dnsEvidence = page.locator('details', {
     has: page.locator('summary', { hasText: 'Email authentication and DNS fixes' }),
   });
@@ -1950,9 +1951,9 @@ test('DNS preview gives card-local progress and review feedback', async ({ page 
   }).first();
   await expect(plan.getByRole('button', { name: '1. Preview change' })).toBeVisible();
   await plan.getByRole('button', { name: '1. Preview change' }).click();
-  await expect(plan.getByText('Preparing a Cloudflare preview...')).toBeVisible();
+  await expect(plan.getByText('Preparing the exact Cloudflare preview...')).toBeVisible();
   await expect(plan.getByText('2. Review before applying')).toBeVisible();
-  await expect(plan.getByText('Preview ready. Review the provider mutation before applying.')).toBeVisible();
+  await expect(plan.getByText('Preview ready. Review the Before/After change below. No live DNS change has been made.')).toBeVisible();
   await expect(plan.getByRole('button', { name: /3\. Apply to Cloudflare/ })).toBeEnabled();
 });
 

--- a/docs/deployment/security-risk-acceptances.md
+++ b/docs/deployment/security-risk-acceptances.md
@@ -57,3 +57,47 @@ following occurs:
    exploit path.
 3. DMARQ begins invoking Perl in a supported runtime path.
 4. The review deadline is reached without a fresh documented assessment.
+
+## Debian `libsqlite3-0` in the Python runtime image
+
+| Field | Decision |
+| --- | --- |
+| Status | Temporarily accepted and tracked in [issue #805](https://github.com/christianlouis/dmarq/issues/805) |
+| Recorded | 2026-07-15 |
+| Review by | 2026-08-16, or the next base-image refresh, whichever comes first |
+| Affected image | Official `python:3.13-slim` runtime base on Debian 13 (trixie) |
+| Affected package | `libsqlite3-0` `3.46.1-7+deb13u1` |
+| Tracked CVEs | CVE-2026-50812, CVE-2026-50813 |
+| Owner | DMARQ maintainers |
+
+### Rationale
+
+- Snyk reported both findings as low severity in the inherited runtime package.
+- DMARQ uses SQLite through Python and SQLAlchemy for supported single-container
+  installations; removing SQLite would break the documented deployment mode.
+- A recheck of `ghcr.io/christianlouis/dmarq:docker-latest` on 2026-07-18
+  found the same installed version as Debian's current trixie candidate.
+- No fixed Debian trixie package or safe application-side remediation was
+  available at the last review. Mixing packages from another Debian suite
+  would create a larger, unsupported runtime dependency risk.
+
+### Required controls
+
+- Rebuild release images from the current official Python base so a fixed
+  package is inherited as soon as Debian publishes one.
+- Scan immutable release images during the release gate and record the
+  installed `libsqlite3-0` version against issue #805.
+- Keep the documented PostgreSQL deployment option available for operators
+  who require a database without the embedded SQLite runtime package.
+- Do not expose SQLite or arbitrary SQL execution through the HTTP surface.
+
+### Exit conditions
+
+End this acceptance and rebuild all published image tags when any of the
+following occurs:
+
+1. Debian trixie or the official Python slim image publishes a fixed package.
+2. A supported base image contains a fixed SQLite version without cross-suite
+   package mixing.
+3. A scanner raises the severity or shows an application-reachable exploit path.
+4. The review deadline is reached without a fresh documented assessment.

--- a/scripts/check-english-canonical.py
+++ b/scripts/check-english-canonical.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Reject accidental German operator copy outside explicit locale resources."""
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCAN_ROOTS = (ROOT / "backend" / "app", ROOT / "docs", ROOT / ".github")
+EXCLUDED_PARTS = {
+    "localization.py",
+    "localization.js",
+    "_REMEDIATION_STEPS_DE",
+    "test_localization.py",
+    "test_report_intake_recommendation.py",
+    "test_dns_guidance.py",
+    "test_diagnostic_plan.py",
+    "diagnostic_plan.py",
+    "report_intake_recommendation.py",
+    "mail_health_guidance.py",
+    "dns_guidance.py",
+    "demo_provider.py",
+    "demo_provider_seed.py",
+    "provider_demo.html",
+    "provider-demo-page.js",
+    "base-layout.js",
+    "base.html",
+    "test_dashboard_template_security.py",
+    "test_dns_endpoints.py",
+}
+GERMAN_MARKERS = re.compile(
+    r"\b(?:für|fuer|nicht|noch|eine|einen|einem|einer|"
+    r"keine|kann|muss|wird|werden|Prüfe|Pruefe|Öffne|Oeffne|Änder|Aender|"
+    r"Bericht|Postfach|Sitzung|Kunde|Bestätige|Bestaetige)\b",
+    re.IGNORECASE,
+)
+
+
+def allowed(path: Path) -> bool:
+    return any(marker in path.name for marker in EXCLUDED_PARTS)
+
+
+def main() -> int:
+    findings = []
+    for root in SCAN_ROOTS:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file() or allowed(path):
+                continue
+            if path.suffix not in {".py", ".js", ".html", ".md", ".yml", ".yaml"}:
+                continue
+            try:
+                lines = path.read_text(encoding="utf-8").splitlines()
+            except UnicodeDecodeError:
+                continue
+            for number, line in enumerate(lines, start=1):
+                if GERMAN_MARKERS.search(line):
+                    findings.append(f"{path.relative_to(ROOT)}:{number}: {line.strip()}")
+    if findings:
+        print("German source literals found outside approved locale resources:")
+        print("\n".join(findings))
+        return 1
+    print("English canonical source check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- prioritize core mail-health remediation ahead of optional DNS hardening
- keep report details projection-first and sender decisions consistent
- make Settings setup state-aware
- expose one deterministic evidence snapshot across sender and remediation projections
- enforce English as the canonical source language for new operator-facing content
- keep the guided Watch/Evidence UX contracts covered by browser smoke tests

## Validation
- `./.venv/bin/pytest -q backend/app/tests` (2368 passed)
- `DMARQ_BROWSER_SMOKE_PYTHON=../.venv/bin/python npm run test:browser -- --project=chromium` (29 passed, 3 provider-demo scenarios skipped by local smoke configuration)
- `python3 scripts/check-english-canonical.py`
- `git diff --check`

#927 #928 #929 #930 #931 #932 #938


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added setup guidance with readiness checklists and recommended next steps.
  * Added saved evidence snapshots with consistent reporting periods and risk counts.
  * Added sender classification for expected forwarding and unauthorized sources.
  * Added remediation labels distinguishing core mail health from optional hardening.
  * Added explicit controls for loading report enrichment when needed.

* **Improvements**
  * DNS previews now clearly indicate they are read-only.
  * Improved English-language consistency across guidance and provider-console text.
  * Reported evidence can now remain available without triggering live lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->