### PR TITLE
fix(onboarding): require org-scoped permission before applying to existing organizations

### DIFF
--- a/backend/app/api/api_v1/endpoints/onboarding.py
+++ b/backend/app/api/api_v1/endpoints/onboarding.py
@@ -9,9 +9,11 @@ from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.core.security import require_admin_auth
+from app.models.organization import Organization
 from app.services.organizations import OrganizationPlanLimitError
 from app.services.workspace_access import (
     PERMISSION_WORKSPACE_ADMIN,
+    require_organization_permission,
     require_workspace_permission,
 )
 from app.services.workspace_onboarding import (
@@ -128,6 +130,13 @@ async def apply_workspace_onboarding(
     """Apply a workspace onboarding template."""
     require_workspace_permission(_auth, PERMISSION_WORKSPACE_ADMIN)
     plan = _build_plan_or_422(payload)
+    existing_organization = db.query(Organization).filter(
+        Organization.slug == plan["organization"]["slug"]
+    ).first()
+    if existing_organization is not None:
+        require_organization_permission(
+            _auth, PERMISSION_WORKSPACE_ADMIN, db, existing_organization
+        )
     try:
         result = apply_onboarding_plan(db, plan=plan, auth_context=_auth, request=request)
     except OrganizationPlanLimitError as exc:

--- a/backend/app/tests/test_workspace_onboarding.py
+++ b/backend/app/tests/test_workspace_onboarding.py
@@ -344,11 +344,11 @@ def test_apply_onboarding_bootstraps_owner_memberships(test_app, db_session: Ses
     assert db_session.query(WorkspaceMembership).count() == 1
 
 
-def test_apply_onboarding_repairs_existing_inactive_owner_memberships(
+def test_apply_onboarding_cannot_claim_existing_organization_with_inactive_memberships(
     test_app,
     db_session: Session,
 ):
-    """Existing non-owner inactive memberships are promoted back to owner access."""
+    """Inactive memberships cannot be used to claim ownership of an organization."""
     organization = Organization(slug="acme", name="Acme", active=True)
     workspace = Workspace(
         slug="client-one",
@@ -383,16 +383,52 @@ def test_apply_onboarding_repairs_existing_inactive_owner_memberships(
             json=_standard_payload(organization={"slug": "acme", "name": "Acme"}),
         )
 
-    assert response.status_code == 200
-    owner = response.json()["result"]["owner"]
-    assert owner["organization_membership"] == "reactivated"
-    assert owner["workspace_membership"] == "reactivated"
+    assert response.status_code == 403
     org_membership = db_session.query(OrganizationMembership).one()
     workspace_membership = db_session.query(WorkspaceMembership).one()
-    assert org_membership.role == "organization_owner"
-    assert org_membership.active is True
-    assert workspace_membership.role == ROLE_WORKSPACE_OWNER
-    assert workspace_membership.active is True
+    assert org_membership.role == "organization_auditor"
+    assert org_membership.active is False
+    assert workspace_membership.role == "auditor"
+    assert workspace_membership.active is False
+
+
+def test_apply_onboarding_cannot_claim_another_users_organization(
+    test_app,
+    db_session: Session,
+):
+    """A tenant user cannot bootstrap owner access in an existing organization."""
+    victim = Organization(slug="victim", name="Victim", active=True)
+    attacker_organization = Organization(slug="attacker", name="Attacker", active=True)
+    attacker = User(email="attacker@example.com", is_active=True, is_verified=True)
+    db_session.add_all([victim, attacker_organization, attacker])
+    db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=attacker_organization.id,
+            user_id=attacker.id,
+            role="organization_owner",
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    with _client_as_user(test_app, db_session, attacker) as client:
+        response = client.post(
+            "/api/v1/onboarding/apply",
+            json=_standard_payload(organization={"slug": "victim", "name": "Victim"}),
+        )
+
+    assert response.status_code == 403
+    assert (
+        db_session.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.organization_id == victim.id,
+            OrganizationMembership.user_id == attacker.id,
+        )
+        .count()
+        == 0
+    )
+    assert db_session.query(Workspace).filter(Workspace.slug == "client-one").count() == 0
 
 
 def test_apply_onboarding_rejects_workspace_owned_by_another_organization(


### PR DESCRIPTION
### Motivation

- The onboarding `apply` endpoint could be used to claim ownership of an existing organization by name because it performed only an unscoped workspace permission check and then unconditionally bootstrapped owner memberships. This allowed cross-tenant ownership escalation.

### Description

- In `backend/app/api/api_v1/endpoints/onboarding.py` import `Organization` and `require_organization_permission` and, after rendering the plan with `_build_plan_or_422`, resolve the requested organization by slug and call `require_organization_permission(_auth, PERMISSION_WORKSPACE_ADMIN, db, existing_organization)` when the organization already exists to enforce organization-scoped authorization. 
- Preserved existing owner bootstrap behavior for newly-created organizations by only enforcing the additional check when an organization is found. 
- Updated tests in `backend/app/tests/test_workspace_onboarding.py` to expect `HTTP 403` when an attacker or an inactive membership attempts to claim an existing organization, and added `test_apply_onboarding_cannot_claim_another_users_organization` to cover the cross-tenant claim scenario.

### Testing

- Ran static checks with `ruff` on the modified files, which succeeded.  
- Ran `pytest -q backend/app/tests/test_workspace_onboarding.py`, and all tests passed (`17 passed`).  
- Verified `git diff --check` and formatting checks on edited files completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d8647c47883338d031f031789a0a2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding authorization for existing organizations.
  * Users without active workspace-admin access can no longer claim or modify an organization.
  * Prevented unauthorized membership or workspace creation during onboarding attempts.
  * Inactive memberships remain unchanged instead of being elevated to owner access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->