### PR TITLE
Secure manual production deployment defaults

### DIFF
--- a/docs/deployment/manual.md
+++ b/docs/deployment/manual.md
@@ -47,10 +47,10 @@ Create a `.env` file in the backend directory with your configuration. For produ
 DATABASE_URL=sqlite:///./data/dmarq.db
 SECRET_KEY=generate_a_secure_random_key
 ADMIN_API_KEY=generate_a_second_random_key
-ENVIRONMENT=development
-PUBLIC_BASE_URL=http://localhost:8080
-AUTH_MODE=disabled
-AUTH_DISABLED=true
+ENVIRONMENT=production
+PUBLIC_BASE_URL=https://dmarq.example.com
+AUTH_MODE=auto
+AUTH_DISABLED=false
 
 # Optional one-time IMAP source bootstrap
 # IMAP_SERVER=imap.gmail.com
@@ -60,6 +60,12 @@ AUTH_DISABLED=true
 # IMAP_FOLDER=INBOX
 DELETE_IMPORTED_EMAILS=false
 ```
+
+Keep authentication enabled for any network-accessible deployment. If you use
+OIDC or a trusted authentication proxy, configure its provider-specific
+settings before starting the service; otherwise, use the generated
+`ADMIN_API_KEY` for authenticated API access. Reserve `AUTH_MODE=disabled` and
+`AUTH_DISABLED=true` for local development bound to localhost.
 
 Generate separate random values for `SECRET_KEY` and `ADMIN_API_KEY`:
 


### PR DESCRIPTION
### Motivation
- The manual installation guide showed a development `.env` example (`ENVIRONMENT=development`, `AUTH_DISABLED=true`) and then reused that file in the production `systemd`/`Nginx` steps, which could expose admin/API endpoints without authentication.
- Change the documented defaults to ensure production startup safety checks are enabled and network-exposed deployments keep authentication active.

### Description
- Replace the example `.env` values with production-safe defaults: `ENVIRONMENT=production`, `PUBLIC_BASE_URL=https://dmarq.example.com`, `AUTH_MODE=auto`, and `AUTH_DISABLED=false` in `docs/deployment/manual.md`.
- Add guidance instructing operators to keep authentication enabled for any network-accessible deployment and to reserve `AUTH_MODE=disabled` / `AUTH_DISABLED=true` for local development bound to localhost.
- Preserve the documented `systemd` `EnvironmentFile=/path/to/dmarq/backend/.env` usage while ensuring the example `.env` no longer carries unsafe development settings into production.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff issues and it succeeded.
- Executed targeted Python assertions that verify the updated `docs/deployment/manual.md` contains `ENVIRONMENT=production`, `AUTH_MODE=auto`, and `AUTH_DISABLED=false`, and that the `systemd` section continues to reference `EnvironmentFile` in the production path, and they all passed.
- Performed a content sanity check of the modified file lines to ensure the development/auth-disabled defaults are not present in the production example and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d4bfeaee88333acb5f33527409d08)