### PR TITLE
fix: restrict shared native DNS credentials to provider operators

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -127,6 +127,7 @@ from app.services.organizations import (
 )
 from app.services.ovh_dns import get_ovh_dns_credentials
 from app.services.ptr_lookup import PtrLookupResult, lookup_ptr_with_fallbacks
+from app.services.provider_access import require_provider_operator_access
 from app.services.remediation_dispatch import (
     attach_remediation_dispatch_previews,
     summarize_remediation_activity,
@@ -220,6 +221,15 @@ REMEDIATION_NOTIFICATION_LIFECYCLE_STATES = {
     "resolved",
     "rejected",
 }
+SHARED_NATIVE_DNS_PROVIDERS = {"hetzner", "route53"}
+
+
+def _require_shared_dns_provider_operator(
+    db: Session, auth_context: Dict[str, Any], provider: str
+) -> None:
+    """Restrict deployment-wide native DNS credentials to provider operators."""
+    if normalize_provider_id(provider) in SHARED_NATIVE_DNS_PROVIDERS:
+        require_provider_operator_access(db, auth_context)
 
 
 def _authorized_domain_workspace(
@@ -6049,6 +6059,7 @@ async def import_dns_provider_domain_zones(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Import selected, or all new, DNS-provider zones as monitored domains."""
+    _require_shared_dns_provider_operator(db, _auth, provider)
     workspace = _authorized_domain_workspace(
         _auth,
         db,
@@ -6968,6 +6979,7 @@ async def apply_domain_dns_change_plan(  # noqa: C901 - orchestration keeps prev
                 ttl=payload.ttl,
             )
         else:
+            _require_shared_dns_provider_operator(db, _auth, payload.provider)
             record_type_replacement = bool(
                 plan.get("current_record_type")
                 and str(plan.get("current_record_type")).upper()

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 import dns.exception
 import dns.resolver
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -1759,6 +1760,30 @@ def test_dns_provider_import_endpoint_returns_import_summary(authed_client: Test
     data = response.json()
     assert data["provider"] == "cloudflare"
     assert data["imported"] == [DOMAIN]
+
+
+@pytest.mark.parametrize("provider", ["route53", "hetzner"])
+def test_shared_native_provider_import_requires_provider_operator(
+    authed_client: TestClient, provider: str
+):
+    import_mock = AsyncMock()
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains.require_provider_operator_access",
+            side_effect=HTTPException(
+                status_code=403, detail="Provider operator access is required"
+            ),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.import_dns_provider_domains",
+            new=import_mock,
+        ),
+    ):
+        response = authed_client.post(f"/api/v1/domains/dns/import/{provider}", json={})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Provider operator access is required"
+    import_mock.assert_not_awaited()
 
 
 def test_dns_provider_import_endpoint_rejects_unknown_provider(authed_client: TestClient):


### PR DESCRIPTION
### Motivation

- Prevent tenant escalation where workspace admins could import Route 53/Hetzner zones discovered via deployment-wide credentials and then perform live DNS writes using those shared credentials.

### Description

- Import `require_provider_operator_access` and introduce `SHARED_NATIVE_DNS_PROVIDERS = {"hetzner", "route53"}` in `backend/app/api/api_v1/endpoints/domains.py`.
- Add helper ` _require_shared_dns_provider_operator(db, auth_context, provider)` which calls `require_provider_operator_access` for shared native providers and invoke it at the start of `import_dns_provider_domain_zones` to block imports when the caller is not a provider operator.
- Call the same helper immediately before confirmed native DNS writes in the `apply_domain_dns_change_plan` flow to prevent non-operators from using shared credentials for live writes.
- Add regression tests in `backend/app/tests/test_cloudflare_dns.py` (`test_shared_native_provider_import_requires_provider_operator`) that assert `POST /api/v1/domains/dns/import/{provider}` returns `403` for `route53` and `hetzner` when provider-operator authorization is not present.

### Testing

- Ran the focused test subset: `python -m pytest app/tests/test_cloudflare_dns.py -k 'shared_native_provider_import_requires_provider_operator or dns_provider_import_endpoint_returns_import_summary'` and all selected tests passed (3 passed).
- Ran static checks and formatting with `ruff check` / `ruff format` and ensured `git diff --check` found no issues.
- Confirmed the changes touch `backend/app/api/api_v1/endpoints/domains.py` and `backend/app/tests/test_cloudflare_dns.py` and committed the fix as `fix: restrict shared native DNS credentials`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d3cb01f0483338e648b48322dc180)