### PR TITLE
fix: bound source projection report generator metadata

### DIFF
--- a/backend/app/services/source_read_projection.py
+++ b/backend/app/services/source_read_projection.py
@@ -21,6 +21,10 @@ logger = logging.getLogger(__name__)
 # The daily projection key spans reports, so locking individual report rows is
 # insufficient when two workers handle reports for the same sender/day.
 _SOURCE_PROJECTION_ADVISORY_LOCK_KEY = 1_144_591_954
+# Report generators come from report-controlled XML and are copied into each
+# per-source row. Keep that shared value small so one report cannot amplify an
+# oversized generator name across every projection it creates.
+MAX_REPORT_GENERATOR_LENGTH = 256
 
 
 def _acquire_source_projection_write_lock(db: Session) -> None:
@@ -61,8 +65,10 @@ def _json_list(value: str | None) -> List[Dict[str, Any]]:
     return [item for item in parsed if isinstance(item, dict)] if isinstance(parsed, list) else []
 
 
-def _add_unique(values: List[str], value: Any) -> None:
+def _add_unique(values: List[str], value: Any, *, max_length: int | None = None) -> None:
     text = str(value or "").strip()
+    if max_length is not None:
+        text = text[:max_length]
     if text and text not in values:
         values.append(text)
 
@@ -99,7 +105,7 @@ def _merge_metadata(current: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[s
         "spf_domains": list(current.get("spf_domains") or []),
         "dkim_domains": list(current.get("dkim_domains") or []),
         "dkim_selectors": list(current.get("dkim_selectors") or []),
-        "report_generators": list(current.get("report_generators") or []),
+        "report_generators": [],
         "extensions": dict(current.get("extensions") or {}),
     }
     for key in (
@@ -110,8 +116,13 @@ def _merge_metadata(current: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[s
         "dkim_selectors",
         "report_generators",
     ):
-        for value in incoming.get(key) or []:
-            _add_unique(merged[key], value)
+        values = list(current.get(key) or []) + list(incoming.get(key) or [])
+        for value in values:
+            _add_unique(
+                merged[key],
+                value,
+                max_length=MAX_REPORT_GENERATOR_LENGTH if key == "report_generators" else None,
+            )
     for key, value in (incoming.get("extensions") or {}).items():
         merged["extensions"].setdefault(str(key), str(value))
     return merged
@@ -142,7 +153,11 @@ def _projection_records(
             },
         )
         count = _int(record.get("count"))
-        _add_unique(item["metadata"]["report_generators"], report_generator)
+        _add_unique(
+            item["metadata"]["report_generators"],
+            report_generator,
+            max_length=MAX_REPORT_GENERATOR_LENGTH,
+        )
         item["message_count"] += count
         spf = str(record.get("spf_result") or record.get("spf") or "unknown").lower()
         dkim = str(record.get("dkim_result") or record.get("dkim") or "unknown").lower()

--- a/backend/app/tests/test_reports_api.py
+++ b/backend/app/tests/test_reports_api.py
@@ -28,6 +28,7 @@ from app.services.report_persistence import persisted_report_to_dict, save_parse
 from app.services.report_store import ReportStore
 from app.services.source_network import SourceNetworkIntelligence
 from app.services.source_read_projection import (
+    MAX_REPORT_GENERATOR_LENGTH,
     _acquire_source_projection_write_lock,
     backfill_source_projections,
     load_domain_source_read_projection,
@@ -121,6 +122,23 @@ def test_save_parsed_report_materializes_daily_sender_facts(db_session):
     assert projection.dmarc_fail_count == 3
     assert json.loads(projection.disposition_counts) == {"none": 7, "reject": 3}
     assert json.loads(projection.metadata_json)["report_generators"] == ["Workspace Test Org"]
+
+
+def test_source_projection_bounds_report_generator_per_source(db_session):
+    """Report-controlled metadata cannot amplify an oversized value across source rows."""
+    workspace = get_or_create_default_workspace(db_session)
+    report = _parsed_report(domain="bounded-generator.example", report_id="bounded-generator")
+    report["org_name"] = "r" * (MAX_REPORT_GENERATOR_LENGTH + 10_000)
+    report["records"].append({**report["records"][0], "source_ip": "192.0.2.56"})
+
+    save_parsed_report(db_session, report, workspace_id=workspace.id)
+    db_session.commit()
+
+    projections = db_session.query(DomainSourceDailyProjection).all()
+    assert len(projections) == 2
+    for projection in projections:
+        generators = json.loads(projection.metadata_json)["report_generators"]
+        assert generators == ["r" * MAX_REPORT_GENERATOR_LENGTH]
 
 
 def test_projection_backfill_materializes_unprojected_reports(db_session):


### PR DESCRIPTION
### Motivation

- Prevent unbounded report-controlled `org_name`/`email` values from being duplicated into every per-source projection row and causing multiplicative storage expansion.

### Description

- Add `MAX_REPORT_GENERATOR_LENGTH = 256` and truncate report generator strings before they are copied into per-source projection metadata in `backend/app/services/source_read_projection.py`.
- Extend `_add_unique()` with an optional `max_length` parameter and apply it when adding `report_generators` to per-source metadata so oversized values are clipped at ingestion time.
- Reapply the same bound inside `_merge_metadata()` so merging existing and incoming metadata normalizes previously oversized stored values on subsequent writes.
- Add a regression test `test_source_projection_bounds_report_generator_per_source` in `backend/app/tests/test_reports_api.py` that verifies oversized `org_name` is truncated per projection and does not amplify across rows.

### Testing

- Ran `pytest -q backend/app/tests/test_reports_api.py` and all tests passed (58 passed). 
- Ran the focused subset `-k 'source_projection_bounds_report_generator_per_source or save_parsed_report_materializes_daily_sender_facts or projection_backfill'` and those tests passed (5 passed).
- Ran `git diff --check` (no issues) and CI-local checks for the modified files; no failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d3c374b9483338c6d053f2e910292)