### PR TITLE
fix: bind DNS record migrations to generated plan values

### DIFF
--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -265,7 +265,13 @@ def lexicon_provider_environment_configured(provider_id: str) -> bool:
 
 
 def _plan_value(plan: Dict[str, Any], value_override: Optional[str]) -> str:
-    value = (value_override or plan.get("proposed_value") or "").strip()
+    planned_value = str(plan.get("proposed_value") or "").strip()
+    override = str(value_override or "").strip()
+    if _is_record_type_replacement(plan) and override and override != planned_value:
+        raise DNSProviderWriteError(
+            "Record-type migrations must use the generated DNS plan value"
+        )
+    value = override or planned_value
     if not value:
         raise DNSProviderWriteError("This DNS plan does not include an apply-ready record value")
     if "<" in value or ">" in value:

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -3731,12 +3731,12 @@ def test_dns_change_plan_apply_rejects_tampered_cname_migration_value(
                 "expected_record_type": "CNAME",
                 "expected_current_values": ["_dmarc.shared.example.net"],
                 "expected_record_id": "dmarc-cname",
-                "expected_proposed_value": plan["proposed_value"],
+                "expected_proposed_value": "v=DMARC1; p=reject",
             },
         )
 
     assert response.status_code == 422
-    assert "Proposed DNS value changed after preview" in response.json()["detail"]
+    assert "must use the generated DNS plan value" in response.json()["detail"]
 
 
 def test_dns_change_plan_requires_reviewed_baseline_for_cname_migration_apply(


### PR DESCRIPTION
### Motivation
- A CNAME-to-TXT DMARC migration path could be abused because the write path accepted a caller-supplied `value` override that `_plan_value()` preferred over the generated `plan['proposed_value']`, allowing an authenticated workspace user to replace the safe generated DMARC TXT with an arbitrary value.

### Description
- Update `_plan_value()` in `backend/app/services/dns_provider_writes.py` to compute `planned_value` and `override`, and to `raise DNSProviderWriteError` when `_is_record_type_replacement(plan)` is true and an `override` is provided that does not match the generated plan value, while preserving overrides for same-type DNS updates.
- Harden the regression test in `backend/app/tests/test_cloudflare_dns.py` so the tampered CNAME migration test exercises the attacker-controlled override scenario and verifies the request is rejected.
- Changes touch `backend/app/services/dns_provider_writes.py` and `backend/app/tests/test_cloudflare_dns.py` to bind record-type migrations to the generated plan value.

### Testing
- Ran `pytest -q backend/app/tests/test_cloudflare_dns.py` and the test suite completed successfully with all tests passing (`162 passed`).
- Ran focused tests exercising the CNAME migration regression and provider write flows and they passed (selected tests passed during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d3fb07a888333948a87b4532d7724)