### PR TITLE
fix(helm): require explicit unsafe auth override

### DIFF
--- a/deploy/helm/dmarq/ci/test-values.yaml
+++ b/deploy/helm/dmarq/ci/test-values.yaml
@@ -2,6 +2,7 @@ existingSecret: dmarq-test
 image:
   tag: docker-stable
 config:
+  environment: development
   publicBaseUrl: http://dmarq.dmarq-test.svc.cluster.local
 bootstrap:
   enabled: true

--- a/deploy/helm/dmarq/values.yaml
+++ b/deploy/helm/dmarq/values.yaml
@@ -37,7 +37,7 @@ secretKeys:
 
 config:
   projectName: DMARQ
-  environment: development
+  environment: production
   publicBaseUrl: http://dmarq.local
   language: en
   appTimezone: UTC


### PR DESCRIPTION
### Motivation
- The Helm chart defaulted to `config.environment: development` and `config.authMode: disabled`, allowing insecure, unauthenticated installs by default; the change forces the chart to exercise its production safety guard. 
- Preserve CI behavior by keeping the disposable CI fixture explicitly in development to avoid weakening test expectations.

### Description
- Updated `deploy/helm/dmarq/values.yaml` to set `config.environment: production` so the chart and backend startup checks reject auth-disabled installs unless explicitly allowed. 
- Added `config.environment: development` to `deploy/helm/dmarq/ci/test-values.yaml` so CI/test rendering remains in development mode. 
- Preserved `config.authMode: disabled` and `config.allowAuthDisabledInProduction: false` so operators must either configure an auth provider or set `allowAuthDisabledInProduction=true` to opt into the unsafe mode.

### Testing
- Ran a Python YAML assertion to confirm `values.yaml` defaults to production and the CI fixture remains in development, which succeeded. 
- Executed `python -m pytest backend/app/tests/test_config.py -q` which ran the test suite and returned `46 passed`. 
- Performed `git diff --check` and local git validations which succeeded and the change was committed. 
- `helm lint`/`helm template` could not be executed in this environment because Helm is not installed, so chart rendering checks were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d4a06485c8333911c9e59768e0af3)