### PR TITLE
fix: prevent support sessions from changing global settings

### DIFF
--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -59,6 +59,15 @@ from app.services.workspaces import assign_default_workspace_to_unscoped_rows
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+
+def _require_global_settings_mutation_access(auth_context: dict) -> None:
+    """Keep workspace-bound support sessions from changing global settings."""
+    if (auth_context or {}).get("auth_type") == "support_session":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Support sessions cannot modify deployment-wide settings",
+        )
+
 # ---------------------------------------------------------------------------
 # Defaults – used to seed missing keys on first read
 # ---------------------------------------------------------------------------
@@ -1186,6 +1195,7 @@ async def update_setting(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ) -> SettingResponse:
     """Update or create a single setting."""
+    _require_global_settings_mutation_access(_auth)
     selected_workspace_id = parse_selected_workspace_id(selected_workspace)
     row = _get_setting(key, db)
     new_value = payload.value
@@ -1245,6 +1255,7 @@ async def bulk_update_settings(
 
     Accepts ``{"settings": {"key1": "value1", "key2": "value2", ...}}``.
     """
+    _require_global_settings_mutation_access(_auth)
     results = []
     selected_workspace_id = parse_selected_workspace_id(selected_workspace)
     for key, value in payload.settings.items():

--- a/backend/app/tests/test_settings.py
+++ b/backend/app/tests/test_settings.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.core.config import Settings
 from app.core.credential_encryption import decrypt_secret, is_encrypted_secret
+from app.core.security import require_admin_auth
 from app.models.alert import AlertConfigurationAudit, AlertHistory
 from app.models.api_token import APIToken
 from app.models.domain import Domain
@@ -391,6 +392,58 @@ class TestSettingsAPI:
         data = {row["key"]: row["value"] for row in res.json()}
         assert data["dmarc.default_policy"] == "quarantine"
         assert data["dmarc.default_percentage"] == "80"
+
+    def test_support_session_cannot_update_global_setting(
+        self,
+        test_app,
+        client: TestClient,
+        db_session: Session,
+    ):
+        """Workspace-bound support access cannot change deployment-wide settings."""
+
+        async def support_session_auth():
+            return {
+                "auth_type": "support_session",
+                "workspace_id": "00000000-0000-0000-0000-000000000001",
+                "support_read_only": True,
+            }
+
+        test_app.dependency_overrides[require_admin_auth] = support_session_auth
+
+        res = client.put(
+            "/api/v1/settings/general.app_name",
+            json={"value": "Changed by support"},
+        )
+
+        assert res.status_code == 403
+        assert res.json()["detail"] == "Support sessions cannot modify deployment-wide settings"
+        assert db_session.query(Setting).filter(Setting.key == "general.app_name").first() is None
+
+    def test_support_session_cannot_bulk_update_global_settings(
+        self,
+        test_app,
+        client: TestClient,
+        db_session: Session,
+    ):
+        """The bulk mutation route applies the same support-session boundary."""
+
+        async def support_session_auth():
+            return {
+                "auth_type": "support_session",
+                "workspace_id": "00000000-0000-0000-0000-000000000001",
+                "support_read_only": False,
+            }
+
+        test_app.dependency_overrides[require_admin_auth] = support_session_auth
+
+        res = client.post(
+            "/api/v1/settings/bulk",
+            json={"settings": {"general.app_name": "Changed by support"}},
+        )
+
+        assert res.status_code == 403
+        assert res.json()["detail"] == "Support sessions cannot modify deployment-wide settings"
+        assert db_session.query(Setting).filter(Setting.key == "general.app_name").first() is None
 
     def test_secret_is_redacted_in_response(self, authed_client: TestClient):
         """cloudflare.api_token value is redacted in GET responses."""


### PR DESCRIPTION
### Motivation
- Support-session cookies were being accepted by the global `require_admin_auth` dependency and mapped to an auth context with `auth_type='support_session'`, but global settings mutation endpoints did not enforce the support-session read-only/workspace scoping, allowing support sessions to mutate deployment-wide configuration.
- The intent is to preserve the support-session boundary and prevent workspace-bound support access from changing global settings that affect all tenants.

### Description
- Add a centralized guard ` _require_global_settings_mutation_access(auth_context: dict)` in `backend/app/api/api_v1/endpoints/settings.py` that rejects any `auth_type == 'support_session'` for global settings mutations.
- Invoke the guard at the start of both `update_setting` and `bulk_update_settings` so workspace-bound support sessions are blocked before any DB writes occur.
- Add regression tests in `backend/app/tests/test_settings.py` covering single-setting and bulk-setting mutation attempts using support-session auth contexts, asserting HTTP 403 and no persisted changes.
- Keep change minimal and targeted to settings mutation paths to preserve existing admin flows for other auth types.

### Testing
- Ran `pytest -q app/tests/test_settings.py -k support_session_cannot` which executed the two new tests: 2 passed.
- Ran the full settings test file `pytest -q app/tests/test_settings.py` and observed: 45 passed (including the two new assertions).
- Ran static checks with `ruff` on the modified files: all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d4d26a4888333b2a5b604df514948)