### PR TITLE
fix: revoke organization roles on SCIM deprovision

### DIFF
--- a/backend/app/api/api_v1/endpoints/scim.py
+++ b/backend/app/api/api_v1/endpoints/scim.py
@@ -269,6 +269,27 @@ def _upsert_memberships(
         organization_membership.active = active
 
 
+def _set_memberships_active(
+    db: Session, *, workspace: Workspace, user: User, active: bool
+) -> None:
+    """Set the active state for memberships managed by this SCIM workspace."""
+    for membership in getattr(user, "_scim_memberships", []):
+        membership.active = active
+
+    if workspace.organization_id is None:
+        return
+    organization_membership = (
+        db.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.organization_id == workspace.organization_id,
+            OrganizationMembership.user_id == user.id,
+        )
+        .first()
+    )
+    if organization_membership is not None:
+        organization_membership.active = active
+
+
 def _scim_user_to_dict(user: User, workspace: Workspace) -> Dict[str, Any]:
     memberships = (
         db_memberships
@@ -542,8 +563,7 @@ async def patch_scim_user(
         path = (operation.path or "").strip().lower()
         if operation.op.strip().lower() in {"replace", "add"} and path == "active":
             active = _coerce_scim_bool(operation.value)
-            for membership in getattr(user, "_scim_memberships", []):
-                membership.active = active
+            _set_memberships_active(db, workspace=workspace, user=user, active=active)
             changed = True
     if not changed:
         raise HTTPException(
@@ -578,8 +598,7 @@ async def deactivate_scim_user(
     """Deactivate a SCIM user without deleting audit history."""
     workspace = _workspace_for_token(db, _auth)
     user = _user_or_404(db, user_id, workspace)
-    for membership in getattr(user, "_scim_memberships", []):
-        membership.active = False
+    _set_memberships_active(db, workspace=workspace, user=user, active=False)
     record_workspace_audit_log(
         db,
         workspace=workspace,

--- a/backend/app/tests/test_scim.py
+++ b/backend/app/tests/test_scim.py
@@ -262,7 +262,7 @@ def test_scim_workspace_role_does_not_create_organization_membership(
 
 
 def test_scim_explicit_org_role_creates_organization_membership(client: TestClient, db_session):
-    """Only explicit SCIM org role groups write organization membership rows."""
+    """SCIM manages the active state of an explicitly mapped organization role."""
     organization = Organization(slug="scim-explicit-org", name="SCIM Explicit Org")
     db_session.add(organization)
     db_session.flush()
@@ -284,6 +284,37 @@ def test_scim_explicit_org_role_creates_organization_membership(client: TestClie
     user = db_session.query(User).filter(User.email == "org-role@example.com").one()
     org_membership = db_session.query(OrganizationMembership).filter_by(user_id=user.id).one()
     assert org_membership.role == "billing_admin"
+    assert org_membership.active is True
+
+    patched = client.patch(
+        f"/api/v1/scim/v2/Users/{user.id}",
+        headers={"X-API-Key": token.secret},
+        json={
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "Replace", "path": "active", "value": False}],
+        },
+    )
+
+    assert patched.status_code == 200
+    db_session.refresh(org_membership)
+    assert org_membership.active is False
+
+    reactivated = client.patch(
+        f"/api/v1/scim/v2/Users/{user.id}",
+        headers={"X-API-Key": token.secret},
+        json={
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "Replace", "path": "active", "value": True}],
+        },
+    )
+    deleted = client.delete(
+        f"/api/v1/scim/v2/Users/{user.id}", headers={"X-API-Key": token.secret}
+    )
+
+    assert reactivated.status_code == 200
+    assert deleted.status_code == 200
+    db_session.refresh(org_membership)
+    assert org_membership.active is False
 
 
 def test_scim_replace_rejects_payload_for_different_user(client: TestClient, db_session):


### PR DESCRIPTION
### Motivation
- SCIM deprovision flows were only toggling workspace memberships and left SCIM-created `OrganizationMembership` rows active, allowing deprovisioned users to retain organization-level access while their session persisted.
- The change ensures SCIM active-state operations consistently apply to both the workspace membership and the organization membership associated with the token workspace.

### Description
- Add a shared helper `_set_memberships_active(db, workspace, user, active)` that sets the active state for the SCIM-managed workspace membership(s) and the corresponding `OrganizationMembership` when the workspace is tied to an organization in `backend/app/api/api_v1/endpoints/scim.py`.
- Use the helper from the `PATCH /Users/{user_id}` flow to ensure `active` updates also affect organization memberships instead of only workspace rows.
- Use the helper from the `DELETE /Users/{user_id}` flow so deletion/deactivation also revokes the organization membership active flag.
- Extend `backend/app/tests/test_scim.py` to assert that explicit SCIM organization roles are created active, then are deactivated by `PATCH active=false`, can be reactivated, and are finally deactivated by `DELETE`.

### Testing
- Ran `ruff check backend/app/api/api_v1/endpoints/scim.py backend/app/tests/test_scim.py` and applied formatting fixes where needed.
- Ran `pytest -q backend/app/tests/test_scim.py` and all tests passed (`12 passed`) with unrelated deprecation warnings reported by dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d53fc37d4833381e9e522f33ff691)