### PR TITLE
fix: require explicit MFA assurance by default

### DIFF
--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -398,7 +398,7 @@ def _mfa_claim_names(settings: Settings | None = None) -> tuple[str, ...]:
 
 def _mfa_claim_values(settings: Settings | None = None) -> set[str]:
     cfg = settings or get_settings()
-    return _split_csv(getattr(cfg, "AUTH_MFA_CLAIM_VALUES", "mfa,otp,totp,webauthn,hwk,swk,phr"))
+    return _split_csv(getattr(cfg, "AUTH_MFA_CLAIM_VALUES", "mfa"))
 
 
 def mfa_claim_context(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -226,7 +226,7 @@ class Settings(BaseSettings):
     OIDC_GROUP_ORGANIZATION_ROLE_MAP: Optional[str] = None
     AUTH_REQUIRE_MFA: bool = False
     AUTH_MFA_CLAIM_NAMES: str = "amr,acr"
-    AUTH_MFA_CLAIM_VALUES: str = "mfa,otp,totp,webauthn,hwk,swk,phr"
+    AUTH_MFA_CLAIM_VALUES: str = "mfa"
 
     AUTHENTIK_ISSUER_URL: Optional[str] = None
     AUTHENTIK_CLIENT_ID: Optional[str] = None

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -314,7 +314,7 @@ class TestExternalAuthProviders:
 
         assert exc.value.status_code == 403
 
-    def test_mfa_claim_context_accepts_common_oidc_assurance_claims(self):
+    def test_mfa_claim_context_requires_explicit_mfa_assurance_by_default(self):
         settings = Settings(AUTH_MFA_CLAIM_NAMES="amr,acr")
 
         verified, claims = mfa_claim_context(
@@ -325,8 +325,13 @@ class TestExternalAuthProviders:
             settings,
         )
 
-        assert verified is True
+        assert verified is False
         assert claims == ("amr:single_factor", "amr:webauthn", "acr:urn:example:loa")
+
+        verified, claims = mfa_claim_context({"amr": ["webauthn", "mfa"]}, settings)
+
+        assert verified is True
+        assert claims == ("amr:webauthn", "amr:mfa")
 
     def test_mfa_claim_context_normalizes_object_and_scalar_claims(self):
         settings = Settings(

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -62,12 +62,14 @@ paths.
 | `GUIDED_MAIL_HEALTH_UI_ENABLED` | Make the optional guided mail-health dashboard available. It remains disabled per workspace until an operator chooses it, so existing workspaces stay on the classic dashboard. Individual signed-in users may then choose their own explanation depth, teaching hints, and Watch, Diagnose, or Evidence context. Auth-disabled single-user installs persist the same choices as a workspace fallback. | `false` | `true`, `false` |
 | `AUTH_REQUIRE_MFA` | Require an accepted MFA assurance claim from Logto, direct OIDC, or trusted-proxy authentication before DMARQ issues a session. | `false` | `true`, `false` |
 | `AUTH_MFA_CLAIM_NAMES` | Comma-separated claim names to inspect for MFA assurance. Common OIDC claims are `amr` and `acr`. | `amr,acr` | `amr,acr` |
-| `AUTH_MFA_CLAIM_VALUES` | Comma-separated claim values accepted as MFA proof. Adjust this to the values emitted by your IdP. | `mfa,otp,totp,webauthn,hwk,swk,phr` | `mfa,webauthn` |
+| `AUTH_MFA_CLAIM_VALUES` | Comma-separated claim values accepted as explicit MFA proof. Adjust this only to assurance values that guarantee MFA under your IdP policy. | `mfa` | `mfa` |
 
 When `AUTH_REQUIRE_MFA=true`, DMARQ does not perform MFA itself. It verifies
 that the upstream identity provider or trusted proxy explicitly states that MFA
-was used. For OIDC providers, this usually comes through `amr` values such as
-`mfa`, `otp`, or `webauthn`. For trusted-proxy deployments, configure the proxy
+was used. For OIDC providers, this usually comes through an `amr` value such as
+`mfa`. Individual method references such as `otp` or `webauthn` are not accepted
+by default because they do not necessarily prove that multiple factors were
+used. For trusted-proxy deployments, configure the proxy
 to forward a dedicated assurance header and strip any inbound spoofed copy of
 that header before the request reaches DMARQ.
 


### PR DESCRIPTION
### Motivation

- The default MFA acceptance policy treated individual OIDC `amr`/`acr` method values (e.g. `otp`, `webauthn`) as sufficient proof of MFA, which can allow single-factor logins to satisfy `AUTH_REQUIRE_MFA`.
- This weakens the intended enforcement when operators rely on DMARQ to require upstream MFA assurance rather than provider-specific method tokens.

### Description

- Restrict the default accepted MFA claim values to the explicit `mfa` assurance token by changing `AUTH_MFA_CLAIM_VALUES` default in `backend/app/core/config.py` to `"mfa"` and the runtime fallback in `_mfa_claim_values` in `backend/app/core/auth_providers.py` to `"mfa"`.
- Preserve operator-configurable overrides so deployments can still accept provider-specific values by setting `AUTH_MFA_CLAIM_VALUES` in their environment.
- Add a regression test in `backend/app/tests/test_auth.py` that asserts `webauthn` alone no longer satisfies the default policy and that an explicit `mfa` claim is accepted.
- Update deployment documentation `docs/deployment/configuration.md` to clarify that method references such as `otp` or `webauthn` do not necessarily prove multiple factors and recommend using explicit assurance tokens.

### Testing

- Ran the full auth test suite with `pytest -q backend/app/tests/test_auth.py` and all tests passed (`71 passed`).
- Ran the targeted MFA tests with `pytest -q backend/app/tests/test_auth.py -k 'mfa_claim_context or callback_enforces_required_logto_mfa_claim or callback_accepts_logto_mfa_amr_claim'` and the targeted tests passed (4 passed).
- Verified there are no `git diff --check` issues after the changes and test run completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d550080508333aaec921cfb8d07f7)