### PR TITLE
fix: isolate privileged release deployment dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,10 @@ jobs:
     name: Semantic Release
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: write
-      id-token: write
+    outputs:
+      released: ${{ steps.semantic.outputs.released }}
+      tag: ${{ steps.semantic.outputs.tag }}
 
     steps:
       - name: Checkout code
@@ -36,12 +37,45 @@ jobs:
           push: true
           vcs_release: true
 
-      - name: Deploy released version through CI GitOps gate
-        if: steps.semantic.outputs.released == 'true'
+  deploy:
+    name: Dispatch release deployment
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Validate released tag and dispatch CI GitOps gate
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.semantic.outputs.tag }}
+          RELEASE_TAG: ${{ needs.release.outputs.tag }}
         run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid semantic-release tag: ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+
+          # Do not trust the release action's output alone. Confirm through the
+          # GitHub API that it names a published release created by this run and
+          # that its commit descends from the triggering main commit.
+          RELEASE_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          PUBLISHED_AT=$(jq -r '.published_at // empty' <<<"${RELEASE_JSON}")
+          if [[ -z "${PUBLISHED_AT}" || "${PUBLISHED_AT}" < "${{ github.event.repository.updated_at }}" ]]; then
+            echo "Release ${RELEASE_TAG} was not published during this main update" >&2
+            exit 1
+          fi
+
+          COMPARE_STATUS=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/compare/${GITHUB_SHA}...${RELEASE_TAG}" \
+            --jq '.status')
+          if [[ "${COMPARE_STATUS}" != "ahead" && "${COMPARE_STATUS}" != "identical" ]]; then
+            echo "Release ${RELEASE_TAG} does not descend from ${GITHUB_SHA}" >&2
+            exit 1
+          fi
+
           gh workflow run ci.yml \
             --ref main \
             -f release_ref="${RELEASE_TAG}" \

--- a/backend/app/tests/test_release_rollout_script.py
+++ b/backend/app/tests/test_release_rollout_script.py
@@ -145,9 +145,17 @@ def test_release_workflow_dispatches_gitops_deploy_after_release():
     """Semantic-release commits must trigger the deploy workflow explicitly."""
     workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
-    assert "actions: write" in workflow
+    release_job, deploy_job = workflow.split("  deploy:", maxsplit=1)
+
+    assert "actions: write" not in release_job
+    assert "contents: write" in release_job
+    assert "actions: write" in deploy_job
+    assert "needs: release" in deploy_job
     assert "id: semantic" in workflow
-    assert "steps.semantic.outputs.released == 'true'" in workflow
+    assert "needs.release.outputs.released == 'true'" in deploy_job
+    assert '[[ ! "${RELEASE_TAG}" =~ ^v[0-9]+' in deploy_job
+    assert 'releases/tags/${RELEASE_TAG}' in deploy_job
+    assert 'compare/${GITHUB_SHA}...${RELEASE_TAG}' in deploy_job
     assert "gh workflow run ci.yml" in workflow
     assert 'release_ref="${RELEASE_TAG}"' in workflow
     assert 'release_tag="${RELEASE_TAG}"' in workflow


### PR DESCRIPTION
### Motivation
- Prevent third-party or release-step code from receiving expanded `GITHUB_TOKEN` privileges that can trigger CI dispatches which perform GitOps updates. 

### Description
- Remove `actions: write` and `id-token: write` from the `release` job in `.github/workflows/release.yml` and publish `steps.semantic` outputs via `outputs` on the `release` job. 
- Add a new `deploy` job that `needs: release`, runs with minimal permissions, and reads `needs.release.outputs.tag` to perform the CI dispatch. 
- Validate the release tag before dispatch using a semantic-version regex and confirm the release is published and descends from the triggering commit via `gh api` and a `compare` check, then run `gh workflow run ci.yml` only after these checks. 
- Update `backend/app/tests/test_release_rollout_script.py` to assert the permission boundary and the new validation/dispatch behavior in the workflow file. 

### Testing
- Ran `python -m pytest backend/app/tests/test_release_rollout_script.py -q` and all tests passed (10 passed). 
- Ran `git diff --check` to ensure no whitespace/patch problems and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d54d184208333ab5ed17674af9418)