### PR TITLE
Fail closed for unmapped IdP roles

### DIFF
--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -60,6 +60,7 @@ class ExternalIdentityClaims:
     groups: tuple[str, ...] = ()
     workspace_roles: tuple[tuple[str, str], ...] = ()
     organization_roles: tuple[tuple[str, str], ...] = ()
+    roles_authoritative: bool = False
     mfa_verified: bool = False
     mfa_claims: tuple[str, ...] = ()
 
@@ -693,6 +694,17 @@ def normalize_external_claims(
             allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
         ),
     )
+    roles_authoritative = bool(
+        (group_workspace_role_map or "").strip() or (group_organization_role_map or "").strip()
+    )
+    if roles_authoritative and not (workspace_roles or organization_roles):
+        logger.warning(
+            "Rejecting external login because configured group mappings granted no roles"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Authenticated identity is not assigned an authorized DMARQ role.",
+        )
     mfa_verified, mfa_claims = enforce_mfa_claims(payload, cfg)
     return ExternalIdentityClaims(
         provider=provider,
@@ -705,6 +717,7 @@ def normalize_external_claims(
         groups=groups,
         workspace_roles=workspace_roles,
         organization_roles=organization_roles,
+        roles_authoritative=roles_authoritative,
         mfa_verified=mfa_verified,
         mfa_claims=mfa_claims,
     )
@@ -938,6 +951,27 @@ def _upsert_organization_membership(
 
 
 def _sync_external_memberships(claims: ExternalIdentityClaims, user: User, db: Session) -> None:
+    if claims.roles_authoritative:
+        workspace_roles = set(claims.workspace_roles)
+        for membership in (
+            db.query(WorkspaceMembership)
+            .join(Workspace, Workspace.id == WorkspaceMembership.workspace_id)
+            .filter(WorkspaceMembership.user_id == user.id)
+        ):
+            if (membership.workspace.slug, membership.role) not in workspace_roles:
+                membership.active = False
+                membership.updated_at = datetime.utcnow()
+
+        organization_roles = set(claims.organization_roles)
+        for membership in (
+            db.query(OrganizationMembership)
+            .join(Organization, Organization.id == OrganizationMembership.organization_id)
+            .filter(OrganizationMembership.user_id == user.id)
+        ):
+            if (membership.organization.slug, membership.role) not in organization_roles:
+                membership.active = False
+                membership.updated_at = datetime.utcnow()
+
     for workspace_slug, role in claims.workspace_roles:
         _upsert_workspace_membership(db, user=user, workspace_slug=workspace_slug, role=role)
     for organization_slug, role in claims.organization_roles:
@@ -1007,6 +1041,25 @@ def trusted_proxy_claims_from_request(
         {"amr": request.headers.get(mfa_header)},
         cfg,
     )
+    workspace_roles = _role_pairs_from_group_map(
+        groups,
+        cfg.AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP,
+        allowed_roles=set(ROLE_PERMISSIONS),
+    )
+    organization_roles = _role_pairs_from_group_map(
+        groups,
+        cfg.AUTH_TRUSTED_PROXY_GROUP_ORGANIZATION_ROLE_MAP,
+        allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
+    )
+    roles_authoritative = bool(
+        (cfg.AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP or "").strip()
+        or (cfg.AUTH_TRUSTED_PROXY_GROUP_ORGANIZATION_ROLE_MAP or "").strip()
+    )
+    if roles_authoritative and not (workspace_roles or organization_roles):
+        logger.warning(
+            "Rejecting trusted proxy login because configured group mappings granted no roles"
+        )
+        return None
     return ExternalIdentityClaims(
         provider=provider,
         subject=subject or email,
@@ -1015,16 +1068,9 @@ def trusted_proxy_claims_from_request(
         username=request.headers.get(cfg.AUTH_TRUSTED_PROXY_USERNAME_HEADER),
         email_verified=True,
         groups=groups,
-        workspace_roles=_role_pairs_from_group_map(
-            groups,
-            cfg.AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP,
-            allowed_roles=set(ROLE_PERMISSIONS),
-        ),
-        organization_roles=_role_pairs_from_group_map(
-            groups,
-            cfg.AUTH_TRUSTED_PROXY_GROUP_ORGANIZATION_ROLE_MAP,
-            allowed_roles=set(ORGANIZATION_ROLE_ALIASES) | set(ROLE_PERMISSIONS),
-        ),
+        workspace_roles=workspace_roles,
+        organization_roles=organization_roles,
+        roles_authoritative=roles_authoritative,
         mfa_verified=mfa_verified,
         mfa_claims=mfa_claims,
     )

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -466,25 +466,44 @@ class TestExternalAuthProviders:
 
     def test_normalize_external_claims_logs_invalid_group_role_mappings(self, caplog):
         with caplog.at_level(logging.WARNING, logger="app.core.auth_providers"):
-            claims = normalize_external_claims(
-                "authentik",
-                {
-                    "sub": "authentik-user-1",
-                    "email": "owner@example.com",
-                    "groups": ["dmarq-admins"],
-                },
-                allowed_domains="example.com",
-                group_workspace_role_map=(
-                    "malformed-entry," "dmarq-admins=primary:root," "dmarq-admins=missing-separator"
-                ),
-            )
+            with pytest.raises(HTTPException) as exc:
+                normalize_external_claims(
+                    "authentik",
+                    {
+                        "sub": "authentik-user-1",
+                        "email": "owner@example.com",
+                        "groups": ["dmarq-admins"],
+                    },
+                    allowed_domains="example.com",
+                    group_workspace_role_map=(
+                        "malformed-entry,"
+                        "dmarq-admins=primary:root,"
+                        "dmarq-admins=missing-separator"
+                    ),
+                )
 
-        assert claims.workspace_roles == ()
+        assert exc.value.status_code == 403
         assert "malformed group-role mapping entry at position=1" in caplog.text
         assert "invalid target at position=2" in caplog.text
         assert "without a target at position=3" in caplog.text
         assert "primary:root" not in caplog.text
         assert "owner@example.com" not in caplog.text
+
+    def test_normalize_external_claims_rejects_user_without_mapped_role(self):
+        with pytest.raises(HTTPException) as exc:
+            normalize_external_claims(
+                "oidc",
+                {
+                    "sub": "unmapped-user",
+                    "email": "user@example.com",
+                    "groups": ["everyone"],
+                },
+                allowed_domains="example.com",
+                group_workspace_role_map="dmarq-admins=primary:workspace_owner",
+            )
+
+        assert exc.value.status_code == 403
+        assert "not assigned" in exc.value.detail
 
     def test_normalize_role_claims_accepts_strings_and_deduplicates_pairs(self):
         roles = _normalize_role_claims(
@@ -690,6 +709,53 @@ class TestExternalAuthProviders:
         assert organization_membership.role == "organization_owner"
         assert organization_membership.active is True
 
+    def test_sync_external_user_revokes_roles_removed_from_authoritative_claims(self, db_session):
+        organization = Organization(slug="customer-one", name="Customer One")
+        primary = Workspace(slug="primary", name="Primary", organization=organization)
+        secondary = Workspace(slug="secondary", name="Secondary", organization=organization)
+        user = User(
+            logto_id="oidc:user-1",
+            email="user@example.com",
+            is_active=True,
+            is_superuser=False,
+        )
+        db_session.add_all([organization, primary, secondary, user])
+        db_session.flush()
+        db_session.add_all(
+            [
+                WorkspaceMembership(
+                    workspace_id=primary.id, user_id=user.id, role="workspace_owner"
+                ),
+                WorkspaceMembership(workspace_id=secondary.id, user_id=user.id, role="analyst"),
+                OrganizationMembership(
+                    organization_id=organization.id,
+                    user_id=user.id,
+                    role="organization_owner",
+                ),
+            ]
+        )
+        db_session.commit()
+
+        sync_external_user(
+            ExternalIdentityClaims(
+                provider="oidc",
+                subject="user-1",
+                email="user@example.com",
+                workspace_roles=(("primary", "workspace_owner"),),
+                roles_authoritative=True,
+            ),
+            db_session,
+        )
+
+        assert db_session.query(WorkspaceMembership).filter_by(workspace_id=primary.id).one().active
+        assert (
+            not db_session.query(WorkspaceMembership)
+            .filter_by(workspace_id=secondary.id)
+            .one()
+            .active
+        )
+        assert not db_session.query(OrganizationMembership).one().active
+
     def test_sync_external_user_ignores_unknown_claim_targets(self, db_session):
         user = sync_external_user(
             ExternalIdentityClaims(
@@ -753,6 +819,21 @@ class TestExternalAuthProviders:
         assert claims.groups == ("dmarq-admins", "other")
         assert claims.workspace_roles == (("primary", "workspace_owner"),)
         assert claims.organization_roles == (("customer-one", "organization_owner"),)
+
+    def test_trusted_proxy_claims_reject_unmapped_user_when_mappings_configured(self):
+        settings = Settings(
+            AUTH_MODE="trusted_proxy",
+            AUTH_TRUSTED_PROXY_ALLOWED_DOMAINS="example.com",
+            AUTH_TRUSTED_PROXY_GROUP_WORKSPACE_ROLE_MAP=("dmarq-admins=primary:workspace_owner"),
+        )
+        request = MagicMock()
+        request.headers = {
+            "X-Authentik-Email": "user@example.com",
+            "X-Authentik-Uid": "user-1",
+            "X-Authentik-Groups": "everyone",
+        }
+
+        assert trusted_proxy_claims_from_request(request, settings) is None
 
     def test_trusted_proxy_claims_enforce_required_mfa_header(self):
         settings = Settings(


### PR DESCRIPTION
### Motivation
- Prevent a fail-open where configured IdP group-to-role mappings grant no roles but the login still provisions a user (or issues a session) that falls back to legacy superuser behavior.
- Ensures deployments that rely on group maps for RBAC receive either explicit mapped roles or denied access, and that existing memberships are reconciled when authoritative mappings change.

### Description
- Add a `roles_authoritative` flag to `ExternalIdentityClaims` to mark when group mappings are configured and authoritative. (`backend/app/core/auth_providers.py`)
- Make `normalize_external_claims` fail closed with HTTP 403 when group mappings are configured but no workspace or organization roles are granted. (`normalize_external_claims`) 
- Apply the same fail-closed logic to trusted-proxy group mappings in `trusted_proxy_claims_from_request` so unmapped proxy identities are rejected. (`trusted_proxy_claims_from_request`) 
- Reconcile memberships when claims are authoritative by deactivating workspace/organization memberships that are not present in the current mapped claims inside `_sync_external_memberships`. (`_sync_external_memberships`) 
- Add regression tests covering malformed mappings, unmapped identities when mappings are configured, membership revocation when authoritative claims change, and trusted-proxy unmapped rejection. (`backend/app/tests/test_auth.py`)

### Testing
- Ran unit tests with `cd backend && pytest -q app/tests/test_auth.py` and all tests passed (`74 passed`).
- Ran formatting and lint checks with `black --check backend/app/core/auth_providers.py backend/app/tests/test_auth.py` and `ruff check backend/app/core/auth_providers.py backend/app/tests/test_auth.py`, both succeeded (files reformatted as needed during the change process).
- Ran `git diff --check` to verify no whitespace/patch issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d6268bec88333b4c86075e65c8622)