### PR TITLE
Prevent stored AI credential exfiltration during connection tests

### DIFF
--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -1091,18 +1091,6 @@ async def test_ai_connection(
             selected_model=None,
         )
 
-    stored_key = _setting_plain_or_default(db, "ai.api_key")
-    api_key = str(payload.api_key or "").strip()
-    if api_key == "**redacted**":
-        api_key = stored_key
-    if not api_key:
-        api_key = stored_key
-    if profile.get("requires_api_key") and not api_key:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Add an API key before testing this AI provider.",
-        )
-
     base_url = _normalize_ai_base_url(
         provider,
         str(payload.base_url or _setting_plain_or_default(db, "ai.remote_base_url") or ""),
@@ -1112,6 +1100,26 @@ async def test_ai_connection(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Add a provider base URL before testing this AI provider.",
+        )
+
+    stored_key = _setting_plain_or_default(db, "ai.api_key")
+    api_key = str(payload.api_key or "").strip()
+    if not api_key or api_key == "**redacted**":
+        stored_provider = str(_setting_plain_or_default(db, "ai.provider") or "template")
+        stored_provider = _ai_provider_profile(stored_provider)["id"]
+        stored_profile = _ai_provider_profile(stored_provider)
+        stored_base_url = _normalize_ai_base_url(
+            stored_provider,
+            _setting_plain_or_default(db, "ai.remote_base_url"),
+            stored_profile,
+        )
+        # A redacted credential may only be reused with the endpoint it was saved for.
+        # Otherwise an authenticated caller could send the secret to an arbitrary host.
+        api_key = stored_key if (provider, base_url) == (stored_provider, stored_base_url) else ""
+    if profile.get("requires_api_key") and not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Add an API key before testing this AI provider or base URL.",
         )
 
     selected_model = str(payload.model or _setting_plain_or_default(db, "ai.model") or "").strip()

--- a/backend/app/tests/test_ai_mcp.py
+++ b/backend/app/tests/test_ai_mcp.py
@@ -422,6 +422,38 @@ def test_ai_connection_uses_saved_redacted_secret_and_discovers_models(
     )
 
 
+@pytest.mark.parametrize("api_key", [None, "**redacted**"])
+def test_ai_connection_does_not_send_saved_secret_to_caller_supplied_url(
+    authed_client: TestClient,
+    api_key: str | None,
+):
+    save_response = authed_client.post(
+        "/api/v1/settings/bulk",
+        json={
+            "settings": {
+                "ai.provider": "openai_compatible",
+                "ai.remote_base_url": "https://saved.example/v1",
+                "ai.api_key": "sk-stored-secret",
+            }
+        },
+    )
+    assert save_response.status_code == 200
+
+    model_fetch = AsyncMock(return_value=[])
+    payload = {
+        "provider": "openai_compatible",
+        "base_url": "https://attacker.example/v1",
+    }
+    if api_key is not None:
+        payload["api_key"] = api_key
+    with patch.object(settings_endpoint, "_fetch_openai_compatible_models", model_fetch):
+        response = authed_client.post("/api/v1/settings/ai/test", json=payload)
+
+    assert response.status_code == 400
+    assert "API key" in response.json()["detail"]
+    model_fetch.assert_not_awaited()
+
+
 def test_ai_summary_requires_explicit_opt_in(authed_client: TestClient):
     _seed_report_store()
     response = authed_client.get(f"/api/v1/ai/domains/{DOMAIN}/summary")


### PR DESCRIPTION
### Motivation

- The AI connection-test endpoint could reuse the stored (redacted) `ai.api_key` for any caller-supplied public `base_url`, allowing an authenticated caller to exfiltrate the stored credential to an attacker-controlled host.
- Stored secrets are explicitly redacted in settings responses and must not be reused with arbitrary endpoints.

### Description

- Restrict reuse of the saved `ai.api_key` so the stored credential is only substituted when the requested provider and the normalized saved base URL exactly match the saved provider and saved base URL; otherwise the stored key is not reused and a fresh API key is required.
- Implemented logic in `backend/app/api/api_v1/endpoints/settings.py` to load the saved provider and normalized saved base URL and compare them to the requested provider/base URL before reusing the stored key.
- Update error text to require an explicit API key when testing a caller-supplied provider endpoint that does not match the saved configuration.
- Add a regression test in `backend/app/tests/test_ai_mcp.py` that asserts the saved secret is not sent when the caller supplies a different `base_url`, covering both omitted and `"**redacted**"` placeholder cases.

### Testing

- Ran the AI-related test cases with `cd backend && pytest -q app/tests/test_ai_mcp.py -k 'ai_connection'`, and the targeted tests passed (`14 passed`).
- Ran `ruff` checks against the modified files and they passed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d644103b8833381fad555207cd8f4)