### PR TITLE
Revoke stale external IdP memberships during login sync

### DIFF
--- a/backend/app/core/auth_providers.py
+++ b/backend/app/core/auth_providers.py
@@ -938,15 +938,34 @@ def _upsert_organization_membership(
 
 
 def _sync_external_memberships(claims: ExternalIdentityClaims, user: User, db: Session) -> None:
+    workspace_ids: set[int] = set()
     for workspace_slug, role in claims.workspace_roles:
-        _upsert_workspace_membership(db, user=user, workspace_slug=workspace_slug, role=role)
+        membership = _upsert_workspace_membership(
+            db, user=user, workspace_slug=workspace_slug, role=role
+        )
+        if membership is not None:
+            workspace_ids.add(membership.workspace_id)
+
+    organization_ids: set[int] = set()
     for organization_slug, role in claims.organization_roles:
-        _upsert_organization_membership(
+        membership = _upsert_organization_membership(
             db,
             user=user,
             organization_slug=organization_slug,
             role=role,
         )
+        if membership is not None:
+            organization_ids.add(membership.organization_id)
+
+    now = datetime.utcnow()
+    for membership in db.query(WorkspaceMembership).filter_by(user_id=user.id, active=True):
+        if membership.workspace_id not in workspace_ids:
+            membership.active = False
+            membership.updated_at = now
+    for membership in db.query(OrganizationMembership).filter_by(user_id=user.id, active=True):
+        if membership.organization_id not in organization_ids:
+            membership.active = False
+            membership.updated_at = now
 
 
 def sync_external_user(claims: ExternalIdentityClaims, db: Session) -> User:

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -690,6 +690,44 @@ class TestExternalAuthProviders:
         assert organization_membership.role == "organization_owner"
         assert organization_membership.active is True
 
+    def test_sync_external_user_deactivates_memberships_removed_from_claims(self, db_session):
+        organization = Organization(slug="customer-one", name="Customer One")
+        workspace = Workspace(slug="primary", name="Primary", organization=organization)
+        db_session.add_all([organization, workspace])
+        db_session.commit()
+
+        user = sync_external_user(
+            ExternalIdentityClaims(
+                provider="authentik",
+                subject="authentik-user-1",
+                email="owner@example.com",
+                workspace_roles=(("primary", "workspace_owner"),),
+                organization_roles=(("customer-one", "organization_owner"),),
+            ),
+            db_session,
+        )
+        sync_external_user(
+            ExternalIdentityClaims(
+                provider="authentik",
+                subject="authentik-user-1",
+                email="owner@example.com",
+            ),
+            db_session,
+        )
+
+        workspace_membership = (
+            db_session.query(WorkspaceMembership)
+            .filter_by(workspace_id=workspace.id, user_id=user.id)
+            .one()
+        )
+        organization_membership = (
+            db_session.query(OrganizationMembership)
+            .filter_by(organization_id=organization.id, user_id=user.id)
+            .one()
+        )
+        assert workspace_membership.active is False
+        assert organization_membership.active is False
+
     def test_sync_external_user_ignores_unknown_claim_targets(self, db_session):
         user = sync_external_user(
             ExternalIdentityClaims(


### PR DESCRIPTION
### Motivation
- External IdP role synchronization was additive-only and never deactivated prior `WorkspaceMembership` or `OrganizationMembership` rows when claims were removed, allowing revoked IdP privileges to persist.

### Description
- Treat the incoming `workspace_roles` and `organization_roles` from `ExternalIdentityClaims` as authoritative and collect the effected `workspace_id` and `organization_id` sets during sync in `_sync_external_memberships` in `backend/app/core/auth_providers.py`.
- Upsert claimed memberships as before, then deactivate any currently-active `WorkspaceMembership` or `OrganizationMembership` for the user whose target id is not present in the latest claims and set `updated_at` to now.
- Added a regression test `test_sync_external_user_deactivates_memberships_removed_from_claims` in `backend/app/tests/test_auth.py` that grants owner roles on first sync and verifies they are deactivated after a subsequent login with no role claims.
- Changes touch `backend/app/core/auth_providers.py` and `backend/app/tests/test_auth.py` and preserve existing behavior for adding/reactivating memberships when claims are present.

### Testing
- Ran the auth test suite with `pytest -q backend/app/tests/test_auth.py`, and all tests passed (`72 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d641159f083339e5ec0e337b0cc70)