### PR TITLE
Restrict Akamai Edge DNS imports to provider operators

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -125,6 +125,7 @@ from app.services.organizations import (
     OrganizationPlanLimitError,
     require_organization_plan_limit,
 )
+from app.services.provider_access import require_provider_operator_access
 from app.services.ovh_dns import get_ovh_dns_credentials
 from app.services.ptr_lookup import PtrLookupResult, lookup_ptr_with_fallbacks
 from app.services.remediation_dispatch import (
@@ -6027,6 +6028,13 @@ async def preview_dns_provider_domain_import(
         db,
         selected_workspace_id=parse_selected_workspace_id(selected_workspace),
     )
+    if normalize_provider_id(provider) in {
+        "akamai",
+        "akamai-edgedns",
+        "edgedns",
+        "fastdns",
+    }:
+        require_provider_operator_access(db, _auth)
     try:
         return await preview_dns_provider_import(
             db,
@@ -6054,6 +6062,13 @@ async def import_dns_provider_domain_zones(
         db,
         selected_workspace_id=parse_selected_workspace_id(selected_workspace),
     )
+    if normalize_provider_id(provider) in {
+        "akamai",
+        "akamai-edgedns",
+        "edgedns",
+        "fastdns",
+    }:
+        require_provider_operator_access(db, _auth)
     try:
         return await import_dns_provider_domains(
             db,

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -24,7 +24,7 @@ from app.models.organization import Entitlement, Organization
 from app.models.setting import Setting
 from app.models.user import User
 from app.models.workspace import Workspace
-from app.models.workspace_access import WorkspaceAuditLog
+from app.models.workspace_access import WorkspaceAuditLog, WorkspaceMembership
 from app.services import (
     akamai_edgedns,
     cloudflare_dns,
@@ -1783,6 +1783,58 @@ def test_dns_provider_import_endpoint_rejects_unknown_provider_on_apply(
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Unsupported DNS provider import: example"
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("get", "/api/v1/domains/dns/import/fastdns/preview"),
+        ("post", "/api/v1/domains/dns/import/akamai-edgedns"),
+    ],
+)
+def test_akamai_import_requires_provider_operator(
+    test_app, db_session: Session, method: str, path: str
+):
+    workspace = get_or_create_default_workspace(db_session)
+    user = User(
+        email="akamai-domain-admin@example.com",
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    db_session.add(user)
+    db_session.flush()
+    db_session.add(
+        WorkspaceMembership(
+            workspace_id=workspace.id,
+            user_id=user.id,
+            role="domain_admin",
+            active=True,
+        )
+    )
+    db_session.commit()
+
+    async def mock_admin_auth():
+        return {"auth_type": "session", "user_id": user.id}
+
+    def override_get_db():
+        yield db_session
+
+    test_app.dependency_overrides[get_db] = override_get_db
+    test_app.dependency_overrides[require_admin_auth] = mock_admin_auth
+    provider_call = AsyncMock()
+    target = (
+        "app.api.api_v1.endpoints.domains.preview_dns_provider_import"
+        if method == "get"
+        else "app.api.api_v1.endpoints.domains.import_dns_provider_domains"
+    )
+    with TestClient(test_app) as client, patch(target, new=provider_call):
+        response = client.request(method, path, json={} if method == "post" else None)
+
+    test_app.dependency_overrides.clear()
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Provider operator access is required"
+    provider_call.assert_not_awaited()
 
 
 def test_dns_provider_import_endpoint_surfaces_plan_limit(


### PR DESCRIPTION
### Motivation
- Prevent deployment-wide Akamai Edge DNS zone discovery and import from being invoked by ordinary workspace domain admins when Akamai credentials are resolved from global settings.
- Close an authorization boundary that allowed low-privileged tenants to enumerate and claim zones visible to global Akamai credentials.

### Description
- Require deployment operator authorization by calling `require_provider_operator_access(db, _auth)` before running Akamai import operations in both the preview (`/dns/import/{provider}/preview`) and apply (`/dns/import/{provider}`) endpoints.
- Apply the operator check for the canonical provider and all Akamai aliases (`"akamai"`, `"akamai-edgedns"`, `"edgedns"`, `"fastdns"`) before any provider discovery or import is performed. 
- Add a regression test `test_akamai_import_requires_provider_operator` (in `backend/app/tests/test_cloudflare_dns.py`) that asserts a workspace `domain_admin` receives HTTP 403 and that the provider functions are not invoked. 
- Import `require_provider_operator_access` in the endpoints module and `WorkspaceMembership` in the tests to set up the test scenario.

### Testing
- Ran the targeted pytest selection with `cd backend && pytest -q app/tests/test_cloudflare_dns.py -k 'akamai_import_requires_provider_operator or dns_provider_import_preview_endpoint_returns_zones or dns_provider_import_endpoint_returns_import_summary'`, and the run completed with `4 passed`.
- Ran static/style checks with `ruff check backend/app/api/api_v1/endpoints/domains.py backend/app/tests/test_cloudflare_dns.py` and formatting with `ruff format`, both succeeded or reported no blocking issues.
- Ran repository checks with `git diff --check` which reported no issues after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d6a6067e483339c1511fda0fad37f)