### PR TITLE
Restrict post-setup Cloudflare credential changes

### DIFF
--- a/backend/app/api/api_v1/endpoints/setup.py
+++ b/backend/app/api/api_v1/endpoints/setup.py
@@ -12,6 +12,7 @@ from app.models.domain import Domain
 from app.models.mail_source import MailSource
 from app.models.mail_source_import import MailSourceImport
 from app.models.setting import Setting
+from app.services.provider_access import require_provider_operator_access
 from app.services.mailbox_recovery import import_row_diagnostic, not_configured_guidance
 from app.services.dns_resolver import resolver_profile_status
 
@@ -212,6 +213,8 @@ async def setup_system(
     """
     cloudflare_api_token = (request.cloudflare_api_token or "").strip()
     cloudflare_zone_id = (request.cloudflare_zone_id or "").strip()
+    if request.cloudflare_enabled and _auth.get("auth_type") != "initial_setup":
+        require_provider_operator_access(db, _auth)
     if request.cloudflare_enabled and not cloudflare_api_token:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/tests/test_setup_endpoints.py
+++ b/backend/app/tests/test_setup_endpoints.py
@@ -11,8 +11,10 @@ from fastapi.testclient import TestClient
 
 from app.api.api_v1.endpoints.setup import setup_status
 from app.core.credential_encryption import decrypt_secret, is_encrypted_secret
+from app.core.logto import SESSION_COOKIE, create_session_token
 from app.core.security import _api_keys, add_api_key
 from app.models.setting import Setting
+from app.models.user import User
 
 
 @pytest.fixture(autouse=True)
@@ -320,6 +322,37 @@ class TestSetupSystem:
 
         assert response.status_code == 200
         assert setup_status["app_name"] == "Changed"
+
+    def test_system_setup_rejects_non_operator_updates_after_complete(
+        self, client: TestClient, db_session
+    ):
+        user = User(
+            email="analyst@example.com",
+            is_active=True,
+            is_superuser=False,
+        )
+        db_session.add(user)
+        db_session.commit()
+        setup_status["is_setup_complete"] = True
+
+        response = client.post(
+            "/api/v1/setup/system",
+            json={
+                "app_name": "Compromised",
+                "base_url": "https://attacker.example.com",
+                "cloudflare_enabled": True,
+                "cloudflare_api_token": "attacker-token",
+                "cloudflare_zone_id": "attacker-zone",
+            },
+            cookies={SESSION_COOKIE: create_session_token(user.id)},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Provider operator access is required"
+        assert (
+            db_session.query(Setting).filter_by(key="cloudflare.api_token").first()
+            is None
+        )
 
     def test_system_setup_persists_cloudflare_credentials_server_side(
         self, client: TestClient, db_session


### PR DESCRIPTION
### Motivation

- Close an authorization gap that allowed any authenticated session to persist global Cloudflare credentials and switch the DNS resolver after initial setup, which could let low-privileged users replace provider tokens and affect later DNS provider operations.

### Description

- Require deployment operator authorization by calling `require_provider_operator_access(db, _auth)` when `cloudflare_enabled` is requested in `POST /api/v1/setup/system` for non-first-run requests in `backend/app/api/api_v1/endpoints/setup.py`.
- Add an import for `require_provider_operator_access` in `backend/app/api/api_v1/endpoints/setup.py` and only enforce the operator check for post-setup Cloudflare enabling so first-run unauthenticated setup remains unchanged.
- Add a regression test `test_system_setup_rejects_non_operator_updates_after_complete` to `backend/app/tests/test_setup_endpoints.py` that creates a non-operator user, uses a `dmarq_session` cookie, attempts to enable Cloudflare, and asserts an HTTP 403 and that `cloudflare.api_token` was not persisted.
- Add supporting test imports (`SESSION_COOKIE`, `create_session_token`, and `User`) used by the new test.

### Testing

- Ran `pytest -q backend/app/tests/test_setup_endpoints.py`, and the suite passed (`20 passed`).
- Ran `ruff check`/`ruff format` on the modified files and the linter/formatting checks passed.
- Verified `git diff --check` had no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d6d8d27bc83339fcc1ef09b73c7d5)