### PR TITLE
fix: disable unsafe global-token Linode imports

### DIFF
--- a/backend/app/services/dns_provider_connectors.py
+++ b/backend/app/services/dns_provider_connectors.py
@@ -145,7 +145,9 @@ _CONNECTORS: tuple[DNSProviderConnector, ...] = (
         name="Linode DNS",
         tier=1,
         auth_models=["personal_access_token", "lexicon_environment"],
-        zone_import_status="ready",
+        # Instance-wide environment credentials cannot safely authorize a
+        # workspace import in multi-tenant deployments.
+        zone_import_status="planned",
         record_read_status="planned",
         record_write_status="lexicon_available",
         dry_run_supported=True,

--- a/backend/app/services/dns_provider_imports.py
+++ b/backend/app/services/dns_provider_imports.py
@@ -15,7 +15,6 @@ from app.services.cloudflare_dns import discover_cloudflare_zones, import_cloudf
 from app.services.dns_provider_connectors import provider_connector_registry
 from app.services.dns_provider_writes import normalize_provider_id
 from app.services.hetzner_dns import discover_hetzner_zones, import_hetzner_domains
-from app.services.linode_dns import discover_linode_domains, import_linode_domains
 from app.services.route53_dns import discover_route53_zones, import_route53_domains
 from app.services.ovh_dns import discover_ovh_zones, import_ovh_domains
 
@@ -66,10 +65,6 @@ def _normalize_import_provider_id(provider: str) -> str:
     return aliases.get(provider_id, provider_id)
 
 
-def _provider_import_item_label(provider_id: str) -> str:
-    return "domain" if provider_id == "linode" else "zone"
-
-
 async def preview_dns_provider_import(
     db: Session,
     *,
@@ -84,8 +79,6 @@ async def preview_dns_provider_import(
         zones = await discover_route53_zones(db, workspace_id=workspace_id)
     elif provider_id == "hetzner":
         zones = await discover_hetzner_zones(db, workspace_id=workspace_id)
-    elif provider_id == "linode":
-        zones = await discover_linode_domains(db, workspace_id=workspace_id)
     elif provider_id == "akamai-edgedns":
         zones = await discover_akamai_edgedns_zones(db, workspace_id=workspace_id)
     elif provider_id == "ovh":
@@ -93,7 +86,6 @@ async def preview_dns_provider_import(
     else:
         raise LookupError(f"Unsupported DNS provider import: {provider_id}")
 
-    item_label = _provider_import_item_label(provider_id)
     items = [
         DNSProviderImportZone(
             provider=provider_id,
@@ -108,7 +100,7 @@ async def preview_dns_provider_import(
                 "Already monitored in this workspace."
                 if zone.get("imported")
                 else (
-                    f"Import this {_provider_name(provider_id)} {item_label} to monitor DNS posture "
+                    f"Import this {_provider_name(provider_id)} zone to monitor DNS posture "
                     "before reports arrive."
                 )
             ),
@@ -147,12 +139,6 @@ async def import_dns_provider_domains(
         )
     elif provider_id == "hetzner":
         result = await import_hetzner_domains(
-            db,
-            requested_domains=requested_domains,
-            workspace_id=workspace_id,
-        )
-    elif provider_id == "linode":
-        result = await import_linode_domains(
             db,
             requested_domains=requested_domains,
             workspace_id=workspace_id,

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -1370,34 +1370,15 @@ def test_dns_provider_import_preview_wraps_hetzner_zones(db_session):
     assert "Hetzner DNS zone" in result["zones"][0]["next_action"]
 
 
-def test_dns_provider_import_preview_wraps_linode_domains(db_session):
-    async def fake_discover(_db, workspace_id=None):
-        assert workspace_id == 123
-        return [
-            {
-                "id": "1",
-                "name": DOMAIN,
-                "status": "master",
-                "account_name": "Linode DNS",
-                "imported": False,
-            }
-        ]
-
-    with patch("app.services.dns_provider_imports.discover_linode_domains", new=fake_discover):
-        result = asyncio.run(
+def test_dns_provider_import_preview_rejects_linode(db_session):
+    with pytest.raises(LookupError, match="Unsupported DNS provider import: linode"):
+        asyncio.run(
             dns_provider_imports.preview_dns_provider_import(
                 db_session,
                 provider="linode",
                 workspace_id=123,
             )
         )
-
-    assert result["provider"] == "linode"
-    assert result["provider_name"] == "Linode DNS"
-    assert result["total_discovered"] == 1
-    assert result["importable_count"] == 1
-    assert result["zones"][0]["domain"] == DOMAIN
-    assert "Linode DNS domain" in result["zones"][0]["next_action"]
 
 
 def test_dns_provider_import_preview_wraps_route53_zones(db_session):
@@ -1456,19 +1437,9 @@ def test_dns_provider_import_apply_wraps_hetzner_import(db_session):
     assert result["imported"] == [DOMAIN]
 
 
-def test_dns_provider_import_apply_wraps_linode_import(db_session):
-    async def fake_import(_db, requested_domains=None, workspace_id=None):
-        assert requested_domains == [DOMAIN]
-        assert workspace_id == 456
-        return {
-            "imported": [DOMAIN],
-            "existing": [],
-            "skipped": [],
-            "total_discovered": 1,
-        }
-
-    with patch("app.services.dns_provider_imports.import_linode_domains", new=fake_import):
-        result = asyncio.run(
+def test_dns_provider_import_apply_rejects_linode(db_session):
+    with pytest.raises(LookupError, match="Unsupported DNS provider import: linode"):
+        asyncio.run(
             dns_provider_imports.import_dns_provider_domains(
                 db_session,
                 provider="linode",
@@ -1476,10 +1447,6 @@ def test_dns_provider_import_apply_wraps_linode_import(db_session):
                 workspace_id=456,
             )
         )
-
-    assert result["provider"] == "linode"
-    assert result["provider_name"] == "Linode DNS"
-    assert result["imported"] == [DOMAIN]
 
 
 def test_dns_provider_import_apply_wraps_route53_import(db_session):
@@ -1831,8 +1798,8 @@ def test_dns_provider_capabilities_mark_cloudflare_import_available(authed_clien
     assert providers["route53"]["import_available"] is True
     assert providers["route53"]["zone_import_status"] == "ready"
     assert "iam_role_external_id" in providers["route53"]["auth_models"]
-    assert providers["linode"]["import_available"] is True
-    assert providers["linode"]["zone_import_status"] == "ready"
+    assert providers["linode"]["import_available"] is False
+    assert providers["linode"]["zone_import_status"] == "planned"
     assert providers["linode"]["record_write_status"] == "lexicon_available"
     assert "personal_access_token" in providers["linode"]["auth_models"]
     assert providers["akamai-edgedns"]["import_available"] is True


### PR DESCRIPTION
### Motivation
- A global Linode API token exposed via instance settings allowed workspace-scoped callers to enumerate provider-visible domains and import them as `verified=True`, creating a cross-tenant inventory and ownership risk. 
- The Linode import/preview endpoints used only workspace authorization and not a workspace-scoped credential check, so the import path must be disabled until credentials can be scoped per workspace. 

### Description
- Mark the Linode connector as not ready for zone import by setting `zone_import_status` to `"planned"` in `backend/app/services/dns_provider_connectors.py` to stop advertising import capability. 
- Remove Linode dispatcher coverage from the generic import preview and apply flows in `backend/app/services/dns_provider_imports.py` so `preview_dns_provider_import` and `import_dns_provider_domains` will raise `LookupError` for `provider_id == "linode"`. 
- Replace the previous Linode happy-path tests with regression tests in `backend/app/tests/test_cloudflare_dns.py` that assert Linode preview and import requests are rejected and that provider capabilities mark Linode import as unavailable. 

### Testing
- Ran `pytest -q backend/app/tests/test_cloudflare_dns.py -k 'linode or dns_provider_import'` and the focused suite passed (`26 passed`). 
- Verified `git diff --check` returned clean and the working tree was committed with the change. 
- Confirmed the modified provider capability assertions and new rejection tests exercise the updated dispatcher behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d6d6238d0833380b2c6568a2d3a51)