### PR TITLE
Restrict Cloudflare OAuth credential updates

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -184,6 +184,7 @@ from app.services.webhook_events import (
 )
 from app.services.workspace_access import (
     PERMISSION_DOMAINS_WRITE,
+    PERMISSION_INTEGRATIONS_WRITE,
     PERMISSION_REPORTS_READ,
     parse_selected_workspace_id,
     resolve_authorized_workspace,
@@ -7971,6 +7972,7 @@ async def get_cloudflare_oauth_authorize_url(
     workspace = _authorized_domain_workspace(
         _auth,
         db,
+        permission=PERMISSION_INTEGRATIONS_WRITE,
         selected_workspace_id=parse_selected_workspace_id(selected_workspace),
     )
     redirect_uri = f"{_public_base_url(request, db)}/api/v1/domains/cloudflare/oauth/callback"
@@ -8059,7 +8061,12 @@ async def cloudflare_oauth_callback(
 
     try:
         state_payload = decode_cloudflare_oauth_state(state_value)
-        _authorized_domain_workspace(_auth, db, selected_workspace_id=state_payload["workspace_id"])
+        _authorized_domain_workspace(
+            _auth,
+            db,
+            permission=PERMISSION_INTEGRATIONS_WRITE,
+            selected_workspace_id=state_payload["workspace_id"],
+        )
         redirect_uri = f"{_public_base_url(request, db)}/api/v1/domains/cloudflare/oauth/callback"
         token_data = await exchange_cloudflare_oauth_code(
             code=code,

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -45,6 +45,7 @@ from app.services.dns_provider_writes import (
     LexiconDNSWriteProvider,
 )
 from app.services.organizations import OrganizationPlanLimitError
+from app.services.workspace_access import PERMISSION_INTEGRATIONS_WRITE
 from app.services.workspaces import get_or_create_default_workspace
 
 DOMAIN = "example.com"
@@ -2466,6 +2467,10 @@ def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(
 ):
     with (
         patch(
+            "app.api.api_v1.endpoints.domains._authorized_domain_workspace",
+            wraps=domains_endpoint._authorized_domain_workspace,
+        ) as authorize_workspace_mock,
+        patch(
             "app.api.api_v1.endpoints.domains.build_cloudflare_oauth_state",
             return_value="state-token",
         ) as state_mock,
@@ -2489,6 +2494,9 @@ def test_cloudflare_oauth_authorize_url_endpoint_returns_redirect(
     assert data["authorization_url"].startswith("https://dash.cloudflare.com/oauth2/auth")
     assert data["scopes"] == "zone.read dns.read"
     assert data["scope_profile"] == "read_only"
+    assert authorize_workspace_mock.call_args.kwargs["permission"] == (
+        PERMISSION_INTEGRATIONS_WRITE
+    )
     state_mock.assert_called_once()
     authorize_mock.assert_called_once()
     assert state_mock.call_args.kwargs["scope_profile"] == "read_only"
@@ -2630,6 +2638,10 @@ def test_cloudflare_oauth_callback_stores_token_and_redirects(
 
     with (
         patch(
+            "app.api.api_v1.endpoints.domains._authorized_domain_workspace",
+            wraps=domains_endpoint._authorized_domain_workspace,
+        ) as authorize_workspace_mock,
+        patch(
             "app.api.api_v1.endpoints.domains.decode_cloudflare_oauth_state",
             return_value={
                 "workspace_id": workspace.id,
@@ -2651,6 +2663,10 @@ def test_cloudflare_oauth_callback_stores_token_and_redirects(
 
     assert response.status_code == 303
     assert response.headers["location"] == "/settings/cloudflare"
+    assert authorize_workspace_mock.call_args.kwargs == {
+        "permission": PERMISSION_INTEGRATIONS_WRITE,
+        "selected_workspace_id": workspace.id,
+    }
     decode_mock.assert_called_once_with("state-token")
     exchange_mock.assert_awaited_once_with(
         code="oauth-code",


### PR DESCRIPTION
### Motivation

- Prevent workspace users with only `domains:write` from replacing a deployment-wide Cloudflare connector token and affecting other tenants.

### Description

- Require `PERMISSION_INTEGRATIONS_WRITE` when generating the Cloudflare OAuth authorize URL by passing `permission=PERMISSION_INTEGRATIONS_WRITE` to `_authorized_domain_workspace` in `backend/app/api/api_v1/endpoints/domains.py`. 
- Re-check `PERMISSION_INTEGRATIONS_WRITE` for the workspace encoded in the OAuth `state` before exchanging the authorization `code` and persisting tokens in the callback handler. 
- Add regression assertions in `backend/app/tests/test_cloudflare_dns.py` to confirm both the authorize and callback paths invoke `_authorized_domain_workspace` with `PERMISSION_INTEGRATIONS_WRITE`.

### Testing

- Ran `pytest -q app/tests/test_cloudflare_dns.py` with all tests passing (`162 passed`).
- Ran the targeted test selection for the two OAuth flows which also passed (`2 passed`).
- Verified `git diff --check` returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d6e1a7ecc83339edfe252f48d43b1)