### PR TITLE
Restrict Route53 imports to provider operators

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -127,6 +127,7 @@ from app.services.organizations import (
 )
 from app.services.ovh_dns import get_ovh_dns_credentials
 from app.services.ptr_lookup import PtrLookupResult, lookup_ptr_with_fallbacks
+from app.services.provider_access import require_provider_operator_access
 from app.services.remediation_dispatch import (
     attach_remediation_dispatch_previews,
     summarize_remediation_activity,
@@ -6022,6 +6023,8 @@ async def preview_dns_provider_domain_import(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Preview DNS-provider zones that can be imported as monitored domains."""
+    if normalize_provider_id(provider) == "route53":
+        require_provider_operator_access(db, _auth)
     workspace = _authorized_domain_workspace(
         _auth,
         db,
@@ -6049,6 +6052,8 @@ async def import_dns_provider_domain_zones(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Import selected, or all new, DNS-provider zones as monitored domains."""
+    if normalize_provider_id(provider) == "route53":
+        require_provider_operator_access(db, _auth)
     workspace = _authorized_domain_workspace(
         _auth,
         db,

--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -128,7 +128,6 @@ from app.services.organizations import (
 from app.services.provider_access import require_provider_operator_access
 from app.services.ovh_dns import get_ovh_dns_credentials
 from app.services.ptr_lookup import PtrLookupResult, lookup_ptr_with_fallbacks
-from app.services.provider_access import require_provider_operator_access
 from app.services.remediation_dispatch import (
     attach_remediation_dispatch_previews,
     summarize_remediation_activity,

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 import dns.exception
 import dns.resolver
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -1759,6 +1760,30 @@ def test_dns_provider_import_endpoint_returns_import_summary(authed_client: Test
     data = response.json()
     assert data["provider"] == "cloudflare"
     assert data["imported"] == [DOMAIN]
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs"),
+    [
+        ("get", "/api/v1/domains/dns/import/route53/preview", {}),
+        ("post", "/api/v1/domains/dns/import/route53", {"json": {}}),
+    ],
+)
+def test_route53_import_endpoints_require_provider_operator_access(
+    authed_client: TestClient,
+    method: str,
+    path: str,
+    kwargs: dict,
+):
+    with patch(
+        "app.api.api_v1.endpoints.domains.require_provider_operator_access",
+        side_effect=HTTPException(status_code=403, detail="Provider operator access is required"),
+    ) as require_operator:
+        response = getattr(authed_client, method)(path, **kwargs)
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Provider operator access is required"
+    require_operator.assert_called_once()
 
 
 def test_dns_provider_import_endpoint_rejects_unknown_provider(authed_client: TestClient):


### PR DESCRIPTION
### Motivation

- The Route53 import path exposed hosted-zone discovery and import using server-wide boto3 credentials to any caller with workspace domain-write privileges, enabling cross-tenant zone enumeration and trusted "verified" domain creation. This change closes that attack vector. 
- For safety, Route53 discovery and import should be restricted to deployment-level provider operators who are explicitly authorized to manage provider-backed DNS across tenants. 

### Description

- Add an explicit provider-operator gate by importing `require_provider_operator_access` and invoking it when `normalize_provider_id(provider) == "route53"` in both the `/dns/import/{provider}/preview` and `/dns/import/{provider}` endpoints. 
- This enforces deployment-wide provider operator authorization before any Route53 discovery or import runs, and before workspace-level domain creation logic executes. 
- Add regression tests in `backend/app/tests/test_cloudflare_dns.py` that assert both the preview and import Route53 endpoints return HTTP 403 when `require_provider_operator_access` denies access, and add the missing `HTTPException` import used by the test. 

### Testing

- Ran `python -m pytest backend/app/tests/test_cloudflare_dns.py -k 'route53_import_endpoints_require_provider_operator_access or dns_provider_import_endpoint_returns' -q` and the targeted tests passed (3 passed). 
- Ran `python -m pytest backend/app/tests/test_cloudflare_dns.py -k 'route53' -q` to exercise the Route53-related test subset and all selected tests passed (16 passed, 148 deselected). 
- All added regression checks asserting HTTP 403 for Route53 preview/import behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d6e1437c483338420850879834eff)