### PR TITLE
fix: restrict Hetzner imports to provider operators

### DIFF
--- a/backend/app/api/api_v1/endpoints/domains.py
+++ b/backend/app/api/api_v1/endpoints/domains.py
@@ -127,6 +127,7 @@ from app.services.organizations import (
 )
 from app.services.ovh_dns import get_ovh_dns_credentials
 from app.services.ptr_lookup import PtrLookupResult, lookup_ptr_with_fallbacks
+from app.services.provider_access import require_provider_operator_access
 from app.services.remediation_dispatch import (
     attach_remediation_dispatch_previews,
     summarize_remediation_activity,
@@ -6022,6 +6023,8 @@ async def preview_dns_provider_domain_import(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Preview DNS-provider zones that can be imported as monitored domains."""
+    if normalize_provider_id(provider) == "hetzner":
+        require_provider_operator_access(db, _auth)
     workspace = _authorized_domain_workspace(
         _auth,
         db,
@@ -6049,6 +6052,8 @@ async def import_dns_provider_domain_zones(
     selected_workspace: Optional[str] = Header(default=None, alias="X-DMARQ-Workspace-ID"),
 ):
     """Import selected, or all new, DNS-provider zones as monitored domains."""
+    if normalize_provider_id(provider) == "hetzner":
+        require_provider_operator_access(db, _auth)
     workspace = _authorized_domain_workspace(
         _auth,
         db,

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 import dns.exception
 import dns.resolver
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -1759,6 +1760,44 @@ def test_dns_provider_import_endpoint_returns_import_summary(authed_client: Test
     data = response.json()
     assert data["provider"] == "cloudflare"
     assert data["imported"] == [DOMAIN]
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("get", "/api/v1/domains/dns/import/hetzner/preview"),
+        ("post", "/api/v1/domains/dns/import/hetzner"),
+    ],
+)
+def test_hetzner_dns_import_requires_provider_operator_access(
+    authed_client: TestClient,
+    method: str,
+    path: str,
+):
+    with (
+        patch(
+            "app.api.api_v1.endpoints.domains.require_provider_operator_access",
+            side_effect=HTTPException(
+                status_code=403, detail="Provider operator access is required"
+            ),
+        ),
+        patch(
+            "app.api.api_v1.endpoints.domains.preview_dns_provider_import",
+            new=AsyncMock(),
+        ) as preview_import,
+        patch(
+            "app.api.api_v1.endpoints.domains.import_dns_provider_domains",
+            new=AsyncMock(),
+        ) as apply_import,
+    ):
+        response = (
+            authed_client.post(path, json={}) if method == "post" else authed_client.get(path)
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Provider operator access is required"
+    preview_import.assert_not_awaited()
+    apply_import.assert_not_awaited()
 
 
 def test_dns_provider_import_endpoint_rejects_unknown_provider(authed_client: TestClient):


### PR DESCRIPTION
### Motivation

- Prevent ordinary workspace admins from previewing or importing Hetzner zones discovered using deployment-wide Hetzner credentials which could allow cross-tenant zone claims and bypass DNS ownership verification.

### Description

- Require deployment operator authorization by calling `require_provider_operator_access` for `hetzner` in both `preview_dns_provider_domain_import` and `import_dns_provider_domain_zones` in `backend/app/api/api_v1/endpoints/domains.py` so discovery/import is blocked before any workspace-level resolution runs.
- Import the operator check helper via `from app.services.provider_access import require_provider_operator_access` and gate access using `normalize_provider_id(provider) == "hetzner"` to limit the restriction to the Hetzner provider only.
- Add a regression test `test_hetzner_dns_import_requires_provider_operator_access` in `backend/app/tests/test_cloudflare_dns.py` that asserts the preview and import endpoints return HTTP 403 for callers denied provider-operator access and that underlying discovery/import functions are not invoked.

### Testing

- Ran `python -m pytest backend/app/tests/test_cloudflare_dns.py -q` which executed the test file including the new regression and completed with all tests passing (`164 passed`).
- Verified formatting and linting adjustments as part of the test iteration and kept changes limited to the authorization gating and test coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d6fcdf7288333b9dab95d6f1eff59)