### PR TITLE
fix: validate Postmark DNS records before automated writes

### DIFF
--- a/backend/app/services/dns_provider_writes.py
+++ b/backend/app/services/dns_provider_writes.py
@@ -281,7 +281,7 @@ def _plan_value(plan: Dict[str, Any], value_override: Optional[str]) -> str:
     return value
 
 
-def _validate_plan_for_automation(plan: Dict[str, Any]) -> None:
+def _validate_plan_for_automation(plan: Dict[str, Any], *, domain: str) -> None:
     operation = str(plan.get("operation") or "").lower()
     record_type = str(plan.get("record_type") or "").upper()
     if operation not in SUPPORTED_AUTOMATED_OPERATIONS:
@@ -292,6 +292,13 @@ def _validate_plan_for_automation(plan: Dict[str, Any]) -> None:
         raise DNSProviderWriteError(
             f"Record type '{record_type}' is not supported for automatic DNS writes yet"
         )
+    normalized_domain = domain.strip().rstrip(".").lower()
+    normalized_name = str(plan.get("name") or "").strip().rstrip(".").lower()
+    if not normalized_domain or not normalized_name or not (
+        normalized_name == normalized_domain
+        or normalized_name.endswith(f".{normalized_domain}")
+    ):
+        raise DNSProviderWriteError("The DNS plan record name is outside the monitored domain")
 
 
 def _current_record_type(plan: Dict[str, Any]) -> str:
@@ -508,7 +515,7 @@ class CloudflareDNSWriteProvider:
         value_override: Optional[str],
         ttl: int,
     ) -> DNSWriteMutation:
-        _validate_plan_for_automation(plan)
+        _validate_plan_for_automation(plan, domain=domain)
         value = _plan_value(plan, value_override)
         record_type = str(plan["record_type"]).upper()
         record_name = str(plan["name"])
@@ -706,7 +713,7 @@ class NativeManagedDNSWriteProvider:
         value_override: Optional[str],
         ttl: int,
     ) -> DNSWriteMutation:
-        _validate_plan_for_automation(plan)
+        _validate_plan_for_automation(plan, domain=domain)
         value = _plan_value(plan, value_override)
         record_type = str(plan["record_type"]).upper()
         record_name = str(plan["name"])
@@ -847,7 +854,7 @@ class LexiconDNSWriteProvider:
     ) -> DNSWriteMutation:
         if not lexicon_runtime_available():
             raise DNSProviderWriteError("dns-lexicon is not installed in this DMARQ runtime")
-        _validate_plan_for_automation(plan)
+        _validate_plan_for_automation(plan, domain=domain)
         value = _plan_value(plan, value_override)
         record_type = str(plan["record_type"]).upper()
         record_name = str(plan["name"])
@@ -1050,7 +1057,7 @@ def _demo_dns_mutation(
     ttl: int = 1,
 ) -> DNSWriteMutation:
     """Return a provider-like mutation for demo flows without provider access."""
-    _validate_plan_for_automation(plan)
+    _validate_plan_for_automation(plan, domain=domain)
     content = _plan_value(plan, value_override)
     provider = normalize_provider_id(provider_id)
     record_type = str(plan.get("record_type") or "").upper()

--- a/backend/app/services/mail_service_imports.py
+++ b/backend/app/services/mail_service_imports.py
@@ -80,6 +80,20 @@ def _normalize_provider(provider: str) -> str:
     return (provider or "").strip().lower().replace("_", "-")
 
 
+def _is_expected_postmark_record(
+    *, domain: str, record_type: str, name: str, purpose: str
+) -> bool:
+    """Return whether a Postmark requirement targets an expected owner name."""
+    normalized_name = name.rstrip(".").lower()
+    normalized_purpose = purpose.strip().lower()
+    if record_type == "TXT" and normalized_purpose == "dkim":
+        suffix = f"._domainkey.{domain}"
+        return normalized_name.endswith(suffix) and normalized_name != suffix.lstrip(".")
+    if record_type == "CNAME" and normalized_purpose == "return_path":
+        return normalized_name == f"pm-bounces.{domain}"
+    return False
+
+
 def _setting_value(db: Session, key: str) -> Optional[str]:
     row = db.query(Setting).filter(Setting.key == key).first()
     if row is None or not row.value:
@@ -349,7 +363,13 @@ async def mail_service_dns_records_for_domain(
             record_type = str(record.get("record_type") or "").strip().upper()
             name = str(record.get("name") or "").strip().strip(".")
             value = str(record.get("value") or "").strip().strip(".")
-            if not record_type or not name or not value:
+            purpose = str(record.get("purpose") or "sender_verification")
+            if not value or not _is_expected_postmark_record(
+                domain=normalized_domain,
+                record_type=record_type,
+                name=name,
+                purpose=purpose,
+            ):
                 continue
             records.append(
                 {
@@ -358,7 +378,7 @@ async def mail_service_dns_records_for_domain(
                     "record_type": record_type,
                     "name": name,
                     "value": value,
-                    "purpose": str(record.get("purpose") or "sender_verification"),
+                    "purpose": purpose,
                 }
             )
     return records

--- a/backend/app/tests/test_cloudflare_dns.py
+++ b/backend/app/tests/test_cloudflare_dns.py
@@ -4318,6 +4318,22 @@ def test_cloudflare_write_provider_rejects_unsupported_apply_operation(db_sessio
             asyncio.run(provider.apply_mutation(db_session, domain=DOMAIN, mutation=mutation))
 
 
+def test_cloudflare_write_provider_rejects_record_outside_monitored_domain(db_session):
+    provider = CloudflareDNSWriteProvider()
+    plan = {**_dns_plan(), "name": "_dmarc.attacker.example"}
+
+    with pytest.raises(DNSProviderWriteError, match="outside the monitored domain"):
+        asyncio.run(
+            provider.prepare_mutation(
+                db_session,
+                domain=DOMAIN,
+                plan=plan,
+                value_override=None,
+                ttl=1,
+            )
+        )
+
+
 def test_lexicon_write_provider_reports_missing_runtime(db_session):
     provider = LexiconDNSWriteProvider("route53")
 

--- a/backend/app/tests/test_mail_service_imports.py
+++ b/backend/app/tests/test_mail_service_imports.py
@@ -360,6 +360,41 @@ def test_mail_service_dns_records_for_domain_is_optional(db_session):
     assert records == []
 
 
+def test_mail_service_dns_records_for_domain_rejects_unexpected_postmark_names(db_session):
+    requirements = [
+        {"record_type": "TXT", "name": "example.com", "value": "attacker", "purpose": "dkim"},
+        {
+            "record_type": "TXT",
+            "name": "pm._domainkey.other.example",
+            "value": "attacker",
+            "purpose": "dkim",
+        },
+        {
+            "record_type": "CNAME",
+            "name": "attacker-controlled.example.com",
+            "value": "attacker.example.net",
+            "purpose": "return_path",
+        },
+        {
+            "record_type": "CNAME",
+            "name": "pm-bounces.example.com",
+            "value": "pm.mtasv.net",
+            "purpose": "return_path",
+        },
+    ]
+    with patch(
+        "app.services.mail_service_imports.discover_postmark_sender_domains",
+        new=AsyncMock(
+            return_value=[{"domain": "example.com", "required_dns_records": requirements}]
+        ),
+    ):
+        records = asyncio.run(
+            mail_service_imports.mail_service_dns_records_for_domain(db_session, "example.com")
+        )
+
+    assert [record["name"] for record in records] == ["pm-bounces.example.com"]
+
+
 def test_mail_service_dns_records_for_domain_skips_provider_discovery_for_cached_reads(
     db_session,
 ):


### PR DESCRIPTION
### Motivation
- Postmark-imported DNS requirements were being accepted and turned into apply-ready change plans without checking that the owner name belonged to the monitored domain or matched expected Postmark DKIM/return-path patterns, enabling attacker-controlled DNS mutations.

### Description
- Add `_is_expected_postmark_record` and use it in `mail_service_dns_records_for_domain` to accept only expected Postmark DKIM TXT selectors under `._domainkey.<domain>` and the `pm-bounces.<domain>` CNAME return-path, rejecting other names and purposes.
- Harden automation by updating `_validate_plan_for_automation` in `dns_provider_writes.py` to accept a `domain` and raise an error if the plan `name` is not the monitored domain or a subdomain, and wire the domain through to all provider `prepare_mutation` and demo paths.
- Add regression tests: one in `test_mail_service_imports.py` that ensures malicious/unexpected Postmark requirement names are rejected, and one in `test_cloudflare_dns.py` that ensures provider mutation preparation rejects plans with record names outside the monitored domain.
- Apply formatting/linters and keep behavior unchanged for legitimate Postmark records and existing DNS-write flows other than the added validations.

### Testing
- Ran `cd backend && python -m pytest app/tests/test_mail_service_imports.py -q` and observed `28 passed`.
- Ran `cd backend && python -m pytest app/tests/test_cloudflare_dns.py -q -k 'write_provider'` and observed `13 passed` (selected tests) with the new out-of-domain rejection test passing.
- Ran `python -m ruff check` on modified files and confirmed linting/formatting checks passed.
- Ran repository checks (`git diff --check`) and test-related checks with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d772ad9ac8333abd0ba85b7fe2e45)