### PR TITLE
Scope Postmark sender-domain imports to one workspace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,6 +165,7 @@ SOURCE_REPUTATION_FEEDS_ENABLED=false
 
 # Other optional integrations
 # POSTMARK_ACCOUNT_TOKEN="your_postmark_account_token"
+# POSTMARK_WORKSPACE_ID=1
 # WEBHOOK_SECRET="generate-a-separate-secret"
 # STRIPE_SECRET_KEY=""
 # STRIPE_WEBHOOK_SECRET=""

--- a/backend/app/api/api_v1/endpoints/settings.py
+++ b/backend/app/api/api_v1/endpoints/settings.py
@@ -205,6 +205,13 @@ SETTING_DEFAULTS: List[Dict[str, Any]] = [
         "value_type": "string",
         "category": "postmark",
     },
+    {
+        "key": "postmark.workspace_id",
+        "value": "",
+        "description": "Workspace ID authorized to use the Postmark account token",
+        "value_type": "integer",
+        "category": "postmark",
+    },
     # ── Forensics ────────────────────────────────────────────────────────────
     {
         "key": "forensics.redaction_mode",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -124,6 +124,7 @@ class Settings(BaseSettings):
     DMARQ_DNS_CUSTOM_DOH_HOSTNAME: Optional[str] = None
     DMARQ_DNS_CUSTOM_DOT_HOSTNAME: Optional[str] = None
     POSTMARK_ACCOUNT_TOKEN: Optional[str] = None
+    POSTMARK_WORKSPACE_ID: Optional[int] = None
     WEBHOOK_SECRET: Optional[str] = None
     WEBHOOK_MAX_EMAIL_SIZE_MB: int = 25
 

--- a/backend/app/services/mail_service_imports.py
+++ b/backend/app/services/mail_service_imports.py
@@ -94,6 +94,30 @@ def get_postmark_account_token(db: Session) -> Optional[str]:
     return _setting_value(db, "postmark.account_token") or get_settings().POSTMARK_ACCOUNT_TOKEN
 
 
+def _postmark_workspace_id(db: Session) -> Optional[int]:
+    """Return the workspace to which the account-wide Postmark token is bound."""
+    value = _setting_value(db, "postmark.workspace_id")
+    if value is None:
+        value = get_settings().POSTMARK_WORKSPACE_ID
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise LookupError("Postmark workspace binding is invalid") from exc
+
+
+def _require_postmark_workspace_scope(db: Session, workspace_id: Optional[int]) -> None:
+    """Prevent an account-wide Postmark token from crossing workspace boundaries."""
+    if workspace_id is None:
+        return
+    configured_workspace_id = _postmark_workspace_id(db)
+    if configured_workspace_id is None:
+        raise LookupError("Postmark account token is not bound to a workspace")
+    if configured_workspace_id != workspace_id:
+        raise LookupError("Postmark is not configured for this workspace")
+
+
 def _domain_from_email(value: Any) -> Optional[str]:
     if not value:
         return None
@@ -227,6 +251,7 @@ async def discover_postmark_sender_domains(
     token = get_postmark_account_token(db)
     if not token:
         raise LookupError("Postmark account token is not configured")
+    _require_postmark_workspace_scope(db, workspace_id)
 
     known_query = db.query(Domain.name)
     if workspace_id is not None:

--- a/backend/app/tests/test_mail_service_imports.py
+++ b/backend/app/tests/test_mail_service_imports.py
@@ -69,6 +69,45 @@ def test_postmark_token_falls_back_to_environment(db_session):
         assert mail_service_imports.get_postmark_account_token(db_session) == "env-token"
 
 
+def test_postmark_discovery_rejects_token_bound_to_another_workspace(db_session):
+    db_session.add(
+        Setting(
+            key="postmark.workspace_id",
+            value="7",
+            category="postmark",
+        )
+    )
+    db_session.commit()
+
+    with (
+        patch("app.services.mail_service_imports.get_postmark_account_token", return_value="token"),
+        patch("app.services.mail_service_imports._postmark_get", new=AsyncMock()) as get_mock,
+        pytest.raises(LookupError, match="not configured for this workspace"),
+    ):
+        asyncio.run(
+            mail_service_imports.discover_postmark_sender_domains(db_session, workspace_id=8)
+        )
+
+    get_mock.assert_not_awaited()
+
+
+def test_postmark_discovery_requires_workspace_binding(db_session):
+    class FakeSettings:
+        POSTMARK_WORKSPACE_ID = None
+
+    with (
+        patch("app.services.mail_service_imports.get_postmark_account_token", return_value="token"),
+        patch("app.services.mail_service_imports.get_settings", return_value=FakeSettings()),
+        patch("app.services.mail_service_imports._postmark_get", new=AsyncMock()) as get_mock,
+        pytest.raises(LookupError, match="not bound to a workspace"),
+    ):
+        asyncio.run(
+            mail_service_imports.discover_postmark_sender_domains(db_session, workspace_id=8)
+        )
+
+    get_mock.assert_not_awaited()
+
+
 def test_mail_service_helpers_handle_empty_values(db_session):
     assert mail_service_imports._domain_from_email(None) is None
     assert mail_service_imports._domain_from_email("not-an-email") is None

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -474,6 +474,7 @@ runtime instead of storing raw secrets in the repository.
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
 | `POSTMARK_ACCOUNT_TOKEN` | Optional Postmark account token for read-only sender-domain discovery | - | `your_postmark_account_token` |
+| `POSTMARK_WORKSPACE_ID` | Workspace authorized to discover and import domains with the Postmark account token (required when the token is configured) | - | `1` |
 | `WEBHOOK_SECRET` | Required secret for inbound email worker webhooks | - | `openssl rand -hex 32` |
 | `WEBHOOK_MAX_EMAIL_SIZE_MB` | Maximum raw RFC 822 email size accepted by inbound report webhooks | `25` | `10`, `50` |
 


### PR DESCRIPTION
### Motivation

- Prevent a deployment-wide Postmark account token from exposing or importing sender domains across tenant workspaces by enforcing a workspace-scoped binding.

### Description

- Add a workspace binding for the Postmark token sourced from `postmark.workspace_id` setting or `POSTMARK_WORKSPACE_ID` configuration and validate its format in `backend/app/services/mail_service_imports.py`.
- Introduce `_postmark_workspace_id` and `_require_postmark_workspace_scope` helpers and call the latter to fail closed before any Postmark API requests in `discover_postmark_sender_domains`.
- Expose the binding in application configuration and admin settings by adding `POSTMARK_WORKSPACE_ID` to `backend/app/core/config.py`, registering `postmark.workspace_id` in `backend/app/api/api_v1/endpoints/settings.py`, updating `.env.example`, and documenting the variable in `docs/deployment/configuration.md`.
- Add regression tests in `backend/app/tests/test_mail_service_imports.py` that assert discovery is rejected and the Postmark client is not invoked when the workspace binding is missing or bound to a different workspace.

### Testing

- Ran `PYTHONPATH=backend pytest -q backend/app/tests/test_mail_service_imports.py` and all tests passed (29 passed).
- Added tests specifically verifying that mismatched and missing Postmark workspace bindings raise `LookupError` and do not perform outbound Postmark calls, and those tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d77cbd7948333bf565de8ef6eaab3)