### PR TITLE
fix: make release GitOps dispatch repository explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
           fi
 
           gh workflow run ci.yml \
+            --repo "${GITHUB_REPOSITORY}" \
             --ref main \
             -f release_ref="${RELEASE_TAG}" \
             -f release_tag="${RELEASE_TAG}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Release deployment dispatch now targets the repository explicitly, so the
+  GitOps promotion gate remains reliable after semantic-release runs in its
+  containerized action context.
 - Remediation queues now keep core DMARC and mail-health actions ahead of optional
   MTA-STS, TLS-RPT, BIMI, and DANE hardening, and label the scope in the primary
   domain action so the next step is unambiguous.


### PR DESCRIPTION
Fixes the release workflow dispatch after semantic-release runs in its containerized action context by passing the repository explicitly to gh. Documents the release-gate reliability fix in CHANGELOG.md.

Local validation: workflow and changelog diff reviewed.