### PR TITLE
fix: ship upstream SQLite security fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,7 @@ jobs:
         run: |
           docker compose exec -T app sh -euxc '
             test "$(dpkg-query -W -f="\${Version}" libsqlite3-0)" = "3.54.0-0dmarq1"
-            python -c "import sqlite3; sqlite3.connect(\":memory:\"); assert sqlite3.sqlite_version_info >= (3, 54, 0), sqlite3.sqlite_version; print(sqlite3.sqlite_version)"
+            python -c "import sqlite3; db = sqlite3.connect(\":memory:\"); assert sqlite3.sqlite_version_info >= (3, 54, 0), sqlite3.sqlite_version; assert any(row[0] == \"ENABLE_SESSION\" for row in db.execute(\"pragma compile_options\")); print(sqlite3.sqlite_version)"
             grep -Eq "/usr/lib/[^ ]*/libsqlite3\.so\.0" /proc/self/maps
           '
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,6 +552,14 @@ jobs:
           curl -fsS http://127.0.0.1:8080/api/v1/domains/domains \
             | grep -q '"name":"example.com"'
 
+      - name: Verify SQLite security-fixed runtime
+        run: |
+          docker compose exec -T app sh -euxc '
+            test "$(dpkg-query -W -f="\${Version}" libsqlite3-0)" = "3.54.0-0dmarq1"
+            python -c "import sqlite3; sqlite3.connect(\":memory:\"); assert sqlite3.sqlite_version_info >= (3, 54, 0), sqlite3.sqlite_version; print(sqlite3.sqlite_version)"
+            grep -Eq "/usr/lib/[^ ]*/libsqlite3\.so\.0" /proc/self/maps
+          '
+
       - name: Show logs on failure
         if: failure()
         run: docker compose logs --no-color --tail=300

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- The backend runtime now builds SQLite from the upstream session-extension
+  security-fix tree and installs it as the image's `libsqlite3-0` package,
+  avoiding the still-unpatched Debian Trixie package for CVE-2026-50812 and
+  CVE-2026-50813.
 - Release deployment dispatch now targets the repository explicitly, so the
   GitOps promotion gate remains reliable after semantic-release runs in its
   containerized action context.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,6 +10,45 @@ COPY app/static/js ./app/static/js
 COPY app/static/css/styles.css ./app/static/css/styles.css
 RUN npm run build:css
 
+FROM python:3.13-slim AS sqlite-builder
+
+ARG SQLITE_FIX_COMMIT=c597ed79d1bd03f57198d10d1f431adda293cf2e
+ARG SQLITE_FIX_SHA256=61586c1331d519381d4e636512fc13bda678beaf7e3354a083c770c7fdd8e6ba
+
+WORKDIR /tmp/sqlite
+
+# Debian Trixie does not yet ship these two SQLite session-extension fixes.
+# Build the upstream fixed tree and package only the shared runtime library so
+# Python's sqlite3 module keeps using the normal libsqlite3 ABI.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    dpkg-dev \
+    && curl -fsSL "https://github.com/sqlite/sqlite/archive/${SQLITE_FIX_COMMIT}.tar.gz" \
+      -o /tmp/sqlite.tar.gz \
+    && echo "${SQLITE_FIX_SHA256}  /tmp/sqlite.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/sqlite.tar.gz --strip-components=1 \
+    && ./configure --prefix=/opt/sqlite --disable-static --fts5 --session \
+    && make -j"$(nproc)" \
+    && make install \
+    && mkdir -p "/tmp/sqlite-package/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+    && cp -a /opt/sqlite/lib/libsqlite3.so* \
+      "/tmp/sqlite-package/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/" \
+    && mkdir -p /tmp/sqlite-package/DEBIAN \
+    && printf '%s\n' \
+      'Package: libsqlite3-0' \
+      'Version: 3.54.0-0dmarq1' \
+      "Architecture: $(dpkg --print-architecture)" \
+      'Multi-Arch: same' \
+      'Maintainer: DMARQ maintainers <maintainers@dmarq.org>' \
+      'Description: SQLite runtime with DMARQ security fixes' \
+      ' This package contains the SQLite runtime built from the upstream' \
+      ' session-extension security-fix tree used by the DMARQ image.' \
+      > /tmp/sqlite-package/DEBIAN/control \
+    && dpkg-deb --build --root-owner-group /tmp/sqlite-package /tmp/libsqlite3-0.deb \
+    && rm -rf /var/lib/apt/lists/* /tmp/sqlite /tmp/sqlite-package /tmp/sqlite.tar.gz
+
 FROM python:3.13-slim
 
 WORKDIR /app
@@ -37,6 +76,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && chmod u-s /usr/bin/mount /usr/bin/umount \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=sqlite-builder /tmp/libsqlite3-0.deb /tmp/libsqlite3-0.deb
+RUN dpkg -i /tmp/libsqlite3-0.deb \
+    && ldconfig \
+    && rm /tmp/libsqlite3-0.deb
 
 # Copy Python requirements and install
 COPY requirements.txt .

--- a/docs/deployment/security-risk-acceptances.md
+++ b/docs/deployment/security-risk-acceptances.md
@@ -62,11 +62,11 @@ following occurs:
 
 | Field | Decision |
 | --- | --- |
-| Status | Temporarily accepted and tracked in [issue #805](https://github.com/christianlouis/dmarq/issues/805) |
+| Status | Mitigation prepared in the SQLite runtime patch PR; keep tracked until the published image is independently rescanned |
 | Recorded | 2026-07-15 |
 | Review by | 2026-08-16, or the next base-image refresh, whichever comes first |
 | Affected image | Official `python:3.13-slim` runtime base on Debian 13 (trixie) |
-| Affected package | `libsqlite3-0` `3.46.1-7+deb13u1` |
+| Affected package | Debian `libsqlite3-0` `3.46.1-7+deb13u1`; replaced in the DMARQ image by an upstream-fixed `3.54.0-0dmarq1` build |
 | Tracked CVEs | CVE-2026-50812, CVE-2026-50813 |
 | Owner | DMARQ maintainers |
 
@@ -75,18 +75,19 @@ following occurs:
 - Snyk reported both findings as low severity in the inherited runtime package.
 - DMARQ uses SQLite through Python and SQLAlchemy for supported single-container
   installations; removing SQLite would break the documented deployment mode.
-- A recheck of `ghcr.io/christianlouis/dmarq:docker-latest` on 2026-07-18
-  found the same installed version as Debian's current trixie candidate.
-- No fixed Debian trixie package or safe application-side remediation was
-  available at the last review. Mixing packages from another Debian suite
-  would create a larger, unsupported runtime dependency risk.
+- Debian's current Trixie package still does not contain the two fixes, while
+  the upstream SQLite fix commits are available. The image now builds that
+  fixed source tree and replaces the runtime library through a package with
+  the same ABI and package name.
 
 ### Required controls
 
-- Rebuild release images from the current official Python base so a fixed
-  package is inherited as soon as Debian publishes one.
+- Rebuild release images from the current official Python base so unrelated
+  Debian security updates continue to flow into the image.
 - Scan immutable release images during the release gate and record the
   installed `libsqlite3-0` version against issue #805.
+- Verify that Python loads the packaged fixed library and that the image does
+  not retain the vulnerable Debian package version.
 - Keep the documented PostgreSQL deployment option available for operators
   who require a database without the embedded SQLite runtime package.
 - Do not expose SQLite or arbitrary SQL execution through the HTTP surface.
@@ -96,8 +97,8 @@ following occurs:
 End this acceptance and rebuild all published image tags when any of the
 following occurs:
 
-1. Debian trixie or the official Python slim image publishes a fixed package.
-2. A supported base image contains a fixed SQLite version without cross-suite
-   package mixing.
+1. Debian trixie or the official Python slim image publishes a maintained
+   fixed package; replace the custom package with that distribution package.
+2. A maintained upstream SQLite release supersedes the pinned fix tree.
 3. A scanner raises the severity or shows an application-reachable exploit path.
 4. The review deadline is reached without a fresh documented assessment.


### PR DESCRIPTION
## Summary
- build SQLite from the upstream session-extension security-fix tree containing the fixes for CVE-2026-50812 and CVE-2026-50813
- package the shared library as a Debian-compatible `libsqlite3-0` runtime package with the normal ABI and install it over the still-vulnerable Debian Trixie package
- verify in the disposable registry-image smoke test that the exact patched package and runtime library are loaded
- document the mitigation and the remaining rescan/retirement conditions for the temporary package pin

## Why
Debian Trixie still exposes `libsqlite3-0` `3.46.1-7+deb13u1` for these findings. The upstream fixed source tree is available, so the image can carry the fix without waiting for the Debian base image refresh.

## Validation
- upstream SQLite source archive configured and built successfully on the local host
- `git diff --check` passed
- direct local Docker image build was attempted but blocked before Dockerfile execution by the local Colima/containerd metadata I/O error
- GitHub CI must complete the multi-architecture image build, registry smoke test, and security scan before this is merged

Closes #805 once the published image has been independently rescanned and the scanner confirms the findings are resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the backend runtime to use a security-fixed SQLite build, addressing known vulnerabilities.
  * Added verification that the deployed container uses the expected SQLite version, Python SQLite support, and shared library.
* **Documentation**
  * Documented the SQLite security mitigation, verification controls, and conditions for future package replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->